### PR TITLE
fix(test): reset AI gateway after adaptive-embed-batch suite (unbreaks master shard 6)

### DIFF
--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -28,7 +28,7 @@
  *      (excluding the OpenAI canonical fast-path recipe).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   configureGateway,
   resetGateway,
@@ -39,6 +39,15 @@ import {
   __getShrinkStateForTests,
 } from '../../src/core/ai/gateway.ts';
 import { AIConfigError, AITransientError } from '../../src/core/ai/errors.ts';
+
+// The last test in this file leaves the gateway configured with a remote
+// provider + fake key and a REAL embed transport. Without a final reset,
+// that config leaks into whichever test file the shard runs next — the
+// first downstream embed then makes a live HTTP call (broke master shard 6
+// when #3022's new test file reshuffled shard composition). The bunfig
+// legacy-embedding preload only re-applies its default when the gateway is
+// UNCONFIGURED, so a configured-but-stale slot survives file boundaries.
+afterAll(() => resetGateway());
 
 // --------- Test helpers ---------
 


### PR DESCRIPTION
## Summary
Master's push CI for #3022 failed twice in shard 6: `synthesize_concepts progress wiring (T4)` attempted a **live Google embedding call** and got `API key not valid`.

Root cause: `test/ai/adaptive-embed-batch.test.ts`'s last test configures the gateway (`configureGoogle()`) with a fake key, and its `afterEach` only clears the mock transport — there is no `afterAll`. The configured-but-stale global gateway survives the file boundary, and the legacy-embedding preload deliberately re-applies defaults only when the slot is EMPTY, so the first downstream file that triggers an embed makes a real HTTP call. #3022 is innocent — adding its new test file merely reshuffled shard composition so the pre-existing leak finally landed upstream of an embed-triggering test.

Fix: `afterAll(() => resetGateway())` at the leaker, with a comment explaining the failure mode.

## Test plan
- [x] `bun test test/ai/adaptive-embed-batch.test.ts test/cycle/synthesize-concepts-progress.test.ts test/ai/recipe-nvidia.test.ts` — 37 pass / 0 fail

## Follow-up
~70 test files call `configureGateway` without a final reset — same latent class. Filing a follow-up for a CI guard (script check: configureGateway ⇒ afterAll resetGateway) rather than hand-editing 70 files in a red-master hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)