### PR TITLE
fix(extract): link-aware Source — Summary delimiter in timeline bullets — stop shattering entries on dashes inside markdown links

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -469,15 +469,53 @@ export async function extractLinksFromFile(
 
 // --- Timeline extraction ---
 
+/**
+ * Index of the first dash (—, –, -) that can serve as the Source — Summary
+ * delimiter: it must have whitespace on both sides and sit outside every
+ * markdown-link span. Hyphens inside link targets
+ * (`../people/pedro-franceschi.md`) and dashes inside link labels
+ * (`[Deals — Q1 Review](...)`) are content, not delimiters — splitting on
+ * them shatters one entry into two fragments whose halves re-insert on
+ * every sync (the (page_id, date, summary, source) uniqueness sees each
+ * fragment shape as a new row). Returns -1 when the line has no delimiter.
+ */
+function findDelimiterOutsideLinks(text: string): number {
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '[' || c === '(') depth++;
+    else if (c === ']' || c === ')') { if (depth > 0) depth--; }
+    else if (
+      depth === 0 &&
+      (c === '—' || c === '–' || c === '-') &&
+      i > 0 && /\s/.test(text[i - 1]) &&
+      i + 1 < text.length && /\s/.test(text[i + 1])
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 /** Extract timeline entries from markdown content */
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
   const entries: ExtractedTimelineEntry[] = [];
 
   // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
-  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
+  // The delimiter search is link-aware (see findDelimiterOutsideLinks); a
+  // bullet with no delimiter (e.g. an auto-generated backlink line
+  // `- **date** | Referenced in [X](y.md)`) is kept whole as the summary
+  // rather than dropped or fragmented.
+  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+)$/gm;
   let match;
   while ((match = bulletPattern.exec(content)) !== null) {
-    entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
+    const rest = match[2].trim();
+    const at = findDelimiterOutsideLinks(rest);
+    if (at >= 0) {
+      entries.push({ slug, date: match[1], source: rest.slice(0, at).trim(), summary: rest.slice(at + 1).trim() });
+    } else {
+      entries.push({ slug, date: match[1], source: 'markdown', summary: rest });
+    }
   }
 
   // Format 2: Header — ### YYYY-MM-DD — Title

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -136,6 +136,38 @@ describe('extractTimelineFromContent', () => {
     expect(entries).toHaveLength(1);
   });
 
+  it('does not split on hyphens inside markdown link targets', () => {
+    const content = `- **2025-03-18** | Referenced in [Pedro](../people/pedro-franceschi.md)`;
+    const entries = extractTimelineFromContent(content, 'companies/brex');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toBe('Referenced in [Pedro](../people/pedro-franceschi.md)');
+  });
+
+  it('does not split on spaced dashes inside link labels', () => {
+    const content = `- **2025-03-18** | Referenced in [Deals — Q1 Review](../deals/q1-review.md)`;
+    const entries = extractTimelineFromContent(content, 'companies/brex');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toBe('Referenced in [Deals — Q1 Review](../deals/q1-review.md)');
+  });
+
+  it('splits on the first spaced dash outside links', () => {
+    const content = `- **2025-03-18** | [Board notes](../meetings/2025-03-18-board.md) — Approved the hire`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('[Board notes](../meetings/2025-03-18-board.md)');
+    expect(entries[0].summary).toBe('Approved the hire');
+  });
+
+  it('keeps delimiterless bullet lines whole instead of dropping them', () => {
+    const content = `- **2025-03-18** | Imported from legacy tracker`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toBe('Imported from legacy tracker');
+  });
+
   it('extracts inline citation format entries', () => {
     const content = `Closed the seed round with fund-a leading. [Source: board meeting notes, 2025-04-02]`;
     const entries = extractTimelineFromContent(content, 'deals/acme-seed');


### PR DESCRIPTION
Fixes #3059.

## What

`extractTimelineFromContent`'s Format-1 parser split `Source — Summary` at the first `[—–-]` after the pipe, which lands inside markdown links: hyphenated link targets (`../people/pedro-franceschi.md`) and em-dash link labels (`[Deals — Q1 Review](...)`) shattered the entry into two fragments. Because `(page_id, date, summary, source)` uniqueness treats each fragment shape as a new tuple, every sync of a touched page re-inserted fragments — corruption that accumulates hourly on active brains (details + repro in #3059).

## How

- Match the bullet up to the pipe, then find the delimiter with `findDelimiterOutsideLinks`: only a whitespace-surrounded dash at bracket-depth 0 (outside every `[label](target)` span) splits Source from Summary.
- Delimiterless bullets — e.g. every auto-generated backlink line `- **date** | Referenced in [X](y.md)` — are captured whole (`source: 'markdown'`, full text as summary) instead of being shattered (before 0.42.x behavior) or silently dropped. This matches `core/link-extraction.ts`'s tolerance of the same lines and Format 2's use of the `'markdown'` source sentinel.

## Tests

4 new cases in `test/extract.test.ts` covering: hyphenated link target, spaced em-dash inside a link label, spaced dash *after* a link (still splits correctly), and delimiterless line kept whole. `bun test test/extract.test.ts`: 32 pass / 0 fail. Full unit suite: 6684 pass; the one failing test (`hardenBrainRepo > installs hook…`) fails identically on a clean master checkout in this environment (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)