### PR TITLE
fix(integrations): retrieval-reflex health check times out — use doctor --fast

### DIFF
--- a/recipes/retrieval-reflex.md
+++ b/recipes/retrieval-reflex.md
@@ -9,7 +9,7 @@ requires: []
 secrets: []
 health_checks:
   - type: command
-    argv: [gbrain, doctor, --json]
+    argv: [gbrain, doctor, --fast, --json]
     label: Retrieval reflex wiring (see retrieval_reflex_health)
 setup_time: 2 min
 cost_estimate: "$0 — zero-LLM deterministic layer + a prose policy skill"
@@ -42,7 +42,7 @@ This reflex has two halves:
 **You are the installer.** Run these steps on behalf of the user.
 
 1. Confirm the deterministic layer isn't disabled:
-   `gbrain doctor --json | jq '.checks[] | select(.name=="retrieval_reflex_health")'`
+   `gbrain doctor --fast --json | jq '.checks[] | select(.name=="retrieval_reflex_health")'`
 2. Install the policy skill into the host repo (the OpenClaw/agent repo that
    holds `skills/RESOLVER.md` or `AGENTS.md`):
    `gbrain integrations install retrieval-reflex --target <host-repo>`


### PR DESCRIPTION
## Problem

`gbrain integrations doctor` reports a permanent FAIL for retrieval-reflex:

```
retrieval-reflex: ISSUES
✗ Retrieval reflex wiring (see retrieval_reflex_health): FAIL
```

even when the underlying doctor check is healthy:

```
retrieval_reflex_health ok — postgres direct; enabled
```

Root cause: the recipe health check runs the FULL doctor (`argv: [gbrain, doctor, --json]`) inside the integrations command runner, which has a fixed 10s `spawnSync` timeout (`src/commands/integrations.ts`). On a real brain the full doctor takes 15-20s+, so the child is killed and the check always fails.

## Fix

Switch the recipe to `gbrain doctor --fast --json` — 4-6s on a 2.7K-page Postgres brain, still includes `retrieval_reflex_health`. Also updates the inline agent instructions in the recipe body to match.

## Validation (2.7K-page Postgres brain)

- `time gbrain doctor --json >/dev/null` → 18-20s (runner timeout)
- `time gbrain doctor --fast --json >/dev/null` → 4-6s
- Simulated the runner (`spawnSync` + 10s timeout) against the new argv → completes in ~6s, exit 0
- `bun test test/integrations.test.ts test/doctor-retrieval-reflex.test.ts` → 113 pass / 0 fail