### PR TITLE
fix(dreamcycle): seal source and daily finalizer authority

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ export function bigintToStringReplacer(_key: string, value: unknown): unknown {
 }
 
 // CLI-only commands that bypass the operation layer
-export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector']);
+export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'dreamcycle', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -104,6 +104,9 @@ const CLI_ONLY_SELF_HELP = new Set([
   // `gbrain connect --help` prints its own usage (flags + examples) from
   // runConnect; route around the generic one-line short-circuit.
   'connect',
+  // Local-only external DreamCycle handoff has a deliberately narrow command
+  // contract; its own help documents the sealed begin/finalize boundary.
+  'dreamcycle',
 ]);
 
 // v114 (#1941): alias -> operation lookup, kept separate from `cliOps` so
@@ -983,7 +986,7 @@ const THIN_CLIENT_REFUSED_COMMANDS = new Set([
   // the volunteer_context MCP op instead.
   'watch',
   // v0.31.1 (CDX-2 op coverage matrix): more local-only commands
-  'dream', 'transcripts', 'storage',
+  'dream', 'dreamcycle', 'transcripts', 'storage',
   // v0.31.1 CDX-2 audit: takes/sources have multiple subcommands; some
   // (takes_list/takes_search, sources_list/sources_status) have MCP
   // equivalents and others are file-system bound (takes mutate commands
@@ -1022,6 +1025,7 @@ const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {
   integrity: 'integrity scans local files. Run on the host machine.',
   serve: 'serve starts a server. Run on the host, not the thin client.',
   dream: 'dream runs the autopilot cycle on the host. `gbrain remote ping` queues one. (Native `gbrain dream` thin-client routing planned for v0.31.2.)',
+  dreamcycle: 'dreamcycle seals a local, server-verified daily batch. Run `gbrain dreamcycle begin` / `finalize` on the host machine.',
   orphans: "orphans needs the host's brain. Run on the host or use the `find_orphans` MCP tool from your agent.",
   transcripts: 'transcripts is server-private (raw chat exports stay on the host). Read transcripts on the host machine.',
   storage: 'storage operates on the local repo on disk. Run on the host.',
@@ -1058,6 +1062,15 @@ function refuseThinClient(command: string, mcpUrl: string): never {
 }
 
 async function handleCliOnly(command: string, args: string[]) {
+  // Keep the local-only handoff contract discoverable even on a fresh client
+  // with no configured database. The actual begin/finalize commands remain
+  // host-only below and never route through MCP.
+  if (command === 'dreamcycle' && (args.includes('--help') || args.includes('-h'))) {
+    const { DREAMCYCLE_HELP } = await import('./commands/dreamcycle.ts');
+    console.log(DREAMCYCLE_HELP);
+    return;
+  }
+
   // Thin-client guard: refuse DB-bound commands cleanly with a pinpoint
   // hint instead of letting them fail later inside connectEngine or
   // mid-handler. v0.31.1 routes through `refuseThinClient` so every
@@ -1367,6 +1380,17 @@ async function handleCliOnly(command: string, args: string[]) {
       // overnight cron, where a lingering-socket hang is a silent zombie
       // (closes the TODOS.md drain-before-owner-disconnect item).
       if (eng) await finishCliTeardown({ engine: eng });
+    }
+    return;
+  }
+
+  if (command === 'dreamcycle') {
+    const { runDreamcycle } = await import('./commands/dreamcycle.ts');
+    const eng = await connectEngine();
+    try {
+      setCliExitVerdict(await runDreamcycle(eng, args));
+    } finally {
+      await finishCliTeardown({ engine: eng });
     }
     return;
   }
@@ -2309,6 +2333,7 @@ TOOLS
   transcripts recent [--days N]      v0.29: recent raw .txt transcripts (local-only)
   dream [--dry-run] [--json]         Run the overnight maintenance cycle once (cron-friendly).
                                      See also: autopilot --install (continuous daemon).
+  dreamcycle begin|finalize [--json] Local-only external daily-batch handoff.
   check-resolvable [--json] [--fix]  Validate skill tree (reachability/MECE/DRY)
   report --type <name> --content ... Save timestamped report to brain/reports/
 

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -521,6 +521,22 @@ export function isGlobalMaintenanceStale(lastGlobalAtIso: string | null, now = D
   return (now - d.getTime()) / 60_000 >= floorMin;
 }
 
+export function getJSTDaySlot(now = new Date()): string {
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  return jst.toISOString().slice(0, 10);
+}
+
+export const DAILY_GLOBAL_ALLOWLIST: CyclePhase[] = ['resolve_symbol_edges', 'embed', 'orphans'];
+
+export async function readGlobalMaintenanceAuthority(engine: BrainEngine): Promise<string> {
+  try {
+    const val = await engine.getConfig('autopilot.global_maintenance.authority');
+    return val ?? 'missing';
+  } catch {
+    return 'read_failure';
+  }
+}
+
 /**
  * #2194 fix #3 / #2227 bug #3 — dispatch the single brain-wide maintenance job
  * that runs the `global` cycle phases (embed, orphans, purge, …) ONCE per
@@ -534,9 +550,31 @@ export async function dispatchGlobalMaintenance(
   engine: BrainEngine,
   queue: MinionQueue,
   opts: { repoPath: string; slot: string; timeoutMs: number; jsonMode: boolean; emit?: (l: string) => void; log?: (l: string) => void },
-): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh' }> {
+): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh' | 'deferred' | 'unauthorized' }> {
   const emit = opts.emit ?? ((line) => process.stderr.write(line + '\n'));
   const log = opts.log ?? ((line) => console.log(line));
+
+  // Check authority — fail-closed on external_dreamcycle, builtin, unknown, missing, read_failure
+  const auth = await readGlobalMaintenanceAuthority(engine);
+  if (auth !== 'daily_finalizer') {
+    return { dispatched: false, reason: auth === 'external_dreamcycle' ? 'unauthorized' : 'deferred' };
+  }
+
+  // All source success receipt check
+  let sources: SourceRow[] = [];
+  try {
+    sources = await engine.listAllSources({ localPathOnly: true });
+  } catch {
+    sources = [];
+  }
+
+  const jstSlot = getJSTDaySlot();
+  for (const src of sources) {
+    const lastSuccess = readLastSuccessAt(src);
+    if (!lastSuccess || getJSTDaySlot(lastSuccess) !== jstSlot) {
+      return { dispatched: false, reason: 'deferred' };
+    }
+  }
 
   let floorMin = GLOBAL_FLOOR_MIN;
   const floorCfg = await engine.getConfig('autopilot.global_floor_min');
@@ -549,21 +587,21 @@ export async function dispatchGlobalMaintenance(
     return { dispatched: false, reason: 'fresh' };
   }
 
+  const slotKey = opts.slot || jstSlot;
   const job = await queue.add(
     'autopilot-global-maintenance',
-    { repoPath: opts.repoPath, phases: GLOBAL_PHASES },
+    { repoPath: opts.repoPath, phases: DAILY_GLOBAL_ALLOWLIST },
     {
       queue: 'default',
-      // Structural single-flight: one global job per slot; maxWaiting:1 coalesces
-      // any surplus so a slow brain-wide pass never stacks duplicates.
-      idempotency_key: `autopilot-global:${opts.slot}`,
+      // Structural single-flight with atomic idempotency slot
+      idempotency_key: `dreamcycle:global:${slotKey}`,
       max_attempts: 2,
       timeout_ms: opts.timeoutMs,
       maxWaiting: 1,
     },
   );
   if (opts.jsonMode) {
-    emit(JSON.stringify({ event: 'dispatched', job_id: job.id, mode: 'global_maintenance', slot: opts.slot }));
+    emit(JSON.stringify({ event: 'dispatched', job_id: job.id, mode: 'global_maintenance', slot: slotKey }));
   } else {
     log(`[dispatch] job #${job.id} autopilot-global-maintenance (brain-wide phases)`);
   }

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -32,7 +32,12 @@
 
 import type { BrainEngine, SourceRow } from '../core/engine.ts';
 import type { MinionQueue } from '../core/minions/queue.ts';
-import { NON_GLOBAL_PHASES, GLOBAL_PHASES, LAST_GLOBAL_AT_KEY } from '../core/cycle.ts';
+import {
+  DREAMCYCLE_GLOBAL_PHASES,
+  DREAMCYCLE_SOURCE_PHASES,
+  LAST_GLOBAL_AT_KEY,
+  type CyclePhase,
+} from '../core/cycle.ts';
 
 const FULL_CYCLE_FLOOR_MIN = 60;
 
@@ -437,11 +442,10 @@ export async function dispatchPerSource(
           repoPath: opts.repoPath,
           source_id: src.id,
           pull: !!remoteUrl,
-          // #2194 fix #3 (cycle split): per-source cycles run ONLY source-scoped
-          // (+ mixed) phases. The brain-wide global phases (embed, orphans,
-          // purge, …) run once in autopilot-global-maintenance, not N times
-          // concurrently here — the fix for the 4→10GB RSS blowout.
-          phases: NON_GLOBAL_PHASES,
+          // DreamCycle source receipts are intentionally narrow. Taxonomy-wide
+          // NON_GLOBAL_PHASES is not an execution allowlist: it contains phases
+          // that can spend or aggregate outside this source batch.
+          phases: [...DREAMCYCLE_SOURCE_PHASES],
         },
         {
           queue: 'default',
@@ -526,7 +530,71 @@ export function getJSTDaySlot(now = new Date()): string {
   return jst.toISOString().slice(0, 10);
 }
 
-export const DAILY_GLOBAL_ALLOWLIST: CyclePhase[] = ['resolve_symbol_edges', 'embed', 'orphans'];
+/** Fixed, non-destructive daily finalizer allowlist. */
+export const DAILY_GLOBAL_ALLOWLIST: CyclePhase[] = [...DREAMCYCLE_GLOBAL_PHASES];
+
+export interface GlobalMaintenanceSourceReceipt {
+  source_id: string;
+  /** Exact source-cycle receipt timestamp that authorizes this finalizer. */
+  receipt_at: string;
+}
+
+export interface GlobalMaintenanceSourceSnapshot {
+  jst_day: string;
+  sources: GlobalMaintenanceSourceReceipt[];
+  /** Deterministic representation of the exact source set + receipts. */
+  revision: string;
+}
+
+/**
+ * Build the receipt snapshot that travels with one daily finalizer job.
+ *
+ * A missing/invalid receipt, a receipt from a different JST day, or an empty
+ * source batch returns null. Callers must defer rather than guessing that the
+ * global work is safe to run.
+ */
+export function createGlobalMaintenanceSourceSnapshot(
+  sources: SourceRow[],
+  jstDay: string,
+): GlobalMaintenanceSourceSnapshot | null {
+  if (sources.length === 0) return null;
+
+  const receipts: GlobalMaintenanceSourceReceipt[] = [];
+  for (const source of sources) {
+    const receipt = readLastSuccessAt(source);
+    if (!receipt || getJSTDaySlot(receipt) !== jstDay) return null;
+    receipts.push({ source_id: source.id, receipt_at: receipt.toISOString() });
+  }
+  receipts.sort((a, b) => a.source_id.localeCompare(b.source_id));
+  const revision = receipts.map((r) => `${r.source_id}\u0000${r.receipt_at}`).join('\u0001');
+  return { jst_day: jstDay, sources: receipts, revision };
+}
+
+/**
+ * Verify the server-created job data against the currently visible batch.
+ * This is deliberately exact: any source add/remove or receipt advancement
+ * invalidates the finalizer, which then waits for the next JST slot.
+ */
+export function globalMaintenanceSnapshotMatches(
+  snapshot: unknown,
+  revision: unknown,
+  jstDay: unknown,
+  currentSources: SourceRow[],
+  now = new Date(),
+): boolean {
+  if (typeof revision !== 'string' || typeof jstDay !== 'string' || !Array.isArray(snapshot)) return false;
+  const currentDay = getJSTDaySlot(now);
+  if (jstDay !== currentDay) return false;
+  const expected = createGlobalMaintenanceSourceSnapshot(currentSources, currentDay);
+  if (!expected || revision !== expected.revision) return false;
+  if (snapshot.length !== expected.sources.length) return false;
+  return snapshot.every((value, index) => {
+    if (!value || typeof value !== 'object') return false;
+    const entry = value as { source_id?: unknown; receipt_at?: unknown };
+    const wanted = expected.sources[index];
+    return entry.source_id === wanted.source_id && entry.receipt_at === wanted.receipt_at;
+  });
+}
 
 export async function readGlobalMaintenanceAuthority(engine: BrainEngine): Promise<string> {
   try {
@@ -539,18 +607,15 @@ export async function readGlobalMaintenanceAuthority(engine: BrainEngine): Promi
 
 /**
  * #2194 fix #3 / #2227 bug #3 — dispatch the single brain-wide maintenance job
- * that runs the `global` cycle phases (embed, orphans, purge, …) ONCE per
- * window, instead of N per-source cycles each running them concurrently (the
- * RSS blowout). Single-flight is structural: one `idempotency_key` +
- * `maxWaiting:1`, so a slow run never stacks. Gated on `autopilot.last_global_at`
- * (stamped by the handler on success). Postgres-only fan-out concern; on PGLite
- * the file lock already serializes, but the job is still correct there.
+ * that runs the fixed non-destructive global phases once per completed source
+ * batch. The queue payload is a sealed-by-construction snapshot: the handler
+ * re-reads and compares it before invoking runCycle. Any uncertainty defers.
  */
 export async function dispatchGlobalMaintenance(
   engine: BrainEngine,
   queue: MinionQueue,
-  opts: { repoPath: string; slot: string; timeoutMs: number; jsonMode: boolean; emit?: (l: string) => void; log?: (l: string) => void },
-): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh' | 'deferred' | 'unauthorized' }> {
+  opts: { repoPath: string; slot?: string; timeoutMs: number; jsonMode: boolean; emit?: (l: string) => void; log?: (l: string) => void },
+): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh' | 'deferred' | 'global_deferred' | 'unauthorized' }> {
   const emit = opts.emit ?? ((line) => process.stderr.write(line + '\n'));
   const log = opts.log ?? ((line) => console.log(line));
 
@@ -560,48 +625,59 @@ export async function dispatchGlobalMaintenance(
     return { dispatched: false, reason: auth === 'external_dreamcycle' ? 'unauthorized' : 'deferred' };
   }
 
-  // All source success receipt check
-  let sources: SourceRow[] = [];
+  // Listing and receipt reads are security/correctness gates. Do not treat an
+  // unreadable source table as an empty, completed batch.
+  let sources: SourceRow[];
   try {
     sources = await engine.listAllSources({ localPathOnly: true });
   } catch {
-    sources = [];
+    return { dispatched: false, reason: 'global_deferred' };
   }
 
-  const jstSlot = getJSTDaySlot();
-  for (const src of sources) {
-    const lastSuccess = readLastSuccessAt(src);
-    if (!lastSuccess || getJSTDaySlot(lastSuccess) !== jstSlot) {
-      return { dispatched: false, reason: 'deferred' };
-    }
-  }
+  const now = new Date();
+  const jstSlot = getJSTDaySlot(now);
+  const snapshot = createGlobalMaintenanceSourceSnapshot(sources, jstSlot);
+  if (!snapshot) return { dispatched: false, reason: 'global_deferred' };
 
   let floorMin = GLOBAL_FLOOR_MIN;
-  const floorCfg = await engine.getConfig('autopilot.global_floor_min');
-  if (floorCfg) {
-    const n = parseInt(floorCfg, 10);
-    if (Number.isFinite(n) && n >= 1) floorMin = n;
+  let lastGlobalAt: string | null;
+  try {
+    const floorCfg = await engine.getConfig('autopilot.global_floor_min');
+    if (floorCfg) {
+      const n = parseInt(floorCfg, 10);
+      if (Number.isFinite(n) && n >= 1) floorMin = n;
+    }
+    lastGlobalAt = await engine.getConfig(LAST_GLOBAL_AT_KEY);
+  } catch {
+    return { dispatched: false, reason: 'global_deferred' };
   }
-  const lastGlobalAt = await engine.getConfig(LAST_GLOBAL_AT_KEY);
   if (!isGlobalMaintenanceStale(lastGlobalAt, Date.now(), floorMin)) {
     return { dispatched: false, reason: 'fresh' };
   }
 
-  const slotKey = opts.slot || jstSlot;
   const job = await queue.add(
     'autopilot-global-maintenance',
-    { repoPath: opts.repoPath, phases: DAILY_GLOBAL_ALLOWLIST },
+    {
+      repoPath: opts.repoPath,
+      phases: [...DAILY_GLOBAL_ALLOWLIST],
+      execution_authority: 'dreamcycle_global',
+      source_snapshot: snapshot.sources,
+      source_snapshot_revision: snapshot.revision,
+      source_snapshot_jst_day: snapshot.jst_day,
+    },
     {
       queue: 'default',
       // Structural single-flight with atomic idempotency slot
-      idempotency_key: `dreamcycle:global:${slotKey}`,
+      idempotency_key: `dreamcycle:global:${jstSlot}`,
       max_attempts: 2,
       timeout_ms: opts.timeoutMs,
       maxWaiting: 1,
     },
+    // The finalizer is intentionally protected from generic CLI/MCP submits.
+    { allowProtectedSubmit: true },
   );
   if (opts.jsonMode) {
-    emit(JSON.stringify({ event: 'dispatched', job_id: job.id, mode: 'global_maintenance', slot: slotKey }));
+    emit(JSON.stringify({ event: 'dispatched', job_id: job.id, mode: 'global_maintenance', slot: jstSlot }));
   } else {
     log(`[dispatch] job #${job.id} autopilot-global-maintenance (brain-wide phases)`);
   }

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -566,7 +566,10 @@ export function createGlobalMaintenanceSourceSnapshot(
     receipts.push({ source_id: source.id, receipt_at: receipt.toISOString() });
   }
   receipts.sort((a, b) => a.source_id.localeCompare(b.source_id));
-  const revision = receipts.map((r) => `${r.source_id}\u0000${r.receipt_at}`).join('\u0001');
+  // `revision` travels inside minion_jobs.data (JSONB). Literal NUL
+  // separators make PostgreSQL reject the payload, so use the canonical JSON
+  // representation of the already-sorted entries instead.
+  const revision = JSON.stringify(receipts);
   return { jst_day: jstDay, sources: receipts, revision };
 }
 
@@ -661,6 +664,7 @@ export async function dispatchGlobalMaintenance(
       repoPath: opts.repoPath,
       phases: [...DAILY_GLOBAL_ALLOWLIST],
       execution_authority: 'dreamcycle_global',
+      finalizer_origin: 'daily_finalizer',
       source_snapshot: snapshot.sources,
       source_snapshot_revision: snapshot.revision,
       source_snapshot_jst_day: snapshot.jst_day,

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -989,10 +989,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const { runCycle } = await import('../core/cycle.ts');
         const report = await runCycle(engine, {
           brainDir: repoPath,
-          // Autopilot daemon path: pulls by default (matches
-          // pre-v0.17 autopilot behavior). CLI dream defaults false
-          // for cron safety; that choice is scoped to dream only.
           pull: true,
+          executionAuthority: 'manual',
           yieldBetweenPhases: async () => {
             await new Promise(r => setImmediate(r));
           },

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -955,6 +955,13 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           // gap the prior implementation had for targeted submits).
           for (const step of plan) {
             try {
+              // Targeted remediation is a generic planner path. It must never
+              // manufacture the server-internal global-finalizer job.
+              const { isInternalOnlyJobName } = await import('../core/minions/protected-names.ts');
+              if (isInternalOnlyJobName(step.job)) {
+                process.stderr.write(`[autopilot] skipped internal-only remediation job: ${step.job}\n`);
+                continue;
+              }
               const isProtected = !!step.protected;
               const submitOpts = {
                 queue: 'default',
@@ -981,16 +988,17 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         }
       } catch (e) { logError('dispatch', e); cycleOk = false; }
     } else {
-      // Inline fallback — delegate to runCycle so lint + backlinks +
-      // orphan sweep run too (previously this path only did sync +
-      // extract + embed, which didn't match the Minions-dispatch
-      // path's phase set). Now both converge on the same primitive.
+      // Inline fallback has no queue-backed receipt/idempotency contract, so
+      // it may run only the source receipt phases. The global finalizer stays
+      // deferred rather than smuggling ALL_PHASES through `manual` authority.
       try {
-        const { runCycle } = await import('../core/cycle.ts');
+        const { runCycle, DREAMCYCLE_SOURCE_PHASES } = await import('../core/cycle.ts');
         const report = await runCycle(engine, {
           brainDir: repoPath,
           pull: true,
-          executionAuthority: 'manual',
+          executionAuthority: 'dreamcycle_source',
+          sourceId: 'default',
+          phases: [...DREAMCYCLE_SOURCE_PHASES],
           yieldBetweenPhases: async () => {
             await new Promise(r => setImmediate(r));
           },

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -16,6 +16,7 @@
  *   gbrain dream --phase lint          # run a single phase
  *   gbrain dream --pull                # also git pull the brain repo
  *   gbrain dream --dir /path/to/brain  # explicit brain location
+ *   gbrain dream --source <id>          # source receipt: sync/extract/extract_facts
  *
  * Cron: 0 2 * * * gbrain dream --json >> /var/log/gbrain-dream.log
  *
@@ -25,6 +26,7 @@
 
 import type { BrainEngine } from '../core/engine.ts';
 import {
+  DREAMCYCLE_SOURCE_PHASES,
   runCycle,
   ALL_PHASES,
   type CyclePhase,
@@ -321,7 +323,10 @@ Options:
                       cycle_freshness check sees a fresh stamp on
                       completion. Without this, gbrain dream's
                       timestamp never lands and federated brains
-                      see "stale cycle" forever.
+                      see "stale cycle" forever. Without --phase,
+                      runs only sync, extract, and extract_facts.
+                      Global phases (embed/orphans/purge/etc.) require
+                      an unscoped \`gbrain dream\` invocation.
   --source-id <id>    Alias for --source. Matches the v0.37.7.0+
                       naming used by import/extract/graph-query.
 
@@ -581,7 +586,14 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     return runDrain(engine, opts, resolvedSourceId, brainDir);
   }
 
-  const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;
+  // An explicit `--source` is a source-maintenance request. Its omitted-phase
+  // default must not smuggle global work through manual authority; global
+  // phases remain available only on the unscoped manual CLI path.
+  const phases: CyclePhase[] | undefined = opts.phase
+    ? [opts.phase]
+    : resolvedSourceId
+      ? [...DREAMCYCLE_SOURCE_PHASES]
+      : undefined;
 
   const report = await runCycle(engine, {
     brainDir,

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -588,6 +588,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     dryRun: opts.dryRun,
     pull: opts.pull,
     phases,
+    executionAuthority: 'manual',
     sourceId: resolvedSourceId, // undefined when --source not set → legacy back-compat
     synthInputFile: opts.inputFile ?? undefined,
     synthDate: opts.date ?? undefined,

--- a/src/commands/dreamcycle.ts
+++ b/src/commands/dreamcycle.ts
@@ -1,0 +1,525 @@
+/**
+ * Local-only external DreamCycle handoff.
+ *
+ * An external scheduler may own the source-cycle cadence, but it must never
+ * choose global phases, manufacture authority, or supply a source receipt.
+ * `begin` records the exact source membership in minion_jobs; `finalize`
+ * requires each member to have a newer same-JST-day source receipt before it
+ * seals the one protected global-maintenance job.
+ *
+ * This is deliberately a CLI command, not an operation: no HTTP/MCP surface,
+ * OAuth scope, migration, config mutation, or destructive phase is added.
+ */
+
+import type { BrainEngine, SourceRow } from '../core/engine.ts';
+import { tryAcquireDbLock, type DbLockHandle } from '../core/db-lock.ts';
+import { isValidSourceId } from '../core/source-id.ts';
+import { MinionQueue } from '../core/minions/queue.ts';
+import { rowToMinionJob, type MinionJob } from '../core/minions/types.ts';
+import {
+  DAILY_GLOBAL_ALLOWLIST,
+  createGlobalMaintenanceSourceSnapshot,
+  getJSTDaySlot,
+  globalMaintenanceSnapshotMatches,
+  readGlobalMaintenanceAuthority,
+} from './autopilot-fanout.ts';
+
+export const EXTERNAL_DREAMCYCLE_AUTHORITY = 'external_dreamcycle';
+export const DREAMCYCLE_BEGIN_JOB_NAME = 'dreamcycle-begin';
+
+const BEGIN_KEY_PREFIX = 'dreamcycle:external:begin:';
+const GLOBAL_KEY_PREFIX = 'dreamcycle:global:';
+const FINALIZE_LOCK_PREFIX = 'gbrain-dreamcycle-finalize:';
+const JST_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface DreamcycleSourceEntry {
+  source_id: string;
+}
+
+/** Immutable source-ID membership snapshot recorded by `dreamcycle begin`. */
+export interface DreamcycleSourceSnapshot {
+  sources: DreamcycleSourceEntry[];
+  revision: string;
+}
+
+export interface ExternalDreamcycleBeginRecord extends DreamcycleSourceSnapshot {
+  job_id: number;
+  jst_day: string;
+  begun_at: string;
+}
+
+export type ExternalDreamcycleResult =
+  | {
+      outcome: 'begun';
+      begin_job_id: number;
+      jst_day: string;
+      source_count: number;
+      revision: string;
+    }
+  | {
+      outcome: 'sealed';
+      global_job_id: number;
+      jst_day: string;
+      source_count: number;
+      revision: string;
+    }
+  | { outcome: 'global_deferred'; detail: string };
+
+export type DreamcycleAction = 'begin' | 'finalize';
+
+export interface ParsedDreamcycleArgs {
+  action: DreamcycleAction | null;
+  json: boolean;
+  help: boolean;
+}
+
+export const DREAMCYCLE_HELP = `Usage: gbrain dreamcycle <begin|finalize> [--json]
+
+Local-only external DreamCycle handoff.
+
+  begin     Record today's exact source membership snapshot.
+  finalize  Verify every snapshotted source has a newer JST-day receipt,
+            then seal one protected global-maintenance job.
+
+No phase, source, authority, or snapshot flags are accepted. They are sealed
+inside GBrain so an external scheduler cannot widen the maintenance scope.`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isJstDay(value: unknown): value is string {
+  if (typeof value !== 'string' || !JST_DAY_RE.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function beginKey(jstDay: string): string {
+  return `${BEGIN_KEY_PREFIX}${jstDay}`;
+}
+
+function globalKey(jstDay: string): string {
+  return `${GLOBAL_KEY_PREFIX}${jstDay}`;
+}
+
+/**
+ * Make an exact, deterministic source-ID membership revision. Source config,
+ * paths, and caller-controlled values are intentionally absent: the only
+ * thing the external batch may depend on is which source IDs it began with.
+ */
+export function createExternalDreamcycleSourceSnapshot(
+  sources: readonly Pick<SourceRow, 'id'>[],
+): DreamcycleSourceSnapshot | null {
+  if (sources.length === 0) return null;
+  const ids = sources.map((source) => source.id);
+  if (ids.some((id) => !isValidSourceId(id))) return null;
+  const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+  if (new Set(sorted).size !== sorted.length) return null;
+  const entries = sorted.map((source_id) => ({ source_id }));
+  return {
+    sources: entries,
+    // Keep the revision JSON-safe because it is stored in minion_jobs.data.
+    // Postgres JSONB rejects a literal NUL even when a source ID itself is
+    // valid. JSON's array representation is both unambiguous and stable
+    // after the explicit sort above.
+    revision: JSON.stringify(sorted),
+  };
+}
+
+function parseSourceSnapshot(
+  rawSources: unknown,
+  rawRevision: unknown,
+): DreamcycleSourceSnapshot | null {
+  if (!Array.isArray(rawSources) || typeof rawRevision !== 'string') return null;
+  const ids: string[] = [];
+  for (const raw of rawSources) {
+    if (!isRecord(raw) || !isValidSourceId(raw.source_id)) return null;
+    ids.push(raw.source_id);
+  }
+  const expected = createExternalDreamcycleSourceSnapshot(ids.map((id) => ({ id })));
+  if (!expected || expected.revision !== rawRevision || expected.sources.length !== rawSources.length) return null;
+  for (let index = 0; index < expected.sources.length; index++) {
+    if ((rawSources[index] as Record<string, unknown>).source_id !== expected.sources[index].source_id) {
+      return null;
+    }
+  }
+  return expected;
+}
+
+/** Validate the durable begin-job payload before trusting it as a receipt. */
+export function parseExternalDreamcycleBeginData(raw: unknown): Omit<ExternalDreamcycleBeginRecord, 'job_id'> | null {
+  if (!isRecord(raw)) return null;
+  if (!isJstDay(raw.jst_day) || typeof raw.begun_at !== 'string') return null;
+  const begunAt = new Date(raw.begun_at);
+  if (!Number.isFinite(begunAt.getTime())) return null;
+  const snapshot = parseSourceSnapshot(raw.source_snapshot, raw.source_snapshot_revision);
+  if (!snapshot) return null;
+  return {
+    jst_day: raw.jst_day,
+    begun_at: begunAt.toISOString(),
+    ...snapshot,
+  };
+}
+
+async function loadExternalDreamcycleBegin(
+  engine: BrainEngine,
+  jstDay: string,
+): Promise<ExternalDreamcycleBeginRecord | null> {
+  const rows = await engine.executeRaw<Record<string, unknown>>(
+    `SELECT * FROM minion_jobs WHERE idempotency_key = $1`,
+    [beginKey(jstDay)],
+  );
+  if (rows.length !== 1) return null;
+  const job = rowToMinionJob(rows[0]);
+  if (job.name !== DREAMCYCLE_BEGIN_JOB_NAME || job.idempotency_key !== beginKey(jstDay)) return null;
+  const parsed = parseExternalDreamcycleBeginData(job.data);
+  if (!parsed || parsed.jst_day !== jstDay) return null;
+  return { job_id: job.id, ...parsed };
+}
+
+function deferred(detail: string): ExternalDreamcycleResult {
+  return { outcome: 'global_deferred', detail };
+}
+
+function hasNewSameDayReceipts(
+  receiptSnapshot: { sources: Array<{ receipt_at: string }> },
+  begunAt: string,
+): boolean {
+  const beganMs = new Date(begunAt).getTime();
+  if (!Number.isFinite(beganMs)) return false;
+  return receiptSnapshot.sources.every((entry) => {
+    const receiptMs = new Date(entry.receipt_at).getTime();
+    return Number.isFinite(receiptMs) && receiptMs > beganMs;
+  });
+}
+
+async function hasLiveGlobalFinalizer(engine: BrainEngine): Promise<boolean> {
+  const rows = await engine.executeRaw<{ id: number }>(
+    `SELECT id FROM minion_jobs
+     WHERE name = 'autopilot-global-maintenance'
+       AND status NOT IN ('completed', 'failed', 'dead', 'cancelled')
+     LIMIT 1`,
+  );
+  return rows.length > 0;
+}
+
+async function hasGlobalFinalizerForDay(engine: BrainEngine, jstDay: string): Promise<boolean> {
+  const rows = await engine.executeRaw<{ id: number }>(
+    `SELECT id FROM minion_jobs WHERE idempotency_key = $1 LIMIT 1`,
+    [globalKey(jstDay)],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Start the external daily batch by storing the exact source-ID membership in
+ * the existing minion job table. This is a durable no-op job, not a worker
+ * request: its data is the receipt finalization must prove against.
+ */
+export async function beginExternalDreamcycle(
+  engine: BrainEngine,
+  queue: MinionQueue,
+  opts: { now?: Date } = {},
+): Promise<ExternalDreamcycleResult> {
+  const now = opts.now ?? new Date();
+  const jstDay = getJSTDaySlot(now);
+  if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+    return deferred('external_dreamcycle_not_enabled');
+  }
+
+  let sources: SourceRow[];
+  try {
+    sources = await engine.listAllSources({ localPathOnly: true });
+  } catch {
+    return deferred('source_listing_unavailable');
+  }
+  const snapshot = createExternalDreamcycleSourceSnapshot(sources);
+  if (!snapshot) return deferred('source_snapshot_incomplete');
+
+  let job: MinionJob;
+  try {
+    job = await queue.add(
+      DREAMCYCLE_BEGIN_JOB_NAME,
+      {
+        jst_day: jstDay,
+        begun_at: now.toISOString(),
+        source_snapshot: snapshot.sources,
+        source_snapshot_revision: snapshot.revision,
+      },
+      {
+        queue: 'default',
+        idempotency_key: beginKey(jstDay),
+        max_attempts: 1,
+      },
+      { allowProtectedSubmit: true },
+    );
+  } catch {
+    return deferred('begin_record_unavailable');
+  }
+
+  // Idempotent repeats may return the existing row. It is safe only if its
+  // immutable source membership is still exactly today's current membership.
+  const stored = parseExternalDreamcycleBeginData(job.data);
+  if (
+    !stored ||
+    stored.jst_day !== jstDay ||
+    stored.revision !== snapshot.revision ||
+    stored.sources.length !== snapshot.sources.length
+  ) {
+    return deferred('begin_snapshot_mismatch');
+  }
+  return {
+    outcome: 'begun',
+    begin_job_id: job.id,
+    jst_day: jstDay,
+    source_count: snapshot.sources.length,
+    revision: snapshot.revision,
+  };
+}
+
+/**
+ * Verify the stored begin receipt and seal one protected global job. No caller
+ * input controls phases, source IDs, authority, receipt snapshots, or paths.
+ */
+async function finalizeExternalDreamcycleLocked(
+  engine: BrainEngine,
+  queue: MinionQueue,
+  now: Date,
+  jstDay: string,
+): Promise<ExternalDreamcycleResult> {
+  try {
+    await queue.ensureSchema();
+  } catch {
+    return deferred('minion_storage_unavailable');
+  }
+
+  let begin: ExternalDreamcycleBeginRecord | null;
+  try {
+    begin = await loadExternalDreamcycleBegin(engine, jstDay);
+  } catch {
+    return deferred('begin_record_unavailable');
+  }
+  if (!begin) return deferred('begin_record_missing_or_invalid');
+
+  let sources: SourceRow[];
+  try {
+    sources = await engine.listAllSources({ localPathOnly: true });
+  } catch {
+    return deferred('source_listing_unavailable');
+  }
+  const membership = createExternalDreamcycleSourceSnapshot(sources);
+  if (!membership || membership.revision !== begin.revision) {
+    return deferred('source_membership_drift');
+  }
+
+  const receipts = createGlobalMaintenanceSourceSnapshot(sources, jstDay);
+  if (!receipts || !hasNewSameDayReceipts(receipts, begin.begun_at)) {
+    return deferred('source_receipts_incomplete_or_pre_begin');
+  }
+
+  // Do not let queue-level maxWaiting coalesce this call into a different
+  // global batch. Any existing finalizer is uncertainty, so fail closed.
+  try {
+    if (
+      await hasGlobalFinalizerForDay(engine, jstDay) ||
+      await hasLiveGlobalFinalizer(engine)
+    ) {
+      return deferred('duplicate_global_finalizer');
+    }
+  } catch {
+    return deferred('global_job_lookup_unavailable');
+  }
+
+  let job: MinionJob;
+  try {
+    job = await queue.add(
+      'autopilot-global-maintenance',
+      {
+        // `null` is explicit: global phases are DB-only and must not inherit
+        // a caller-selected checkout or read a fallback path.
+        repoPath: null,
+        phases: [...DAILY_GLOBAL_ALLOWLIST],
+        execution_authority: 'dreamcycle_global',
+        finalizer_origin: EXTERNAL_DREAMCYCLE_AUTHORITY,
+        source_snapshot: receipts.sources,
+        source_snapshot_revision: receipts.revision,
+        source_snapshot_jst_day: receipts.jst_day,
+        external_dreamcycle_begin_job_id: begin.job_id,
+        external_dreamcycle_begin_revision: begin.revision,
+        external_dreamcycle_begin_jst_day: begin.jst_day,
+        external_dreamcycle_begin_at: begin.begun_at,
+      },
+      {
+        queue: 'default',
+        idempotency_key: globalKey(jstDay),
+        max_attempts: 2,
+        maxWaiting: 1,
+      },
+      { allowProtectedSubmit: true },
+    );
+  } catch {
+    return deferred('global_job_seal_failed');
+  }
+
+  // A concurrent caller cannot create a second row because idempotency_key is
+  // unique. If queue backpressure returned a different waiting job, however,
+  // this caller did not seal its verified batch and must report deferred.
+  if (job.idempotency_key !== globalKey(jstDay)) {
+    return deferred('duplicate_global_finalizer');
+  }
+  return {
+    outcome: 'sealed',
+    global_job_id: job.id,
+    jst_day: jstDay,
+    source_count: receipts.sources.length,
+    revision: receipts.revision,
+  };
+}
+
+export async function finalizeExternalDreamcycle(
+  engine: BrainEngine,
+  queue: MinionQueue,
+  opts: { now?: Date } = {},
+): Promise<ExternalDreamcycleResult> {
+  const now = opts.now ?? new Date();
+  const jstDay = getJSTDaySlot(now);
+  if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+    return deferred('external_dreamcycle_not_enabled');
+  }
+
+  // The idempotency key prevents a second global row, while this narrow,
+  // existing DB lock also makes a racing second caller report deferred rather
+  // than treating the first caller's row as its own success. It is released
+  // immediately; no new schema or durable lock protocol is introduced.
+  let finalizeLock: DbLockHandle | null;
+  try {
+    finalizeLock = await tryAcquireDbLock(engine, `${FINALIZE_LOCK_PREFIX}${jstDay}`, 2);
+  } catch {
+    return deferred('finalize_lock_unavailable');
+  }
+  if (!finalizeLock) return deferred('duplicate_global_finalizer');
+
+  try {
+    // The authority can change while a competing caller holds the lock. Read
+    // it again immediately before checking and sealing the batch.
+    if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+      return deferred('external_dreamcycle_not_enabled');
+    }
+    return await finalizeExternalDreamcycleLocked(engine, queue, now, jstDay);
+  } finally {
+    try {
+      await finalizeLock.release();
+    } catch {
+      // The DB lock has a short TTL fallback. Never turn an already-safe
+      // deferred/sealed verdict into an unhandled CLI error on cleanup.
+    }
+  }
+}
+
+/**
+ * Defense in depth for the protected global job handler. It replays every
+ * batch gate at claim time, including the current config value, exact source
+ * membership, newer same-day receipts, and the sealed receipt snapshot.
+ */
+export async function externalDreamcycleFinalizerBatchMatches(
+  engine: BrainEngine,
+  data: Record<string, unknown>,
+  opts: { now?: Date; currentSources?: SourceRow[] } = {},
+): Promise<boolean> {
+  try {
+    if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) return false;
+    const now = opts.now ?? new Date();
+    const jstDay = getJSTDaySlot(now);
+    const begin = await loadExternalDreamcycleBegin(engine, jstDay);
+    if (!begin) return false;
+    if (
+      data.finalizer_origin !== EXTERNAL_DREAMCYCLE_AUTHORITY ||
+      data.external_dreamcycle_begin_job_id !== begin.job_id ||
+      data.external_dreamcycle_begin_revision !== begin.revision ||
+      data.external_dreamcycle_begin_jst_day !== begin.jst_day ||
+      data.external_dreamcycle_begin_at !== begin.begun_at
+    ) {
+      return false;
+    }
+
+    const sources = opts.currentSources ?? await engine.listAllSources({ localPathOnly: true });
+    const membership = createExternalDreamcycleSourceSnapshot(sources);
+    if (!membership || membership.revision !== begin.revision) return false;
+
+    const receipts = createGlobalMaintenanceSourceSnapshot(sources, jstDay);
+    if (!receipts || !hasNewSameDayReceipts(receipts, begin.begun_at)) return false;
+
+    return globalMaintenanceSnapshotMatches(
+      data.source_snapshot,
+      data.source_snapshot_revision,
+      data.source_snapshot_jst_day,
+      sources,
+      now,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Parse the intentionally tiny CLI contract. */
+export function parseDreamcycleArgs(args: string[]): ParsedDreamcycleArgs {
+  if (args.includes('--help') || args.includes('-h')) {
+    return { action: null, json: false, help: true };
+  }
+  const [rawAction, ...rest] = args;
+  if (rawAction !== 'begin' && rawAction !== 'finalize') {
+    throw new Error('Usage: gbrain dreamcycle <begin|finalize> [--json]');
+  }
+  const unsupported = rest.filter((arg) => arg !== '--json');
+  if (unsupported.length > 0) {
+    throw new Error(
+      `gbrain dreamcycle ${rawAction} accepts no phase/source/authority/snapshot overrides ` +
+      `(unsupported: ${unsupported.join(', ')})`,
+    );
+  }
+  return { action: rawAction, json: rest.includes('--json'), help: false };
+}
+
+function printResult(result: ExternalDreamcycleResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (result.outcome === 'begun') {
+    console.log(
+      `[dreamcycle] begin recorded: JST ${result.jst_day}, ` +
+      `${result.source_count} source(s), receipt job #${result.begin_job_id}`,
+    );
+    return;
+  }
+  if (result.outcome === 'sealed') {
+    console.log(
+      `[dreamcycle] global finalizer sealed: job #${result.global_job_id}, ` +
+      `JST ${result.jst_day}, ${result.source_count} source(s)`,
+    );
+    return;
+  }
+  console.error(`[dreamcycle] global_deferred: ${result.detail}`);
+}
+
+/** CLI handler. Returns a process verdict; cli.ts owns process exit/teardown. */
+export async function runDreamcycle(engine: BrainEngine, args: string[]): Promise<number> {
+  let parsed: ParsedDreamcycleArgs;
+  try {
+    parsed = parseDreamcycleArgs(args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+  if (parsed.help) {
+    console.log(DREAMCYCLE_HELP);
+    return 0;
+  }
+
+  const queue = new MinionQueue(engine);
+  const result = parsed.action === 'begin'
+    ? await beginExternalDreamcycle(engine, queue)
+    : await finalizeExternalDreamcycle(engine, queue);
+  printResult(result, parsed.json);
+  return result.outcome === 'global_deferred' ? 3 : 0;
+}

--- a/src/commands/dreamcycle.ts
+++ b/src/commands/dreamcycle.ts
@@ -1,14 +1,15 @@
 /**
- * Local-only external DreamCycle handoff.
- *
- * An external scheduler may own the source-cycle cadence, but it must never
- * choose global phases, manufacture authority, or supply a source receipt.
- * `begin` records the exact source membership in minion_jobs; `finalize`
- * requires each member to have a newer same-JST-day source receipt before it
- * seals the one protected global-maintenance job.
- *
- * This is deliberately a CLI command, not an operation: no HTTP/MCP surface,
- * OAuth scope, migration, config mutation, or destructive phase is added.
+ * [2026-07-19][feat]
+ * User intent:
+ * - Let the Hermes external DreamCycle scheduler request the one safe,
+ *   once-per-JST-day global finalizer after its source passes complete.
+ * Invariant:
+ * - External callers never choose phases, source membership, authority, or
+ *   receipts. A missing, changed, or unreadable authority fails closed as
+ *   `global_deferred`, and the worker rechecks the sealed batch at claim time.
+ * Rejected alternative:
+ * - A generic jobs/MCP endpoint or caller-supplied snapshot could manufacture
+ *   global-maintenance authority, so this remains a narrow local CLI only.
  */
 
 import type { BrainEngine, SourceRow } from '../core/engine.ts';
@@ -181,6 +182,20 @@ function deferred(detail: string): ExternalDreamcycleResult {
   return { outcome: 'global_deferred', detail };
 }
 
+/**
+ * Authority reads are an execution gate, not an advisory status lookup. Keep
+ * the defensive catch here as well as inside readGlobalMaintenanceAuthority:
+ * a database adapter, test double, or future implementation may throw before
+ * that helper can turn the failure into its normal read_failure sentinel.
+ */
+async function hasExternalDreamcycleAuthority(engine: BrainEngine): Promise<boolean> {
+  try {
+    return (await readGlobalMaintenanceAuthority(engine)) === EXTERNAL_DREAMCYCLE_AUTHORITY;
+  } catch {
+    return false;
+  }
+}
+
 function hasNewSameDayReceipts(
   receiptSnapshot: { sources: Array<{ receipt_at: string }> },
   begunAt: string,
@@ -223,7 +238,7 @@ export async function beginExternalDreamcycle(
 ): Promise<ExternalDreamcycleResult> {
   const now = opts.now ?? new Date();
   const jstDay = getJSTDaySlot(now);
-  if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+  if (!(await hasExternalDreamcycleAuthority(engine))) {
     return deferred('external_dreamcycle_not_enabled');
   }
 
@@ -383,7 +398,7 @@ export async function finalizeExternalDreamcycle(
 ): Promise<ExternalDreamcycleResult> {
   const now = opts.now ?? new Date();
   const jstDay = getJSTDaySlot(now);
-  if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+  if (!(await hasExternalDreamcycleAuthority(engine))) {
     return deferred('external_dreamcycle_not_enabled');
   }
 
@@ -402,7 +417,7 @@ export async function finalizeExternalDreamcycle(
   try {
     // The authority can change while a competing caller holds the lock. Read
     // it again immediately before checking and sealing the batch.
-    if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) {
+    if (!(await hasExternalDreamcycleAuthority(engine))) {
       return deferred('external_dreamcycle_not_enabled');
     }
     return await finalizeExternalDreamcycleLocked(engine, queue, now, jstDay);
@@ -427,7 +442,7 @@ export async function externalDreamcycleFinalizerBatchMatches(
   opts: { now?: Date; currentSources?: SourceRow[] } = {},
 ): Promise<boolean> {
   try {
-    if (await readGlobalMaintenanceAuthority(engine) !== EXTERNAL_DREAMCYCLE_AUTHORITY) return false;
+    if (!(await hasExternalDreamcycleAuthority(engine))) return false;
     const now = opts.now ?? new Date();
     const jstDay = getJSTDaySlot(now);
     const begin = await loadExternalDreamcycleBegin(engine, jstDay);

--- a/src/commands/dreamcycle.ts
+++ b/src/commands/dreamcycle.ts
@@ -196,6 +196,29 @@ async function hasExternalDreamcycleAuthority(engine: BrainEngine): Promise<bool
   }
 }
 
+/**
+ * The sealed global row, not the worker's wall clock, owns its JST batch day.
+ * Require both independent day fields so a hand-crafted or corrupted row
+ * cannot replay a begin receipt from one day against receipts from another.
+ */
+function sealedExternalDreamcycleBatchDay(data: Record<string, unknown>): string | null {
+  const beginJstDay = data.external_dreamcycle_begin_jst_day;
+  const snapshotJstDay = data.source_snapshot_jst_day;
+  if (!isJstDay(beginJstDay) || !isJstDay(snapshotJstDay) || beginJstDay !== snapshotJstDay) {
+    return null;
+  }
+  return beginJstDay;
+}
+
+/**
+ * `globalMaintenanceSnapshotMatches` accepts a clock so daily jobs can use
+ * today. External jobs must instead compare against their sealed JST slot;
+ * this UTC instant deterministically maps back to that same JST date.
+ */
+function referenceInstantForJstDay(jstDay: string): Date {
+  return new Date(`${jstDay}T00:00:00.000Z`);
+}
+
 function hasNewSameDayReceipts(
   receiptSnapshot: { sources: Array<{ receipt_at: string }> },
   begunAt: string,
@@ -439,19 +462,25 @@ export async function finalizeExternalDreamcycle(
 export async function externalDreamcycleFinalizerBatchMatches(
   engine: BrainEngine,
   data: Record<string, unknown>,
-  opts: { now?: Date; currentSources?: SourceRow[] } = {},
+  opts: {
+    /** Test-only compatibility clock; never selects the sealed batch slot. */
+    now?: Date;
+    currentSources?: SourceRow[];
+  } = {},
 ): Promise<boolean> {
   try {
     if (!(await hasExternalDreamcycleAuthority(engine))) return false;
-    const now = opts.now ?? new Date();
-    const jstDay = getJSTDaySlot(now);
-    const begin = await loadExternalDreamcycleBegin(engine, jstDay);
+    // A global job can be claimed after JST midnight. Its sealed batch day is
+    // authoritative; never derive this from the worker clock or an option.
+    const batchJstDay = sealedExternalDreamcycleBatchDay(data);
+    if (!batchJstDay) return false;
+    const begin = await loadExternalDreamcycleBegin(engine, batchJstDay);
     if (!begin) return false;
     if (
       data.finalizer_origin !== EXTERNAL_DREAMCYCLE_AUTHORITY ||
       data.external_dreamcycle_begin_job_id !== begin.job_id ||
       data.external_dreamcycle_begin_revision !== begin.revision ||
-      data.external_dreamcycle_begin_jst_day !== begin.jst_day ||
+      begin.jst_day !== batchJstDay ||
       data.external_dreamcycle_begin_at !== begin.begun_at
     ) {
       return false;
@@ -461,15 +490,15 @@ export async function externalDreamcycleFinalizerBatchMatches(
     const membership = createExternalDreamcycleSourceSnapshot(sources);
     if (!membership || membership.revision !== begin.revision) return false;
 
-    const receipts = createGlobalMaintenanceSourceSnapshot(sources, jstDay);
+    const receipts = createGlobalMaintenanceSourceSnapshot(sources, batchJstDay);
     if (!receipts || !hasNewSameDayReceipts(receipts, begin.begun_at)) return false;
 
     return globalMaintenanceSnapshotMatches(
       data.source_snapshot,
       data.source_snapshot_revision,
-      data.source_snapshot_jst_day,
+      batchJstDay,
       sources,
-      now,
+      referenceInstantForJstDay(batchJstDay),
     );
   } catch {
     return false;

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -4,6 +4,7 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
+import type { CyclePhase } from '../core/cycle.ts';
 import { MinionQueue } from '../core/minions/queue.ts';
 import { MinionWorker } from '../core/minions/worker.ts';
 import { WORKER_EXIT_RSS_WATCHDOG } from '../core/minions/worker-exit-codes.ts';
@@ -225,6 +226,16 @@ HANDLER TYPES (built in)
       if (!name) {
         console.error('Error: job name required. Usage: gbrain jobs submit <name>');
         process.exit(1);
+      }
+
+      // This job has a server-internal source-snapshot contract. Generic CLI
+      // submission must not manufacture a DreamCycle global authority, even
+      // though this is a trusted local process.
+      const { isInternalOnlyJobName } = await import('../core/minions/protected-names.ts');
+      if (isInternalOnlyJobName(name)) {
+        console.error(`Error: '${name.trim()}' is reserved for server-internal DreamCycle finalization`);
+        process.exit(1);
+        return;
       }
 
       const paramsStr = parseFlag(args, '--params');
@@ -1676,7 +1687,7 @@ export async function registerBuiltinHandlers(
   // `gbrain jobs get <id>` shows the full structured report. Does NOT
   // throw on partial: a flaky phase must not block every future cycle.
   worker.register('autopilot-cycle', async (job) => {
-    const { runCycle } = await import('../core/cycle.ts');
+    const { runCycle, DREAMCYCLE_SOURCE_PHASES } = await import('../core/cycle.ts');
     // v0.41.30 (T2): fall back to null (NOT cwd '.') when no repo is configured.
     // The queued cycle is the same primitive `gbrain dream` uses; a checkout-less
     // postgres brain should skip filesystem phases (no_brain_dir) and run the
@@ -1750,13 +1761,24 @@ export async function registerBuiltinHandlers(
     // against the wrong tree. Legacy (no source_id) keeps the global repoPath.
     const effectiveBrainDir: string | null = sourceId ? sourceLocalPath : repoPath;
 
-    // Allow callers to select phases via job data (e.g. skip embed for
-    // fast cycles). Validates against ALL_PHASES to prevent injection.
-    const { ALL_PHASES } = await import('../core/cycle.ts');
-    const validPhases = new Set(ALL_PHASES);
-    const requestedPhases = Array.isArray(job.data.phases)
-      ? (job.data.phases as string[]).filter(p => validPhases.has(p as any))
-      : undefined;
+    // DreamCycle source jobs may select only the fixed receipt phases. Raw
+    // invalid data is rejected, never filtered into an accidental fallback;
+    // absence alone receives the safe default.
+    const rawPhases = job.data.phases;
+    let phases: CyclePhase[];
+    if (rawPhases === undefined) {
+      phases = [...DREAMCYCLE_SOURCE_PHASES];
+    } else {
+      if (!Array.isArray(rawPhases) || rawPhases.length === 0) {
+        throw new Error('autopilot-cycle: phases must be a non-empty DreamCycle source phase array');
+      }
+      const allowed = new Set<string>(DREAMCYCLE_SOURCE_PHASES);
+      const invalid = rawPhases.filter((phase) => typeof phase !== 'string' || !allowed.has(phase));
+      if (invalid.length > 0) {
+        throw new Error(`autopilot-cycle: unsupported DreamCycle source phase(s): ${invalid.map(String).join(', ')}`);
+      }
+      phases = rawPhases as CyclePhase[];
+    }
 
     // Pull default: legacy `true` for back-compat; explicit boolean wins.
     const pull = typeof job.data.pull === 'boolean' ? job.data.pull : true;
@@ -1782,9 +1804,7 @@ export async function registerBuiltinHandlers(
       signal: job.signal, // propagate abort so cycle bails on timeout/cancel
       executionAuthority: 'dreamcycle_source',
       sourceId: sourceId ?? 'default',
-      phases: requestedPhases && requestedPhases.length > 0
-        ? (requestedPhases.filter(p => ['sync', 'extract', 'extract_facts'].includes(p)) as any)
-        : ['sync', 'extract', 'extract_facts'],
+      phases,
       yieldBetweenPhases: async () => {
         // Yield to the event loop so worker lock-renewal can fire.
         await new Promise<void>(r => setImmediate(r));
@@ -1798,24 +1818,60 @@ export async function registerBuiltinHandlers(
     };
   });
 
-  // #2194 fix #3 / #2227 bug #3 — brain-wide maintenance. Runs the `global`
-  // cycle phases (embed, orphans, purge, resolve_symbol_edges, grade_takes,
-  // calibration_profile, synthesize_concepts, skillopt) ONCE per window instead
-  // of N times concurrently across per-source cycles (the 4→10GB RSS blowout).
-  // No source_id → uses the legacy global cycle lock; stamps autopilot.last_global_at
-  // on success so the dispatch gate backs off.
+  // Server-internal daily finalizer. A generic submitted job cannot reach this
+  // handler through either CLI or submit_job, and this handler still verifies
+  // the snapshot/revision before granting dreamcycle_global authority.
   worker.register('autopilot-global-maintenance', async (job) => {
     const { runCycle, LAST_GLOBAL_AT_KEY } = await import('../core/cycle.ts');
-    const { DAILY_GLOBAL_ALLOWLIST } = await import('./autopilot-fanout.ts');
+    const {
+      DAILY_GLOBAL_ALLOWLIST,
+      globalMaintenanceSnapshotMatches,
+    } = await import('./autopilot-fanout.ts');
+
+    const globalDeferred = (detail: string) => ({
+      partial: false,
+      status: 'skipped',
+      report: { reason: 'global_deferred', detail },
+    });
+
+    if (job.data.execution_authority !== 'dreamcycle_global') {
+      return globalDeferred('missing_or_invalid_internal_authority');
+    }
+
+    let currentSources;
+    try {
+      currentSources = await engine.listAllSources({ localPathOnly: true });
+    } catch {
+      return globalDeferred('source_listing_unavailable');
+    }
+    if (!globalMaintenanceSnapshotMatches(
+      job.data.source_snapshot,
+      job.data.source_snapshot_revision,
+      job.data.source_snapshot_jst_day,
+      currentSources,
+    )) {
+      return globalDeferred('source_snapshot_mismatch_or_incomplete');
+    }
+
     const repoPath: string | null = typeof job.data.repoPath === 'string'
       ? job.data.repoPath
       : (await engine.getConfig('sync.repo_path')) ?? null;
 
-    const validPhases = new Set(DAILY_GLOBAL_ALLOWLIST);
-    const requested = Array.isArray(job.data.phases)
-      ? (job.data.phases as string[]).filter((p) => validPhases.has(p as never))
-      : DAILY_GLOBAL_ALLOWLIST;
-    const phases = (requested.length > 0 ? requested : DAILY_GLOBAL_ALLOWLIST) as typeof DAILY_GLOBAL_ALLOWLIST;
+    const rawPhases = job.data.phases;
+    let phases: CyclePhase[];
+    if (rawPhases === undefined) {
+      phases = [...DAILY_GLOBAL_ALLOWLIST];
+    } else {
+      if (!Array.isArray(rawPhases) || rawPhases.length === 0) {
+        throw new Error('autopilot-global-maintenance: phases must be a non-empty daily finalizer phase array');
+      }
+      const allowed = new Set<string>(DAILY_GLOBAL_ALLOWLIST);
+      const invalid = rawPhases.filter((phase) => typeof phase !== 'string' || !allowed.has(phase));
+      if (invalid.length > 0) {
+        throw new Error(`autopilot-global-maintenance: unsupported finalizer phase(s): ${invalid.map(String).join(', ')}`);
+      }
+      phases = rawPhases as CyclePhase[];
+    }
 
     const report = await runCycle(engine, {
       brainDir: repoPath,

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1780,8 +1780,11 @@ export async function registerBuiltinHandlers(
       brainDir: effectiveBrainDir,
       pull,
       signal: job.signal, // propagate abort so cycle bails on timeout/cancel
-      ...(sourceId ? { sourceId } : {}),
-      ...(requestedPhases && requestedPhases.length > 0 ? { phases: requestedPhases as any } : {}),
+      executionAuthority: 'dreamcycle_source',
+      sourceId: sourceId ?? 'default',
+      phases: requestedPhases && requestedPhases.length > 0
+        ? (requestedPhases.filter(p => ['sync', 'extract', 'extract_facts'].includes(p)) as any)
+        : ['sync', 'extract', 'extract_facts'],
       yieldBetweenPhases: async () => {
         // Yield to the event loop so worker lock-renewal can fire.
         await new Promise<void>(r => setImmediate(r));
@@ -1802,20 +1805,22 @@ export async function registerBuiltinHandlers(
   // No source_id → uses the legacy global cycle lock; stamps autopilot.last_global_at
   // on success so the dispatch gate backs off.
   worker.register('autopilot-global-maintenance', async (job) => {
-    const { runCycle, GLOBAL_PHASES, LAST_GLOBAL_AT_KEY, ALL_PHASES } = await import('../core/cycle.ts');
+    const { runCycle, LAST_GLOBAL_AT_KEY } = await import('../core/cycle.ts');
+    const { DAILY_GLOBAL_ALLOWLIST } = await import('./autopilot-fanout.ts');
     const repoPath: string | null = typeof job.data.repoPath === 'string'
       ? job.data.repoPath
       : (await engine.getConfig('sync.repo_path')) ?? null;
 
-    const validPhases = new Set(ALL_PHASES);
+    const validPhases = new Set(DAILY_GLOBAL_ALLOWLIST);
     const requested = Array.isArray(job.data.phases)
       ? (job.data.phases as string[]).filter((p) => validPhases.has(p as never))
-      : GLOBAL_PHASES;
-    const phases = (requested.length > 0 ? requested : GLOBAL_PHASES) as typeof GLOBAL_PHASES;
+      : DAILY_GLOBAL_ALLOWLIST;
+    const phases = (requested.length > 0 ? requested : DAILY_GLOBAL_ALLOWLIST) as typeof DAILY_GLOBAL_ALLOWLIST;
 
     const report = await runCycle(engine, {
       brainDir: repoPath,
       pull: false, // brain-wide DB/maintenance work never git-pulls
+      executionAuthority: 'dreamcycle_global',
       signal: job.signal,
       phases,
       yieldBetweenPhases: async () => { await new Promise<void>((r) => setImmediate(r)); },
@@ -1961,6 +1966,7 @@ export async function registerBuiltinHandlers(
     const report = await runCycle(engine, {
       brainDir: repoPath,
       phases: [phase as any],
+      executionAuthority: 'manual',
       signal: job.signal,
     });
     return { phase, status: report.status, report };

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -23,6 +23,33 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+/**
+ * Internal captured-slug contract for autopilot-cycle jobs.
+ *
+ * Accept only an array of non-empty strings, trim whitespace, and perform
+ * deterministic first-seen deduplication. This is a strict no-op for
+ * non-arrays/malformed values; malformed entries cannot widen scope or
+ * bypass source-authority guards.
+ */
+function parseCapturedSlugs(rawCapturedSlugs: unknown): string[] {
+  if (!Array.isArray(rawCapturedSlugs)) return [];
+  const candidate: string[] = [];
+  for (const value of rawCapturedSlugs) {
+    if (typeof value !== 'string') continue;
+    const slug = value.trim();
+    if (!slug) continue;
+    candidate.push(slug);
+  }
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const slug of candidate) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    deduped.push(slug);
+  }
+  return deduped;
+}
+
 /** Parse `--max-waiting N` from CLI args. Returns undefined if absent.
  *  Throws on malformed input (caller should surface the error and exit).
  *  Clamps to [1, 100] to match the queue-layer clamp in MinionQueue.add.
@@ -1765,6 +1792,7 @@ export async function registerBuiltinHandlers(
     // invalid data is rejected, never filtered into an accidental fallback;
     // absence alone receives the safe default.
     const rawPhases = job.data.phases;
+    const capturedSlugs = parseCapturedSlugs(job.data.capturedSlugs);
     let phases: CyclePhase[];
     if (rawPhases === undefined) {
       phases = [...DREAMCYCLE_SOURCE_PHASES];
@@ -1804,6 +1832,7 @@ export async function registerBuiltinHandlers(
       signal: job.signal, // propagate abort so cycle bails on timeout/cancel
       executionAuthority: 'dreamcycle_source',
       sourceId: sourceId ?? 'default',
+      capturedSlugs,
       phases,
       yieldBetweenPhases: async () => {
         // Yield to the event loop so worker lock-renewal can fire.

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1847,6 +1847,36 @@ export async function registerBuiltinHandlers(
     };
   });
 
+  // Durable source-membership receipt for the local-only external DreamCycle
+  // CLI. It is intentionally a no-op worker handler: `dreamcycle begin`
+  // writes the trusted payload itself, and finalization re-reads that immutable
+  // minion row before granting any global authority.
+  {
+    const {
+      DREAMCYCLE_BEGIN_JOB_NAME,
+      parseExternalDreamcycleBeginData,
+    } = await import('./dreamcycle.ts');
+    worker.register(DREAMCYCLE_BEGIN_JOB_NAME, async (job) => {
+      const receipt = parseExternalDreamcycleBeginData(job.data);
+      if (!receipt) {
+        return {
+          partial: false,
+          status: 'skipped',
+          report: { reason: 'global_deferred', detail: 'invalid_external_begin_receipt' },
+        };
+      }
+      return {
+        partial: false,
+        status: 'ok',
+        report: {
+          jst_day: receipt.jst_day,
+          source_count: receipt.sources.length,
+          revision: receipt.revision,
+        },
+      };
+    });
+  }
+
   // Server-internal daily finalizer. A generic submitted job cannot reach this
   // handler through either CLI or submit_job, and this handler still verifies
   // the snapshot/revision before granting dreamcycle_global authority.
@@ -1882,8 +1912,30 @@ export async function registerBuiltinHandlers(
       return globalDeferred('source_snapshot_mismatch_or_incomplete');
     }
 
+    // The local-only external finalizer carries an additional begin receipt.
+    // Revalidate it at claim time so a source add/remove, a stale/pre-begin
+    // receipt, a config flip, or a hand-crafted queue row cannot execute
+    // brain-wide work. Missing origin remains the legacy daily-finalizer shape
+    // for jobs queued before this CLI existed.
+    const finalizerOrigin = job.data.finalizer_origin;
+    if (
+      finalizerOrigin !== undefined &&
+      finalizerOrigin !== 'daily_finalizer' &&
+      finalizerOrigin !== 'external_dreamcycle'
+    ) {
+      return globalDeferred('unknown_finalizer_origin');
+    }
+    if (finalizerOrigin === 'external_dreamcycle') {
+      const { externalDreamcycleFinalizerBatchMatches } = await import('./dreamcycle.ts');
+      if (!(await externalDreamcycleFinalizerBatchMatches(engine, job.data, { currentSources }))) {
+        return globalDeferred('external_batch_mismatch_or_incomplete');
+      }
+    }
+
     const repoPath: string | null = typeof job.data.repoPath === 'string'
       ? job.data.repoPath
+      : job.data.repoPath === null
+        ? null
       : (await engine.getConfig('sync.repo_path')) ?? null;
 
     const rawPhases = job.data.phases;

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1935,7 +1935,11 @@ export async function registerBuiltinHandlers(
     } catch {
       return globalDeferred('source_listing_unavailable');
     }
-    if (!globalMaintenanceSnapshotMatches(
+    // Daily/legacy finalizers are bound to today's slot. The external CLI
+    // finalizer is different: its authoritative slot is sealed in the job and
+    // is verified below, so it remains valid when a worker claims it after
+    // JST midnight instead of being compared to the worker's current day.
+    if (finalizerOrigin !== 'external_dreamcycle' && !globalMaintenanceSnapshotMatches(
       job.data.source_snapshot,
       job.data.source_snapshot_revision,
       job.data.source_snapshot_jst_day,

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1885,6 +1885,7 @@ export async function registerBuiltinHandlers(
     const {
       DAILY_GLOBAL_ALLOWLIST,
       globalMaintenanceSnapshotMatches,
+      readGlobalMaintenanceAuthority,
     } = await import('./autopilot-fanout.ts');
 
     const globalDeferred = (detail: string) => ({
@@ -1895,6 +1896,37 @@ export async function registerBuiltinHandlers(
 
     if (job.data.execution_authority !== 'dreamcycle_global') {
       return globalDeferred('missing_or_invalid_internal_authority');
+    }
+
+    // Every global job is bound to the authority that sealed it. A queued
+    // daily/legacy row must not cross an operator's switch to the external
+    // scheduler, and an external row must replay its begin/receipt proof.
+    const finalizerOrigin = job.data.finalizer_origin;
+    if (
+      finalizerOrigin !== undefined &&
+      finalizerOrigin !== 'daily_finalizer' &&
+      finalizerOrigin !== 'external_dreamcycle'
+    ) {
+      return globalDeferred('unknown_finalizer_origin');
+    }
+
+    // Fail closed even if a future authority reader (or a database adapter)
+    // throws instead of returning its read_failure sentinel.
+    let currentAuthority: string;
+    try {
+      currentAuthority = await readGlobalMaintenanceAuthority(engine);
+    } catch {
+      return globalDeferred('global_authority_unavailable');
+    }
+
+    if (finalizerOrigin === 'external_dreamcycle') {
+      if (currentAuthority !== 'external_dreamcycle') {
+        return globalDeferred('external_batch_mismatch_or_incomplete');
+      }
+    } else if (currentAuthority !== 'daily_finalizer') {
+      // Legacy rows (no origin) are daily-finalizer rows. They cannot execute
+      // while external_dreamcycle owns the global-maintenance authority.
+      return globalDeferred('daily_finalizer_not_enabled');
     }
 
     let currentSources;
@@ -1915,21 +1947,18 @@ export async function registerBuiltinHandlers(
     // The local-only external finalizer carries an additional begin receipt.
     // Revalidate it at claim time so a source add/remove, a stale/pre-begin
     // receipt, a config flip, or a hand-crafted queue row cannot execute
-    // brain-wide work. Missing origin remains the legacy daily-finalizer shape
-    // for jobs queued before this CLI existed.
-    const finalizerOrigin = job.data.finalizer_origin;
-    if (
-      finalizerOrigin !== undefined &&
-      finalizerOrigin !== 'daily_finalizer' &&
-      finalizerOrigin !== 'external_dreamcycle'
-    ) {
-      return globalDeferred('unknown_finalizer_origin');
-    }
+    // brain-wide work.
     if (finalizerOrigin === 'external_dreamcycle') {
-      const { externalDreamcycleFinalizerBatchMatches } = await import('./dreamcycle.ts');
-      if (!(await externalDreamcycleFinalizerBatchMatches(engine, job.data, { currentSources }))) {
-        return globalDeferred('external_batch_mismatch_or_incomplete');
+      let externalBatchMatches = false;
+      try {
+        const { externalDreamcycleFinalizerBatchMatches } = await import('./dreamcycle.ts');
+        externalBatchMatches = await externalDreamcycleFinalizerBatchMatches(engine, job.data, { currentSources });
+      } catch {
+        // The external proof includes a second authority read. Any failure is
+        // indistinguishable from an incomplete batch at this safety boundary.
+        externalBatchMatches = false;
       }
+      if (!externalBatchMatches) return globalDeferred('external_batch_mismatch_or_incomplete');
     }
 
     const repoPath: string | null = typeof job.data.repoPath === 'string'

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -465,6 +465,13 @@ export interface CycleOpts {
    */
   signal?: AbortSignal;
   /**
+   * Internal DreamCycle capture hook (webhook + webhook-integration path).
+   *
+   * Non-empty trimmed strings only; duplicates are ignored. Only authoritative
+   * `dreamcycle_source` callers are allowed to pass this through runCycle.
+   */
+  capturedSlugs?: string[];
+  /**
    * v0.38: source-scope the cycle lock. When set, the cycle acquires
    * `gbrain-cycle:<source_id>` instead of the legacy global `gbrain-cycle`,
    * so two cycles for different sources can run concurrently on Postgres.
@@ -830,6 +837,82 @@ export async function runPhaseBacklinks(brainDir: string, dryRun: boolean): Prom
 interface SyncPhaseResult extends PhaseResult {
   /** Slugs that sync added or modified. Used by extract for incremental processing. */
   pagesAffected?: string[];
+}
+
+/**
+ * Deterministic list de-duplication with stable first-seen order.
+ */
+function dedupeStringList(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+/**
+ * Parse captured slugs defensively: only non-empty trimmed strings, deduped.
+ */
+function normalizeCapturedSlugs(rawCapturedSlugs: unknown): string[] {
+  if (!Array.isArray(rawCapturedSlugs)) return [];
+  const candidate: string[] = [];
+  for (const item of rawCapturedSlugs) {
+    if (typeof item !== 'string') continue;
+    const slug = item.trim();
+    if (!slug) continue;
+    candidate.push(slug);
+  }
+  return dedupeStringList(candidate);
+}
+
+/**
+ * Filter captured slugs to one source. Only slugs that resolve to existing
+ * pages in `sourceId` are allowed to pass through.
+ */
+async function scopeCapturedSlugs(
+  engine: BrainEngine,
+  sourceId: string | undefined,
+  capturedSlugs: string[],
+): Promise<string[]> {
+  if (!engine || sourceId === undefined || capturedSlugs.length === 0) return [];
+  const scoped: string[] = [];
+  const seen = new Set<string>();
+  for (const slug of capturedSlugs) {
+    try {
+      const page = await engine.getPage(slug, { sourceId });
+      if (!page) continue;
+    } catch {
+      continue;
+    }
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    scoped.push(slug);
+  }
+  return scoped;
+}
+
+/**
+ * Merge capture hints with sync results for incremental work sets.
+ */
+function mergeIncrementalSlugs(
+  syncPagesAffected: string[] | undefined,
+  capturedSlugs: string[],
+): string[] | undefined {
+  const canonicalSync = syncPagesAffected ? dedupeStringList(syncPagesAffected) : undefined;
+  if (canonicalSync === undefined) {
+    return capturedSlugs.length > 0 ? capturedSlugs : undefined;
+  }
+  const merged = [...canonicalSync];
+  const seen = new Set(merged);
+  for (const slug of capturedSlugs) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    merged.push(slug);
+  }
+  return merged;
 }
 
 /**
@@ -1492,6 +1575,15 @@ export async function runCycle(
     ? (opts.sourceId ?? (await resolveSourceForDir(engine, brainDir)))
     : opts.sourceId;
 
+  const normalizedCapturedSlugs = normalizeCapturedSlugs(opts.capturedSlugs);
+  const capturedSlugs = authority === 'dreamcycle_source'
+    ? await scopeCapturedSlugs(
+      engine,
+      cycleSourceId,
+      normalizedCapturedSlugs,
+    )
+    : [];
+
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
 
   // Decide if we need the cycle lock: any state-mutating phase in the selection.
@@ -1756,11 +1848,13 @@ export async function runCycle(
       } else if (brainDir === null) {
         phaseResults.push(skipNoBrainDir('extract'));
       } else {
-        // Pass changed slugs from sync for incremental extract.
+        // Pass changed slugs from sync (plus capturedSlugs from authoritative
+        // internal jobs) for incremental extract.
         // If sync didn't run (phases exclude it) or failed, syncPagesAffected
         // is undefined → extract falls back to full walk (safe default).
         progress.start('cycle.extract');
-        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, brainDir, dryRun, syncPagesAffected, opts.signal, cycleSourceId));
+        const xfTargetSlugs = mergeIncrementalSlugs(syncPagesAffected, capturedSlugs);
+        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, brainDir, dryRun, xfTargetSlugs, opts.signal, cycleSourceId));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();
@@ -1807,7 +1901,7 @@ export async function runCycle(
         // (#1928, codex: keying off phases.includes('sync') wrongly suppressed
         // the skipped-sync full reconcile).
         const syncRanButFailed = syncAttempted && syncPagesAffected === undefined;
-        const xfSlugs = syncRanButFailed ? [] : syncPagesAffected;
+        const xfSlugs = syncRanButFailed ? [] : mergeIncrementalSlugs(syncPagesAffected, capturedSlugs);
         const { result, duration_ms } = await timePhase(() =>
           runPhaseExtractFacts(engine, brainDir, xfSourceId, dryRun, xfSlugs, opts.signal));
         result.duration_ms = duration_ms;

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -245,18 +245,21 @@ export const PHASE_SCOPE: Record<CyclePhase, PhaseScope> = {
 /**
  * #2194 fix #3 / #2227 bug #3 — the cycle split.
  *
- * Per-source autopilot cycles run ONLY the source-scoped (and mixed) phases;
- * the brain-wide `global` phases (embed, orphans, purge, resolve_symbol_edges,
- * grade_takes, calibration_profile, synthesize_concepts, skillopt) run ONCE in
- * a separate `autopilot-global-maintenance` job instead of N times concurrently
- * across per-source cycles (the 4→10GB RSS blowout). Single-flight is
- * structural: one global job, not a skip-and-pretend-fresh hack (codex #1/#2).
+ * Per-source autopilot cycles and the daily finalizer deliberately use smaller,
+ * fixed phase allowlists. `GLOBAL_PHASES` and `NON_GLOBAL_PHASES` remain useful
+ * taxonomy exports, but are not execution permissions.
  *
  * GLOBAL_PHASES ∪ NON_GLOBAL_PHASES == ALL_PHASES, with no overlap — pinned by
  * test/autopilot-global-maintenance.test.ts.
  */
 export const GLOBAL_PHASES: CyclePhase[] = ALL_PHASES.filter((p) => PHASE_SCOPE[p] === 'global');
 export const NON_GLOBAL_PHASES: CyclePhase[] = ALL_PHASES.filter((p) => PHASE_SCOPE[p] !== 'global');
+
+/** The only phases a per-source DreamCycle receipt may execute. */
+export const DREAMCYCLE_SOURCE_PHASES = ['sync', 'extract', 'extract_facts'] as const satisfies readonly CyclePhase[];
+
+/** The only phases a server-internal daily DreamCycle finalizer may execute. */
+export const DREAMCYCLE_GLOBAL_PHASES = ['resolve_symbol_edges', 'embed', 'orphans'] as const satisfies readonly CyclePhase[];
 
 /** Config key holding the ISO timestamp of the last successful global-maintenance run. */
 export const LAST_GLOBAL_AT_KEY = 'autopilot.last_global_at';
@@ -484,7 +487,7 @@ export interface CycleOpts {
    * - 'dreamcycle_source': per-source cycle pass (requires sourceId, sync/extract/extract_facts only).
    * - 'dreamcycle_global': server internal daily finalizer pass (resolve_symbol_edges/embed/orphans only).
    */
-  executionAuthority?: ExecutionAuthority;
+  executionAuthority: ExecutionAuthority;
   sourceId?: string;
 }
 
@@ -1434,7 +1437,7 @@ export async function runCycle(
     if (!opts.sourceId) {
       throw new Error('[cycle] dreamcycle_source requires sourceId');
     }
-    const allowed = new Set<CyclePhase>(['sync', 'extract', 'extract_facts']);
+    const allowed = new Set<CyclePhase>(DREAMCYCLE_SOURCE_PHASES);
     const invalidPhases = phases.filter(p => !allowed.has(p));
     if (invalidPhases.length > 0) {
       throw new Error(`[cycle] dreamcycle_source does not allow phase(s): ${invalidPhases.join(', ')}`);
@@ -1443,7 +1446,7 @@ export async function runCycle(
     if (opts.sourceId) {
       throw new Error('[cycle] dreamcycle_global cannot be scoped to a single sourceId');
     }
-    const allowed = new Set<CyclePhase>(['resolve_symbol_edges', 'embed', 'orphans']);
+    const allowed = new Set<CyclePhase>(DREAMCYCLE_GLOBAL_PHASES);
     const invalidPhases = phases.filter(p => !allowed.has(p));
     if (invalidPhases.length > 0) {
       throw new Error(`[cycle] dreamcycle_global does not allow phase(s): ${invalidPhases.join(', ')}`);

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -478,8 +478,17 @@ export interface CycleOpts {
    *
    * Validated via `assertValidSourceId` in `cycleLockIdFor` (defense-in-depth).
    */
+  /**
+   * Internal execution authority — required to prevent unauthorized / misconfigured cycle execution.
+   * - 'manual': user CLI invocation (`gbrain dream`).
+   * - 'dreamcycle_source': per-source cycle pass (requires sourceId, sync/extract/extract_facts only).
+   * - 'dreamcycle_global': server internal daily finalizer pass (resolve_symbol_edges/embed/orphans only).
+   */
+  executionAuthority?: ExecutionAuthority;
   sourceId?: string;
 }
+
+export type ExecutionAuthority = 'manual' | 'dreamcycle_source' | 'dreamcycle_global';
 
 // ─── Lock primitives ───────────────────────────────────────────────
 
@@ -1416,6 +1425,38 @@ export async function runCycle(
 ): Promise<CycleReport> {
   const start = performance.now();
   const phases = opts.phases ?? ALL_PHASES;
+  const authority = opts.executionAuthority;
+  if (!authority || (authority !== 'manual' && authority !== 'dreamcycle_source' && authority !== 'dreamcycle_global')) {
+    throw new Error(`[cycle] missing or invalid executionAuthority: ${String(authority)}`);
+  }
+
+  if (authority === 'dreamcycle_source') {
+    if (!opts.sourceId) {
+      throw new Error('[cycle] dreamcycle_source requires sourceId');
+    }
+    const allowed = new Set<CyclePhase>(['sync', 'extract', 'extract_facts']);
+    const invalidPhases = phases.filter(p => !allowed.has(p));
+    if (invalidPhases.length > 0) {
+      throw new Error(`[cycle] dreamcycle_source does not allow phase(s): ${invalidPhases.join(', ')}`);
+    }
+  } else if (authority === 'dreamcycle_global') {
+    if (opts.sourceId) {
+      throw new Error('[cycle] dreamcycle_global cannot be scoped to a single sourceId');
+    }
+    const allowed = new Set<CyclePhase>(['resolve_symbol_edges', 'embed', 'orphans']);
+    const invalidPhases = phases.filter(p => !allowed.has(p));
+    if (invalidPhases.length > 0) {
+      throw new Error(`[cycle] dreamcycle_global does not allow phase(s): ${invalidPhases.join(', ')}`);
+    }
+  } else if (authority === 'manual') {
+    if (opts.sourceId) {
+      const hasGlobal = phases.some(p => GLOBAL_PHASES.includes(p));
+      if (hasGlobal) {
+        throw new Error('[cycle] manual --source cannot be combined with global phases. Run source maintenance or global maintenance separately.');
+      }
+    }
+  }
+
   const dryRun = !!opts.dryRun;
   const pull = !!opts.pull;
   const timestamp = new Date().toISOString();

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -873,7 +873,7 @@ function normalizeCapturedSlugs(rawCapturedSlugs: unknown): string[] {
  * pages in `sourceId` are allowed to pass through.
  */
 async function scopeCapturedSlugs(
-  engine: BrainEngine,
+  engine: BrainEngine | null,
   sourceId: string | undefined,
   capturedSlugs: string[],
 ): Promise<string[]> {
@@ -1538,7 +1538,11 @@ export async function runCycle(
     if (opts.sourceId) {
       const hasGlobal = phases.some(p => GLOBAL_PHASES.includes(p));
       if (hasGlobal) {
-        throw new Error('[cycle] manual --source cannot be combined with global phases. Run source maintenance or global maintenance separately.');
+        throw new Error(
+          '[cycle] manual --source cannot be combined with global phases. ' +
+          'Omit --source and rerun unscoped with `gbrain dream --phase <global-phase>`. ' +
+          'Run source maintenance separately.',
+        );
       }
     }
   }

--- a/src/core/minions/protected-names.ts
+++ b/src/core/minions/protected-names.ts
@@ -18,6 +18,11 @@
  * locally trusted; only the named internal dispatcher may enqueue them.
  */
 export const INTERNAL_ONLY_JOB_NAMES: ReadonlySet<string> = new Set([
+  // A durable, no-op receipt written only by `gbrain dreamcycle begin`.
+  // It seals the source membership snapshot that an externally scheduled
+  // daily finalizer must later prove against; generic submitters must never
+  // be able to manufacture that receipt.
+  'dreamcycle-begin',
   'autopilot-global-maintenance',
 ]);
 

--- a/src/core/minions/protected-names.ts
+++ b/src/core/minions/protected-names.ts
@@ -12,6 +12,15 @@
  * pay them at module load.
  */
 
+/**
+ * Jobs reserved for server-internal dispatch. They are also protected at the
+ * queue boundary, but generic CLI/MCP submitters must reject them even when
+ * locally trusted; only the named internal dispatcher may enqueue them.
+ */
+export const INTERNAL_ONLY_JOB_NAMES: ReadonlySet<string> = new Set([
+  'autopilot-global-maintenance',
+]);
+
 export const PROTECTED_JOB_NAMES: ReadonlySet<string> = new Set([
   'shell',
   // v0.15: subagent + aggregator are protected because they call the
@@ -63,9 +72,15 @@ export const PROTECTED_JOB_NAMES: ReadonlySet<string> = new Set([
   // auto-drain branch, an explicit `gbrain jobs submit extract-atoms-drain
   // --allow-protected`) can insert it.
   'extract-atoms-drain',
+  ...INTERNAL_ONLY_JOB_NAMES,
 ]);
 
 /** Check a job name against the protected set. Normalizes whitespace first. */
 export function isProtectedJobName(name: string): boolean {
   return PROTECTED_JOB_NAMES.has(name.trim());
+}
+
+/** Check whether a name is reserved for a server-internal dispatcher. */
+export function isInternalOnlyJobName(name: string): boolean {
+  return INTERNAL_ONLY_JOB_NAMES.has(name.trim());
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2848,6 +2848,14 @@ const submit_job: Operation = {
   scope: 'admin',
   handler: async (ctx, p) => {
     const name = typeof p.name === 'string' ? p.name.trim() : '';
+    const { isInternalOnlyJobName, isProtectedJobName } = await import('./minions/protected-names.ts');
+
+    // Server-internal finalizers are never exposed through generic submission,
+    // including a locally trusted CLI OperationContext. Their payload binds a
+    // verified source snapshot and is created only by the internal fanout path.
+    if (isInternalOnlyJobName(name)) {
+      throw new OperationError('permission_denied', `'${name}' is reserved for server-internal DreamCycle dispatch`);
+    }
     if (ctx.dryRun) return { dry_run: true, action: 'submit_job', name };
 
     // Submit-side MCP guard: reject protected job names from untrusted callers
@@ -2855,7 +2863,6 @@ const submit_job: Operation = {
     // (the second is MinionQueue.add's check). Independent of the worker-side
     // GBRAIN_ALLOW_SHELL_JOBS env flag — even if that flag is on, MCP callers
     // cannot submit protected-type jobs.
-    const { isProtectedJobName } = await import('./minions/protected-names.ts');
     // F7b fail-closed: anything that is not strictly false (i.e., remote=true OR
     // the field somehow leaks in undefined despite the required type) rejects
     // protected job submissions. Closes the HTTP MCP shell-job RCE that surfaced

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5077,6 +5077,13 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+        ) as islanded_pages,
+        (SELECT count(*) FROM pages p
+         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+        ) as pages_without_inbound_links,
+        (SELECT count(*) FROM pages p
+         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
@@ -5105,7 +5112,9 @@ export class PGLiteEngine implements BrainEngine {
     const r = h as Record<string, unknown>;
     const pageCount = Number(r.page_count);
     const embedCoverage = Number(r.embed_coverage);
-    const orphanPages = Number(r.orphan_pages);
+    const islandedPages = Number(r.islanded_pages ?? r.orphan_pages ?? 0);
+    const pagesWithoutInboundLinks = Number(r.pages_without_inbound_links ?? 0);
+    const orphanPages = islandedPages;
     const deadLinks = Number(r.dead_links);
     const linkCount = Number(r.link_count);
     const pagesWithTimeline = Number(r.pages_with_timeline);
@@ -5135,6 +5144,8 @@ export class PGLiteEngine implements BrainEngine {
       embed_coverage: embedCoverage,
       stale_pages: Number(r.stale_pages),
       orphan_pages: orphanPages,
+      islanded_pages: islandedPages,
+      pages_without_inbound_links: pagesWithoutInboundLinks,
       missing_embeddings: Number(r.missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5171,6 +5171,13 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+        ) as islanded_pages,
+        (SELECT count(*) FROM pages p
+         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+        ) as pages_without_inbound_links,
+        (SELECT count(*) FROM pages p
+         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
@@ -5197,7 +5204,9 @@ export class PostgresEngine implements BrainEngine {
 
     const pageCount = Number(h.page_count);
     const embedCoverage = Number(h.embed_coverage);
-    const orphanPages = Number(h.orphan_pages);
+    const islandedPages = Number(h.islanded_pages ?? h.orphan_pages ?? 0);
+    const pagesWithoutInboundLinks = Number(h.pages_without_inbound_links ?? 0);
+    const orphanPages = islandedPages;
     const deadLinks = Number(h.dead_links);
     const linkCount = Number(h.link_count);
     const pagesWithTimeline = Number(h.pages_with_timeline);
@@ -5227,6 +5236,8 @@ export class PostgresEngine implements BrainEngine {
       embed_coverage: embedCoverage,
       stale_pages: Number(h.stale_pages),
       orphan_pages: orphanPages,
+      islanded_pages: islandedPages,
+      pages_without_inbound_links: pagesWithoutInboundLinks,
       missing_embeddings: Number(h.missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1413,6 +1413,10 @@ export interface BrainHealth {
    * semantics after Bug 11 doc-drift fix.
    */
   orphan_pages: number;
+  /** Islanded pages — zero inbound AND zero outbound links. */
+  islanded_pages: number;
+  /** Pages with zero inbound links (regardless of outbound links). */
+  pages_without_inbound_links: number;
   missing_embeddings: number;
   /**
    * Composite quality score, 0-100. Weighted sum of five components: embed

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1413,10 +1413,18 @@ export interface BrainHealth {
    * semantics after Bug 11 doc-drift fix.
    */
   orphan_pages: number;
-  /** Islanded pages — zero inbound AND zero outbound links. */
-  islanded_pages: number;
-  /** Pages with zero inbound links (regardless of outbound links). */
-  pages_without_inbound_links: number;
+  /**
+   * Islanded pages — zero inbound AND zero outbound links.
+   *
+   * Additive JSON field. Engines always return it, while older callers that
+   * construct a BrainHealth fixture remain compatible during rollout.
+   */
+  islanded_pages?: number;
+  /**
+   * Pages with zero inbound links (regardless of outbound links).
+   * Additive JSON field; see islanded_pages for compatibility semantics.
+   */
+  pages_without_inbound_links?: number;
   missing_embeddings: number;
   /**
    * Composite quality score, 0-100. Weighted sum of five components: embed

--- a/test/autopilot-cycle-handler.test.ts
+++ b/test/autopilot-cycle-handler.test.ts
@@ -66,47 +66,47 @@ async function runHandlerOnce(jobData: Record<string, unknown>): Promise<{ parti
 
 describe('autopilot-cycle handler source_id validation + archive recheck', () => {
   test('missing source_id (legacy caller) runs cycle normally', async () => {
-    const result = await runHandlerOnce({ repoPath: brainDir, phases: ['lint'] });
+    const result = await runHandlerOnce({ repoPath: brainDir, phases: ['extract_facts'] });
     // status is whatever runCycle decided; just ensure handler didn't reject
     expect(['ok', 'clean', 'partial', 'failed', 'skipped']).toContain(result.status);
   });
 
   test('valid source_id + existing source runs cycle', async () => {
     await seedSource('alpha');
-    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'alpha', phases: ['lint'] });
+    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'alpha', phases: ['extract_facts'] });
     expect(['ok', 'clean']).toContain(result.status);
   });
 
   test('source_id pointing at non-existent source returns skipped', async () => {
-    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'no-such-source', phases: ['lint'] });
+    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'no-such-source', phases: ['extract_facts'] });
     expect(result.status).toBe('skipped');
     expect(result.report.reason).toBe('source_not_found');
   });
 
   test('source_id pointing at archived source returns skipped (codex P1-5)', async () => {
     await seedSource('archived-src', { archived: true });
-    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'archived-src', phases: ['lint'] });
+    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'archived-src', phases: ['extract_facts'] });
     expect(result.status).toBe('skipped');
     expect(result.report.reason).toBe('source_archived');
   });
 
   test('malformed source_id (regex fail) throws (codex P1-B)', async () => {
     await expect(
-      runHandlerOnce({ repoPath: brainDir, source_id: 'BAD ID', phases: ['lint'] }),
+      runHandlerOnce({ repoPath: brainDir, source_id: 'BAD ID', phases: ['extract_facts'] }),
     ).rejects.toThrow(/invalid source_id/);
   });
 
   test('non-string source_id throws', async () => {
     await expect(
-      runHandlerOnce({ repoPath: brainDir, source_id: 42, phases: ['lint'] }),
+      runHandlerOnce({ repoPath: brainDir, source_id: 42, phases: ['extract_facts'] }),
     ).rejects.toThrow(/not a string/);
   });
 
   test('explicit pull: false overrides default pull: true', async () => {
     // Behavior check via lack-of-throw + return shape — no actual pull
-    // is invoked because the phase set is just ['lint'].
+    // is invoked because the phase set is just ['extract_facts'].
     await seedSource('echo');
-    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'echo', pull: false, phases: ['lint'] });
+    const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'echo', pull: false, phases: ['extract_facts'] });
     expect(['ok', 'clean']).toContain(result.status);
   });
 });

--- a/test/autopilot-cycle-handler.test.ts
+++ b/test/autopilot-cycle-handler.test.ts
@@ -33,6 +33,7 @@ beforeEach(async () => {
   await engine.executeRaw('DELETE FROM minion_jobs').catch(() => {});
   await engine.executeRaw('DELETE FROM gbrain_cycle_locks').catch(() => {});
   await engine.executeRaw(`DELETE FROM sources WHERE id <> 'default'`).catch(() => {});
+  await engine.executeRaw('DELETE FROM pages').catch(() => {});
   brainDir = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-handler-'));
 });
 
@@ -43,6 +44,10 @@ async function seedSource(id: string, opts: { archived?: boolean } = {}): Promis
      ON CONFLICT (id) DO UPDATE SET archived = EXCLUDED.archived`,
     [id, id, brainDir, opts.archived === true],
   );
+}
+
+async function seedPage(sourceId: string, slug: string, title = 'Captured'): Promise<void> {
+  await engine.putPage(slug, { type: 'note', title, compiled_truth: `${slug} content` }, { sourceId });
 }
 
 /**
@@ -114,5 +119,22 @@ describe('autopilot-cycle handler source_id validation + archive recheck', () =>
     await expect(
       runHandlerOnce({ repoPath: brainDir, phases: ['embed'] }),
     ).rejects.toThrow('unsupported DreamCycle source phase(s): embed');
+  });
+
+  test('capturedSlugs are source-scoped and malformed entries are ignored', async () => {
+    await seedSource('alpha');
+    await seedSource('beta');
+    await seedPage('alpha', 'alpha/page');
+    await seedPage('beta', 'beta/page');
+
+    const result = await runHandlerOnce({
+      repoPath: brainDir,
+      source_id: 'alpha',
+      phases: ['extract_facts'],
+      capturedSlugs: ['alpha/page', '', '  ', 'beta/page', 7, 'alpha/page'],
+    });
+    const extractFacts = result.report.phases.find((p: any) => p.phase === 'extract_facts');
+    expect(extractFacts?.status).toBe('ok');
+    expect(extractFacts?.details.pagesScanned).toBe(1);
   });
 });

--- a/test/autopilot-cycle-handler.test.ts
+++ b/test/autopilot-cycle-handler.test.ts
@@ -109,4 +109,10 @@ describe('autopilot-cycle handler source_id validation + archive recheck', () =>
     const result = await runHandlerOnce({ repoPath: brainDir, source_id: 'echo', pull: false, phases: ['extract_facts'] });
     expect(['ok', 'clean']).toContain(result.status);
   });
+
+  test('raw unsupported phase is rejected instead of filtered into the source default', async () => {
+    await expect(
+      runHandlerOnce({ repoPath: brainDir, phases: ['embed'] }),
+    ).rejects.toThrow('unsupported DreamCycle source phase(s): embed');
+  });
 });

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -62,11 +62,16 @@ describe('isGlobalMaintenanceStale', () => {
 });
 
 describe('dispatchGlobalMaintenance — single-flight gate', () => {
-  function stubs(lastGlobalAt: string | null) {
+  function stubs(lastGlobalAt: string | null, authority: string | null = 'daily_finalizer', sources: any[] = []) {
     const added: Array<{ name: string; data: any; opts: any }> = [];
     const engine = {
       kind: 'postgres' as const,
-      getConfig: async (k: string) => (k === LAST_GLOBAL_AT_KEY ? lastGlobalAt : null),
+      getConfig: async (k: string) => {
+        if (k === LAST_GLOBAL_AT_KEY) return lastGlobalAt;
+        if (k === 'autopilot.global_maintenance.authority') return authority;
+        return null;
+      },
+      listAllSources: async () => sources,
     } as unknown as BrainEngine;
     const queue = {
       add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
@@ -76,19 +81,30 @@ describe('dispatchGlobalMaintenance — single-flight gate', () => {
     return { engine, queue, added };
   }
 
-  test('stale (never run) → dispatches one global job with single-flight opts', async () => {
-    const { engine, queue, added } = stubs(null);
+  test('stale (never run) with daily_finalizer authority → dispatches one global job with single-flight opts', async () => {
+    const { engine, queue, added } = stubs(null, 'daily_finalizer', []);
     const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 's1', timeoutMs: 1, jsonMode: true, emit: () => {} });
     expect(r.dispatched).toBe(true);
     expect(added.length).toBe(1);
     expect(added[0].name).toBe('autopilot-global-maintenance');
-    expect(added[0].opts.idempotency_key).toBe('autopilot-global:s1');
+    expect(added[0].opts.idempotency_key).toBe('dreamcycle:global:s1');
     expect(added[0].opts.maxWaiting).toBe(1); // structural single-flight
-    expect(added[0].data.phases).toEqual(GLOBAL_PHASES);
+    expect(added[0].data.phases).toEqual(['resolve_symbol_edges', 'embed', 'orphans']);
+  });
+
+  test('external_dreamcycle / builtin / unknown / missing authority → fail closed 0 / deferred / unauthorized', async () => {
+    for (const auth of ['external_dreamcycle', 'builtin', 'unknown', null]) {
+      const { engine, queue, added } = stubs(null, auth, []);
+      const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 's1', timeoutMs: 1, jsonMode: true, emit: () => {} });
+      expect(r.dispatched).toBe(false);
+      expect(added.length).toBe(0);
+      if (auth === 'external_dreamcycle') expect(r.reason).toBe('unauthorized');
+      else expect(r.reason).toBe('deferred');
+    }
   });
 
   test('fresh → does NOT dispatch', async () => {
-    const { engine, queue, added } = stubs(new Date().toISOString());
+    const { engine, queue, added } = stubs(new Date().toISOString(), 'daily_finalizer', []);
     const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 's1', timeoutMs: 1, jsonMode: true, emit: () => {} });
     expect(r.dispatched).toBe(false);
     expect(added.length).toBe(0);

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -169,7 +169,12 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
   let engine: PGLiteEngine;
   beforeAll(async () => { engine = new PGLiteEngine(); await engine.connect({}); await engine.initSchema(); }, 30000);
   afterAll(async () => { await engine.disconnect(); });
-  beforeEach(async () => { await resetPgliteState(engine); });
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    // Legacy/global handler fixtures model the built-in daily finalizer unless
+    // a test deliberately switches authority to exercise the external gate.
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+  });
 
   async function captureHandlers() {
     const handlers = new Map<string, (job: any) => Promise<any>>();
@@ -218,7 +223,7 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     expect(Number.isFinite(new Date(stamped!).getTime())).toBe(true);
   });
 
-  test('missing authority/snapshot and a changed receipt defer without global execution', async () => {
+  test('missing internal authority/snapshot and a changed receipt defer without global execution', async () => {
     const handlers = await captureHandlers();
     const handler = handlers.get('autopilot-global-maintenance');
     expect(handler).toBeTruthy();
@@ -257,17 +262,87 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     const job = await queue.getJob(sealed.global_job_id);
     expect(job).not.toBeNull();
 
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    // The sealed external flow remains valid while its authority and receipt
+    // proof are intact.
+    const approved = await handler!({ data: job!.data, signal: undefined });
+    expect(approved.status).not.toBe('skipped');
+
     // The queued payload was valid when sealed, but the handler must refuse
     // it when today's external authority is no longer active.
     await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
-    const handlers = await captureHandlers();
-    const handler = handlers.get('autopilot-global-maintenance');
     const result = await handler!({ data: job!.data, signal: undefined });
     expect(result.status).toBe('skipped');
     expect(result.report).toMatchObject({
       reason: 'global_deferred',
       detail: 'external_batch_mismatch_or_incomplete',
     });
+  });
+
+  test('queued daily and legacy finalizers defer when authority flips to external_dreamcycle before claim', async () => {
+    await engine.setConfig('version', '123');
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+    const queue = new MinionQueue(engine);
+    const queuedJobs = [];
+    for (const [label, finalizerOrigin] of [
+      ['daily', 'daily_finalizer'],
+      ['legacy', undefined],
+    ] as const) {
+      queuedJobs.push(await queue.add(
+        'autopilot-global-maintenance',
+        {
+          ...await makeVerifiedFinalizerData(['orphans']),
+          ...(finalizerOrigin === undefined ? {} : { finalizer_origin: finalizerOrigin }),
+        },
+        {
+          queue: 'default',
+          idempotency_key: `test:${label}-finalizer-authority-flip`,
+          max_attempts: 1,
+        },
+        { allowProtectedSubmit: true },
+      ));
+    }
+
+    await engine.setConfig('autopilot.global_maintenance.authority', 'external_dreamcycle');
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    for (const queued of queuedJobs) {
+      const result = await handler!({ data: queued.data, signal: undefined });
+      expect(result).toMatchObject({
+        status: 'skipped',
+        report: { reason: 'global_deferred', detail: 'daily_finalizer_not_enabled' },
+      });
+      expect(result.report.phases).toBeUndefined();
+    }
+    expect(await engine.getConfig(LAST_GLOBAL_AT_KEY)).toBeNull();
+  });
+
+  test('authority config-read failure defers a global job at claim time', async () => {
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+    const data = {
+      ...await makeVerifiedFinalizerData(['orphans']),
+      finalizer_origin: 'daily_finalizer',
+    };
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    const originalGetConfig = engine.getConfig;
+    engine.getConfig = async (key: string) => {
+      if (key === 'autopilot.global_maintenance.authority') {
+        throw new Error('configuration database unavailable');
+      }
+      return originalGetConfig.call(engine, key);
+    };
+    try {
+      const result = await handler!({ data, signal: undefined });
+      expect(result).toMatchObject({
+        status: 'skipped',
+        report: { reason: 'global_deferred', detail: 'daily_finalizer_not_enabled' },
+      });
+      expect(result.report.phases).toBeUndefined();
+    } finally {
+      engine.getConfig = originalGetConfig;
+    }
   });
 
   test('raw invalid global phase is rejected rather than filtered to a default', async () => {

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -14,6 +14,11 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { registerBuiltinHandlers } from '../src/commands/jobs.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import {
+  beginExternalDreamcycle,
+  finalizeExternalDreamcycle,
+} from '../src/commands/dreamcycle.ts';
 import {
   ALL_PHASES,
   DREAMCYCLE_SOURCE_PHASES,
@@ -227,6 +232,42 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     const changed = await handler!({ data, signal: undefined });
     expect(changed.status).toBe('skipped');
     expect(changed.report.reason).toBe('global_deferred');
+  });
+
+  test('external DreamCycle finalizer revalidates its begin batch at handler claim time', async () => {
+    // resetPgliteState intentionally truncates user config; MinionQueue's
+    // existing schema guard reads this normal runtime version key.
+    await engine.setConfig('version', '123');
+    await engine.setConfig('autopilot.global_maintenance.authority', 'external_dreamcycle');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config, archived, created_at)
+       VALUES ($1, $2, $3, '{}'::jsonb, false, NOW())`,
+      ['external-source', 'external-source', '/tmp/gbrain-external-source'],
+    );
+    const queue = new MinionQueue(engine);
+    const begun = await beginExternalDreamcycle(engine, queue);
+    expect(begun.outcome).toBe('begun');
+    await engine.updateSourceConfig('external-source', {
+      last_source_cycle_at: new Date(Date.now() + 1_000).toISOString(),
+      last_full_cycle_at: new Date(Date.now() + 1_000).toISOString(),
+    });
+    const sealed = await finalizeExternalDreamcycle(engine, queue);
+    expect(sealed.outcome).toBe('sealed');
+    if (sealed.outcome !== 'sealed') throw new Error('fixture did not seal external finalizer');
+    const job = await queue.getJob(sealed.global_job_id);
+    expect(job).not.toBeNull();
+
+    // The queued payload was valid when sealed, but the handler must refuse
+    // it when today's external authority is no longer active.
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    const result = await handler!({ data: job!.data, signal: undefined });
+    expect(result.status).toBe('skipped');
+    expect(result.report).toMatchObject({
+      reason: 'global_deferred',
+      detail: 'external_batch_mismatch_or_incomplete',
+    });
   });
 
   test('raw invalid global phase is rejected rather than filtered to a default', async () => {

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -16,6 +16,7 @@ import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { registerBuiltinHandlers } from '../src/commands/jobs.ts';
 import {
   ALL_PHASES,
+  DREAMCYCLE_SOURCE_PHASES,
   GLOBAL_PHASES,
   NON_GLOBAL_PHASES,
   PHASE_SCOPE,
@@ -23,6 +24,8 @@ import {
 } from '../src/core/cycle.ts';
 import {
   dispatchGlobalMaintenance,
+  createGlobalMaintenanceSourceSnapshot,
+  getJSTDaySlot,
   isGlobalMaintenanceStale,
   dispatchPerSource,
 } from '../src/commands/autopilot-fanout.ts';
@@ -62,8 +65,12 @@ describe('isGlobalMaintenanceStale', () => {
 });
 
 describe('dispatchGlobalMaintenance — single-flight gate', () => {
-  function stubs(lastGlobalAt: string | null, authority: string | null = 'daily_finalizer', sources: any[] = []) {
-    const added: Array<{ name: string; data: any; opts: any }> = [];
+  function receiptSource(id = 'source-a', receiptAt = new Date().toISOString()) {
+    return { id, name: id, local_path: '/tmp/brain', config: { last_source_cycle_at: receiptAt } };
+  }
+
+  function stubs(lastGlobalAt: string | null, authority: string | null = 'daily_finalizer', sources: any[] = [receiptSource()]) {
+    const added: Array<{ name: string; data: any; opts: any; trusted: any }> = [];
     const engine = {
       kind: 'postgres' as const,
       getConfig: async (k: string) => {
@@ -74,22 +81,26 @@ describe('dispatchGlobalMaintenance — single-flight gate', () => {
       listAllSources: async () => sources,
     } as unknown as BrainEngine;
     const queue = {
-      add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
-        added.push({ name, data, opts }); return { id: 1 };
+      add: async (name: string, data: unknown, opts: Record<string, unknown>, trusted: unknown) => {
+        added.push({ name, data, opts, trusted }); return { id: 1 };
       },
     } as any;
     return { engine, queue, added };
   }
 
   test('stale (never run) with daily_finalizer authority → dispatches one global job with single-flight opts', async () => {
-    const { engine, queue, added } = stubs(null, 'daily_finalizer', []);
-    const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 's1', timeoutMs: 1, jsonMode: true, emit: () => {} });
+    const { engine, queue, added } = stubs(null, 'daily_finalizer');
+    const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 'caller-controlled-slot', timeoutMs: 1, jsonMode: true, emit: () => {} });
     expect(r.dispatched).toBe(true);
     expect(added.length).toBe(1);
     expect(added[0].name).toBe('autopilot-global-maintenance');
-    expect(added[0].opts.idempotency_key).toBe('dreamcycle:global:s1');
+    expect(added[0].opts.idempotency_key).toBe(`dreamcycle:global:${getJSTDaySlot()}`);
     expect(added[0].opts.maxWaiting).toBe(1); // structural single-flight
     expect(added[0].data.phases).toEqual(['resolve_symbol_edges', 'embed', 'orphans']);
+    expect(added[0].data.execution_authority).toBe('dreamcycle_global');
+    expect(added[0].data.source_snapshot).toHaveLength(1);
+    expect(added[0].data.source_snapshot_revision).toBeTypeOf('string');
+    expect(added[0].trusted).toEqual({ allowProtectedSubmit: true });
   });
 
   test('external_dreamcycle / builtin / unknown / missing authority → fail closed 0 / deferred / unauthorized', async () => {
@@ -104,15 +115,33 @@ describe('dispatchGlobalMaintenance — single-flight gate', () => {
   });
 
   test('fresh → does NOT dispatch', async () => {
-    const { engine, queue, added } = stubs(new Date().toISOString(), 'daily_finalizer', []);
+    const { engine, queue, added } = stubs(new Date().toISOString(), 'daily_finalizer');
     const r = await dispatchGlobalMaintenance(engine, queue, { repoPath: '/tmp', slot: 's1', timeoutMs: 1, jsonMode: true, emit: () => {} });
     expect(r.dispatched).toBe(false);
     expect(added.length).toBe(0);
   });
+
+  test('source listing failure or incomplete receipt fails closed with zero enqueue', async () => {
+    const unavailable = {
+      kind: 'postgres' as const,
+      getConfig: async (k: string) => k === 'autopilot.global_maintenance.authority' ? 'daily_finalizer' : null,
+      listAllSources: async () => { throw new Error('database unavailable'); },
+    } as unknown as BrainEngine;
+    const added: unknown[] = [];
+    const queue = { add: async (...args: unknown[]) => { added.push(args); return { id: 1 }; } } as any;
+    const unavailableResult = await dispatchGlobalMaintenance(unavailable, queue, { repoPath: '/tmp', timeoutMs: 1, jsonMode: true, emit: () => {} });
+    expect(unavailableResult).toEqual({ dispatched: false, reason: 'global_deferred' });
+    expect(added).toHaveLength(0);
+
+    const incomplete = stubs(null, 'daily_finalizer', [{ id: 'source-a', name: 'source-a', local_path: '/tmp/brain', config: {} }]);
+    const incompleteResult = await dispatchGlobalMaintenance(incomplete.engine, incomplete.queue, { repoPath: '/tmp', timeoutMs: 1, jsonMode: true, emit: () => {} });
+    expect(incompleteResult).toEqual({ dispatched: false, reason: 'global_deferred' });
+    expect(incomplete.added).toHaveLength(0);
+  });
 });
 
-describe('dispatchPerSource — per-source jobs carry NON_GLOBAL phases (no embed)', () => {
-  test('each per-source job sets phases = NON_GLOBAL_PHASES', async () => {
+describe('dispatchPerSource — per-source jobs carry exact DreamCycle source phases', () => {
+  test('each per-source job sets the fixed source receipt allowlist', async () => {
     const sources = [{ id: 'repo-a', name: 'a', config: {} }, { id: 'repo-b', name: 'b', config: {} }];
     const added: any[] = [];
     const engine = {
@@ -125,7 +154,7 @@ describe('dispatchPerSource — per-source jobs carry NON_GLOBAL phases (no embe
     await dispatchPerSource(engine, queue, { repoPath: '/tmp', slot: 's', timeoutMs: 1, fanoutMax: 4, jsonMode: true, emit: () => {}, log: () => {} });
     expect(added.length).toBe(2);
     for (const j of added) {
-      expect(j.data.phases).toEqual(NON_GLOBAL_PHASES);
+      expect(j.data.phases).toEqual(DREAMCYCLE_SOURCE_PHASES);
       expect(j.data.phases).not.toContain('embed');
     }
   });
@@ -144,13 +173,37 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     return handlers;
   }
 
+  async function makeVerifiedFinalizerData(phases: string[] = ['orphans', 'embed']) {
+    const nowIso = new Date().toISOString();
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config, archived, created_at)
+       VALUES ($1, $2, $3, '{}'::jsonb, false, NOW())
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path, archived = false`,
+      ['daily-source', 'daily-source', '/tmp/gbrain-daily-source'],
+    );
+    await engine.updateSourceConfig('daily-source', {
+      last_source_cycle_at: nowIso,
+      last_full_cycle_at: nowIso,
+    });
+    const sources = await engine.listAllSources({ localPathOnly: true });
+    const snapshot = createGlobalMaintenanceSourceSnapshot(sources, getJSTDaySlot());
+    if (!snapshot) throw new Error('test fixture did not create a valid source snapshot');
+    return {
+      phases,
+      execution_authority: 'dreamcycle_global',
+      source_snapshot: snapshot.sources,
+      source_snapshot_revision: snapshot.revision,
+      source_snapshot_jst_day: snapshot.jst_day,
+    };
+  }
+
   test('runs global phases (no source_id) and stamps autopilot.last_global_at on success', async () => {
     expect(await engine.getConfig(LAST_GLOBAL_AT_KEY)).toBeNull();
     const handlers = await captureHandlers();
     const handler = handlers.get('autopilot-global-maintenance');
     expect(handler).toBeTruthy();
 
-    const result = await handler!({ data: { phases: ['orphans', 'embed'] }, signal: undefined });
+    const result = await handler!({ data: await makeVerifiedFinalizerData(), signal: undefined });
     // The cycle ran the requested global phases (DB-only on an empty brain).
     expect(result.report.phases.some((p: any) => p.phase === 'orphans')).toBe(true);
     expect(['ok', 'clean', 'partial']).toContain(result.report.status);
@@ -158,5 +211,29 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     const stamped = await engine.getConfig(LAST_GLOBAL_AT_KEY);
     expect(stamped).not.toBeNull();
     expect(Number.isFinite(new Date(stamped!).getTime())).toBe(true);
+  });
+
+  test('missing authority/snapshot and a changed receipt defer without global execution', async () => {
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    expect(handler).toBeTruthy();
+
+    const missing = await handler!({ data: { phases: ['orphans'] }, signal: undefined });
+    expect(missing.status).toBe('skipped');
+    expect(missing.report.reason).toBe('global_deferred');
+
+    const data = await makeVerifiedFinalizerData(['orphans']);
+    await engine.updateSourceConfig('daily-source', { last_source_cycle_at: new Date(Date.now() + 60_000).toISOString() });
+    const changed = await handler!({ data, signal: undefined });
+    expect(changed.status).toBe('skipped');
+    expect(changed.report.reason).toBe('global_deferred');
+  });
+
+  test('raw invalid global phase is rejected rather than filtered to a default', async () => {
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    expect(handler).toBeTruthy();
+    await expect(handler!({ data: await makeVerifiedFinalizerData(['purge']), signal: undefined }))
+      .rejects.toThrow('unsupported finalizer phase(s): purge');
   });
 });

--- a/test/brain-score-breakdown.test.ts
+++ b/test/brain-score-breakdown.test.ts
@@ -92,14 +92,18 @@ describe('Bug 11 — orphan_pages is "no inbound links"', () => {
     const h = await engine.getHealth();
     // hub has outbound, no inbound → NOT orphan (under the fixed definition).
     // leaf1/2/3 have inbound from hub → NOT orphan.
-    // So orphan_pages should be 0.
+    // So orphan_pages and islanded_pages should be 0, pages_without_inbound_links is 1 (hub).
     expect(h.orphan_pages).toBe(0);
+    expect(h.islanded_pages).toBe(0);
+    expect(h.pages_without_inbound_links).toBe(1);
   });
 
   test('a page with no links at all IS an orphan', async () => {
     await engine.putPage('loner', { type: 'note', title: 'Loner', compiled_truth: 'alone', frontmatter: {} });
     const h = await engine.getHealth();
     expect(h.orphan_pages).toBe(1);
+    expect(h.islanded_pages).toBe(1);
+    expect(h.pages_without_inbound_links).toBe(1);
   });
 
   test('a page with inbound links only is NOT an orphan', async () => {
@@ -116,6 +120,8 @@ describe('Bug 11 — orphan_pages is "no inbound links"', () => {
     // sink has 1 inbound (from source) → not orphan.
     // source has no inbound (but has outbound) → not orphan under new definition.
     expect(h.orphan_pages).toBe(0);
+    expect(h.islanded_pages).toBe(0);
+    expect(h.pages_without_inbound_links).toBe(1);
   });
 });
 
@@ -134,6 +140,8 @@ describe('Bug 11 — BrainHealth type shape', () => {
   test('type includes dead_links + breakdown scores', async () => {
     const typesSource = await Bun.file(new URL('../src/core/types.ts', import.meta.url)).text();
     expect(typesSource).toContain('dead_links: number');
+    expect(typesSource).toContain('islanded_pages: number');
+    expect(typesSource).toContain('pages_without_inbound_links: number');
     expect(typesSource).toContain('embed_coverage_score: number');
     expect(typesSource).toContain('link_density_score: number');
     expect(typesSource).toContain('timeline_coverage_score: number');

--- a/test/brain-score-breakdown.test.ts
+++ b/test/brain-score-breakdown.test.ts
@@ -140,8 +140,11 @@ describe('Bug 11 — BrainHealth type shape', () => {
   test('type includes dead_links + breakdown scores', async () => {
     const typesSource = await Bun.file(new URL('../src/core/types.ts', import.meta.url)).text();
     expect(typesSource).toContain('dead_links: number');
-    expect(typesSource).toContain('islanded_pages: number');
-    expect(typesSource).toContain('pages_without_inbound_links: number');
+    // These additive health fields remain optional in the public TypeScript
+    // shape so stored/fixture JSON produced before their introduction still
+    // deserializes. Engines themselves always populate both values.
+    expect(typesSource).toContain('islanded_pages?: number');
+    expect(typesSource).toContain('pages_without_inbound_links?: number');
     expect(typesSource).toContain('embed_coverage_score: number');
     expect(typesSource).toContain('link_density_score: number');
     expect(typesSource).toContain('timeline_coverage_score: number');

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -19,8 +19,10 @@ let lintCalls: Array<{ target: string; fix: boolean; dryRun: boolean | undefined
 let backlinksCalls: Array<{ action: string; dir: string; dryRun: boolean | undefined }> = [];
 let syncCalls: Array<{ dryRun: boolean | undefined; noPull: boolean | undefined; noExtract: boolean | undefined; sourceId: string | undefined }> = [];
 let extractCalls: Array<{ mode: string; dir: string; slugs: string[] | undefined }> = [];
+let extractFactsCalls: Array<{ slugs: string[] | undefined; sourceId: string; dryRun: boolean | undefined }> = [];
 let embedCalls: Array<{ stale: boolean | undefined; dryRun: boolean | undefined }> = [];
 let orphansCalls: number = 0;
+let nextSyncPagesAffected: string[] | undefined = ['a', 'b'];
 
 // Mock lint
 mock.module('../../src/commands/lint.ts', () => ({
@@ -60,13 +62,41 @@ mock.module('../../src/commands/sync.ts', () => ({
       renamed: 0,
       chunksCreated: opts.dryRun ? 0 : 10,
       embedded: 0,
-      pagesAffected: opts.dryRun ? [] : ['a', 'b'],
+      pagesAffected: opts.dryRun ? [] : nextSyncPagesAffected,
     };
   },
   runSync: async () => {},
   buildSyncManifest: () => ({ added: [], modified: [], deleted: [], renamed: [] }),
   isSyncable: () => true,
   pathToSlug: (s: string) => s,
+}));
+
+// Mock extract_facts so cycle-level merge/scope behavior can be asserted
+// without running full SQL-backed fence reconciliation.
+mock.module('../../src/core/cycle/extract-facts.ts', () => ({
+  runExtractFacts: async (_engine: any, opts: any) => {
+    extractFactsCalls.push({
+      slugs: opts.slugs,
+      sourceId: opts.sourceId,
+      dryRun: opts.dryRun,
+    });
+    const pagesScanned = Array.isArray(opts?.slugs) ? opts.slugs.length : 0;
+    return {
+      pagesScanned,
+      pagesWithFacts: pagesScanned,
+      factsInserted: 0,
+      factsDeleted: 0,
+      legacyRowsPending: 0,
+      guardTriggered: false,
+      warnings: [],
+      phantomsScanned: 0,
+      phantomsRedirected: 0,
+      phantomsAmbiguous: 0,
+      phantomsSkippedDrift: 0,
+      phantomsLockBusy: false,
+      phantomsMorePending: false,
+    };
+  },
 }));
 
 // Mock extract
@@ -146,6 +176,8 @@ beforeEach(() => {
   backlinksCalls = [];
   syncCalls = [];
   extractCalls = [];
+  extractFactsCalls = [];
+  nextSyncPagesAffected = ['a', 'b'];
   embedCalls = [];
   orphansCalls = 0;
 });
@@ -444,6 +476,97 @@ describe('runCycle — incremental extract slug propagation (#417)', () => {
     expect(syncCalls.length).toBe(0);
     expect(extractCalls.length).toBe(1);
     expect(extractCalls[0].slugs).toBeUndefined();
+  });
+});
+
+describe('runCycle — capturedSlugs handoff contract (#DreamCycle)', () => {
+  beforeEach(async () => {
+    await truncateCycleLocks(sharedEngine);
+    syncCalls = [];
+    extractCalls = [];
+    extractFactsCalls = [];
+  });
+
+  test('sync delta 0 + capturedSlugs still scans the captured page in extract_facts', async () => {
+    nextSyncPagesAffected = [];
+    await sharedEngine.putPage(
+      'captured/page',
+      { type: 'note', title: 'Captured', compiled_truth: 'captured page' },
+      { sourceId: 'default' },
+    );
+
+    const report = await runCycle(sharedEngine, {
+      executionAuthority: 'dreamcycle_source',
+      brainDir: '/tmp/brain',
+      sourceId: 'default',
+      capturedSlugs: ['captured/page'],
+      phases: ['sync', 'extract_facts'],
+    });
+
+    expect(extractFactsCalls.at(-1)?.slugs).toEqual(['captured/page']);
+    const extractFactsPhase = report.phases.find(p => p.phase === 'extract_facts');
+    expect(extractFactsPhase?.details.pagesScanned).toBe(1);
+    expect(extractFactsCalls.at(-1)?.sourceId).toBe('default');
+  });
+
+  test('capturedSlugs + syncPagesAffected duplicates are deduped deterministically before extract_facts', async () => {
+    nextSyncPagesAffected = ['dup/page', 'dup/page', 'alpha/page'];
+    await sharedEngine.putPage(
+      'dup/page',
+      { type: 'note', title: 'Dup', compiled_truth: 'dup page' },
+      { sourceId: 'default' },
+    );
+    await sharedEngine.putPage(
+      'alpha/page',
+      { type: 'note', title: 'Alpha', compiled_truth: 'alpha page' },
+      { sourceId: 'default' },
+    );
+
+    await runCycle(sharedEngine, {
+      executionAuthority: 'dreamcycle_source',
+      brainDir: '/tmp/brain',
+      sourceId: 'default',
+      capturedSlugs: ['alpha/page', 'dup/page', 'alpha/page', 'dup/page'],
+      phases: ['sync', 'extract_facts'],
+    });
+
+    expect(extractFactsCalls.at(-1)?.slugs).toEqual(['dup/page', 'alpha/page']);
+  });
+
+  test('malformed and cross-source capturedSlugs are ignored after source scoping', async () => {
+    nextSyncPagesAffected = [];
+    await sharedEngine.putPage(
+      'alpha/page',
+      { type: 'note', title: 'Alpha', compiled_truth: 'alpha page' },
+      { sourceId: 'alpha' },
+    );
+    await sharedEngine.putPage(
+      'beta/page',
+      { type: 'note', title: 'Beta', compiled_truth: 'beta page' },
+      { sourceId: 'beta' },
+    );
+
+    await runCycle(sharedEngine, {
+      executionAuthority: 'dreamcycle_source',
+      brainDir: '/tmp/brain',
+      sourceId: 'alpha',
+      capturedSlugs: ['alpha/page', '', '  ', 'beta/page', 42 as unknown as string],
+      phases: ['extract_facts'],
+    });
+
+    expect(extractFactsCalls.at(-1)?.slugs).toEqual(['alpha/page']);
+  });
+
+  test('existing no-capturedSlugs path remains unchanged for full reconcile', async () => {
+    const report = await runCycle(sharedEngine, {
+      executionAuthority: 'manual',
+      brainDir: '/tmp/brain',
+      phases: ['extract_facts'],
+    });
+
+    const extractFactsPhase = report.phases.find((p) => p.phase === 'extract_facts');
+    expect(extractFactsPhase).not.toBeUndefined();
+    expect(extractFactsCalls.at(-1)?.slugs).toBeUndefined();
   });
 });
 

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -563,25 +563,25 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
 
 describe('runCycle — executionAuthority validation', () => {
   test('missing or invalid executionAuthority throws error', async () => {
-    expect(runCycle(sharedEngine, { brainDir: '/tmp/brain' } as any)).rejects.toThrow('missing or invalid executionAuthority');
-    expect(runCycle(sharedEngine, { executionAuthority: 'fake_auth' as any, brainDir: '/tmp/brain' })).rejects.toThrow('missing or invalid executionAuthority');
+    await expect(runCycle(sharedEngine, { brainDir: '/tmp/brain' } as any)).rejects.toThrow('missing or invalid executionAuthority');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'fake_auth' as any, brainDir: '/tmp/brain' })).rejects.toThrow('missing or invalid executionAuthority');
   });
 
   test('dreamcycle_source requires sourceId and allows only sync/extract/extract_facts', async () => {
-    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', brainDir: '/tmp/brain', phases: ['sync'] })).rejects.toThrow('dreamcycle_source requires sourceId');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', brainDir: '/tmp/brain', phases: ['sync'] })).rejects.toThrow('dreamcycle_source requires sourceId');
 
     // Attempting global phase (embed) on dreamcycle_source throws
-    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_source does not allow phase(s): embed');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_source does not allow phase(s): embed');
   });
 
   test('dreamcycle_global rejects sourceId and non-allowlisted phases', async () => {
-    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('dreamcycle_global cannot be scoped to a single sourceId');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('dreamcycle_global cannot be scoped to a single sourceId');
 
     // Attempting non-allowlisted phase (sync/purge) on dreamcycle_global throws
-    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_global does not allow phase(s): sync');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_global does not allow phase(s): sync');
   });
 
   test('manual with --source and global phases emits helpful error', async () => {
-    expect(runCycle(sharedEngine, { executionAuthority: 'manual', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('manual --source cannot be combined with global phases');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'manual', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('manual --source cannot be combined with global phases');
   });
 });

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -158,7 +158,7 @@ describe('runCycle — dryRun propagates to every phase', () => {
   });
 
   test('dryRun:true reaches lint, backlinks, sync, embed', async () => {
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', dryRun: true });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', dryRun: true });
 
     expect(lintCalls.at(-1)?.dryRun).toBe(true);
     expect(backlinksCalls.at(-1)?.dryRun).toBe(true);
@@ -167,7 +167,7 @@ describe('runCycle — dryRun propagates to every phase', () => {
   });
 
   test('dryRun:false does not let maintenance append generated backlinks to tracked pages', async () => {
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', dryRun: false });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', dryRun: false });
 
     expect(lintCalls.at(-1)?.dryRun).toBe(false);
     // Maintenance should audit backlink gaps but not run the legacy fixer that
@@ -182,7 +182,7 @@ describe('runCycle — dryRun propagates to every phase', () => {
   });
 
   test('dryRun skips extract phase (no dry-run support)', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain', dryRun: true });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', dryRun: true });
     expect(extractCalls.length).toBe(0);
     const extractPhase = report.phases.find(p => p.phase === 'extract');
     expect(extractPhase?.status).toBe('skipped');
@@ -198,12 +198,12 @@ describe('runCycle — phase selection', () => {
   });
 
   test('default: all 6 phases run in order', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
     expect(report.phases.map(p => p.phase)).toEqual(ALL_PHASES);
   });
 
   test('--phase lint only runs lint', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['lint'] });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['lint'] });
     expect(report.phases.map(p => p.phase)).toEqual(['lint']);
     expect(lintCalls.length).toBe(1);
     expect(backlinksCalls.length).toBe(0);
@@ -211,7 +211,7 @@ describe('runCycle — phase selection', () => {
   });
 
   test('--phase orphans only runs orphans', async () => {
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['orphans'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['orphans'] });
     expect(orphansCalls).toBe(1);
     expect(syncCalls.length).toBe(0);
   });
@@ -229,20 +229,20 @@ describe('runCycle — cycle lock acquire/release semantics', () => {
     // never written to. Seeding a stale holder and verifying it survives
     // the run would also work, but a simpler assertion: no rows ever
     // existed for a read-only-only selection.
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['orphans'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['orphans'] });
     const { rows } = await (sharedEngine as any).db.query('SELECT COUNT(*)::int AS n FROM gbrain_cycle_locks');
     expect(rows[0].n).toBe(0);
   });
 
   test('phases including lint DOES acquire + release (table empty after run)', async () => {
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['lint'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['lint'] });
     // Lock is released in finally, so no rows survive the run.
     const { rows } = await (sharedEngine as any).db.query('SELECT COUNT(*)::int AS n FROM gbrain_cycle_locks');
     expect(rows[0].n).toBe(0);
   });
 
   test('phases including sync DOES acquire + release the lock', async () => {
-    await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['sync'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['sync'] });
     const { rows } = await (sharedEngine as any).db.query('SELECT COUNT(*)::int AS n FROM gbrain_cycle_locks');
     expect(rows[0].n).toBe(0);
   });
@@ -262,7 +262,7 @@ describe('runCycle — cycle_already_running skip', () => {
        VALUES ('gbrain-cycle', 99999, 'other-host', NOW(), NOW() + INTERVAL '1 hour')`
     );
 
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
 
     expect(report.status).toBe('skipped');
     expect(report.reason).toBe('cycle_already_running');
@@ -279,7 +279,7 @@ describe('runCycle — cycle_already_running skip', () => {
        VALUES ('gbrain-cycle', 99999, 'crashed-host', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '1 hour')`
     );
 
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
 
     expect(report.status).not.toBe('skipped');
     expect(syncCalls.length).toBe(1); // cycle ran
@@ -296,7 +296,7 @@ describe('runCycle — engine = null (filesystem-only mode)', () => {
   });
 
   test('filesystem phases still run when engine is null', async () => {
-    const report = await runCycle(null, { brainDir: '/tmp/brain' });
+    const report = await runCycle(null, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
 
     // Lint and backlinks ran.
     expect(lintCalls.length).toBe(1);
@@ -323,7 +323,7 @@ describe('runCycle — engine = null (filesystem-only mode)', () => {
     mkdirSync(path.dirname(lockFile), { recursive: true });
     writeFileSync(lockFile, `1\n${new Date().toISOString()}\n`);
 
-    const report = await runCycle(null, { brainDir: '/tmp/brain' });
+    const report = await runCycle(null, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
     expect(report.status).toBe('skipped');
     expect(report.reason).toBe('cycle_already_running');
     // None of the filesystem phases ran because the lock blocked entry.
@@ -340,7 +340,7 @@ describe('runCycle — status derivation', () => {
   });
 
   test('ok when work was done (non-dry-run)', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
     expect(['ok', 'partial']).toContain(report.status);
     // Non-dry-run fixtures produce work (fixes:2, added:4 etc.), so:
     expect(report.status).toBe('ok');
@@ -352,12 +352,12 @@ describe('runCycle — status derivation', () => {
   });
 
   test('schema_version is stable at "1"', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
     expect(report.schema_version).toBe('1');
   });
 
   test('CycleReport shape includes all required top-level fields', async () => {
-    const report = await runCycle(sharedEngine,{ brainDir: '/tmp/brain' });
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
     expect(report).toHaveProperty('schema_version');
     expect(report).toHaveProperty('timestamp');
     expect(report).toHaveProperty('duration_ms');
@@ -377,7 +377,7 @@ describe('runCycle — yieldBetweenPhases hook', () => {
 
   test('hook is called between every phase', async () => {
     let hookCalls = 0;
-    await runCycle(sharedEngine,{
+    await runCycle(sharedEngine, { executionAuthority: "manual", 
       brainDir: '/tmp/brain',
       yieldBetweenPhases: async () => {
         hookCalls++;
@@ -398,7 +398,7 @@ describe('runCycle — yieldBetweenPhases hook', () => {
   });
 
   test('hook exceptions do not abort the cycle', async () => {
-    const report = await runCycle(sharedEngine,{
+    const report = await runCycle(sharedEngine, { executionAuthority: "manual", 
       brainDir: '/tmp/brain',
       yieldBetweenPhases: async () => {
         throw new Error('synthetic hook error');
@@ -427,7 +427,7 @@ describe('runCycle — incremental extract slug propagation (#417)', () => {
   test('cycle threads sync.pagesAffected into extract phase as the slugs argument', async () => {
     // performSync mock returns pagesAffected = ['a', 'b']. The extract phase
     // must receive those exact slugs, not undefined (which would trigger a full walk).
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain' });
 
     // Sync ran once
     expect(syncCalls.length).toBe(1);
@@ -439,7 +439,7 @@ describe('runCycle — incremental extract slug propagation (#417)', () => {
   test('extract phase falls back to full walk when sync was skipped (slugs undefined)', async () => {
     // Run only the extract phase — sync didn't run, so syncPagesAffected
     // is undefined and extract should walk the full directory (slugs:undefined).
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['extract'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['extract'] });
 
     expect(syncCalls.length).toBe(0);
     expect(extractCalls.length).toBe(1);
@@ -455,7 +455,7 @@ describe('runCycle — Codex F2: noExtract is gated on whether extract phase run
   });
 
   test('full cycle (sync + extract): noExtract=true so sync skips inline extraction (extract phase handles it)', async () => {
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['sync', 'extract'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['sync', 'extract'] });
 
     expect(syncCalls.length).toBe(1);
     expect(syncCalls[0].noExtract).toBe(true);  // dedupe enabled
@@ -463,7 +463,7 @@ describe('runCycle — Codex F2: noExtract is gated on whether extract phase run
   });
 
   test('phases:[sync] only: noExtract=false so sync runs inline extraction (no silent extract drop)', async () => {
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['sync'] });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain', phases: ['sync'] });
 
     expect(syncCalls.length).toBe(1);
     // Critical: noExtract must be false here. If it were true, the user just lost
@@ -495,12 +495,12 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
       `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
       ['default', 'default', '/tmp/brain-475-a'],
     );
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain-475-a' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-a' });
     expect(syncCalls.at(-1)?.sourceId).toBe('default');
   });
 
   test('no matching sources row → performSync receives sourceId=undefined', async () => {
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain-475-b' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-b' });
     expect(syncCalls.at(-1)?.sourceId).toBeUndefined();
   });
 
@@ -509,7 +509,7 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
       `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
       ['other', 'other', '/some/other/brain'],
     );
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain-475-c' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-c' });
     expect(syncCalls.at(-1)?.sourceId).toBeUndefined();
   });
 
@@ -524,7 +524,7 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
     await fresh.initSchema();
     await (fresh as any).db.query('DROP TABLE IF EXISTS sources CASCADE');
     try {
-      await runCycle(fresh, { brainDir: '/tmp/brain-475-d' });
+      await runCycle(fresh, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-d' });
       expect(syncCalls.at(-1)?.sourceId).toBeUndefined();
     } finally {
       await fresh.disconnect();
@@ -541,7 +541,7 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
         ('first', 'first', '/tmp/brain-475-e'),
         ('second', 'second', '/tmp/brain-475-e')`,
     );
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain-475-e' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-e' });
     const sourceId = syncCalls.at(-1)?.sourceId;
     expect(sourceId).toBeDefined();
     expect(['first', 'second']).toContain(sourceId as string);
@@ -556,7 +556,32 @@ describe('runCycle — sourceId resolution (regression #475)', () => {
     await (sharedEngine as any).db.query(
       `INSERT INTO sources (id, name, local_path) VALUES ('', 'empty', '/tmp/brain-475-f')`,
     );
-    await runCycle(sharedEngine, { brainDir: '/tmp/brain-475-f' });
+    await runCycle(sharedEngine, { executionAuthority: "manual",  brainDir: '/tmp/brain-475-f' });
     expect(syncCalls.at(-1)?.sourceId).toBe('');
+  });
+});
+
+describe('runCycle — executionAuthority validation', () => {
+  test('missing or invalid executionAuthority throws error', async () => {
+    expect(runCycle(sharedEngine, { brainDir: '/tmp/brain' } as any)).rejects.toThrow('missing or invalid executionAuthority');
+    expect(runCycle(sharedEngine, { executionAuthority: 'fake_auth' as any, brainDir: '/tmp/brain' })).rejects.toThrow('missing or invalid executionAuthority');
+  });
+
+  test('dreamcycle_source requires sourceId and allows only sync/extract/extract_facts', async () => {
+    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', brainDir: '/tmp/brain', phases: ['sync'] })).rejects.toThrow('dreamcycle_source requires sourceId');
+
+    // Attempting global phase (embed) on dreamcycle_source throws
+    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_source', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_source does not allow phase(s): embed');
+  });
+
+  test('dreamcycle_global rejects sourceId and non-allowlisted phases', async () => {
+    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('dreamcycle_global cannot be scoped to a single sourceId');
+
+    // Attempting non-allowlisted phase (sync/purge) on dreamcycle_global throws
+    expect(runCycle(sharedEngine, { executionAuthority: 'dreamcycle_global', brainDir: '/tmp/brain', phases: ['sync', 'embed'] })).rejects.toThrow('dreamcycle_global does not allow phase(s): sync');
+  });
+
+  test('manual with --source and global phases emits helpful error', async () => {
+    expect(runCycle(sharedEngine, { executionAuthority: 'manual', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('manual --source cannot be combined with global phases');
   });
 });

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -535,6 +535,14 @@ describe('runCycle — capturedSlugs handoff contract (#DreamCycle)', () => {
 
   test('malformed and cross-source capturedSlugs are ignored after source scoping', async () => {
     nextSyncPagesAffected = [];
+    // `pages.source_id` is an FK. Seed both sources explicitly so this
+    // contract test stays independent of earlier suite state.
+    await (sharedEngine as any).db.query(
+      `INSERT INTO sources (id, name, local_path) VALUES
+        ('alpha', 'alpha', '/tmp/captured-alpha'),
+        ('beta', 'beta', '/tmp/captured-beta')
+       ON CONFLICT (id) DO NOTHING`,
+    );
     await sharedEngine.putPage(
       'alpha/page',
       { type: 'note', title: 'Alpha', compiled_truth: 'alpha page' },
@@ -705,6 +713,6 @@ describe('runCycle — executionAuthority validation', () => {
   });
 
   test('manual with --source and global phases emits helpful error', async () => {
-    await expect(runCycle(sharedEngine, { executionAuthority: 'manual', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('manual --source cannot be combined with global phases');
+    await expect(runCycle(sharedEngine, { executionAuthority: 'manual', sourceId: 'src1', brainDir: '/tmp/brain', phases: ['embed'] })).rejects.toThrow('Omit --source and rerun unscoped with `gbrain dream --phase <global-phase>`');
   });
 });

--- a/test/cycle-abort.test.ts
+++ b/test/cycle-abort.test.ts
@@ -35,6 +35,7 @@ describe('CycleOpts.signal contract (v0.20.5)', () => {
     // Call with null engine + minimal opts — should return a report
     // (phases that need engine will be skipped)
     const report = await runCycle(null, {
+      executionAuthority: 'manual',
       brainDir: '/nonexistent-for-test',
       phases: [], // empty phases = no work
       signal: abort.signal,
@@ -53,6 +54,7 @@ describe('CycleOpts.signal contract (v0.20.5)', () => {
     // throw or return failed (depending on which phase catches it first)
     try {
       const report = await runCycle(null, {
+        executionAuthority: 'manual',
         brainDir: '/nonexistent-for-test',
         phases: ['lint'], // lint doesn't need engine, would normally run
         signal: abort.signal,
@@ -75,6 +77,7 @@ describe('CycleOpts.signal contract (v0.20.5)', () => {
 
     try {
       const report = await runCycle(null, {
+        executionAuthority: 'manual',
         brainDir: '/nonexistent-for-test',
         phases: ['lint', 'backlinks', 'orphans'],
         signal: abort.signal,
@@ -162,6 +165,7 @@ describe('#1972 — complete cooperative-abort coverage', () => {
     const abort = new AbortController();
     abort.abort(new Error('timeout'));
     const report = await runCycle(null, {
+      executionAuthority: 'manual',
       brainDir: '/nonexistent-for-test',
       phases: [],
       signal: abort.signal,

--- a/test/cycle-extract-source.test.ts
+++ b/test/cycle-extract-source.test.ts
@@ -70,6 +70,7 @@ describe('cycle extract phase on a federated brain (#1503)', () => {
   test('extract phase resolves the source from brainDir and writes links + timeline there', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       const report = await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         phases: ['extract'],
       });
@@ -102,6 +103,7 @@ describe('cycle extract phase on a federated brain (#1503)', () => {
   test('explicit opts.sourceId wins (checkout-less --source shape)', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       const report = await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         sourceId: 'wiki',
         phases: ['extract'],

--- a/test/cycle-last-full-cycle-at.test.ts
+++ b/test/cycle-last-full-cycle-at.test.ts
@@ -75,6 +75,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
       // Run a minimal cycle: just lint (filesystem, no DB writes, always returns 'ok')
       const t0 = Date.now();
       const report = await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         sourceId: 'alpha',
         phases: ['lint'],
@@ -95,6 +96,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
       await seedSource('default-like');
       // No sourceId passed; should remain untouched.
       await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         phases: ['lint'],
       });
@@ -108,6 +110,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       await seedSource('beta');
       await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         sourceId: 'beta',
         phases: ['lint'],
@@ -131,6 +134,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
         [lockId, pid + 99999],
       );
       const report = await runCycle(engine, {
+        executionAuthority: 'manual',
         brainDir,
         sourceId: 'gamma',
         phases: ['lint', 'sync'], // sync triggers lock acquisition
@@ -145,12 +149,12 @@ describe('runCycle last_full_cycle_at exit hook', () => {
   test('two consecutive per-source cycles update the timestamp on each run', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       await seedSource('delta');
-      await runCycle(engine, { brainDir, sourceId: 'delta', phases: ['lint'] });
+      await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'delta', phases: ['lint'] });
       const first = await readLastFullCycleAt('delta');
       expect(first).not.toBeNull();
       // Wait 10ms so the timestamp can advance
       await new Promise(r => setTimeout(r, 10));
-      await runCycle(engine, { brainDir, sourceId: 'delta', phases: ['lint'] });
+      await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'delta', phases: ['lint'] });
       const second = await readLastFullCycleAt('delta');
       expect(second).not.toBeNull();
       expect(new Date(second!).getTime()).toBeGreaterThan(new Date(first!).getTime());

--- a/test/cycle-pglite-lock-ordering.serial.test.ts
+++ b/test/cycle-pglite-lock-ordering.serial.test.ts
@@ -77,6 +77,7 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
     // right after acquisition by hooking into yieldBetweenPhases.
     let lockFileExisted = false;
     await runCycle(engine, {
+      executionAuthority: 'manual',
       brainDir,
       sourceId: 'alpha',
       phases: ['lint', 'backlinks'], // sync triggers DB-needing phase set
@@ -120,9 +121,9 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
     // this test as the "lock exists during cycle" companion to test #1.
 
     // Run cycle alpha to clear our planted file (recovers as stale)
-    await runCycle(engine, { brainDir, sourceId: 'alpha', phases: ['lint', 'backlinks'] });
+    await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'alpha', phases: ['lint', 'backlinks'] });
     // Run cycle beta — should succeed too (alpha already released)
-    const r = await runCycle(engine, { brainDir, sourceId: 'beta', phases: ['lint', 'backlinks'] });
+    const r = await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'beta', phases: ['lint', 'backlinks'] });
     // Status: succeeded after the previous cycle released the file lock
     expect(['ok', 'clean']).toContain(r.status);
   });
@@ -140,6 +141,7 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
       [lockId, process.pid + 99999],
     );
     const r = await runCycle(engine, {
+      executionAuthority: 'manual',
       brainDir,
       sourceId: 'gamma',
       phases: ['lint'], // needs lock (lint is in NEEDS_LOCK_PHASES)
@@ -153,6 +155,7 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
   test('cycle without engine (file-lock-only path) still works', async () => {
     // engine=null path: file lock acquired, no DB lock involved.
     const r = await runCycle(null, {
+      executionAuthority: 'manual',
       brainDir,
       phases: ['lint'], // no DB phases
     });
@@ -165,6 +168,7 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
     await seed('epsilon');
     let dbLockRowSeen: { id: string } | null = null;
     await runCycle(engine, {
+      executionAuthority: 'manual',
       brainDir,
       sourceId: 'epsilon',
       phases: ['lint', 'backlinks'],
@@ -183,8 +187,8 @@ describe('PGLite cycle: file lock + per-source DB lock ordering', () => {
   test('subsequent cycle after clean exit can acquire both locks', async () => {
     await seed('zeta');
     // Run twice — confirms release worked correctly the first time
-    const r1 = await runCycle(engine, { brainDir, sourceId: 'zeta', phases: ['lint', 'backlinks'] });
-    const r2 = await runCycle(engine, { brainDir, sourceId: 'zeta', phases: ['lint', 'backlinks'] });
+    const r1 = await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'zeta', phases: ['lint', 'backlinks'] });
+    const r2 = await runCycle(engine, { executionAuthority: 'manual', brainDir, sourceId: 'zeta', phases: ['lint', 'backlinks'] });
     expect(['ok', 'clean']).toContain(r1.status);
     expect(['ok', 'clean']).toContain(r2.status);
     // Both locks released after second cycle too

--- a/test/dream-postgres.serial.test.ts
+++ b/test/dream-postgres.serial.test.ts
@@ -94,6 +94,11 @@ describe('runDream — checkout-less brain (no --dir, no sync.repo_path)', () =>
     if (!report) return;
     expect(report.brain_dir).toBeNull();
     expect(report.status).not.toBe('failed');
+    expect(report.phases.map((entry: any) => entry.phase)).toEqual(['sync', 'extract', 'extract_facts']);
+
+    await expect(
+      runDream(engine, ['--source', 'repo-a', '--phase', 'embed', '--dry-run', '--json']),
+    ).rejects.toThrow('manual --source cannot be combined with global phases');
   });
 });
 
@@ -196,7 +201,7 @@ describe('runCycle — A7 deriveStatus counts resolved edges as work', () => {
       [caller[0]!.id],
     );
 
-    const report = await runCycle(engine, { brainDir: null, phases: ['resolve_symbol_edges'] });
+    const report = await runCycle(engine, { executionAuthority: 'manual', brainDir: null, phases: ['resolve_symbol_edges'] });
     expect(report.totals.edges_resolved).toBe(1);
     expect(report.status).toBe('ok'); // pre-A7 this was 'clean'
   });

--- a/test/dreamcycle-finalize.test.ts
+++ b/test/dreamcycle-finalize.test.ts
@@ -200,6 +200,37 @@ describe('external DreamCycle begin/finalize', () => {
     expect(await externalDreamcycleFinalizerBatchMatches(engine, job!.data, { now: NOW })).toBe(false);
   });
 
+  test('sealed external batch remains valid across JST midnight only for its sealed day', async () => {
+    const begunAt = new Date('2026-07-19T14:59:00.000Z'); // JST 2026-07-19 23:59
+    const receiptAt = new Date('2026-07-19T14:59:30.000Z');
+    const claimedAt = new Date('2026-07-19T15:01:00.000Z'); // JST 2026-07-20 00:01
+    await seedSource('alpha');
+
+    const begun = await beginExternalDreamcycle(engine, queue, { now: begunAt });
+    expect(begun.outcome).toBe('begun');
+    await markSourceComplete('alpha', receiptAt);
+    const sealed = await finalizeExternalDreamcycle(engine, queue, { now: receiptAt });
+    expect(sealed.outcome).toBe('sealed');
+    if (sealed.outcome !== 'sealed') throw new Error('expected sealed finalizer');
+    const job = await queue.getJob(sealed.global_job_id);
+    expect(job).not.toBeNull();
+
+    // The next-day worker clock must not select a new begin record or require
+    // next-day source receipts. The sealed job owns its original JST day.
+    expect(await externalDreamcycleFinalizerBatchMatches(engine, job!.data, { now: claimedAt })).toBe(true);
+
+    // Both sealed day fields are independent integrity gates. A malformed or
+    // mismatched day must never turn this into a cross-day replay.
+    expect(await externalDreamcycleFinalizerBatchMatches(engine, {
+      ...job!.data,
+      source_snapshot_jst_day: '2026-07-20',
+    }, { now: claimedAt })).toBe(false);
+    expect(await externalDreamcycleFinalizerBatchMatches(engine, {
+      ...job!.data,
+      external_dreamcycle_begin_jst_day: 'not-a-jst-day',
+    }, { now: claimedAt })).toBe(false);
+  });
+
   test('CLI parser accepts no phase/source/authority/snapshot override', () => {
     expect(parseDreamcycleArgs(['begin', '--json'])).toEqual({ action: 'begin', json: true, help: false });
     expect(() => parseDreamcycleArgs(['finalize', '--phase', 'orphans']))

--- a/test/dreamcycle-finalize.test.ts
+++ b/test/dreamcycle-finalize.test.ts
@@ -70,6 +70,18 @@ describe('external DreamCycle begin/finalize', () => {
     expect(jobs[0]?.count).toBe('0');
   });
 
+  test('authority config-read failures fail closed at every external entry point', async () => {
+    const unavailable = {
+      getConfig: async () => { throw new Error('configuration database unavailable'); },
+    } as unknown as PGLiteEngine;
+
+    expect(await beginExternalDreamcycle(unavailable, queue, { now: NOW }))
+      .toEqual({ outcome: 'global_deferred', detail: 'external_dreamcycle_not_enabled' });
+    expect(await finalizeExternalDreamcycle(unavailable, queue, { now: NOW }))
+      .toEqual({ outcome: 'global_deferred', detail: 'external_dreamcycle_not_enabled' });
+    expect(await externalDreamcycleFinalizerBatchMatches(unavailable, {}, { now: NOW })).toBe(false);
+  });
+
   test('begin persists a source-id snapshot, then finalize seals one fixed protected global job', async () => {
     await seedSource('alpha');
     await seedSource('beta');

--- a/test/dreamcycle-finalize.test.ts
+++ b/test/dreamcycle-finalize.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Local-only external DreamCycle finalization contract.
+ *
+ * The external scheduler may only call begin/finalize. These tests pin that
+ * begin records source membership in minion_jobs, finalization needs receipts
+ * newer than begin, drift/de-dup defer safely, and the worker can revalidate
+ * the sealed batch without a new HTTP/MCP operation.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import {
+  beginExternalDreamcycle,
+  EXTERNAL_DREAMCYCLE_AUTHORITY,
+  externalDreamcycleFinalizerBatchMatches,
+  finalizeExternalDreamcycle,
+  parseDreamcycleArgs,
+} from '../src/commands/dreamcycle.ts';
+
+let engine: PGLiteEngine;
+let queue: MinionQueue;
+
+const NOW = new Date('2026-07-19T01:00:00.000Z'); // JST 10:00, safely inside one day
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+  queue = new MinionQueue(engine);
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  // Keep the schema/version config that MinionQueue.ensureSchema() needs.
+  await engine.executeRaw('DELETE FROM minion_jobs');
+  await engine.executeRaw('DELETE FROM gbrain_cycle_locks');
+  await engine.executeRaw(`DELETE FROM sources WHERE id <> 'default'`);
+  await engine.setConfig('autopilot.global_maintenance.authority', EXTERNAL_DREAMCYCLE_AUTHORITY);
+});
+
+async function seedSource(id: string): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config, archived, created_at)
+     VALUES ($1, $2, $3, '{}'::jsonb, false, NOW())`,
+    [id, id, `/tmp/gbrain-dreamcycle-${id}`],
+  );
+}
+
+async function markSourceComplete(id: string, at = new Date(NOW.getTime() + 1_000)): Promise<void> {
+  await engine.updateSourceConfig(id, {
+    last_source_cycle_at: at.toISOString(),
+    last_full_cycle_at: at.toISOString(),
+  });
+}
+
+describe('external DreamCycle begin/finalize', () => {
+  test('requires the existing external_dreamcycle authority before recording anything', async () => {
+    await seedSource('alpha');
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+
+    const result = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(result).toEqual({ outcome: 'global_deferred', detail: 'external_dreamcycle_not_enabled' });
+    const jobs = await engine.executeRaw<{ count: string }>(
+      `SELECT count(*)::text AS count FROM minion_jobs`,
+    );
+    expect(jobs[0]?.count).toBe('0');
+  });
+
+  test('begin persists a source-id snapshot, then finalize seals one fixed protected global job', async () => {
+    await seedSource('alpha');
+    await seedSource('beta');
+
+    const begun = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(begun.outcome).toBe('begun');
+    if (begun.outcome !== 'begun') throw new Error('expected begin receipt');
+
+    const beginJob = await queue.getJob(begun.begin_job_id);
+    expect(beginJob?.name).toBe('dreamcycle-begin');
+    expect(beginJob?.idempotency_key).toBe('dreamcycle:external:begin:2026-07-19');
+    expect(beginJob?.data.source_snapshot).toEqual([
+      { source_id: 'alpha' },
+      { source_id: 'beta' },
+    ]);
+    expect(beginJob?.data.source_snapshot_revision).toBe('["alpha","beta"]');
+
+    await markSourceComplete('alpha');
+    await markSourceComplete('beta');
+    const sealed = await finalizeExternalDreamcycle(engine, queue, { now: NOW });
+    expect(sealed.outcome).toBe('sealed');
+    if (sealed.outcome !== 'sealed') throw new Error('expected sealed finalizer');
+
+    const globalJob = await queue.getJob(sealed.global_job_id);
+    expect(globalJob?.name).toBe('autopilot-global-maintenance');
+    expect(globalJob?.idempotency_key).toBe('dreamcycle:global:2026-07-19');
+    expect(globalJob?.data).toMatchObject({
+      repoPath: null,
+      phases: ['resolve_symbol_edges', 'embed', 'orphans'],
+      execution_authority: 'dreamcycle_global',
+      finalizer_origin: EXTERNAL_DREAMCYCLE_AUTHORITY,
+      external_dreamcycle_begin_job_id: begun.begin_job_id,
+      external_dreamcycle_begin_jst_day: '2026-07-19',
+    });
+    expect(globalJob?.data.source_snapshot).toEqual([
+      { source_id: 'alpha', receipt_at: new Date(NOW.getTime() + 1_000).toISOString() },
+      { source_id: 'beta', receipt_at: new Date(NOW.getTime() + 1_000).toISOString() },
+    ]);
+
+    // Duplicate calls never enqueue a second global pass, even after the
+    // first job has left the waiting state in a real worker deployment.
+    const duplicate = await finalizeExternalDreamcycle(engine, queue, { now: NOW });
+    expect(duplicate).toEqual({ outcome: 'global_deferred', detail: 'duplicate_global_finalizer' });
+    const globals = await engine.executeRaw<{ count: string }>(
+      `SELECT count(*)::text AS count FROM minion_jobs WHERE name = 'autopilot-global-maintenance'`,
+    );
+    expect(globals[0]?.count).toBe('1');
+  });
+
+  test('pre-begin or missing source receipts fail closed without a global job', async () => {
+    await seedSource('alpha');
+    await markSourceComplete('alpha', new Date(NOW.getTime() - 1_000));
+    const begun = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(begun.outcome).toBe('begun');
+
+    const result = await finalizeExternalDreamcycle(engine, queue, { now: NOW });
+    expect(result).toEqual({ outcome: 'global_deferred', detail: 'source_receipts_incomplete_or_pre_begin' });
+    const globals = await engine.executeRaw<{ count: string }>(
+      `SELECT count(*)::text AS count FROM minion_jobs WHERE name = 'autopilot-global-maintenance'`,
+    );
+    expect(globals[0]?.count).toBe('0');
+  });
+
+  test('racing finalize calls seal one job and defer the duplicate caller', async () => {
+    await seedSource('alpha');
+    const begun = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(begun.outcome).toBe('begun');
+    await markSourceComplete('alpha');
+
+    const results = await Promise.all([
+      finalizeExternalDreamcycle(engine, queue, { now: NOW }),
+      finalizeExternalDreamcycle(engine, queue, { now: NOW }),
+    ]);
+    expect(results.filter((result) => result.outcome === 'sealed')).toHaveLength(1);
+    expect(results.filter((result) => result.outcome === 'global_deferred')).toHaveLength(1);
+    const globals = await engine.executeRaw<{ count: string }>(
+      `SELECT count(*)::text AS count FROM minion_jobs WHERE name = 'autopilot-global-maintenance'`,
+    );
+    expect(globals[0]?.count).toBe('1');
+  });
+
+  test('source membership drift or list failure defers with zero global enqueue', async () => {
+    await seedSource('alpha');
+    const begun = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(begun.outcome).toBe('begun');
+    await markSourceComplete('alpha');
+    await seedSource('beta');
+
+    const drifted = await finalizeExternalDreamcycle(engine, queue, { now: NOW });
+    expect(drifted).toEqual({ outcome: 'global_deferred', detail: 'source_membership_drift' });
+
+    const unavailable = await beginExternalDreamcycle(
+      {
+        getConfig: async () => EXTERNAL_DREAMCYCLE_AUTHORITY,
+        listAllSources: async () => { throw new Error('database unavailable'); },
+      } as unknown as PGLiteEngine,
+      queue,
+      { now: NOW },
+    );
+    expect(unavailable).toEqual({ outcome: 'global_deferred', detail: 'source_listing_unavailable' });
+  });
+
+  test('claim-time validation rechecks current config, membership, and newer receipts', async () => {
+    await seedSource('alpha');
+    const begun = await beginExternalDreamcycle(engine, queue, { now: NOW });
+    expect(begun.outcome).toBe('begun');
+    await markSourceComplete('alpha');
+    const sealed = await finalizeExternalDreamcycle(engine, queue, { now: NOW });
+    expect(sealed.outcome).toBe('sealed');
+    if (sealed.outcome !== 'sealed') throw new Error('expected sealed finalizer');
+    const job = await queue.getJob(sealed.global_job_id);
+    expect(job).not.toBeNull();
+    expect(await externalDreamcycleFinalizerBatchMatches(engine, job!.data, { now: NOW })).toBe(true);
+
+    await engine.setConfig('autopilot.global_maintenance.authority', 'daily_finalizer');
+    expect(await externalDreamcycleFinalizerBatchMatches(engine, job!.data, { now: NOW })).toBe(false);
+  });
+
+  test('CLI parser accepts no phase/source/authority/snapshot override', () => {
+    expect(parseDreamcycleArgs(['begin', '--json'])).toEqual({ action: 'begin', json: true, help: false });
+    expect(() => parseDreamcycleArgs(['finalize', '--phase', 'orphans']))
+      .toThrow('accepts no phase/source/authority/snapshot overrides');
+    expect(() => parseDreamcycleArgs(['finalize', '--source', 'alpha']))
+      .toThrow('accepts no phase/source/authority/snapshot overrides');
+    expect(() => parseDreamcycleArgs(['finalize', '--authority', 'dreamcycle_global']))
+      .toThrow('accepts no phase/source/authority/snapshot overrides');
+    expect(() => parseDreamcycleArgs(['finalize', '--snapshot', 'forged']))
+      .toThrow('accepts no phase/source/authority/snapshot overrides');
+  });
+});

--- a/test/e2e/cycle-recompute-emotional-weight-pglite.test.ts
+++ b/test/e2e/cycle-recompute-emotional-weight-pglite.test.ts
@@ -63,6 +63,7 @@ describe('v0.29 — recompute_emotional_weight phase is registered', () => {
 describe('v0.29 — recompute_emotional_weight phase runs end-to-end', () => {
   test('--phase recompute_emotional_weight populates the column for every page (full mode)', async () => {
     const report = await runCycle(engine, {
+      executionAuthority: 'manual',
       brainDir,
       phases: ['recompute_emotional_weight'],
     });
@@ -92,6 +93,7 @@ describe('v0.29 — recompute_emotional_weight phase runs end-to-end', () => {
     await engine.executeRaw(`UPDATE pages SET emotional_weight = 0.99`);
 
     const report = await runCycle(engine, {
+      executionAuthority: 'manual',
       brainDir,
       phases: ['recompute_emotional_weight'],
       dryRun: true,

--- a/test/e2e/cycle.test.ts
+++ b/test/e2e/cycle.test.ts
@@ -93,6 +93,7 @@ describeE2E('E2E: runCycle against real Postgres', () => {
     );
 
     const report = await runCycle(getEngine(), {
+      executionAuthority: 'manual',
       brainDir: repo,
       dryRun: true,
       pull: false,
@@ -126,6 +127,7 @@ describeE2E('E2E: runCycle against real Postgres', () => {
     const conn = getConn();
 
     const report = await runCycle(getEngine(), {
+      executionAuthority: 'manual',
       brainDir: repo,
       dryRun: false,
       pull: false,
@@ -166,6 +168,7 @@ describeE2E('E2E: runCycle against real Postgres', () => {
 
     try {
       const report = await runCycle(getEngine(), {
+        executionAuthority: 'manual',
         brainDir: repo,
         dryRun: true,
         pull: false,
@@ -189,6 +192,7 @@ describeE2E('E2E: runCycle against real Postgres', () => {
     );
 
     const report = await runCycle(getEngine(), {
+      executionAuthority: 'manual',
       brainDir: repo,
       dryRun: true,
       pull: false,
@@ -213,6 +217,7 @@ describeE2E('E2E: runCycle against real Postgres', () => {
 
     try {
       const report = await runCycle(getEngine(), {
+        executionAuthority: 'manual',
         brainDir: repo,
         phases: ['orphans'],
         pull: false,

--- a/test/e2e/dream-cycle-phase-order-pglite.test.ts
+++ b/test/e2e/dream-cycle-phase-order-pglite.test.ts
@@ -146,6 +146,7 @@ describe('E2E full cycle phase order', () => {
     try {
       await withoutAnthropicKey(async () => {
         const report = await runCycle(rig.engine, {
+          executionAuthority: 'manual',
           brainDir: rig.brainDir,
           dryRun: true,
         });
@@ -178,6 +179,7 @@ describe('E2E full cycle phase order', () => {
     try {
       await withoutAnthropicKey(async () => {
         const report = await runCycle(rig.engine, {
+          executionAuthority: 'manual',
           brainDir: rig.brainDir,
           dryRun: false,
           phases: ['synthesize'],
@@ -196,6 +198,7 @@ describe('E2E full cycle phase order', () => {
     try {
       await withoutAnthropicKey(async () => {
         const report = await runCycle(rig.engine, {
+          executionAuthority: 'manual',
           brainDir: rig.brainDir,
           dryRun: false,
           phases: ['patterns'],
@@ -218,6 +221,7 @@ describe('E2E full cycle phase order', () => {
       try {
         await withoutAnthropicKey(async () => {
           const report = await runCycle(rig.engine, {
+            executionAuthority: 'manual',
             brainDir: rig.brainDir,
             dryRun: false,
             phases: ['synthesize'],

--- a/test/operations-trust-boundary.test.ts
+++ b/test/operations-trust-boundary.test.ts
@@ -247,6 +247,17 @@ describe('handler invocation — historically-broken trust-boundary classes', ()
     expect(result).toMatchObject({ dry_run: true, action: 'submit_job', name: 'shell' });
   });
 
+  test('submit_job rejects server-internal global finalizer even for local trusted callers', async () => {
+    // `remote=false` is deliberately not enough here. This finalizer must be
+    // created by the server fanout with a verified source snapshot, never by
+    // the generic operation surface (including dry-run).
+    const submitJob = operations.find(op => op.name === 'submit_job');
+    const ctx = makeContext({ remote: false, dryRun: true });
+    await expect(
+      submitJob!.handler(ctx, { name: 'autopilot-global-maintenance', data: {} }),
+    ).rejects.toMatchObject({ code: 'permission_denied' });
+  });
+
   test('search_by_image rejects image_path with ctx.remote=true (D18 P0)', async () => {
     const searchByImage = operations.find(op => op.name === 'search_by_image');
     expect(searchByImage).toBeDefined();

--- a/test/operations-trust-boundary.test.ts
+++ b/test/operations-trust-boundary.test.ts
@@ -247,15 +247,17 @@ describe('handler invocation — historically-broken trust-boundary classes', ()
     expect(result).toMatchObject({ dry_run: true, action: 'submit_job', name: 'shell' });
   });
 
-  test('submit_job rejects server-internal global finalizer even for local trusted callers', async () => {
-    // `remote=false` is deliberately not enough here. This finalizer must be
-    // created by the server fanout with a verified source snapshot, never by
+  test('submit_job rejects server-internal DreamCycle records even for local trusted callers', async () => {
+    // `remote=false` is deliberately not enough here. Neither the global
+    // finalizer nor the external begin receipt may be manufactured through
     // the generic operation surface (including dry-run).
     const submitJob = operations.find(op => op.name === 'submit_job');
     const ctx = makeContext({ remote: false, dryRun: true });
-    await expect(
-      submitJob!.handler(ctx, { name: 'autopilot-global-maintenance', data: {} }),
-    ).rejects.toMatchObject({ code: 'permission_denied' });
+    for (const name of ['autopilot-global-maintenance', 'dreamcycle-begin']) {
+      await expect(
+        submitJob!.handler(ctx, { name, data: {} }),
+      ).rejects.toMatchObject({ code: 'permission_denied' });
+    }
   });
 
   test('search_by_image rejects image_path with ctx.remote=true (D18 P0)', async () => {

--- a/test/trust-boundary-contract.test.ts
+++ b/test/trust-boundary-contract.test.ts
@@ -21,6 +21,7 @@ import {
   type OperationContext,
 } from '../src/core/operations.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
+import { isInternalOnlyJobName, isProtectedJobName } from '../src/core/minions/protected-names.ts';
 
 const submit_job = operations.find(o => o.name === 'submit_job') as Operation;
 if (!submit_job) throw new Error('submit_job operation missing');
@@ -46,6 +47,11 @@ function castUndefinedRemoteCtx(): OperationContext {
 }
 
 describe('F7b — trust-boundary contract fail-closed semantics', () => {
+  test('global finalizer is both protected and reserved for server-internal dispatch', () => {
+    expect(isProtectedJobName('autopilot-global-maintenance')).toBe(true);
+    expect(isInternalOnlyJobName(' autopilot-global-maintenance ')).toBe(true);
+  });
+
   test('protected job submission rejected when remote is undefined (cast bypass)', async () => {
     const ctx = castUndefinedRemoteCtx();
     await expect(

--- a/test/trust-boundary-contract.test.ts
+++ b/test/trust-boundary-contract.test.ts
@@ -47,9 +47,11 @@ function castUndefinedRemoteCtx(): OperationContext {
 }
 
 describe('F7b — trust-boundary contract fail-closed semantics', () => {
-  test('global finalizer is both protected and reserved for server-internal dispatch', () => {
-    expect(isProtectedJobName('autopilot-global-maintenance')).toBe(true);
-    expect(isInternalOnlyJobName(' autopilot-global-maintenance ')).toBe(true);
+  test('DreamCycle begin receipt and global finalizer are protected and server-internal', () => {
+    for (const name of ['autopilot-global-maintenance', 'dreamcycle-begin']) {
+      expect(isProtectedJobName(name)).toBe(true);
+      expect(isInternalOnlyJobName(` ${name} `)).toBe(true);
+    }
   });
 
   test('protected job submission rejected when remote is undefined (cast bypass)', async () => {


### PR DESCRIPTION
## Summary

Implements the sealed DreamCycle authority boundary required for the Hermes 5-minute source runner and daily global finalizer.

- Adds `gbrain dreamcycle begin|finalize` as the only path that can schedule the daily global work.
- Keeps the 5-minute runner source-only (`sync`, `extract`, `extract_facts`) and scopes its captured slugs to the named source.
- Fails closed for malformed or changed authority/configuration, protected jobs, and missing daily receipts.
- Preserves a sealed batch across the JST midnight boundary.
- Does not add automatic page deletion or purge.

## Validation

- `bun run typecheck`
- Focused DreamCycle/authority test suite: 89 passing, 0 failing
- `bun src/cli.ts dreamcycle --help`
- `git diff --check`

## Rollout order

1. Merge this core release and deploy it to the Mac mini.
2. Confirm `gbrain dreamcycle --help` on the live runtime.
3. Only then merge and deploy the Hermes runners that invoke the sealed workflow.

Related issue: N/A
