### PR TITLE
fix(migrate): bootstrap --to pglite --path destination as a standalone GBRAIN_HOME

### DIFF
--- a/src/commands/migrate-engine.ts
+++ b/src/commands/migrate-engine.ts
@@ -3,7 +3,11 @@
  *
  * Usage:
  *   gbrain migrate --to supabase [--url <connection_string>]
+ *     (--url is persisted to config.json, mode 0600, so the migrated brain
+ *      works without env — #1271)
  *   gbrain migrate --to pglite [--path <db_path>]
+ *     (an explicit --path destination is bootstrapped with its own
+ *      <path>/.gbrain/config.json so GBRAIN_HOME=<path> just works — #1271)
  *   gbrain migrate --to <engine> --force  (overwrite non-empty target)
  */
 
@@ -11,9 +15,9 @@ import { createEngine } from '../core/engine-factory.ts';
 import { loadConfig, saveConfig, toEngineConfig, gbrainPath, effectiveEnvDatabaseUrl, type GBrainConfig } from '../core/config.ts';
 import type { BrainEngine } from '../core/engine.ts';
 import type { EngineConfig } from '../core/types.ts';
-import { writeFileSync, readFileSync, existsSync, unlinkSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, chmodSync } from 'fs';
 import { createHash } from 'crypto';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 
@@ -57,6 +61,31 @@ export interface MigrateManifest {
   target_id?: string;
   schema_version?: number;
   started_at: string;
+}
+
+/**
+ * #1271 Finding 1: make an explicit `--to pglite --path P` destination usable
+ * as a standalone brain. Writes `P/.gbrain/config.json` (mode 0600, plus a
+ * `*` .gitignore) so `GBRAIN_HOME=P` resolves without a manual `gbrain init`.
+ * Never clobbers an existing config at the destination. Returns the written
+ * config path, or null when skipped.
+ */
+export function bootstrapDestinationConfig(dbPath: string): string | null {
+  const abs = resolve(dbPath);
+  const dir = join(abs, '.gbrain');
+  const file = join(dir, 'config.json');
+  if (existsSync(file)) return null;
+  mkdirSync(dir, { recursive: true });
+  const cfg: GBrainConfig = { engine: 'pglite', database_path: abs };
+  writeFileSync(file, JSON.stringify(cfg, null, 2) + '\n', { mode: 0o600 });
+  try { chmodSync(file, 0o600); } catch { /* platform-specific */ }
+  // Same worktree-safety pattern as saveConfig()'s ensureGitignore, scoped
+  // to the destination home. Don't clobber a user-customized .gitignore.
+  const gitignore = join(dir, '.gitignore');
+  if (!existsSync(gitignore)) {
+    writeFileSync(gitignore, '*\n', { mode: 0o600 });
+  }
+  return file;
 }
 
 export function migrationTargetId(config: EngineConfig): string {
@@ -351,6 +380,25 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
       : { database_path: targetConfig.database_path, database_url: undefined }),
   };
   saveConfig(newConfig);
+
+  // #1271 Finding 2 (by design, but say it out loud): the connection string
+  // is persisted so the migrated brain works without env. Mode 0600.
+  if (opts.targetEngine === 'postgres' && opts.targetUrl) {
+    console.error('Note: the --url connection string (including credentials) is persisted to config.json (mode 0600).');
+  }
+
+  // #1271 Finding 1: an explicit --path destination doubles as a standalone
+  // GBRAIN_HOME. Best-effort — never fail a completed migration over it.
+  if (opts.targetEngine === 'pglite' && opts.targetPath) {
+    try {
+      const written = bootstrapDestinationConfig(opts.targetPath);
+      if (written) {
+        console.log(`Destination bootstrapped: ${written} (usable via GBRAIN_HOME=${resolve(opts.targetPath)})`);
+      }
+    } catch (e) {
+      console.warn(`  WARN could not bootstrap destination config: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
 
   // Clean up
   clearManifest();

--- a/test/migrate-engine-dest-bootstrap.test.ts
+++ b/test/migrate-engine-dest-bootstrap.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { bootstrapDestinationConfig } from '../src/commands/migrate-engine.ts';
+import { loadConfigFileOnly } from '../src/core/config.ts';
+
+describe('migrate --to pglite destination bootstrap (#1271)', () => {
+  test('writes <path>/.gbrain/config.json so GBRAIN_HOME=<path> resolves a brain', () => {
+    const dest = mkdtempSync(join(tmpdir(), 'gbrain-dest-'));
+    const written = bootstrapDestinationConfig(dest);
+    const file = join(dest, '.gbrain', 'config.json');
+    expect(written).toBe(file);
+
+    const cfg = JSON.parse(readFileSync(file, 'utf-8'));
+    expect(cfg.engine).toBe('pglite');
+    expect(cfg.database_path).toBe(resolve(dest));
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    // worktree safety: destination home is git-ignored like saveConfig()'s home
+    expect(readFileSync(join(dest, '.gbrain', '.gitignore'), 'utf-8')).toBe('*\n');
+
+    // The exact failure mode from #1271: config resolution under
+    // GBRAIN_HOME=<path> used to find nothing ("No brain configured").
+    const prev = process.env.GBRAIN_HOME;
+    process.env.GBRAIN_HOME = dest;
+    try {
+      const loaded = loadConfigFileOnly();
+      expect(loaded?.engine).toBe('pglite');
+      expect(loaded?.database_path).toBe(resolve(dest));
+    } finally {
+      if (prev === undefined) delete process.env.GBRAIN_HOME;
+      else process.env.GBRAIN_HOME = prev;
+    }
+  });
+
+  test('never clobbers an existing destination config', () => {
+    const dest = mkdtempSync(join(tmpdir(), 'gbrain-dest-'));
+    mkdirSync(join(dest, '.gbrain'), { recursive: true });
+    writeFileSync(join(dest, '.gbrain', 'config.json'), '{"engine":"postgres"}\n');
+
+    expect(bootstrapDestinationConfig(dest)).toBe(null);
+    expect(JSON.parse(readFileSync(join(dest, '.gbrain', 'config.json'), 'utf-8')).engine).toBe('postgres');
+  });
+});

--- a/test/migrate-engine-dest-bootstrap.test.ts
+++ b/test/migrate-engine-dest-bootstrap.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { bootstrapDestinationConfig } from '../src/commands/migrate-engine.ts';
 import { loadConfigFileOnly } from '../src/core/config.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 describe('migrate --to pglite destination bootstrap (#1271)', () => {
-  test('writes <path>/.gbrain/config.json so GBRAIN_HOME=<path> resolves a brain', () => {
+  test('writes <path>/.gbrain/config.json so GBRAIN_HOME=<path> resolves a brain', async () => {
     const dest = mkdtempSync(join(tmpdir(), 'gbrain-dest-'));
     const written = bootstrapDestinationConfig(dest);
     const file = join(dest, '.gbrain', 'config.json');
@@ -21,16 +22,11 @@ describe('migrate --to pglite destination bootstrap (#1271)', () => {
 
     // The exact failure mode from #1271: config resolution under
     // GBRAIN_HOME=<path> used to find nothing ("No brain configured").
-    const prev = process.env.GBRAIN_HOME;
-    process.env.GBRAIN_HOME = dest;
-    try {
+    await withEnv({ GBRAIN_HOME: dest }, () => {
       const loaded = loadConfigFileOnly();
       expect(loaded?.engine).toBe('pglite');
       expect(loaded?.database_path).toBe(resolve(dest));
-    } finally {
-      if (prev === undefined) delete process.env.GBRAIN_HOME;
-      else process.env.GBRAIN_HOME = prev;
-    }
+    });
   });
 
   test('never clobbers an existing destination config', () => {


### PR DESCRIPTION
Fixes #1271

**Finding 1 (fixed):** `gbrain migrate --to pglite --path P` completed successfully but left the destination unusable — `GBRAIN_HOME=P gbrain query ...` failed with `No brain configured` because nothing wrote `P/.gbrain/config.json`. The migration finalization now bootstraps the explicit-`--path` destination with its own `config.json` (`{engine: 'pglite', database_path: <abs path>}`, mode 0600) plus a `*` `.gitignore` (same worktree-safety pattern as `saveConfig`). It never clobbers an existing destination config and is best-effort — a completed migration never fails over it. Default-path migrations (no `--path`) are unchanged; the current home's config already covers those.

**Finding 2 (documented, by design):** persisting `--url` to config.json is required for the migrated brain to work without env — `gbrain init` for postgres persists `database_url` identically, and `saveConfig` already writes 0600 + a home `.gitignore`. Rather than change behavior, the persistence is now stated out loud: a one-line stderr note at migrate time when `--url` is used, and a note in the command's usage header.

**Test:** `test/migrate-engine-dest-bootstrap.test.ts` — asserts the destination config shape, 0600 mode, .gitignore, that `loadConfigFileOnly()` under `GBRAIN_HOME=<dest>` now resolves (the exact failure mode from the issue), and the no-clobber guard. Fails without the fix.

Gate: `bun run typecheck` exit 0; new + adjacent migrate-engine tests pass. (`test/migrate-stdout-clean.test.ts` hook-timeout is pre-existing on master, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)