### PR TITLE
Resolve relative storage paths in doctor image_assets check

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7178,9 +7178,17 @@ export async function buildChecks(
       let vanished = 0;
       const vanishedPaths: string[] = [];
       const fs = await import('node:fs');
+      const nodePath = await import('node:path');
+      // storage_path is repo-relative for sync-ingested assets. Resolving
+      // against cwd made this check a false-positive WARN whenever doctor
+      // ran outside the brain repo.
+      const repoRoot = (await engine.getConfig('sync.repo_path')) ?? process.cwd();
       for (const r of rows) {
+        const abs = nodePath.isAbsolute(r.storage_path)
+          ? r.storage_path
+          : nodePath.join(repoRoot, r.storage_path);
         try {
-          fs.statSync(r.storage_path);
+          fs.statSync(abs);
         } catch {
           vanished++;
           if (vanishedPaths.length < 5) vanishedPaths.push(r.storage_path);


### PR DESCRIPTION
The image_assets check statSyncs files.storage_path directly, but sync-ingested assets store repo-relative paths. Running doctor from any directory other than the brain repo reports every image as missing from disk — a persistent false WARN whose suggested fix (`gbrain sync --skip-failed`) does nothing.

Resolve relative paths against sync.repo_path before statting; absolute paths are untouched. Falls back to cwd when the config key is unset, preserving the old behavior for brains without a configured repo.