### PR TITLE
feat(search): retire pages from search via a frontmatter status marker

### DIFF
--- a/src/core/lifecycle.ts
+++ b/src/core/lifecycle.ts
@@ -1,0 +1,120 @@
+/**
+ * Page lifecycle marker: an author-set frontmatter signal that RETIRES a page
+ * from search without deleting it.
+ *
+ * Why this exists (the gap it closes):
+ *   gbrain already models supersession richly at the *facts / takes* layer
+ *   (auto-supersession, `valid_until`, `forgotten`). But a raw markdown *page*
+ *   had no author-facing way to say "this is out of date — stop surfacing it."
+ *   `deleted_at` (soft-delete) hides a page entirely and is an operator action;
+ *   `quarantine` is reserved for auto-detected junk. Neither fits the common
+ *   authoring case: "I wrote a newer page; keep the old one reachable by slug
+ *   for history, but don't let search return it as if it were current."
+ *
+ * The design mirrors `quarantine` (HIDES) vs `content_flag` (WARNS):
+ *   - A page whose frontmatter `status` is one of `LIFECYCLE_HIDE_VALUES`
+ *     (`superseded`, `deprecated`, `retired`, `obsolete`) is EXCLUDED from
+ *     keyword/vector search via `LIFECYCLE_FILTER_FRAGMENT`, injected by
+ *     `buildVisibilityClause` (`src/core/search/sql-ranking.ts`).
+ *   - The page is NOT deleted: it stays fetchable by slug (`get_page`), stays
+ *     in `list`, and its links/backlinks resolve. `buildVisibilityClause` is a
+ *     SEARCH-path filter only, so retirement means "not surfaced by search",
+ *     exactly like a page moved to a `cold-storage/` shelf — but driven by a
+ *     one-line frontmatter edit instead of a file move.
+ *
+ * Backward-compatible by construction: only the explicit hide values retire a
+ * page. Every other `status` value an author already uses — `active`, `draft`,
+ * `done`, `in-progress`, `review`, … — is inert and stays fully searchable.
+ * Pages with no `status` key are unaffected.
+ *
+ * Sibling of `src/core/quarantine.ts` and `src/core/embed-skip.ts` — same
+ * marker-as-frontmatter-JSONB pattern, same JSONB access that works identically
+ * on Postgres (real) and PGLite (PostgreSQL 17.5 in WASM). NO schema migration:
+ * `status` is read straight out of the existing `frontmatter` JSONB column.
+ *
+ * Follow-up (mirrors quarantine's `content_flag`): a WARN tier — e.g.
+ * `status: stale` — that keeps a page searchable but rides a marker into
+ * `SearchResult` so the agent is told "this may be dated." Deliberately not in
+ * this first cut; there is NO SQL filter for the WARN tier by design.
+ */
+
+// ---------------------------------------------------------------------------
+// lifecycle marker (RETIRES / hides from search)
+// ---------------------------------------------------------------------------
+
+/** Frontmatter key inspected for the retire signal. Stable contract.
+ *  Chosen as the plain `status` field authors already reach for, rather than a
+ *  namespaced key, because only the explicit hide values below trigger — so
+ *  co-opting `status` cannot hide a page that means `status: active`. */
+export const LIFECYCLE_KEY = 'status';
+
+/** The `status` values that HIDE a page from search. Lower-cased, trimmed
+ *  comparison. Kept deliberately tight and unambiguous — each reads as "this
+ *  page is no longer the current answer." `archived` is intentionally excluded
+ *  to avoid confusion with the source-level archive flag; add it here (single
+ *  change site) if a workspace wants page-frontmatter `status: archived` to
+ *  retire too. */
+export const LIFECYCLE_HIDE_VALUES: readonly string[] = [
+  'superseded',
+  'deprecated',
+  'retired',
+  'obsolete',
+] as const;
+
+/** SQL string list for the hide values, single-quoted + lower-cased. All
+ *  members are hardcoded constants (never user input), so plain quoting is
+ *  injection-safe. */
+const HIDE_VALUES_SQL = LIFECYCLE_HIDE_VALUES.map((v) => `'${v}'`).join(', ');
+
+/** SQL fragment that excludes retired pages from search, parameterized on the
+ *  page-table alias. Single source of truth — `buildVisibilityClause`
+ *  (`src/core/search/sql-ranking.ts`) calls this so the search filter and the
+ *  marker vocabulary can never drift. Mirrors `quarantineFilterFragment`:
+ *  negated so we KEEP rows that are NOT retired. Rows with no `status`, or a
+ *  `status` outside the hide set, coalesce to a non-matching value and survive.
+ *  `pageAlias` is engine-supplied (never user input), so no escaping needed. */
+export function lifecycleFilterFragment(pageAlias: string): string {
+  return (
+    `NOT (lower(trim(COALESCE(${pageAlias}.frontmatter ->> '${LIFECYCLE_KEY}', ''))) ` +
+    `IN (${HIDE_VALUES_SQL}))`
+  );
+}
+
+/** The `p`-aliased instance — the common case (all search call sites alias
+ *  pages as `p`). Kept as a constant for parity with `QUARANTINE_FILTER_FRAGMENT`. */
+export const LIFECYCLE_FILTER_FRAGMENT = lifecycleFilterFragment('p');
+
+/** Normalize a raw frontmatter `status` value the way the SQL does
+ *  (string-coerce, trim, lower-case). Non-string values (objects/arrays/numbers)
+ *  coerce to a value that will not be in the hide set. */
+function normalizeStatus(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim().toLowerCase();
+}
+
+/** JS-side predicate mirroring the SQL fragment. True when the frontmatter
+ *  `status` is one of the hide values. Accepts null/undefined frontmatter. */
+export function isRetired(frontmatter: Record<string, unknown> | null | undefined): boolean {
+  if (!frontmatter) return false;
+  return (LIFECYCLE_HIDE_VALUES as readonly string[]).includes(
+    normalizeStatus(frontmatter[LIFECYCLE_KEY]),
+  );
+}
+
+/** Diagnostic accessor: the matched hide value (already normalized) when the
+ *  page is retired, else null. Useful for operator/doctor reporting. */
+export function retiredStatus(
+  frontmatter: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!frontmatter) return null;
+  const status = normalizeStatus(frontmatter[LIFECYCLE_KEY]);
+  return (LIFECYCLE_HIDE_VALUES as readonly string[]).includes(status) ? status : null;
+}
+
+/** JS-side filter: returns a new array with retired pages excluded. Parity with
+ *  `filterOutQuarantined` for any post-fusion / non-SQL path that needs it. */
+export function filterOutRetired<T extends { frontmatter?: Record<string, unknown> | null }>(
+  pages: ReadonlyArray<T>,
+): T[] {
+  return pages.filter((p) => !isRetired(p.frontmatter ?? null));
+}

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -18,6 +18,7 @@
  */
 
 import { quarantineFilterFragment } from '../quarantine.ts';
+import { lifecycleFilterFragment } from '../lifecycle.ts';
 
 /**
  * Escape `%`, `_`, and `\` so a string can be used as a LIKE prefix literal.
@@ -145,14 +146,24 @@ export function buildHardExcludeClause(slugColumn: string, prefixes: string[]): 
  * @param sourceAlias — source table alias (e.g. `'s'`); the caller is
  *                      responsible for joining `sources` so this alias resolves.
  *
+ * Also hides RETIRED pages — those whose author-set frontmatter `status` is a
+ * lifecycle hide value (`superseded`/`deprecated`/`retired`/`obsolete`). Like
+ * quarantine this is a search-only filter: a retired page stays fetchable by
+ * slug (`get_page`) and in `list`, it is just not surfaced by keyword/vector
+ * search. Single source of truth: `lifecycleFilterFragment` in `lifecycle.ts`.
+ *
  * @returns raw SQL fragment, e.g.
- *   `AND p.deleted_at IS NULL AND NOT s.archived AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'quarantine')`
+ *   `AND p.deleted_at IS NULL AND NOT s.archived AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'quarantine') AND NOT (lower(trim(COALESCE(p.frontmatter ->> 'status', ''))) IN ('superseded', 'deprecated', 'retired', 'obsolete'))`
  */
 export function buildVisibilityClause(pageAlias: string, sourceAlias: string): string {
   // Single source of truth for the quarantine SQL lives in quarantine.ts so
   // the marker key + filter can't drift from the search filter (#1699).
   const quarantine = quarantineFilterFragment(pageAlias);
-  return `AND ${pageAlias}.deleted_at IS NULL AND NOT ${sourceAlias}.archived AND ${quarantine}`;
+  // Author-set lifecycle retirement (superseded/deprecated/…). Single source of
+  // truth in lifecycle.ts, same reason: marker vocabulary and search filter
+  // must never drift.
+  const lifecycle = lifecycleFilterFragment(pageAlias);
+  return `AND ${pageAlias}.deleted_at IS NULL AND NOT ${sourceAlias}.archived AND ${quarantine} AND ${lifecycle}`;
 }
 
 // ============================================================

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  LIFECYCLE_KEY,
+  LIFECYCLE_HIDE_VALUES,
+  LIFECYCLE_FILTER_FRAGMENT,
+  lifecycleFilterFragment,
+  isRetired,
+  retiredStatus,
+  filterOutRetired,
+} from '../src/core/lifecycle.ts';
+import { buildVisibilityClause } from '../src/core/search/sql-ranking.ts';
+
+describe('lifecycle marker (retires / hides from search)', () => {
+  test('LIFECYCLE_KEY is the plain `status` field', () => {
+    expect(LIFECYCLE_KEY).toBe('status');
+  });
+
+  test('hide values are the unambiguous "no longer current" set', () => {
+    expect([...LIFECYCLE_HIDE_VALUES].sort()).toEqual(
+      ['deprecated', 'obsolete', 'retired', 'superseded'],
+    );
+  });
+
+  test('isRetired: true only for a hide value (case/space-insensitive)', () => {
+    expect(isRetired({ status: 'superseded' })).toBe(true);
+    expect(isRetired({ status: 'Superseded' })).toBe(true);
+    expect(isRetired({ status: '  DEPRECATED  ' })).toBe(true);
+    expect(isRetired({ status: 'retired' })).toBe(true);
+    expect(isRetired({ status: 'obsolete' })).toBe(true);
+  });
+
+  test('isRetired: false for non-retire statuses and absent/odd values', () => {
+    // The whole point: everyday `status` values stay searchable.
+    expect(isRetired({ status: 'active' })).toBe(false);
+    expect(isRetired({ status: 'draft' })).toBe(false);
+    expect(isRetired({ status: 'done' })).toBe(false);
+    expect(isRetired({ status: 'in-progress' })).toBe(false);
+    expect(isRetired({})).toBe(false);
+    expect(isRetired(null)).toBe(false);
+    expect(isRetired(undefined)).toBe(false);
+    expect(isRetired({ status: null })).toBe(false);
+    // Non-string status coerces to a non-matching value, never hides.
+    expect(isRetired({ status: { superseded: true } })).toBe(false);
+    expect(isRetired({ status: ['superseded'] })).toBe(false);
+  });
+
+  test('retiredStatus returns the normalized matched value or null', () => {
+    expect(retiredStatus({ status: 'SUPERSEDED' })).toBe('superseded');
+    expect(retiredStatus({ status: 'active' })).toBeNull();
+    expect(retiredStatus(null)).toBeNull();
+  });
+
+  test('filterOutRetired drops only retired pages', () => {
+    const pages = [
+      { slug: 'a', frontmatter: { status: 'active' } },
+      { slug: 'b', frontmatter: { status: 'superseded' } },
+      { slug: 'c', frontmatter: null },
+      { slug: 'd', frontmatter: {} },
+      { slug: 'e', frontmatter: { status: 'deprecated' } },
+    ];
+    expect(filterOutRetired(pages).map((p) => p.slug)).toEqual(['a', 'c', 'd']);
+  });
+
+  test('LIFECYCLE_FILTER_FRAGMENT is a negated membership check on p', () => {
+    expect(LIFECYCLE_FILTER_FRAGMENT).toContain('p.frontmatter');
+    expect(LIFECYCLE_FILTER_FRAGMENT).toContain("->> 'status'");
+    expect(LIFECYCLE_FILTER_FRAGMENT.startsWith('NOT (')).toBe(true);
+    for (const v of LIFECYCLE_HIDE_VALUES) {
+      expect(LIFECYCLE_FILTER_FRAGMENT).toContain(`'${v}'`);
+    }
+  });
+
+  test('lifecycleFilterFragment(alias) parameterizes the page alias; constant is the p-instance', () => {
+    expect(lifecycleFilterFragment('p')).toBe(LIFECYCLE_FILTER_FRAGMENT);
+    expect(lifecycleFilterFragment('xx')).toContain('xx.frontmatter');
+    expect(lifecycleFilterFragment('xx')).toContain("->> 'status'");
+  });
+});
+
+describe('buildVisibilityClause wires in the lifecycle filter', () => {
+  test('the composed clause keeps soft-delete + archive + quarantine + lifecycle', () => {
+    const clause = buildVisibilityClause('p', 's');
+    expect(clause).toContain('p.deleted_at IS NULL');
+    expect(clause).toContain('NOT s.archived');
+    expect(clause).toContain("? 'quarantine'");
+    // the new arm
+    expect(clause).toContain("->> 'status'");
+    expect(clause).toContain("'superseded'");
+  });
+
+  test('alias is threaded through to the lifecycle arm', () => {
+    const clause = buildVisibilityClause('page', 'src');
+    expect(clause).toContain("page.frontmatter ->> 'status'");
+  });
+});


### PR DESCRIPTION
## Problem

gbrain models supersession richly at the **facts / takes** layer (`auto-supersession`, `valid_until`, `forgotten`). But a raw markdown **page** has no author-facing way to say *"this is out of date — stop surfacing it."* The two existing page-level controls don't fit the common authoring case:

- `delete_page` (`deleted_at`) hides a page **entirely** and is an operator action.
- `quarantine` is reserved for **auto-detected junk** (the content-quality gate).

The everyday case is: *I wrote a newer page that supersedes an old one. Keep the old one reachable by slug for history, but don't let search return it as if it were current.* Today, moving the page to a `cold-storage/` folder does **nothing** — gbrain indexes and ranks it the same as any other page. So stale pages keep coming back as top hits.

## Approach — mirror the `quarantine` pattern

This adds a page **lifecycle** marker that is the exact sibling of `quarantine` (HIDES) / `content_flag` (WARNS):

- A page whose frontmatter `status` is a **hide value** — `superseded`, `deprecated`, `retired`, `obsolete` — is excluded from keyword/vector search via `lifecycleFilterFragment`, injected by `buildVisibilityClause` (the single filter all 6 search sites share).
- **Search-only.** A retired page is *not* deleted: it stays fetchable by slug (`get_page`), stays in `list`, and its links/backlinks resolve. Retirement means "not surfaced by search" — a one-line frontmatter edit instead of a file move.
- **No schema migration.** `status` is read straight from the existing `frontmatter` JSONB column (same property that made `quarantine` cheap). Works identically on Postgres and PGLite.
- **Backward compatible by construction.** Only the four explicit hide values retire a page. Every other `status` an author already uses — `active`, `draft`, `done`, `in-progress`, `review` — is inert and stays fully searchable. Pages with no `status` are unaffected.

`lifecycle.ts` is the single source of truth for the marker key + hide vocabulary + SQL fragment, exactly like `quarantine.ts`, so the search filter and the marker can never drift.

## Usage

```yaml
---
type: project
title: Adaptig platform integration (v1)
tags: [adaptig, platform]
status: superseded   # <- gbrain search now skips this page; get_page still returns it
---
```

## Not in this PR (deliberate, documented extension points)

- **WARN tier** (`status: stale` → stays searchable but rides a marker into `SearchResult`, mirroring `content_flag`). No SQL filter for it, by design.
- **`archived` as a hide value** — left out to avoid confusion with the source-level `archived` flag; one-line add in `LIFECYCLE_HIDE_VALUES` if wanted.
- **Rank-penalty (demote instead of hide)** — the fragment hides; a softer post-fusion penalty could be layered later.

## Tests

`test/lifecycle.test.ts` — 10 unit tests, no DB: predicate (`isRetired`, case/space-insensitive, non-string safety), `retiredStatus`, `filterOutRetired`, fragment shape + alias parameterization, and `buildVisibilityClause` wiring. All pass. The JSONB positional-param guard is not in scope (this reads a raw SQL fragment, adds no parameterized insert).
