### PR TITLE
fix(cli): remove sync --install-cron help text — no handler ever existed (#2795)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2258,7 +2258,7 @@ IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
-  sync --install-cron                Install persistent sync daemon
+                                     See also: autopilot --install (continuous daemon).
   export [--dir ./out/]              Export to markdown
   export --restore-only [--repo <p>] Restore missing supabase-only files
         [--type T] [--slug-prefix S] With optional filters

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -98,6 +98,33 @@ describe('WARN-6 — main `gbrain --help` lists capture/brainstorm/lsd', () => {
   });
 });
 
+describe('#2795 — `sync --install-cron` help line no longer promises an unbuilt feature', () => {
+  test('main `gbrain --help` does not advertise install-cron', () => {
+    // Pre-fix: `sync --install-cron  Install persistent sync daemon` was
+    // listed in the top-level help with no flag parsing or handler behind
+    // it anywhere in src/commands/sync.ts — `gbrain sync --install-cron`
+    // silently ran an ordinary sync instead of installing anything.
+    const { stdout, status } = runCli(['--help']);
+    expect(status).toBe(0);
+    expect(stdout).not.toContain('install-cron');
+    expect(stdout).not.toContain('Install persistent sync daemon');
+  });
+
+  test('main `gbrain --help` points sync users at the real continuous-daemon command', () => {
+    const { stdout } = runCli(['--help']);
+    // autopilot --install already runs sync+extract+embed on a schedule
+    // (docs/architecture/KEY_FILES.md); point discoverability there instead
+    // of promising a separate sync-only cron installer that never existed.
+    expect(stdout).toMatch(/sync --watch \[--interval N\][^\n]*\n\s*See also: autopilot --install/);
+  });
+
+  test('`gbrain sync --help` never listed install-cron either', () => {
+    const { stdout, status } = runCli(['sync', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).not.toContain('install-cron');
+  });
+});
+
 describe('#1175 — main `gbrain --help` SOURCES block matches the real subcommand set', () => {
   test('archive and its lifecycle siblings are listed', () => {
     const { stdout, status } = runCli(['--help']);


### PR DESCRIPTION
## Problem

`gbrain --help` advertised:

```
sync --install-cron                Install persistent sync daemon
```

but no handler ever existed. A whole-tree grep for `install-cron` /
`installCron` finds nothing in `src/commands/sync.ts` — no flag parsing, no
`sync --help` mention, no unknown-flag validation. `gbrain sync --install-cron`
silently performed an ordinary one-off incremental sync while the operator
believed a persistent daemon had been installed.

`git log -S"sync --install-cron" -- src/cli.ts` shows the line was introduced
exactly once (the v0.42.29.0 top-level help scaffold) and never touched again
— there's no recoverable design intent, just a help-text line that outran the
implementation.

## Fix

Removed the misleading line and pointed the `sync --watch` entry at the
daemon that already does this job:

```
sync [--repo <path>] [flags]       Git-to-brain incremental sync
sync --watch [--interval N]        Continuous sync (loops until stopped)
                                   See also: autopilot --install (continuous daemon).
```

## Why removal, not implementation

`gbrain autopilot --install` already installs a self-maintaining daemon
(launchd/systemd/cron/ephemeral-container target) that runs sync+extract+embed
on a schedule — including a per-source freshness check that submits `sync`
jobs on its own interval (`src/commands/autopilot.ts`, the D17 freshness-gate
block). A second, sync-only cron installer would be a competing scheduler
sitting outside the D10 cycle-lock invariant that already keeps autopilot's
targeted-submit and full-cycle paths from double-processing — i.e. building
it would risk reintroducing the exact double-processing class autopilot's
own locking was built to close, for a use case autopilot already covers.

There's also a separate, unrelated `installCron` mechanism
(`src/core/brain-repo-durability.ts`, wired through `gbrain sources harden`)
that installs a periodic `git pull` for a *source repo*. It's a different
command scoped to git-pull durability, not `gbrain sync` (the git-to-brain
import+embed step), so it isn't a fit to repurpose here either.

Given no recoverable intent, an existing daemon that already covers the use
case, and a real risk in bolting on a second scheduler, deleting the
help-text promise (with a pointer to the real command) is the minimal,
honest fix.

## Test plan

- Added regression coverage to `test/cli-help-discoverability.test.ts`
  (`#2795` describe block):
  - `gbrain --help` no longer contains `install-cron` / `Install persistent
    sync daemon`.
  - `gbrain --help`'s `sync --watch` entry is followed by a
    `See also: autopilot --install` pointer.
  - `gbrain sync --help` never listed `install-cron` (confirms this was
    always a top-level-help-only artifact, not a real dispatch path).
- `bun run typecheck` — clean.
- `bun test test/cli-help-discoverability.test.ts` — 10 pass (3 new).
- `bun run verify` — 31/31 checks green.
- Codex adversarial review (`gpt-5.6-sol`, high reasoning effort) — no P1/P2
  findings; confirmed the change is documentation-only with no runtime
  behavior impact.

Fixes #2795.
