### PR TITLE
fix(init,mcp): seed init AI options from env on cold install; whoami reports stdio transport

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -161,13 +161,48 @@ interface ResolveAIOptionsArgs {
   nonInteractive: boolean;       // --non-interactive (forces D3 fail-loud, no picker)
 }
 
-interface ResolvedAIOptions {
+export interface ResolvedAIOptions {
   embedding_model?: string;
   embedding_dimensions?: number;
   expansion_model?: string;
   chat_model?: string;
   /** v0.37 (D9): user opted into deferred embedding setup. */
   noEmbedding?: boolean;
+}
+
+/**
+ * Seed init's AI options from persisted config, falling back to the raw env
+ * vars when loadConfig() returned null (#1058). On a cold install (no
+ * config.json AND no DATABASE_URL) loadConfig short-circuits BEFORE its env
+ * merge, so GBRAIN_EMBEDDING_MODEL / GBRAIN_EMBEDDING_DIMENSIONS /
+ * GBRAIN_EXPANSION_MODEL / GBRAIN_CHAT_MODEL were silently ignored by init
+ * and Tier-3 detection auto-picked by API key instead. Exported for unit
+ * tests (env injectable).
+ */
+export function seedAIOptionsFromConfig(
+  cfg: GBrainConfig | null,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedAIOptions {
+  const envDims = env.GBRAIN_EMBEDDING_DIMENSIONS
+    ? parseInt(env.GBRAIN_EMBEDDING_DIMENSIONS, 10)
+    : NaN;
+  const seed = cfg ?? {
+    embedding_disabled: undefined,
+    embedding_model: env.GBRAIN_EMBEDDING_MODEL,
+    embedding_dimensions: Number.isFinite(envDims) ? envDims : undefined,
+    expansion_model: env.GBRAIN_EXPANSION_MODEL,
+    chat_model: env.GBRAIN_CHAT_MODEL,
+  };
+  const out: ResolvedAIOptions = {};
+  if (seed.embedding_disabled) {
+    out.noEmbedding = true;
+  } else if (seed.embedding_model) {
+    out.embedding_model = seed.embedding_model;
+    if (seed.embedding_dimensions) out.embedding_dimensions = seed.embedding_dimensions;
+  }
+  if (seed.expansion_model) out.expansion_model = seed.expansion_model;
+  if (seed.chat_model) out.chat_model = seed.chat_model;
+  return out;
 }
 
 /**
@@ -203,18 +238,13 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
   // user already opted into deferred mode.
   try {
     const { loadConfig } = await import('../core/config.ts');
-    const cfg = loadConfig();
-    if (cfg?.embedding_disabled) {
-      out.noEmbedding = true;
-    } else if (cfg?.embedding_model) {
-      out.embedding_model = cfg.embedding_model;
-      if (cfg.embedding_dimensions) out.embedding_dimensions = cfg.embedding_dimensions;
-    }
-    if (cfg?.expansion_model) out.expansion_model = cfg.expansion_model;
-    if (cfg?.chat_model) out.chat_model = cfg.chat_model;
+    // #1058: loadConfig() returns null on a cold install (no config.json AND
+    // no DATABASE_URL) — before it ever reaches its env merge. The seed helper
+    // falls back to the same GBRAIN_* env vars directly in that case.
+    Object.assign(out, seedAIOptionsFromConfig(loadConfig()));
   } catch {
-    // loadConfig throws when no brain configured — first-time install, fall
-    // through to env detection.
+    // loadConfig threw — treat as first-time install, fall through to env
+    // detection.
   }
 
   // --- Tier 1+2: explicit flags ---------------------------------------------

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -333,6 +333,15 @@ export interface OperationContext {
    */
   remote: boolean;
   /**
+   * Transport marker for auth-less remote surfaces (#1061). The stdio MCP
+   * dispatch sets 'stdio' — it is deliberately `remote: true` (agent-facing,
+   * untrusted) but has no per-token auth (local pipe), so identity ops like
+   * whoami need a way to distinguish "known auth-less transport" from "a
+   * transport bug forgot to thread ctx.auth". Trust decisions MUST NOT key
+   * off this field — only `ctx.remote === false` grants trust.
+   */
+  transport?: 'stdio';
+  /**
    * Subagent runtime context (v0.16+). Set by the subagent tool dispatcher when
    * dispatching an op as a tool call from an LLM loop. Used to enforce per-op
    * agent policy (e.g. put_page namespace rule).
@@ -3713,9 +3722,10 @@ const whoami: Operation = {
     'Introspect the calling identity. Returns one of three transport shapes: ' +
     '{transport: "oauth", client_id, client_name, scopes, expires_at}, ' +
     '{transport: "legacy", token_name, scopes, expires_at: null}, or ' +
-    '{transport: "local", scopes: []}. Throws unknown_transport when the ' +
-    'context is ambiguous (remote=true without auth) — fail-closed posture ' +
-    'mirroring the v0.26.9 trust-boundary contract.',
+    '{transport: "local", scopes: []}, or {transport: "stdio", scopes: []} ' +
+    'for the auth-less stdio MCP pipe. Throws unknown_transport when the ' +
+    'context is ambiguous (remote=true without auth and no transport marker) ' +
+    '— fail-closed posture mirroring the v0.26.9 trust-boundary contract.',
   params: {},
   scope: 'read',
   handler: async (ctx) => {
@@ -3726,6 +3736,12 @@ const whoami: Operation = {
     // special-case `transport: 'local'` explicitly.
     if (ctx.remote === false) {
       return { transport: 'local', scopes: [] };
+    }
+    // #1061: stdio MCP is remote/untrusted by design but has no per-token
+    // auth (local pipe) — a known transport, not a bug. Report it instead of
+    // throwing. Empty scopes: nothing here may be used to gate anything.
+    if (!ctx.auth && ctx.transport === 'stdio') {
+      return { transport: 'stdio', scopes: [] };
     }
     if (!ctx.auth) {
       throw new OperationError(

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -33,6 +33,12 @@ export interface DispatchOpts {
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
   /**
+   * #1061: transport marker for auth-less remote surfaces. The stdio MCP
+   * server passes 'stdio' so identity ops (whoami) can report the transport
+   * instead of throwing unknown_transport. Never used for trust decisions.
+   */
+  transport?: OperationContext['transport'];
+  /**
    * v0.28: per-token allow-list for the takes.holder field. Threaded by
    * the HTTP/stdio transport from `access_tokens.permissions.takes_holders`.
    * When set, takes_list / takes_search / query (when it returns takes)
@@ -203,6 +209,7 @@ export function buildOperationContext(
     logger: opts.logger || stderrLogger,
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
+    transport: opts.transport,
     takesHoldersAllowList: opts.takesHoldersAllowList,
     // v0.34 D4: sourceId is REQUIRED at the type level. Auto-fill 'default'
     // for single-source brains and any caller who didn't resolve a sourceId.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -42,6 +42,10 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      // #1061: mark the transport so whoami can report {transport: 'stdio'}
+      // instead of throwing unknown_transport. Trust posture unchanged —
+      // stdio stays remote/untrusted.
+      transport: 'stdio',
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/init-env-detection.test.ts
+++ b/test/init-env-detection.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { groupReadyByProvider, findEnvKeyTypos } from '../src/commands/init.ts';
+import { groupReadyByProvider, findEnvKeyTypos, seedAIOptionsFromConfig } from '../src/commands/init.ts';
 
 describe('groupReadyByProvider — embedding touchpoint', () => {
   test('OPENAI_API_KEY alone → openai is ready', async () => {
@@ -147,5 +147,49 @@ describe('findEnvKeyTypos', () => {
     const got = await findEnvKeyTypos({ COMPLETELY_UNRELATED_KEY: 'foo' });
     // Should not match any canonical via Levenshtein ≤ 3.
     expect(got.find(t => t.userSet === 'COMPLETELY_UNRELATED_KEY')).toBeUndefined();
+  });
+});
+
+describe('seedAIOptionsFromConfig — #1058 cold-install env fallback', () => {
+  test('null config (no config.json, no DATABASE_URL) falls back to GBRAIN_* env vars', () => {
+    const got = seedAIOptionsFromConfig(null, {
+      GBRAIN_EMBEDDING_MODEL: 'voyage:voyage-3-large',
+      GBRAIN_EMBEDDING_DIMENSIONS: '1024',
+      GBRAIN_EXPANSION_MODEL: 'openai:gpt-5-mini',
+      GBRAIN_CHAT_MODEL: 'anthropic:claude-sonnet-4-6',
+    });
+    expect(got.embedding_model).toBe('voyage:voyage-3-large');
+    expect(got.embedding_dimensions).toBe(1024);
+    expect(got.expansion_model).toBe('openai:gpt-5-mini');
+    expect(got.chat_model).toBe('anthropic:claude-sonnet-4-6');
+  });
+
+  test('null config + no env vars → empty seed (Tier-3 detection takes over)', () => {
+    const got = seedAIOptionsFromConfig(null, {});
+    expect(got).toEqual({});
+  });
+
+  test('persisted config wins (loadConfig already merged env when non-null)', () => {
+    const got = seedAIOptionsFromConfig(
+      { engine: 'pglite', embedding_model: 'openai:text-embedding-3-small', embedding_dimensions: 1536 } as any,
+      { GBRAIN_EMBEDDING_MODEL: 'voyage:voyage-3-large' },
+    );
+    expect(got.embedding_model).toBe('openai:text-embedding-3-small');
+    expect(got.embedding_dimensions).toBe(1536);
+  });
+
+  test('embedding_disabled sentinel honored on re-init', () => {
+    const got = seedAIOptionsFromConfig({ engine: 'pglite', embedding_disabled: true } as any, {});
+    expect(got.noEmbedding).toBe(true);
+    expect(got.embedding_model).toBeUndefined();
+  });
+
+  test('non-numeric GBRAIN_EMBEDDING_DIMENSIONS ignored, model still seeds', () => {
+    const got = seedAIOptionsFromConfig(null, {
+      GBRAIN_EMBEDDING_MODEL: 'voyage:voyage-3-large',
+      GBRAIN_EMBEDDING_DIMENSIONS: 'not-a-number',
+    });
+    expect(got.embedding_model).toBe('voyage:voyage-3-large');
+    expect(got.embedding_dimensions).toBeUndefined();
   });
 });

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -94,6 +94,35 @@ describe('whoami op contract', () => {
     expect(result.expires_at).toBeNull();
   });
 
+  // #1061: stdio MCP is remote/untrusted by design but has no per-token auth
+  // (local pipe). The stdio dispatch marks ctx.transport='stdio'; whoami
+  // reports it instead of throwing unknown_transport.
+  test('stdio transport (remote=true, no auth, transport marker) reports stdio', async () => {
+    const result = (await whoami.handler(
+      ctxWith({ remote: true, auth: undefined, transport: 'stdio' }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('stdio');
+    expect(result.scopes).toEqual([]);
+  });
+
+  test('stdio marker does not mask real auth (auth still wins)', async () => {
+    const result = (await whoami.handler(
+      ctxWith({
+        remote: true,
+        transport: 'stdio',
+        auth: {
+          token: 'gbrain_at_xxx',
+          clientId: 'gbrain_cl_abc',
+          scopes: ['read'],
+          expiresAt: 1,
+        } as AuthInfo,
+      }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('oauth');
+  });
+
   // Q3: ambiguous transport — fail-closed. The footgun this guards against
   // is a future transport that lands without threading auth, where a buggy
   // caller might trust whoami's output to gate sensitive ops.


### PR DESCRIPTION
Two adversarially-verified backlog items (work unit c50).

## Fixes #1058 — init: GBRAIN_EMBEDDING_MODEL/DIMENSIONS env vars ignored on cold install

`loadConfig()` returns `null` when there is no `config.json` AND no `DATABASE_URL` — short-circuiting before its env merge — so `GBRAIN_EMBEDDING_MODEL`, `GBRAIN_EMBEDDING_DIMENSIONS`, `GBRAIN_EXPANSION_MODEL`, and `GBRAIN_CHAT_MODEL` were silently ignored by `gbrain init` and Tier-3 detection auto-picked by API-key readiness instead (or fail-louded for local providers like lmstudio that have no auth env). The config-seed block in `resolveAIOptions` now falls back to those env vars directly when `loadConfig()` is null, via a new exported, env-injectable helper `seedAIOptionsFromConfig`. No change to the `loadConfig` contract; flag tiers still win over the seed.

## Fixes #1061 — mcp__gbrain__whoami throws unknown_transport on stdio MCP

The stdio MCP dispatch is deliberately `remote: true` (agent-facing, untrusted) and has no per-token auth (local pipe), so `whoami` threw `unknown_transport` on the primary stdio surface. The stdio call site now marks `ctx.transport = 'stdio'` (threaded through `DispatchOpts` → `buildOperationContext`), and `whoami` returns `{transport: 'stdio', scopes: []}` for it. Trust posture unchanged: `remote` stays `true`, the marker is documented as never-for-trust-decisions, and an unmarked auth-less remote context still throws (fail-closed contract preserved — the issue's own suggested fix of flipping `remote: false` was rejected for breaching that invariant).

## Tests

- `test/init-env-detection.test.ts`: 5 new cases for `seedAIOptionsFromConfig` (null-config env fallback, empty seed, persisted-config precedence, `embedding_disabled` sentinel, non-numeric dims).
- `test/whoami.test.ts`: stdio marker returns `{transport: 'stdio', scopes: []}`; marker does not mask real auth; existing fail-closed throw cases untouched and still pass.
- `bun run typecheck` exit 0; touched suites + adjacent init/mcp suites (92 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)