### PR TITLE
Preserve modality and symbol metadata in embed-stale merge

### DIFF
--- a/src/core/embed-stale.ts
+++ b/src/core/embed-stale.ts
@@ -206,6 +206,22 @@ export async function embedStaleForSource(
           chunk_source: c.chunk_source,
           embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
           token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
+          // Carry through per-chunk metadata. upsertChunks writes these as
+          // EXCLUDED.<col> (not COALESCE), so omitting them here resets image
+          // rows to modality='text' (breaking the image search arm's
+          // modality='image' filter) and wipes code-chunk symbol metadata on
+          // every embed-stale pass. embedding_image is deliberately NOT
+          // carried: the upsert COALESCEs it, and getChunks returns the
+          // pgvector as a string which upsertChunks would mis-serialize.
+          modality: c.modality ?? undefined,
+          language: c.language ?? undefined,
+          symbol_name: c.symbol_name ?? undefined,
+          symbol_type: c.symbol_type ?? undefined,
+          start_line: c.start_line ?? undefined,
+          end_line: c.end_line ?? undefined,
+          parent_symbol_path: c.parent_symbol_path ?? undefined,
+          doc_comment: c.doc_comment ?? undefined,
+          symbol_name_qualified: c.symbol_name_qualified ?? undefined,
         }));
         await observed(pacer, () => engine.upsertChunks(slug, merged, { sourceId: keySourceId }));
         // v0.41.31: stamp provenance only when EVERY chunk was stale (fully

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -581,6 +581,13 @@ export interface Chunk {
   parent_symbol_path?: string[] | null;
   doc_comment?: string | null;
   symbol_name_qualified?: string | null;
+  /**
+   * v0.27.1 multimodal. Read side of ChunkInput.modality — must round-trip
+   * through getChunks → embed-stale merge → upsertChunks or image rows get
+   * reset to 'text' (EXCLUDED.modality on the upsert) and vanish from the
+   * image search arm.
+   */
+  modality?: 'text' | 'image';
 }
 
 /**

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -329,6 +329,7 @@ export function rowToChunk(row: Record<string, unknown>, includeEmbedding = fals
     parent_symbol_path: (row.parent_symbol_path as string[] | null | undefined) ?? null,
     doc_comment: (row.doc_comment as string | null | undefined) ?? null,
     symbol_name_qualified: (row.symbol_name_qualified as string | null | undefined) ?? null,
+    modality: (row.modality as 'text' | 'image' | undefined) ?? undefined,
   };
 }
 

--- a/test/embed-stale.serial.test.ts
+++ b/test/embed-stale.serial.test.ts
@@ -227,4 +227,53 @@ describe('embedStaleForSource', () => {
     const otherStale = await engine.countStaleChunks({ sourceId: 'other' });
     expect(otherStale).toBe(3);
   });
+
+  test('preserves modality and code-symbol metadata across the merge round-trip', async () => {
+    // Regression: the merged ChunkInput[] used to rebuild rows with only 5
+    // fields; upsertChunks writes modality/symbol columns as EXCLUDED.<col>,
+    // so an image page with one stale TEXT chunk got its image row reset to
+    // modality='text' — permanently invisible to the image search arm.
+    await engine.putPage('media/mixed-page', {
+      type: 'image',
+      title: 'mixed',
+      compiled_truth: 'mixed modality page',
+    });
+    const imgVec = new Float32Array(1024).fill(0.03);
+    await engine.upsertChunks('media/mixed-page', [
+      {
+        chunk_index: 0,
+        chunk_text: 'field-photo.jpg',
+        chunk_source: 'image_asset',
+        modality: 'image',
+        embedding_image: imgVec,
+        // embedding intentionally present so this row is NOT stale.
+        embedding: new Float32Array(1536).fill(0.01),
+        token_count: 4,
+      },
+      {
+        chunk_index: 1,
+        chunk_text: 'ocr caption text needing embed',
+        chunk_source: 'compiled_truth',
+        language: 'python',
+        symbol_name: 'kept_symbol',
+        symbol_type: 'function',
+        symbol_name_qualified: 'mod::kept_symbol',
+        token_count: 6,
+        embedding: undefined, // stale — triggers the merge path
+      },
+    ]);
+
+    const result = await embedStaleForSource(engine, 'default', { embedFn: fakeEmbedFn });
+    expect(result.embedded).toBe(1);
+
+    const after = await engine.getChunks('media/mixed-page');
+    const imgRow = after.find((c) => c.chunk_index === 0)!;
+    const txtRow = after.find((c) => c.chunk_index === 1)!;
+    expect(imgRow.modality).toBe('image');
+    expect(txtRow.language).toBe('python');
+    expect(txtRow.symbol_name).toBe('kept_symbol');
+    expect(txtRow.symbol_name_qualified).toBe('mod::kept_symbol');
+    // The stale text row actually got its embedding.
+    expect(txtRow.embedded_at).not.toBeNull();
+  });
 });


### PR DESCRIPTION
embedStaleForSource rebuilds each page's chunks as a merged ChunkInput[] carrying only five fields (chunk_index, chunk_text, chunk_source, embedding, token_count), while upsertChunks writes the metadata columns as `EXCLUDED.<col>`. Any page containing at least one stale chunk therefore has all of its chunks' metadata reset on the next embed-stale pass:

- image chunks flip modality `image` → `text` and disappear from the cross-modal image search arm permanently (it filters on `modality = 'image'`), while keeping their embedding_image vector — the data looks intact but is unreachable;
- code chunks lose language, symbol_name, symbol_type, and symbol_name_qualified.

The read side compounds it: rowToChunk never returned modality, so a correct merge wasn't possible without also extending the Chunk shape.

This PR exposes modality on Chunk/rowToChunk and carries modality, language, and the symbol fields through the merge. embedding_image is deliberately not carried — upsertChunks already COALESCEs it server-side.

Repair for brains that have already lost modality:

    UPDATE content_chunks SET modality = 'image'
    WHERE chunk_source = 'image_asset' AND embedding_image IS NOT NULL;

The new test seeds a mixed page (settled image chunk plus a stale text chunk with symbol metadata) and asserts both survive an embedStaleForSource pass. It fails on master.