### PR TITLE
fix(search): drop compiled_truth from pages.search_vector — overflows tsvector on large pages (#2704)

### DIFF
--- a/src/commands/reindex-search-vector.ts
+++ b/src/commands/reindex-search-vector.ts
@@ -179,10 +179,16 @@ export async function runReindexSearchVector(
   }
 
   // Recreate trigger functions. The strings are intentionally identical to
-  // the v123 migration body — keeping them in lockstep is the contract.
+  // the v124 migration body — keeping them in lockstep is the contract.
   // `SET search_path = pg_catalog, public` mirrors the v120/#1647 hardening:
   // CREATE OR REPLACE resets proconfig, so omitting it here would strip the
   // hardening from every brain that runs this command.
+  //
+  // #2704: compiled_truth (the unbounded whole-page body) is deliberately
+  // NOT indexed here — it overflows Postgres's 1MB tsvector cap on large
+  // pages, and content_chunks.search_vector (populated separately, chunk-
+  // grain, well under the cap) is what searchKeyword() actually queries.
+  // See migrate.ts's v124 for the full rationale; keep this copy in sync.
   const recreatePagesFn = `
     CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger SET search_path = pg_catalog, public AS $fn$
     DECLARE
@@ -195,7 +201,6 @@ export async function runReindexSearchVector(
 
       NEW.search_vector :=
         setweight(to_tsvector('${lang}', coalesce(NEW.title, '')), 'A') ||
-        setweight(to_tsvector('${lang}', coalesce(NEW.compiled_truth, '')), 'B') ||
         setweight(to_tsvector('${lang}', coalesce(NEW.timeline, '')), 'C') ||
         setweight(to_tsvector('${lang}', coalesce(timeline_text, '')), 'C');
 

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5596,6 +5596,74 @@ export const MIGRATIONS: Migration[] = [
       console.log(`  v123: trigger functions recreated with language='${lang}' + backfilled existing rows`);
     },
   },
+  {
+    version: 124,
+    name: 'page_search_vector_drop_compiled_truth',
+    // #2704: a single markdown page whose compiled_truth exceeds Postgres's
+    // hard 1,048,575-byte tsvector cap made update_page_search_vector()
+    // throw "string is too long for tsvector" INSIDE the pages UPSERT
+    // transaction — not a per-file ledger entry, a transaction abort. The
+    // whole source's sync checkpoint stayed pinned (Sync BLOCKED) until the
+    // oversized file was fixed or manually skipped, even though every
+    // OTHER file in the run imported fine.
+    //
+    // Fix: drop compiled_truth (the unbounded whole-page body) from this
+    // trigger. It was already redundant — content_chunks.search_vector
+    // (Cathedral II Layer 3, v0.20.0) is the ACTUAL keyword-search source:
+    // searchKeyword() in postgres-engine.ts/pglite-engine.ts ranks and
+    // queries `cc.search_vector` exclusively; `pages.search_vector` is
+    // written by this trigger but never read by any query in this
+    // codebase (verified: no `pages.search_vector`/bare `search_vector`
+    // appears on either side of a WHERE/ts_rank anywhere outside this
+    // trigger's own definition and the reindex/backfill machinery that
+    // maintains it). And chunking already bounds each chunk_text well
+    // under the tsvector limit (chunkText() targets embedding-sized
+    // pieces, several orders of magnitude smaller than 1MB) — the overflow
+    // was specific to the whole-page grain this trigger no longer builds.
+    //
+    // title + timeline (both naturally small — a compiled_truth-sized
+    // title or timeline field would be its own bug) stay, so
+    // pages.search_vector keeps carrying SOME signal rather than going
+    // fully inert; a future PR can drop the column outright once its
+    // last non-search consumer (if any turns up) is confirmed gone.
+    //
+    // No backfill: existing rows keep whatever search_vector they already
+    // computed until their next UPDATE (harmless — nothing reads this
+    // column, so staleness has zero behavioral effect). The brains that
+    // actually hit this bug never successfully wrote a value for the
+    // oversized page in the first place, so there's nothing stale to fix
+    // for them specifically — the NEXT sync of that exact file is what
+    // proves the fix, not a backfill of already-working rows.
+    //
+    // Function body mirrors reindex-search-vector.ts's recreatePagesFn
+    // (documented contract there: keep both in lockstep) and the fresh-
+    // install baselines in pglite-schema.ts / schema-embedded.ts — all
+    // four updated in the same commit as this migration.
+    sql: '',
+    handler: async (engine) => {
+      const lang = getFtsLanguage();
+      await engine.executeRaw(`
+        CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger SET search_path = pg_catalog, public AS $fn$
+        DECLARE
+          timeline_text TEXT;
+        BEGIN
+          SELECT coalesce(string_agg(summary || ' ' || detail, ' '), '')
+          INTO timeline_text
+          FROM timeline_entries
+          WHERE page_id = NEW.id;
+
+          NEW.search_vector :=
+            setweight(to_tsvector('${lang}', coalesce(NEW.title, '')), 'A') ||
+            setweight(to_tsvector('${lang}', coalesce(NEW.timeline, '')), 'C') ||
+            setweight(to_tsvector('${lang}', coalesce(timeline_text, '')), 'C');
+
+          RETURN NEW;
+        END;
+        $fn$ LANGUAGE plpgsql;
+      `);
+      console.log(`  v124: update_page_search_vector() no longer indexes compiled_truth (was overflowing tsvector on large pages, #2704)`);
+    },
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -1022,6 +1022,12 @@ ALTER TABLE pages ADD COLUMN IF NOT EXISTS search_vector tsvector;
 
 CREATE INDEX IF NOT EXISTS idx_pages_search ON pages USING GIN(search_vector);
 
+-- #2704: compiled_truth (unbounded whole-page body) deliberately NOT
+-- indexed — overflows Postgres's 1MB tsvector cap on large pages.
+-- content_chunks.search_vector (chunk-grain, populated separately) is
+-- what searchKeyword() actually queries. See migrate.ts's v124 migration
+-- for the full rationale; keep in sync with that + reindex-search-vector.ts
+-- + schema-embedded.ts.
 CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger SET search_path = pg_catalog, public AS $$
 DECLARE
   timeline_text TEXT;
@@ -1033,7 +1039,6 @@ BEGIN
 
   NEW.search_vector :=
     setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
-    setweight(to_tsvector('english', coalesce(NEW.compiled_truth, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(NEW.timeline, '')), 'C') ||
     setweight(to_tsvector('english', coalesce(timeline_text, '')), 'C');
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -830,6 +830,12 @@ ALTER TABLE pages ADD COLUMN IF NOT EXISTS search_vector tsvector;
 CREATE INDEX IF NOT EXISTS idx_pages_search ON pages USING GIN(search_vector);
 
 -- Function to rebuild search_vector for a page
+-- #2704: compiled_truth (unbounded whole-page body) deliberately NOT
+-- indexed — overflows Postgres's 1MB tsvector cap on large pages.
+-- content_chunks.search_vector (chunk-grain, populated separately) is
+-- what searchKeyword() actually queries. See migrate.ts's v124 migration
+-- for the full rationale; keep in sync with that + reindex-search-vector.ts
+-- + pglite-schema.ts.
 CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger SET search_path = pg_catalog, public AS \$\$
 DECLARE
   timeline_text TEXT;
@@ -843,7 +849,6 @@ BEGIN
   -- Build weighted tsvector
   NEW.search_vector :=
     setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
-    setweight(to_tsvector('english', coalesce(NEW.compiled_truth, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(NEW.timeline, '')), 'C') ||
     setweight(to_tsvector('english', coalesce(timeline_text, '')), 'C');
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -826,6 +826,12 @@ ALTER TABLE pages ADD COLUMN IF NOT EXISTS search_vector tsvector;
 CREATE INDEX IF NOT EXISTS idx_pages_search ON pages USING GIN(search_vector);
 
 -- Function to rebuild search_vector for a page
+-- #2704: compiled_truth (unbounded whole-page body) deliberately NOT
+-- indexed — overflows Postgres's 1MB tsvector cap on large pages.
+-- content_chunks.search_vector (chunk-grain, populated separately) is
+-- what searchKeyword() actually queries. See migrate.ts's v124 migration
+-- for the full rationale; keep in sync with that + reindex-search-vector.ts
+-- + pglite-schema.ts.
 CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger SET search_path = pg_catalog, public AS $$
 DECLARE
   timeline_text TEXT;
@@ -839,7 +845,6 @@ BEGIN
   -- Build weighted tsvector
   NEW.search_vector :=
     setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
-    setweight(to_tsvector('english', coalesce(NEW.compiled_truth, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(NEW.timeline, '')), 'C') ||
     setweight(to_tsvector('english', coalesce(timeline_text, '')), 'C');
 

--- a/test/fts-language-migration.serial.test.ts
+++ b/test/fts-language-migration.serial.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import type { BrainEngine } from '../src/core/engine.ts';
-import { MIGRATIONS, LATEST_VERSION } from '../src/core/migrate.ts';
+import { MIGRATIONS } from '../src/core/migrate.ts';
 import { resetFtsLanguageCache } from '../src/core/fts-language.ts';
 
 const ENV_KEY = 'GBRAIN_FTS_LANGUAGE';
@@ -24,9 +24,11 @@ describe('configurable_fts_language migration', () => {
     expect(ftsMig?.version).toBeGreaterThan(115);
   });
 
-  test('fts migration is the latest migration', () => {
-    expect(MIGRATIONS.find(m => m.name === 'configurable_fts_language')?.version).toBe(LATEST_VERSION);
-  });
+  // #2704 (v124, page_search_vector_drop_compiled_truth) landed after this
+  // migration — "is the latest migration" was only ever true at the
+  // moment v123 was added and would break on every subsequent migration,
+  // so it's removed rather than bumped to a hardcoded v124. The
+  // registration + shape assertions below don't depend on migration order.
 
   test('ftsMig uses handler (not static SQL) because language interpolation is dynamic', () => {
     const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');

--- a/test/page-search-vector-overflow.test.ts
+++ b/test/page-search-vector-overflow.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #2704 — a single markdown page whose compiled_truth exceeds Postgres's
+ * hard 1,048,575-byte tsvector cap made update_page_search_vector() throw
+ * "string is too long for tsvector" INSIDE the pages UPSERT transaction,
+ * blocking the whole source's sync checkpoint (Sync BLOCKED) even though
+ * every other file in the run imported fine.
+ *
+ * v124 (migrate.ts) drops compiled_truth from the trigger — it was
+ * already redundant with content_chunks.search_vector (chunk-grain,
+ * populated separately and well under the tsvector cap), which is what
+ * searchKeyword() actually queries.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+// #2704: the 1,048,575-byte tsvector cap is on to_tsvector's SERIALIZED
+// OUTPUT (lexemes + position lists), not the raw input byte length —
+// repeating the same few words produces a tiny deduplicated vector
+// regardless of input size (verified: a 2.2MB string of 5 repeated words
+// does NOT overflow). Genuinely diverse, mostly-unique tokens are what
+// blows the output past the cap, matching a real large export (a Google
+// Docs dump, a long mailing-list thread) where the words don't repeat
+// like lorem-ipsum filler does.
+const OVERSIZED_BODY = Array.from({ length: 200_000 }, (_, i) => `token${i.toString(36)}`).join(' '); // ~2MB, ~2.7MB serialized tsvector
+
+describe('#2704: oversized page body no longer overflows pages.search_vector', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  }, 60_000);
+
+  afterAll(async () => {
+    await engine.disconnect();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  });
+
+  test('putPage with a >1MB compiled_truth succeeds (previously threw "string is too long for tsvector")', async () => {
+    expect(OVERSIZED_BODY.length).toBeGreaterThan(1_048_575);
+
+    const page = await engine.putPage('oversized-page', {
+      type: 'note',
+      title: 'Oversized Page',
+      compiled_truth: OVERSIZED_BODY,
+    });
+
+    expect(page).not.toBeNull();
+    expect(page.slug).toBe('oversized-page');
+  }, 30_000);
+
+  test('an oversized page is still keyword-searchable via chunk-grain search after import', async () => {
+    // Mirrors import-file.ts: chunking is what actually feeds
+    // content_chunks.search_vector, independent of the pages-level
+    // trigger this fix touches. A distinctive token near the start proves
+    // the chunk (not just the page row) is queryable.
+    const distinctiveBody = `zzdistinctivetoken2704 ${OVERSIZED_BODY}`;
+    await engine.putPage('oversized-searchable', {
+      type: 'note',
+      title: 'Oversized Searchable',
+      compiled_truth: distinctiveBody,
+    });
+    const { chunkText } = await import('../src/core/chunkers/recursive.ts');
+    let chunkIndex = 0;
+    const chunks = chunkText(distinctiveBody).map((c) => ({
+      chunk_index: chunkIndex++,
+      chunk_text: c.text,
+      chunk_source: 'compiled_truth' as const,
+    }));
+    await engine.upsertChunks('oversized-searchable', chunks);
+
+    const results = await engine.searchKeyword('zzdistinctivetoken2704');
+    expect(results.some((r) => r.slug === 'oversized-searchable')).toBe(true);
+  }, 30_000);
+
+  test('normal-sized page search_vector still carries title/timeline signal (not fully inert)', async () => {
+    await engine.putPage('small-page', {
+      type: 'note',
+      title: 'zzTitleToken2704',
+      compiled_truth: 'short body',
+    });
+    const rows = await engine.executeRaw<{ has_vector: boolean }>(
+      `SELECT search_vector IS NOT NULL AS has_vector FROM pages WHERE slug = 'small-page'`,
+    );
+    expect(rows[0]?.has_vector).toBe(true);
+  }, 30_000);
+});


### PR DESCRIPTION
## What

A single page whose `compiled_truth` (the whole-page body) exceeds Postgres's hard 1,048,575-byte tsvector cap made `update_page_search_vector()` throw `string is too long for tsvector` **inside the `pages` UPSERT transaction**. That's not a per-file ledger entry — it's a transaction abort, so the source's sync checkpoint stayed pinned (`Sync BLOCKED`) even though every other file in the run imported fine. `--retry-failed` re-failed the same file every run; only the 3-consecutive-failure auto-skip eventually moved past it.

## Root cause

`pages.search_vector` indexed `compiled_truth` — the unbounded whole-page body — but nothing reads it. `searchKeyword()` (`postgres-engine.ts` / `pglite-engine.ts`) queries `content_chunks.search_vector` exclusively (chunk-grain, populated separately at import time via chunking, and comfortably under the tsvector cap since chunks target embedding-sized pieces). Verified: no `pages.search_vector` read exists anywhere outside this trigger's own definition and the reindex/backfill machinery that maintains it.

## Fix

v124 migration recreates `update_page_search_vector()` without `compiled_truth` — `title` + `timeline` stay (both naturally small), so the column keeps carrying some signal instead of going fully inert. Updated in lockstep (the contract `reindex-search-vector.ts` documents): `migrate.ts`'s new v124, `reindex-search-vector.ts`'s `recreatePagesFn`, and the fresh-install baselines in `pglite-schema.ts` + `src/schema.sql` (regenerates `schema-embedded.ts` via `bun run build:schema`).

No backfill: existing rows keep whatever `search_vector` they already computed until their next UPDATE — harmless, since nothing reads this column, and brains that hit this bug never successfully wrote a value for the oversized page in the first place.

**Considered and rejected** (from the issue): truncating `compiled_truth` to fit under the cap. Silent, position-dependent recall loss, and the byte cap doesn't line up with any natural token/character boundary for UTF-8 content. `content_chunks.search_vector` already gives full, untruncated chunk-grain coverage — truncating a now-redundant whole-page vector would trade a real bug for a subtler one.

## Design consultation

Investigated jointly with `masa-codex` (async design review over `agmsg`) before implementing. Their independent read of the codebase — `content_chunks.search_vector` already covers keyword search; `pages.search_vector`'s `compiled_truth` feed is the only overflow-prone, effectively-dead write — matched my own verification and confirmed "remove from trigger" over the issue's alternatives (chunk-grain rebuild — largely already exists; truncation — rejected above; ledger-entry-only — insufficient alone, since the page upsert failing in the same transaction also loses the chunk write, so a ledger entry without this fix would make the content permanently unsearchable, not just delayed).

## Test plan

- New `test/page-search-vector-overflow.test.ts`: a >1MB page (genuinely diverse tokens — a repetitive lorem-ipsum fixture does **not** reproduce this bug, since the tsvector cap is on `to_tsvector`'s deduplicated output size, not raw input length) now imports successfully; stays keyword-searchable via the chunk-grain path; a normal page's `search_vector` still carries title signal. Verified both directions: reproduces the exact reported error on the pre-fix trigger (`string is too long for tsvector (2684620 bytes, max 1048575 bytes)`), passes with the fix.
- Updated `test/fts-language-migration.serial.test.ts`: removed an assertion that v123 is `LATEST_VERSION` — only ever true until the next migration landed (mirrors the `toBeGreaterThanOrEqual` pattern already used elsewhere for this).
- `bun run typecheck` clean, `bun run verify` 31/31 green.
- `test/page-search-vector-overflow.test.ts` (3/3), `test/reindex-search-vector.serial.test.ts`, `test/fts-language-migration.serial.test.ts`, `test/migration-v120.test.ts`, `test/sync.test.ts`, `test/bootstrap.test.ts`, `test/migrate.test.ts` — 254 total, 0 fail, no regressions.
- Codex review (`gpt-5.6-sol`, high effort) against `origin/master`: clean, no findings.

Closes #2704

🤖 Generated with [Claude Code](https://claude.com/claude-code)