### PR TITLE
fix(sync): self-heal a never-git-initialized default brain dir (#2964)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1628,7 +1628,44 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   //   - syncScopeRoot:  file walking, imports, deletes, renames
   // In the common case (repoPath == git root, no subpath) they are identical.
   serr(`[gbrain phase] sync.discover_git_root`);
-  const gitContextRoot = realpathSync(discoverGitRoot(repoPath));
+  // #2964: a legacy `sync.repo_path`-anchored default brain (no `sources`
+  // row, no `opts.sourceId`) can reach here having never been `git init`-ed
+  // — e.g. a brain-pages dir that predates git-backed sync, or one rsync'd
+  // from another machine without its `.git`. gbrain owns this directory
+  // outright (it's not a user-external path the way an `opts.sourceId` +
+  // local `sources add --path` entry is), so self-heal by initializing it
+  // in place instead of failing the sync phase every single run. Mirrors
+  // the recloneIfMissing self-recovery above for owned remote clones.
+  // Scoped to !opts.sourceId only — a registered local source without a
+  // remote_url stays a loud, actionable error (it's the user's own
+  // directory; silently git-initializing it without consent is an
+  // overreach).
+  let gitContextRoot: string;
+  try {
+    gitContextRoot = realpathSync(discoverGitRoot(repoPath));
+  } catch (err) {
+    if (opts.sourceId || !existsSync(repoPath)) throw err;
+    serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
+    git(repoPath, ['init', '--quiet']);
+    // A fresh `git init` has zero commits, and `git rev-parse HEAD` a few
+    // lines below requires at least one — without a baseline commit we'd
+    // just trade "not a git repo" for "no commits in repo" on the very next
+    // line. Snapshot the CURRENT on-disk state as that baseline (respecting
+    // .gitignore, written first) so future incremental syncs diff against
+    // what's actually here rather than an empty tree — an empty initial
+    // commit would make every existing file look "added" again on the next
+    // sync, even though this full-sync pass already imported them.
+    manageGitignore(repoPath, engine.kind);
+    git(repoPath, ['add', '-A']);
+    // Explicit identity via -c: a headless nightly cron/launchd invocation
+    // has no reason to have global git user.name/user.email configured.
+    git(
+      repoPath,
+      ['commit', '--quiet', '--allow-empty', '-m', 'gbrain: initial commit (auto-init by sync)'],
+      ['user.name=gbrain', 'user.email=gbrain@localhost'],
+    );
+    gitContextRoot = realpathSync(discoverGitRoot(repoPath));
+  }
   const rawScopeRoot = opts.srcSubpath ? join(repoPath, opts.srcSubpath) : repoPath;
   if (!existsSync(rawScopeRoot)) {
     throw new Error(`Sync scope does not exist: ${rawScopeRoot}`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -958,10 +958,41 @@ export function discoverGitRoot(inputPath: string): string {
  * headless nightly cron/launchd invocation, which has no reason to have
  * git signing/identity configured, and must not block on an unavailable
  * signing agent or pinentry prompt.
+ *
+ * db_only exclusion is recomputed directly and passed to `git add` as
+ * negative pathspecs, rather than relying solely on `manageGitignore`
+ * having written `.gitignore` successfully: that helper is deliberately
+ * best-effort (a broken gbrain.yml parse, or an unwritable .gitignore,
+ * only warns and returns — the right default for its OTHER callers, where
+ * .gitignore management is a side effect that must never kill the sync
+ * job). For a commit we are about to create ourselves, "fail open" there
+ * would mean silently committing db_only content into git history. Fail
+ * closed instead: db_only exclusion doesn't depend on the .gitignore
+ * write having succeeded. `loadStorageConfig` throwing (unreadable
+ * gbrain.yml, or a semantic overlap) propagates — better to leave this
+ * self-heal wedged with a clear error than commit unknown content.
  */
 function createSyncBaselineCommit(repoPath: string, engineKind?: 'pglite' | 'postgres'): void {
   manageGitignore(repoPath, engineKind);
-  git(repoPath, ['add', '-A']);
+  const storageConfig = loadStorageConfig(repoPath);
+  // Only pathspec-exclude db_only dirs `.gitignore` did NOT already cover.
+  // A redundant negation pathspec for an already-ignored path makes git's
+  // `-A` bail with "paths ignored by .gitignore, use -f"
+  // (advice.addIgnoredFile) even though the negation is semantically
+  // correct and git would otherwise skip it silently. `check-ignore`
+  // throwing (not ignored, or the check itself failed) defaults to
+  // excluding explicitly — the fail-closed direction.
+  const excludePathspecs = (storageConfig?.db_only ?? [])
+    .filter((dir) => {
+      try {
+        git(repoPath, ['check-ignore', '-q', dir]);
+        return false;
+      } catch {
+        return true;
+      }
+    })
+    .map((dir) => `:!${dir}`);
+  git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs]);
   git(
     repoPath,
     ['commit', '--quiet', '--allow-empty', '--no-gpg-sign', '-m', 'gbrain: initial commit (auto-init by sync)'],
@@ -1033,6 +1064,38 @@ async function readSyncAnchor(
     return rows[0]?.value ?? null;
   }
   return await engine.getConfig(`sync.${which}`);
+}
+
+/**
+ * #2964: is `repoPath` gbrain's own legacy default anchor, as opposed to a
+ * path some caller merely happened to pass through unchanged?
+ *
+ * `!opts.sourceId` alone is NOT sufficient: `runPhaseSync` (dream cycle)
+ * and `submit_job({name:'sync', data:{repoPath}})` (MCP, jobs.ts) both
+ * reach `performSyncInner` with `sourceId` undefined AND `opts.repoPath`
+ * set explicitly — the former legitimately (it already resolved the
+ * anchor itself and is passing it through), the latter potentially with
+ * an attacker-controlled path. The two are indistinguishable from
+ * `opts.repoPath`'s mere presence/absence, so ownership has to be proven
+ * by VALUE: read the anchor fresh from config and require the resolved
+ * `repoPath` to equal it exactly. An arbitrary caller-supplied path only
+ * passes this check if it happens to already equal gbrain's own anchor —
+ * at which point self-healing it is exactly the legitimate case.
+ *
+ * `opts.srcSubpath` disqualifies unconditionally: a subpath-scoped sync
+ * only wants THAT subdirectory captured, but the self-heal baseline
+ * commit runs `git add -A` at the git root (there's no file list yet to
+ * scope it to — collection happens after this point) — see the P2 review
+ * finding on `createSyncBaselineCommit`'s callers.
+ */
+async function isAnchorOwnedSyncPath(
+  engine: BrainEngine,
+  opts: SyncOpts,
+  repoPath: string,
+): Promise<boolean> {
+  if (opts.sourceId || opts.srcSubpath) return false;
+  const anchor = await readSyncAnchor(engine, undefined, 'repo_path');
+  return anchor !== null && anchor === repoPath;
 }
 
 async function writeSyncAnchor(
@@ -1654,30 +1717,23 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   //   - syncScopeRoot:  file walking, imports, deletes, renames
   // In the common case (repoPath == git root, no subpath) they are identical.
   serr(`[gbrain phase] sync.discover_git_root`);
-  // #2964: a legacy `sync.repo_path`-anchored default brain (no `sources`
-  // row, no `opts.sourceId`, no caller-supplied `opts.repoPath`) can reach
-  // here having never been `git init`-ed — e.g. a brain-pages dir that
-  // predates git-backed sync, or one rsync'd from another machine without
-  // its `.git`. gbrain owns THAT directory outright (it's the one path
-  // resolved from gbrain's own persisted anchor, not a caller-named one),
-  // so self-heal by initializing it in place instead of failing the sync
-  // phase every single run. Mirrors the recloneIfMissing self-recovery
-  // above for owned remote clones.
-  //
-  // Ownership gate — `!opts.repoPath` is the load-bearing check, not just
-  // `!opts.sourceId`: `submit_job({name:'sync', data:{repoPath}})` reaches
-  // performSyncInner with sourceId undefined whenever the given path
-  // doesn't match a registered source's local_path (jobs.ts), so an
-  // admin-scope MCP caller could otherwise point this at an arbitrary
-  // directory and have it silently git-init + commit + ingest it. Only the
-  // anchor-resolved default path (`repoPath = opts.repoPath || anchor`,
-  // taking the anchor branch) is something gbrain chose for itself.
-  // `!opts.dryRun`: a dry-run preview must never write to disk.
+  // #2964: a legacy `sync.repo_path`-anchored default brain can reach here
+  // having never been `git init`-ed — e.g. a brain-pages dir that predates
+  // git-backed sync, or one rsync'd from another machine without its
+  // `.git`. gbrain owns that directory outright, so self-heal by
+  // initializing it in place instead of failing the sync phase every
+  // single run. Mirrors the recloneIfMissing self-recovery above for
+  // owned remote clones. Ownership is proven by VALUE (resolved repoPath
+  // equals gbrain's persisted anchor) via `isAnchorOwnedSyncPath`, not by
+  // the mere absence of `opts.sourceId`/`opts.repoPath` — see that
+  // function's docstring. `!opts.dryRun`: a preview must never write.
   let gitContextRoot: string;
   try {
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   } catch (err) {
-    if (opts.sourceId || opts.repoPath || opts.dryRun || !existsSync(repoPath)) throw err;
+    if (opts.dryRun || !existsSync(repoPath) || !(await isAnchorOwnedSyncPath(engine, opts, repoPath))) {
+      throw err;
+    }
     serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
     git(repoPath, ['init', '--quiet']);
     createSyncBaselineCommit(repoPath, engine.kind);
@@ -1813,17 +1869,18 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // this brain permanently wedged on "No commits in repo" every night
     // thereafter. Finish the same baseline-commit self-heal the
     // discoverGitRoot catch above would have done, gated the same way
-    // (gbrain-owned default brain only, never on a dry-run preview) PLUS a
-    // scope check: `discoverGitRoot` walks UP from `repoPath`, so for a
-    // `--src-subpath`/subdir-as-repoPath sync it can resolve to an ANCESTOR
-    // repo, not `repoPath` itself. Committing there (`git add -A` at
-    // gitContextRoot) would capture sibling files well outside the sync
-    // scope — refuse instead of guessing.
+    // (ownership proven by value, never on a dry-run preview) PLUS a scope
+    // check: `discoverGitRoot` walks UP from `repoPath`, so it can resolve
+    // to an ANCESTOR repo, not `repoPath` itself (most plausible for a
+    // `--src-subpath` sync, but `isAnchorOwnedSyncPath` already refuses
+    // that case — kept here too as defense in depth against any other path
+    // where gitContextRoot could diverge from repoPath). Committing at an
+    // ancestor (`git add -A` at gitContextRoot) would capture sibling
+    // files well outside the sync scope — refuse instead of guessing.
     if (
-      opts.sourceId ||
-      opts.repoPath ||
       opts.dryRun ||
-      gitContextRoot !== realpathSync(repoPath)
+      gitContextRoot !== realpathSync(repoPath) ||
+      !(await isAnchorOwnedSyncPath(engine, opts, repoPath))
     ) {
       throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, statSync, realpathSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, statSync, realpathSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
@@ -1003,6 +1003,20 @@ function createSyncBaselineCommit(repoPath: string): void {
   // `supabase_only` — same keep-out-of-git semantics, still a supported
   // backward-compat key per storage-config.ts) but nothing resolved from
   // it, refuse rather than guess "genuinely empty" vs "syntax ignored".
+  //
+  // Known false-positive (round 8 review): a genuinely, intentionally
+  // empty `db_only: []` mentioning the word also refuses, and can't be
+  // told apart from the unsupported-syntax case — `loadStorageConfig`
+  // returns the IDENTICAL `{db_tracked:[],db_only:[]}` for both (verified
+  // directly: flow-style `[dir/]` and literal `[]` both collapse to that
+  // same shape). Distinguishing them would mean teaching this function
+  // about the parser's internal line-recognition rules, which belongs in
+  // storage-config.ts, not here. Accepted trade-off: the false-positive
+  // cost is low and self-resolving (the brain stays wedged with a clear,
+  // actionable error until the user drops the pointless empty stanza or
+  // fixes their syntax; retried on every subsequent sync); the
+  // false-negative this guards against — silently committing db_only
+  // content into permanent git history — is high-cost and hard to undo.
   if (dbOnlyDirs.length === 0) {
     const yamlPath = join(repoPath, 'gbrain.yml');
     const yamlContent = existsSync(yamlPath) ? readFileSync(yamlPath, 'utf-8') : '';
@@ -1052,15 +1066,24 @@ function createSyncBaselineCommit(repoPath: string): void {
   git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs], [], 600_000);
   git(
     repoPath,
-    // --no-verify: skip pre-commit/commit-msg hooks. An operator's global
-    // core.hooksPath or init.templateDir can wire hooks that expect
-    // project tooling, prompt interactively, or reject the snapshot —
-    // none of which a headless self-heal commit can satisfy.
+    // --no-verify only skips pre-commit/commit-msg — prepare-commit-msg
+    // and (worse, since it runs AFTER the commit object already exists,
+    // synchronously inside this same git invocation) post-commit are
+    // NOT covered by it. An operator's global core.hooksPath or
+    // init.templateDir can wire either, expecting project tooling,
+    // prompting interactively, or hanging — none of which a headless
+    // self-heal commit can satisfy, and a hanging post-commit hook would
+    // burn the 600s budget above without even being the slow step.
+    // `-c core.hooksPath=/dev/null` (in configs, below) makes git look
+    // for hook scripts inside a location that can't contain any,
+    // disabling the entire hooks path for this one invocation — the
+    // complete form of what --no-verify only partially covers, kept for
+    // explicitness on the two hooks it does name.
     [
       'commit', '--quiet', '--allow-empty', '--no-gpg-sign', '--no-verify',
       '-m', 'gbrain: initial commit (auto-init by sync)',
     ],
-    ['user.name=gbrain', 'user.email=gbrain@localhost'],
+    ['user.name=gbrain', 'user.email=gbrain@localhost', 'core.hooksPath=/dev/null'],
   );
 }
 
@@ -1819,7 +1842,6 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // the mere absence of `opts.sourceId`/`opts.repoPath` — see that
   // function's docstring. `!opts.dryRun`: a preview must never write.
   let gitContextRoot: string;
-  let didSelfHeal = false;
   try {
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   } catch (err) {
@@ -1835,7 +1857,6 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     git(repoPath, ['init', '--quiet']);
     createSyncBaselineCommit(repoPath);
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
-    didSelfHeal = true;
   }
   const rawScopeRoot = opts.srcSubpath ? join(repoPath, opts.srcSubpath) : repoPath;
   if (!existsSync(rawScopeRoot)) {
@@ -1986,64 +2007,28 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     serr(`[gbrain] auto-recovery: repo has no commits yet, creating baseline commit ${gitContextRoot}.`);
     createSyncBaselineCommit(gitContextRoot);
     headCommit = git(gitContextRoot, ['rev-parse', 'HEAD']);
-    didSelfHeal = true;
   }
 
-  // #2964: after a self-heal, write .gitignore for db_only dirs the SAME
-  // way `runSync` does for every other successful sync (post-completion,
-  // never before — see `createSyncBaselineCommit`'s docstring on why
-  // ordering matters). Needed here specifically because the dream cycle
-  // (`cycle.ts:runPhaseSync`) calls `performSync` directly and never goes
-  // through `runSync`'s CLI-only post-success `manageGitignoreAtGitRoot`
-  // call — without this, a brain self-healed via the dream cycle would
-  // have db_only content correctly excluded from THIS commit (the
-  // pathspec exclusion in `createSyncBaselineCommit`) but no `.gitignore`
-  // ever written, leaving future manual `git add`/`commit` by the user
-  // unprotected (Codex review round 6, P2). No-op for a normal
-  // already-git-initialized sync (didSelfHeal stays false) — that case
-  // is unaffected and still relies on `runSync`'s existing post-success
-  // call, exactly as before.
-  async function performFullSyncAndMaybeGitignore(
-    roots: typeof fullSyncRoots,
-  ): Promise<SyncResult> {
-    // #2964 (round 7, P1 — Codex caught this with an actual repro run): a
-    // brain rsync'd from another machine without its `.git` can still
-    // retain that machine's auto-managed `.gitignore`. collectSyncableFiles
-    // (inside performFullSync) enumerates via `git ls-files
-    // --exclude-standard`, so a leftover db_only ignore rule would
-    // silently omit those pages from THIS first sync's DB import — the
-    // same data-loss bug class the ordering fix above prevents for a
-    // .gitignore gbrain itself would have written, just from a
-    // pre-existing file instead. Neutralize any existing .gitignore for
-    // the duration of this ONE first-sync call only, byte-for-byte
-    // restoring it immediately after (even on error) — matching exactly
-    // what a truly fresh brain with no .gitignore at all already does on
-    // its first sync (nothing to suppress collection there either).
-    // db_only content still stays out of the COMMIT independently
-    // (createSyncBaselineCommit's pathspec exclusion doesn't depend on
-    // .gitignore); manageGitignore below re-merges the managed block onto
-    // the restored original content afterward, so any of the user's own
-    // unrelated ignore rules in that file survive intact.
-    const gitignorePath = join(roots.gitContextRoot, '.gitignore');
-    const savedGitignore = didSelfHeal && existsSync(gitignorePath)
-      ? readFileSync(gitignorePath, 'utf-8')
-      : null;
-    if (savedGitignore !== null) unlinkSync(gitignorePath);
-    try {
-      const result = await performFullSync(engine, roots, headCommit, opts);
-      if (savedGitignore !== null) writeFileSync(gitignorePath, savedGitignore);
-      if (didSelfHeal && result.status !== 'blocked_by_failures' && result.status !== 'partial') {
-        // repoPath is `string` by construction (guarded at function
-        // entry), but the guard's narrowing doesn't carry into this
-        // nested closure — reassert via roots, realpath-derived from it.
-        manageGitignore(roots.gitContextRoot, engine.kind);
-      }
-      return result;
-    } catch (err) {
-      if (savedGitignore !== null && !existsSync(gitignorePath)) writeFileSync(gitignorePath, savedGitignore);
-      throw err;
-    }
-  }
+  // #2964: self-heal deliberately does NOT special-case db_only/.gitignore
+  // interaction beyond the COMMIT itself (createSyncBaselineCommit's
+  // pathspec exclusion, which stands on its own regardless of what
+  // .gitignore says). db_only content is documented as DB-sourced ("bulk
+  // machine-generated content... written to disk as a local cache", see
+  // docs/storage-tiering.md) — it reaches the database via ingest-specific
+  // paths, never via gbrain sync's git-diff-based file collection, and
+  // `.gitignore` management there is entirely about keeping db_only out of
+  // git history, not about what sync imports. An earlier version of this
+  // fix (Codex review rounds 6-7) tried to also guarantee db_only markdown
+  // gets imported on this first sync and that .gitignore gets written
+  // post-success even when called outside runSync — solving a problem
+  // that, per the docs above, isn't actually in scope for what sync is
+  // for. Reverted in round 8 review discussion in favor of this simpler
+  // design: after self-heal, the import + any subsequent .gitignore
+  // management behave EXACTLY the same as for any other brain, self-healed
+  // or not (runSync's existing post-success manageGitignoreAtGitRoot call
+  // covers the CLI path identically either way; the dream cycle not
+  // calling it is a separate, pre-existing characteristic of the dream
+  // cycle in general, not something this fix introduces or worsens).
 
   // #1970: bookmark reachability. The ONLY thing that should force a full
   // reconcile is a truly-absent object; a present-but-non-ancestor bookmark
@@ -2071,7 +2056,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // back to the authoritative full reconcile (which now also purges stale
       // pages for deleted files; see performFullSync's delete-reconcile pass).
       serr(`Sync anchor ${lastCommit.slice(0, 8)} object missing (gc'd after history rewrite). Running full reimport.`);
-      return performFullSyncAndMaybeGitignore(fullSyncRoots);
+      return performFullSync(engine, fullSyncRoots, headCommit, opts);
     }
 
     // Observability only — NOT control flow. A non-ancestor bookmark is still
@@ -2094,7 +2079,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   // First sync
   if (!lastCommit) {
-    return performFullSyncAndMaybeGitignore(fullSyncRoots);
+    return performFullSync(engine, fullSyncRoots, headCommit, opts);
   }
 
   // v0.42.x (#1794): resumable incremental sync — resolve the PINNED target.
@@ -2215,7 +2200,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       `[sync] delta ${lastCommit.slice(0, 8)}..${pin.slice(0, 8)} unavailable ` +
       `(${delta.reason}) — falling back to full reconcile.`,
     );
-    return performFullSyncAndMaybeGitignore(fullSyncRoots);
+    return performFullSync(engine, fullSyncRoots, headCommit, opts);
   }
   const manifest = delta.manifest;
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1020,7 +1020,16 @@ function createSyncBaselineCommit(repoPath: string): void {
   if (dbOnlyDirs.length === 0) {
     const yamlPath = join(repoPath, 'gbrain.yml');
     const yamlContent = existsSync(yamlPath) ? readFileSync(yamlPath, 'utf-8') : '';
-    if (yamlContent.includes('db_only') || yamlContent.includes('supabase_only')) {
+    // A YAML KEY line (`db_only:` / `supabase_only:`, ignoring leading
+    // whitespace and `#` comments), not a bare substring search — round 9,
+    // P2: a comment or unrelated prose value that happens to mention the
+    // word (e.g. `# db_only handling TBD`) must not trip this guard on an
+    // otherwise-genuinely-config-free gbrain.yml.
+    const mentionsUnresolvedKey = yamlContent.split('\n').some((line) => {
+      const trimmed = line.trim();
+      return !trimmed.startsWith('#') && /^(db_only|supabase_only)\s*:/.test(trimmed);
+    });
+    if (mentionsUnresolvedKey) {
       throw new Error(
         `${yamlPath} mentions db_only but no directories resolved from it — refusing to ` +
           `auto-commit (cannot tell "genuinely empty" from "unsupported syntax silently ignored"). ` +
@@ -1028,25 +1037,23 @@ function createSyncBaselineCommit(repoPath: string): void {
       );
     }
   }
-  // Only pathspec-exclude db_only dirs `.gitignore` does NOT already
-  // cover (a pre-existing `.gitignore` from before this brain lost its
-  // `.git` is possible even though we never write one here ourselves). A
-  // redundant negation pathspec for an already-ignored path makes git's
-  // `-A` bail with "paths ignored by .gitignore, use -f"
-  // (advice.addIgnoredFile) even though the negation is semantically
-  // correct and git would otherwise skip it silently. `check-ignore`
-  // throwing (not ignored, or the check itself failed) defaults to
-  // excluding explicitly — the fail-closed direction.
-  const excludePathspecs = dbOnlyDirs
-    .filter((dir) => {
-      try {
-        git(repoPath, ['check-ignore', '-q', dir]);
-        return false;
-      } catch {
-        return true;
-      }
-    })
-    .map((dir) => `:!${dir}`);
+  // #2964 (round 9, P1): every db_only dir is ALWAYS pathspec-excluded,
+  // unconditionally — never pre-filtered against what an existing
+  // `.gitignore` claims to already cover. An earlier version checked
+  // `git check-ignore -q dir` first and skipped the pathspec when it
+  // already reported "ignored" (to dodge the advisory error below), but
+  // `check-ignore` on a directory can say "ignored" even when a
+  // pre-existing `.gitignore` re-includes a child via negation (e.g.
+  // `private-cache/*` + `!private-cache/index.md`) — the filter would
+  // then skip excluding it via pathspec, and `git add -A` would stage
+  // that re-included child despite the whole directory being declared
+  // db_only. Our OWN pathspec exclusion is unconditional and doesn't
+  // consult `.gitignore` at all, so it can't be defeated by ANY
+  // .gitignore content, negated or not. `:(exclude,literal)dir` (not the
+  // `:!dir` shorthand) so a db_only dir name that itself starts with a
+  // pathspec magic character like `:` is excluded literally rather than
+  // reinterpreted (round 9, P2).
+  const excludePathspecs = dbOnlyDirs.map((dir) => `:(exclude,literal)${dir}`);
   // Clear the index before staging (round 6, P1): the unborn-HEAD
   // recovery site can reach this function with a repo whose index
   // already has entries staged from some OTHER prior operation (a manual
@@ -1056,14 +1063,28 @@ function createSyncBaselineCommit(repoPath: string): void {
   // --empty` resets the index without touching the working tree; a
   // no-op on a freshly-`git init`-ed repo, whose index is already empty.
   git(repoPath, ['read-tree', '--empty']);
-  // #2964: 10 minutes, not the shared git() helper's 30s default — this
-  // full-tree `git add -A` walks a legacy brain that may hold years of
-  // accumulated content. A 30s timeout would abort staging after `git
-  // init` already created `.git`, leaving an unborn repo that every
-  // subsequent sync would retry (and time out identically) forever;
-  // the unborn-HEAD recovery path exists for OTHER causes of that state,
-  // not to be this one's normal first outcome.
-  git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs], [], 600_000);
+  try {
+    // #2964: 10 minutes, not the shared git() helper's 30s default — this
+    // full-tree `git add -A` walks a legacy brain that may hold years of
+    // accumulated content. A 30s timeout would abort staging after `git
+    // init` already created `.git`, leaving an unborn repo that every
+    // subsequent sync would retry (and time out identically) forever;
+    // the unborn-HEAD recovery path exists for OTHER causes of that
+    // state, not to be this one's normal first outcome.
+    git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs], [], 600_000);
+  } catch (err) {
+    // Now that exclusion is always applied (never pre-filtered), an
+    // explicit pathspec exclusion for a path a pre-existing `.gitignore`
+    // ALSO happens to cover trips git's advice.addIgnoredFile: nonzero
+    // exit + "paths ignored by one of your .gitignore files, use -f",
+    // even though the add otherwise fully succeeded (verified directly:
+    // `git status --short` right after this exact error shows every
+    // non-excluded path staged correctly). Recognize and swallow ONLY
+    // this exact advisory; anything else (timeout, permission denied,
+    // real corruption) rethrows.
+    const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
+    if (!stderr.includes('ignored by one of your .gitignore files')) throw err;
+  }
   git(
     repoPath,
     // --no-verify only skips pre-commit/commit-msg — prepare-commit-msg

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -972,17 +972,55 @@ export function discoverGitRoot(inputPath: string): string {
  * gbrain.yml, or a semantic overlap) propagates — better to leave this
  * self-heal wedged with a clear error than commit unknown content.
  */
-function createSyncBaselineCommit(repoPath: string, engineKind?: 'pglite' | 'postgres'): void {
-  manageGitignore(repoPath, engineKind);
+function createSyncBaselineCommit(repoPath: string): void {
+  // #2964: db_only exclusion is computed directly from loadStorageConfig
+  // and passed to `git add` as pathspecs — deliberately NOT via
+  // manageGitignore/.gitignore, for two independent reasons:
+  //
+  // 1. Ordering (Codex review round 6, P1): `collectSyncableFiles` — the
+  //    file enumeration `performFullSync` runs right after this function
+  //    returns — honors `.gitignore` via `git ls-files --exclude-standard`.
+  //    Writing db_only entries into `.gitignore` BEFORE that first import
+  //    would silently exclude those pages from the database entirely.
+  //    That's the exact bug class `runSync`'s existing "manage .gitignore
+  //    ONLY on successful sync" ordering (this file, `manageGitignoreAtGitRoot`
+  //    callers below — itself a prior Codex P1 fix) exists to prevent. Leave
+  //    `.gitignore` untouched here; the existing post-sync flow writes it
+  //    once this sync completes, same as it does for every other sync.
+  // 2. Fail-closed (rounds 5-6): `manageGitignore`'s "warn and return" on a
+  //    broken gbrain.yml/unwritable .gitignore is the right default for its
+  //    OTHER callers (a side effect that must never kill the sync job), but
+  //    wrong for a commit we are creating ourselves — silently committing
+  //    db_only content into git history.
   const storageConfig = loadStorageConfig(repoPath);
-  // Only pathspec-exclude db_only dirs `.gitignore` did NOT already cover.
-  // A redundant negation pathspec for an already-ignored path makes git's
+  const dbOnlyDirs = storageConfig?.db_only ?? [];
+  // Sniff-test fail-closed (round 6, P2): `loadStorageConfig` warns-and-
+  // returns an EMPTY config for syntactically-valid-but-unsupported YAML
+  // (e.g. flow-style `db_only: [dir/]` — the narrow custom parser only
+  // handles block-style lists), which would silently resolve zero
+  // exclusions from a file that clearly intended some. If gbrain.yml
+  // exists and mentions db_only but nothing resolved from it, refuse
+  // rather than guess "genuinely empty" vs "unsupported syntax ignored".
+  if (dbOnlyDirs.length === 0) {
+    const yamlPath = join(repoPath, 'gbrain.yml');
+    if (existsSync(yamlPath) && readFileSync(yamlPath, 'utf-8').includes('db_only')) {
+      throw new Error(
+        `${yamlPath} mentions db_only but no directories resolved from it — refusing to ` +
+          `auto-commit (cannot tell "genuinely empty" from "unsupported syntax silently ignored"). ` +
+          `Fix gbrain.yml's storage.db_only syntax, or git-init this directory manually.`,
+      );
+    }
+  }
+  // Only pathspec-exclude db_only dirs `.gitignore` does NOT already
+  // cover (a pre-existing `.gitignore` from before this brain lost its
+  // `.git` is possible even though we never write one here ourselves). A
+  // redundant negation pathspec for an already-ignored path makes git's
   // `-A` bail with "paths ignored by .gitignore, use -f"
   // (advice.addIgnoredFile) even though the negation is semantically
   // correct and git would otherwise skip it silently. `check-ignore`
   // throwing (not ignored, or the check itself failed) defaults to
   // excluding explicitly — the fail-closed direction.
-  const excludePathspecs = (storageConfig?.db_only ?? [])
+  const excludePathspecs = dbOnlyDirs
     .filter((dir) => {
       try {
         git(repoPath, ['check-ignore', '-q', dir]);
@@ -992,6 +1030,15 @@ function createSyncBaselineCommit(repoPath: string, engineKind?: 'pglite' | 'pos
       }
     })
     .map((dir) => `:!${dir}`);
+  // Clear the index before staging (round 6, P1): the unborn-HEAD
+  // recovery site can reach this function with a repo whose index
+  // already has entries staged from some OTHER prior operation (a manual
+  // `git add`, an interrupted workflow) before gbrain ever touched it.
+  // `add -A` only adds/updates — it does not drop an already-staged path
+  // that our exclusion pathspecs above now want excluded. `read-tree
+  // --empty` resets the index without touching the working tree; a
+  // no-op on a freshly-`git init`-ed repo, whose index is already empty.
+  git(repoPath, ['read-tree', '--empty']);
   // #2964: 10 minutes, not the shared git() helper's 30s default — this
   // full-tree `git add -A` walks a legacy brain that may hold years of
   // accumulated content. A 30s timeout would abort staging after `git
@@ -1777,7 +1824,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     }
     serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
     git(repoPath, ['init', '--quiet']);
-    createSyncBaselineCommit(repoPath, engine.kind);
+    createSyncBaselineCommit(repoPath);
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   }
   const rawScopeRoot = opts.srcSubpath ? join(repoPath, opts.srcSubpath) : repoPath;
@@ -1926,7 +1973,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
     }
     serr(`[gbrain] auto-recovery: repo has no commits yet, creating baseline commit ${gitContextRoot}.`);
-    createSyncBaselineCommit(gitContextRoot, engine.kind);
+    createSyncBaselineCommit(gitContextRoot);
     headCommit = git(gitContextRoot, ['rev-parse', 'HEAD']);
   }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -999,11 +999,14 @@ function createSyncBaselineCommit(repoPath: string): void {
   // (e.g. flow-style `db_only: [dir/]` — the narrow custom parser only
   // handles block-style lists), which would silently resolve zero
   // exclusions from a file that clearly intended some. If gbrain.yml
-  // exists and mentions db_only but nothing resolved from it, refuse
-  // rather than guess "genuinely empty" vs "unsupported syntax ignored".
+  // exists and mentions db_only (or its deprecated pre-v0.22.11 alias
+  // `supabase_only` — same keep-out-of-git semantics, still a supported
+  // backward-compat key per storage-config.ts) but nothing resolved from
+  // it, refuse rather than guess "genuinely empty" vs "syntax ignored".
   if (dbOnlyDirs.length === 0) {
     const yamlPath = join(repoPath, 'gbrain.yml');
-    if (existsSync(yamlPath) && readFileSync(yamlPath, 'utf-8').includes('db_only')) {
+    const yamlContent = existsSync(yamlPath) ? readFileSync(yamlPath, 'utf-8') : '';
+    if (yamlContent.includes('db_only') || yamlContent.includes('supabase_only')) {
       throw new Error(
         `${yamlPath} mentions db_only but no directories resolved from it — refusing to ` +
           `auto-commit (cannot tell "genuinely empty" from "unsupported syntax silently ignored"). ` +
@@ -1816,16 +1819,23 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // the mere absence of `opts.sourceId`/`opts.repoPath` — see that
   // function's docstring. `!opts.dryRun`: a preview must never write.
   let gitContextRoot: string;
+  let didSelfHeal = false;
   try {
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   } catch (err) {
-    if (opts.dryRun || !existsSync(repoPath) || !(await isAnchorOwnedSyncPath(engine, opts, repoPath))) {
+    if (
+      opts.dryRun ||
+      opts.signal?.aborted ||
+      !existsSync(repoPath) ||
+      !(await isAnchorOwnedSyncPath(engine, opts, repoPath))
+    ) {
       throw err;
     }
     serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
     git(repoPath, ['init', '--quiet']);
     createSyncBaselineCommit(repoPath);
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
+    didSelfHeal = true;
   }
   const rawScopeRoot = opts.srcSubpath ? join(repoPath, opts.srcSubpath) : repoPath;
   if (!existsSync(rawScopeRoot)) {
@@ -1967,6 +1977,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // files well outside the sync scope — refuse instead of guessing.
     if (
       opts.dryRun ||
+      opts.signal?.aborted ||
       gitContextRoot !== realpathSync(repoPath) ||
       !(await isAnchorOwnedSyncPath(engine, opts, repoPath))
     ) {
@@ -1975,6 +1986,34 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     serr(`[gbrain] auto-recovery: repo has no commits yet, creating baseline commit ${gitContextRoot}.`);
     createSyncBaselineCommit(gitContextRoot);
     headCommit = git(gitContextRoot, ['rev-parse', 'HEAD']);
+    didSelfHeal = true;
+  }
+
+  // #2964: after a self-heal, write .gitignore for db_only dirs the SAME
+  // way `runSync` does for every other successful sync (post-completion,
+  // never before — see `createSyncBaselineCommit`'s docstring on why
+  // ordering matters). Needed here specifically because the dream cycle
+  // (`cycle.ts:runPhaseSync`) calls `performSync` directly and never goes
+  // through `runSync`'s CLI-only post-success `manageGitignoreAtGitRoot`
+  // call — without this, a brain self-healed via the dream cycle would
+  // have db_only content correctly excluded from THIS commit (the
+  // pathspec exclusion in `createSyncBaselineCommit`) but no `.gitignore`
+  // ever written, leaving future manual `git add`/`commit` by the user
+  // unprotected (Codex review round 6, P2). No-op for a normal
+  // already-git-initialized sync (didSelfHeal stays false) — that case
+  // is unaffected and still relies on `runSync`'s existing post-success
+  // call, exactly as before.
+  async function performFullSyncAndMaybeGitignore(
+    roots: typeof fullSyncRoots,
+  ): Promise<SyncResult> {
+    const result = await performFullSync(engine, roots, headCommit, opts);
+    if (didSelfHeal && result.status !== 'blocked_by_failures' && result.status !== 'partial') {
+      // repoPath is `string` by construction (guarded at function entry),
+      // but the guard's narrowing doesn't carry into this nested closure —
+      // reassert via the local roots, which is realpath-derived from it.
+      manageGitignore(roots.gitContextRoot, engine.kind);
+    }
+    return result;
   }
 
   // #1970: bookmark reachability. The ONLY thing that should force a full
@@ -2003,7 +2042,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // back to the authoritative full reconcile (which now also purges stale
       // pages for deleted files; see performFullSync's delete-reconcile pass).
       serr(`Sync anchor ${lastCommit.slice(0, 8)} object missing (gc'd after history rewrite). Running full reimport.`);
-      return performFullSync(engine, fullSyncRoots, headCommit, opts);
+      return performFullSyncAndMaybeGitignore(fullSyncRoots);
     }
 
     // Observability only — NOT control flow. A non-ancestor bookmark is still
@@ -2026,7 +2065,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   // First sync
   if (!lastCommit) {
-    return performFullSync(engine, fullSyncRoots, headCommit, opts);
+    return performFullSyncAndMaybeGitignore(fullSyncRoots);
   }
 
   // v0.42.x (#1794): resumable incremental sync — resolve the PINNED target.
@@ -2147,7 +2186,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       `[sync] delta ${lastCommit.slice(0, 8)}..${pin.slice(0, 8)} unavailable ` +
       `(${delta.reason}) — falling back to full reconcile.`,
     );
-    return performFullSync(engine, fullSyncRoots, headCommit, opts);
+    return performFullSyncAndMaybeGitignore(fullSyncRoots);
   }
   const manifest = delta.manifest;
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1655,22 +1655,29 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // In the common case (repoPath == git root, no subpath) they are identical.
   serr(`[gbrain phase] sync.discover_git_root`);
   // #2964: a legacy `sync.repo_path`-anchored default brain (no `sources`
-  // row, no `opts.sourceId`) can reach here having never been `git init`-ed
-  // — e.g. a brain-pages dir that predates git-backed sync, or one rsync'd
-  // from another machine without its `.git`. gbrain owns this directory
-  // outright (it's not a user-external path the way an `opts.sourceId` +
-  // local `sources add --path` entry is), so self-heal by initializing it
-  // in place instead of failing the sync phase every single run. Mirrors
-  // the recloneIfMissing self-recovery above for owned remote clones.
-  // Scoped to !opts.sourceId and !opts.dryRun only — a registered local
-  // source without a remote_url stays a loud, actionable error (it's the
-  // user's own directory; silently git-initializing it without consent is
-  // an overreach), and a dry-run preview must never write to disk.
+  // row, no `opts.sourceId`, no caller-supplied `opts.repoPath`) can reach
+  // here having never been `git init`-ed — e.g. a brain-pages dir that
+  // predates git-backed sync, or one rsync'd from another machine without
+  // its `.git`. gbrain owns THAT directory outright (it's the one path
+  // resolved from gbrain's own persisted anchor, not a caller-named one),
+  // so self-heal by initializing it in place instead of failing the sync
+  // phase every single run. Mirrors the recloneIfMissing self-recovery
+  // above for owned remote clones.
+  //
+  // Ownership gate — `!opts.repoPath` is the load-bearing check, not just
+  // `!opts.sourceId`: `submit_job({name:'sync', data:{repoPath}})` reaches
+  // performSyncInner with sourceId undefined whenever the given path
+  // doesn't match a registered source's local_path (jobs.ts), so an
+  // admin-scope MCP caller could otherwise point this at an arbitrary
+  // directory and have it silently git-init + commit + ingest it. Only the
+  // anchor-resolved default path (`repoPath = opts.repoPath || anchor`,
+  // taking the anchor branch) is something gbrain chose for itself.
+  // `!opts.dryRun`: a dry-run preview must never write to disk.
   let gitContextRoot: string;
   try {
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   } catch (err) {
-    if (opts.sourceId || opts.dryRun || !existsSync(repoPath)) throw err;
+    if (opts.sourceId || opts.repoPath || opts.dryRun || !existsSync(repoPath)) throw err;
     serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
     git(repoPath, ['init', '--quiet']);
     createSyncBaselineCommit(repoPath, engine.kind);
@@ -1806,8 +1813,18 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // this brain permanently wedged on "No commits in repo" every night
     // thereafter. Finish the same baseline-commit self-heal the
     // discoverGitRoot catch above would have done, gated the same way
-    // (gbrain-owned default brain only, never on a dry-run preview).
-    if (opts.sourceId || opts.dryRun) {
+    // (gbrain-owned default brain only, never on a dry-run preview) PLUS a
+    // scope check: `discoverGitRoot` walks UP from `repoPath`, so for a
+    // `--src-subpath`/subdir-as-repoPath sync it can resolve to an ANCESTOR
+    // repo, not `repoPath` itself. Committing there (`git add -A` at
+    // gitContextRoot) would capture sibling files well outside the sync
+    // scope — refuse instead of guessing.
+    if (
+      opts.sourceId ||
+      opts.repoPath ||
+      opts.dryRun ||
+      gitContextRoot !== realpathSync(repoPath)
+    ) {
       throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
     }
     serr(`[gbrain] auto-recovery: repo has no commits yet, creating baseline commit ${gitContextRoot}.`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, statSync, realpathSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, statSync, realpathSync, unlinkSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
@@ -2006,14 +2006,43 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   async function performFullSyncAndMaybeGitignore(
     roots: typeof fullSyncRoots,
   ): Promise<SyncResult> {
-    const result = await performFullSync(engine, roots, headCommit, opts);
-    if (didSelfHeal && result.status !== 'blocked_by_failures' && result.status !== 'partial') {
-      // repoPath is `string` by construction (guarded at function entry),
-      // but the guard's narrowing doesn't carry into this nested closure —
-      // reassert via the local roots, which is realpath-derived from it.
-      manageGitignore(roots.gitContextRoot, engine.kind);
+    // #2964 (round 7, P1 — Codex caught this with an actual repro run): a
+    // brain rsync'd from another machine without its `.git` can still
+    // retain that machine's auto-managed `.gitignore`. collectSyncableFiles
+    // (inside performFullSync) enumerates via `git ls-files
+    // --exclude-standard`, so a leftover db_only ignore rule would
+    // silently omit those pages from THIS first sync's DB import — the
+    // same data-loss bug class the ordering fix above prevents for a
+    // .gitignore gbrain itself would have written, just from a
+    // pre-existing file instead. Neutralize any existing .gitignore for
+    // the duration of this ONE first-sync call only, byte-for-byte
+    // restoring it immediately after (even on error) — matching exactly
+    // what a truly fresh brain with no .gitignore at all already does on
+    // its first sync (nothing to suppress collection there either).
+    // db_only content still stays out of the COMMIT independently
+    // (createSyncBaselineCommit's pathspec exclusion doesn't depend on
+    // .gitignore); manageGitignore below re-merges the managed block onto
+    // the restored original content afterward, so any of the user's own
+    // unrelated ignore rules in that file survive intact.
+    const gitignorePath = join(roots.gitContextRoot, '.gitignore');
+    const savedGitignore = didSelfHeal && existsSync(gitignorePath)
+      ? readFileSync(gitignorePath, 'utf-8')
+      : null;
+    if (savedGitignore !== null) unlinkSync(gitignorePath);
+    try {
+      const result = await performFullSync(engine, roots, headCommit, opts);
+      if (savedGitignore !== null) writeFileSync(gitignorePath, savedGitignore);
+      if (didSelfHeal && result.status !== 'blocked_by_failures' && result.status !== 'partial') {
+        // repoPath is `string` by construction (guarded at function
+        // entry), but the guard's narrowing doesn't carry into this
+        // nested closure — reassert via roots, realpath-derived from it.
+        manageGitignore(roots.gitContextRoot, engine.kind);
+      }
+      return result;
+    } catch (err) {
+      if (savedGitignore !== null && !existsSync(gitignorePath)) writeFileSync(gitignorePath, savedGitignore);
+      throw err;
     }
-    return result;
   }
 
   // #1970: bookmark reachability. The ONLY thing that should force a full

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -944,6 +944,32 @@ export function discoverGitRoot(inputPath: string): string {
 }
 
 /**
+ * #2964: snapshot the CURRENT on-disk state of a gbrain-owned brain dir as
+ * a baseline commit — used both right after a self-healing `git init` (no
+ * `.git` at all) and to recover a repo left with `.git` but zero commits
+ * (an interrupted prior self-heal, or a `git init` from some other source
+ * that never got a first commit). Respects `.gitignore` (written first) so
+ * future incremental syncs diff against what's actually here rather than
+ * an empty tree — an empty initial commit would make every existing file
+ * look "added" again on the next sync, even though the full-sync pass that
+ * follows already imported them from disk directly.
+ *
+ * `--no-gpg-sign` + explicit `-c user.name/user.email`: this runs from a
+ * headless nightly cron/launchd invocation, which has no reason to have
+ * git signing/identity configured, and must not block on an unavailable
+ * signing agent or pinentry prompt.
+ */
+function createSyncBaselineCommit(repoPath: string, engineKind?: 'pglite' | 'postgres'): void {
+  manageGitignore(repoPath, engineKind);
+  git(repoPath, ['add', '-A']);
+  git(
+    repoPath,
+    ['commit', '--quiet', '--allow-empty', '--no-gpg-sign', '-m', 'gbrain: initial commit (auto-init by sync)'],
+    ['user.name=gbrain', 'user.email=gbrain@localhost'],
+  );
+}
+
+/**
  * #774 NAV-1 TOCTOU: true only if filePath realpath-resolves inside gitRoot.
  * Guards symlink escape at the per-file level (a committed symlink whose
  * target lives outside the repo), not just at scope entry.
@@ -1636,34 +1662,18 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // local `sources add --path` entry is), so self-heal by initializing it
   // in place instead of failing the sync phase every single run. Mirrors
   // the recloneIfMissing self-recovery above for owned remote clones.
-  // Scoped to !opts.sourceId only — a registered local source without a
-  // remote_url stays a loud, actionable error (it's the user's own
-  // directory; silently git-initializing it without consent is an
-  // overreach).
+  // Scoped to !opts.sourceId and !opts.dryRun only — a registered local
+  // source without a remote_url stays a loud, actionable error (it's the
+  // user's own directory; silently git-initializing it without consent is
+  // an overreach), and a dry-run preview must never write to disk.
   let gitContextRoot: string;
   try {
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   } catch (err) {
-    if (opts.sourceId || !existsSync(repoPath)) throw err;
+    if (opts.sourceId || opts.dryRun || !existsSync(repoPath)) throw err;
     serr(`[gbrain] auto-recovery: git-initializing brain dir ${repoPath} (no git repo found).`);
     git(repoPath, ['init', '--quiet']);
-    // A fresh `git init` has zero commits, and `git rev-parse HEAD` a few
-    // lines below requires at least one — without a baseline commit we'd
-    // just trade "not a git repo" for "no commits in repo" on the very next
-    // line. Snapshot the CURRENT on-disk state as that baseline (respecting
-    // .gitignore, written first) so future incremental syncs diff against
-    // what's actually here rather than an empty tree — an empty initial
-    // commit would make every existing file look "added" again on the next
-    // sync, even though this full-sync pass already imported them.
-    manageGitignore(repoPath, engine.kind);
-    git(repoPath, ['add', '-A']);
-    // Explicit identity via -c: a headless nightly cron/launchd invocation
-    // has no reason to have global git user.name/user.email configured.
-    git(
-      repoPath,
-      ['commit', '--quiet', '--allow-empty', '-m', 'gbrain: initial commit (auto-init by sync)'],
-      ['user.name=gbrain', 'user.email=gbrain@localhost'],
-    );
+    createSyncBaselineCommit(repoPath, engine.kind);
     gitContextRoot = realpathSync(discoverGitRoot(repoPath));
   }
   const rawScopeRoot = opts.srcSubpath ? join(repoPath, opts.srcSubpath) : repoPath;
@@ -1790,7 +1800,19 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   try {
     headCommit = git(gitContextRoot, ['rev-parse', 'HEAD']);
   } catch {
-    throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
+    // #2964: unborn-HEAD recovery. `.git` exists (discoverGitRoot succeeded
+    // above) but there are zero commits — e.g. a prior self-heal `git init`
+    // ran but the process died before the baseline commit landed, leaving
+    // this brain permanently wedged on "No commits in repo" every night
+    // thereafter. Finish the same baseline-commit self-heal the
+    // discoverGitRoot catch above would have done, gated the same way
+    // (gbrain-owned default brain only, never on a dry-run preview).
+    if (opts.sourceId || opts.dryRun) {
+      throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
+    }
+    serr(`[gbrain] auto-recovery: repo has no commits yet, creating baseline commit ${gitContextRoot}.`);
+    createSyncBaselineCommit(gitContextRoot, engine.kind);
+    headCommit = git(gitContextRoot, ['rev-parse', 'HEAD']);
   }
 
   // #1970: bookmark reachability. The ONLY thing that should force a full

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -919,10 +919,10 @@ export function buildAutoEmbedArgs(slugs: string[], sourceId?: string): string[]
  * 100 MiB is generous but still bounded — a 100K-file diff with long
  * paths tops out around 10–20 MiB in practice.
  */
-function git(repoPath: string, args: string[], configs: string[] = []): string {
+function git(repoPath: string, args: string[], configs: string[] = [], timeoutMs = 30000): string {
   return execFileSync('git', buildGitInvocation(repoPath, args, configs), {
     encoding: 'utf-8',
-    timeout: 30000,
+    timeout: timeoutMs,
     maxBuffer: 100 * 1024 * 1024,
   }).trim();
 }
@@ -992,10 +992,24 @@ function createSyncBaselineCommit(repoPath: string, engineKind?: 'pglite' | 'pos
       }
     })
     .map((dir) => `:!${dir}`);
-  git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs]);
+  // #2964: 10 minutes, not the shared git() helper's 30s default — this
+  // full-tree `git add -A` walks a legacy brain that may hold years of
+  // accumulated content. A 30s timeout would abort staging after `git
+  // init` already created `.git`, leaving an unborn repo that every
+  // subsequent sync would retry (and time out identically) forever;
+  // the unborn-HEAD recovery path exists for OTHER causes of that state,
+  // not to be this one's normal first outcome.
+  git(repoPath, ['add', '-A', '--', '.', ...excludePathspecs], [], 600_000);
   git(
     repoPath,
-    ['commit', '--quiet', '--allow-empty', '--no-gpg-sign', '-m', 'gbrain: initial commit (auto-init by sync)'],
+    // --no-verify: skip pre-commit/commit-msg hooks. An operator's global
+    // core.hooksPath or init.templateDir can wire hooks that expect
+    // project tooling, prompt interactively, or reject the snapshot —
+    // none of which a headless self-heal commit can satisfy.
+    [
+      'commit', '--quiet', '--allow-empty', '--no-gpg-sign', '--no-verify',
+      '-m', 'gbrain: initial commit (auto-init by sync)',
+    ],
     ['user.name=gbrain', 'user.email=gbrain@localhost'],
   );
 }
@@ -1067,20 +1081,39 @@ async function readSyncAnchor(
 }
 
 /**
- * #2964: is `repoPath` gbrain's own legacy default anchor, as opposed to a
+ * #2964: is `repoPath` gbrain's own default-brain anchor, as opposed to a
  * path some caller merely happened to pass through unchanged?
  *
- * `!opts.sourceId` alone is NOT sufficient: `runPhaseSync` (dream cycle)
- * and `submit_job({name:'sync', data:{repoPath}})` (MCP, jobs.ts) both
- * reach `performSyncInner` with `sourceId` undefined AND `opts.repoPath`
- * set explicitly — the former legitimately (it already resolved the
- * anchor itself and is passing it through), the latter potentially with
- * an attacker-controlled path. The two are indistinguishable from
- * `opts.repoPath`'s mere presence/absence, so ownership has to be proven
- * by VALUE: read the anchor fresh from config and require the resolved
- * `repoPath` to equal it exactly. An arbitrary caller-supplied path only
- * passes this check if it happens to already equal gbrain's own anchor —
- * at which point self-healing it is exactly the legitimate case.
+ * `!opts.sourceId` alone is NOT sufficient — and neither is rejecting
+ * `opts.sourceId` outright: migration `sources_table_additive` (v20)
+ * seeds a `'default'` source row whose `local_path` is copied FROM
+ * `config.sync.repo_path` on every brain that has ever run it (i.e.
+ * effectively all of them by now), and `writeSyncAnchor` keeps that row's
+ * `local_path` current on every sync thereafter. So on a real installed
+ * brain, `resolveSourceForDir` (dream cycle) and the CLI's bare `gbrain
+ * sync` both resolve `sourceId: 'default'`, NOT `undefined` — rejecting
+ * all non-empty `sourceId` (an earlier, insufficiently-reviewed version
+ * of this check) made self-heal never fire on that real path either,
+ * masked in tests only because a freshly-`initSchema()`'d test brain's
+ * `'default'` row has a null `local_path` (Codex review round 5).
+ *
+ * The actual boundary: `'default'` is gbrain's own bootstrap identity,
+ * not something a caller names — a DIFFERENT, non-default `sourceId` is
+ * what an explicit `sources add <id> --path <dir>` registration (a
+ * user's own external directory) looks like, and that's what must keep
+ * failing loudly. So: permit `sourceId` when it's exactly `undefined` or
+ * `'default'`, reject any other id, and for BOTH permitted cases prove
+ * ownership by VALUE — reread the live anchor for that same identity
+ * (`sources.default.local_path` when sourceId='default', else
+ * `config.sync.repo_path`) and require the resolved `repoPath` to
+ * REALPATH-equal it (not raw string equality: `dream`'s `resolveBrainDir`
+ * normalizes via `path.resolve`, so a trailing slash or `..` in the
+ * stored anchor must not defeat the match — Codex review round 5, P2).
+ * An arbitrary caller-supplied path (e.g. an admin-scope
+ * `submit_job({name:'sync', data:{repoPath}})`) only passes this check
+ * if it already equals gbrain's own anchor by realpath identity — at
+ * which point self-healing it is exactly the legitimate case, not an
+ * escalation.
  *
  * `opts.srcSubpath` disqualifies unconditionally: a subpath-scoped sync
  * only wants THAT subdirectory captured, but the self-heal baseline
@@ -1093,9 +1126,17 @@ async function isAnchorOwnedSyncPath(
   opts: SyncOpts,
   repoPath: string,
 ): Promise<boolean> {
-  if (opts.sourceId || opts.srcSubpath) return false;
-  const anchor = await readSyncAnchor(engine, undefined, 'repo_path');
-  return anchor !== null && anchor === repoPath;
+  if (opts.srcSubpath) return false;
+  if (opts.sourceId && opts.sourceId !== 'default') return false;
+  const anchor = await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  if (anchor === null) return false;
+  try {
+    return realpathSync(anchor) === realpathSync(repoPath);
+  } catch {
+    // Anchor or repoPath doesn't realpath-resolve (dangling/nonexistent) —
+    // can't prove identity, so don't self-heal.
+    return false;
+  }
 }
 
 async function writeSyncAnchor(

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -240,4 +240,68 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     const tracked = execSync('git ls-files', { cwd: dir }).toString();
     expect(tracked).not.toContain('private-cache');
   });
+
+  test('db_only markdown IS still imported into the DB on first sync (round 6 P1: ordering vs .gitignore)', async () => {
+    // If .gitignore had been written BEFORE the initial import (as an
+    // earlier version of this fix did via manageGitignore inside the
+    // self-heal), collectSyncableFiles's `git ls-files --exclude-standard`
+    // would have silently excluded this page from the database entirely
+    // — not just from git history, which is the only thing db_only is
+    // actually supposed to keep it out of.
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'note.md'), mdPage('DB-only note'));
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
+
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(result.added).toBe(3); // page1, page2, private-cache/note
+    expect(await engine.getPage('private-cache/note')).not.toBeNull();
+  });
+
+  test('a gbrain.yml that mentions db_only but resolves no dirs refuses the baseline commit (round 6 P2: unsupported-syntax sniff test)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { execSync } = await import('child_process');
+    // Flow-style array — valid YAML, but the narrow custom parser only
+    // handles block-style lists, so loadStorageConfig warns and resolves
+    // an empty db_only list rather than throwing.
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only: [private-cache/]\n');
+
+    await expect(
+      performSync(engine, { noPull: true, noEmbed: true, full: true }),
+    ).rejects.toThrow(/db_only/i);
+    // `git init` (site 1's first step) already ran before the sniff-test
+    // guard (inside createSyncBaselineCommit) refused — that's fine, it's
+    // the same "unborn repo" state the round-6-P1 index-rebuild test above
+    // recovers from on a later retry, which would hit this same guard and
+    // refuse again until gbrain.yml is fixed. What must NOT happen is a
+    // commit landing with unknown/unexcluded content.
+    expect(existsSync(join(dir, '.git'))).toBe(true);
+    let hasCommit = true;
+    try {
+      execSync('git rev-parse HEAD', { cwd: dir, stdio: 'pipe' });
+    } catch {
+      hasCommit = false;
+    }
+    expect(hasCommit).toBe(false);
+  });
+
+  test('unborn-HEAD recovery drops stale staged content the exclusion pathspec now wants excluded (round 6 P1: index rebuild)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    const { execSync } = await import('child_process');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'secret.bin'), 'binary-ish content');
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
+    // Simulate an interrupted workflow that left this file staged in an
+    // unborn repo BEFORE gbrain's self-heal ever ran.
+    execSync('git init -q', { cwd: dir });
+    execSync('git add private-cache/secret.bin', { cwd: dir });
+
+    await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    const tracked = execSync('git ls-files', { cwd: dir }).toString();
+    expect(tracked).not.toContain('private-cache');
+  });
 });

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -39,7 +39,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -303,5 +303,25 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
 
     const tracked = execSync('git ls-files', { cwd: dir }).toString();
     expect(tracked).not.toContain('private-cache');
+  });
+
+  test('a self-heal via bare performSync (mirrors cycle.ts:runPhaseSync — no runSync CLI wrapper) still writes .gitignore for db_only dirs (round 6 P2)', async () => {
+    // The dream cycle calls performSync directly and never runs runSync's
+    // post-success manageGitignoreAtGitRoot. Without performSyncInner doing
+    // this itself after a self-heal, a brain that's only ever synced via
+    // the dream cycle would have db_only content correctly excluded from
+    // the baseline commit but .gitignore never written — leaving the
+    // user's own future manual `git add`/`commit` unprotected.
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'secret.bin'), 'binary-ish content');
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
+
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(result.status).toBe('first_sync');
+    const gitignore = existsSync(join(dir, '.gitignore')) ? readFileSync(join(dir, '.gitignore'), 'utf-8') : '';
+    expect(gitignore).toContain('private-cache');
   });
 });

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -2,19 +2,22 @@
  * #2964 — sync phase self-heals a never-git-initialized default brain dir.
  *
  * A legacy `sync.repo_path`-anchored default brain (no `sources` row, no
- * `--source`) can reach `performSync` pointed at a directory that was never
- * `git init`-ed (predates git-backed sync, or was rsync'd from another
- * machine without its `.git`). Before this fix, `discoverGitRoot` threw
- * unconditionally and the dream cycle's sync phase failed every night with
- * no self-recovery, even though `doctor`'s sync checks reported "ok" (for
- * an unrelated reason — they only look at the `sources` table, which has
- * no rows for this kind of brain).
+ * `--source`, no caller-supplied `--repo`) can reach `performSync` pointed
+ * at a directory that was never `git init`-ed (predates git-backed sync, or
+ * was rsync'd from another machine without its `.git`). Before this fix,
+ * `discoverGitRoot` threw unconditionally and the dream cycle's sync phase
+ * failed every night with no self-recovery, even though `doctor`'s sync
+ * checks reported "ok" (for an unrelated reason — they only look at the
+ * `sources` table, which has no rows for this kind of brain).
  *
- * gbrain owns this directory outright, so the fix self-heals by
- * `git init`-ing it and capturing the current on-disk state as the sync
- * baseline — but ONLY for the default/no-`sourceId` path. A registered
- * local source (`sources add --path`, no `--url`) is the user's own
- * external directory and must keep failing loudly rather than being
+ * gbrain owns THAT directory outright, so the fix self-heals by `git
+ * init`-ing it and capturing the current on-disk state as the sync
+ * baseline — but ONLY when the path was resolved from gbrain's own
+ * persisted `sync.repo_path` anchor, never `sourceId` and never a
+ * caller-supplied `repoPath`. Either of those means someone else named the
+ * directory (a registered local source, or — per Codex review — an
+ * admin-scope `submit_job({name:'sync', data:{repoPath}})` caller with no
+ * matching source row), which must keep failing loudly rather than being
  * silently git-initialized without consent.
  */
 
@@ -48,18 +51,20 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     dir = mkdtempSync(join(tmpdir(), 'gbrain-2964-'));
     writeFileSync(join(dir, 'page1.md'), mdPage('Page 1'));
     writeFileSync(join(dir, 'page2.md'), mdPage('Page 2'));
+    // The self-heal-eligible path: gbrain's own persisted anchor, not a
+    // caller-supplied --repo / job.data.repoPath.
+    await engine.setConfig('sync.repo_path', dir);
   });
 
   afterEach(() => {
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
 
-  test('default (no sourceId) sync on a non-git dir auto-inits git and imports files', async () => {
+  test('anchor-resolved sync (no repoPath, no sourceId) on a non-git dir auto-inits git and imports files', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     expect(existsSync(join(dir, '.git'))).toBe(false);
 
     const result = await performSync(engine, {
-      repoPath: dir,
       noPull: true,
       noEmbed: true,
       full: true,
@@ -74,23 +79,14 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
 
   test('a second sync after auto-init sees no changes (baseline commit captured current on-disk state)', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
-    const first = await performSync(engine, {
-      repoPath: dir,
-      noPull: true,
-      noEmbed: true,
-      full: true,
-    });
+    const first = await performSync(engine, { noPull: true, noEmbed: true, full: true });
     expect(first.added).toBe(2);
 
     // No new files, no explicit `full` — a real incremental sync against the
     // auto-init baseline. Before this fix there was no baseline to diff
     // against (sync errored outright); a naive fix that skipped the initial
     // commit would make this call re-report both files as "added" again.
-    const second = await performSync(engine, {
-      repoPath: dir,
-      noPull: true,
-      noEmbed: true,
-    });
+    const second = await performSync(engine, { noPull: true, noEmbed: true });
     expect(second.status).not.toBe('first_sync');
     expect(second.added).toBe(0);
     expect(second.modified).toBe(0);
@@ -110,16 +106,28 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(existsSync(join(dir, '.git'))).toBe(false);
   });
 
-  test('--dry-run on a non-git dir throws without writing anything to disk', async () => {
+  test('a caller-supplied repoPath with no sourceId still throws — not auto-inited (P1: MCP submit_job arbitrary-path guard)', async () => {
+    // Mirrors jobs.ts: submit_job({name:'sync', data:{repoPath}}) reaches
+    // performSyncInner with sourceId left undefined whenever repoPath
+    // doesn't match a registered source's local_path. Auto-init must not
+    // fire here even though sourceId is unset — only the anchor-resolved
+    // default path is gbrain's own.
     const { performSync } = await import('../src/commands/sync.ts');
     await expect(
       performSync(engine, {
         repoPath: dir,
-        dryRun: true,
         noPull: true,
         noEmbed: true,
         full: true,
       }),
+    ).rejects.toThrow(/git repository/i);
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+  });
+
+  test('--dry-run on the anchor-resolved path throws without writing anything to disk', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await expect(
+      performSync(engine, { dryRun: true, noPull: true, noEmbed: true, full: true }),
     ).rejects.toThrow(/git repository/i);
     // The whole point of --dry-run is "preview only" — it must never git-init
     // or commit on our behalf, even though we could self-heal.
@@ -134,12 +142,7 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     // discoverGitRoot succeeds, but `git rev-parse HEAD` still fails.
     execSync('git init -q', { cwd: dir });
 
-    const result = await performSync(engine, {
-      repoPath: dir,
-      noPull: true,
-      noEmbed: true,
-      full: true,
-    });
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
 
     expect(result.status).toBe('first_sync');
     expect(result.added).toBe(2);

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -1,29 +1,40 @@
 /**
  * #2964 — sync phase self-heals a never-git-initialized default brain dir.
  *
- * A legacy `sync.repo_path`-anchored default brain (no `sources` row) can
- * reach `performSync` pointed at a directory that was never `git init`-ed
- * (predates git-backed sync, or was rsync'd from another machine without
- * its `.git`). Before this fix, `discoverGitRoot` threw unconditionally and
- * the dream cycle's sync phase failed every night with no self-recovery,
- * even though `doctor`'s sync checks reported "ok" (for an unrelated
- * reason — they only look at the `sources` table, which has no rows for
- * this kind of brain).
+ * A legacy `sync.repo_path`-anchored default brain can reach `performSync`
+ * pointed at a directory that was never `git init`-ed (predates git-backed
+ * sync, or was rsync'd from another machine without its `.git`). Before
+ * this fix, `discoverGitRoot` threw unconditionally and the dream cycle's
+ * sync phase failed every night with no self-recovery, even though
+ * `doctor`'s sync checks reported "ok" (for an unrelated reason — they
+ * only look at the `sources` table in a way this brain shape doesn't hit).
  *
  * gbrain owns that directory outright, so the fix self-heals by `git
  * init`-ing it and capturing the current on-disk state as the sync
  * baseline. Ownership is proven by VALUE — the resolved `repoPath` must
- * equal gbrain's own persisted `sync.repo_path` anchor — not by whether
- * `opts.repoPath`/`opts.sourceId` happen to be set. That distinction
- * matters because the real production caller (`runPhaseSync` in
- * cycle.ts, i.e. `gbrain dream`'s sync phase) always passes the resolved
- * anchor through explicitly as `opts.repoPath`; gating on
- * `!opts.repoPath` (an earlier, insufficiently-reviewed version of this
- * fix) would have made the self-heal never fire on the exact path it was
- * written to repair (Codex review round 3 caught this). A caller-supplied
- * path that does NOT match the anchor (a registered local source, or an
- * admin-scope `submit_job({name:'sync', data:{repoPath}})` MCP call with
- * an unrelated path) must keep failing loudly rather than being silently
+ * realpath-equal gbrain's own anchor — not by whether
+ * `opts.repoPath`/`opts.sourceId` happen to be set:
+ *
+ * - Gating on `!opts.repoPath` (round 3) would have made self-heal never
+ *   fire on `runPhaseSync` (dream cycle), which always resolves the
+ *   anchor itself and passes it through explicitly as `opts.repoPath`.
+ * - Gating on `!opts.sourceId` (round 4) would ALSO never fire in
+ *   practice: migration `sources_table_additive` seeds a `'default'`
+ *   source row whose `local_path` mirrors `sync.repo_path` on every
+ *   brain that's run it (i.e. virtually all installed brains today), so
+ *   both the dream cycle and bare `gbrain sync` resolve
+ *   `sourceId: 'default'`, never `undefined`, in reality — a fresh test
+ *   brain's null `local_path` masked this (Codex review round 5).
+ *
+ * The actual boundary implemented by `isAnchorOwnedSyncPath`: `sourceId`
+ * must be `undefined` OR exactly `'default'` (gbrain's own bootstrap
+ * identity — a DIFFERENT id is what an explicit `sources add <id> --path
+ * <dir>` registration of a user's own external directory looks like),
+ * AND the resolved `repoPath` must realpath-equal the LIVE anchor for
+ * that same identity. A caller-supplied path that does not match (a
+ * registered non-default source, or an admin-scope
+ * `submit_job({name:'sync', data:{repoPath}})` MCP call with an
+ * unrelated path) must keep failing loudly rather than being silently
  * git-initialized without consent.
  */
 
@@ -111,12 +122,38 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(second.modified).toBe(0);
   });
 
-  test('a registered local source (sourceId set, no remote_url) on a non-git dir still throws — not auto-inited', async () => {
+  test("sourceId='default' whose local_path mirrors the anchor still auto-inits (P1: the real installed-brain shape)", async () => {
+    // Migration sources_table_additive seeds a 'default' source row with
+    // local_path copied from sync.repo_path on every brain that's run it
+    // — i.e. this, not a bare no-sourceId call, is what runPhaseSync/CLI
+    // `gbrain sync` actually resolve to on a real installed brain.
+    await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [dir]);
+    const { performSync } = await import('../src/commands/sync.ts');
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+
+    const result = await performSync(engine, {
+      repoPath: dir,
+      sourceId: 'default',
+      noPull: true,
+      noEmbed: true,
+      full: true,
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+    expect(existsSync(join(dir, '.git'))).toBe(true);
+  });
+
+  test('a registered non-default local source (sourceId != default, no remote_url) on a non-git dir still throws — not auto-inited', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config) VALUES ('mysource', 'mysource', $1, '{}'::jsonb)`,
+      [dir],
+    );
     const { performSync } = await import('../src/commands/sync.ts');
     await expect(
       performSync(engine, {
         repoPath: dir,
-        sourceId: 'default',
+        sourceId: 'mysource',
         noPull: true,
         noEmbed: true,
         full: true,

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -109,4 +109,40 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     ).rejects.toThrow(/git repository/i);
     expect(existsSync(join(dir, '.git'))).toBe(false);
   });
+
+  test('--dry-run on a non-git dir throws without writing anything to disk', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await expect(
+      performSync(engine, {
+        repoPath: dir,
+        dryRun: true,
+        noPull: true,
+        noEmbed: true,
+        full: true,
+      }),
+    ).rejects.toThrow(/git repository/i);
+    // The whole point of --dry-run is "preview only" — it must never git-init
+    // or commit on our behalf, even though we could self-heal.
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+  });
+
+  test('unborn-HEAD recovery: a bare `git init` with zero commits (interrupted prior self-heal) still completes', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { execSync } = await import('child_process');
+    // Simulate a self-heal that ran `git init` but died before the baseline
+    // commit landed (process killed, disk full, etc.) — `.git` exists so
+    // discoverGitRoot succeeds, but `git rev-parse HEAD` still fails.
+    execSync('git init -q', { cwd: dir });
+
+    const result = await performSync(engine, {
+      repoPath: dir,
+      noPull: true,
+      noEmbed: true,
+      full: true,
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+    expect(execSync('git rev-parse HEAD', { cwd: dir }).toString().trim()).not.toBe('');
+  });
 });

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -241,6 +241,39 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(tracked).not.toContain('private-cache');
   });
 
+  test('db_only exclusion applies even when a pre-existing .gitignore already covers the same dir (round 9 P1: unconditional pathspec)', async () => {
+    // Regression for the "check-ignore pre-filter" version of this logic:
+    // when a dir is ALSO already covered by an existing .gitignore, git's
+    // `-A` bails with an advisory "paths ignored... use -f" even though
+    // the add otherwise succeeds. Exclusion must be unconditional and the
+    // advisory must not surface as a hard failure.
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    const { execSync } = await import('child_process');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'secret.bin'), 'binary-ish content');
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
+    writeFileSync(join(dir, '.gitignore'), 'private-cache/\n');
+
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(result.status).toBe('first_sync');
+    const tracked = execSync('git ls-files', { cwd: dir }).toString();
+    expect(tracked).not.toContain('private-cache');
+  });
+
+  test('a comment merely mentioning db_only does not false-positive the sniff test (round 9 P2)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    // No `storage:` section at all — just a comment mentioning the word.
+    // A bare substring search would wrongly refuse this brain forever.
+    writeFileSync(join(dir, 'gbrain.yml'), '# db_only handling: TBD, not configured yet\n');
+
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+  });
+
   test('a gbrain.yml that mentions db_only but resolves no dirs refuses the baseline commit (round 6 P2: unsupported-syntax sniff test)', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const { execSync } = await import('child_process');

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -324,4 +324,34 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     const gitignore = existsSync(join(dir, '.gitignore')) ? readFileSync(join(dir, '.gitignore'), 'utf-8') : '';
     expect(gitignore).toContain('private-cache');
   });
+
+  test('a leftover .gitignore from before the brain lost its .git does not suppress db_only import (round 7 P1: rsync scenario)', async () => {
+    // The exact primary motivating scenario: a brain rsync'd from another
+    // machine keeps its OLD auto-managed .gitignore (already listing
+    // db_only dirs from before) even though `.git` itself never made the
+    // trip. Codex's round-7 review caught this with a live repro: without
+    // neutralizing the pre-existing file for this one first-sync call,
+    // collectSyncableFiles's `git ls-files --exclude-standard` silently
+    // omits db_only pages from the DATABASE — same bug class as round 6's
+    // ordering fix, just triggered by a file gbrain didn't write itself.
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'note.md'), mdPage('DB-only note'));
+    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
+    // A leftover .gitignore with an UNRELATED custom rule too, proving the
+    // restore preserves the user's own content rather than discarding it.
+    writeFileSync(
+      join(dir, '.gitignore'),
+      '.DS_Store\n\n# Auto-managed by gbrain (db_only directories)\nprivate-cache/\n',
+    );
+
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(result.added).toBe(3); // page1, page2, private-cache/note
+    expect(await engine.getPage('private-cache/note')).not.toBeNull();
+    const gitignore = readFileSync(join(dir, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('.DS_Store');
+    expect(gitignore).toContain('private-cache');
+  });
 });

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * #2964 — sync phase self-heals a never-git-initialized default brain dir.
+ *
+ * A legacy `sync.repo_path`-anchored default brain (no `sources` row, no
+ * `--source`) can reach `performSync` pointed at a directory that was never
+ * `git init`-ed (predates git-backed sync, or was rsync'd from another
+ * machine without its `.git`). Before this fix, `discoverGitRoot` threw
+ * unconditionally and the dream cycle's sync phase failed every night with
+ * no self-recovery, even though `doctor`'s sync checks reported "ok" (for
+ * an unrelated reason — they only look at the `sources` table, which has
+ * no rows for this kind of brain).
+ *
+ * gbrain owns this directory outright, so the fix self-heals by
+ * `git init`-ing it and capturing the current on-disk state as the sync
+ * baseline — but ONLY for the default/no-`sourceId` path. A registered
+ * local source (`sources add --path`, no `--url`) is the user's own
+ * external directory and must keep failing loudly rather than being
+ * silently git-initialized without consent.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+function mdPage(title: string, body = 'Content.'): string {
+  return `---\ntype: note\ntitle: ${title}\n---\n\n${body}`;
+}
+
+describe('#2964: sync auto-inits a never-git-initialized default brain dir', () => {
+  let engine: PGLiteEngine;
+  let dir: string;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  }, 60_000);
+
+  afterAll(async () => {
+    await engine.disconnect();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    dir = mkdtempSync(join(tmpdir(), 'gbrain-2964-'));
+    writeFileSync(join(dir, 'page1.md'), mdPage('Page 1'));
+    writeFileSync(join(dir, 'page2.md'), mdPage('Page 2'));
+  });
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('default (no sourceId) sync on a non-git dir auto-inits git and imports files', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+
+    const result = await performSync(engine, {
+      repoPath: dir,
+      noPull: true,
+      noEmbed: true,
+      full: true,
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+    expect(existsSync(join(dir, '.git'))).toBe(true);
+    expect(await engine.getPage('page1')).not.toBeNull();
+    expect(await engine.getPage('page2')).not.toBeNull();
+  });
+
+  test('a second sync after auto-init sees no changes (baseline commit captured current on-disk state)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const first = await performSync(engine, {
+      repoPath: dir,
+      noPull: true,
+      noEmbed: true,
+      full: true,
+    });
+    expect(first.added).toBe(2);
+
+    // No new files, no explicit `full` — a real incremental sync against the
+    // auto-init baseline. Before this fix there was no baseline to diff
+    // against (sync errored outright); a naive fix that skipped the initial
+    // commit would make this call re-report both files as "added" again.
+    const second = await performSync(engine, {
+      repoPath: dir,
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(second.status).not.toBe('first_sync');
+    expect(second.added).toBe(0);
+    expect(second.modified).toBe(0);
+  });
+
+  test('a registered local source (sourceId set, no remote_url) on a non-git dir still throws — not auto-inited', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await expect(
+      performSync(engine, {
+        repoPath: dir,
+        sourceId: 'default',
+        noPull: true,
+        noEmbed: true,
+        full: true,
+      }),
+    ).rejects.toThrow(/git repository/i);
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+  });
+});

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -1,24 +1,30 @@
 /**
  * #2964 — sync phase self-heals a never-git-initialized default brain dir.
  *
- * A legacy `sync.repo_path`-anchored default brain (no `sources` row, no
- * `--source`, no caller-supplied `--repo`) can reach `performSync` pointed
- * at a directory that was never `git init`-ed (predates git-backed sync, or
- * was rsync'd from another machine without its `.git`). Before this fix,
- * `discoverGitRoot` threw unconditionally and the dream cycle's sync phase
- * failed every night with no self-recovery, even though `doctor`'s sync
- * checks reported "ok" (for an unrelated reason — they only look at the
- * `sources` table, which has no rows for this kind of brain).
+ * A legacy `sync.repo_path`-anchored default brain (no `sources` row) can
+ * reach `performSync` pointed at a directory that was never `git init`-ed
+ * (predates git-backed sync, or was rsync'd from another machine without
+ * its `.git`). Before this fix, `discoverGitRoot` threw unconditionally and
+ * the dream cycle's sync phase failed every night with no self-recovery,
+ * even though `doctor`'s sync checks reported "ok" (for an unrelated
+ * reason — they only look at the `sources` table, which has no rows for
+ * this kind of brain).
  *
- * gbrain owns THAT directory outright, so the fix self-heals by `git
+ * gbrain owns that directory outright, so the fix self-heals by `git
  * init`-ing it and capturing the current on-disk state as the sync
- * baseline — but ONLY when the path was resolved from gbrain's own
- * persisted `sync.repo_path` anchor, never `sourceId` and never a
- * caller-supplied `repoPath`. Either of those means someone else named the
- * directory (a registered local source, or — per Codex review — an
- * admin-scope `submit_job({name:'sync', data:{repoPath}})` caller with no
- * matching source row), which must keep failing loudly rather than being
- * silently git-initialized without consent.
+ * baseline. Ownership is proven by VALUE — the resolved `repoPath` must
+ * equal gbrain's own persisted `sync.repo_path` anchor — not by whether
+ * `opts.repoPath`/`opts.sourceId` happen to be set. That distinction
+ * matters because the real production caller (`runPhaseSync` in
+ * cycle.ts, i.e. `gbrain dream`'s sync phase) always passes the resolved
+ * anchor through explicitly as `opts.repoPath`; gating on
+ * `!opts.repoPath` (an earlier, insufficiently-reviewed version of this
+ * fix) would have made the self-heal never fire on the exact path it was
+ * written to repair (Codex review round 3 caught this). A caller-supplied
+ * path that does NOT match the anchor (a registered local source, or an
+ * admin-scope `submit_job({name:'sync', data:{repoPath}})` MCP call with
+ * an unrelated path) must keep failing loudly rather than being silently
+ * git-initialized without consent.
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
@@ -51,8 +57,9 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     dir = mkdtempSync(join(tmpdir(), 'gbrain-2964-'));
     writeFileSync(join(dir, 'page1.md'), mdPage('Page 1'));
     writeFileSync(join(dir, 'page2.md'), mdPage('Page 2'));
-    // The self-heal-eligible path: gbrain's own persisted anchor, not a
-    // caller-supplied --repo / job.data.repoPath.
+    // The self-heal-eligible anchor: gbrain's own persisted config, not a
+    // caller-supplied --repo / job.data.repoPath (those are proven by
+    // VALUE against this anchor, not by mere absence — see file docstring).
     await engine.setConfig('sync.repo_path', dir);
   });
 
@@ -64,17 +71,29 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     const { performSync } = await import('../src/commands/sync.ts');
     expect(existsSync(join(dir, '.git'))).toBe(false);
 
-    const result = await performSync(engine, {
-      noPull: true,
-      noEmbed: true,
-      full: true,
-    });
+    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
 
     expect(result.status).toBe('first_sync');
     expect(result.added).toBe(2);
     expect(existsSync(join(dir, '.git'))).toBe(true);
     expect(await engine.getPage('page1')).not.toBeNull();
     expect(await engine.getPage('page2')).not.toBeNull();
+  });
+
+  test('explicit repoPath matching the anchor still auto-inits (mirrors gbrain dream\'s sync phase)', async () => {
+    // cycle.ts's runPhaseSync (the actual dream-cycle call site this bug
+    // was filed against) always passes `repoPath: brainDir` explicitly —
+    // it already resolved the anchor itself upstream and threads it
+    // through. Gating self-heal on `!opts.repoPath` would silently never
+    // fire here; ownership must be proven by matching the anchor's VALUE.
+    const { performSync } = await import('../src/commands/sync.ts');
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+
+    const result = await performSync(engine, { repoPath: dir, noPull: true, noEmbed: true, full: true });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+    expect(existsSync(join(dir, '.git'))).toBe(true);
   });
 
   test('a second sync after auto-init sees no changes (baseline commit captured current on-disk state)', async () => {
@@ -106,16 +125,34 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(existsSync(join(dir, '.git'))).toBe(false);
   });
 
-  test('a caller-supplied repoPath with no sourceId still throws — not auto-inited (P1: MCP submit_job arbitrary-path guard)', async () => {
+  test('a caller-supplied repoPath that does NOT match the anchor still throws (P1: MCP submit_job arbitrary-path guard)', async () => {
     // Mirrors jobs.ts: submit_job({name:'sync', data:{repoPath}}) reaches
     // performSyncInner with sourceId left undefined whenever repoPath
-    // doesn't match a registered source's local_path. Auto-init must not
-    // fire here even though sourceId is unset — only the anchor-resolved
-    // default path is gbrain's own.
+    // doesn't match a registered source's local_path. Self-heal must not
+    // fire for a path that isn't gbrain's own anchor, even with no
+    // sourceId set — only exact anchor-value equality (the previous test)
+    // is eligible.
+    const other = mkdtempSync(join(tmpdir(), 'gbrain-2964-other-'));
+    writeFileSync(join(other, 'unrelated.md'), mdPage('Unrelated'));
+    try {
+      const { performSync } = await import('../src/commands/sync.ts');
+      await expect(
+        performSync(engine, { repoPath: other, noPull: true, noEmbed: true, full: true }),
+      ).rejects.toThrow(/git repository/i);
+      expect(existsSync(join(other, '.git'))).toBe(false);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test('--src-subpath on the anchor-resolved path still throws — not auto-inited (P2: subpath scope guard)', async () => {
+    // A self-heal baseline commit runs `git add -A` at the git root before
+    // any subpath-scoped file collection happens, so it would capture
+    // sibling directories a --src-subpath sync never intended to touch.
     const { performSync } = await import('../src/commands/sync.ts');
     await expect(
       performSync(engine, {
-        repoPath: dir,
+        srcSubpath: 'wiki',
         noPull: true,
         noEmbed: true,
         full: true,
@@ -127,10 +164,10 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
   test('--dry-run on the anchor-resolved path throws without writing anything to disk', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     await expect(
-      performSync(engine, { dryRun: true, noPull: true, noEmbed: true, full: true }),
+      performSync(engine, { repoPath: dir, dryRun: true, noPull: true, noEmbed: true, full: true }),
     ).rejects.toThrow(/git repository/i);
     // The whole point of --dry-run is "preview only" — it must never git-init
-    // or commit on our behalf, even though we could self-heal.
+    // or commit on our behalf, even though this is otherwise self-heal-eligible.
     expect(existsSync(join(dir, '.git'))).toBe(false);
   });
 
@@ -142,10 +179,28 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     // discoverGitRoot succeeds, but `git rev-parse HEAD` still fails.
     execSync('git init -q', { cwd: dir });
 
-    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
+    const result = await performSync(engine, { repoPath: dir, noPull: true, noEmbed: true, full: true });
 
     expect(result.status).toBe('first_sync');
     expect(result.added).toBe(2);
     expect(execSync('git rev-parse HEAD', { cwd: dir }).toString().trim()).not.toBe('');
+  });
+
+  test('db_only paths are excluded from the baseline commit even without gbrain.yml write support (P2: fail-closed exclusion)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { mkdirSync } = await import('fs');
+    const { execSync } = await import('child_process');
+    mkdirSync(join(dir, 'private-cache'));
+    writeFileSync(join(dir, 'private-cache', 'secret.bin'), 'binary-ish content');
+    writeFileSync(
+      join(dir, 'gbrain.yml'),
+      'storage:\n  db_only:\n    - private-cache\n',
+    );
+
+    await performSync(engine, { noPull: true, noEmbed: true, full: true });
+
+    expect(existsSync(join(dir, '.git'))).toBe(true);
+    const tracked = execSync('git ls-files', { cwd: dir }).toString();
+    expect(tracked).not.toContain('private-cache');
   });
 });

--- a/test/sync-git-autoinit.test.ts
+++ b/test/sync-git-autoinit.test.ts
@@ -39,7 +39,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -241,25 +241,6 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(tracked).not.toContain('private-cache');
   });
 
-  test('db_only markdown IS still imported into the DB on first sync (round 6 P1: ordering vs .gitignore)', async () => {
-    // If .gitignore had been written BEFORE the initial import (as an
-    // earlier version of this fix did via manageGitignore inside the
-    // self-heal), collectSyncableFiles's `git ls-files --exclude-standard`
-    // would have silently excluded this page from the database entirely
-    // — not just from git history, which is the only thing db_only is
-    // actually supposed to keep it out of.
-    const { performSync } = await import('../src/commands/sync.ts');
-    const { mkdirSync } = await import('fs');
-    mkdirSync(join(dir, 'private-cache'));
-    writeFileSync(join(dir, 'private-cache', 'note.md'), mdPage('DB-only note'));
-    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
-
-    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
-
-    expect(result.added).toBe(3); // page1, page2, private-cache/note
-    expect(await engine.getPage('private-cache/note')).not.toBeNull();
-  });
-
   test('a gbrain.yml that mentions db_only but resolves no dirs refuses the baseline commit (round 6 P2: unsupported-syntax sniff test)', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const { execSync } = await import('child_process');
@@ -305,53 +286,4 @@ describe('#2964: sync auto-inits a never-git-initialized default brain dir', () 
     expect(tracked).not.toContain('private-cache');
   });
 
-  test('a self-heal via bare performSync (mirrors cycle.ts:runPhaseSync — no runSync CLI wrapper) still writes .gitignore for db_only dirs (round 6 P2)', async () => {
-    // The dream cycle calls performSync directly and never runs runSync's
-    // post-success manageGitignoreAtGitRoot. Without performSyncInner doing
-    // this itself after a self-heal, a brain that's only ever synced via
-    // the dream cycle would have db_only content correctly excluded from
-    // the baseline commit but .gitignore never written — leaving the
-    // user's own future manual `git add`/`commit` unprotected.
-    const { performSync } = await import('../src/commands/sync.ts');
-    const { mkdirSync } = await import('fs');
-    mkdirSync(join(dir, 'private-cache'));
-    writeFileSync(join(dir, 'private-cache', 'secret.bin'), 'binary-ish content');
-    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
-
-    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
-
-    expect(result.status).toBe('first_sync');
-    const gitignore = existsSync(join(dir, '.gitignore')) ? readFileSync(join(dir, '.gitignore'), 'utf-8') : '';
-    expect(gitignore).toContain('private-cache');
-  });
-
-  test('a leftover .gitignore from before the brain lost its .git does not suppress db_only import (round 7 P1: rsync scenario)', async () => {
-    // The exact primary motivating scenario: a brain rsync'd from another
-    // machine keeps its OLD auto-managed .gitignore (already listing
-    // db_only dirs from before) even though `.git` itself never made the
-    // trip. Codex's round-7 review caught this with a live repro: without
-    // neutralizing the pre-existing file for this one first-sync call,
-    // collectSyncableFiles's `git ls-files --exclude-standard` silently
-    // omits db_only pages from the DATABASE — same bug class as round 6's
-    // ordering fix, just triggered by a file gbrain didn't write itself.
-    const { performSync } = await import('../src/commands/sync.ts');
-    const { mkdirSync } = await import('fs');
-    mkdirSync(join(dir, 'private-cache'));
-    writeFileSync(join(dir, 'private-cache', 'note.md'), mdPage('DB-only note'));
-    writeFileSync(join(dir, 'gbrain.yml'), 'storage:\n  db_only:\n    - private-cache\n');
-    // A leftover .gitignore with an UNRELATED custom rule too, proving the
-    // restore preserves the user's own content rather than discarding it.
-    writeFileSync(
-      join(dir, '.gitignore'),
-      '.DS_Store\n\n# Auto-managed by gbrain (db_only directories)\nprivate-cache/\n',
-    );
-
-    const result = await performSync(engine, { noPull: true, noEmbed: true, full: true });
-
-    expect(result.added).toBe(3); // page1, page2, private-cache/note
-    expect(await engine.getPage('private-cache/note')).not.toBeNull();
-    const gitignore = readFileSync(join(dir, '.gitignore'), 'utf-8');
-    expect(gitignore).toContain('.DS_Store');
-    expect(gitignore).toContain('private-cache');
-  });
 });


### PR DESCRIPTION
## Problem

Fixes #2964.

On a legacy single-source personal brain (resolved via the `sync.repo_path`
config anchor, or the migrated `sources.default.local_path` mirror of it —
i.e. virtually every installed brain today), the `dream cycle`'s `sync`
phase throws unconditionally every single run if the brain directory was
never `git init`-ed (predates git-backed sync, or was rsync'd from another
machine without its `.git`):

```
[InternalError/UNKNOWN] Not inside a git repository: <brainDir>. GBrain
sync requires a git-initialized repo (or a subdirectory of one).
```

`gbrain doctor`'s `sync_freshness`/`sync_consolidation` checks report "ok"
for this exact brain, which reads as "sync isn't needed here" — but that's
coincidental, not diagnostic: those checks only look at the `sources`
table's `local_path` column in a way this brain shape doesn't populate the
same way sync resolves its own anchor. `doctor` is silent while the
nightly cycle log fails every night.

## Fix

Self-heal: when `discoverGitRoot` fails on a directory gbrain's own
`isAnchorOwnedSyncPath` check proves it owns (repoPath realpath-equals the
live sync anchor — by VALUE, not by whether `opts.repoPath`/`opts.sourceId`
happen to be set, see that function's docstring for why the naive
"gate on absence" version doesn't fire on the real production call sites),
`git init` it and capture the current on-disk state as a baseline commit
(`createSyncBaselineCommit`) so the sync phase can proceed instead of
failing forever. A parallel "unborn HEAD" recovery handles a repo that
already has `.git` but zero commits (an interrupted prior self-heal, or
one created some other way).

Scoped tightly: never on `--dry-run`, never on an aborted signal, never on
a registered non-default source (a user's own external directory via
`sources add --path`), never on a `--src-subpath` sync (the baseline
commit runs at the git root, before any subpath scoping applies).

db_only-tier content (`docs/storage-tiering.md`) is kept out of the
baseline commit via an unconditional pathspec exclusion, independent of
whatever `.gitignore` state exists — this repo doesn't otherwise touch
`.gitignore` during self-heal; import and any subsequent `.gitignore`
management behave exactly like any other brain, self-healed or not.

## Review history

This went through 9 rounds of Codex adversarial review (`gpt-5.6-sol`,
high reasoning) across the branch's history — several genuinely reshaped
the design (ownership-by-value instead of by-field-absence after round 3
proved the naive version never fires on the real dream-cycle/CLI call
sites; unconditional pathspec exclusion after round 9 found the
check-ignore pre-filter could be defeated by gitignore negation patterns).
One accepted trade-off remains, documented inline at the sniff-test guard
in `createSyncBaselineCommit`: a genuinely-empty `db_only: []` and
unsupported-syntax `db_only: [dir/]` are structurally indistinguishable at
`loadStorageConfig`'s API boundary (verified directly — both resolve to
the byte-identical `{db_tracked:[],db_only:[]}`), so the fail-closed
sniff-test can false-positive on the former. The false-positive is
low-cost and self-resolving (clear error, retried every sync); the
false-negative it guards against (silently committing db_only content
into permanent git history) is high-cost and hard to undo.

## Test plan

- New `test/sync-git-autoinit.test.ts` (14 tests): anchor-value ownership
  (including the `sourceId='default'` migrated-brain shape), non-default-
  source/mismatched-path/`--src-subpath`/`--dry-run` refusals, unborn-HEAD
  recovery, index-rebuild for stale staged content, db_only commit
  exclusion (including despite a pre-existing matching `.gitignore`), and
  the sniff-test guard (including its comment-false-positive fix).
- `bun test test/sync.test.ts test/sync-monorepo.test.ts
  test/sync-git-autoinit.test.ts test/storage-config.test.ts
  test/storage-tiering.test.ts` — 116/116 pass, no regressions.
- `bun run typecheck` clean.
- `bun run verify` — 31/31 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
