### PR TITLE
fix(cli): honor search --json output (#2042)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -464,7 +464,7 @@ async function main() {
     // routed path. Date → ISO string; bigint → string (postgres.js shape);
     // Buffer → object. Microsecond-cost; eliminates a whole drift bug class.
     const result = JSON.parse(JSON.stringify(rawResult, bigintToStringReplacer));
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     // v0.42.20.0 (codex D4): on error, set exitCode + return so the `finally`
@@ -547,7 +547,7 @@ async function runThinClientRouted(
       signal: sigintController.signal,
     });
     const result = unpackToolResult(raw);
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     if (e instanceof RemoteMcpError) {
@@ -777,6 +777,10 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
       const paramDef = op.params[key];
       if (paramDef?.type === 'boolean') {
         params[key] = true;
+      } else if (key === 'json') {
+        // Generic operation formatter flag. It is intentionally CLI-local:
+        // do not add it to the operation contract exposed over MCP/tools.
+        params[key] = true;
       } else if (i + 1 < args.length) {
         params[key] = args[++i];
         if (paramDef?.type === 'number') params[key] = Number(params[key]);
@@ -838,7 +842,11 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
 }
 
 // Exported for tests (same import-safety contract as cliAliases/printOpHelp).
-export function formatResult(opName: string, result: unknown): string {
+export function formatResult(
+  opName: string,
+  result: unknown,
+  params: Record<string, unknown> = {},
+): string {
   switch (opName) {
     case 'volunteer_context': {
       const r = result as any;
@@ -877,6 +885,7 @@ export function formatResult(opName: string, result: unknown): string {
     case 'search':
     case 'query': {
       const results = result as any[];
+      if (params.json === true) return JSON.stringify(results, null, 2) + '\n';
       if (results.length === 0) return 'No results.\n';
       // v0.40.4 — --explain switches to per-stage attribution formatter.
       // Reads CliOptions.explain via the module-level singleton.

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -20,5 +20,16 @@ describe('parseOpArgs', () => {
       source_id: 'gstack-code-repo-0e4763c9',
     });
   });
-});
 
+  test('--json is a CLI-local formatter flag for shared operations', () => {
+    const params = parseOpArgs(operationsByName.search, [
+      'needle',
+      '--json',
+    ]);
+
+    expect(params).toEqual({
+      query: 'needle',
+      json: true,
+    });
+  });
+});

--- a/test/cli-format-search-json.test.ts
+++ b/test/cli-format-search-json.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { formatResult } from '../src/cli.ts';
+
+describe('formatResult - search/query --json', () => {
+  test('search --json renders the raw result array as parseable JSON', () => {
+    const out = formatResult('search', [
+      {
+        slug: 'docs/example',
+        score: 0.42,
+        chunk_text: 'Example result text',
+      },
+    ], { json: true });
+
+    expect(JSON.parse(out)).toEqual([
+      {
+        slug: 'docs/example',
+        score: 0.42,
+        chunk_text: 'Example result text',
+      },
+    ]);
+  });
+
+  test('query --json keeps empty results machine-readable', () => {
+    const out = formatResult('query', [], { json: true });
+
+    expect(JSON.parse(out)).toEqual([]);
+  });
+});

--- a/test/cli-search-dispatch.test.ts
+++ b/test/cli-search-dispatch.test.ts
@@ -49,6 +49,15 @@ describe('T5 — gbrain search dispatch', () => {
     });
   });
 
+  test('`search "<freetext>" --json` emits a parseable result array', () => {
+    withHome((home) => {
+      const { stdout, stderr, status } = run(['search', 'zzz-no-such-page-xyz', '--json'], home);
+      expect(status).toBe(0);
+      expect(stderr).not.toContain('Unknown subcommand');
+      expect(JSON.parse(stdout)).toEqual([]);
+    });
+  });
+
   test('`search stats --json` routes to the dashboard', () => {
     withHome((home) => {
       const { stdout, status } = run(['search', 'stats', '--json'], home);


### PR DESCRIPTION
Takeover of #2531 (author: @javieraldape), rebased onto master. Fixes #2042.

`gbrain search <q> --json` silently printed human text: search/query declare no `json` param, `parseOpArgs` dropped the undeclared trailing flag, and `formatResult`'s search/query case only emitted human text or `--explain` output.

- `parseOpArgs` treats `--json` as a CLI-local boolean formatter flag (deliberately NOT added to the operation contract; MCP `validateParams` ignores the extra key, so the thin-client routed path is unaffected).
- `formatResult(op, result, params)` emits the raw result array as parseable JSON for search/query when `params.json === true`.
- Rebase note: the local-path call site keeps master's `bigintToStringReplacer` argument; PR semantics carry over unchanged.

Tests: `test/cli-args.test.ts` (flag parsing), `test/cli-format-search-json.test.ts` (formatter, incl. empty array), `test/cli-search-dispatch.test.ts` (subprocess regression against the real cli.ts entrypoint). `bun run typecheck` exit 0; all three files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)