### PR TITLE
fix(jobs): prune --status filter + --older-than 0d as explicit no-age-floor

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2387,7 +2387,7 @@ JOBS (Minions)
   jobs get <id>                       Job details + history
   jobs cancel <id>                    Cancel job
   jobs retry <id>                     Re-queue failed/dead job
-  jobs prune [--older-than 30d]       Clean old jobs
+  jobs prune [--older-than 30d] [--status s,..]  Clean old terminal jobs (0d = no age floor)
   jobs stats                          Job health dashboard
   jobs work [--queue Q]               Start worker daemon (Postgres only)
 

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -111,6 +111,21 @@ export function parseMaxRssFlag(args: string[]): number | undefined {
  *  - the validated integer in [-20, 19] otherwise
  *  Errors and exits the process on non-integer / out-of-range input (mirrors
  *  parseMaxRssFlag's fail-fast). Flag wins over env. (issue #1815) */
+/** Terminal statuses `jobs prune --status` accepts (PR #2282). Matches what
+ *  queue.prune can safely delete; anything else (waiting/active/…) is live. */
+export const PRUNE_STATUSES = ['completed', 'failed', 'dead', 'cancelled'] as const satisfies readonly MinionJobStatus[];
+
+/** Parse a `--status a,b,c` value into prune statuses. Throws on any value
+ *  outside PRUNE_STATUSES (fail-fast, mirrors parseNiceValue). */
+export function parsePruneStatuses(raw: string): MinionJobStatus[] {
+  const requested = raw.split(',').map(s => s.trim()).filter(Boolean);
+  const invalid = requested.filter(s => !(PRUNE_STATUSES as readonly string[]).includes(s));
+  if (requested.length === 0 || invalid.length > 0) {
+    throw new Error(`--status accepts a comma-separated subset of [${PRUNE_STATUSES.join(', ')}]${invalid.length ? `. Invalid: ${invalid.join(', ')}` : ''}`);
+  }
+  return requested as MinionJobStatus[];
+}
+
 export function parseNiceFlag(args: string[], env: NodeJS.ProcessEnv = process.env): number | undefined {
   const raw = parseFlag(args, '--nice') ?? env.GBRAIN_NICE;
   if (raw === undefined || raw === '') return undefined;
@@ -208,7 +223,9 @@ USAGE
   gbrain jobs get <id>
   gbrain jobs cancel <id>
   gbrain jobs retry <id>
-  gbrain jobs prune [--older-than 30d]
+  gbrain jobs prune [--older-than 30d] [--status completed,failed,dead,cancelled]
+                            (--older-than 0d = no age floor: deletes ALL
+                             matching terminal jobs; pair with --status)
   gbrain jobs delete <id>
   gbrain jobs stats
   gbrain jobs smoke
@@ -600,16 +617,27 @@ HANDLER TYPES (built in)
     case 'prune': {
       const olderThanStr = parseFlag(args, '--older-than') ?? '30d';
       const days = parseInt(olderThanStr, 10);
-      if (isNaN(days) || days <= 0) {
-        console.error('Error: --older-than must be a positive number (days). Example: --older-than 30d');
+      if (isNaN(days) || days < 0) {
+        console.error('Error: --older-than must be a non-negative number (days). Example: --older-than 30d; --older-than 0d removes the age floor (deletes ALL matching terminal jobs).');
         process.exit(1);
+      }
+      const statusFlag = parseFlag(args, '--status');
+      let statuses: MinionJobStatus[] | undefined;
+      if (statusFlag !== undefined) {
+        try { statuses = parsePruneStatuses(statusFlag); }
+        catch (e) { console.error(`Error: ${e instanceof Error ? e.message : String(e)}`); process.exit(1); }
       }
 
       try { await queue.ensureSchema(); }
       catch (e) { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); }
 
-      const count = await queue.prune({ olderThan: new Date(Date.now() - days * 86400000) });
-      console.log(`Pruned ${count} jobs older than ${days} days.`);
+      const count = await queue.prune({
+        olderThan: new Date(Date.now() - days * 86400000),
+        ...(statuses ? { status: statuses } : {}),
+      });
+      const statusLabel = statuses ? statuses.join('+') : 'completed+dead+cancelled';
+      const ageLabel = days === 0 ? 'regardless of age' : `older than ${days} days`;
+      console.log(`Pruned ${count} ${statusLabel} jobs ${ageLabel}.`);
       break;
     }
 

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -106,11 +106,6 @@ export function parseMaxRssFlag(args: string[]): number | undefined {
   return parsed;
 }
 
-/** Parse `--nice N` (then `GBRAIN_NICE` env). Returns:
- *  - undefined if absent (no priority change — inherit)
- *  - the validated integer in [-20, 19] otherwise
- *  Errors and exits the process on non-integer / out-of-range input (mirrors
- *  parseMaxRssFlag's fail-fast). Flag wins over env. (issue #1815) */
 /** Terminal statuses `jobs prune --status` accepts (PR #2282). Matches what
  *  queue.prune can safely delete; anything else (waiting/active/…) is live. */
 export const PRUNE_STATUSES = ['completed', 'failed', 'dead', 'cancelled'] as const satisfies readonly MinionJobStatus[];
@@ -126,6 +121,11 @@ export function parsePruneStatuses(raw: string): MinionJobStatus[] {
   return requested as MinionJobStatus[];
 }
 
+/** Parse `--nice N` (then `GBRAIN_NICE` env). Returns:
+ *  - undefined if absent (no priority change — inherit)
+ *  - the validated integer in [-20, 19] otherwise
+ *  Errors and exits the process on non-integer / out-of-range input (mirrors
+ *  parseMaxRssFlag's fail-fast). Flag wins over env. (issue #1815) */
 export function parseNiceFlag(args: string[], env: NodeJS.ProcessEnv = process.env): number | undefined {
   const raw = parseFlag(args, '--nice') ?? env.GBRAIN_NICE;
   if (raw === undefined || raw === '') return undefined;

--- a/test/jobs-prune-flags.test.ts
+++ b/test/jobs-prune-flags.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Unit tests for parsePruneStatuses (PR #2282) — `jobs prune --status` parsing.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parsePruneStatuses, PRUNE_STATUSES } from '../src/commands/jobs.ts';
+
+describe('parsePruneStatuses', () => {
+  test('parses a single status', () => {
+    expect(parsePruneStatuses('failed')).toEqual(['failed']);
+  });
+
+  test('parses a comma-separated list with whitespace', () => {
+    expect(parsePruneStatuses(' completed, dead ')).toEqual(['completed', 'dead']);
+  });
+
+  test('accepts every documented terminal status', () => {
+    expect(parsePruneStatuses(PRUNE_STATUSES.join(','))).toEqual([...PRUNE_STATUSES]);
+  });
+
+  test('throws on non-terminal statuses', () => {
+    expect(() => parsePruneStatuses('waiting')).toThrow(/Invalid: waiting/);
+    expect(() => parsePruneStatuses('completed,active')).toThrow(/Invalid: active/);
+  });
+
+  test('throws on empty value', () => {
+    expect(() => parsePruneStatuses('')).toThrow(/comma-separated subset/);
+    expect(() => parsePruneStatuses(',')).toThrow(/comma-separated subset/);
+  });
+});

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -702,6 +702,32 @@ describe('MinionQueue: Prune', () => {
     const count = await queue.prune({ olderThan: new Date(Date.now() + 86400000) }); // future date = prune everything old enough
     expect(count).toBe(1); // only the cancelled one
   });
+
+  // PR #2282: `jobs prune --status` passes an explicit status subset through.
+  test('status filter prunes only the requested terminal statuses', async () => {
+    const cancelled = await queue.add('sync', {});
+    await queue.cancelJob(cancelled.id);
+    const dead = await queue.add('embed', {}, { max_attempts: 1 });
+    await queue.claim('tok1', 30000, 'default', ['embed']);
+    await queue.failJob(dead.id, 'tok1', 'boom', 'dead');
+
+    const count = await queue.prune({ olderThan: new Date(Date.now() + 86400000), status: ['dead'] });
+    expect(count).toBe(1); // only the dead one
+
+    const remaining = await queue.getJobs({ status: 'cancelled' });
+    expect(remaining.length).toBe(1);
+  });
+
+  // PR #2282: `--older-than 0d` = no age floor — olderThan of "now" deletes
+  // terminal jobs that finished moments ago.
+  test('olderThan now (0d semantics) prunes just-terminated jobs', async () => {
+    const job = await queue.add('sync', {});
+    await queue.cancelJob(job.id);
+    await new Promise(r => setTimeout(r, 5)); // ensure updated_at < now
+
+    const count = await queue.prune({ olderThan: new Date() });
+    expect(count).toBe(1);
+  });
 });
 
 // --- Stats (1 test) ---


### PR DESCRIPTION
Takeover of #2282 (author: @brettdavies, credited via Co-authored-by).

Master's `queue.prune` already accepts a `status[]` param, but the CLI exposed neither a status filter nor any way below a 1-day floor. This salvages the CLI plumbing from #2282 and repairs the flaws found in adversarial verification:

- **`--status completed,failed,dead,cancelled`** — comma-separated terminal subset passed through to `queue.prune`; any non-terminal value fails fast. Parsing extracted into exported `parsePruneStatuses` (unit-tested, same pattern as `parseNiceFlag`).
- **`--older-than 0d` documented as what it does** — the original PR titled/described it as "same-day prune (preserves the audit trail)" while the code implemented *no age filter at all*. This lands it honestly: help text and the success line both say it removes the age floor and deletes ALL matching terminal jobs ("regardless of age"), so operators can't mistake it for a start-of-today cutoff.
- **Real tests** — the original body cited cases in `test/jobs.test.ts`, a file that does not exist. This PR adds queue-level status-filter + zero-age-floor tests to `test/minions.test.ts` and parser tests in `test/jobs-prune-flags.test.ts`.

Gates: `bun run typecheck` clean; `bun test test/minions.test.ts test/jobs-prune-flags.test.ts` → 187 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)