### PR TITLE
fix(facts): transport fence-authored supersessions into DB columns (#3014)

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -54,6 +54,11 @@ interface ExistingPageFact {
   fact: string;
   source: string | null;
   row_num: number | string | null;
+  // v0.42 (#3014) — supersession columns, read so a struck row whose
+  // fence says "superseded" but whose DB columns are still NULL counts as
+  // drifted and re-heals through the wipe+reinsert fallback.
+  superseded_by: number | string | null;
+  expired_at: Date | string | null;
 }
 
 function factContentKey(fact: string, source: string | null | undefined): string {
@@ -85,7 +90,7 @@ async function listExistingFactsForPage(
   sourceId: string,
 ): Promise<ExistingPageFact[]> {
   return engine.executeRaw<ExistingPageFact>(
-    `SELECT fact, source, row_num
+    `SELECT fact, source, row_num, superseded_by, expired_at
        FROM facts
       WHERE source_id = $1
         AND source_markdown_slug = $2
@@ -313,18 +318,35 @@ export async function runExtractFacts(
       const desired = desiredByKey.get(factContentKey(f.fact, f.source));
       return desired !== undefined && Number(f.row_num) !== desired.row_num;
     });
+    // v0.42 (#3014) — a struck row whose fence says "superseded" (or
+    // otherwise inactive) but whose DB columns are still NULL has an
+    // identical content key + row_num, so the checks above miss it. Treat
+    // a mismatch between the fence-desired supersession/expiry state and
+    // the DB columns as drift so the wipe+reinsert fallback re-heals the
+    // row (transports superseded_by + expired_at that a pre-fix cycle
+    // dropped).
+    const hasSupersessionDrift = existing.some(f => {
+      const desired = desiredByKey.get(factContentKey(f.fact, f.source));
+      if (desired === undefined) return false;
+      const desiredSuperseded = desired.superseded_by_row !== undefined;
+      const dbSuperseded = f.superseded_by != null;
+      const desiredExpired = desired.expired_at != null;
+      const dbExpired = f.expired_at != null;
+      return desiredSuperseded !== dbSuperseded || desiredExpired !== dbExpired;
+    });
 
     if (
       existing.length === extracted.length &&
       !hasStaleExisting &&
       !hasDuplicateExisting &&
-      !hasRowNumDrift
+      !hasRowNumDrift &&
+      !hasSupersessionDrift
     ) {
       continue;
     }
 
     let toInsert = extracted.filter(f => !existingKeys.has(factContentKey(f.fact, f.source)));
-    if (hasStaleExisting || hasDuplicateExisting || hasRowNumDrift) {
+    if (hasStaleExisting || hasDuplicateExisting || hasRowNumDrift || hasSupersessionDrift) {
       // Fall back to the legacy page-level reconcile when old DB rows must
       // be removed. Same delete scoping as above: legacy
       // NULL-source_markdown_slug rows and `cli:`-origin conversation
@@ -368,6 +390,10 @@ export async function runExtractFacts(
 
     const inserted = await engine.insertFacts(toInsert, { source_id: sourceId }); // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
     result.factsInserted += inserted.inserted;
+    // v0.42 (#3014) — surface unresolvable `superseded by #N` references
+    // (self / dangling / chain) as cycle warnings; the row still inserts
+    // with superseded_by NULL + expired_at set (never a guessed FK).
+    for (const w of inserted.warnings) result.warnings.push(`${slug}: ${w}`);
   }
 
   // v0.42 Wave B3: receipt + rollup. extract_facts is deterministic

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -39,8 +39,10 @@ import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { parseFactsFence } from '../facts-fence.ts';
 import {
   extractFactsFromFenceText,
+  resolveSupersededByRow,
   FENCE_SOURCE_DEFAULT,
   type FenceExtractedFact,
+  type SupersedeTarget,
 } from '../facts/extract-from-fence.ts';
 import {
   runPhantomRedirectPass,
@@ -51,6 +53,10 @@ import { embed, isAvailable } from '../ai/gateway.ts';
 import { isAborted } from '../abort-check.ts';
 
 interface ExistingPageFact {
+  // v0.42 (#3014) — the row's own fact id. Read so the supersession-drift
+  // check can compare the DB's stored `superseded_by` (a fact id) against
+  // the fence reference re-resolved to the target row's current id.
+  id: number | string;
   fact: string;
   source: string | null;
   row_num: number | string | null;
@@ -90,7 +96,7 @@ async function listExistingFactsForPage(
   sourceId: string,
 ): Promise<ExistingPageFact[]> {
   return engine.executeRaw<ExistingPageFact>(
-    `SELECT fact, source, row_num, superseded_by, expired_at
+    `SELECT id, fact, source, row_num, superseded_by, expired_at
        FROM facts
       WHERE source_id = $1
         AND source_markdown_slug = $2
@@ -325,14 +331,47 @@ export async function runExtractFacts(
     // the DB columns as drift so the wipe+reinsert fallback re-heals the
     // row (transports superseded_by + expired_at that a pre-fix cycle
     // dropped).
+    //
+    // The supersession term keys off the RESOLVED reference, not merely
+    // "the fence carries a reference": we re-resolve the fence's
+    // `superseded by #N` against the current DB rows with the SAME resolver
+    // insertFacts uses, then compare the resolved target id to the id the
+    // DB stored. A permanently-unresolvable reference (self / dangling /
+    // chain) resolves to NULL every cycle and matches the DB's NULL, so it
+    // never churns; a pre-fix NULL, or a CHANGED reference (even between two
+    // resolvable targets), still differs and re-heals. Resolution stays
+    // page-local — `superseded_by` only ever points within this page — so a
+    // row_num → id lookup over `existing` is a faithful mirror of the
+    // insert-time SELECT.
+    const existingByRowNum = new Map<number, ExistingPageFact>();
+    for (const f of existing) {
+      const rn = f.row_num == null ? NaN : Number(f.row_num);
+      if (Number.isFinite(rn)) existingByRowNum.set(rn, f);
+    }
     const hasSupersessionDrift = existing.some(f => {
       const desired = desiredByKey.get(factContentKey(f.fact, f.source));
       if (desired === undefined) return false;
-      const desiredSuperseded = desired.superseded_by_row !== undefined;
-      const dbSuperseded = f.superseded_by != null;
+
+      // Expiry dimension: a struck row must carry expired_at; a pre-fix row
+      // (both columns NULL) drifts here and re-heals.
       const desiredExpired = desired.expired_at != null;
       const dbExpired = f.expired_at != null;
-      return desiredSuperseded !== dbSuperseded || desiredExpired !== dbExpired;
+      if (desiredExpired !== dbExpired) return true;
+
+      // Supersession dimension: resolve the fence reference against the
+      // current DB rows and compare the resolved target id to what the DB
+      // stored.
+      const desiredRow = desired.superseded_by_row;
+      let resolvedTargetId: number | null = null;
+      if (desiredRow !== undefined) {
+        const targetExisting = existingByRowNum.get(desiredRow);
+        const target: SupersedeTarget | undefined = targetExisting
+          ? { id: Number(targetExisting.id), struck: targetExisting.expired_at != null }
+          : undefined;
+        resolvedTargetId = resolveSupersededByRow(Number(f.row_num), desiredRow, target, slug).superseded_by;
+      }
+      const dbTargetId = f.superseded_by == null ? null : Number(f.superseded_by);
+      return resolvedTargetId !== dbTargetId;
     });
 
     if (
@@ -346,15 +385,17 @@ export async function runExtractFacts(
     }
 
     let toInsert = extracted.filter(f => !existingKeys.has(factContentKey(f.fact, f.source)));
+    // v0.42 (#3014) — when old DB rows must be removed, defer the wipe into
+    // insertFacts' own transaction (deleteForPageFirst) rather than calling
+    // deleteFactsForPage here. A standalone delete self-commits, so a
+    // failing insert afterward left the page permanently emptied; running
+    // the delete as the first statement of the insert transaction makes the
+    // reconcile atomic — a failed insert rolls the delete back. Same delete
+    // scoping as above: legacy NULL-source_markdown_slug rows and
+    // `cli:`-origin conversation facts (#1928) survive.
+    let deleteForPageFirst: { slug: string; excludeSourcePrefixes: string[] } | undefined;
     if (hasStaleExisting || hasDuplicateExisting || hasRowNumDrift || hasSupersessionDrift) {
-      // Fall back to the legacy page-level reconcile when old DB rows must
-      // be removed. Same delete scoping as above: legacy
-      // NULL-source_markdown_slug rows and `cli:`-origin conversation
-      // facts (#1928) survive.
-      const deleted = await engine.deleteFactsForPage(slug, sourceId, {
-        excludeSourcePrefixes: ['cli:'],
-      });
-      result.factsDeleted += deleted.deleted;
+      deleteForPageFirst = { slug, excludeSourcePrefixes: ['cli:'] };
       toInsert = extracted;
     }
 
@@ -388,8 +429,15 @@ export async function runExtractFacts(
 
     if (toInsert.length === 0) continue;
 
-    const inserted = await engine.insertFacts(toInsert, { source_id: sourceId }); // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
+    const inserted = await engine.insertFacts(
+      toInsert,
+      { source_id: sourceId },
+      deleteForPageFirst ? { deleteForPageFirst } : undefined,
+    ); // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
     result.factsInserted += inserted.inserted;
+    // v0.42 (#3014) — the wipe (when needed) ran inside insertFacts' txn;
+    // count it here from the atomic result rather than a separate delete.
+    result.factsDeleted += inserted.deleted;
     // v0.42 (#3014) — surface unresolvable `superseded by #N` references
     // (self / dangling / chain) as cycle warnings; the row still inserts
     // with superseded_by NULL + expired_at set (never a guessed FK).

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -33,16 +33,14 @@
  * while legacy rows linger in the DB.
  */
 
-import type { BrainEngine } from '../engine.ts';
+import { resolveSupersededByRow, type BrainEngine, type SupersedeTarget } from '../engine.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { parseFactsFence } from '../facts-fence.ts';
 import {
   extractFactsFromFenceText,
-  resolveSupersededByRow,
   FENCE_SOURCE_DEFAULT,
   type FenceExtractedFact,
-  type SupersedeTarget,
 } from '../facts/extract-from-fence.ts';
 import {
   runPhantomRedirectPass,
@@ -353,7 +351,11 @@ export async function runExtractFacts(
       if (desired === undefined) return false;
 
       // Expiry dimension: a struck row must carry expired_at; a pre-fix row
-      // (both columns NULL) drifts here and re-heals.
+      // (both columns NULL) drifts here and re-heals. Compare NULL-ness, NOT
+      // the timestamp value: the mapper stamps `expired_at = valid_until ??
+      // today`, so a value comparison would see the stored timestamp differ
+      // from a freshly-recomputed `today` every day and churn the page each
+      // cycle. NULL-ness is the stable "is this row struck?" signal.
       const desiredExpired = desired.expired_at != null;
       const dbExpired = f.expired_at != null;
       if (desiredExpired !== dbExpired) return true;
@@ -439,9 +441,11 @@ export async function runExtractFacts(
     // count it here from the atomic result rather than a separate delete.
     result.factsDeleted += inserted.deleted;
     // v0.42 (#3014) — surface unresolvable `superseded by #N` references
-    // (self / dangling / chain) as cycle warnings; the row still inserts
-    // with superseded_by NULL + expired_at set (never a guessed FK).
-    for (const w of inserted.warnings) result.warnings.push(`${slug}: ${w}`);
+    // (self / dangling / struck target) as cycle warnings; the row still
+    // inserts with superseded_by NULL + expired_at set (never a guessed FK).
+    // resolveSupersededByRow already prefixes each message with the slug +
+    // row, so push verbatim — no `${slug}: ` re-prefix.
+    for (const w of inserted.warnings) result.warnings.push(w);
   }
 
   // v0.42 Wave B3: receipt + rollup. extract_facts is deterministic

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -513,6 +513,17 @@ export interface NewFact {
   context?: string | null;
   valid_from?: Date;                   // default now()
   valid_until?: Date | null;
+  /**
+   * v0.42 (#3014) — explicit expiry timestamp. When set, the row is
+   * inactive: excluded from active views (recall, listFactsByEntity's
+   * activeOnly default) and eligible for listSupersessions. The fence
+   * mapper stamps this for struck rows (superseded / forgotten /
+   * inactive-unrecognized) because no DB derivation from `valid_until`
+   * exists — no trigger, sweep, or read-time coalesce populates it.
+   * Active-row callers leave it undefined; insertFact/insertFacts default
+   * it to NULL.
+   */
+  expired_at?: Date | null;
   source: string;                       // 'mcp:put_page' | 'mcp:extract_facts' | 'cli:think' | etc
   source_session?: string | null;
   confidence?: number;                  // [0,1], default 1.0
@@ -1746,11 +1757,18 @@ export interface BrainEngine {
    *
    * Returns the inserted ids in input-order so callers can correlate
    * fence-row → DB-id without a separate lookup.
+   *
+   * v0.42 (#3014): `superseded_by_row` carries a struck row's page-local
+   * `superseded by #N` reference. A second pass in the same transaction
+   * resolves it to `facts.superseded_by` (a FK to facts.id), keyed on
+   * (source_id, source_markdown_slug, row_num). Unresolvable references
+   * (self / dangling / chained) leave `superseded_by` NULL and surface a
+   * `warnings` entry — never an FK to a guessed id.
    */
   insertFacts(
-    rows: Array<NewFact & { row_num: number; source_markdown_slug: string }>,
+    rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[] }>;
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }>;
 
   /**
    * v0.32.2: hard-delete every fact row scoped to a single fence page.
@@ -1816,8 +1834,13 @@ export interface BrainEngine {
   ): Promise<FactRow[]>;
 
   /**
-   * Audit log: facts that were superseded (expired_at + superseded_by both set),
-   * newest first. Drives `gbrain recall --supersessions`.
+   * Audit log: facts that were superseded (superseded_by set), newest
+   * first. Drives `gbrain recall --supersessions`. v0.42 (#3014): the
+   * filter requires only `superseded_by IS NOT NULL`, not `expired_at`
+   * too — the ontology-dimension writer closes a superseded row via
+   * `valid_until` (not `expired_at`) so `--asof` time-travel still sees
+   * it, so requiring `expired_at` here would drop every ontology
+   * supersession. Ordering / `since` use COALESCE(expired_at, valid_until).
    */
   listSupersessions(
     source_id: string,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -550,6 +550,87 @@ export interface NewFact {
   event_type?: string | null;
 }
 
+/**
+ * v0.42 (#3014) — the target row a struck `superseded by #N` reference
+ * resolves to, as seen at insert time.
+ */
+export interface SupersedeTarget {
+  id: number;
+  /**
+   * true when the target row is itself inactive (its `expired_at` is set)
+   * — e.g. `#N` points at a forgotten row or an already-superseded row. A
+   * supersession target must be a live row, so a struck target is rejected.
+   */
+  struck: boolean;
+}
+
+/** Outcome of resolving a `superseded by #N` reference to a fact id. */
+export interface SupersedeResolution {
+  /** The resolved target fact id, or null when the reference is unsafe. */
+  superseded_by: number | null;
+  /** A human-readable warning when the reference could not be resolved. */
+  warning: string | null;
+}
+
+/** Largest value a Postgres `int4` column (`facts.row_num`) can hold. */
+export const PG_INT4_MAX = 2147483647;
+
+/**
+ * v0.42 (#3014) — can `n` safely target the `row_num` (int4) column in
+ * insertFacts' supersession-resolution SELECT? The fence parser accepts any
+ * finite `#N`, but a value outside int4 range would overflow the comparison
+ * and raise `integer out of range`, aborting the whole extract cycle. The
+ * engines gate the lookup on this so an absurd `#N` is treated as a dangling
+ * reference (resolveSupersededByRow with `target` undefined → NULL + warning)
+ * rather than an uncaught throw.
+ */
+export function isInt4RowRef(n: number): boolean {
+  return Number.isInteger(n) && n >= 1 && n <= PG_INT4_MAX;
+}
+
+/**
+ * v0.42 (#3014) — resolve a struck row's `superseded by #N` page-local
+ * reference to a fact id. Pure: the caller supplies the already-looked-up
+ * `target` (keyed on source + row_num within the same transaction) so
+ * this decision is unit-testable without a DB. Lives here (not in the
+ * fence-boundary module) so the engines can resolve without importing
+ * upward across the layer boundary.
+ *
+ * Three references are unsafe and resolve to NULL + a warning (never an
+ * FK write to a guessed id); `expired_at` is set by the mapper regardless
+ * of the outcome so the struck row still exits active views:
+ *   - self-reference (`#N` == the row's own number)
+ *   - dangling (`#N` names a row absent from the page)
+ *   - struck target (`#N` names a row that is itself inactive — a
+ *     supersession chain, or a forgotten target)
+ */
+export function resolveSupersededByRow(
+  ownRowNum: number,
+  supersededByRow: number,
+  target: SupersedeTarget | undefined,
+  slug: string,
+): SupersedeResolution {
+  if (supersededByRow === ownRowNum) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" references itself — leaving superseded_by NULL`,
+    };
+  }
+  if (!target) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row absent from the fence — leaving superseded_by NULL`,
+    };
+  }
+  if (target.struck) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row that is itself struck (inactive) — a supersession target must be a live row; leaving superseded_by NULL`,
+    };
+  }
+  return { superseded_by: target.id, warning: null };
+}
+
 /** Options shared by list-facts methods. */
 export interface FactListOpts {
   /** Hide expired_at IS NOT NULL rows. Default true. */

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1764,11 +1764,22 @@ export interface BrainEngine {
    * (source_id, source_markdown_slug, row_num). Unresolvable references
    * (self / dangling / chained) leave `superseded_by` NULL and surface a
    * `warnings` entry — never an FK to a guessed id.
+   *
+   * v0.42 (#3014): `opts.deleteForPageFirst` makes the wipe-then-reinsert
+   * reconcile atomic. When set, the page's fence-owned rows are DELETEd as
+   * the first statement of the SAME transaction that inserts `rows`, so a
+   * failing insert rolls the delete back and the page is never left emptied.
+   * (The pre-fix reconcile called `deleteFactsForPage` — a separate,
+   * self-committing transaction — before `insertFacts`, so an insert throw
+   * permanently lost the page's facts.) `slug` + `excludeSourcePrefixes`
+   * mirror `deleteFactsForPage`; the deleted count is returned as `deleted`.
+   * Callers that omit it get the standalone insert (deleted: 0), unchanged.
    */
   insertFacts(
     rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }>;
+    opts?: { deleteForPageFirst?: { slug: string; excludeSourcePrefixes?: string[] } },
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[]; deleted: number }>;
 
   /**
    * v0.32.2: hard-delete every fact row scoped to a single fence page.

--- a/src/core/facts/extract-from-fence.ts
+++ b/src/core/facts/extract-from-fence.ts
@@ -76,6 +76,22 @@ export interface SupersedeResolution {
   warning: string | null;
 }
 
+/** Largest value a Postgres `int4` column (`facts.row_num`) can hold. */
+export const PG_INT4_MAX = 2147483647;
+
+/**
+ * v0.42 (#3014) — can `n` safely target the `row_num` (int4) column in
+ * insertFacts' supersession-resolution SELECT? The fence parser accepts any
+ * finite `#N`, but a value outside int4 range would overflow the comparison
+ * and raise `integer out of range`, aborting the whole extract cycle. The
+ * engines gate the lookup on this so an absurd `#N` is treated as a dangling
+ * reference (resolveSupersededByRow with `target` undefined → NULL + warning)
+ * rather than an uncaught throw.
+ */
+export function isInt4RowRef(n: number): boolean {
+  return Number.isInteger(n) && n >= 1 && n <= PG_INT4_MAX;
+}
+
 /**
  * v0.42 (#3014) — resolve a struck row's `superseded by #N` page-local
  * reference to a fact id. Pure: the caller supplies the already-looked-up

--- a/src/core/facts/extract-from-fence.ts
+++ b/src/core/facts/extract-from-fence.ts
@@ -43,7 +43,78 @@ import type { ParsedFact } from '../facts-fence.ts';
 export type FenceExtractedFact = NewFact & {
   row_num: number;
   source_markdown_slug: string;
+  /**
+   * v0.42 (#3014) — page-local row reference parsed from `~~claim~~` +
+   * `superseded by #N` (the `#N`). NOT a fact id: `facts.superseded_by`
+   * is a FK to `facts.id`, so `insertFacts` resolves this row number to
+   * the target row's id in a second pass. undefined when the row is not
+   * a supersession.
+   */
+  superseded_by_row?: number;
 };
+
+/**
+ * v0.42 (#3014) — the target row a struck `superseded by #N` reference
+ * resolves to, as seen at insert time.
+ */
+export interface SupersedeTarget {
+  id: number;
+  /**
+   * true when the target row is itself inactive (its `expired_at` is
+   * set) — i.e. `#N` points at another struck row (a chain). A
+   * supersession target must be a live row, so a struck target is
+   * rejected.
+   */
+  struck: boolean;
+}
+
+/** Outcome of resolving a `superseded by #N` reference to a fact id. */
+export interface SupersedeResolution {
+  /** The resolved target fact id, or null when the reference is unsafe. */
+  superseded_by: number | null;
+  /** A human-readable warning when the reference could not be resolved. */
+  warning: string | null;
+}
+
+/**
+ * v0.42 (#3014) — resolve a struck row's `superseded by #N` page-local
+ * reference to a fact id. Pure: the caller supplies the already-looked-up
+ * `target` (keyed on source + row_num within the same transaction) so
+ * this decision is unit-testable without a DB.
+ *
+ * Three references are unsafe and resolve to NULL + a warning (never an
+ * FK write to a guessed id); `expired_at` is set by the mapper regardless
+ * of the outcome so the struck row still exits active views:
+ *   - self-reference (`#N` == the row's own number)
+ *   - dangling (`#N` names a row absent from the page)
+ *   - chain (`#N` names another struck row)
+ */
+export function resolveSupersededByRow(
+  ownRowNum: number,
+  supersededByRow: number,
+  target: SupersedeTarget | undefined,
+  slug: string,
+): SupersedeResolution {
+  if (supersededByRow === ownRowNum) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" references itself — leaving superseded_by NULL`,
+    };
+  }
+  if (!target) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row absent from the fence — leaving superseded_by NULL`,
+    };
+  }
+  if (target.struck) {
+    return {
+      superseded_by: null,
+      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row that is itself superseded (chain) — leaving superseded_by NULL`,
+    };
+  }
+  return { superseded_by: target.id, warning: null };
+}
 
 /**
  * Default `source` value when a fence row doesn't carry one. The string
@@ -204,6 +275,15 @@ export function extractFactsFromFenceText(
       validUntil = null;
     }
 
+    // v0.42 (#3014) — struck rows carry their expiry + supersession
+    // reference into the DB. `expired_at` has no DB derivation from
+    // `valid_until` (no trigger, sweep, or read-time coalesce), so the
+    // mapper stamps it explicitly for EVERY inactive row (superseded,
+    // forgotten, or inactive-unrecognized) — that is how a struck row
+    // exits active views. `valid_until ?? today` keeps it deterministic
+    // under nowOverride. Active rows leave it null.
+    const expiredAt: Date | null = !f.active ? (validUntil ?? today) : null;
+
     const row: FenceExtractedFact = {
       fact: f.claim,
       kind: f.kind as FactKind,
@@ -213,10 +293,15 @@ export function extractFactsFromFenceText(
       context: f.context ?? null,
       valid_from: validFrom,
       valid_until: validUntil,
+      expired_at: expiredAt,
       source: f.source ?? FENCE_SOURCE_DEFAULT,
       confidence: f.confidence,
       row_num: f.rowNum,
       source_markdown_slug: slug,
+      // v0.42 (#3014) — carry the page-local `superseded by #N` reference
+      // for insertFacts to resolve to a fact id. undefined for non-struck
+      // rows and for struck rows with no supersession context.
+      superseded_by_row: f.supersededBy,
       // v0.35.4 (D-CDX-5) — typed-claim threading. Metric label normalized
       // here so the DB-side index hits use the canonical name; value /
       // unit / period stored verbatim.

--- a/src/core/facts/extract-from-fence.ts
+++ b/src/core/facts/extract-from-fence.ts
@@ -11,7 +11,15 @@
  * It is intentionally pure: no engine call, no I/O. Inputs are the parsed
  * facts plus the page-level binding (entity slug + source_id). Output is
  * a `FenceExtractedFact[]` — structural superset of `NewFact` that
- * carries the v51 fence columns (`row_num`, `source_markdown_slug`).
+ * carries the v51 fence columns (`row_num`, `source_markdown_slug`) and,
+ * for struck rows, the v0.42 (#3014) supersession-transport fields:
+ *   - `expired_at` stamped on every inactive row (superseded / forgotten
+ *     / inactive-unrecognized) so the row exits active views — there is
+ *     no DB derivation from `valid_until`, so the mapper sets it here.
+ *   - `superseded_by_row` carrying the page-local `superseded by #N`
+ *     reference for the engine's insert-time resolution to a fact id
+ *     (the resolver + its types live in `engine.ts`, the layer that owns
+ *     the id lookup).
  *
  * Codex Q7 resolution: engines stay markdown-unaware. The cycle phase
  * (commit 7) and the backstop rewrite (commit 5) call this function to
@@ -19,12 +27,12 @@
  * batch insert.
  *
  * Strikethrough → date derivation:
- *   - `forgotten` rows get `valid_until = today` so the DB's existing
- *     `expired_at = valid_until + now()` rule produces the same forget
- *     state after `gbrain rebuild` (v0.32.3) as before.
+ *   - `forgotten` rows get `valid_until = today` (and `expired_at`) so the
+ *     row is inactive after reconcile.
  *   - `supersededBy` rows preserve their existing `validUntil` if set;
- *     otherwise leave `valid_until = null` (the consolidator phase fills
- *     this in based on the newer row's `valid_from`).
+ *     otherwise leave `valid_until = null`. `expired_at` is set to
+ *     `valid_until ?? today` regardless, so the struck row exits active
+ *     views and satisfies `listSupersessions`.
  *   - Inactive rows with neither flag (parser-tolerated hand-edits) are
  *     treated like `forgotten` for DB-derivation purposes — the user's
  *     strikethrough intent is honored; the lost reason is a JSONL
@@ -52,85 +60,6 @@ export type FenceExtractedFact = NewFact & {
    */
   superseded_by_row?: number;
 };
-
-/**
- * v0.42 (#3014) — the target row a struck `superseded by #N` reference
- * resolves to, as seen at insert time.
- */
-export interface SupersedeTarget {
-  id: number;
-  /**
-   * true when the target row is itself inactive (its `expired_at` is
-   * set) — i.e. `#N` points at another struck row (a chain). A
-   * supersession target must be a live row, so a struck target is
-   * rejected.
-   */
-  struck: boolean;
-}
-
-/** Outcome of resolving a `superseded by #N` reference to a fact id. */
-export interface SupersedeResolution {
-  /** The resolved target fact id, or null when the reference is unsafe. */
-  superseded_by: number | null;
-  /** A human-readable warning when the reference could not be resolved. */
-  warning: string | null;
-}
-
-/** Largest value a Postgres `int4` column (`facts.row_num`) can hold. */
-export const PG_INT4_MAX = 2147483647;
-
-/**
- * v0.42 (#3014) — can `n` safely target the `row_num` (int4) column in
- * insertFacts' supersession-resolution SELECT? The fence parser accepts any
- * finite `#N`, but a value outside int4 range would overflow the comparison
- * and raise `integer out of range`, aborting the whole extract cycle. The
- * engines gate the lookup on this so an absurd `#N` is treated as a dangling
- * reference (resolveSupersededByRow with `target` undefined → NULL + warning)
- * rather than an uncaught throw.
- */
-export function isInt4RowRef(n: number): boolean {
-  return Number.isInteger(n) && n >= 1 && n <= PG_INT4_MAX;
-}
-
-/**
- * v0.42 (#3014) — resolve a struck row's `superseded by #N` page-local
- * reference to a fact id. Pure: the caller supplies the already-looked-up
- * `target` (keyed on source + row_num within the same transaction) so
- * this decision is unit-testable without a DB.
- *
- * Three references are unsafe and resolve to NULL + a warning (never an
- * FK write to a guessed id); `expired_at` is set by the mapper regardless
- * of the outcome so the struck row still exits active views:
- *   - self-reference (`#N` == the row's own number)
- *   - dangling (`#N` names a row absent from the page)
- *   - chain (`#N` names another struck row)
- */
-export function resolveSupersededByRow(
-  ownRowNum: number,
-  supersededByRow: number,
-  target: SupersedeTarget | undefined,
-  slug: string,
-): SupersedeResolution {
-  if (supersededByRow === ownRowNum) {
-    return {
-      superseded_by: null,
-      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" references itself — leaving superseded_by NULL`,
-    };
-  }
-  if (!target) {
-    return {
-      superseded_by: null,
-      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row absent from the fence — leaving superseded_by NULL`,
-    };
-  }
-  if (target.struck) {
-    return {
-      superseded_by: null,
-      warning: `${slug} row ${ownRowNum}: "superseded by #${supersededByRow}" names a row that is itself superseded (chain) — leaving superseded_by NULL`,
-    };
-  }
-  return { superseded_by: target.id, warning: null };
-}
 
 /**
  * Default `source` value when a fence row doesn't carry one. The string

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -275,6 +275,12 @@ export async function writeFactsToFence(
       }));
 
       const result = await engine.insertFacts(enriched, { source_id: target.sourceId }); // gbrain-allow-direct-insert: writeFactsToFence is the markdown-first reconcile path; runs only after the atomic fence write commits
+      // v0.42 (#3014) — an unresolvable `superseded by #N` reference (self
+      // / dangling / chain) leaves superseded_by NULL; log it rather than
+      // swallow it. The row still lands (expired_at set), never a bad FK.
+      for (const w of result.warnings) {
+        console.warn(`[facts.supersession] ${w}`);
+      }
       return { inserted: result.inserted, ids: result.ids };
     },
     { timeoutMs: 5_000 },

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -276,9 +276,10 @@ export async function writeFactsToFence(
 
       const result = await engine.insertFacts(enriched, { source_id: target.sourceId }); // gbrain-allow-direct-insert: writeFactsToFence is the markdown-first reconcile path; runs only after the atomic fence write commits
       // v0.42 (#3014) — an unresolvable `superseded by #N` reference (self
-      // / dangling / chain) leaves superseded_by NULL; log it rather than
-      // swallow it. The row still lands (expired_at set), never a bad FK.
+      // / dangling / struck target) leaves superseded_by NULL; log it rather
+      // than swallow it. The row still lands (expired_at set), never a bad FK.
       for (const w of result.warnings) {
+        // eslint-disable-next-line no-console
         console.warn(`[facts.supersession] ${w}`);
       }
       return { inserted: result.inserted, ids: result.ids };

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3977,7 +3977,7 @@ const recall: Operation = {
     since: { type: 'string', description: 'ISO datetime or duration shorthand (e.g. "8 hours ago"). Returns facts created since.' },
     session_id: { type: 'string', description: 'Source session id (e.g. topic-A). Returns facts captured in that session.' },
     include_expired: { type: 'boolean', description: 'When true, include expired_at IS NOT NULL rows. Default false.' },
-    supersessions: { type: 'boolean', description: 'When true, return only the supersession audit log (expired_at + superseded_by both set).' },
+    supersessions: { type: 'boolean', description: 'When true, return only the supersession audit log (facts with superseded_by set), newest first by COALESCE(expired_at, valid_until).' },
     limit: { type: 'number', description: 'Max rows to return. Default 50, cap 100.' },
     grep: { type: 'string', description: 'Substring filter on fact text (case-insensitive). Applied client-side after recall.' },
     include_pending: { type: 'boolean', description: 'v0.32: when true, response includes pending_consolidation_count (facts not yet promoted to takes by the dream-cycle consolidate phase). One round trip; backward-compatible (field omitted when false).' },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -16,7 +16,7 @@ import type {
   NewFact, FactListOpts, FactsHealth,
   SourceRow,
 } from './engine.ts';
-import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { MAX_SEARCH_LIMIT, clampSearchLimit, resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './engine.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import { runMigrations } from './migrate.ts';
@@ -49,7 +49,6 @@ import type {
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
-import { resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -49,6 +49,7 @@ import type {
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
+import { resolveSupersededByRow, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
@@ -4089,21 +4090,26 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async insertFacts(
-    rows: Array<NewFact & { row_num: number; source_markdown_slug: string }>,
+    rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[] }> {
-    if (rows.length === 0) return { inserted: 0, ids: [] };
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }> {
+    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [] };
 
+    const warnings: string[] = [];
     // Single transaction so the v51 partial UNIQUE index can roll back the
     // whole batch on constraint violation. Per-row INSERTs (not multi-row
     // VALUES) keep the embedding-vs-no-embedding branching readable; batch
     // sizes are small (5-30 rows per page in practice) so the loop overhead
     // is negligible vs the embedding compute cost.
+    // v0.42 (#3014): the fence path carries struck rows — `expired_at` is
+    // stamped inline, and `superseded by #N` references are resolved to
+    // `facts.superseded_by` in a second pass below (same transaction).
     const ids = await this.db.transaction(async (tx) => {
       const out: number[] = [];
       for (const input of rows) {
         const validFrom = input.valid_from ?? new Date();
         const validUntil = input.valid_until ?? null;
+        const expiredAt = input.expired_at ?? null;
         const kind = input.kind ?? 'fact';
         const visibility = input.visibility ?? 'private';
         const notability = input.notability ?? 'medium';
@@ -4124,47 +4130,74 @@ export class PGLiteEngine implements BrainEngine {
 
         // Param-positional dispatch: embedStr presence shifts the trailing
         // slots by one. Order of named slots stays stable across both
-        // branches: embedded_at, row_num, source_markdown_slug,
+        // branches: expired_at, embedded_at, row_num, source_markdown_slug,
         // claim_metric, claim_value, claim_unit, claim_period, event_type.
         const ins = await tx.query<{ id: number }>(
           embedStr === null
             ? `INSERT INTO facts (
                  source_id, entity_slug, fact, kind, visibility, notability, context,
-                 valid_from, valid_until, source, source_session, confidence,
+                 valid_from, valid_until, expired_at, source, source_session, confidence,
                  embedding, embedded_at,
                  row_num, source_markdown_slug,
                  claim_metric, claim_value, claim_unit, claim_period,
                  event_type
                ) VALUES (
-                 $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,
-                 NULL, $13,
-                 $14, $15,
-                 $16, $17, $18, $19,
-                 $20
-               ) RETURNING id`
-            : `INSERT INTO facts (
-                 source_id, entity_slug, fact, kind, visibility, notability, context,
-                 valid_from, valid_until, source, source_session, confidence,
-                 embedding, embedded_at,
-                 row_num, source_markdown_slug,
-                 claim_metric, claim_value, claim_unit, claim_period,
-                 event_type
-               ) VALUES (
-                 $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,
-                 $13::vector, $14,
+                 $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,
+                 NULL, $14,
                  $15, $16,
                  $17, $18, $19, $20,
                  $21
+               ) RETURNING id`
+            : `INSERT INTO facts (
+                 source_id, entity_slug, fact, kind, visibility, notability, context,
+                 valid_from, valid_until, expired_at, source, source_session, confidence,
+                 embedding, embedded_at,
+                 row_num, source_markdown_slug,
+                 claim_metric, claim_value, claim_unit, claim_period,
+                 event_type
+               ) VALUES (
+                 $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,
+                 $14::vector, $15,
+                 $16, $17,
+                 $18, $19, $20, $21,
+                 $22
                ) RETURNING id`,
           embedStr === null
-            ? [ctx.source_id, entitySlug, input.fact, kind, visibility, notability, context, validFrom, validUntil, input.source, sourceSession, confidence, embeddedAt, input.row_num, input.source_markdown_slug, claimMetric, claimValue, claimUnit, claimPeriod, eventType]
-            : [ctx.source_id, entitySlug, input.fact, kind, visibility, notability, context, validFrom, validUntil, input.source, sourceSession, confidence, embedStr, embeddedAt, input.row_num, input.source_markdown_slug, claimMetric, claimValue, claimUnit, claimPeriod, eventType],
+            ? [ctx.source_id, entitySlug, input.fact, kind, visibility, notability, context, validFrom, validUntil, expiredAt, input.source, sourceSession, confidence, embeddedAt, input.row_num, input.source_markdown_slug, claimMetric, claimValue, claimUnit, claimPeriod, eventType]
+            : [ctx.source_id, entitySlug, input.fact, kind, visibility, notability, context, validFrom, validUntil, expiredAt, input.source, sourceSession, confidence, embedStr, embeddedAt, input.row_num, input.source_markdown_slug, claimMetric, claimValue, claimUnit, claimPeriod, eventType],
         );
         out.push(ins.rows[0].id);
       }
+
+      // v0.42 (#3014) — second pass: resolve `superseded by #N` page-local
+      // references to fact ids. Same transaction so a target row inserted
+      // above is visible. Keyed on (source_id, source_markdown_slug,
+      // row_num) — the v51 unique index — so a reference also resolves
+      // against a target that already existed before this batch. A target
+      // whose `expired_at` is set is itself struck (chain) and rejected.
+      for (let i = 0; i < rows.length; i++) {
+        const targetRow = rows[i].superseded_by_row;
+        if (targetRow === undefined) continue;
+        const slug = rows[i].source_markdown_slug;
+        const found = await tx.query<{ id: number; expired_at: Date | string | null }>(
+          `SELECT id, expired_at FROM facts
+             WHERE source_id = $1 AND source_markdown_slug = $2 AND row_num = $3
+             LIMIT 1`,
+          [ctx.source_id, slug, targetRow],
+        );
+        const hit = found.rows[0];
+        const target: SupersedeTarget | undefined = hit
+          ? { id: Number(hit.id), struck: hit.expired_at != null }
+          : undefined;
+        const { superseded_by, warning } = resolveSupersededByRow(rows[i].row_num, targetRow, target, slug);
+        if (warning) warnings.push(warning);
+        if (superseded_by !== null) {
+          await tx.query(`UPDATE facts SET superseded_by = $1 WHERE id = $2`, [superseded_by, out[i]]);
+        }
+      }
       return out;
     });
-    return { inserted: ids.length, ids };
+    return { inserted: ids.length, ids, warnings };
   }
 
   async deleteFactsForPage(
@@ -4242,10 +4275,16 @@ export class PGLiteEngine implements BrainEngine {
     source_id: string,
     opts?: { since?: Date; limit?: number },
   ): Promise<FactRow[]> {
-    const where: string[] = [`expired_at IS NOT NULL`, `superseded_by IS NOT NULL`];
+    // v0.42 (#3014) — filter on `superseded_by` alone; the ontology
+    // writer closes a superseded row via `valid_until` (not `expired_at`,
+    // which would break its `--asof` time-travel), so requiring both
+    // columns dropped every ontology supersession AND every fence-authored
+    // one. Order / `since` fall back to `valid_until` when `expired_at` is
+    // NULL.
+    const where: string[] = [`superseded_by IS NOT NULL`];
     const params: Record<string, unknown> = {};
     if (opts?.since) {
-      where.push(`expired_at >= $since`);
+      where.push(`COALESCE(expired_at, valid_until) >= $since`);
       params.since = opts.since;
     }
     return this._listFacts(source_id, {
@@ -4253,7 +4292,7 @@ export class PGLiteEngine implements BrainEngine {
       limit: opts?.limit,
       whereClauses: where,
       whereParams: params,
-      order: 'expired_at DESC, id DESC',
+      order: 'COALESCE(expired_at, valid_until) DESC, id DESC',
     });
   }
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -49,7 +49,7 @@ import type {
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
-import { resolveSupersededByRow, type SupersedeTarget } from './facts/extract-from-fence.ts';
+import { resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
@@ -4092,10 +4092,14 @@ export class PGLiteEngine implements BrainEngine {
   async insertFacts(
     rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }> {
-    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [] };
+    opts?: { deleteForPageFirst?: { slug: string; excludeSourcePrefixes?: string[] } },
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[]; deleted: number }> {
+    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [], deleted: 0 };
 
     const warnings: string[] = [];
+    // v0.42 (#3014): captured inside the transaction below when
+    // deleteForPageFirst runs; stays 0 for the standalone insert path.
+    let deleted = 0;
     // Single transaction so the v51 partial UNIQUE index can roll back the
     // whole batch on constraint violation. Per-row INSERTs (not multi-row
     // VALUES) keep the embedding-vs-no-embedding branching readable; batch
@@ -4105,6 +4109,31 @@ export class PGLiteEngine implements BrainEngine {
     // stamped inline, and `superseded by #N` references are resolved to
     // `facts.superseded_by` in a second pass below (same transaction).
     const ids = await this.db.transaction(async (tx) => {
+      // v0.42 (#3014) — atomic reconcile: wipe the page's fence-owned rows
+      // as the FIRST statement of this transaction so a failing insert
+      // below rolls the delete back too. Inlined (not a deleteFactsForPage
+      // call) so it shares this transaction. Delete scoping mirrors
+      // deleteFactsForPage exactly.
+      const del = opts?.deleteForPageFirst;
+      if (del) {
+        const prefixes = del.excludeSourcePrefixes;
+        if (prefixes && prefixes.length > 0) {
+          const patterns = prefixes.map(p => `${p}%`);
+          const r = await tx.query(
+            `DELETE FROM facts
+               WHERE source_id = $1 AND source_markdown_slug = $2
+                 AND NOT (COALESCE(source, '') LIKE ANY($3::text[]))`,
+            [ctx.source_id, del.slug, patterns],
+          );
+          deleted = r.affectedRows ?? 0;
+        } else {
+          const r = await tx.query(
+            `DELETE FROM facts WHERE source_id = $1 AND source_markdown_slug = $2`,
+            [ctx.source_id, del.slug],
+          );
+          deleted = r.affectedRows ?? 0;
+        }
+      }
       const out: number[] = [];
       for (const input of rows) {
         const validFrom = input.valid_from ?? new Date();
@@ -4179,16 +4208,24 @@ export class PGLiteEngine implements BrainEngine {
         const targetRow = rows[i].superseded_by_row;
         if (targetRow === undefined) continue;
         const slug = rows[i].source_markdown_slug;
-        const found = await tx.query<{ id: number; expired_at: Date | string | null }>(
-          `SELECT id, expired_at FROM facts
-             WHERE source_id = $1 AND source_markdown_slug = $2 AND row_num = $3
-             LIMIT 1`,
-          [ctx.source_id, slug, targetRow],
-        );
-        const hit = found.rows[0];
-        const target: SupersedeTarget | undefined = hit
-          ? { id: Number(hit.id), struck: hit.expired_at != null }
-          : undefined;
+        // v0.42 (#3014) — only look up an int4-safe target. An absurd `#N`
+        // (11+ digits) would overflow the `row_num` comparison and abort
+        // the cycle; skipping the lookup leaves `target` undefined, so
+        // resolveSupersededByRow treats it as a dangling reference (NULL +
+        // warning) instead of throwing.
+        let target: SupersedeTarget | undefined;
+        if (isInt4RowRef(targetRow)) {
+          const found = await tx.query<{ id: number; expired_at: Date | string | null }>(
+            `SELECT id, expired_at FROM facts
+               WHERE source_id = $1 AND source_markdown_slug = $2 AND row_num = $3
+               LIMIT 1`,
+            [ctx.source_id, slug, targetRow],
+          );
+          const hit = found.rows[0];
+          target = hit
+            ? { id: Number(hit.id), struck: hit.expired_at != null }
+            : undefined;
+        }
         const { superseded_by, warning } = resolveSupersededByRow(rows[i].row_num, targetRow, target, slug);
         if (warning) warnings.push(warning);
         if (superseded_by !== null) {
@@ -4197,7 +4234,7 @@ export class PGLiteEngine implements BrainEngine {
       }
       return out;
     });
-    return { inserted: ids.length, ids, warnings };
+    return { inserted: ids.length, ids, warnings, deleted };
   }
 
   async deleteFactsForPage(

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -21,7 +21,7 @@ import type {
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
-import { resolveSupersededByRow, type SupersedeTarget } from './facts/extract-from-fence.ts';
+import { resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { runMigrations } from './migrate.ts';
@@ -4288,8 +4288,9 @@ export class PostgresEngine implements BrainEngine {
   async insertFacts(
     rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }> {
-    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [] };
+    opts?: { deleteForPageFirst?: { slug: string; excludeSourcePrefixes?: string[] } },
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[]; deleted: number }> {
+    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [], deleted: 0 };
 
     const sql = this.sql;
     // v0.41.15.0 (T6, codex #20): resolve the embedding-cast suffix
@@ -4297,6 +4298,9 @@ export class PostgresEngine implements BrainEngine {
     // (halfvec vs vector). The probe is cached after first call.
     const castSuffix = await this.resolveFactsEmbeddingCast();
     const warnings: string[] = [];
+    // v0.42 (#3014): captured inside the transaction below when
+    // deleteForPageFirst runs; stays 0 for the standalone insert path.
+    let deleted = 0;
     // Single transaction so the v51 partial UNIQUE index can roll back
     // the whole batch on constraint violation. Per-row INSERTs (not
     // multi-row VALUES) keep the embedding-vs-no-embedding branching
@@ -4305,6 +4309,31 @@ export class PostgresEngine implements BrainEngine {
     // stamped inline here, and `superseded by #N` references are resolved
     // to `facts.superseded_by` in a second pass below (same transaction).
     const ids = await sql.begin(async (tx) => {
+      // v0.42 (#3014) — atomic reconcile: wipe the page's fence-owned rows
+      // as the FIRST statement of this transaction so a failing insert
+      // below rolls the delete back too. Inlined (not a deleteFactsForPage
+      // call) so it shares this transaction — deleteFactsForPage runs on the
+      // pool (`this.sql`), a separate self-committing transaction, which is
+      // exactly the split this fix removes. Scoping mirrors it exactly.
+      const del = opts?.deleteForPageFirst;
+      if (del) {
+        const prefixes = del.excludeSourcePrefixes;
+        if (prefixes && prefixes.length > 0) {
+          const patterns = prefixes.map(p => `${p}%`);
+          const r = await tx`
+            DELETE FROM facts
+            WHERE source_id = ${ctx.source_id}
+              AND source_markdown_slug = ${del.slug}
+              AND NOT (COALESCE(source, '') LIKE ANY(${patterns}))
+          `;
+          deleted = r.count ?? 0;
+        } else {
+          const r = await tx`
+            DELETE FROM facts WHERE source_id = ${ctx.source_id} AND source_markdown_slug = ${del.slug}
+          `;
+          deleted = r.count ?? 0;
+        }
+      }
       const out: number[] = [];
       for (const input of rows) {
         const validFrom = input.valid_from ?? new Date();
@@ -4358,16 +4387,24 @@ export class PostgresEngine implements BrainEngine {
         const targetRow = rows[i].superseded_by_row;
         if (targetRow === undefined) continue;
         const slug = rows[i].source_markdown_slug;
-        const found = await tx<Array<{ id: number; expired_at: Date | null }>>`
-          SELECT id, expired_at FROM facts
-          WHERE source_id = ${ctx.source_id}
-            AND source_markdown_slug = ${slug}
-            AND row_num = ${targetRow}
-          LIMIT 1
-        `;
-        const target: SupersedeTarget | undefined = found[0]
-          ? { id: Number(found[0].id), struck: found[0].expired_at != null }
-          : undefined;
+        // v0.42 (#3014) — only look up an int4-safe target. An absurd `#N`
+        // (11+ digits) would overflow the `row_num` comparison and abort
+        // the cycle; skipping the lookup leaves `target` undefined, so
+        // resolveSupersededByRow treats it as a dangling reference (NULL +
+        // warning) instead of throwing.
+        let target: SupersedeTarget | undefined;
+        if (isInt4RowRef(targetRow)) {
+          const found = await tx<Array<{ id: number; expired_at: Date | null }>>`
+            SELECT id, expired_at FROM facts
+            WHERE source_id = ${ctx.source_id}
+              AND source_markdown_slug = ${slug}
+              AND row_num = ${targetRow}
+            LIMIT 1
+          `;
+          target = found[0]
+            ? { id: Number(found[0].id), struck: found[0].expired_at != null }
+            : undefined;
+        }
         const { superseded_by, warning } = resolveSupersededByRow(rows[i].row_num, targetRow, target, slug);
         if (warning) warnings.push(warning);
         if (superseded_by !== null) {
@@ -4376,7 +4413,7 @@ export class PostgresEngine implements BrainEngine {
       }
       return out;
     });
-    return { inserted: ids.length, ids, warnings };
+    return { inserted: ids.length, ids, warnings, deleted };
   }
 
   async deleteFactsForPage(

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -21,6 +21,7 @@ import type {
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
+import { resolveSupersededByRow, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { runMigrations } from './migrate.ts';
@@ -4285,27 +4286,30 @@ export class PostgresEngine implements BrainEngine {
   }
 
   async insertFacts(
-    rows: Array<NewFact & { row_num: number; source_markdown_slug: string }>,
+    rows: Array<NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number }>,
     ctx: { source_id: string },
-  ): Promise<{ inserted: number; ids: number[] }> {
-    if (rows.length === 0) return { inserted: 0, ids: [] };
+  ): Promise<{ inserted: number; ids: number[]; warnings: string[] }> {
+    if (rows.length === 0) return { inserted: 0, ids: [], warnings: [] };
 
     const sql = this.sql;
     // v0.41.15.0 (T6, codex #20): resolve the embedding-cast suffix
     // ONCE per process so the cast matches the actual column type
     // (halfvec vs vector). The probe is cached after first call.
     const castSuffix = await this.resolveFactsEmbeddingCast();
+    const warnings: string[] = [];
     // Single transaction so the v51 partial UNIQUE index can roll back
     // the whole batch on constraint violation. Per-row INSERTs (not
     // multi-row VALUES) keep the embedding-vs-no-embedding branching
     // readable; batch sizes are small (5-30 rows per page in practice).
-    // No supersede flow in this path — fence reconciliation is the
-    // canonical source-of-truth direction, not the consolidator path.
+    // v0.42 (#3014): the fence path carries struck rows — `expired_at` is
+    // stamped inline here, and `superseded by #N` references are resolved
+    // to `facts.superseded_by` in a second pass below (same transaction).
     const ids = await sql.begin(async (tx) => {
       const out: number[] = [];
       for (const input of rows) {
         const validFrom = input.valid_from ?? new Date();
         const validUntil = input.valid_until ?? null;
+        const expiredAt = input.expired_at ?? null;
         const kind = input.kind ?? 'fact';
         const visibility = input.visibility ?? 'private';
         const notability = input.notability ?? 'medium';
@@ -4327,14 +4331,14 @@ export class PostgresEngine implements BrainEngine {
         const ins = await tx<Array<{ id: number }>>`
           INSERT INTO facts (
             source_id, entity_slug, fact, kind, visibility, notability, context,
-            valid_from, valid_until, source, source_session, confidence,
+            valid_from, valid_until, expired_at, source, source_session, confidence,
             embedding, embedded_at,
             row_num, source_markdown_slug,
             claim_metric, claim_value, claim_unit, claim_period,
             event_type
           ) VALUES (
             ${ctx.source_id}, ${entitySlug}, ${input.fact}, ${kind}, ${visibility}, ${notability}, ${context},
-            ${validFrom}, ${validUntil}, ${input.source}, ${sourceSession}, ${confidence},
+            ${validFrom}, ${validUntil}, ${expiredAt}, ${input.source}, ${sourceSession}, ${confidence},
             ${embedLit === null ? null : tx.unsafe(`'${embedLit}'${castSuffix}`)}, ${embeddedAt},
             ${input.row_num}, ${input.source_markdown_slug},
             ${claimMetric}, ${claimValue}, ${claimUnit}, ${claimPeriod},
@@ -4343,9 +4347,36 @@ export class PostgresEngine implements BrainEngine {
         `;
         out.push(Number(ins[0].id));
       }
+
+      // v0.42 (#3014) — second pass: resolve `superseded by #N` page-local
+      // references to fact ids. Same transaction so a target row inserted
+      // above is visible. Keyed on (source_id, source_markdown_slug,
+      // row_num) — the v51 unique index — so a reference also resolves
+      // against a target that already existed before this batch. A target
+      // whose `expired_at` is set is itself struck (chain) and rejected.
+      for (let i = 0; i < rows.length; i++) {
+        const targetRow = rows[i].superseded_by_row;
+        if (targetRow === undefined) continue;
+        const slug = rows[i].source_markdown_slug;
+        const found = await tx<Array<{ id: number; expired_at: Date | null }>>`
+          SELECT id, expired_at FROM facts
+          WHERE source_id = ${ctx.source_id}
+            AND source_markdown_slug = ${slug}
+            AND row_num = ${targetRow}
+          LIMIT 1
+        `;
+        const target: SupersedeTarget | undefined = found[0]
+          ? { id: Number(found[0].id), struck: found[0].expired_at != null }
+          : undefined;
+        const { superseded_by, warning } = resolveSupersededByRow(rows[i].row_num, targetRow, target, slug);
+        if (warning) warnings.push(warning);
+        if (superseded_by !== null) {
+          await tx`UPDATE facts SET superseded_by = ${superseded_by} WHERE id = ${out[i]}`;
+        }
+      }
       return out;
     });
-    return { inserted: ids.length, ids };
+    return { inserted: ids.length, ids, warnings };
   }
 
   async deleteFactsForPage(
@@ -4455,13 +4486,18 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const since = opts?.since ?? null;
+    // v0.42 (#3014) — filter on `superseded_by` alone; the ontology
+    // writer closes a superseded row via `valid_until` (not `expired_at`,
+    // which would break its `--asof` time-travel), so requiring both
+    // columns dropped every ontology supersession AND every fence-authored
+    // one. Order / `since` fall back to `valid_until` when `expired_at` is
+    // NULL.
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
-        AND expired_at IS NOT NULL
         AND superseded_by IS NOT NULL
-        ${since ? sql`AND expired_at >= ${since}` : sql``}
-      ORDER BY expired_at DESC, id DESC
+        ${since ? sql`AND COALESCE(expired_at, valid_until) >= ${since}` : sql``}
+      ORDER BY COALESCE(expired_at, valid_until) DESC, id DESC
       LIMIT ${limit}
     `;
     return rows.map(rowToFactPg);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -18,10 +18,9 @@ import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatch
 import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
 } from './types.ts';
-import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { MAX_SEARCH_LIMIT, clampSearchLimit, resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './engine.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
-import { resolveSupersededByRow, isInt4RowRef, type SupersedeTarget } from './facts/extract-from-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { runMigrations } from './migrate.ts';

--- a/test/chronicle-ontology.test.ts
+++ b/test/chronicle-ontology.test.ts
@@ -61,6 +61,27 @@ describe('mergeOntologyFact + getOntology', () => {
     expect(past[0].value).toBe('founder');
   });
 
+  test('#3014 option B — a forward supersession surfaces in listSupersessions while --asof still sees it', async () => {
+    // The ontology writer closes the prior row via valid_until + superseded_by
+    // but leaves expired_at NULL (so --asof time-travel keeps seeing it). The
+    // pre-fix listSupersessions required expired_at IS NOT NULL, so this row
+    // was invisible. Option B filters on superseded_by alone.
+    await engine.mergeOntologyFact({ entitySlug: SARAH, dimension: 'role', value: 'founder', source: 'meetings/a', validFrom: '2024-01-01' });
+    const r = await engine.mergeOntologyFact({ entitySlug: SARAH, dimension: 'role', value: 'advisor', source: 'meetings/b', validFrom: '2026-05-01' });
+    expect(r.action).toBe('superseded_prior');
+
+    const sup = await engine.listSupersessions('default');
+    expect(sup).toHaveLength(1);
+    expect(sup[0].fact).toContain('founder');   // the superseded prior row
+    expect(sup[0].superseded_by).not.toBeNull();
+    expect(sup[0].expired_at).toBeNull();        // ontology closes via valid_until, not expired_at
+
+    // The regression that option A ("writers set both columns") would have
+    // caused: --asof time-travel must still return the superseded value.
+    const past = await engine.getOntology(SARAH, { asof: '2025-01-01' });
+    expect(past[0].value).toBe('founder');
+  });
+
   test('novel dimensions quarantine (excluded from current unless asked)', async () => {
     await engine.mergeOntologyFact({ entitySlug: SARAH, dimension: 'vibe', value: 'chaotic', source: 'meetings/a' });
     expect(await engine.getOntology(SARAH)).toHaveLength(0); // quarantined → hidden

--- a/test/e2e/facts-fence-reconcile-postgres.test.ts
+++ b/test/e2e/facts-fence-reconcile-postgres.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { PostgresEngine } from '../../src/core/postgres-engine.ts';
 import { runExtractFacts } from '../../src/core/cycle/extract-facts.ts';
 import { parseFactsFence, renderFactsTable, type ParsedFact } from '../../src/core/facts-fence.ts';
@@ -92,6 +92,16 @@ describe.skipIf(skip)('facts-fence supersession transport on Postgres (#3014)', 
       await engine.executeRaw('DELETE FROM pages WHERE slug = $1', [slug]);
       await engine.disconnect();
     }
+  });
+
+  // Each test putPages its own fence and expects a fresh reconcile, so wipe
+  // the page's DB rows first. Without this, two consecutive tests whose
+  // struck rows both resolve to NULL (e.g. dangling #9 then int4-overflow
+  // #99999999999) share a claim + slug, so the second reconcile sees no
+  // drift and skips — correct no-churn behavior, but it would starve a test
+  // that asserts a fresh warning.
+  beforeEach(async () => {
+    await engine.executeRaw('DELETE FROM facts WHERE source_markdown_slug = $1', [slug]);
   });
 
   // Row 1 struck + "superseded by #2"; row 2 the live superseding fact.
@@ -282,5 +292,68 @@ describe.skipIf(skip)('facts-fence supersession transport on Postgres (#3014)', 
       [slug],
     );
     expect(Array.from(facts).map(f => f.fact)).toEqual(['keeper one', 'keeper two']);
+  }, 30_000);
+});
+
+// v0.42 (#3014) option B — the ontology-dimension writer closes a superseded
+// row via valid_until + superseded_by (NOT expired_at, so getOntology's
+// --asof time-travel still sees it). listSupersessions must surface it anyway
+// (filter on superseded_by alone) and order/since via COALESCE(expired_at,
+// valid_until). Both verified here on real Postgres.
+describe.skipIf(skip)('facts supersession visibility on Postgres — ontology + since (#3014)', () => {
+  const SARAH = 'people/zz-sarah-ontology-3014';
+  let engine: PostgresEngine;
+
+  beforeAll(async () => {
+    engine = new PostgresEngine();
+    await engine.connect({ database_url: databaseUrl! });
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    if (engine) {
+      await engine.executeRaw('DELETE FROM facts WHERE entity_slug = $1', [SARAH]);
+      await engine.disconnect();
+    }
+  });
+
+  beforeEach(async () => {
+    await engine.executeRaw('DELETE FROM facts WHERE entity_slug = $1', [SARAH]);
+  });
+
+  // founder (2024) → advisor (2026-05-01): the prior 'founder' row is closed
+  // via valid_until = 2026-05-01, superseded_by set, expired_at left NULL.
+  const supersede = async () => {
+    await engine.mergeOntologyFact({ entitySlug: SARAH, dimension: 'role', value: 'founder', source: 'meetings/a', validFrom: '2024-01-01' });
+    const r = await engine.mergeOntologyFact({ entitySlug: SARAH, dimension: 'role', value: 'advisor', source: 'meetings/b', validFrom: '2026-05-01' });
+    expect(r.action).toBe('superseded_prior');
+  };
+
+  test('a forward ontology supersession surfaces in listSupersessions while --asof still time-travels', async () => {
+    await supersede();
+
+    const sup = await engine.listSupersessions('default');
+    const founder = sup.find(s => s.fact.includes('founder'));
+    expect(founder).toBeDefined();
+    expect(founder!.superseded_by).not.toBeNull();
+    // Option A ("writers set both columns") would have set expired_at here and
+    // broken the --asof read below; option B leaves it NULL and surfaces anyway.
+    expect(founder!.expired_at).toBeNull();
+
+    const past = await engine.getOntology(SARAH, { asof: '2025-01-01' });
+    expect(past[0].value).toBe('founder');
+  }, 30_000);
+
+  test('listSupersessions({since}) filters a NULL-expired_at row by COALESCE(expired_at, valid_until)', async () => {
+    await supersede(); // founder row: valid_until = 2026-05-01, expired_at NULL
+
+    // since before the close date → COALESCE falls back to valid_until, included.
+    const included = await engine.listSupersessions('default', { since: new Date('2026-01-01T00:00:00Z') });
+    expect(included.some(s => s.fact.includes('founder'))).toBe(true);
+
+    // since after the close date → excluded (a pre-fix `expired_at >= since`
+    // would have dropped it unconditionally since expired_at is NULL).
+    const excluded = await engine.listSupersessions('default', { since: new Date('2026-09-01T00:00:00Z') });
+    expect(excluded.some(s => s.fact.includes('founder'))).toBe(false);
   }, 30_000);
 });

--- a/test/e2e/facts-fence-reconcile-postgres.test.ts
+++ b/test/e2e/facts-fence-reconcile-postgres.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { PostgresEngine } from '../../src/core/postgres-engine.ts';
 import { runExtractFacts } from '../../src/core/cycle/extract-facts.ts';
 import { parseFactsFence, renderFactsTable, type ParsedFact } from '../../src/core/facts-fence.ts';
+import type { NewFact } from '../../src/core/engine.ts';
 
 const databaseUrl = process.env.DATABASE_URL;
 const skip = !databaseUrl;
@@ -128,6 +129,26 @@ describe.skipIf(skip)('facts-fence supersession transport on Postgres (#3014)', 
       [slug],
     ));
 
+  const readIds = async (): Promise<number[]> =>
+    (await readRows()).map(r => Number(r.id));
+
+  // Row 1 struck with an unresolvable `superseded by #N`; no target row.
+  const buildDanglingFence = (ref: number): string => renderFactsTable([
+    {
+      rowNum: 1,
+      claim: 'Retired claim with a bad reference',
+      kind: 'commitment',
+      confidence: 0.6,
+      visibility: 'world',
+      notability: 'medium',
+      validFrom: '2026-01-01',
+      source: 'call',
+      context: `superseded by #${ref}`,
+      active: false,
+      supersededBy: ref,
+    },
+  ]);
+
   test('struck row lands with superseded_by + expired_at and surfaces in listSupersessions', async () => {
     await engine.putPage(slug, {
       title: 'Supersession E2E Example',
@@ -181,5 +202,85 @@ describe.skipIf(skip)('facts-fence supersession transport on Postgres (#3014)', 
     const target = after.find(r => Number(r.row_num) === 2)!;
     expect(Number(healed.superseded_by)).toBe(Number(target.id));
     expect(healed.expired_at).not.toBeNull();
+  }, 30_000);
+
+  // Finding A (#3014) — a dangling reference resolves to NULL every cycle
+  // and matches the DB's NULL, so it must not re-drift (pre-fix it wiped +
+  // reinserted the page every cycle, advancing the fact ids).
+  test('idempotent: a dangling reference does not churn on re-reconcile', async () => {
+    await engine.putPage(slug, {
+      title: 'Supersession E2E Example',
+      type: 'person',
+      compiled_truth: buildDanglingFence(9),
+      frontmatter: {},
+      timeline: '',
+    });
+    const first = await runExtractFacts(engine, { slugs: [slug] });
+    expect(first.warnings.some(w => w.includes('absent from the fence'))).toBe(true);
+    const idsAfterFirst = await readIds();
+
+    const second = await runExtractFacts(engine, { slugs: [slug] });
+    expect(second.factsInserted).toBe(0);
+    expect(second.factsDeleted).toBe(0);
+    expect(second.warnings).toEqual([]);
+    expect(await readIds()).toEqual(idsAfterFirst);
+  }, 30_000);
+
+  // Finding C (#3014) — an int4-overflowing #N would raise `integer out of
+  // range` in the resolution SELECT and abort the cycle; the guard treats it
+  // as a dangling reference instead.
+  test('int4-overflow reference (11-digit #N) resolves as dangling — cycle completes', async () => {
+    await engine.putPage(slug, {
+      title: 'Supersession E2E Example',
+      type: 'person',
+      compiled_truth: buildDanglingFence(99999999999),
+      frontmatter: {},
+      timeline: '',
+    });
+    const r = await runExtractFacts(engine, { slugs: [slug] });
+    expect(r.warnings.some(w => w.includes('absent from the fence'))).toBe(true);
+    const row1 = (await readRows()).find(x => Number(x.row_num) === 1)!;
+    expect(row1.superseded_by).toBeNull();
+    expect(row1.expired_at).not.toBeNull();
+  }, 30_000);
+
+  // Finding B (#3014) — the wipe now runs inside insertFacts' transaction, so
+  // a failing insert rolls it back and the page is never left emptied.
+  test('deleteForPageFirst rolls the wipe back when the insert fails — the page survives', async () => {
+    type Row = NewFact & { row_num: number; source_markdown_slug: string };
+    const fixture = (rowNum: number, fact: string): Row => ({
+      fact,
+      kind: 'fact',
+      entity_slug: 'people/zz-supersession-e2e-3014',
+      visibility: 'world',
+      notability: 'medium',
+      source: 'fence:reconcile',
+      confidence: 1.0,
+      row_num: rowNum,
+      source_markdown_slug: slug,
+    });
+
+    await engine.executeRaw('DELETE FROM facts WHERE source_markdown_slug = $1', [slug]);
+    await engine.insertFacts([fixture(1, 'keeper one'), fixture(2, 'keeper two')], { source_id: 'default' });
+
+    let threw = false;
+    try {
+      // Two row_num=1 rows collide on the v51 UNIQUE index AFTER the delete
+      // has run inside the same transaction.
+      await engine.insertFacts(
+        [fixture(1, 'replacement a'), fixture(1, 'dup collides')],
+        { source_id: 'default' },
+        { deleteForPageFirst: { slug, excludeSourcePrefixes: ['cli:'] } },
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
+    const facts = await engine.executeRaw<{ fact: string }>(
+      'SELECT fact FROM facts WHERE source_markdown_slug = $1 ORDER BY row_num',
+      [slug],
+    );
+    expect(Array.from(facts).map(f => f.fact)).toEqual(['keeper one', 'keeper two']);
   }, 30_000);
 });

--- a/test/e2e/facts-fence-reconcile-postgres.test.ts
+++ b/test/e2e/facts-fence-reconcile-postgres.test.ts
@@ -73,3 +73,113 @@ describe.skipIf(skip)('facts-fence escaped-pipe reconciliation on Postgres', () 
     ]);
   }, 30_000);
 });
+
+// v0.42 (#3014) — fence-authored supersession transport end to end.
+describe.skipIf(skip)('facts-fence supersession transport on Postgres (#3014)', () => {
+  const slug = 'people/zz-supersession-e2e-3014';
+  let engine: PostgresEngine;
+
+  beforeAll(async () => {
+    engine = new PostgresEngine();
+    await engine.connect({ database_url: databaseUrl! });
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    if (engine) {
+      await engine.executeRaw('DELETE FROM facts WHERE source_markdown_slug = $1', [slug]);
+      await engine.executeRaw('DELETE FROM pages WHERE slug = $1', [slug]);
+      await engine.disconnect();
+    }
+  });
+
+  // Row 1 struck + "superseded by #2"; row 2 the live superseding fact.
+  const buildFence = (): string => renderFactsTable([
+    {
+      rowNum: 1,
+      claim: 'Will close the deal by Q2',
+      kind: 'commitment',
+      confidence: 0.6,
+      visibility: 'world',
+      notability: 'medium',
+      validFrom: '2026-01-01',
+      source: 'call',
+      context: 'superseded by #2',
+      active: false,
+      supersededBy: 2,
+    },
+    {
+      rowNum: 2,
+      claim: 'Deal closed in Q3',
+      kind: 'fact',
+      confidence: 1,
+      visibility: 'world',
+      notability: 'high',
+      validFrom: '2026-07-01',
+      source: 'call',
+      active: true,
+    },
+  ]);
+
+  interface SupRow { id: number | string; row_num: number | string; superseded_by: number | string | null; expired_at: Date | string | null }
+  const readRows = async (): Promise<SupRow[]> =>
+    Array.from(await engine.executeRaw<SupRow>(
+      'SELECT id, row_num, superseded_by, expired_at FROM facts WHERE source_markdown_slug = $1 ORDER BY row_num',
+      [slug],
+    ));
+
+  test('struck row lands with superseded_by + expired_at and surfaces in listSupersessions', async () => {
+    await engine.putPage(slug, {
+      title: 'Supersession E2E Example',
+      type: 'person',
+      compiled_truth: buildFence(),
+      frontmatter: {},
+      timeline: '',
+    });
+    const result = await runExtractFacts(engine, { slugs: [slug] });
+    expect(result.factsInserted).toBe(2);
+
+    const rows = await readRows();
+    expect(rows).toHaveLength(2);
+    const [row1, row2] = rows;
+    // The struck row's page-local "#2" reference resolved to row 2's fact id.
+    expect(Number(row1.superseded_by)).toBe(Number(row2.id));
+    expect(row1.expired_at).not.toBeNull();
+    // The live superseding row is untouched.
+    expect(row2.superseded_by).toBeNull();
+    expect(row2.expired_at).toBeNull();
+
+    const sup = await engine.listSupersessions('default');
+    expect(sup.some(s => s.id === Number(row1.id) && s.superseded_by === Number(row2.id))).toBe(true);
+  }, 30_000);
+
+  test('idempotent heal: a struck row with NULL columns re-populates on re-reconcile (#2932)', async () => {
+    await engine.putPage(slug, {
+      title: 'Supersession E2E Example',
+      type: 'person',
+      compiled_truth: buildFence(),
+      frontmatter: {},
+      timeline: '',
+    });
+    await runExtractFacts(engine, { slugs: [slug] });
+
+    // Simulate the pre-#3014 mis-transport: the struck row was inserted with
+    // both columns NULL. The fence is unchanged, so only the drift check on
+    // the supersession columns can trigger a re-heal.
+    await engine.executeRaw(
+      'UPDATE facts SET superseded_by = NULL, expired_at = NULL WHERE source_markdown_slug = $1 AND row_num = 1',
+      [slug],
+    );
+    const before = await readRows();
+    expect(before.find(r => Number(r.row_num) === 1)!.superseded_by).toBeNull();
+
+    // Re-reconcile: hasSupersessionDrift fires → wipe+reinsert heals the row.
+    await runExtractFacts(engine, { slugs: [slug] });
+
+    const after = await readRows();
+    const healed = after.find(r => Number(r.row_num) === 1)!;
+    const target = after.find(r => Number(r.row_num) === 2)!;
+    expect(Number(healed.superseded_by)).toBe(Number(target.id));
+    expect(healed.expired_at).not.toBeNull();
+  }, 30_000);
+});

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -439,6 +439,14 @@ describe('runExtractFacts — v0.42 (#3014) supersession transport + heal', () =
     return r.rows as Array<{ row_num: number; superseded_by: number | null; expired_at: unknown }>;
   };
 
+  const readIds = async (): Promise<number[]> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await (engine as any).db.query(
+      `SELECT id FROM facts WHERE source_markdown_slug = 'people/deal' ORDER BY row_num, id`,
+    );
+    return (r.rows as Array<{ id: number }>).map(x => Number(x.id));
+  };
+
   test('reconcile transports superseded_by (resolved to the target row id) + expired_at', async () => {
     await putPage('people/deal', SUPERSEDE_FENCE);
     const r = await runExtractFacts(engine, { slugs: ['people/deal'] });
@@ -502,5 +510,145 @@ describe('runExtractFacts — v0.42 (#3014) supersession transport + heal', () =
     const row1 = (await readSupersessionCols()).find(x => x.row_num === 1)!;
     expect(row1.superseded_by).toBeNull();
     expect(row1.expired_at).not.toBeNull();
+  });
+
+  // Finding A: a permanently-unresolvable reference must NOT re-drift every
+  // cycle. Pre-fix, the drift term keyed off "the fence has a reference" vs
+  // "the DB resolved one", so self / dangling / chain (which correctly stay
+  // NULL) drifted forever — a full wipe+reinsert + duplicate warning each
+  // cycle, with the fact ids advancing 1→2→3→…
+  test('idempotent: a dangling reference does not churn — second reconcile is a no-op', async () => {
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Retired claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #9 |`,
+    ));
+    const first = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(first.factsInserted).toBeGreaterThan(0);
+    const idsAfterFirst = await readIds();
+
+    const second = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(second.factsInserted).toBe(0);
+    expect(second.factsDeleted).toBe(0);
+    expect(second.warnings).toEqual([]);
+    expect(await readIds()).toEqual(idsAfterFirst);
+  });
+
+  test('idempotent: a self-reference does not churn — second reconcile is a no-op', async () => {
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Ouroboros claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #1 |`,
+    ));
+    const first = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(first.warnings.some(w => w.includes('references itself'))).toBe(true);
+    const idsAfterFirst = await readIds();
+
+    const second = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(second.factsInserted).toBe(0);
+    expect(second.factsDeleted).toBe(0);
+    expect(second.warnings).toEqual([]);
+    expect(await readIds()).toEqual(idsAfterFirst);
+  });
+
+  test('idempotent: a chain (struck → struck) does not churn — second reconcile is a no-op', async () => {
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Link a~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #2 |
+| 2 | ~~Link b~~ | commitment | 0.6 | world | medium | 2026-02-01 |  | call | superseded by #3 |
+| 3 | Live tail | fact | 1.0 | world | high | 2026-03-01 |  | call |  |`,
+    ));
+    const first = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(first.warnings.some(w => w.includes('chain'))).toBe(true);
+    const idsAfterFirst = await readIds();
+
+    const second = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(second.factsInserted).toBe(0);
+    expect(second.factsDeleted).toBe(0);
+    expect(second.warnings).toEqual([]);
+    expect(await readIds()).toEqual(idsAfterFirst);
+  });
+
+  // Finding A: the no-churn fix must not mask a genuine reference change.
+  test('changed reference re-attempts: dangling → resolvable re-resolves superseded_by', async () => {
+    // Cycle 1: row 1 struck, superseded by #9 (dangling); row 2 live.
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Old claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #9 |
+| 2 | New claim | fact | 1.0 | world | high | 2026-07-01 |  | call |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect((await readSupersessionCols()).find(x => x.row_num === 1)!.superseded_by).toBeNull();
+
+    // Cycle 2: the operator fixes the reference to #2. The claim text and
+    // row_num are unchanged, so only the supersession-drift term can catch
+    // it — and it must, keying off the now-resolvable reference.
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Old claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #2 |
+| 2 | New claim | fact | 1.0 | world | high | 2026-07-01 |  | call |  |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(r.factsInserted).toBeGreaterThan(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ids = await (engine as any).db.query(
+      `SELECT row_num, id FROM facts WHERE source_markdown_slug = 'people/deal' ORDER BY row_num`,
+    );
+    const row2Id = Number(ids.rows.find((x: { row_num: number }) => Number(x.row_num) === 2).id);
+    const row1 = (await readSupersessionCols()).find(x => x.row_num === 1)!;
+    expect(Number(row1.superseded_by)).toBe(row2Id);
+
+    // And it settles: a third cycle is a no-op.
+    const third = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(third.factsInserted).toBe(0);
+    expect(third.factsDeleted).toBe(0);
+  });
+
+  // Finding B: pre-fix, the reconcile deleted the page in a self-committing
+  // transaction BEFORE the separate insertFacts transaction; an insert throw
+  // left the page permanently emptied. The caller now defers the wipe into
+  // insertFacts' own transaction, so a failing insert can never empty it.
+  test('a failing insert during the wipe+reinsert path leaves the page intact', async () => {
+    await putPage('people/deal', SUPERSEDE_FENCE);
+    await runExtractFacts(engine, { slugs: ['people/deal'] });
+    const before = await readIds();
+    expect(before).toHaveLength(2);
+
+    // Force a drift so the reconcile takes the wipe+reinsert path.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `UPDATE facts SET superseded_by = NULL, expired_at = NULL WHERE source_markdown_slug = 'people/deal' AND row_num = 1`,
+    );
+
+    // Make the insert throw. Pre-fix, the separate-commit delete had already
+    // emptied the page by the time this threw; now no delete runs outside
+    // insertFacts, so the rows survive.
+    const original = engine.insertFacts.bind(engine);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).insertFacts = async () => { throw new Error('simulated insert failure'); };
+    try {
+      await expect(runExtractFacts(engine, { slugs: ['people/deal'] })).rejects.toThrow('simulated insert failure');
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (engine as any).insertFacts = original;
+    }
+
+    // The page keeps its rows — not silently emptied.
+    expect(await readIds()).toEqual(before);
+  });
+
+  // Finding C: an int4-overflowing #N in the fence must be treated as a
+  // dangling reference, never overflow the resolution SELECT and abort the
+  // cycle.
+  test('int4-overflow reference in the fence → warning, cycle completes, second cycle no-op', async () => {
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Retired claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #99999999999 |`,
+    ));
+    const first = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(first.warnings.some(w => w.includes('absent from the fence'))).toBe(true);
+    const row1 = (await readSupersessionCols()).find(x => x.row_num === 1)!;
+    expect(row1.superseded_by).toBeNull();
+    expect(row1.expired_at).not.toBeNull();
+    const idsAfterFirst = await readIds();
+
+    const second = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(second.factsInserted).toBe(0);
+    expect(second.factsDeleted).toBe(0);
+    expect(second.warnings).toEqual([]);
+    expect(await readIds()).toEqual(idsAfterFirst);
   });
 });

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -423,3 +423,84 @@ describe('runExtractFacts — empty-slugs guard (v0.36.x #1096 regression)', () 
     expect(r.pagesScanned).toBe(1);
   });
 });
+
+describe('runExtractFacts — v0.42 (#3014) supersession transport + heal', () => {
+  // Row 1 struck + "superseded by #2"; row 2 the live superseding fact.
+  const SUPERSEDE_FENCE = FACT_FENCE(
+    `| 1 | ~~Will close by Q2~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #2 |
+| 2 | Closed in Q3 | fact | 1.0 | world | high | 2026-07-01 |  | call |  |`,
+  );
+
+  const readSupersessionCols = async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await (engine as any).db.query(
+      `SELECT row_num, superseded_by, expired_at FROM facts WHERE source_markdown_slug = 'people/deal' ORDER BY row_num`,
+    );
+    return r.rows as Array<{ row_num: number; superseded_by: number | null; expired_at: unknown }>;
+  };
+
+  test('reconcile transports superseded_by (resolved to the target row id) + expired_at', async () => {
+    await putPage('people/deal', SUPERSEDE_FENCE);
+    const r = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(r.factsInserted).toBe(2);
+    expect(r.warnings).toEqual([]);
+
+    const rows = await readSupersessionCols();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ids = await (engine as any).db.query(
+      `SELECT row_num, id FROM facts WHERE source_markdown_slug = 'people/deal' ORDER BY row_num`,
+    );
+    const row2Id = ids.rows.find((x: { row_num: number; id: number }) => x.row_num === 2).id;
+    const row1 = rows.find(x => x.row_num === 1)!;
+    expect(Number(row1.superseded_by)).toBe(Number(row2Id));
+    expect(row1.expired_at).not.toBeNull();
+
+    const sup = await engine.listSupersessions('default');
+    expect(sup.some(s => s.superseded_by === Number(row2Id))).toBe(true);
+  });
+
+  test('idempotent: a second reconcile with the struck row already healed is a no-op', async () => {
+    await putPage('people/deal', SUPERSEDE_FENCE);
+    await runExtractFacts(engine, { slugs: ['people/deal'] });
+    const r2 = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    // Columns already match the fence-desired state → no drift → no churn.
+    expect(r2.factsInserted).toBe(0);
+    expect(r2.factsDeleted).toBe(0);
+  });
+
+  test('heal: a struck row with NULL supersession columns re-populates on re-reconcile', async () => {
+    await putPage('people/deal', SUPERSEDE_FENCE);
+    await runExtractFacts(engine, { slugs: ['people/deal'] });
+
+    // Simulate the pre-#3014 mis-transport: struck row inserted with NULL
+    // columns. The fence text is unchanged, so only the supersession-column
+    // drift check can trigger a re-heal.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `UPDATE facts SET superseded_by = NULL, expired_at = NULL WHERE source_markdown_slug = 'people/deal' AND row_num = 1`,
+    );
+    const drifted = (await readSupersessionCols()).find(x => x.row_num === 1)!;
+    expect(drifted.superseded_by).toBeNull();
+    expect(drifted.expired_at).toBeNull();
+
+    const healRun = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    // Drift detected → wipe+reinsert re-transports the columns.
+    expect(healRun.factsInserted).toBeGreaterThan(0);
+
+    const healed = (await readSupersessionCols()).find(x => x.row_num === 1)!;
+    expect(healed.superseded_by).not.toBeNull();
+    expect(healed.expired_at).not.toBeNull();
+  });
+
+  test('dangling reference (#N absent from fence) → warning, superseded_by NULL, expired_at set', async () => {
+    await putPage('people/deal', FACT_FENCE(
+      `| 1 | ~~Retired claim~~ | commitment | 0.6 | world | medium | 2026-01-01 |  | call | superseded by #9 |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/deal'] });
+    expect(r.warnings.some(w => w.includes('absent from the fence'))).toBe(true);
+
+    const row1 = (await readSupersessionCols()).find(x => x.row_num === 1)!;
+    expect(row1.superseded_by).toBeNull();
+    expect(row1.expired_at).not.toBeNull();
+  });
+});

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -554,7 +554,7 @@ describe('runExtractFacts — v0.42 (#3014) supersession transport + heal', () =
 | 3 | Live tail | fact | 1.0 | world | high | 2026-03-01 |  | call |  |`,
     ));
     const first = await runExtractFacts(engine, { slugs: ['people/deal'] });
-    expect(first.warnings.some(w => w.includes('chain'))).toBe(true);
+    expect(first.warnings.some(w => w.includes('struck'))).toBe(true);
     const idsAfterFirst = await readIds();
 
     const second = await runExtractFacts(engine, { slugs: ['people/deal'] });

--- a/test/extract-from-fence.test.ts
+++ b/test/extract-from-fence.test.ts
@@ -5,6 +5,9 @@
  *   - All-fields happy path
  *   - The strikethrough date-derivation contract (forgotten / superseded
  *     / inactive-unrecognized branches)
+ *   - v0.42 (#3014) supersession transport: struck rows carry expired_at
+ *     + the `superseded by #N` row reference; resolveSupersededByRow's
+ *     self / dangling / chain edge cases
  *   - source default when fence row has no `source` cell
  *   - row_num and source_markdown_slug threading
  *   - ISO date parsing tolerance + UTC determinism
@@ -15,6 +18,8 @@ import { describe, test, expect } from 'bun:test';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
+  resolveSupersededByRow,
+  type SupersedeTarget,
 } from '../src/core/facts/extract-from-fence.ts';
 import type { ParsedFact } from '../src/core/facts-fence.ts';
 
@@ -135,7 +140,7 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
     expect(out[0].valid_until).toBeNull();
   });
 
-  test('forgotten row → valid_until = today (UTC midnight)', () => {
+  test('forgotten row → valid_until = today (UTC midnight) + expired_at set, no supersession', () => {
     const out = extractFactsFromFenceText(
       [baseFact({
         active: false,
@@ -147,6 +152,10 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
       { nowOverride: FROZEN_TODAY },
     );
     expect(out[0].valid_until).toEqual(FROZEN_TODAY);
+    // v0.42 (#3014) — a struck row stamps expired_at so it exits active
+    // views; a forgotten row is not a supersession, so no row reference.
+    expect(out[0].expired_at).toEqual(FROZEN_TODAY);
+    expect(out[0].superseded_by_row).toBeUndefined();
   });
 
   test('forgotten row with explicit validUntil → explicit value wins', () => {
@@ -168,7 +177,12 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
     expect(out[0].valid_until).not.toEqual(FROZEN_TODAY);
   });
 
-  test('supersededBy row without explicit validUntil → null (consolidator owns derivation)', () => {
+  test('supersededBy row without explicit validUntil → valid_until null, expired_at today, superseded_by_row carried', () => {
+    // v0.42 (#3014): pre-fix the mapper dropped supersededBy and left
+    // valid_until null "for the consolidator". The mapper now owns the
+    // transport: it carries the row reference and stamps expired_at so the
+    // struck row exits active views. valid_until stays null (no explicit
+    // date, and the superseding row's valid_from isn't visible here).
     const out = extractFactsFromFenceText(
       [baseFact({
         active: false,
@@ -180,9 +194,11 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
       { nowOverride: FROZEN_TODAY },
     );
     expect(out[0].valid_until).toBeNull();
+    expect(out[0].expired_at).toEqual(FROZEN_TODAY);
+    expect(out[0].superseded_by_row).toBe(4);
   });
 
-  test('supersededBy row with explicit validUntil → explicit value wins', () => {
+  test('supersededBy row with explicit validUntil → explicit value wins for both valid_until and expired_at', () => {
     const out = extractFactsFromFenceText(
       [baseFact({
         active: false,
@@ -195,6 +211,10 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
       { nowOverride: FROZEN_TODAY },
     );
     expect(out[0].valid_until!.getUTCFullYear()).toBe(2026);
+    // expired_at derives from valid_until when present (valid_until ?? today).
+    expect(out[0].expired_at!.getUTCFullYear()).toBe(2026);
+    expect(out[0].expired_at!.getUTCMonth()).toBe(5); // June
+    expect(out[0].superseded_by_row).toBe(4);
   });
 
   test('inactive-unrecognized row (strikethrough but no forgotten/superseded flag) → today', () => {
@@ -212,6 +232,49 @@ describe('extractFactsFromFenceText — date derivation contract', () => {
       { nowOverride: FROZEN_TODAY },
     );
     expect(out[0].valid_until).toEqual(FROZEN_TODAY);
+    // v0.42 (#3014) — unrecognized-inactive still exits active views via
+    // expired_at, but is not a supersession.
+    expect(out[0].expired_at).toEqual(FROZEN_TODAY);
+    expect(out[0].superseded_by_row).toBeUndefined();
+  });
+
+  test('active row → expired_at null, no supersession reference', () => {
+    const out = extractFactsFromFenceText(
+      [baseFact()],
+      'people/alice',
+      'default',
+      { nowOverride: FROZEN_TODAY },
+    );
+    expect(out[0].expired_at).toBeNull();
+    expect(out[0].superseded_by_row).toBeUndefined();
+  });
+});
+
+describe('resolveSupersededByRow — reference resolution', () => {
+  const live: SupersedeTarget = { id: 42, struck: false };
+
+  test('valid reference → resolves to the target fact id, no warning', () => {
+    const r = resolveSupersededByRow(1, 2, live, 'deals/acme');
+    expect(r.superseded_by).toBe(42);
+    expect(r.warning).toBeNull();
+  });
+
+  test('self-reference → NULL + warning', () => {
+    const r = resolveSupersededByRow(3, 3, { id: 99, struck: false }, 'deals/acme');
+    expect(r.superseded_by).toBeNull();
+    expect(r.warning).toContain('references itself');
+  });
+
+  test('dangling reference (target absent from fence) → NULL + warning', () => {
+    const r = resolveSupersededByRow(1, 9, undefined, 'deals/acme');
+    expect(r.superseded_by).toBeNull();
+    expect(r.warning).toContain('absent from the fence');
+  });
+
+  test('chain (target is itself struck) → NULL + warning', () => {
+    const r = resolveSupersededByRow(1, 2, { id: 7, struck: true }, 'deals/acme');
+    expect(r.superseded_by).toBeNull();
+    expect(r.warning).toContain('chain');
   });
 });
 

--- a/test/extract-from-fence.test.ts
+++ b/test/extract-from-fence.test.ts
@@ -18,11 +18,13 @@ import { describe, test, expect } from 'bun:test';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
+} from '../src/core/facts/extract-from-fence.ts';
+import {
   resolveSupersededByRow,
   isInt4RowRef,
   PG_INT4_MAX,
   type SupersedeTarget,
-} from '../src/core/facts/extract-from-fence.ts';
+} from '../src/core/engine.ts';
 import type { ParsedFact } from '../src/core/facts-fence.ts';
 
 const baseFact = (overrides: Partial<ParsedFact> = {}): ParsedFact => ({
@@ -273,10 +275,12 @@ describe('resolveSupersededByRow — reference resolution', () => {
     expect(r.warning).toContain('absent from the fence');
   });
 
-  test('chain (target is itself struck) → NULL + warning', () => {
+  test('struck target (chain or forgotten) → NULL + warning', () => {
     const r = resolveSupersededByRow(1, 2, { id: 7, struck: true }, 'deals/acme');
     expect(r.superseded_by).toBeNull();
-    expect(r.warning).toContain('chain');
+    // The warning names the target as struck/inactive, not specifically a
+    // chain — a forgotten target is struck too but isn't a supersession chain.
+    expect(r.warning).toContain('struck');
   });
 });
 

--- a/test/extract-from-fence.test.ts
+++ b/test/extract-from-fence.test.ts
@@ -19,6 +19,8 @@ import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
   resolveSupersededByRow,
+  isInt4RowRef,
+  PG_INT4_MAX,
   type SupersedeTarget,
 } from '../src/core/facts/extract-from-fence.ts';
 import type { ParsedFact } from '../src/core/facts-fence.ts';
@@ -275,6 +277,32 @@ describe('resolveSupersededByRow — reference resolution', () => {
     const r = resolveSupersededByRow(1, 2, { id: 7, struck: true }, 'deals/acme');
     expect(r.superseded_by).toBeNull();
     expect(r.warning).toContain('chain');
+  });
+});
+
+describe('isInt4RowRef — supersession-target overflow guard (#3014)', () => {
+  test('accepts a normal positive row reference', () => {
+    expect(isInt4RowRef(1)).toBe(true);
+    expect(isInt4RowRef(42)).toBe(true);
+  });
+
+  test('accepts the int4 maximum, rejects one past it', () => {
+    expect(isInt4RowRef(PG_INT4_MAX)).toBe(true);
+    expect(isInt4RowRef(PG_INT4_MAX + 1)).toBe(false);
+  });
+
+  test('rejects an 11-digit reference (the reported overflow shape)', () => {
+    // The parser accepts any finite #N; this one would overflow int4 in the
+    // resolution SELECT and abort the cycle if it reached the DB.
+    expect(isInt4RowRef(99999999999)).toBe(false);
+  });
+
+  test('rejects zero, negatives, and non-integers', () => {
+    expect(isInt4RowRef(0)).toBe(false);
+    expect(isInt4RowRef(-5)).toBe(false);
+    expect(isInt4RowRef(1.5)).toBe(false);
+    expect(isInt4RowRef(Number.NaN)).toBe(false);
+    expect(isInt4RowRef(Number.POSITIVE_INFINITY)).toBe(false);
   });
 });
 

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -273,6 +273,37 @@ describe('writeFactsToFence — stub guard (v0.34.5)', () => {
   });
 });
 
+describe('writeFactsToFence — v0.42 (#3014) supersession-warning seam', () => {
+  test('forwards an unresolvable `superseded by #N` warning to console.warn', async () => {
+    // The reachable shape through this path: writeFactsToFence appends
+    // active rows, but `context` is caller-controlled free text, so a
+    // "superseded by #N" context re-parses to supersededBy=N. When #N names
+    // no row, insertFacts resolves it to NULL + a warning; this test pins
+    // that writeFactsToFence forwards that warning to console.warn (the
+    // no-swallowed-errors seam) rather than dropping it.
+    const captured: string[] = [];
+    const original = console.warn;
+    // eslint-disable-next-line no-console
+    console.warn = (msg?: unknown) => { captured.push(String(msg)); };
+    let result;
+    try {
+      result = await writeFactsToFence(
+        engine,
+        { sourceId: 'default', localPath: brainDir, slug: 'people/alice' },
+        [baseInput({ fact: 'Points at a row that is not there', context: 'superseded by #99' })],
+      );
+    } finally {
+      // eslint-disable-next-line no-console
+      console.warn = original;
+    }
+
+    // The row still lands (the bad reference doesn't block the insert).
+    expect(result.inserted).toBe(1);
+    // The warning was logged with the category tag, not swallowed.
+    expect(captured.some(w => w.includes('[facts.supersession]') && w.includes('absent from the fence'))).toBe(true);
+  });
+});
+
 describe('lookupSourceLocalPath', () => {
   test('returns the configured local_path for an existing source', async () => {
     const got = await lookupSourceLocalPath(engine, 'default');

--- a/test/insert-facts-batch.test.ts
+++ b/test/insert-facts-batch.test.ts
@@ -392,7 +392,7 @@ describe('engine.insertFacts — v0.42 (#3014) supersession transport', () => {
     );
     // Row 1 → row 2 is a chain (row 2 struck) → NULL + warning.
     // Row 2 → row 3 (live) resolves cleanly.
-    expect(r.warnings.some(w => w.includes('chain'))).toBe(true);
+    expect(r.warnings.some(w => w.includes('struck'))).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const persisted = await (engine as any).db.query(
       `SELECT row_num, superseded_by FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,

--- a/test/insert-facts-batch.test.ts
+++ b/test/insert-facts-batch.test.ts
@@ -61,7 +61,7 @@ const fixtureFact = (rowNum: number, overrides: Partial<BatchFact> = {}): BatchF
 describe('engine.insertFacts — batch insert', () => {
   test('empty batch returns inserted:0, ids:[]', async () => {
     const r = await engine.insertFacts([], { source_id: 'default' });
-    expect(r).toEqual({ inserted: 0, ids: [], warnings: [] });
+    expect(r).toEqual({ inserted: 0, ids: [], warnings: [], deleted: 0 });
   });
 
   test('single-row batch inserts and persists v51 columns', async () => {
@@ -399,5 +399,98 @@ describe('engine.insertFacts — v0.42 (#3014) supersession transport', () => {
     );
     expect(persisted.rows[0].superseded_by).toBeNull();          // row 1: chain rejected
     expect(Number(persisted.rows[1].superseded_by)).toBe(Number(r.ids[2])); // row 2 → row 3
+  });
+
+  test('int4-overflow reference (11-digit #N) resolves as dangling — never throws', async () => {
+    // The fence parser accepts any finite #N; an 11-digit value would
+    // overflow the int4 row_num comparison in the resolution SELECT and
+    // abort the whole cycle. The guard treats it as a dangling reference:
+    // NULL superseded_by + warning, expired_at still set, no exception.
+    const r = await engine.insertFacts(
+      [struck(1, 99999999999, { fact: 'points at an absurd row' })],
+      { source_id: 'default' },
+    );
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toContain('absent from the fence');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT superseded_by, expired_at FROM facts WHERE row_num = 1 AND source_markdown_slug = 'people/alice'`,
+    );
+    expect(persisted.rows[0].superseded_by).toBeNull();
+    expect(persisted.rows[0].expired_at).not.toBeNull();
+  });
+});
+
+describe('engine.insertFacts — v0.42 (#3014) atomic deleteForPageFirst reconcile', () => {
+  test('replaces the page atomically and reports the deleted count', async () => {
+    await engine.insertFacts(
+      [fixtureFact(1, { fact: 'old one' }), fixtureFact(2, { fact: 'old two' })],
+      { source_id: 'default' },
+    );
+    const r = await engine.insertFacts(
+      [fixtureFact(1, { fact: 'new one' })],
+      { source_id: 'default' },
+      { deleteForPageFirst: { slug: 'people/alice', excludeSourcePrefixes: ['cli:'] } },
+    );
+    expect(r.inserted).toBe(1);
+    expect(r.deleted).toBe(2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((x: { fact: string }) => x.fact)).toEqual(['new one']);
+  });
+
+  test('a failing insert rolls the wipe back — the page is never left emptied', async () => {
+    // Seed the page's current rows (the ones a pre-fix separate-commit delete
+    // would have destroyed before the insert threw).
+    await engine.insertFacts(
+      [fixtureFact(1, { fact: 'keeper one' }), fixtureFact(2, { fact: 'keeper two' })],
+      { source_id: 'default' },
+    );
+
+    // The insert batch collides with itself (two row_num=1) AFTER the delete
+    // has already run inside the same transaction. The v51 UNIQUE index
+    // throws on the second row_num=1, rolling the whole transaction back.
+    let threw = false;
+    try {
+      await engine.insertFacts(
+        [fixtureFact(1, { fact: 'replacement a' }), fixtureFact(1, { fact: 'dup collides' })],
+        { source_id: 'default' },
+        { deleteForPageFirst: { slug: 'people/alice', excludeSourcePrefixes: ['cli:'] } },
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
+    // Atomicity: the delete rolled back with the failed insert, so the
+    // original rows survive rather than the page being silently emptied.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((x: { fact: string }) => x.fact)).toEqual(['keeper one', 'keeper two']);
+  });
+
+  test('cli:-origin rows survive the atomic wipe (excludeSourcePrefixes honored)', async () => {
+    await engine.insertFacts(
+      [
+        fixtureFact(1, { fact: 'fence row', source: 'fence:reconcile' }),
+        fixtureFact(2, { fact: 'conversation row', source: 'cli:think' }),
+      ],
+      { source_id: 'default' },
+    );
+    const r = await engine.insertFacts(
+      [fixtureFact(1, { fact: 'fresh fence row', source: 'fence:reconcile' })],
+      { source_id: 'default' },
+      { deleteForPageFirst: { slug: 'people/alice', excludeSourcePrefixes: ['cli:'] } },
+    );
+    expect(r.deleted).toBe(1); // only the fence row was wiped
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((x: { fact: string }) => x.fact)).toEqual(['fresh fence row', 'conversation row']);
   });
 });

--- a/test/insert-facts-batch.test.ts
+++ b/test/insert-facts-batch.test.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
   await (engine as any).db.query('DELETE FROM facts');
 });
 
-type BatchFact = NewFact & { row_num: number; source_markdown_slug: string };
+type BatchFact = NewFact & { row_num: number; source_markdown_slug: string; superseded_by_row?: number };
 
 const fixtureFact = (rowNum: number, overrides: Partial<BatchFact> = {}): BatchFact => ({
   fact: `Claim ${rowNum}`,
@@ -61,7 +61,7 @@ const fixtureFact = (rowNum: number, overrides: Partial<BatchFact> = {}): BatchF
 describe('engine.insertFacts — batch insert', () => {
   test('empty batch returns inserted:0, ids:[]', async () => {
     const r = await engine.insertFacts([], { source_id: 'default' });
-    expect(r).toEqual({ inserted: 0, ids: [] });
+    expect(r).toEqual({ inserted: 0, ids: [], warnings: [] });
   });
 
   test('single-row batch inserts and persists v51 columns', async () => {
@@ -316,5 +316,88 @@ describe('insertFacts + deleteFactsForPage round-trip (the reconciliation patter
     expect(rows.rows).toHaveLength(2);
     expect(rows.rows[0]).toMatchObject({ fact: 'A', row_num: 1, source_markdown_slug: 'people/alice' });
     expect(rows.rows[1]).toMatchObject({ fact: 'B', row_num: 2, source_markdown_slug: 'people/alice' });
+  });
+});
+
+describe('engine.insertFacts — v0.42 (#3014) supersession transport', () => {
+  const struck = (rowNum: number, supersededByRow: number, overrides: Partial<BatchFact> = {}): BatchFact =>
+    fixtureFact(rowNum, {
+      expired_at: new Date('2026-06-01T00:00:00Z'),
+      superseded_by_row: supersededByRow,
+      ...overrides,
+    });
+
+  test('struck row resolves superseded by #N to the target fact id + persists expired_at', async () => {
+    // Row 1 struck, superseded by row 2 (active). Same batch.
+    const r = await engine.insertFacts(
+      [struck(1, 2, { fact: 'old claim' }), fixtureFact(2, { fact: 'new claim' })],
+      { source_id: 'default' },
+    );
+    expect(r.warnings).toEqual([]);
+    const targetId = r.ids[1];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT row_num, superseded_by, expired_at FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(Number(persisted.rows[0].superseded_by)).toBe(Number(targetId));
+    expect(persisted.rows[0].expired_at).not.toBeNull();
+    // The active target keeps superseded_by NULL.
+    expect(persisted.rows[1].superseded_by).toBeNull();
+
+    // The row surfaces in listSupersessions (superseded_by filter, option B).
+    const sup = await engine.listSupersessions('default');
+    expect(sup.some(s => s.id === r.ids[0] && s.superseded_by === Number(targetId))).toBe(true);
+  });
+
+  test('reference to a pre-existing target row (not in this batch) still resolves', async () => {
+    // Insert the target first (its own batch), then the struck row later.
+    const target = await engine.insertFacts([fixtureFact(2, { fact: 'survivor' })], { source_id: 'default' });
+    const r = await engine.insertFacts([struck(1, 2, { fact: 'retired' })], { source_id: 'default' });
+    expect(r.warnings).toEqual([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT superseded_by FROM facts WHERE row_num = 1 AND source_markdown_slug = 'people/alice'`,
+    );
+    expect(Number(persisted.rows[0].superseded_by)).toBe(Number(target.ids[0]));
+  });
+
+  test('dangling reference (#N absent) → superseded_by NULL + warning, expired_at still set', async () => {
+    const r = await engine.insertFacts([struck(1, 99, { fact: 'orphaned' })], { source_id: 'default' });
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toContain('absent from the fence');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT superseded_by, expired_at FROM facts WHERE row_num = 1 AND source_markdown_slug = 'people/alice'`,
+    );
+    expect(persisted.rows[0].superseded_by).toBeNull();
+    expect(persisted.rows[0].expired_at).not.toBeNull();
+  });
+
+  test('self-reference (#N == own row) → superseded_by NULL + warning', async () => {
+    const r = await engine.insertFacts([struck(1, 1, { fact: 'ouroboros' })], { source_id: 'default' });
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toContain('references itself');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT superseded_by FROM facts WHERE row_num = 1 AND source_markdown_slug = 'people/alice'`,
+    );
+    expect(persisted.rows[0].superseded_by).toBeNull();
+  });
+
+  test('chain (#N names another struck row) → superseded_by NULL + warning', async () => {
+    // Row 1 superseded by #2; row 2 is itself struck (superseded by #3).
+    const r = await engine.insertFacts(
+      [struck(1, 2, { fact: 'link a' }), struck(2, 3, { fact: 'link b' }), fixtureFact(3, { fact: 'live tail' })],
+      { source_id: 'default' },
+    );
+    // Row 1 → row 2 is a chain (row 2 struck) → NULL + warning.
+    // Row 2 → row 3 (live) resolves cleanly.
+    expect(r.warnings.some(w => w.includes('chain'))).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const persisted = await (engine as any).db.query(
+      `SELECT row_num, superseded_by FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(persisted.rows[0].superseded_by).toBeNull();          // row 1: chain rejected
+    expect(Number(persisted.rows[1].superseded_by)).toBe(Number(r.ids[2])); // row 2 → row 3
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3014: `gbrain recall --supersessions` is structurally empty on any fence-authored store. The `## Facts` fence parser understands `~~claim~~` + `superseded by #N`, but the data was dropped between the parser and the DB, and the query filtered on columns a fence-authored row could never satisfy. This PR transports fence supersessions all the way into `facts.superseded_by` / `facts.expired_at`, reconciles the query, and adds unit + engine + phase + real-Postgres e2e coverage.

## Root cause (the four drop points from #3014)

1. **Parser — OK.** `parseFactsFence` correctly maps `~~claim~~` + `context: superseded by #N` to `active=false, supersededBy=N` (`src/core/facts-fence.ts`).
2. **Mapper drops it.** `extractFactsFromFenceText` (`src/core/facts/extract-from-fence.ts`) read `supersededBy` only to (not) derive `valid_until`; it emitted no `superseded_by`, no `expired_at`, and deferred "the rest" to a consolidator phase that never honors it.
3. **Insert shape can't carry it.** `interface NewFact` (`src/core/engine.ts`) had `valid_until` but no `superseded_by`/`expired_at` members, and `insertFacts` never wrote them.
4. **Query requires both columns.** `listSupersessions` filtered `expired_at IS NOT NULL AND superseded_by IS NOT NULL`; no fence-authored row set either, and the ontology-dimension writer sets `superseded_by` + `valid_until` (not `expired_at`), so even those never appeared.

## The fix

- **Transport.** The mapper stamps `expired_at` on every inactive row (superseded / forgotten / inactive-unrecognized) — there is no DB derivation from `valid_until`, so it is set explicitly — and carries the page-local `superseded by #N` reference as a new `superseded_by_row` field. `NewFact` gains `expired_at`. Both engines' `insertFacts` insert `expired_at` and resolve `superseded_by_row` → `facts.superseded_by` in a **second pass inside the same transaction**, keyed on `(source_id, source_markdown_slug, row_num)` so a reference resolves against both just-inserted and pre-existing target rows. `superseded_by` is a real FK, so self / dangling / struck-target references resolve to NULL + a logged warning — never a guessed id.
- **Filter reconcile (chosen rule).** `listSupersessions` now filters on `superseded_by IS NOT NULL` alone, ordering / `since` via `COALESCE(expired_at, valid_until)`. The alternative — making every writer set both columns — was rejected: the ontology-dimension writer deliberately closes a superseded row via `valid_until` (not `expired_at`) so `getOntology(--asof)` time-travel still sees it, and `getOntology` filters `expired_at IS NULL` unconditionally. Forcing `expired_at` there fails the existing `test/chronicle-ontology.test.ts` "forward supersession + --asof valid-time travel" case. The relaxed query surfaces both fence-authored and ontology supersessions without touching any writer.
- **Idempotent heal, atomic.** The reconcile phase detects a struck row whose DB columns drifted from the fence (keyed off the *resolved* reference id, so a permanently-unresolvable reference does not churn every cycle) and re-heals it. The wipe runs as the first statement of `insertFacts`' own transaction (opt-in `deleteForPageFirst`), so a failing insert rolls the delete back — the page is never left emptied.
- **int4 guard.** The parser accepts any finite `#N`; an 11+ digit value would overflow the `row_num` (int4) comparison and abort the cycle. Both engines gate the resolution SELECT on `isInt4RowRef`, degrading an absurd `#N` to a dangling reference instead of an uncaught throw.
- **Layering.** The pure resolver + its types + the int4 guard live in `engine.ts`, so the engines resolve without importing upward from the fence-boundary module.

## Tests

- Unit / engine / phase (in-memory PGLite): mapper emit + `resolveSupersededByRow` self/dangling/struck + `isInt4RowRef` (`test/extract-from-fence.test.ts`, 30); engine-level resolution + atomic `deleteForPageFirst` rollback + cli-exclusion (`test/insert-facts-batch.test.ts`, 22); reconcile transport + no-churn idempotency + heal + int4 (`test/extract-facts-phase.test.ts`, 27); option-B ontology visibility + --asof (`test/chronicle-ontology.test.ts`, 11); fence-write warning seam (`test/fence-write.test.ts`, 15).
- E2E (real Postgres, `DATABASE_URL`-gated): `test/e2e/facts-fence-reconcile-postgres.test.ts` — struck-row transport, idempotent heal, dangling/int4 no-churn, `deleteForPageFirst` rollback, ontology visibility, and `{since}` COALESCE fallback. **8/8 on real Postgres.**
- `bunx tsc --noEmit` clean.

## Live-store evidence

Verified on a real fence-authored store (a synthetic staged-terminal fixture page, `deals/zz-fixture-epic57-staged-terminal`; no other store content shown).

- Before: `superseded_by | expired_at` counts = `0 | 0` (of ~388–487 total facts) — structurally empty, matching #3014's readout.
- After a targeted re-extract of the fixture page: `superseded_by | expired_at` = `1 | 1`. The fixture's struck row 1 (`superseded by #3`) healed to `superseded_by =` (row 3's id) + `expired_at` set.
- `gbrain recall --supersessions` now surfaces it (structure): `- id=<row1> expired=2026-07-21T00:00:00.000Z superseded_by=<row3>` for the synthetic fixture commitment.

## Notes for maintainers (deferred, not in this PR)

- No index on `facts.superseded_by`; the relaxed `listSupersessions` predicate is a filtered scan. Fine at current scale, worth an index at large-store scale.
- The second-pass resolution is per-row sequential (one SELECT + one UPDATE per struck row). Struck rows are rare per page, but it is batchable (single `WHERE row_num = ANY(...)` lookup + a `CASE` update) if a hot path emerges.
- Ontology-dimension supersessions now appear in `listSupersessions` while remaining active in `getOntology` (they close via `valid_until`, not `expired_at`). This is intentional per the `--asof` time-travel contract; flagging it since it slightly widens what `recall --supersessions` returns.
