### PR TITLE
fix(providers): route multimodal-only embedding models through embedMultimodal in providers test

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -6,7 +6,7 @@
  */
 
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
-import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
+import { configureGateway, embedOne, embedMultimodal, getEmbeddingModel, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
@@ -215,9 +215,28 @@ async function runTest(args: string[]): Promise<void> {
   const start = Date.now();
   try {
     if (tpArg === 'embedding') {
+      // Multimodal-only models (voyage:voyage-multimodal-3) are rejected by
+      // /embeddings; the recipe declares them via multimodal_models. Route the
+      // probe through embedMultimodal() so `providers test` exercises the same
+      // endpoint the gateway uses at ingest time instead of a false 400.
+      const modelStr = modelArg ?? getEmbeddingModel();
+      let isMultimodalOnly = false;
+      try {
+        const [providerId, ...modelParts] = modelStr.split(':');
+        const probeRecipe = getRecipe(providerId);
+        const tp = probeRecipe?.touchpoints.embedding;
+        isMultimodalOnly = !!tp?.supports_multimodal
+          && !!tp?.multimodal_models?.includes(modelParts.join(':'));
+      } catch { /* fall through to embedOne */ }
+      if (isMultimodalOnly) {
+        const vs = await embedMultimodal([{ kind: 'text', text: 'gbrain smoke test' }]);
+        const ms = Date.now() - start;
+        console.log(`  ✓ ${ms}ms, ${vs[0]?.length ?? 0} dims (multimodal endpoint)`);
+      } else {
       const v = await embedOne('gbrain smoke test');
       const ms = Date.now() - start;
       console.log(`  ✓ ${ms}ms, ${v.length} dims`);
+      }
     } else {
       const result = await gwChat({
         messages: [{ role: 'user', content: 'Reply with just the word: pong' }],


### PR DESCRIPTION
## Problem

`gbrain providers test --model voyage:voyage-multimodal-3` probes via `embedOne()`, which POSTs `/embeddings`. Voyage rejects multimodal-only models on that endpoint with HTTP 400, so the probe reports a false failure for a model that works fine at ingest time — the gateway routes it through `/multimodalembeddings` (`gateway.ts embedMultimodal`). The voyage recipe already documents this asymmetry (`multimodal_models: ['voyage-multimodal-3']` — "embedMultimodal() would let voyage:voyage-3-large through ... HTTP 400"), but `providers test` never learned it.

## Fix

In the embedding probe path, detect multimodal-only models via the recipe declaration (`supports_multimodal` + `multimodal_models.includes(modelId)`) and probe `embedMultimodal()` with a text input — the same routing production uses. All other models keep the existing `embedOne()` path.

## Validation

- Before: `gbrain providers test --model voyage:voyage-multimodal-3` → ✗ 400 Bad Request
- After: `✓ 1214ms, 1024 dims (multimodal endpoint)` (live Voyage call)
- `bun test test/providers.test.ts test/ai/recipes-existing-regression.test.ts` → 27 pass / 0 fail