### PR TITLE
fix(extract): --dry-run must not write the extract_rollup_7d cache row

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -1069,7 +1069,8 @@ export async function runExtractConversationFactsCore(
       }
       // Fall through to receipt+rollup write so the partial run is
       // still observable in extract_health doctor + extracts/ pages.
-      await writeRunReceiptAndRollup(engine, sourceId, result, /* halted */ true);
+      // ...but not under --dry-run: a preview must not persist cache state.
+      if (!dryRun) await writeRunReceiptAndRollup(engine, sourceId, result, /* halted */ true);
       // Return partial result — caller (CLI / Minion) decides how to
       // surface. NOT a thrown failure.
       return result;
@@ -1081,7 +1082,9 @@ export async function runExtractConversationFactsCore(
   // (queryable + citable per D-EXTRACT-17/19) AND UPSERTs the per-day
   // rollup row (best-effort cache per F-OUT-19). Both are best-effort —
   // failures stderr-warn but never fail the parent operation.
-  await writeRunReceiptAndRollup(engine, sourceId, result, /* halted */ false);
+  // --dry-run must not persist cache/knowledge state: skip the rollup UPSERT +
+  // receipt-page write so a preview leaves no extract cache row behind.
+  if (!dryRun) await writeRunReceiptAndRollup(engine, sourceId, result, /* halted */ false);
 
   return result;
 }

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -306,6 +306,7 @@ describe('runExtractConversationFactsCore', () => {
     // truncation semantics than the canonical reset helper.
     await engine.executeRaw(`DELETE FROM facts WHERE source LIKE 'cli:extract-conversation-facts%'`);
     await engine.executeRaw(`DELETE FROM op_checkpoints WHERE op = 'extract-conversation-facts'`);
+    await engine.executeRaw(`DELETE FROM extract_rollup_7d`);
     await engine.executeRaw(`DELETE FROM pages WHERE slug LIKE 'conversations/%' OR slug LIKE 'people/alice%'`);
     // Set facts.extraction_enabled=true so kill-switch doesn't refuse.
     await engine.setConfig('facts.extraction_enabled', 'true');
@@ -363,6 +364,21 @@ describe('runExtractConversationFactsCore', () => {
     expect(result.pages_processed).toBe(1);
     expect(result.facts_inserted).toBe(0);
     expect(result.segments_processed).toBeGreaterThanOrEqual(1);
+  });
+
+  test('dry-run does not write the extract_rollup_7d cache row', async () => {
+    // Regression: --dry-run promises "no DB writes" but writeRunReceiptAndRollup
+    // upsert-ed extract_rollup_7d unconditionally. A preview must not mutate the DB.
+    await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'conversations/imessage/alice-example',
+      dryRun: true,
+      sleepMs: 0,
+    });
+    const rows = await engine.executeRaw<{ count: string | number }>(
+      `SELECT COUNT(*) AS count FROM extract_rollup_7d WHERE kind = 'facts.conversation' AND source_id = 'default'`,
+    );
+    expect(Number(rows[0]?.count ?? 0)).toBe(0);
   });
 
   test('non-conversation pages are skipped', async () => {


### PR DESCRIPTION
**Impact:** `extract-conversation-facts --dry-run` documents *"no DB writes, no checkpoint advance"* (help text), but a dry run **UPSERTs a row into `extract_rollup_7d`** — so a "preview" mutates the DB (bumps `round_completed_count` / `updated_at` for `kind='facts.conversation'`, which feeds doctor's `extract_health`). Anyone using `--dry-run` to safely preview extraction is silently writing cache state.

**Root cause:** `writeRunReceiptAndRollup` is called unconditionally at both exit paths (`extract-conversation-facts.ts` — budget-exhausted and normal). Inside it, the receipt-page write is already gated on `facts_inserted > 0` (always 0 in dry-run), but the rollup `upsertExtractRollup` fires **unconditionally** (commented "ALWAYS fire so doctor's extract_health sees the cycle ran"). Every other side-effect — fact INSERTs, orphan delete, checkpoint advance, audit row — is correctly `!dryRun`-gated; this one write path was missed.

**Fix:** gate both `writeRunReceiptAndRollup` call sites on `!dryRun`. The writer returns void and its only non-rollup action (the receipt page) is already suppressed in dry-run, so gating at the call site skips nothing else — and it mirrors the existing `!dryRun` guards already used on the insert / checkpoint / audit paths.

**Not changed (called out):** `--dry-run` still calls the extractor (LLM) — `facts_extracted` is the reported "would extract N" preview count, a designed dry-run signal that requires the model call. Left as-is; happy to add a segmentation-only / `--no-llm` mode separately if that's wanted.

**Verified** — fail-before / pass-after, fully hermetic:
- Extended `test/extract-conversation-facts.test.ts` (in-memory PGLite + stubbed chat/embed transports — no live LLM, no live brain): a dry run leaves `extract_rollup_7d` empty. **Fails on unpatched code (`Received: 1`), passes with the fix.**
- Full test file 29/29; `bun run verify` 31/31.

Blast radius: 2 gated call sites + 1 regression test (+ a `DELETE FROM extract_rollup_7d` in the test's `beforeEach` for isolation). No schema, no API, no signature change.

**Scope note:** this is about the *persistent* cache write. A dry run still briefly acquires the per-page advisory lock (`gbrain_cycle_locks` INSERT on acquire / DELETE on release) — transient, net-zero, and pre-existing — so it's not literally zero-DML; that's out of scope here. This PR stops the one write that leaves durable state (the `extract_rollup_7d` cache row feeding doctor's `extract_health`).