### PR TITLE
fix(extract): recognize plain-bullet timeline format (- YYYY-MM-DD — Summary)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -509,8 +509,12 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
   // DB-level uniqueness cannot collapse.
   const citationPattern = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
   const bulletLinePattern = /^-\s+\*\*\d{4}-\d{2}-\d{2}\*\*\s*\|/;
+  // Lines captured by Format 4 (plain bullet) are skipped for the same
+  // reason: quality.md mandates a trailing [Source: ...] on those bullets,
+  // and re-extracting the citation would double-count the event.
+  const plainBulletLinePattern = /^-\s+\d{4}-\d{2}-\d{2}\s*[—–-]/;
   for (const line of content.split(/\r?\n/)) {
-    if (bulletLinePattern.test(line)) continue;
+    if (bulletLinePattern.test(line) || plainBulletLinePattern.test(line)) continue;
     const lineMatches = [...line.matchAll(citationPattern)];
     if (lineMatches.length === 0) continue;
     // Strip every citation marker from the line to leave the annotated text.
@@ -524,6 +528,19 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
     for (const m of lineMatches) {
       entries.push({ slug, date: m[2], source: m[1].trim().slice(0, 200), summary });
     }
+  }
+
+  // Format 4: Plain bullet — - YYYY-MM-DD — Summary
+  // This is the format gbrain's own enrich skill writes (no bold, no source
+  // pipe). Without it, every brain-authored timeline entry is invisible to
+  // extraction and timeline_coverage stays at 0%. Anchored at line start so a
+  // date inside a summary/link cannot start a spurious entry; a bold Format-1
+  // line (`- **…**`) cannot match here (a `*` follows the bullet, not a
+  // digit), and the citation loop above skips these lines, so a plain bullet
+  // carrying its own [Source: ...] files exactly one entry.
+  const plainBulletPattern = /^-\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+)$/gm;
+  while ((match = plainBulletPattern.exec(content)) !== null) {
+    entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim() });
   }
 
   return entries;

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1103,6 +1103,11 @@ export interface TimelineCandidate {
 // Match: `- **YYYY-MM-DD** | summary` or `- **YYYY-MM-DD** -- summary`
 // or `- **YYYY-MM-DD** - summary` or just `**YYYY-MM-DD** | summary`.
 const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*(.+?)\s*$/;
+// Plain bullet: `- YYYY-MM-DD — summary` (no bold, no source pipe). Kept in
+// sync with extractTimelineFromContent's Format 4 (the fs-source path).
+// Anchored flush-left so a date inside an indented continuation line cannot
+// start a spurious entry.
+const PLAIN_TIMELINE_LINE_RE = /^-\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+?)\s*$/;
 
 /**
  * Parse timeline entries from content. Looks at:
@@ -1119,7 +1124,7 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
 
   let i = 0;
   while (i < lines.length) {
-    const m = TIMELINE_LINE_RE.exec(lines[i]);
+    const m = TIMELINE_LINE_RE.exec(lines[i]) ?? PLAIN_TIMELINE_LINE_RE.exec(lines[i]);
     if (!m) {
       i++;
       continue;
@@ -1136,7 +1141,7 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
     let j = i + 1;
     while (j < lines.length) {
       const next = lines[j];
-      if (TIMELINE_LINE_RE.test(next)) break;
+      if (TIMELINE_LINE_RE.test(next) || PLAIN_TIMELINE_LINE_RE.test(next)) break;
       if (/^#{1,6}\s/.test(next)) break;
       if (next.trim().length === 0 && detailLines.length === 0) {
         // skip leading blank line; if we hit a blank after detail content
@@ -1166,7 +1171,7 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
   // bullet pass are skipped (a bullet often carries its own citation).
   const citationRe = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
   for (const line of lines) {
-    if (TIMELINE_LINE_RE.test(line)) continue;
+    if (TIMELINE_LINE_RE.test(line) || PLAIN_TIMELINE_LINE_RE.test(line)) continue;
     const matches = [...line.matchAll(citationRe)];
     if (matches.length === 0) continue;
     const summary = line

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -185,6 +185,49 @@ describe('extractTimelineFromContent', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].summary).toBe('Landed the enterprise pilot with acme-example.');
   });
+
+  // Format 4: the plain bullet `- YYYY-MM-DD — Summary` that gbrain's own
+  // enrich skill writes. Before this was supported, every brain-authored
+  // timeline entry was invisible and timeline_coverage was stuck at 0%.
+  it('extracts plain bullet format (- YYYY-MM-DD — Summary)', () => {
+    const content = `## Timeline\n- 2026-06-01 — Catch-up call with alice-example; intros offered.`;
+    const entries = extractTimelineFromContent(content, 'people/alice-example');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-06-01');
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toBe('Catch-up call with alice-example; intros offered.');
+  });
+
+  it('files exactly one entry for a plain bullet that carries its own citation', () => {
+    // quality.md mandates this shape; it must not double-count via the
+    // citation arm (Format 3) AND the plain-bullet arm (Format 4).
+    const content = `- 2026-05-31 — Confirmed full name. [Source: User, 2026-05-31]`;
+    const entries = extractTimelineFromContent(content, 'people/charlie-example');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-05-31');
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toContain('Confirmed full name.');
+  });
+
+  it('does not double-count bold (Format 1) lines as plain bullets', () => {
+    const content = `- **2025-03-18** | Meeting — Discussed partnership`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('Meeting');
+  });
+
+  it('does not start a spurious entry from a date inside a summary', () => {
+    const content = `- 2026-06-01 — See [meeting](meetings/2026-06-01).`;
+    const entries = extractTimelineFromContent(content, 'people/alice-example');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-06-01');
+  });
+
+  it('handles en dash and hyphen separators in plain bullets', () => {
+    const content = `- 2026-06-01 – First\n- 2026-06-02 - Second`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(2);
+  });
 });
 
 describe('walkMarkdownFiles', () => {

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -720,6 +720,30 @@ More prose here.
     const entries = parseTimelineEntries(content);
     expect(entries.length).toBe(2);
   });
+
+  // Plain bullet (extract.ts Format 4 parity — the db-source path must see
+  // the same entries as the fs-source path).
+  test('parses plain bullet: - YYYY-MM-DD — summary', () => {
+    const entries = parseTimelineEntries('## Timeline\n- 2026-06-01 — Catch-up call with alice-example');
+    expect(entries.length).toBe(1);
+    expect(entries[0].date).toBe('2026-06-01');
+    expect(entries[0].summary).toBe('Catch-up call with alice-example');
+  });
+
+  test('files exactly one entry for a plain bullet carrying its own citation', () => {
+    const entries = parseTimelineEntries('- 2026-05-31 — Confirmed full name. [Source: User, 2026-05-31]');
+    expect(entries.length).toBe(1);
+    expect(entries[0].date).toBe('2026-05-31');
+  });
+
+  test('skips invalid dates in plain bullets', () => {
+    expect(parseTimelineEntries('- 2026-13-45 — Bad date').length).toBe(0);
+  });
+
+  test('does not double-count a bold bullet as a plain bullet', () => {
+    const entries = parseTimelineEntries('- **2026-01-15** | Met with Alice');
+    expect(entries.length).toBe(1);
+  });
 });
 
 // ─── isAutoLinkEnabled ─────────────────────────────────────────


### PR DESCRIPTION
Takeover of #1896 (rebased onto master; original by @ElliotDrel, credited as co-author).

## What

Adds a Format 4 arm to `extractTimelineFromContent` for the plain bullet `- YYYY-MM-DD — Summary` — the format gbrain's own enrich skill writes. Without it, every brain-authored timeline entry is invisible to extraction and timeline coverage stays at 0%.

## Why a takeover instead of merging #1896 as-is

Since #1896 was opened, #2524 landed an inline-citation arm as **Format 3** at the exact insertion point the PR targeted, so:

- The diff no longer applies and the "Format 3" name collides — the plain-bullet arm now lands as **Format 4**.
- Force-applying it would double-count: a plain bullet carrying a citation (`- 2026-05-31 — text [Source: User, 2026-05-31]`, the shape quality.md mandates) matches BOTH the plain-bullet pattern AND master's citation loop, whose skip regex only excludes bold Format-1 bullets. The citation loop's skip is extended to plain-bullet lines so that shape files exactly one entry (regression test included).

## Tests

- `bun test test/extract.test.ts` — 33 pass, 0 fail (5 new tests: plain-bullet extraction, single-entry for bullet+citation, no double-count of Format 1, no spurious entry from a date inside a summary, en dash/hyphen separators)
- `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)