### PR TITLE
fix(migrate): v124 migration notice to stderr — unbreak master's stdout guard

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5667,7 +5667,8 @@ export const MIGRATIONS: Migration[] = [
         END;
         $fn$ LANGUAGE plpgsql;
       `);
-      console.log(`  v124: update_page_search_vector() no longer indexes compiled_truth (was overflowing tsvector on large pages, #2704)`);
+      process.stderr.write(`  v124: update_page_search_vector() no longer indexes compiled_truth (was overflowing tsvector on large pages, #2704)
+`);
     },
   },
 ];


### PR DESCRIPTION
Master's Test run is red: #2977's v124 migration handler printed its notice via console.log, and the migrate-stdout-clean guard (added with #3019, which fixed the identical v123 case) caught it on the very next push — both original run and rerun failed on the guard, so this is a true positive, not a flake.

One line: route the notice through process.stderr.write like every other migration message. Guard test 3/3 locally, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)