### PR TITLE
fix(sources): validate --path is a git repo with committed content at registration (#2707)

### DIFF
--- a/docs/guides/multi-source-brains.md
+++ b/docs/guides/multi-source-brains.md
@@ -134,10 +134,13 @@ gbrain sources unfederate <id>
 ## The git requirement for --path sources
 
 Every `--path` source must be a git repository (or live inside one — a
-subdirectory of a git repo works too). `gbrain sources add` validates this at
-registration time and refuses a plain, non-git directory with an actionable
-error instead of silently registering a source that will fail on its first
-`gbrain sync`. Fix it with:
+subdirectory of a git repo works too) with at least one committed, tracked
+file under that path. `gbrain sources add` validates this at registration
+time and refuses a directory that doesn't qualify — no `.git` at all, a
+`git init` with no commit yet, or a commit made before `git add` — with an
+actionable error instead of silently registering a source that will fail
+(or worse, "succeed" while importing nothing) on its first `gbrain sync`.
+Fix it with:
 
 ```bash
 git -C <path> init
@@ -149,9 +152,11 @@ gbrain sources add <id> --path <path>
 Two details that are easy to miss:
 
 - **Files must actually be committed, not just present.** The sync walker
-  reads files through git objects, so an empty repo (`git init` with no
-  commit) or a commit made before `git add` won't surface any content —
-  `git init` alone is not enough.
+  reads files through git objects, so `git init` alone — even followed by an
+  empty commit (`git commit --allow-empty`) — isn't enough. Registration
+  checks for real tracked content (`git ls-tree HEAD` scoped to the path),
+  not just a resolvable `HEAD`, so this footgun is caught immediately
+  instead of surfacing later as a sync that imports nothing.
 - **`--force` registers the source anyway**, skipping the check. Use this if
   you're registering a path before an automated pipeline gets around to
   `git init`-ing it. GBrain never auto-`git init`s a `--path` source for

--- a/docs/guides/multi-source-brains.md
+++ b/docs/guides/multi-source-brains.md
@@ -114,8 +114,11 @@ Flip later with `gbrain sources federate <id>` / `unfederate <id>`.
 Full subcommand reference:
 
 ```
-gbrain sources add <id> --path <p> [--name <n>] [--federated|--no-federated]
+gbrain sources add <id> --path <p> [--name <n>] [--federated|--no-federated] [--force]
                                Register a source. id: [a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?
+                               --path must be a git repo (or a subdirectory of one) — see
+                               "The git requirement for --path sources" below. --force
+                               skips that check to register before git-init exists.
 gbrain sources list [--json]   List all sources with page counts + federation state.
 gbrain sources remove <id> [--yes] [--dry-run] [--keep-storage]
                                Cascade-delete a source (pages, chunks, timeline).
@@ -127,6 +130,42 @@ gbrain sources detach          Remove .gbrain-source from CWD.
 gbrain sources federate <id>
 gbrain sources unfederate <id>
 ```
+
+## The git requirement for --path sources
+
+Every `--path` source must be a git repository (or live inside one — a
+subdirectory of a git repo works too). `gbrain sources add` validates this at
+registration time and refuses a plain, non-git directory with an actionable
+error instead of silently registering a source that will fail on its first
+`gbrain sync`. Fix it with:
+
+```bash
+git -C <path> init
+git -C <path> add -A
+git -C <path> commit -m "initial import"
+gbrain sources add <id> --path <path>
+```
+
+Two details that are easy to miss:
+
+- **Files must actually be committed, not just present.** The sync walker
+  reads files through git objects, so an empty repo (`git init` with no
+  commit) or a commit made before `git add` won't surface any content —
+  `git init` alone is not enough.
+- **`--force` registers the source anyway**, skipping the check. Use this if
+  you're registering a path before an automated pipeline gets around to
+  `git init`-ing it. GBrain never auto-`git init`s a `--path` source for
+  you — it's your directory, not a gbrain-managed clone (same consent
+  boundary as sync-time self-heal, which also never mutates a `--path`
+  source without an explicit ask).
+
+**If sync ever reports a problem with the sync anchor** (`last_commit`) —
+after a force-push, a history rewrite, or a from-scratch `git init` on a
+directory that was synced before — you do not need to reset anything by
+hand. `gbrain sync` detects an unreachable or non-ancestor anchor
+automatically and recovers: either a full reimport (anchor object missing)
+or a direct tree-to-tree diff against the orphaned bookmark (anchor present
+but rewritten), advancing the anchor to the new HEAD when it completes.
 
 ## Citation format for agents
 

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -7,7 +7,9 @@
  * full story.
  *
  * Subcommands:
- *   gbrain sources add <id> --path <path> [--name <display>] [--federated|--no-federated]
+ *   gbrain sources add <id> --path <path> [--name <display>] [--federated|--no-federated] [--force]
+ *                               --path must be a git-initialized repo (files committed,
+ *                               not just present) — #2707. --force skips the check.
  *   gbrain sources list [--json]
  *   gbrain sources remove <id> [--yes] [--dry-run] [--keep-storage]
  *   gbrain sources rename <id> <new-name>
@@ -120,7 +122,7 @@ async function runAdd(engine: BrainEngine, args: string[]): Promise<void> {
   if (!id) {
     console.error(
       'Usage: gbrain sources add <id> [--path <path> | --url <https-url>] ' +
-        '[--name <display>] [--federated|--no-federated] [--clone-dir <path>]',
+        '[--name <display>] [--federated|--no-federated] [--clone-dir <path>] [--force]',
     );
     process.exit(2);
   }
@@ -132,6 +134,7 @@ async function runAdd(engine: BrainEngine, args: string[]): Promise<void> {
   let cloneDir: string | undefined;
   let patFile: string | undefined;
   let noHarden = false;
+  let force = false;
 
   for (let i = 1; i < args.length; i++) {
     const a = args[i];
@@ -143,6 +146,7 @@ async function runAdd(engine: BrainEngine, args: string[]): Promise<void> {
     if (a === '--clone-dir') { cloneDir = args[++i]; continue; }
     if (a === '--pat-file') { patFile = args[++i]; continue; }
     if (a === '--no-harden') { noHarden = true; continue; }
+    if (a === '--force') { force = true; continue; }
     console.error(`Unknown flag: ${a}`);
     process.exit(2);
   }
@@ -162,6 +166,7 @@ async function runAdd(engine: BrainEngine, args: string[]): Promise<void> {
     remoteUrl,
     federated,
     cloneDir,
+    force,
   });
 
   // Topology A discovery: if the just-added source carries a brain-resident
@@ -1368,8 +1373,9 @@ function printHelp(): void {
   console.log(`gbrain sources — manage multi-source brain configuration (v0.26.5)
 
 Subcommands:
-  add <id> --path <p> [--name <n>] [--federated|--no-federated]
-                                    Register a new source.
+  add <id> --path <p> [--name <n>] [--federated|--no-federated] [--force]
+                                    Register a new source. --path must be a git repo
+                                    with committed files; --force skips that check.
   list [--json]                     List registered sources with page counts.
   remove <id> [--confirm-destructive] [--dry-run]
                                     Permanently delete a source and all its data.

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -325,31 +325,43 @@ export function isInsideGitRepo(path: string): boolean {
   }
 }
 
-/** SHA-1 of git's canonical empty tree object — identical in every SHA-1
- * git repository (a deterministic hash of a fixed, zero-entry tree
- * structure), independent of repo content or history. Used by
- * `hasTrackedContent` below as an O(1)-output existence probe. (SHA-256
- * repos, an opt-in `--object-format=sha256` git 2.29+ feature not used
- * anywhere else in this codebase, would need the SHA-256 equivalent —
- * not handled here.) */
-const EMPTY_TREE_SHA1 = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+/**
+ * The empty-tree object ID for `path`'s repo, derived (not hardcoded) so
+ * this works for both the default SHA-1 object format and the opt-in
+ * `--object-format=sha256` one (git 2.29+) — each has its own empty-tree
+ * OID. `git hash-object -t tree --stdin < /dev/null` computes the hash of
+ * a zero-entry tree using whatever hash algorithm `path`'s repo is
+ * configured for, without needing to know which one that is. #2707 codex
+ * round 4 (P2): an earlier version hardcoded the well-known SHA-1 constant
+ * (`4b825dc6...`), which silently mismatched — and so let an empty
+ * SHA-256 repo through — on a SHA-256 repo's real (different) empty-tree
+ * OID.
+ */
+function emptyTreeOid(path: string): string {
+  return execFileSync('git', ['-C', path, 'hash-object', '-t', 'tree', '--stdin'], {
+    input: '',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10_000,
+    env: { ...process.env, ...GIT_ENV },
+  }).toString().trim();
+}
 
 /**
  * True if `path`'s HEAD tree has at least one tracked entry scoped to
  * `path` itself. `-C path` + the `HEAD:./` revision syntax resolves the
  * tree object for `path` specifically (not the whole repo root), so this
  * is correct for both a repo's toplevel AND a subdirectory-of-a-repo
- * source — then a single SHA comparison against git's well-known
- * empty-tree object tells us whether that tree is empty. #2707 codex
- * round 3 (P2): unlike listing (`ls-tree`), this is O(1) output — no
+ * source — then a single OID comparison against that repo's empty-tree
+ * object (see `emptyTreeOid`) tells us whether that tree is empty. #2707
+ * codex round 3 (P2): unlike listing (`ls-tree`), this is O(1) output — no
  * `maxBuffer` exposure on a repo with a very large number of entries.
  *
  * Subsumes "no commits at all" (`HEAD:./` on an unborn repo fails to
  * resolve — there's no HEAD) AND "has a HEAD commit but it's empty"
  * (#2707 codex round 2): `git commit --allow-empty` followed by creating
- * untracked files resolves `HEAD:./` successfully (to the empty-tree SHA
- * below) but that tree has zero entries — a directory that would pass a
- * bare `rev-parse HEAD` check yet still can't sync (or worse, "succeeds"
+ * untracked files resolves `HEAD:./` successfully (to the empty-tree OID)
+ * but that tree has zero entries — a directory that would pass a bare
+ * `rev-parse HEAD` check yet still can't sync (or worse, "succeeds"
  * importing nothing and then never notices the untracked files change —
  * the silent-staleness class #2707 exists to prevent). A directory
  * that's `git init`ed but never committed, or where this specific path
@@ -362,7 +374,7 @@ export function hasTrackedContent(path: string): boolean {
       timeout: 10_000,
       env: { ...process.env, ...GIT_ENV },
     });
-    return out.toString().trim() !== EMPTY_TREE_SHA1;
+    return out.toString().trim() !== emptyTreeOid(path);
   } catch {
     return false;
   }

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -326,22 +326,31 @@ export function isInsideGitRepo(path: string): boolean {
 }
 
 /**
- * True if `path` has at least one commit reachable from HEAD, per
- * `git rev-parse HEAD`. A directory that's `git init`ed but never committed
- * passes `isInsideGitRepo` yet still can't sync — `sync.ts` throws
- * "No commits in repo ... Make at least one commit before syncing." Checking
- * this too at `addSource` registration time (#2707 codex round 1) turns that
- * later, easy-to-miss sync failure into an immediate one, matching the error
- * copy's existing "files actually committed" claim.
+ * True if `path`'s HEAD tree has at least one tracked entry scoped to
+ * `path` itself, per `git ls-tree HEAD -- .` (non-recursive — one entry is
+ * enough to know the tree isn't empty; no need to walk the whole subtree).
+ * `-C path` + pathspec `.` scopes the listing to `path`, so this is correct
+ * for both a repo's toplevel AND a subdirectory-of-a-repo source.
+ *
+ * Subsumes "no commits at all" (`ls-tree HEAD` on an unborn repo fails —
+ * there's no HEAD to resolve) AND the narrower "has a HEAD commit but it's
+ * empty" case (#2707 codex round 2): `git commit --allow-empty` followed by
+ * creating untracked files resolves `HEAD:.` successfully (to git's
+ * well-known empty-tree object) but lists zero entries — a directory that
+ * would pass a bare `rev-parse HEAD` check yet still can't sync (or worse,
+ * syncs "successfully" importing nothing, then silently never notices the
+ * untracked files change — the exact silent-staleness class #2707 exists to
+ * prevent). A directory that's `git init`ed but never committed, or where
+ * this specific path was never `git add`ed, fails this check either way.
  */
-export function hasGitCommits(path: string): boolean {
+export function hasTrackedContent(path: string): boolean {
   try {
-    execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+    const out = execFileSync('git', ['-C', path, 'ls-tree', 'HEAD', '--', '.'], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 10_000,
+      timeout: 30_000,
       env: { ...process.env, ...GIT_ENV },
     });
-    return true;
+    return out.toString().trim().length > 0;
   } catch {
     return false;
   }

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -325,32 +325,44 @@ export function isInsideGitRepo(path: string): boolean {
   }
 }
 
+/** SHA-1 of git's canonical empty tree object — identical in every SHA-1
+ * git repository (a deterministic hash of a fixed, zero-entry tree
+ * structure), independent of repo content or history. Used by
+ * `hasTrackedContent` below as an O(1)-output existence probe. (SHA-256
+ * repos, an opt-in `--object-format=sha256` git 2.29+ feature not used
+ * anywhere else in this codebase, would need the SHA-256 equivalent —
+ * not handled here.) */
+const EMPTY_TREE_SHA1 = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
 /**
  * True if `path`'s HEAD tree has at least one tracked entry scoped to
- * `path` itself, per `git ls-tree HEAD -- .` (non-recursive — one entry is
- * enough to know the tree isn't empty; no need to walk the whole subtree).
- * `-C path` + pathspec `.` scopes the listing to `path`, so this is correct
- * for both a repo's toplevel AND a subdirectory-of-a-repo source.
+ * `path` itself. `-C path` + the `HEAD:./` revision syntax resolves the
+ * tree object for `path` specifically (not the whole repo root), so this
+ * is correct for both a repo's toplevel AND a subdirectory-of-a-repo
+ * source — then a single SHA comparison against git's well-known
+ * empty-tree object tells us whether that tree is empty. #2707 codex
+ * round 3 (P2): unlike listing (`ls-tree`), this is O(1) output — no
+ * `maxBuffer` exposure on a repo with a very large number of entries.
  *
- * Subsumes "no commits at all" (`ls-tree HEAD` on an unborn repo fails —
- * there's no HEAD to resolve) AND the narrower "has a HEAD commit but it's
- * empty" case (#2707 codex round 2): `git commit --allow-empty` followed by
- * creating untracked files resolves `HEAD:.` successfully (to git's
- * well-known empty-tree object) but lists zero entries — a directory that
- * would pass a bare `rev-parse HEAD` check yet still can't sync (or worse,
- * syncs "successfully" importing nothing, then silently never notices the
- * untracked files change — the exact silent-staleness class #2707 exists to
- * prevent). A directory that's `git init`ed but never committed, or where
- * this specific path was never `git add`ed, fails this check either way.
+ * Subsumes "no commits at all" (`HEAD:./` on an unborn repo fails to
+ * resolve — there's no HEAD) AND "has a HEAD commit but it's empty"
+ * (#2707 codex round 2): `git commit --allow-empty` followed by creating
+ * untracked files resolves `HEAD:./` successfully (to the empty-tree SHA
+ * below) but that tree has zero entries — a directory that would pass a
+ * bare `rev-parse HEAD` check yet still can't sync (or worse, "succeeds"
+ * importing nothing and then never notices the untracked files change —
+ * the silent-staleness class #2707 exists to prevent). A directory
+ * that's `git init`ed but never committed, or where this specific path
+ * was never `git add`ed, fails this check either way.
  */
 export function hasTrackedContent(path: string): boolean {
   try {
-    const out = execFileSync('git', ['-C', path, 'ls-tree', 'HEAD', '--', '.'], {
+    const out = execFileSync('git', ['-C', path, 'rev-parse', '--verify', 'HEAD:./'], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 30_000,
+      timeout: 10_000,
       env: { ...process.env, ...GIT_ENV },
     });
-    return out.toString().trim().length > 0;
+    return out.toString().trim() !== EMPTY_TREE_SHA1;
   } catch {
     return false;
   }

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -325,6 +325,28 @@ export function isInsideGitRepo(path: string): boolean {
   }
 }
 
+/**
+ * True if `path` has at least one commit reachable from HEAD, per
+ * `git rev-parse HEAD`. A directory that's `git init`ed but never committed
+ * passes `isInsideGitRepo` yet still can't sync — `sync.ts` throws
+ * "No commits in repo ... Make at least one commit before syncing." Checking
+ * this too at `addSource` registration time (#2707 codex round 1) turns that
+ * later, easy-to-miss sync failure into an immediate one, matching the error
+ * copy's existing "files actually committed" claim.
+ */
+export function hasGitCommits(path: string): boolean {
+  try {
+    execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      env: { ...process.env, ...GIT_ENV },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ── Durability helpers (v0.42.44) ───────────────────────────────────────────
 // Used by the brain-repo durability feature (`gbrain sources harden/pull`) and
 // the DB-free pull cron. These are the auth-capable, rebase-aware counterparts

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -303,6 +303,28 @@ export function validateRepoState(
   return 'healthy';
 }
 
+/**
+ * True if `path` is itself a git repo OR a subdirectory of one, per
+ * `git rev-parse --show-toplevel`. Mirrors the walk-up discovery
+ * `sync.ts:discoverGitRoot` performs at sync time (#753/#774 — subdir-of-git
+ * sources are valid), so a directory that passes this check is guaranteed
+ * not to hit sync's "Not inside a git repository" error later. Used by
+ * `addSource` (#2707) to validate `--path` at registration time instead of
+ * deferring the failure to the first sync.
+ */
+export function isInsideGitRepo(path: string): boolean {
+  try {
+    execFileSync('git', ['-C', path, 'rev-parse', '--show-toplevel'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      env: { ...process.env, ...GIT_ENV },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ── Durability helpers (v0.42.44) ───────────────────────────────────────────
 // Used by the brain-repo durability feature (`gbrain sources harden/pull`) and
 // the DB-free pull cron. These are the auth-capable, rebase-aware counterparts

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -46,7 +46,7 @@ import {
   cloneRepo,
   validateRepoState,
   isInsideGitRepo,
-  hasGitCommits,
+  hasTrackedContent,
   RemoteUrlError,
   GitOperationError,
   type RepoState,
@@ -479,25 +479,29 @@ export async function addSource(
     // report ("plain directory accepted, sync fails later") rather than a
     // broader "does this path exist" check nobody asked for.
     //
-    // Both isInsideGitRepo AND hasGitCommits must hold: a `git init`ed-but-
-    // never-committed directory passes the first check yet still can't sync
-    // (codex round 1 finding — sync.ts throws "No commits in repo ...").
+    // Both isInsideGitRepo AND hasTrackedContent must hold. isInsideGitRepo
+    // alone lets through a `git init`ed-but-never-committed directory (fails
+    // sync's "No commits in repo ..."), AND an empty-commit-then-untracked-
+    // files directory (git resolves HEAD fine but the tree is empty — the
+    // exact silent-staleness footgun #2707(c) describes: sync "succeeds"
+    // importing nothing, then never notices the untracked files change).
+    // hasTrackedContent's `ls-tree HEAD -- .` catches both (codex round 2).
     if (
       opts.localPath &&
       !opts.force &&
       existsSync(opts.localPath) &&
-      (!isInsideGitRepo(opts.localPath) || !hasGitCommits(opts.localPath))
+      (!isInsideGitRepo(opts.localPath) || !hasTrackedContent(opts.localPath))
     ) {
       const q = shellQuote(opts.localPath);
       throw new SourceOpError(
         'not_a_git_repo',
-        `"${opts.localPath}" is not a git repository with at least one commit ` +
+        `"${opts.localPath}" is not a git repository with committed, tracked files ` +
           `(or a subdirectory of one). GBrain sync requires every --path source to ` +
-          `be git-initialized, with the files actually committed (an empty commit is ` +
-          `not enough — the walker reads through git objects, so untracked files stay ` +
-          `invisible). Fix: \`git -C ${q} init && git -C ${q} add -A && git -C ${q} ` +
-          `commit -m "initial import"\`, then re-run this command. To register ` +
-          `anyway and git-init later, pass --force.`,
+          `be git-initialized, with the files actually committed — an empty commit ` +
+          `is not enough (the walker reads through git objects, so untracked files ` +
+          `stay invisible). Fix: \`git -C ${q} init && git -C ${q} add -A && ` +
+          `git -C ${q} commit -m "initial import"\`, then re-run this command. To ` +
+          `register anyway and git-init later, pass --force.`,
       );
     }
     const config: Record<string, unknown> = {};

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -46,6 +46,7 @@ import {
   cloneRepo,
   validateRepoState,
   isInsideGitRepo,
+  hasGitCommits,
   RemoteUrlError,
   GitOperationError,
   type RepoState,
@@ -165,6 +166,20 @@ export interface RemoveSourceOpts {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * POSIX single-quote `arg` unless it's already shell-safe. #2707 codex round
+ * 1: the `not_a_git_repo` remediation error prints a pasteable `git ...`
+ * command built from the caller-supplied path — spaces, `$()`, backticks,
+ * etc. must be inert literals when pasted, which double-quoting would not
+ * guarantee (command substitution still runs inside "..."). Mirrors
+ * `src/commands/connect.ts:shellQuote` (not imported — that file is a
+ * commands/ caller of core/, not the other way around).
+ */
+function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_.:/@-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
 
 /**
  * Validate via the canonical regex from `source-id.ts` but rethrow as the
@@ -463,21 +478,26 @@ export async function addSource(
     // gating on existsSync keeps this a fail-fast check on the exact bug
     // report ("plain directory accepted, sync fails later") rather than a
     // broader "does this path exist" check nobody asked for.
+    //
+    // Both isInsideGitRepo AND hasGitCommits must hold: a `git init`ed-but-
+    // never-committed directory passes the first check yet still can't sync
+    // (codex round 1 finding — sync.ts throws "No commits in repo ...").
     if (
       opts.localPath &&
       !opts.force &&
       existsSync(opts.localPath) &&
-      !isInsideGitRepo(opts.localPath)
+      (!isInsideGitRepo(opts.localPath) || !hasGitCommits(opts.localPath))
     ) {
+      const q = shellQuote(opts.localPath);
       throw new SourceOpError(
         'not_a_git_repo',
-        `"${opts.localPath}" is not a git repository (or a subdirectory of one). ` +
-          `GBrain sync requires every --path source to be git-initialized, with the ` +
-          `files actually committed (an empty commit is not enough — the walker reads ` +
-          `through git objects, so untracked files stay invisible). Fix: ` +
-          `\`git -C ${opts.localPath} init && git -C ${opts.localPath} add -A && ` +
-          `git -C ${opts.localPath} commit -m "initial import"\`, then re-run this ` +
-          `command. To register anyway and git-init later, pass --force.`,
+        `"${opts.localPath}" is not a git repository with at least one commit ` +
+          `(or a subdirectory of one). GBrain sync requires every --path source to ` +
+          `be git-initialized, with the files actually committed (an empty commit is ` +
+          `not enough — the walker reads through git objects, so untracked files stay ` +
+          `invisible). Fix: \`git -C ${q} init && git -C ${q} add -A && git -C ${q} ` +
+          `commit -m "initial import"\`, then re-run this command. To register ` +
+          `anyway and git-init later, pass --force.`,
       );
     }
     const config: Record<string, unknown> = {};

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -45,6 +45,7 @@ import {
   parseRemoteUrl,
   cloneRepo,
   validateRepoState,
+  isInsideGitRepo,
   RemoteUrlError,
   GitOperationError,
   type RepoState,
@@ -67,7 +68,8 @@ export type SourceOpErrorCode =
   | 'protected_id'
   | 'clone_dir_outside_gbrain'
   | 'symlink_escape'
-  | 'unmanaged_path';
+  | 'unmanaged_path'
+  | 'not_a_git_repo';
 
 export class SourceOpError extends Error {
   constructor(
@@ -145,6 +147,13 @@ export interface AddSourceOpts {
    * Only honored when remoteUrl is set.
    */
   cloneDir?: string;
+  /**
+   * Skip the #2707 git-repo validation on `localPath`. Opt-in escape hatch
+   * for registering a path before it's git-initialized (e.g. an automated
+   * pipeline that populates + `git init`s the directory after `sources add`
+   * runs). Does NOT auto-`git init` anything — see `addSource` docstring.
+   */
+  force?: boolean;
 }
 
 export interface RemoveSourceOpts {
@@ -310,6 +319,18 @@ export function unownedHint(
 
 // ── addSource ───────────────────────────────────────────────────────────────
 
+/**
+ * #2707: `--path` registration used to accept any existing directory with
+ * zero git validation, deferring the failure to the first `gbrain sync`
+ * ("Not inside a git repository: ..."). By the time that surfaces the
+ * source has already been silently stale for however long nobody read the
+ * sync logs. This is registration-time, fail-fast validation ONLY — it
+ * never auto-`git init`s the directory (that would cross the consent
+ * boundary #2967 established for sync-time self-heal: a `--path` source is
+ * the user's own external directory, and gbrain must not mutate it without
+ * explicit ask). Callers who want to register before git-init exists opt in
+ * via `force: true` (CLI: `--force`).
+ */
 export async function addSource(
   engine: BrainEngine,
   opts: AddSourceOpts,
@@ -437,6 +458,28 @@ export async function addSource(
     }
   } else {
     // ── Path B: --path or no path (existing behavior, pre-v0.28) ─────────
+    // #2707: only validate when the path actually exists — a not-yet-created
+    // path is a different (pre-existing, out of scope) failure mode, and
+    // gating on existsSync keeps this a fail-fast check on the exact bug
+    // report ("plain directory accepted, sync fails later") rather than a
+    // broader "does this path exist" check nobody asked for.
+    if (
+      opts.localPath &&
+      !opts.force &&
+      existsSync(opts.localPath) &&
+      !isInsideGitRepo(opts.localPath)
+    ) {
+      throw new SourceOpError(
+        'not_a_git_repo',
+        `"${opts.localPath}" is not a git repository (or a subdirectory of one). ` +
+          `GBrain sync requires every --path source to be git-initialized, with the ` +
+          `files actually committed (an empty commit is not enough — the walker reads ` +
+          `through git objects, so untracked files stay invisible). Fix: ` +
+          `\`git -C ${opts.localPath} init && git -C ${opts.localPath} add -A && ` +
+          `git -C ${opts.localPath} commit -m "initial import"\`, then re-run this ` +
+          `command. To register anyway and git-init later, pass --force.`,
+      );
+    }
     const config: Record<string, unknown> = {};
     if (opts.federated !== null && opts.federated !== undefined) {
       config.federated = opts.federated;

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -946,6 +946,63 @@ describe('addSource --path — #2707 git-repo validation', () => {
     expect(row.local_path).toBe(bigDir);
   });
 
+  // Codex round 4 (P2): the empty-tree OID is hash-algorithm-specific — a
+  // hardcoded SHA-1 constant silently mismatched (and so accepted) an empty
+  // SHA-256 repo. --object-format=sha256 needs git 2.29+; skip rather than
+  // hard-fail on an older CI git.
+  const SHA256_SUPPORTED = (() => {
+    try {
+      const probe = join(tmpdir(), `gbrain-2707-sha256-probe-${process.pid}`);
+      mkdirSync(probe, { recursive: true });
+      execFileSync('git', ['-C', probe, 'init', '-q', '--object-format=sha256'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      rmSync(probe, { recursive: true, force: true });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  test.skipIf(!SHA256_SUPPORTED)(
+    'rejects an empty-commit SHA-256 repo the same as a SHA-1 one (codex round 4)',
+    async () => {
+      const sha256Dir = join(SANDBOX, 'sha256-empty');
+      mkdirSync(sha256Dir, { recursive: true });
+      execFileSync('git', ['-C', sha256Dir, 'init', '-q', '--object-format=sha256']);
+      execFileSync('git', ['-C', sha256Dir, 'config', 'user.email', 'test@example.com']);
+      execFileSync('git', ['-C', sha256Dir, 'config', 'user.name', 'Test']);
+      execFileSync('git', ['-C', sha256Dir, 'commit', '--allow-empty', '-q', '-m', 'empty']);
+      writeFileSync(join(sha256Dir, 'notes.md'), 'never committed');
+
+      let threw: SourceOpError | undefined;
+      try {
+        await addSource(engine, { id: 'sha256-empty-src', localPath: sha256Dir });
+      } catch (e) {
+        threw = e as SourceOpError;
+      }
+      expect(threw).toBeInstanceOf(SourceOpError);
+      expect(threw?.code).toBe('not_a_git_repo');
+    },
+  );
+
+  test.skipIf(!SHA256_SUPPORTED)(
+    'registers a SHA-256 repo with real committed content (no regression)',
+    async () => {
+      const sha256Dir = join(SANDBOX, 'sha256-real');
+      mkdirSync(sha256Dir, { recursive: true });
+      writeFileSync(join(sha256Dir, 'README.md'), '# fixture');
+      execFileSync('git', ['-C', sha256Dir, 'init', '-q', '--object-format=sha256']);
+      execFileSync('git', ['-C', sha256Dir, 'config', 'user.email', 'test@example.com']);
+      execFileSync('git', ['-C', sha256Dir, 'config', 'user.name', 'Test']);
+      execFileSync('git', ['-C', sha256Dir, 'add', '-A']);
+      execFileSync('git', ['-C', sha256Dir, 'commit', '-q', '-m', 'initial import']);
+
+      const row = await addSource(engine, { id: 'sha256-real-src', localPath: sha256Dir });
+      expect(row.local_path).toBe(sha256Dir);
+    },
+  );
+
   test('quotes a path with a space in the remediation command (codex round 1)', async () => {
     const spacedDir = join(SANDBOX, 'has space here');
     mkdirSync(spacedDir, { recursive: true });

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -925,6 +925,27 @@ describe('addSource --path — #2707 git-repo validation', () => {
     expect(threw?.code).toBe('not_a_git_repo');
   });
 
+  test('registers a repo with many tracked entries without buffer-size false rejection (codex round 3)', async () => {
+    // Codex round 3 (P2): the earlier `git ls-tree` listing implementation
+    // buffered the whole tree and could exceed execFileSync's default 1 MiB
+    // maxBuffer on a large repo, causing an incorrect rejection. The
+    // rev-parse HEAD:./ + empty-tree-SHA-comparison implementation reads a
+    // fixed ~40-byte SHA regardless of tree size — this locks that in.
+    const bigDir = join(SANDBOX, 'many-entries');
+    mkdirSync(bigDir, { recursive: true });
+    for (let i = 0; i < 300; i++) {
+      writeFileSync(join(bigDir, `file-${i}.md`), `# entry ${i}`);
+    }
+    execFileSync('git', ['-C', bigDir, 'init', '-q']);
+    execFileSync('git', ['-C', bigDir, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', bigDir, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', bigDir, 'add', '-A']);
+    execFileSync('git', ['-C', bigDir, 'commit', '-q', '-m', 'many files']);
+
+    const row = await addSource(engine, { id: 'many-entries-src', localPath: bigDir });
+    expect(row.local_path).toBe(bigDir);
+  });
+
   test('quotes a path with a space in the remediation command (codex round 1)', async () => {
     const spacedDir = join(SANDBOX, 'has space here');
     mkdirSync(spacedDir, { recursive: true });

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import {
   addSource,
@@ -358,7 +359,10 @@ describe('removeSource — clone-cleanup', () => {
       const userPath = join(GBRAIN_HOME, 'user-managed-fixture');
       mkdirSync(userPath, { recursive: true });
       writeFileSync(join(userPath, 'file'), 'hi');
-      await addSource(engine, { id: 'cleanup-no', localPath: userPath });
+      // #2707: this fixture is intentionally not a git repo (unrelated to
+      // what this test covers — clone-cleanup ownership) — force past the
+      // registration-time git check.
+      await addSource(engine, { id: 'cleanup-no', localPath: userPath, force: true });
       const result = await removeSource(engine, {
         id: 'cleanup-no',
         confirmDestructive: true,
@@ -485,8 +489,10 @@ describe('getSourceStatus', () => {
       // path-only source still gets validateRepoState — but with no expected
       // URL, it just probes existence + .git. Path exists with no .git → 'no-git'.
       // To match contract docstring we'd want 'not-applicable' only when
-      // local_path is null. Test the truthful behavior:
-      await addSource(engine, { id: 'status-no-url', localPath: userPath });
+      // local_path is null. Test the truthful behavior. #2707: this fixture
+      // is deliberately no-git (that's what's under test for getSourceStatus)
+      // — force past the registration-time git check to construct it.
+      await addSource(engine, { id: 'status-no-url', localPath: userPath, force: true });
       const s = await getSourceStatus(engine, 'status-no-url');
       // local_path set but no .git: returns 'no-git'
       expect(s.clone_state).toBe('no-git');
@@ -811,6 +817,100 @@ describe('addSource --url — writes ownership marker', () => {
       expect(recloned).toBe(true);
       expect(existsSync(join(externalClone, '.git'))).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addSource --path — #2707 git-repo validation at registration time
+//
+// Deliberately does NOT run under withEnv2 (the fake-git harness above):
+// writeFakeGit()'s catch-all `exit 0` would make `rev-parse --show-toplevel`
+// (and therefore isInsideGitRepo) succeed unconditionally for any path,
+// which defeats the point of these tests. Real system git applies here.
+// ---------------------------------------------------------------------------
+
+describe('addSource --path — #2707 git-repo validation', () => {
+  const SANDBOX = join(tmpdir(), `gbrain-2707-git-validate-${process.pid}`);
+
+  beforeEach(() => {
+    rmSync(SANDBOX, { recursive: true, force: true });
+    mkdirSync(SANDBOX, { recursive: true });
+  });
+  afterAll(() => {
+    rmSync(SANDBOX, { recursive: true, force: true });
+  });
+
+  test('rejects an existing non-git directory with an actionable error', async () => {
+    const plainDir = join(SANDBOX, 'plain');
+    mkdirSync(plainDir, { recursive: true });
+    writeFileSync(join(plainDir, 'notes.md'), 'not committed anywhere');
+
+    let threw: SourceOpError | undefined;
+    try {
+      await addSource(engine, { id: 'plain-src', localPath: plainDir });
+    } catch (e) {
+      threw = e as SourceOpError;
+    }
+    expect(threw).toBeInstanceOf(SourceOpError);
+    expect(threw?.code).toBe('not_a_git_repo');
+    expect(threw?.message).toContain(plainDir);
+    expect(threw?.message).toContain('--force');
+    expect(threw?.message).toMatch(/git .*init/);
+
+    // Source was never registered — no partial row left behind.
+    const rows = await engine.executeRaw<{ id: string }>(
+      `SELECT id FROM sources WHERE id = 'plain-src'`,
+    );
+    expect(rows.length).toBe(0);
+  });
+
+  test('--force bypasses the check and registers the plain directory as-is', async () => {
+    const plainDir = join(SANDBOX, 'plain-forced');
+    mkdirSync(plainDir, { recursive: true });
+
+    const row = await addSource(engine, {
+      id: 'plain-forced-src',
+      localPath: plainDir,
+      force: true,
+    });
+    expect(row.local_path).toBe(plainDir);
+  });
+
+  test('an already git-initialized directory registers unaffected (no regression)', async () => {
+    const gitDir = join(SANDBOX, 'gitrepo');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(join(gitDir, 'README.md'), '# fixture');
+    execFileSync('git', ['-C', gitDir, 'init', '-q']);
+    execFileSync('git', ['-C', gitDir, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', gitDir, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', gitDir, 'add', '-A']);
+    execFileSync('git', ['-C', gitDir, 'commit', '-q', '-m', 'initial import']);
+
+    const row = await addSource(engine, { id: 'gitrepo-src', localPath: gitDir });
+    expect(row.local_path).toBe(gitDir);
+  });
+
+  test('a subdirectory of a git repo registers unaffected (#753/#774 parity with sync-time discovery)', async () => {
+    const gitDir = join(SANDBOX, 'gitrepo-parent');
+    const subDir = join(gitDir, 'sub');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'README.md'), '# fixture');
+    execFileSync('git', ['-C', gitDir, 'init', '-q']);
+    execFileSync('git', ['-C', gitDir, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', gitDir, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', gitDir, 'add', '-A']);
+    execFileSync('git', ['-C', gitDir, 'commit', '-q', '-m', 'initial import']);
+
+    const row = await addSource(engine, { id: 'subdir-src', localPath: subDir });
+    expect(row.local_path).toBe(subDir);
+  });
+
+  test('a not-yet-created path is unaffected (pre-existing lenient behavior, out of #2707 scope)', async () => {
+    const missingDir = join(SANDBOX, 'does-not-exist-yet');
+    expect(existsSync(missingDir)).toBe(false);
+
+    const row = await addSource(engine, { id: 'missing-src', localPath: missingDir });
+    expect(row.local_path).toBe(missingDir);
   });
 });
 

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -864,6 +864,35 @@ describe('addSource --path — #2707 git-repo validation', () => {
     expect(rows.length).toBe(0);
   });
 
+  test('rejects a git-initialized directory with zero commits (codex round 1)', async () => {
+    const unbornDir = join(SANDBOX, 'unborn');
+    mkdirSync(unbornDir, { recursive: true });
+    execFileSync('git', ['-C', unbornDir, 'init', '-q']);
+    // No `git add` / `git commit` — isInsideGitRepo alone would pass this.
+
+    let threw: SourceOpError | undefined;
+    try {
+      await addSource(engine, { id: 'unborn-src', localPath: unbornDir });
+    } catch (e) {
+      threw = e as SourceOpError;
+    }
+    expect(threw).toBeInstanceOf(SourceOpError);
+    expect(threw?.code).toBe('not_a_git_repo');
+  });
+
+  test('quotes a path with a space in the remediation command (codex round 1)', async () => {
+    const spacedDir = join(SANDBOX, 'has space here');
+    mkdirSync(spacedDir, { recursive: true });
+
+    let threw: SourceOpError | undefined;
+    try {
+      await addSource(engine, { id: 'spaced-src', localPath: spacedDir });
+    } catch (e) {
+      threw = e as SourceOpError;
+    }
+    expect(threw?.message).toContain(`'${spacedDir}'`);
+  });
+
   test('--force bypasses the check and registers the plain directory as-is', async () => {
     const plainDir = join(SANDBOX, 'plain-forced');
     mkdirSync(plainDir, { recursive: true });

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -880,6 +880,51 @@ describe('addSource --path — #2707 git-repo validation', () => {
     expect(threw?.code).toBe('not_a_git_repo');
   });
 
+  test('rejects an empty-commit repo whose files are untracked (codex round 2)', async () => {
+    // git commit --allow-empty gives a resolvable HEAD (so a bare "has a
+    // commit" check would wrongly pass this) but the tree is empty; files
+    // written afterward are untracked and invisible to the sync walker.
+    const emptyCommitDir = join(SANDBOX, 'empty-commit');
+    mkdirSync(emptyCommitDir, { recursive: true });
+    execFileSync('git', ['-C', emptyCommitDir, 'init', '-q']);
+    execFileSync('git', ['-C', emptyCommitDir, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', emptyCommitDir, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', emptyCommitDir, 'commit', '--allow-empty', '-q', '-m', 'empty']);
+    writeFileSync(join(emptyCommitDir, 'notes.md'), 'never committed');
+
+    let threw: SourceOpError | undefined;
+    try {
+      await addSource(engine, { id: 'empty-commit-src', localPath: emptyCommitDir });
+    } catch (e) {
+      threw = e as SourceOpError;
+    }
+    expect(threw).toBeInstanceOf(SourceOpError);
+    expect(threw?.code).toBe('not_a_git_repo');
+  });
+
+  test('rejects an untracked subdirectory of an otherwise-real git repo (codex round 2)', async () => {
+    const parent = join(SANDBOX, 'partial-repo');
+    const trackedFile = join(parent, 'README.md');
+    const untrackedSub = join(parent, 'untracked-sub');
+    mkdirSync(untrackedSub, { recursive: true });
+    writeFileSync(trackedFile, '# fixture');
+    execFileSync('git', ['-C', parent, 'init', '-q']);
+    execFileSync('git', ['-C', parent, 'config', 'user.email', 'test@example.com']);
+    execFileSync('git', ['-C', parent, 'config', 'user.name', 'Test']);
+    execFileSync('git', ['-C', parent, 'add', 'README.md']);
+    execFileSync('git', ['-C', parent, 'commit', '-q', '-m', 'initial import']);
+    writeFileSync(join(untrackedSub, 'x.md'), 'never git add-ed');
+
+    let threw: SourceOpError | undefined;
+    try {
+      await addSource(engine, { id: 'partial-repo-src', localPath: untrackedSub });
+    } catch (e) {
+      threw = e as SourceOpError;
+    }
+    expect(threw).toBeInstanceOf(SourceOpError);
+    expect(threw?.code).toBe('not_a_git_repo');
+  });
+
   test('quotes a path with a space in the remediation command (codex round 1)', async () => {
     const spacedDir = join(SANDBOX, 'has space here');
     mkdirSync(spacedDir, { recursive: true });

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -6,7 +6,10 @@
  * shape, validation, and flag parsing.
  */
 
-import { describe, test, expect, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { runSources } from '../src/commands/sources.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
@@ -155,6 +158,47 @@ describe('sources add', () => {
     // New source at /tmp/gstack/plans is inside existing gstack at /tmp/gstack.
     await expect(runSources(engine, ['add', 'plans', '--path', '/tmp/gstack/plans']))
       .rejects.toThrow(/overlaps with existing source "gstack"/);
+  });
+});
+
+// ── add — #2707 git-repo validation (CLI wiring) ───────────────
+//
+// Uses a REAL on-disk temp dir (unlike the fake-path tests above) so the
+// core addSource git check actually runs; the stub engine still fakes the
+// DB round-trip. Confirms --force parses through to opsAddSource.
+
+describe('sources add — #2707 --force flag wiring', () => {
+  let plainDir: string;
+
+  beforeEach(() => {
+    plainDir = mkdtempSync(join(tmpdir(), 'gbrain-sources-cli-2707-'));
+  });
+  afterEach(() => {
+    rmSync(plainDir, { recursive: true, force: true });
+  });
+
+  test('rejects a real non-git --path directory by default', async () => {
+    const { engine } = makeStub();
+    await expect(runSources(engine, ['add', 'cli-plain', '--path', plainDir]))
+      .rejects.toThrow(/not a git repository/);
+  });
+
+  test('--force registers the same directory anyway', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [{
+        id: 'cli-forced',
+        name: 'cli-forced',
+        local_path: plainDir,
+        last_commit: null,
+        last_sync_at: null,
+        config: '{}',
+        created_at: new Date(),
+      }],
+    });
+    await runSources(engine, ['add', 'cli-forced', '--path', plainDir, '--force']);
+    const insert = calls.find(c => c.sql.includes('INSERT INTO sources'));
+    expect(insert).toBeDefined();
+    expect(insert!.params[2]).toBe(plainDir);
   });
 });
 

--- a/test/sync-sole-non-default-routing.test.ts
+++ b/test/sync-sole-non-default-routing.test.ts
@@ -164,9 +164,13 @@ describe('#1434 — runSync auto-routes to sole_non_default source', () => {
   test('2+ non-default sources: no auto-route, no nudge, falls through to default', async () => {
     // Both need local_path to be counted by the sole_non_default helper.
     // Pre-existing helper filters local_path IS NOT NULL.
+    // secondRepo is a bare temp dir (no git init) — its content is
+    // irrelevant to what this test verifies (that 2+ non-default sources
+    // disable auto-routing); --force skips #2707's registration-time git
+    // validation, which is orthogonal to this test's assertion.
     const secondRepo = mkdtempSync(join(tmpdir(), 'gbrain-snd-routing-second-'));
     await runSources(engine, ['add', 'studiovault', '--path', repoPath, '--no-federated']);
-    await runSources(engine, ['add', 'second-vault', '--path', secondRepo, '--no-federated']);
+    await runSources(engine, ['add', 'second-vault', '--path', secondRepo, '--no-federated', '--force']);
     const { runSync } = await import('../src/commands/sync.ts');
 
     const origWrite = process.stderr.write.bind(process.stderr);


### PR DESCRIPTION
## Summary

`sources add --path <dir>` registered a source with **zero git validation**, deferring the failure to the first `gbrain sync` ("Not inside a git repository: ..."). This adds registration-time validation, closing #2707's item (a) and (c), and documents that (b) — a stale/unreachable sync anchor — is already self-healing on current `master` (verified manually, see below; no code change needed there).

- `gbrain sources add <id> --path <dir>` now rejects an existing directory that isn't a git repo with committed, tracked content, with an actionable error pointing at `git init && git add -A && git commit`.
- `--force` opts back into the old lenient behavior for callers who want to register before an automated pipeline gets around to `git init`-ing the directory.
- A not-yet-created path is unaffected (out of scope — a different, pre-existing failure mode from the one this issue reports).
- Docs (`docs/guides/multi-source-brains.md`) now spell out the git requirement, including the "an empty commit is not enough" gotcha from #2707(c).

## Design: consistent with #2967's consent boundary

#2967 (merged) established that a `--path` source is the **user's own external directory** — sync-time self-heal must never silently `git init` it without consent. This PR is the other half of that same boundary: **validate at registration time** instead of mutating anything. It never auto-`git init`s a directory; `--force` is explicit opt-in to skip the check, not an auto-heal.

## What "git repo" actually means here

Went through 4 rounds of Codex review (`gpt-5.6-sol`, high effort) narrowing this down. The final check (`isInsideGitRepo` + `hasTrackedContent` in `src/core/git-remote.ts`) requires:

1. The path is a git repo or a subdirectory of one (mirrors `sync.ts`'s `discoverGitRoot` walk-up from #753/#774, so subdir-of-repo sources that sync fine also register fine).
2. HEAD resolves to a **non-empty tree scoped to that path** — catches not just "never committed" but the sneakier "`git commit --allow-empty` then dropped in untracked files" case, which would otherwise pass a naive "has a commit" check, "succeed" at sync while importing nothing, and then silently never notice the untracked files change (the exact silent-staleness class #2707 exists to prevent).

The emptiness check reads a single ~40-64 byte object ID (`git rev-parse --verify HEAD:./` vs. that repo's own empty-tree OID, derived per-repo via `git hash-object -t tree --stdin < /dev/null` so it's correct for SHA-256 repos too) rather than listing the tree — O(1) output regardless of repo size, no `maxBuffer` exposure.

## Item (b) — already fixed, verified manually

I built a local repro (fresh gbrain init + a scratch git source) to check whether #2707(b)'s stale-anchor complaints still reproduce on current `master`. They don't:

- **Anchor object genuinely missing** (history rewritten from scratch): `gbrain sync --source <id>` (no `--full` needed) prints `Sync anchor <sha> object missing (gc'd after history rewrite). Running full reimport.` and completes successfully, advancing the anchor. This is `sync.ts`'s #1970 fix (merged 2026-06-08, a month before #2707 was filed).
- **Anchor present but non-ancestor** (force-push / rebase): sync diffs directly against the orphaned bookmark and advances cleanly, no full reimport needed.

Neither case needs a manual `sources reset-anchor` command or DB surgery — `gbrain sync` self-heals both. Docs now say so explicitly.

## Codex review rounds (gpt-5.6-sol, high effort, 4 rounds)

1. **P2** unquoted path in the remediation shell command (breaks/mis-executes on paths with spaces/`$()`) → fixed with POSIX single-quoting (mirrors `connect.ts:shellQuote`).
2. **P2** `isInsideGitRepo` alone accepts a `git init`ed-but-never-committed dir → added a second, stronger check.
3. **P1** that check (`hasGitCommits`, bare `rev-parse HEAD`) still accepted an empty-commit-then-untracked-files repo → replaced with `hasTrackedContent` (tree-emptiness check scoped to the path).
4. **P2** the tree-emptiness check (`git ls-tree`) could exceed `execFileSync`'s 1 MiB default `maxBuffer` on a very large repo, incorrectly rejecting it → replaced listing with an O(1)-output OID comparison against the repo's empty-tree object.
5. **P2** (round 4) the empty-tree OID comparison hardcoded the SHA-1 constant, so an empty **SHA-256** repo (`git init --object-format=sha256`) slipped through → derive the OID per-repo instead of hardcoding it.

One round-3 finding I declined: rejecting a directory if **any** file anywhere under it is untracked (not just when the tree is entirely empty). Untracked files never being synced is standard, existing git-source behavior throughout this codebase — identical for `--url` managed clones — not a bug specific to this validation. Enforcing zero-untracked-files at registration would reject ordinary repos with gitignored build output, `.DS_Store`, editor swapfiles, etc.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test test/sources-ops.test.ts test/sources.test.ts` — 68 pass, 0 fail (13 new tests: rejection + `--force` + no-regression on real git repos/subdirs/not-yet-created paths + the empty-commit/untracked-subdir/large-tree/SHA-256 edge cases from the review rounds)
- [x] `bun run verify` — 31/31 checks green
- [x] Manual CLI repro: non-git dir rejected with the actionable message, `--force` registers it anyway, empty-commit-then-untracked-files dir rejected, stale/unreachable sync anchor self-heals on plain `gbrain sync` (both the "object missing" and "non-ancestor" sub-cases)

Fixes #2707.
