### PR TITLE
fix(takes): fail closed when takes-write source resolution errors (#2698 follow-up)

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -101,12 +101,18 @@ async function getPageId(engine: BrainEngine, slug: string, sourceId?: string): 
   return rows[0].id;
 }
 
-async function resolveTakesSourceId(engine: BrainEngine): Promise<string | undefined> {
-  try {
-    return await resolveSourceId(engine, null);
-  } catch {
-    return undefined;
-  }
+// Fail-closed (#2698 residual, TODOS.md): `resolveSourceId` only ever
+// throws when a source WAS explicitly in play — an invalid or
+// unregistered `GBRAIN_SOURCE`, a `.gbrain-source` dotfile pointing at a
+// source that doesn't exist, or a genuine DB error — never for "nothing
+// configured" (that path resolves cleanly to the seeded `'default'`
+// source, tier 6 of resolveSourceId). Swallowing those errors here used
+// to fall back to the unscoped slug-only page lookup, silently
+// reintroducing the pre-#2698 cross-source write bug whenever resolution
+// merely errored instead of resolving cleanly. Let it propagate so the
+// write is blocked instead of silently unscoped.
+async function resolveTakesSourceId(engine: BrainEngine): Promise<string> {
+  return resolveSourceId(engine, null);
 }
 
 function readBodyOrEmpty(path: string): string {

--- a/test/takes-command-source-scope.test.ts
+++ b/test/takes-command-source-scope.test.ts
@@ -14,14 +14,29 @@ afterEach(() => {
   }
 });
 
-function makeEngine() {
+function makeEngine(opts: { knownSources?: string[] } = {}) {
   const added: TakeBatchInput[][] = [];
   const pageLookups: unknown[][] = [];
   const engine = {
     getConfig: async () => null,
     executeRaw: async (sql: string, params: unknown[] = []) => {
       if (sql.includes('FROM sources WHERE id = $1')) {
-        return [{ id: params[0] as string }];
+        // Default (no `knownSources` override): every id "exists", matching
+        // the original test's assumption. When `knownSources` is passed,
+        // only ids in that list resolve — used to simulate a source that
+        // was explicitly requested (via GBRAIN_SOURCE) but isn't registered.
+        if (!opts.knownSources) return [{ id: params[0] as string }];
+        return opts.knownSources.includes(params[0] as string) ? [{ id: params[0] as string }] : [];
+      }
+      if (sql.includes('FROM sources WHERE local_path IS NOT NULL AND id != ')) {
+        // resolveSourceId tier 5.5 (sole-non-default-source). No registered
+        // sources with a local_path in these tests.
+        return [];
+      }
+      if (sql.includes('FROM sources WHERE local_path IS NOT NULL')) {
+        // resolveSourceId tier 4 (registered source whose local_path
+        // contains CWD). No registered sources in these tests.
+        return [];
       }
       if (sql.includes('FROM pages WHERE slug = $1 AND source_id = $2')) {
         pageLookups.push(params);
@@ -72,5 +87,67 @@ describe('gbrain takes CLI source scoping', () => {
     const written = join(brainDir, 'shared/page.md');
     expect(existsSync(written)).toBe(true);
     expect(readFileSync(written, 'utf-8')).toContain('Dept-scoped claim');
+  });
+
+  test('add with no source configuration at all still resolves cleanly (no regression)', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-takes-source-'));
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-takes-home-'));
+    tmpRoots.push(brainDir, home);
+    const { engine, added, pageLookups } = makeEngine();
+
+    // No GBRAIN_SOURCE, no dotfile, no registered local_path match, no
+    // sources.default config, no sole non-default source — resolveSourceId
+    // falls through every tier to the seeded 'default' source (tier 6) and
+    // never throws. `resolveTakesSourceId` must resolve, not error.
+    await withEnv({ GBRAIN_SOURCE: undefined, GBRAIN_HOME: home }, async () => {
+      await runTakes(engine, [
+        'add',
+        'shared/page',
+        '--claim',
+        'Unscoped-default claim',
+        '--kind',
+        'take',
+        '--who',
+        'self',
+        '--dir',
+        brainDir,
+      ]);
+    });
+
+    expect(pageLookups).toEqual([['shared/page', 'default']]);
+    expect(added).toHaveLength(1);
+    expect(added[0]![0]!.page_id).toBe(11);
+  });
+
+  test('add fails closed (blocks the write) when GBRAIN_SOURCE names a source that does not resolve (#2684 residual)', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-takes-source-'));
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-takes-home-'));
+    tmpRoots.push(brainDir, home);
+    // 'ghost' is a well-formed source id (passes SOURCE_ID_RE) but is not a
+    // registered source — resolveSourceId's assertSourceExists throws.
+    const { engine, added, pageLookups } = makeEngine({ knownSources: ['dept', 'default'] });
+
+    await withEnv({ GBRAIN_SOURCE: 'ghost', GBRAIN_HOME: home }, async () => {
+      await expect(
+        runTakes(engine, [
+          'add',
+          'shared/page',
+          '--claim',
+          'Should never land',
+          '--kind',
+          'take',
+          '--who',
+          'self',
+          '--dir',
+          brainDir,
+        ]),
+      ).rejects.toThrow(/Source "ghost" not found/);
+    });
+
+    // Fail-closed: the write must be blocked entirely, not silently
+    // downgraded to an unscoped cross-source lookup.
+    expect(pageLookups).toHaveLength(0);
+    expect(added).toHaveLength(0);
+    expect(existsSync(join(brainDir, 'shared/page.md'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `resolveTakesSourceId()` in `src/commands/takes.ts` caught every error from
  `resolveSourceId()` and fell back to `undefined`, which restores the
  pre-#2698 unscoped (cross-source) slug-only page lookup for `takes
  add/update/supersede/resolve` — reintroducing the exact cross-source write
  bug #2698 fixed, whenever resolution merely *errored* rather than resolving
  cleanly (an invalid/unregistered `GBRAIN_SOURCE`, or a `.gbrain-source`
  dotfile pointing at a source that doesn't exist).
- `resolveSourceId()` never throws for "nothing configured" — that path
  resolves cleanly through to the seeded `'default'` source (tier 6). Every
  throw it can raise corresponds to a source that WAS explicitly in play but
  didn't resolve, or a genuine DB error. So the swallow-and-fallback had no
  legitimate case to protect; it just silently downgraded write scoping on
  any resolution failure.
- Fix: let the error propagate. `resolveTakesSourceId()` now returns
  `Promise<string>` (was `Promise<string | undefined>`) and no longer
  catches — a resolution failure now blocks the write with a clear error
  instead of silently falling back to an unscoped lookup.

Follow-up to #2698 (filed as a TODOS.md P1 during the v0.42.60.0 release
ship, found by cross-model adversarial review).

## Test plan

- Added `test/takes-command-source-scope.test.ts` coverage for both paths:
  - No source configuration at all still resolves cleanly to the seeded
    `'default'` source (no regression on the happy path).
  - An unregistered `GBRAIN_SOURCE` now blocks the write (throws) instead of
    falling back to an unscoped cross-source lookup.
- `bun test test/takes-command-source-scope.test.ts` — 3 pass / 0 fail
- `bun run typecheck` — clean
- `bun run verify` — 31/31 checks pass
- `codex review -c model="gpt-5.6-sol" -c model_reasoning_effort="high" --base origin/master` — no Critical/Warning findings; verdict: "The change correctly propagates source-resolution failures before any takes mutation can occur, while preserving the no-configuration fallback to the default source. The targeted tests and TypeScript typecheck pass."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
