### PR TITLE
fix(gateway): pooler fallback when derived direct host is unreachable on IPv4-only networks

### DIFF
--- a/docs/guides/live-sync.md
+++ b/docs/guides/live-sync.md
@@ -21,14 +21,17 @@ GBrain is tuned for the Supabase **Transaction pooler** (port 6543): it
 auto-disables prepared statements there and routes `engine.transaction()`
 (migrations, DDL, sync imports) to a derived **direct** connection
 (`db.<ref>.supabase.co:5432`). That direct host is IPv6-only, so on an
-IPv4-only host, reads work but sync **silently skips most pages**. This is the
-number one cause of "sync ran but nothing happened."
+IPv4-only host it is unreachable. When that happens gbrain now falls back to
+the pooler automatically (one stderr warning, then single-pool mode for the
+rest of the process) — but the pooler's ~2-min statement timeout can truncate
+very long migrations or bulk imports.
 
 Fix: make the direct connection reachable over IPv4. Either set
 `GBRAIN_DIRECT_DATABASE_URL` to the **Session pooler** string (port 5432 on the
-`pooler.supabase.com` host, IPv4), or enable Supabase's IPv4 add-on. Verify by
-running `gbrain sync` and checking that the page count in `gbrain stats` matches
-the syncable file count in the repo.
+`pooler.supabase.com` host, IPv4), or enable Supabase's IPv4 add-on.
+`GBRAIN_DISABLE_DIRECT_POOL=1` skips the direct pool (and the fallback warning)
+entirely. Verify by running `gbrain sync` and checking that the page count in
+`gbrain stats` matches the syncable file count in the repo.
 
 ### The Primitives
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2720,14 +2720,17 @@ GBrain is tuned for the Supabase **Transaction pooler** (port 6543): it
 auto-disables prepared statements there and routes `engine.transaction()`
 (migrations, DDL, sync imports) to a derived **direct** connection
 (`db.<ref>.supabase.co:5432`). That direct host is IPv6-only, so on an
-IPv4-only host, reads work but sync **silently skips most pages**. This is the
-number one cause of "sync ran but nothing happened."
+IPv4-only host it is unreachable. When that happens gbrain now falls back to
+the pooler automatically (one stderr warning, then single-pool mode for the
+rest of the process) — but the pooler's ~2-min statement timeout can truncate
+very long migrations or bulk imports.
 
 Fix: make the direct connection reachable over IPv4. Either set
 `GBRAIN_DIRECT_DATABASE_URL` to the **Session pooler** string (port 5432 on the
-`pooler.supabase.com` host, IPv4), or enable Supabase's IPv4 add-on. Verify by
-running `gbrain sync` and checking that the page count in `gbrain stats` matches
-the syncable file count in the repo.
+`pooler.supabase.com` host, IPv4), or enable Supabase's IPv4 add-on.
+`GBRAIN_DISABLE_DIRECT_POOL=1` skips the direct pool (and the fallback warning)
+entirely. Verify by running `gbrain sync` and checking that the page count in
+`gbrain stats` matches the syncable file count in the repo.
 
 ### The Primitives
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1078,6 +1078,9 @@ async function initPostgres(opts: {
     console.warn('  Direct connections are IPv6 only and fail in many environments.');
     console.warn('  Use the Transaction pooler connection string instead (port 6543):');
     console.warn('  Supabase Dashboard > Connect (top bar) > Connection String > Transaction pooler');
+    console.warn('  (With a pooler URL, gbrain derives a direct connection for DDL and falls back');
+    console.warn('  to the pooler automatically if that host is unreachable. Power users:');
+    console.warn('  GBRAIN_DIRECT_DATABASE_URL overrides the derived URL; GBRAIN_DISABLE_DIRECT_POOL=1 disables it.)');
     console.warn('');
   }
 
@@ -1091,6 +1094,9 @@ async function initPostgres(opts: {
       if (databaseUrl.includes('supabase.co') && (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT'))) {
         console.error('Connection failed. Supabase direct connections (db.*.supabase.co:5432) are IPv6 only.');
         console.error('Use the Transaction pooler connection string instead (port 6543).');
+        console.error('(gbrain derives its own direct connection from pooler URLs for DDL; if that host is');
+        console.error('unreachable it falls back to the pooler. GBRAIN_DIRECT_DATABASE_URL overrides the');
+        console.error('derived URL; GBRAIN_DISABLE_DIRECT_POOL=1 disables the direct pool entirely.)');
       }
       throw e;
     }

--- a/src/core/connection-manager.ts
+++ b/src/core/connection-manager.ts
@@ -168,6 +168,25 @@ export function deriveDirectUrl(url: string): string | null {
 }
 
 /**
+ * Error codes that mean "the direct host is unreachable from this network"
+ * (#1641). The auto-derived db.<ref>.supabase.co host is IPv6-only without
+ * the paid IPv4 add-on, so ENOTFOUND/ECONNREFUSED here is expected on
+ * IPv4-only networks — we fall back to the pooler instead of failing init.
+ */
+const NETWORK_UNREACHABLE_CODES = [
+  'ENOTFOUND', 'ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH',
+  'ETIMEDOUT', 'CONNECT_TIMEOUT',
+];
+
+/** True when err looks like a network-unreachable failure (not auth/SQL). */
+export function isNetworkUnreachableError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (typeof code === 'string' && NETWORK_UNREACHABLE_CODES.includes(code)) return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return NETWORK_UNREACHABLE_CODES.some(c => msg.includes(c));
+}
+
+/**
  * Read kill-switch state from env. Subordinate to parent manager's state
  * when present (A2 inheritance).
  */
@@ -319,7 +338,30 @@ export class ConnectionManager {
         throw err;
       });
     }
-    const pool = await this._directInit;
+    let pool: Sql | null;
+    try {
+      pool = await this._directInit;
+    } catch (err) {
+      // #1641: the derived direct host (db.<ref>.supabase.co) is IPv6-only
+      // without Supabase's IPv4 add-on. On IPv4-only networks the direct
+      // pool can never connect — permanently fall back to the read pool
+      // (self-activating kill-switch) instead of failing init/migrations.
+      // Non-network errors (auth, SQL) still throw: they mean misconfig,
+      // not unreachability.
+      if (isNetworkUnreachableError(err)) {
+        const alreadyWarned = this._killSwitch;
+        this._killSwitch = true;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!alreadyWarned) console.error(
+          `gbrain: direct connection to ${this._directUrl ? this.hostOnly(this._directUrl) : 'unknown host'} unreachable (${msg}); ` +
+          'falling back to the pooler for DDL/bulk (long migrations may hit the pooler statement timeout). ' +
+          'Set GBRAIN_DIRECT_DATABASE_URL to a reachable direct URL (e.g. the Session pooler, port 5432) or enable the Supabase IPv4 add-on; ' +
+          'GBRAIN_DISABLE_DIRECT_POOL=1 silences this.',
+        );
+        return this.getReadPool();
+      }
+      throw err;
+    }
     if (!pool) {
       // Defensive — initDirectPool should have thrown.
       throw new Error('connection-manager: direct pool init returned null');
@@ -350,8 +392,9 @@ export class ConnectionManager {
       },
     };
     const t0 = Date.now();
+    let pool: Sql | null = null;
     try {
-      const pool = postgres(this._directUrl, opts);
+      pool = postgres(this._directUrl, opts);
       // Probe to validate connectivity early.
       await pool`SELECT 1`;
       logConnectionEvent({
@@ -362,6 +405,9 @@ export class ConnectionManager {
       });
       return pool;
     } catch (err) {
+      // Don't leak the failed pool's sockets/timers (#1641 fallback keeps
+      // the process running afterward).
+      if (pool) await endPoolBounded(pool);
       logConnectionEvent({
         pool: 'ddl',
         op: 'error',

--- a/test/connection-manager.serial.test.ts
+++ b/test/connection-manager.serial.test.ts
@@ -3,6 +3,7 @@ import {
   isSupabasePoolerUrl,
   deriveDirectUrl,
   readKillSwitchEnv,
+  isNetworkUnreachableError,
   resolveDirectPoolSize,
   ConnectionManager,
   DEFAULT_DIRECT_POOL_SIZE,
@@ -237,4 +238,66 @@ describe('ConnectionManager — parent inheritance (A2)', () => {
       else process.env.GBRAIN_DISABLE_DIRECT_POOL = original;
     }
   });
+});
+
+describe('isNetworkUnreachableError (#1641)', () => {
+  test('classifies network codes as unreachable', () => {
+    for (const code of ['ENOTFOUND', 'ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH', 'ETIMEDOUT', 'CONNECT_TIMEOUT']) {
+      const err = Object.assign(new Error('connect failed'), { code });
+      expect(isNetworkUnreachableError(err)).toBe(true);
+    }
+  });
+
+  test('classifies by message when code absent', () => {
+    expect(isNetworkUnreachableError(new Error('getaddrinfo ENOTFOUND db.abc.supabase.co'))).toBe(true);
+  });
+
+  test('auth/SQL errors are NOT unreachable', () => {
+    expect(isNetworkUnreachableError(new Error('password authentication failed for user "postgres"'))).toBe(false);
+    expect(isNetworkUnreachableError(new Error('syntax error at or near "SELEC"'))).toBe(false);
+    expect(isNetworkUnreachableError(null)).toBe(false);
+  });
+});
+
+describe('ConnectionManager — direct-pool fallback on unreachable host (#1641)', () => {
+  let originalKillSwitch: string | undefined;
+  let originalError: typeof console.error;
+  let errLines: string[];
+  beforeEach(() => {
+    originalKillSwitch = process.env.GBRAIN_DISABLE_DIRECT_POOL;
+    delete process.env.GBRAIN_DISABLE_DIRECT_POOL;
+    originalError = console.error;
+    errLines = [];
+    console.error = (...args: unknown[]) => { errLines.push(args.join(' ')); };
+  });
+  afterEach(() => {
+    console.error = originalError;
+    if (originalKillSwitch === undefined) delete process.env.GBRAIN_DISABLE_DIRECT_POOL;
+    else process.env.GBRAIN_DISABLE_DIRECT_POOL = originalKillSwitch;
+  });
+
+  test('ddl() falls back to the read pool when the direct host is unreachable', async () => {
+    const cm = new ConnectionManager({
+      url: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+      // 127.0.0.1:9 (discard) → instant ECONNREFUSED, the IPv4-only-network shape.
+      directUrl: 'postgresql://postgres:p@127.0.0.1:9/db',
+    });
+    const fakeReadPool = {} as ReturnType<typeof ConnectionManager.prototype.read>;
+    cm.setReadPool(fakeReadPool);
+    expect(cm.isDualPoolActive()).toBe(true);
+
+    const pool = await cm.ddl(); // without the fix this throws ECONNREFUSED
+    expect(pool).toBe(fakeReadPool);
+    // Self-activating kill-switch: subsequent calls skip the direct pool.
+    expect(cm.isKillSwitchActive()).toBe(true);
+    expect(cm.isDualPoolActive()).toBe(false);
+    expect(cm.describeMode().mode).toBe('single (kill-switch)');
+    // One stderr line mentioning the power-user override.
+    const warning = errLines.filter(l => l.includes('GBRAIN_DIRECT_DATABASE_URL'));
+    expect(warning.length).toBe(1);
+
+    const again = await cm.ddl();
+    expect(again).toBe(fakeReadPool);
+    expect(errLines.filter(l => l.includes('GBRAIN_DIRECT_DATABASE_URL')).length).toBe(1);
+  }, 20000);
 });


### PR DESCRIPTION
Fixes #1641

## Problem

`deriveDirectUrl()` in `src/core/connection-manager.ts` unconditionally swaps a Supabase pooler URL's host to `db.<ref>.supabase.co:5432`, which is IPv6-only without the paid IPv4 add-on. On IPv4-only networks the direct pool can never connect, and `initDirectPool()` threw with no fallback — so `gbrain init --url` and migrations died with ENOTFOUND/ECONNREFUSED.

## Fix

- `getDirectPool()` now catches network-unreachable errors (ENOTFOUND, ECONNREFUSED, ENETUNREACH, EHOSTUNREACH, ETIMEDOUT, CONNECT_TIMEOUT — classified by the new exported `isNetworkUnreachableError()`), self-activates the kill-switch, logs ONE stderr line (pointing power users at `GBRAIN_DIRECT_DATABASE_URL` and `GBRAIN_DISABLE_DIRECT_POOL=1`), and returns the read pool. Subsequent `ddl()`/`bulk()` calls short-circuit via the kill-switch, so init/migrations proceed on the pooler.
- Auth/SQL errors still throw — they mean misconfiguration, not unreachability.
- The failed direct pool is ended via `endPoolBounded` so it can't leak sockets/timers into the now-continuing process.
- The `init.ts` IPv6 warning blocks and `docs/guides/live-sync.md` now mention the fallback + both env overrides (previously `GBRAIN_DISABLE_DIRECT_POOL` was undocumented outside `connection-manager.ts`). `llms-full.txt` regenerated via `bun run build:llms`.

## Tests

- `test/connection-manager.serial.test.ts`: new `isNetworkUnreachableError` classification tests + a behavioral test where a manager with a Supabase pooler URL and an unreachable direct URL (`127.0.0.1:9`, instant ECONNREFUSED) has `ddl()` return the read pool, flip the kill-switch, and warn exactly once. Fails without the fix (previously threw ECONNREFUSED).
- `bun run typecheck` exit 0; `bun test test/connection-manager.serial.test.ts test/connection-resilience.test.ts test/build-llms.test.ts` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)