### PR TITLE
fix(put_page): run auto-timeline for remote callers

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -967,6 +967,12 @@ const put_page: Operation = {
       && ctx.allowedSlugPrefixes.length > 0;
     if (ctx.remote !== false && !trustedWorkspace) {
       autoLinks = { skipped: 'remote' };
+      // Default for remote callers; overwritten below by the timeline
+      // extraction when result.parsedPage is present. Kept here so a remote
+      // write that never parses (e.g. oversized content, no parsedPage) still
+      // reports auto_timeline: { skipped: 'remote' } instead of dropping the
+      // key, preserving the original paired-skip response contract.
+      autoTimeline = { skipped: 'remote' };
     }
     // Auto-timeline is decoupled from the remote gate: unlike auto-link's
     // cross-page bare-slug matching, timeline entries are keyed to the page's
@@ -993,13 +999,26 @@ const put_page: Operation = {
         const enabled = await isAutoTimelineEnabled(ctx.engine);
         if (enabled) {
           const fullContent = result.parsedPage.compiled_truth + '\n' + result.parsedPage.timeline;
-          const entries = parseTimelineEntries(fullContent);
+          // This path is now reachable by remote/untrusted callers, so bound the
+          // work and align validation with the manual add_timeline_entry op:
+          // cap the batch (bulk-insert amplification) and drop out-of-range years
+          // (PG DATE silently accepts year 5874897).
+          const MAX_AUTO_TIMELINE_ENTRIES = 500;
+          const entries = parseTimelineEntries(fullContent)
+            .filter(e => { const y = Number(String(e.date).slice(0, 4)); return y >= 1900 && y <= 2199; })
+            .slice(0, MAX_AUTO_TIMELINE_ENTRIES);
           if (entries.length > 0) {
             const batch = entries.map(e => ({
               slug,
               date: e.date,
               summary: e.summary,
               detail: e.detail || '',
+              // Scope each entry to the caller's own source, mirroring the
+              // runAutoLink call above. Without source_id the batch defaults to
+              // source_id='default', so a write under a non-default source would
+              // attach timeline rows to a same-slug page in the default source
+              // (cross-source forgery / silent drop). See TimelineBatchInput.
+              source_id: ctx.sourceId,
             }));
             // v0.41.18.0: engine self-retries on Supavisor circuit-breaker
             // recovery. auditSite label routes the audit JSONL emission so

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -967,8 +967,15 @@ const put_page: Operation = {
       && ctx.allowedSlugPrefixes.length > 0;
     if (ctx.remote !== false && !trustedWorkspace) {
       autoLinks = { skipped: 'remote' };
-      autoTimeline = { skipped: 'remote' };
-    } else if (result.parsedPage) {
+    }
+    // Auto-timeline is decoupled from the remote gate: unlike auto-link's
+    // cross-page bare-slug matching, timeline entries are keyed to the page's
+    // OWN slug (see batch.map below), so a remote/untrusted writer can only
+    // add entries about the page it is already writing — it cannot forge
+    // edges onto other pages or manipulate cross-page search ranking. Auto-link
+    // stays gated for remote callers; auto-timeline is safe to run for them.
+    if (result.parsedPage) {
+      if (ctx.remote === false || trustedWorkspace) {
       try {
         const enabled = await isAutoLinkEnabled(ctx.engine);
         if (enabled) {
@@ -976,6 +983,7 @@ const put_page: Operation = {
         }
       } catch (e) {
         autoLinks = { error: e instanceof Error ? e.message : String(e) };
+      }
       }
       // Timeline extraction mirrors auto-link: runs post-write, best-effort,
       // never blocks the write. ON CONFLICT DO NOTHING in

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -999,14 +999,19 @@ const put_page: Operation = {
         const enabled = await isAutoTimelineEnabled(ctx.engine);
         if (enabled) {
           const fullContent = result.parsedPage.compiled_truth + '\n' + result.parsedPage.timeline;
-          // This path is now reachable by remote/untrusted callers, so bound the
-          // work and align validation with the manual add_timeline_entry op:
-          // cap the batch (bulk-insert amplification) and drop out-of-range years
-          // (PG DATE silently accepts year 5874897).
+          // This path is now reachable by remote/untrusted callers. Bound the
+          // work and drop out-of-range years (PG DATE silently accepts year
+          // 5874897) ONLY for those callers — trusted local writers keep the
+          // prior unbounded behavior, so a legitimate large local import is not
+          // silently truncated.
+          const untrusted = ctx.remote !== false && !trustedWorkspace;
           const MAX_AUTO_TIMELINE_ENTRIES = 500;
-          const entries = parseTimelineEntries(fullContent)
-            .filter(e => { const y = Number(String(e.date).slice(0, 4)); return y >= 1900 && y <= 2199; })
-            .slice(0, MAX_AUTO_TIMELINE_ENTRIES);
+          const parsed = parseTimelineEntries(fullContent);
+          const entries = untrusted
+            ? parsed
+                .filter(e => { const y = Number(String(e.date).slice(0, 4)); return y >= 1900 && y <= 2199; })
+                .slice(0, MAX_AUTO_TIMELINE_ENTRIES)
+            : parsed;
           if (entries.length > 0) {
             const batch = entries.map(e => ({
               slug,

--- a/test/e2e/graph-quality.test.ts
+++ b/test/e2e/graph-quality.test.ts
@@ -276,6 +276,68 @@ Grace works at people/acme.
     expect((result as any).auto_links).toEqual({ skipped: 'remote' });
   });
 
+  test('auto-timeline reports skipped for a remote write that never parses', async () => {
+    // Oversized content early-returns from importFromContent with no parsedPage,
+    // so neither extraction runs. The response must still report
+    // auto_timeline: { skipped: 'remote' } (paired with auto_links), not drop the
+    // key. Regression guard for the remote-gate decoupling (parsedPage-falsy case).
+    const putOp = operationsByName['put_page'];
+    const huge = 'x'.repeat(5_000_001); // > MAX_FILE_SIZE (5MB)
+    const result = await putOp.handler(
+      { ...makeContext(), remote: true },
+      { slug: 'people/heidi', content: huge },
+    );
+    expect((result as any).auto_links).toEqual({ skipped: 'remote' });
+    expect((result as any).auto_timeline).toEqual({ skipped: 'remote' });
+  });
+
+  test('auto-timeline scopes remote entries to the caller source (no cross-source forgery)', async () => {
+    // Regression for the CRITICAL found in security review: without threading
+    // ctx.sourceId into the batch, a remote write under a non-default source
+    // defaults to source_id='default' and forges a timeline row onto the
+    // same-slug page in the default source. This test writes a house page in
+    // 'default', then a remote write of the SAME slug under 'tenantB', and
+    // asserts tenantB's entry lands on tenantB — never on the default page.
+    const putOp = operationsByName['put_page'];
+    const slug = 'people/shared';
+
+    await putOp.handler(
+      { ...makeContext(), remote: false, sourceId: 'default' },
+      { slug, content: `---
+type: person
+title: Shared (house)
+---
+
+## Timeline
+
+- **2026-01-01** | House event
+` },
+    );
+
+    const result = await putOp.handler(
+      { ...makeContext(), remote: true, sourceId: 'tenantB' },
+      { slug, content: `---
+type: person
+title: Shared (tenantB)
+---
+
+## Timeline
+
+- **2026-06-06** | Tenant B event
+` },
+    );
+    expect((result as any).auto_timeline.created).toBe(1);
+
+    const bDates = (await engine.getTimeline(slug, { sourceId: 'tenantB' }))
+      .map((e) => String(e.date).slice(0, 10));
+    expect(bDates).toContain('2026-06-06');
+
+    const defDates = (await engine.getTimeline(slug, { sourceId: 'default' }))
+      .map((e) => String(e.date).slice(0, 10));
+    expect(defDates).toContain('2026-01-01');      // house entry survives
+    expect(defDates).not.toContain('2026-06-06');  // no cross-source forgery
+  });
+
   test('auto-link respects auto_link=false config', async () => {
     await engine.setConfig('auto_link', 'false');
     try {

--- a/test/e2e/graph-quality.test.ts
+++ b/test/e2e/graph-quality.test.ts
@@ -241,6 +241,41 @@ title: Frank
     }
   });
 
+  test('auto-timeline runs for remote callers while auto-link stays gated', async () => {
+    // Regression for the remote gate: auto-link is skipped for remote/untrusted
+    // callers (its cross-page bare-slug matching can forge edges), but timeline
+    // entries are keyed to the page's own slug, so they are safe on remote and
+    // must still be extracted. See put_page in src/core/operations.ts.
+    const putOp = operationsByName['put_page'];
+    const result = await putOp.handler(
+      { ...makeContext(), remote: true },
+      {
+        slug: 'people/grace',
+        content: `---
+type: person
+title: Grace
+---
+
+Grace works at people/acme.
+
+## Timeline
+
+- **2026-03-15** | Joined Acme
+- **2026-04-02** | Led Series A
+`,
+      },
+    );
+
+    // Timeline now runs for remote callers.
+    expect((result as any).auto_timeline).toBeDefined();
+    expect((result as any).auto_timeline.created).toBe(2);
+    const entries = await engine.getTimeline('people/grace');
+    expect(entries.length).toBe(2);
+
+    // Auto-link stays gated for remote callers (cross-page injection defense).
+    expect((result as any).auto_links).toEqual({ skipped: 'remote' });
+  });
+
   test('auto-link respects auto_link=false config', async () => {
     await engine.setConfig('auto_link', 'false');
     try {


### PR DESCRIPTION
## Summary

`put_page` skips **both** auto-link and auto-timeline for remote/untrusted MCP callers via one gate. The gate is correct for auto-link — its bare-slug regex matches slugs anywhere in page text, so a remote writer could plant `see meetings/board-q1` and forge a cross-page edge that the backlink boost then surfaces. But auto-timeline is bundled into the same gate unnecessarily, so a remote-first / company-brain deployment (the documented primary mode) gets **zero timeline coverage on `put_page`, permanently**.

This decouples the two: auto-link stays gated for remote callers; auto-timeline runs for them.

## Why auto-timeline is safe on remote

Timeline entries are keyed to the page's **own** slug (`batch.map` uses the closure `slug`), so a remote/untrusted writer can only add entries to the page it is already authoring — it cannot forge entries on other pages or influence cross-page ranking. The multi-tenant threat model that motivates the auto-link gate does not apply.

## Changes

- **Decouple** auto-timeline from the remote gate; auto-link stays gated. Local/trusted behavior unchanged.
- **Scope each timeline row to `ctx.sourceId`** (mirrors the `runAutoLink` call). Without this the batch defaults to `source_id='default'`, so a write under a non-default source would attach timeline rows to a same-slug page in the default source (cross-source forgery / silent drop). This makes the new path correct for multi-source brains.
- **Bound the newly remote-reachable path, untrusted callers only**: cap the batch at 500 entries (bulk-insert amplification) and drop out-of-range years (align with `add_timeline_entry`'s 1900–2199). Trusted/local writers keep the prior unbounded behavior so a legitimate large local import is not silently truncated.
- Preserve the paired `auto_links`/`auto_timeline` skip contract when a remote write never parses (oversized content, no `parsedPage`).

## Files Changed

- `src/core/operations.ts` — Modified (put_page auto-timeline block)
- `test/e2e/graph-quality.test.ts` — Modified (3 new e2e tests)

## Testing

Three e2e regressions added to `test/e2e/graph-quality.test.ts`:
1. timeline runs on `remote: true` while `auto_links` stays `{ skipped: 'remote' }`;
2. remote entries scope to the caller source — a `tenantB` write of a `default`-source slug never forges onto the default page;
3. a remote write that never parses (oversized content) still reports `auto_timeline: { skipped: 'remote' }`.

These live under `test/e2e/` and require the real-Postgres harness (`DATABASE_URL`, per CONTRIBUTING), so they run in CI rather than the unit shard. Verified locally by static syntax check + type-compatible trace; not executed against a DB in my environment.

## Notes / follow-ups

- Known residual (pre-existing, not introduced here): request-count rate limiting bounds calls but not aggregate timeline-entry volume across calls. Out of scope for this fix.
- Commits can be squash-merged; the second/third commits fold in security-review hardening.

## Related Issues

None.
