### PR TITLE
fix(providers): route diagnostics through buildGatewayConfig so file-plane keys are visible (closes #2728)

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -9,6 +9,7 @@ import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
+import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
 import type { Recipe } from '../core/ai/types.ts';
 
@@ -33,16 +34,19 @@ interface ProviderOption {
 
 function configureFromEnv(): void {
   const config = loadConfig();
-  configureGateway({
-    embedding_model: config?.embedding_model,
-    embedding_dimensions: config?.embedding_dimensions,
-    expansion_model: config?.expansion_model,
-    chat_model: config?.chat_model,
-    chat_fallback_chain: config?.chat_fallback_chain,
-    base_urls: config?.provider_base_urls,
-    provider_chat_options: config?.provider_chat_options,
-    env: { ...process.env },
-  });
+  // Route through buildGatewayConfig — the single ownership seam that folds
+  // file-plane API keys (openrouter_api_key, zeroentropy_api_key, ...) into
+  // the gateway env — instead of hand-assembling AIGatewayConfig field by
+  // field. Hand-building it here let this diagnostic report a provider as
+  // missing env even when ~/.gbrain/config.json had it and the real gateway
+  // path resolved it fine (#2728). Pre-init (no file-plane config yet) falls
+  // back to a bare env passthrough so the command still works before
+  // `gbrain init`.
+  if (config) {
+    configureGateway(buildGatewayConfig(config));
+    return;
+  }
+  configureGateway({ env: { ...process.env } });
 }
 
 export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {
@@ -137,7 +141,12 @@ EXAMPLES
 }
 
 function runList(_args: string[]): void {
-  console.log(formatRecipeTable(listRecipes()));
+  // Same env the gateway actually sees (file-plane keys folded in), not bare
+  // process.env — keeps this table's STATUS column honest with what
+  // `providers test` (and the real init/gateway path) would report.
+  const cfg = loadConfig();
+  const env = cfg ? buildGatewayConfig(cfg).env : process.env;
+  console.log(formatRecipeTable(listRecipes(), env));
 }
 
 async function runTest(args: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

`gbrain providers list` / `gbrain providers test` build their own `AIGatewayConfig` in `configureFromEnv()` instead of using `buildGatewayConfig()` — the single ownership seam that folds file-plane API keys (`openrouter_api_key`, `zeroentropy_api_key`, ...) into the gateway env. Result: the diagnostics command can report a provider as `✗ missing <ENV_VAR>` even when it's correctly configured via `~/.gbrain/config.json` and the real runtime gateway path resolves it fine. Closes #2728.

## The fix

- `configureFromEnv()`: when `loadConfig()` returns a config, call `configureGateway(buildGatewayConfig(config))` instead of hand-assembling the gateway config field-by-field. Falls back to a bare `configureGateway({ env: { ...process.env } })` when there is no file-plane config yet (pre-`gbrain init`), so the command keeps working before init.
- `runList()`: pass `buildGatewayConfig(cfg).env` into `formatRecipeTable(recipes, env)` — an existing optional parameter already used by `init-provider-picker.ts` (no new API). Keeps the `list` table's `env_ready` column honest with what `providers test` (and the real gateway) would actually see.

## Note on the alternate shape in #2728

The issue's proposed fix suggests `buildGatewayConfig(loadConfig() ?? { engine: 'pglite' })` so the pre-init path still runs through `buildGatewayConfig`. This patch instead falls back to a bare env-only `configureGateway()` call pre-init, which is simpler but skips base-URL threading in the pre-init case. Open question for review: is the pre-init base-URL case worth the synthetic `{ engine: 'pglite' }` config object, or is bare env-passthrough fine there since `gbrain providers` pre-init is mostly used to check *whether* to run init in the first place?

Out of scope (per #2728's own comment thread): `providers test --model` base-URL-override behavior, and adding config.json slots for google/voyage keys.

## Tests

Existing `test/providers.test.ts` behavior for the `process.env`-only case is preserved — this only adds visibility for the previously-invisible file-plane case. Happy to add a case asserting `providers list` reflects a `config.json`-only key if maintainers want it in this PR. `bun test test/providers.test.ts` passes (10/10), as does `test/init-provider-picker.test.ts` (7/7, shares `formatRecipeTable`), and `bun run typecheck` is clean.
