### PR TITLE
fix(thin-client): map --source scope onto source_id for remote-routed ops

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import type { GBrainConfig } from './core/config.ts';
 import type { AIGatewayConfig } from './core/ai/types.ts';
 import type { BrainEngine } from './core/engine.ts';
 import { operations, OperationError } from './core/operations.ts';
+import { resolveSourceIdEngineFree } from './core/source-resolver.ts';
 import { formatVolunteeredPage } from './core/context/volunteer.ts';
 import type { Operation, OperationContext } from './core/operations.ts';
 import { shouldForceExitAfterMain, finishCliTeardown, flushThenExit, currentExitCode, setCliExitVerdict } from './core/cli-force-exit.ts';
@@ -381,6 +382,15 @@ async function main() {
   if (isThinClient(cfgPre)) {
     if (op.localOnly) {
       refuseThinClient(command, cfgPre!.remote_mcp!.mcp_url);
+    }
+    // #2098: the local path resolves --source / GBRAIN_SOURCE / .gbrain-source
+    // inside makeContext (ctx.sourceId), which this route never reaches — so
+    // scope must be mapped onto the op's source_id wire param before the call.
+    try {
+      applyThinClientSourceScope(op, params);
+    } catch (e: unknown) {
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exit(1);
     }
     await runThinClientRouted(op, params, cfgPre!, cliOpts);
     return;
@@ -800,6 +810,52 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
   }
 
   return params;
+}
+
+/**
+ * #2098: thin-client source scoping. Locally, --source / GBRAIN_SOURCE /
+ * .gbrain-source resolve to ctx.sourceId in makeContext; the thin-client
+ * route short-circuits before that, so `gbrain query --source X` against a
+ * remote brain silently searched unscoped. This runs the engine-free tiers
+ * (flag → env → dotfile; the DB-backed tiers can't run without an engine —
+ * the server's grant scoping covers the rest) and maps the result onto the
+ * op's `source_id` wire param.
+ *
+ * Ops that declare their OWN `source` param (facts add, etc.) are left
+ * untouched — their --source is an op param, not scope. An explicit --source
+ * on an op with no source_id wire param throws (loud beats silent drop);
+ * ambient env/dotfile scope with nowhere to send it is ignored, matching the
+ * pre-fix behavior for non-scopeable ops. Exported for tests.
+ */
+export function applyThinClientSourceScope(
+  op: Operation,
+  params: Record<string, unknown>,
+  cwd?: string,
+): void {
+  if ('source' in op.params) return; // the op owns --source; not a scope flag
+  const explicit = typeof params.source === 'string' && params.source.length > 0
+    ? (params.source as string)
+    : null;
+  delete params.source; // never a wire param on these ops — don't leak it
+  // Explicit per-call scope already on the wire wins over ambient tiers.
+  if (params.source_id !== undefined || params.all_sources === true) {
+    if (explicit) {
+      throw new Error('Pass either --source or --source-id/--all-sources, not both.');
+    }
+    return;
+  }
+  const resolved = resolveSourceIdEngineFree(explicit, cwd);
+  if (!resolved) return;
+  if (!('source_id' in op.params)) {
+    if (explicit) {
+      throw new Error(
+        `gbrain ${op.cliHints?.name || op.name} does not accept --source on a thin-client install ` +
+        `(the remote op has no source_id parameter; the server scopes it to your grant).`,
+      );
+    }
+    return; // ambient env/dotfile scope with nowhere to send it
+  }
+  params.source_id = resolved;
 }
 
 async function makeContext(engine: BrainEngine, params: Record<string, unknown>): Promise<OperationContext> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -827,6 +827,12 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
  * ambient env/dotfile scope with nowhere to send it is ignored, matching the
  * pre-fix behavior for non-scopeable ops. Exported for tests.
  */
+// Ops whose `source_id` wire param is NOT read-scope semantics: get_skill's
+// source_id flips the lookup from host catalog to brain-resident-pack
+// (getResidentSkillDetail). Ambient env/dotfile scope must never leak into
+// these; an explicit --source-id still passes through untouched above.
+const NON_SCOPE_SOURCE_ID_OPS = new Set(['get_skill']);
+
 export function applyThinClientSourceScope(
   op: Operation,
   params: Record<string, unknown>,
@@ -846,11 +852,13 @@ export function applyThinClientSourceScope(
   }
   const resolved = resolveSourceIdEngineFree(explicit, cwd);
   if (!resolved) return;
-  if (!('source_id' in op.params)) {
+  if (!('source_id' in op.params) || NON_SCOPE_SOURCE_ID_OPS.has(op.name)) {
     if (explicit) {
+      const hint = NON_SCOPE_SOURCE_ID_OPS.has(op.name)
+        ? `(its source_id parameter is not a scope filter; pass --source-id explicitly if you mean it)`
+        : `(the remote op has no source_id parameter; the server scopes it to your grant)`;
       throw new Error(
-        `gbrain ${op.cliHints?.name || op.name} does not accept --source on a thin-client install ` +
-        `(the remote op has no source_id parameter; the server scopes it to your grant).`,
+        `gbrain ${op.cliHints?.name || op.name} does not accept --source on a thin-client install ${hint}.`,
       );
     }
     return; // ambient env/dotfile scope with nowhere to send it

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -161,6 +161,33 @@ export async function resolveSourceId(
 }
 
 /**
+ * Engine-free tiers (1-3) of the resolution chain: explicit flag →
+ * GBRAIN_SOURCE env → .gbrain-source dotfile walk. Used by the thin-client
+ * CLI path (#2098), which has no local engine to run tiers 4-6 or
+ * assertSourceExists against — the remote server enforces existence + grant.
+ * Returns null when no engine-free tier fires.
+ */
+export function resolveSourceIdEngineFree(
+  explicit: string | null | undefined,
+  cwd: string = process.cwd(),
+): string | null {
+  if (explicit) {
+    if (!SOURCE_ID_RE.test(explicit)) {
+      throw new Error(`Invalid --source value "${explicit}". Must match [a-z0-9-]{1,32}.`);
+    }
+    return explicit;
+  }
+  const env = process.env.GBRAIN_SOURCE;
+  if (env && env.length > 0) {
+    if (!SOURCE_ID_RE.test(env)) {
+      throw new Error(`Invalid GBRAIN_SOURCE value "${env}". Must match [a-z0-9-]{1,32}.`);
+    }
+    return env;
+  }
+  return readDotfileWalk(cwd);
+}
+
+/**
  * Returns the id of the SINGLE registered non-default source with a
  * local_path, when exactly one such row exists. Returns null when:
  *   - zero non-default sources are registered (fresh install)

--- a/test/thin-client-source-scope.test.ts
+++ b/test/thin-client-source-scope.test.ts
@@ -11,97 +11,105 @@
  * without the fix (params.source_id stays undefined / params.source leaks).
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { applyThinClientSourceScope, parseOpArgs } from '../src/cli.ts';
 import { operationsByName } from '../src/core/operations.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 const queryOp = operationsByName.query;
 
-let savedEnv: string | undefined;
-beforeEach(() => {
-  savedEnv = process.env.GBRAIN_SOURCE;
-  delete process.env.GBRAIN_SOURCE;
-});
-afterEach(() => {
-  if (savedEnv === undefined) delete process.env.GBRAIN_SOURCE;
-  else process.env.GBRAIN_SOURCE = savedEnv;
-});
-
 describe('applyThinClientSourceScope (#2098)', () => {
-  test('--source maps onto the query op wire param source_id', () => {
-    const params = parseOpArgs(queryOp, ['find things', '--source', 'wiki']);
-    expect(params.source).toBe('wiki'); // pre-fix state: wrong key
-    applyThinClientSourceScope(queryOp, params, '/');
-    expect(params.source_id).toBe('wiki');
-    expect('source' in params).toBe(false); // never leaks the unknown key
+  test('--source maps onto the query op wire param source_id', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const params = parseOpArgs(queryOp, ['find things', '--source', 'wiki']);
+      expect(params.source).toBe('wiki'); // pre-fix state: wrong key
+      applyThinClientSourceScope(queryOp, params, '/');
+      expect(params.source_id).toBe('wiki');
+      expect('source' in params).toBe(false); // never leaks the unknown key
+    });
   });
 
-  test('GBRAIN_SOURCE env tier fires when no flag is passed', () => {
-    process.env.GBRAIN_SOURCE = 'gstack';
-    const params = parseOpArgs(queryOp, ['find things']);
-    applyThinClientSourceScope(queryOp, params, '/');
-    expect(params.source_id).toBe('gstack');
-  });
-
-  test('.gbrain-source dotfile tier fires when flag and env are absent', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-thin-scope-'));
-    try {
-      writeFileSync(join(tmp, '.gbrain-source'), 'essays\n');
+  test('GBRAIN_SOURCE env tier fires when no flag is passed', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'gstack' }, () => {
       const params = parseOpArgs(queryOp, ['find things']);
-      applyThinClientSourceScope(queryOp, params, tmp);
-      expect(params.source_id).toBe('essays');
-    } finally {
-      rmSync(tmp, { recursive: true, force: true });
-    }
+      applyThinClientSourceScope(queryOp, params, '/');
+      expect(params.source_id).toBe('gstack');
+    });
   });
 
-  test('explicit --source-id on the wire wins over ambient env scope', () => {
-    process.env.GBRAIN_SOURCE = 'gstack';
-    const params = parseOpArgs(queryOp, ['find things', '--source-id', 'wiki']);
-    applyThinClientSourceScope(queryOp, params, '/');
-    expect(params.source_id).toBe('wiki');
+  test('.gbrain-source dotfile tier fires when flag and env are absent', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const tmp = mkdtempSync(join(tmpdir(), 'gbrain-thin-scope-'));
+      try {
+        writeFileSync(join(tmp, '.gbrain-source'), 'essays\n');
+        const params = parseOpArgs(queryOp, ['find things']);
+        applyThinClientSourceScope(queryOp, params, tmp);
+        expect(params.source_id).toBe('essays');
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
   });
 
-  test('--source together with --source-id is rejected loudly', () => {
-    const params = parseOpArgs(queryOp, ['q', '--source', 'a', '--source-id', 'b']);
-    expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/not both/);
+  test('explicit --source-id on the wire wins over ambient env scope', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'gstack' }, () => {
+      const params = parseOpArgs(queryOp, ['find things', '--source-id', 'wiki']);
+      applyThinClientSourceScope(queryOp, params, '/');
+      expect(params.source_id).toBe('wiki');
+    });
   });
 
-  test('invalid --source value is rejected loudly', () => {
-    const params = parseOpArgs(queryOp, ['q', '--source', 'Bad_Value!']);
-    expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/Invalid --source/);
+  test('--source together with --source-id is rejected loudly', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const params = parseOpArgs(queryOp, ['q', '--source', 'a', '--source-id', 'b']);
+      expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/not both/);
+    });
   });
 
-  test('--source on an op with no source_id wire param errors instead of silently dropping', () => {
-    const op = operationsByName.add_tag;
-    expect('source_id' in op.params).toBe(false);
-    const params = { slug: 'x', tag: 'y', source: 'wiki' };
-    expect(() => applyThinClientSourceScope(op, params, '/')).toThrow(/--source/);
+  test('invalid --source value is rejected loudly', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const params = parseOpArgs(queryOp, ['q', '--source', 'Bad_Value!']);
+      expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/Invalid --source/);
+    });
   });
 
-  test('ambient env scope on an op with no source_id wire param is ignored (no throw)', () => {
-    process.env.GBRAIN_SOURCE = 'wiki';
-    const op = operationsByName.add_tag;
-    const params: Record<string, unknown> = { slug: 'x', tag: 'y' };
-    applyThinClientSourceScope(op, params, '/');
-    expect(params.source_id).toBeUndefined();
+  test('--source on an op with no source_id wire param errors instead of silently dropping', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const op = operationsByName.add_tag;
+      expect('source_id' in op.params).toBe(false);
+      const params = { slug: 'x', tag: 'y', source: 'wiki' };
+      expect(() => applyThinClientSourceScope(op, params, '/')).toThrow(/--source/);
+    });
   });
 
-  test('ops that declare their OWN source param are left untouched', () => {
-    const op = operationsByName.put_raw_data;
-    expect('source' in op.params).toBe(true);
-    const params: Record<string, unknown> = { slug: 'x', source: 'crustdata', data: {} };
-    applyThinClientSourceScope(op, params, '/');
-    expect(params.source).toBe('crustdata');
-    expect(params.source_id).toBeUndefined();
+  test('ambient env scope on an op with no source_id wire param is ignored (no throw)', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'wiki' }, () => {
+      const op = operationsByName.add_tag;
+      const params: Record<string, unknown> = { slug: 'x', tag: 'y' };
+      applyThinClientSourceScope(op, params, '/');
+      expect(params.source_id).toBeUndefined();
+    });
   });
 
-  test('no scope from any tier leaves params unchanged', () => {
-    const params = parseOpArgs(queryOp, ['find things']);
-    applyThinClientSourceScope(queryOp, params, '/');
-    expect(params.source_id).toBeUndefined();
+  test('ops that declare their OWN source param are left untouched', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const op = operationsByName.put_raw_data;
+      expect('source' in op.params).toBe(true);
+      const params: Record<string, unknown> = { slug: 'x', source: 'crustdata', data: {} };
+      applyThinClientSourceScope(op, params, '/');
+      expect(params.source).toBe('crustdata');
+      expect(params.source_id).toBeUndefined();
+    });
+  });
+
+  test('no scope from any tier leaves params unchanged', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const params = parseOpArgs(queryOp, ['find things']);
+      applyThinClientSourceScope(queryOp, params, '/');
+      expect(params.source_id).toBeUndefined();
+    });
   });
 });

--- a/test/thin-client-source-scope.test.ts
+++ b/test/thin-client-source-scope.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #2098: thin-client routing dropped --source / GBRAIN_SOURCE / .gbrain-source.
+ *
+ * The local CLI path resolves source scope in makeContext (ctx.sourceId); the
+ * thin-client route short-circuits before that and sent params verbatim, so
+ * `gbrain query --source X` against a remote brain silently searched unscoped
+ * (the server op ignores the unknown `source` key).
+ *
+ * applyThinClientSourceScope runs the engine-free tiers (flag → env → dotfile)
+ * and maps the result onto the op's `source_id` wire param. These tests fail
+ * without the fix (params.source_id stays undefined / params.source leaks).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { applyThinClientSourceScope, parseOpArgs } from '../src/cli.ts';
+import { operationsByName } from '../src/core/operations.ts';
+
+const queryOp = operationsByName.query;
+
+let savedEnv: string | undefined;
+beforeEach(() => {
+  savedEnv = process.env.GBRAIN_SOURCE;
+  delete process.env.GBRAIN_SOURCE;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.GBRAIN_SOURCE;
+  else process.env.GBRAIN_SOURCE = savedEnv;
+});
+
+describe('applyThinClientSourceScope (#2098)', () => {
+  test('--source maps onto the query op wire param source_id', () => {
+    const params = parseOpArgs(queryOp, ['find things', '--source', 'wiki']);
+    expect(params.source).toBe('wiki'); // pre-fix state: wrong key
+    applyThinClientSourceScope(queryOp, params, '/');
+    expect(params.source_id).toBe('wiki');
+    expect('source' in params).toBe(false); // never leaks the unknown key
+  });
+
+  test('GBRAIN_SOURCE env tier fires when no flag is passed', () => {
+    process.env.GBRAIN_SOURCE = 'gstack';
+    const params = parseOpArgs(queryOp, ['find things']);
+    applyThinClientSourceScope(queryOp, params, '/');
+    expect(params.source_id).toBe('gstack');
+  });
+
+  test('.gbrain-source dotfile tier fires when flag and env are absent', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-thin-scope-'));
+    try {
+      writeFileSync(join(tmp, '.gbrain-source'), 'essays\n');
+      const params = parseOpArgs(queryOp, ['find things']);
+      applyThinClientSourceScope(queryOp, params, tmp);
+      expect(params.source_id).toBe('essays');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('explicit --source-id on the wire wins over ambient env scope', () => {
+    process.env.GBRAIN_SOURCE = 'gstack';
+    const params = parseOpArgs(queryOp, ['find things', '--source-id', 'wiki']);
+    applyThinClientSourceScope(queryOp, params, '/');
+    expect(params.source_id).toBe('wiki');
+  });
+
+  test('--source together with --source-id is rejected loudly', () => {
+    const params = parseOpArgs(queryOp, ['q', '--source', 'a', '--source-id', 'b']);
+    expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/not both/);
+  });
+
+  test('invalid --source value is rejected loudly', () => {
+    const params = parseOpArgs(queryOp, ['q', '--source', 'Bad_Value!']);
+    expect(() => applyThinClientSourceScope(queryOp, params, '/')).toThrow(/Invalid --source/);
+  });
+
+  test('--source on an op with no source_id wire param errors instead of silently dropping', () => {
+    const op = operationsByName.add_tag;
+    expect('source_id' in op.params).toBe(false);
+    const params = { slug: 'x', tag: 'y', source: 'wiki' };
+    expect(() => applyThinClientSourceScope(op, params, '/')).toThrow(/--source/);
+  });
+
+  test('ambient env scope on an op with no source_id wire param is ignored (no throw)', () => {
+    process.env.GBRAIN_SOURCE = 'wiki';
+    const op = operationsByName.add_tag;
+    const params: Record<string, unknown> = { slug: 'x', tag: 'y' };
+    applyThinClientSourceScope(op, params, '/');
+    expect(params.source_id).toBeUndefined();
+  });
+
+  test('ops that declare their OWN source param are left untouched', () => {
+    const op = operationsByName.put_raw_data;
+    expect('source' in op.params).toBe(true);
+    const params: Record<string, unknown> = { slug: 'x', source: 'crustdata', data: {} };
+    applyThinClientSourceScope(op, params, '/');
+    expect(params.source).toBe('crustdata');
+    expect(params.source_id).toBeUndefined();
+  });
+
+  test('no scope from any tier leaves params unchanged', () => {
+    const params = parseOpArgs(queryOp, ['find things']);
+    applyThinClientSourceScope(queryOp, params, '/');
+    expect(params.source_id).toBeUndefined();
+  });
+});

--- a/test/thin-client-source-scope.test.ts
+++ b/test/thin-client-source-scope.test.ts
@@ -105,6 +105,33 @@ describe('applyThinClientSourceScope (#2098)', () => {
     });
   });
 
+  test('get_skill: ambient scope never leaks into its non-scope source_id param', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'wiki' }, () => {
+      const op = operationsByName.get_skill;
+      expect('source_id' in op.params).toBe(true); // has the param, but it is a mode switch
+      const params: Record<string, unknown> = { name: 'ingest' };
+      applyThinClientSourceScope(op, params, '/');
+      expect(params.source_id).toBeUndefined(); // would flip host catalog → brain-pack lookup
+    });
+  });
+
+  test('get_skill: explicit --source errors instead of masquerading as --source-id', async () => {
+    await withEnv({ GBRAIN_SOURCE: undefined }, () => {
+      const op = operationsByName.get_skill;
+      const params: Record<string, unknown> = { name: 'ingest', source: 'wiki' };
+      expect(() => applyThinClientSourceScope(op, params, '/')).toThrow(/--source-id/);
+    });
+  });
+
+  test('get_skill: explicit --source-id passes through untouched', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'gstack' }, () => {
+      const op = operationsByName.get_skill;
+      const params: Record<string, unknown> = { name: 'ingest', source_id: 'wiki' };
+      applyThinClientSourceScope(op, params, '/');
+      expect(params.source_id).toBe('wiki');
+    });
+  });
+
   test('no scope from any tier leaves params unchanged', async () => {
     await withEnv({ GBRAIN_SOURCE: undefined }, () => {
       const params = parseOpArgs(queryOp, ['find things']);


### PR DESCRIPTION
## Backlog unit c24: clamp remote source overrides

Fixes #2098

**Bug:** the thin-client route (`src/cli.ts` isThinClient branch) short-circuits before `makeContext`, so the 6-tier source resolution never ran. `gbrain query --source X` against a remote brain sent the unknown `source` key verbatim; the server op ignored it and searched **unscoped** — a silent P0 scope drop.

**Fix:**
- `resolveSourceIdEngineFree()` in `src/core/source-resolver.ts` — the engine-free tiers of the canonical chain (explicit flag → `GBRAIN_SOURCE` → `.gbrain-source` dotfile walk), same validation throws as tiers 1-2 of `resolveSourceId`. The DB-backed tiers (path-match, brain default) can't run without an engine; the server's grant scoping (`resolveRequestedScope`) covers existence + grant enforcement.
- `applyThinClientSourceScope()` in `src/cli.ts`, called in the thin-client branch before `runThinClientRouted`: maps the resolved scope onto the op's `source_id` wire param and strips the never-a-wire-param `source` key.
- Edge handling: ops that declare their **own** `source` param (e.g. `put_raw_data`) are untouched; explicit `--source` on an op with no `source_id` wire param **errors loudly** instead of silently dropping; explicit `--source-id`/`--all-sources` on the wire win over ambient env/dotfile tiers (passing both `--source` and `--source-id` is rejected).

**Tests:** `test/thin-client-source-scope.test.ts` — 10 cases covering the three engine-free tiers, precedence, loud-error paths, own-`source`-param ops, and the no-scope no-op. Fails without the fix (source_id never set, `source` key leaks on the wire).

**Gates:** `bun run typecheck` exit 0; new test file + `cli-dispatch-thin-client`, `thin-client-routing-audit`, `cli-args`, `source-resolver` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)