### PR TITLE
fix(autopilot): forward process.env to execSync under Bun (#2747)

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -109,7 +109,21 @@ function logError(phase: string, e: unknown) {
  */
 export function resolveGbrainCliPath(): string {
   try {
-    const which = execSync('which gbrain', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    // #2747: `env: process.env` is required under Bun. Bun's execSync
+    // snapshots process.env at Bun's OWN startup, not at call time — a
+    // runtime PATH mutation (dotenv/config loading, shell-profile sourcing
+    // in a wrapper, etc.) happening between Bun boot and this call is
+    // invisible to `which` without explicitly forwarding the current env.
+    // This is why "which gbrain" succeeds when run standalone (fresh Bun
+    // process, no prior mutation) but can fail from inside autopilot's own
+    // process at this exact call site. Same fix already applied to
+    // detectTini() in spawn-helpers.ts (see its comment) — this call site
+    // was missed.
+    const which = execSync('which gbrain', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      env: process.env,
+    }).trim();
     if (which) return which;
   } catch { /* not on $PATH — fall through */ }
 
@@ -123,7 +137,14 @@ export function resolveGbrainCliPath(): string {
     return arg1;
   }
 
-  throw new Error('Could not resolve the gbrain CLI path. Install gbrain so it is on $PATH (e.g. /usr/local/bin/gbrain), or run autopilot from the compiled binary directly.');
+  // #2747: include what we actually saw so an operator (or a future bug
+  // report) doesn't have to guess whether PATH/execPath/argv[1] looked
+  // sane at the moment of failure.
+  throw new Error(
+    'Could not resolve the gbrain CLI path. Install gbrain so it is on $PATH ' +
+      '(e.g. /usr/local/bin/gbrain), or run autopilot from the compiled binary directly. ' +
+      `Debug: PATH=${JSON.stringify(process.env.PATH ?? '')} execPath=${JSON.stringify(exec)} argv1=${JSON.stringify(arg1)}`,
+  );
 }
 
 export function shouldSpawnAutopilotWorker(args: string[]): boolean {

--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -100,7 +100,15 @@ function gbrainHome(): string {
  *  core→commands import). which gbrain → process.execPath → argv[1] → "gbrain". */
 function resolveGbrainCliPath(): string {
   try {
-    const which = execSync('which gbrain', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    // #2747: `env: process.env` required under Bun — see the sibling copy
+    // of this function in commands/autopilot.ts for the full explanation
+    // (Bun snapshots process.env at its own startup; execSync without an
+    // explicit env is blind to any PATH mutation since then).
+    const which = execSync('which gbrain', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      env: process.env,
+    }).trim();
     if (which) return which;
   } catch { /* not on PATH */ }
   const exec = process.execPath ?? '';


### PR DESCRIPTION
## Problem

Fixes #2747.

After migrating from PGLite to Postgres, `gbrain autopilot` triggers the
managed-worker dispatch path (`useMinionsDispatch` requires
`engineType === 'postgres'`), which calls `resolveGbrainCliPath()`. This
throws `Could not resolve the gbrain CLI path...` even though `gbrain` is
confirmed on `$PATH` — reproducing the exact same `execSync('which
gbrain')` call standalone, in the same shell/process context, succeeds.

Impact: since this only fires when `spawnManagedWorker` is true (Postgres
engine + minion_mode enabled), autopilot's dispatch loop keeps submitting
jobs but no worker ever picks them up — including embed jobs. This
silently accumulates stale/missing embeddings with no error surfaced;
`gbrain doctor` just shows a growing "N stale chunks" warning that reads
like an ordinary backlog, not a broken worker.

## Root cause

`resolveGbrainCliPath()` (both the copy in `src/commands/autopilot.ts`
and the inlined duplicate in `src/core/brain-repo-durability.ts`) calls
`execSync('which gbrain', {...})` without an explicit `env`. **Under Bun,
`execSync`/`execFileSync` snapshot `process.env` at Bun's own startup, not
at call time** — a runtime PATH mutation (dotenv/config loading, a
wrapper script sourcing a shell profile, etc.) happening after Bun boots
but before this call is invisible to `which` unless the current env is
forwarded explicitly.

This is a known, already-precedented Bun quirk in this exact codebase:
`spawn-helpers.ts`'s `detectTini()` was already fixed for the identical
symptom with the identical one-line fix (`env: process.env`), with a
comment explaining the mechanism. This call site was simply missed.

Verified directly (reproduced live during review):
```js
// {} → FAIL: Command failed: which gbrain
// {env: process.env} → succeeds, returns the resolved path
```

## Fix

- Forward `env: process.env` explicitly at both `resolveGbrainCliPath()`
  call sites (`autopilot.ts`, `brain-repo-durability.ts`).
- Improved the throw-path error message to include the actual
  `PATH`/`execPath`/`argv[1]` values observed at failure time, so a
  future report doesn't require guessing.

## Out of scope (flagged, not fixed here)

A third call site with the identical missing-`env` pattern exists in
`src/core/claw-test/runners/openclaw.ts` (`'which openclaw'`). Left out
of scope since this PR is specifically about #2747's reported symptom;
worth a small follow-up.

## Test plan

- `bun run typecheck` — clean.
- `bun run verify` — 31/31 green.
- `test/autopilot-resolve-cli.test.ts` — 4/4 pass (existing coverage, no
  regressions). A genuinely-simulated Bun-env-snapshot race isn't
  reproducible in a same-process unit test, and this codebase's own
  convention explicitly avoids `mock.module` for `child_process` per
  `doctor-orphan-ratio.test.ts`'s stated test-isolation rule — this PR
  relies on the fix's precedent-match plus the live repro above rather
  than a new mock-based regression test.
- `codex review -c model="gpt-5.6-sol" -c model_reasoning_effort="high"
  --base origin/master` — clean, and independently reproduced the exact
  Bun behavior live (see snippet above) before signing off.
- Noted: `test/brain-durability-hook.serial.test.ts` shows a flaky
  git-lock-contention failure when run together with other
  `.serial.test.ts` files in one `bun test` invocation (test-harness
  artifact of combining serial-suffixed files, not a regression —
  confirmed by running it in isolation, on `origin/master`, and repeatedly
  in this branch's worktree, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
