### PR TITLE
fix(migrations): v0.32.2 dirty-check scoped to targeted sources + failed-phase detail at CLI

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -438,6 +438,13 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
       const result = await m.orchestrator(orchestratorOptsFrom(cli));
       if (result.status === 'failed') {
         console.error(`Migration v${m.version} reported status=failed.`);
+        // Surface each failed phase's detail — the ledger records it, but
+        // the operator needs it on stderr to act (#921).
+        for (const p of result.phases) {
+          if (p.status === 'failed') {
+            console.error(`  phase ${p.name}: ${p.detail ?? '(no detail)'}`);
+          }
+        }
         // Record the attempt as 'partial' (not 'complete') so the cap counts
         // it. Don't let a failed orchestrator look like it never ran.
         try {

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -186,17 +186,6 @@ async function phaseBFenceFacts(
     const localPathById = new Map<string, string | null>();
     for (const s of sources) localPathById.set(s.id, s.local_path);
 
-    // Dirty-tree refusal: check every source's local_path before writing.
-    for (const [id, localPath] of localPathById) {
-      if (localPath && isLocalPathDirty(localPath)) {
-        return {
-          name: 'fence_facts',
-          status: 'failed',
-          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
-        };
-      }
-    }
-
     // Walk legacy rows in (source_id, entity_slug) groups for per-page
     // atomic writes.
     const legacy = await engine.executeRaw<LegacyFactRow>(
@@ -233,6 +222,21 @@ async function phaseBFenceFacts(
       const list = groups.get(key) ?? [];
       list.push(row);
       groups.set(key, list);
+    }
+
+    // Dirty-tree refusal: check ONLY the sources we are about to write
+    // into. A dirty tree in an unrelated source (or zero fenceable rows
+    // at all) must not block a no-op or a targeted backfill (#927).
+    const targetSourceIds = new Set([...groups.keys()].map(k => k.split('\0')[0]));
+    for (const id of targetSourceIds) {
+      const localPath = localPathById.get(id);
+      if (localPath && isLocalPathDirty(localPath)) {
+        return {
+          name: 'fence_facts',
+          status: 'failed',
+          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
+        };
+      }
     }
 
     for (const [key, group] of groups) {

--- a/test/apply-migrations.test.ts
+++ b/test/apply-migrations.test.ts
@@ -180,3 +180,16 @@ describe('runApplyMigrations exit codes (v0.36.1.x #1062)', () => {
     expect(src).toMatch(/All migrations up to date[\s\S]{0,80}process\.exit\(0\)/);
   });
 });
+
+// #921: a failed orchestrator must print each failed phase's detail to
+// stderr — not just "reported status=failed" — so the operator can act
+// without digging through the ledger.
+describe('failed migration prints phase detail (#921)', () => {
+  test('runner loops result.phases and console.errors failed phase details', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync('src/commands/apply-migrations.ts', 'utf8');
+    expect(src).toMatch(
+      /reported status=failed[\s\S]{0,400}for \(const p of result\.phases\)[\s\S]{0,200}p\.status === 'failed'[\s\S]{0,200}console\.error\([\s\S]{0,80}p\.name[\s\S]{0,80}p\.detail/,
+    );
+  });
+});

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -10,10 +10,11 @@
  * __setTestEngineOverride so we don't need a configured brain.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { v0_32_2, __setTestEngineOverride, __testing } from '../src/commands/migrations/v0_32_2.ts';
@@ -235,6 +236,52 @@ describe('phaseBFenceFacts — happy path backfill', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows = await (engine as any).db.query('SELECT row_num FROM facts');
     expect(rows.rows[0].row_num).toBeNull();
+  });
+});
+
+describe('phaseBFenceFacts — dirty-tree refusal scoping (#927)', () => {
+  let dirtyDir: string;
+
+  beforeEach(async () => {
+    // A second source whose local_path is a git repo with uncommitted changes.
+    dirtyDir = mkdtempSync(join(tmpdir(), 'mig-v0_32_2-dirty-'));
+    execFileSync('git', ['-C', dirtyDir, 'init', '-q']);
+    writeFileSync(join(dirtyDir, 'uncommitted.md'), 'dirty', 'utf-8');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO sources (id, name, local_path) VALUES ('other', 'other', $1)`,
+      [dirtyDir],
+    );
+  });
+
+  afterEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(`DELETE FROM sources WHERE id = 'other'`);
+    rmSync(dirtyDir, { recursive: true, force: true });
+  });
+
+  test('no legacy facts at all → complete, dirty unrelated source ignored', async () => {
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('scanned=0');
+  });
+
+  test('facts scoped to a clean source fence despite dirty unrelated source', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Founded Acme' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('fenced=1');
+    expect(existsSync(join(brainDir, 'people/alice.md'))).toBe(true);
+  });
+
+  test('still refuses when the TARGETED source is dirty', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'F1', source_id: 'other' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('failed');
+    expect(r.detail).toContain('"other"');
+    expect(r.detail).toContain('uncommitted changes');
   });
 });
 


### PR DESCRIPTION
Two operator-facing fixes to the v0.32.2 facts-migration path.

## Fixes #927 — dirty-check unrelated sources before no-op detection

`phaseBFenceFacts` dirty-checked every source's `local_path` before even querying for legacy (`row_num IS NULL`) rows. A brain with zero fenceable facts — or facts scoped only to source A — failed the migration because unrelated source B had uncommitted changes, and the refusal named the unrelated source.

Now the legacy query + grouping runs first, and the dirty-tree refusal checks only the source_ids the phase will actually write into. Zero groups = zero dirty checks = clean no-op complete. The refusal for a genuinely targeted dirty source is unchanged.

## Fixes #921 — status=failed printed with no actionable detail

`apply-migrations` printed only `Migration vX reported status=failed.`; the failed phase's detail (e.g. the commit-or-stash instruction) went to the ledger but never to the operator. The runner now loops `result.phases` and prints each failed phase's name + detail to stderr (same path covers the WEDGED force-retry loop).

## Tests

- `test/migrations-v0_32_2.test.ts`: new describe block — no-op with dirty unrelated source completes; clean-source facts fence despite dirty unrelated source; targeted dirty source still refuses. First two fail without the fix.
- `test/apply-migrations.test.ts`: source assertion (file's established pattern for runner-path behavior) that failed phase details are console.error'd. Fails without the fix.
- `bun run typecheck` exit 0; both test files 37 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)