### PR TITLE
feat(ops): reflex_pointers op — Retrieval Reflex over MCP transport

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2633,6 +2633,40 @@ const get_raw_data: Operation = {
 
 // --- Resolution & Chunks ---
 
+const reflex_pointers: Operation = {
+  name: 'reflex_pointers',
+  description:
+    'Retrieval Reflex (#1981) over an op transport: extract salient entities from a turn of ' +
+    'user text and resolve them to compact page pointers. Same pipeline, gate, timeout and ' +
+    'heartbeat as the context-engine layer — for hosts (per-prompt hooks, non-context-engine ' +
+    'agents) that consume the brain over MCP instead of assemble().',
+  params: {
+    text: { type: 'string', required: true },
+    prior_context: { type: 'string', required: false },
+    max_pointers: { type: 'number', required: false },
+  },
+  handler: async (ctx, p) => {
+    const { buildReflexAddition } = await import('./context/reflex.ts');
+    const { resolveEntitiesToPointers } = await import('./context/retrieval-reflex.ts');
+    const maxPointers =
+      typeof p.max_pointers === 'number' && p.max_pointers > 0 ? p.max_pointers : undefined;
+    const text = await buildReflexAddition({
+      workspaceDir: process.cwd(),
+      currentUserText: p.text as string,
+      priorContextText: (p.prior_context as string) ?? '',
+      // Host-resolver arm of the ladder: reuse THIS op's already-open engine +
+      // source scope instead of letting the ladder open a second connection.
+      resolveEntities: (candidates, opts) =>
+        resolveEntitiesToPointers(ctx.engine, ctx.sourceId || 'default', candidates, {
+          ...opts,
+          maxPointers: maxPointers ?? opts.maxPointers,
+        }),
+    });
+    return { text };
+  },
+  scope: 'read',
+};
+
 const resolve_slugs: Operation = {
   name: 'resolve_slugs',
   description: 'Fuzzy-resolve a partial slug to matching page slugs',
@@ -5387,7 +5421,7 @@ export const operations: Operation[] = [
   // Raw data
   put_raw_data, get_raw_data,
   // Resolution & chunks
-  resolve_slugs, get_chunks,
+  reflex_pointers, resolve_slugs, get_chunks,
   // Ingest log
   log_ingest, get_ingest_log,
   // Files


### PR DESCRIPTION
## Problem

The Retrieval Reflex pointer layer (#1981) is only reachable through the context engine's `assemble()` path. Hosts that consume the brain via MCP ops — per-prompt hooks, non-context-engine agents, thin remote harnesses — have no way to get reflex pointers for a prompt, so the pointer layer is invisible to exactly the integration surface MCP exists for.

## Change

New contract-first `reflex_pointers` op in `src/core/operations.ts` (read scope): bridges the pointer layer to MCP/CLI transports by reusing `buildReflexAddition` through the host-resolver arm, bound to the op's already-open engine and source scope — so the gate, timeout, and heartbeat behave identically to the context-engine path. No new pipeline, no duplicated logic; one file, 35 lines.

Being contract-first, the op appears in CLI, MCP server, and tools-json automatically.

Running in production on our install since June (per-prompt recall hook consuming it over MCP-HTTP).

## Tests

Contract parity pinned by the existing generators: `test/parity.test.ts` 10 pass / 1297 assertions with the new op present. `bun run verify` all 31 checks green; typecheck clean. Happy to add a dedicated op test if you'd like one — the op is a thin binding over the already-tested `buildReflexAddition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)