### PR TITLE
feat(dream): orchestrator-owned transcript metadata + transcriptSource discovery field

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -1139,7 +1139,8 @@ async function collectChildPutPageSlugs(
        FROM subagent_tool_executions
       WHERE job_id = ANY($1::int[])
         AND tool_name = 'brain_put_page'
-        AND status = 'complete'`,
+        AND status = 'complete'
+      ORDER BY id`,
     [childIds],
   );
   const rewritten = new Map<string, number>();
@@ -1149,7 +1150,10 @@ async function collectChildPutPageSlugs(
     const finalSlug = meta && meta.chunkTotal > 1
       ? rewriteChunkedSlug(r.slug, meta.hash6, meta.idx)
       : r.slug;
-    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, r.job_id);
+    // Last writer wins, in execution-row order (ORDER BY id): if two children
+    // collide on a final slug, the pages row holds the LAST put_page write, so
+    // the stamp must attribute that child's transcript — not an arbitrary one.
+    rewritten.set(finalSlug, r.job_id);
   }
   return [...rewritten.entries()]
     .sort(([a], [b]) => a.localeCompare(b))

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -428,8 +428,13 @@ export async function runPhaseSynthesize(
 
     const queue = new MinionQueue(engine);
     const childIds: number[] = [];
-    /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
-    const chunkInfo = new Map<number, { idx: number; hash6: string }>();
+    /**
+     * Map child job_id → transcript metadata. Drives D6 orchestrator-side
+     * slug rewrite for chunked transcripts AND the deterministic frontmatter
+     * stampDreamProvenance merges into each written page. Populated for
+     * every child (single-chunk children carry chunkTotal=1).
+     */
+    const childMeta = new Map<number, ChildMeta>();
     /** Skip reasons for the cycle report (D5 cap hits, D8 legacy-key skips). */
     const skipReports: Array<{ filePath: string; reason: string }> = [];
 
@@ -513,9 +518,14 @@ export async function runPhaseSynthesize(
           { allowProtectedSubmit: true },
         );
         childIds.push(child.id);
-        if (isChunked) {
-          chunkInfo.set(child.id, { idx: i, hash6 });
-        }
+        childMeta.set(child.id, {
+          idx: i,
+          hash6,
+          chunkTotal: chunks.length,
+          transcriptSource: t.transcriptSource,
+          transcriptId: stripContentVersionSuffix(t.basename),
+          inferredDate: t.inferredDate,
+        });
       }
     }
 
@@ -544,14 +554,14 @@ export async function runPhaseSynthesize(
 
     // Collect slugs from put_page tool executions across the children
     // (codex finding #2: deterministic provenance, NOT pages.updated_at).
-    // D6 orchestrator slug rewrite: chunkInfo drives post-hoc rewrite of
+    // D6 orchestrator slug rewrite: childMeta drives post-hoc rewrite of
     // bare-hash slugs to `<hash6>-c<idx>` so chunked siblings can't collide
     // even if Sonnet drops the chunk suffix.
     // v0.32.8: refs carry source_id so reverseWriteRefs picks the correct
     // (source, slug) row. #1586: refs are stamped with the cycle's resolved
     // source (children write there via SubagentHandlerData.source_id).
     const cycleSourceId = opts.sourceId ?? 'default';
-    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, chunkInfo, cycleSourceId);
+    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, childMeta, cycleSourceId);
 
     const summaryDate = opts.date ?? today();
 
@@ -559,7 +569,12 @@ export async function runPhaseSynthesize(
     // of every child-written page BEFORE reverse-rendering, so generated pages
     // are queryable (`frontmatter->>'dream_generated'`) and a later put_page
     // write-through (which re-renders from the DB row) can't erase the stamp.
-    await stampDreamProvenance(engine, writtenRefs, summaryDate);
+    // #2285: the stamp also carries the orchestrator-owned deterministic
+    // frontmatter (transcript_id, transcript_source, transcript_hash, date,
+    // chunk) derived from childMeta — subagent drift on those fields can't
+    // leak, and reverseWriteRefs below re-reads the row so the same fields
+    // land in the on-disk markdown.
+    await stampDreamProvenance(engine, writtenRefs, summaryDate, childMeta);
 
     // Dual-write: reverse-render each DB row → markdown file.
     const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs, cycleSourceId);
@@ -1095,15 +1110,17 @@ function sanitizeForSlug(s: string): string {
  * fake"): we no longer need detection because the rewrite enforces
  * uniqueness at slug-write time.
  *
- * `chunkInfo` maps child job_id → { chunk_index, hash6 }. Single-chunk
- * children are absent from the map and pass through unchanged.
+ * `childMeta` maps child job_id → per-child transcript metadata. Chunked
+ * children (chunkTotal > 1) get the slug rewrite; single-chunk children
+ * pass through unchanged. Each returned ref carries the job_id that wrote
+ * it so stampDreamProvenance can pair the slug back to its childMeta entry.
  */
 async function collectChildPutPageSlugs(
   engine: BrainEngine,
   childIds: number[],
-  chunkInfo: Map<number, { idx: number; hash6: string }>,
+  childMeta: Map<number, ChildMeta>,
   sourceId = 'default',
-): Promise<Array<{ slug: string; source_id: string }>> {
+): Promise<Array<{ slug: string; source_id: string; jobId: number }>> {
   if (childIds.length === 0) return [];
   // Raw fetch — NO SELECT DISTINCT. Preserves per-child slug duplicates so
   // the orchestrator sees what each child wrote. COALESCE handles both
@@ -1125,13 +1142,66 @@ async function collectChildPutPageSlugs(
         AND status = 'complete'`,
     [childIds],
   );
-  const rewritten = new Set<string>();
+  const rewritten = new Map<string, number>();
   for (const r of rows) {
     if (typeof r.slug !== 'string' || r.slug.length === 0) continue;
-    const ci = chunkInfo.get(r.job_id);
-    rewritten.add(ci ? rewriteChunkedSlug(r.slug, ci.hash6, ci.idx) : r.slug);
+    const meta = childMeta.get(r.job_id);
+    const finalSlug = meta && meta.chunkTotal > 1
+      ? rewriteChunkedSlug(r.slug, meta.hash6, meta.idx)
+      : r.slug;
+    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, r.job_id);
   }
-  return Array.from(rewritten).sort().map(slug => ({ slug, source_id: sourceId }));
+  return [...rewritten.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([slug, jobId]) => ({ slug, source_id: sourceId, jobId }));
+}
+
+/**
+ * Per-child orchestrator state. Drives D6 chunked-slug rewrite (idx + hash6)
+ * AND the deterministic frontmatter stampDreamProvenance merges into each
+ * written page. Populated for every child, not just chunked ones.
+ */
+interface ChildMeta {
+  idx: number;
+  hash6: string;
+  chunkTotal: number;
+  transcriptSource: string | null;
+  transcriptId: string;
+  inferredDate: string | null;
+}
+
+/**
+ * Strip the content-version suffix that claude-code-archive appends when a
+ * conversation is edited (`<uuid>--<contentHash>.md`). The session UUID is
+ * the stable transcript identifier; the suffix changes with content. Used to
+ * populate `transcript_id` so edits of the same session collapse to one id.
+ */
+function stripContentVersionSuffix(basename: string): string {
+  return basename.replace(/--[a-f0-9]+$/i, '');
+}
+
+/**
+ * Deterministic frontmatter for one synthesized page (#2285). Every field
+ * here is owned by the orchestrator — the subagent's value for any of these
+ * is overwritten. The subagent retains authority over type / title / tags /
+ * body. `date` feeds the effective-date precedence chain
+ * (src/core/effective-date.ts) so re-imports keep the conversation date even
+ * when sync tools re-stamp file mtimes.
+ */
+function buildDeterministicFrontmatter(
+  meta: ChildMeta,
+  cycleDate: string,
+): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {
+    dream_generated: true,
+    dream_cycle_date: cycleDate,
+    transcript_id: meta.transcriptId,
+    transcript_hash: meta.hash6,
+  };
+  if (meta.transcriptSource) overrides.transcript_source = meta.transcriptSource;
+  if (meta.chunkTotal > 1) overrides.chunk = `${meta.idx + 1}/${meta.chunkTotal}`;
+  if (meta.inferredDate) overrides.date = meta.inferredDate;
+  return overrides;
 }
 
 /**
@@ -1177,12 +1247,19 @@ async function hasLegacySingleChunkCompletion(
  */
 async function stampDreamProvenance(
   engine: BrainEngine,
-  refs: Array<{ slug: string; source_id: string }>,
+  refs: Array<{ slug: string; source_id: string; jobId?: number }>,
   cycleDate: string,
+  childMeta?: Map<number, ChildMeta>,
 ): Promise<void> {
   if (refs.length === 0) return;
   const { executeRawJsonb } = await import('../sql-query.ts');
-  for (const { slug, source_id } of refs) {
+  for (const { slug, source_id, jobId } of refs) {
+    // #2285: when the ref pairs back to a child, the stamp also carries the
+    // orchestrator-owned deterministic frontmatter for that transcript.
+    const meta = jobId !== undefined ? childMeta?.get(jobId) : undefined;
+    const stamp = meta
+      ? buildDeterministicFrontmatter(meta, cycleDate)
+      : { dream_generated: true, dream_cycle_date: cycleDate };
     try {
       await executeRawJsonb(
         engine,
@@ -1190,7 +1267,7 @@ async function stampDreamProvenance(
             SET frontmatter = COALESCE(frontmatter, '{}'::jsonb) || $3::jsonb
           WHERE slug = $1 AND source_id = $2`,
         [slug, source_id],
-        [{ dream_generated: true, dream_cycle_date: cycleDate }],
+        [stamp],
       );
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/core/cycle/transcript-discovery.ts
+++ b/src/core/cycle/transcript-discovery.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { pruneDir } from '../sync.ts';
 
@@ -23,8 +23,22 @@ export interface DiscoveredTranscript {
   content: string;
   /** Filename basename without extension; used as a topic-slug seed. */
   basename: string;
-  /** Inferred date if the basename matches `YYYY-MM-DD...` (or null). */
+  /**
+   * Inferred conversation date (YYYY-MM-DD) or null. Precedence: the
+   * `| First message | <ISO> |` row in the transcript's `## Metadata`
+   * table (stable across mtime-restamping re-syncs) wins; a leading
+   * `YYYY-MM-DD` in the basename is the fallback.
+   */
   inferredDate: string | null;
+  /**
+   * Transcript source archive name, derived from the path's grandparent
+   * directory (the immediate parent of the date directory). For the
+   * canonical layout `<corpus>/<source>/<date>/<id>.md` this yields the
+   * source-name segment — e.g. `claude-code` for the claude-code-archive
+   * output, `meetings` for meeting recordings. Null when the file does
+   * not live under a `<source>/<date>/` pair (ad-hoc inputs).
+   */
+  transcriptSource: string | null;
 }
 
 export interface DiscoverOpts {
@@ -161,6 +175,36 @@ function matchesAnyExclude(text: string, patterns: RegExp[]): boolean {
   return false;
 }
 
+/**
+ * Content-based conversation date: the `| First message | <ISO timestamp> |`
+ * row claude-code-archive writes into the transcript's `## Metadata` table.
+ * Stable across rsync/Dropbox/Syncthing/B2 re-syncs that re-stamp mtime,
+ * unlike anything derived from file metadata. Returns YYYY-MM-DD or null.
+ */
+const FIRST_MESSAGE_RE = /^\|\s*First message\s*\|\s*(\d{4}-\d{2}-\d{2})/im;
+
+export function inferContentDate(content: string): string | null {
+  const m = FIRST_MESSAGE_RE.exec(content);
+  return m ? m[1] : null;
+}
+
+/**
+ * Derive the archive source name from a transcript path. Returns the basename
+ * of the directory two levels above the file when the immediate parent is a
+ * date directory and the grandparent looks like a source-name slug (lowercase
+ * alphanumeric segments separated by hyphens); otherwise null. This pins the
+ * canonical claude-code-archive layout `<corpus>/<source>/<date>/<id>.md`
+ * without claiming a source for ad-hoc inputs that don't match.
+ */
+export function deriveTranscriptSource(filePath: string): string | null {
+  const parentName = basename(dirname(filePath));
+  if (!/^\d{4}-\d{2}-\d{2}/.test(parentName)) return null;
+  const grandparentName = basename(dirname(dirname(filePath)));
+  if (!grandparentName) return null;
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(grandparentName)) return null;
+  return grandparentName;
+}
+
 function listTextFiles(dir: string): string[] {
   // Recursive walk with descent-time pruning (closes codex C12/C13 spec gap).
   // Accepts BOTH .txt and .md per transcript-discovery's domain rules — does
@@ -225,8 +269,11 @@ export function discoverTranscripts(opts: DiscoverOpts): DiscoveredTranscript[] 
       const ext = filePath.endsWith('.md') ? '.md' : '.txt';
       const baseName = basename(filePath, ext);
       const dateMatch = DATE_RE.exec(baseName);
-      const inferredDate = dateMatch ? dateMatch[1] : null;
-      if (!isInDateRange(inferredDate, opts)) continue;
+      const filenameDate = dateMatch ? dateMatch[1] : null;
+      // Fast path: date-named files outside the window skip before the read.
+      // ponytail: a date-named file whose content date differs is filtered on
+      // its filename date — acceptable; archive layouts use UUID basenames.
+      if (filenameDate && !isInDateRange(filenameDate, opts)) continue;
 
       let content: string;
       try {
@@ -241,12 +288,17 @@ export function discoverTranscripts(opts: DiscoverOpts): DiscoveredTranscript[] 
       }
       if (matchesAnyExclude(content, excludeRes)) continue;
 
+      // Content-metadata date wins (survives mtime restamps); filename next.
+      const inferredDate = inferContentDate(content) ?? filenameDate;
+      if (!isInDateRange(inferredDate, opts)) continue;
+
       results.push({
         filePath,
         contentHash: hashContent(content),
         content,
         basename: baseName,
         inferredDate,
+        transcriptSource: deriveTranscriptSource(filePath),
       });
     }
   }
@@ -290,6 +342,7 @@ export function readSingleTranscript(
     contentHash: hashContent(content),
     content,
     basename: baseName,
-    inferredDate: dateMatch ? dateMatch[1] : null,
+    inferredDate: inferContentDate(content) ?? (dateMatch ? dateMatch[1] : null),
+    transcriptSource: deriveTranscriptSource(filePath),
   };
 }

--- a/test/cycle-dream-output-root.test.ts
+++ b/test/cycle-dream-output-root.test.ts
@@ -26,6 +26,7 @@ const transcript: DiscoveredTranscript = {
   content: 'User: hello world',
   contentHash: 'abcdef0123456789',
   inferredDate: '2026-07-17',
+  transcriptSource: null,
 } as DiscoveredTranscript;
 
 describe('#2415: buildSynthesisPrompt output root', () => {

--- a/test/cycle-synthesize-slug-collection.test.ts
+++ b/test/cycle-synthesize-slug-collection.test.ts
@@ -152,3 +152,75 @@ describe('#2569: stampDreamProvenance persists the marker into DB frontmatter', 
     await stampDreamProvenance(engine as any, refs, '2026-07-17'); // idempotent
   });
 });
+
+describe('#2285: orchestrator-owned deterministic transcript frontmatter', () => {
+  const meta = {
+    idx: 1,
+    hash6: 'abc123',
+    chunkTotal: 3,
+    transcriptSource: 'claude-code',
+    transcriptId: 'session-uuid',
+    inferredDate: '2026-05-15',
+  };
+
+  test('collectChildPutPageSlugs pairs each ref back to the writing job', async () => {
+    const refs = await collectChildPutPageSlugs(
+      engine as any, [1001], new Map([[1001, { ...meta, chunkTotal: 1 }]]), 'mybrain',
+    );
+    expect(refs.length).toBeGreaterThan(0);
+    for (const r of refs) {
+      expect(r.jobId).toBe(1001);
+      expect(r.source_id).toBe('mybrain'); // #1586: cycle source, never hardcoded 'default'
+    }
+  });
+
+  test('stampDreamProvenance merges the transcript metadata into DB frontmatter', async () => {
+    const slug = 'wiki/originals/ideas/2026-07-17-transcript-meta-abc123';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Meta stamp',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: { keep_me: 'yes', transcript_id: 'subagent-drift' },
+    });
+    await stampDreamProvenance(
+      engine as any,
+      [{ slug, source_id: 'default', jobId: 42 }],
+      '2026-07-17',
+      new Map([[42, meta]]),
+    );
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`, [slug],
+    );
+    const fm = rows[0].fm as Record<string, unknown>;
+    expect(fm.dream_generated).toBe(true);
+    expect(fm.dream_cycle_date).toBe('2026-07-17');
+    expect(fm.transcript_id).toBe('session-uuid'); // orchestrator wins over subagent drift
+    expect(fm.transcript_hash).toBe('abc123');
+    expect(fm.transcript_source).toBe('claude-code');
+    expect(fm.chunk).toBe('2/3');
+    expect(fm.date).toBe('2026-05-15');
+    expect(fm.keep_me).toBe('yes'); // subagent-owned keys survive
+  });
+
+  test('single-chunk children with no inferredDate stamp only the applicable fields', async () => {
+    const slug = 'wiki/originals/ideas/2026-07-17-minimal-meta-abc123';
+    await engine.putPage(slug, {
+      type: 'note', title: 'Minimal', compiled_truth: 'b', timeline: '', frontmatter: {},
+    });
+    await stampDreamProvenance(
+      engine as any,
+      [{ slug, source_id: 'default', jobId: 43 }],
+      '2026-07-17',
+      new Map([[43, { ...meta, chunkTotal: 1, transcriptSource: null, inferredDate: null }]]),
+    );
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`, [slug],
+    );
+    const fm = rows[0].fm as Record<string, unknown>;
+    expect(fm.transcript_id).toBe('session-uuid');
+    expect(fm.chunk).toBeUndefined();
+    expect(fm.transcript_source).toBeUndefined();
+    expect(fm.date).toBeUndefined();
+  });
+});

--- a/test/cycle-synthesize-slug-collection.test.ts
+++ b/test/cycle-synthesize-slug-collection.test.ts
@@ -174,6 +174,25 @@ describe('#2285: orchestrator-owned deterministic transcript frontmatter', () =>
     }
   });
 
+  test('slug collision across children attributes the LAST writer (matches surviving putPage)', async () => {
+    const db = (engine as any).db;
+    // Jobs 1001 then 1002 write the same slug; the pages row would hold
+    // 1002's content (last put_page wins), so the ref must carry jobId 1002.
+    await db.query(
+      `INSERT INTO subagent_tool_executions (job_id, message_idx, tool_use_id, tool_name, status, input)
+       VALUES (1001, 9, 'tool_dup_a', 'brain_put_page', 'complete', $1::jsonb)`,
+      [JSON.stringify({ slug: 'wiki/agents/test/collision', body: 'first' })],
+    );
+    await db.query(
+      `INSERT INTO subagent_tool_executions (job_id, message_idx, tool_use_id, tool_name, status, input)
+       VALUES (1002, 9, 'tool_dup_b', 'brain_put_page', 'complete', $1::jsonb)`,
+      [JSON.stringify({ slug: 'wiki/agents/test/collision', body: 'second' })],
+    );
+    const refs = await collectChildPutPageSlugs(engine as any, [1001, 1002], new Map());
+    const hit = refs.find((r: { slug: string }) => r.slug === 'wiki/agents/test/collision');
+    expect(hit?.jobId).toBe(1002);
+  });
+
   test('stampDreamProvenance merges the transcript metadata into DB frontmatter', async () => {
     const slug = 'wiki/originals/ideas/2026-07-17-transcript-meta-abc123';
     await engine.putPage(slug, {

--- a/test/cycle-synthesize.test.ts
+++ b/test/cycle-synthesize.test.ts
@@ -302,6 +302,7 @@ describe('judgeSignificance', () => {
       content: 'A short conversation about something interesting.',
       basename: 'x',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 
@@ -415,6 +416,7 @@ describe('judgeSignificance — UTF-16 safety (v0.41.13)', () => {
       content,
       basename: 'long',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -45,6 +45,7 @@ const FIXTURE_TRANSCRIPT: DiscoveredTranscript = {
   content: 'Synthetic transcript content for gateway-adapter parity tests.',
   contentHash: 'sha-fixture-1',
   inferredDate: '2026-05-24',
+  transcriptSource: null,
 };
 
 describe('makeJudgeClient — construction-time provider probe', () => {

--- a/test/cycle/transcript-discovery-metadata.test.ts
+++ b/test/cycle/transcript-discovery-metadata.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #2285 — transcript metadata discovery.
+ *
+ * Pins the two discovery-side additions:
+ *   1. `transcriptSource` — derived from the `<source>/<date>/<file>` path
+ *      layout; null for ad-hoc inputs that don't match.
+ *   2. Content-based date inference — the `| First message | <ISO> |` row in
+ *      the transcript's `## Metadata` table wins over the filename-regex
+ *      date (stable across mtime-restamping re-syncs); filename is the
+ *      fallback.
+ *
+ * Pure filesystem; no engine, no LLM.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import {
+  discoverTranscripts,
+  readSingleTranscript,
+  deriveTranscriptSource,
+  inferContentDate,
+} from '../../src/core/cycle/transcript-discovery.ts';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gbrain-transcript-meta-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(relPath: string, body: string): string {
+  const full = join(tmpDir, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, body);
+  return full;
+}
+
+const FILLER = 'User: hello world. '.repeat(200);
+const METADATA_BLOCK =
+  '## Metadata\n\n| Key | Value |\n| --- | --- |\n| First message | 2026-05-15T03:51:11.584Z |\n\n';
+
+describe('deriveTranscriptSource', () => {
+  test('extracts the source slug from <source>/<date>/<file> layout', () => {
+    expect(deriveTranscriptSource('/corpus/claude-code/2026-06-12/abc.md')).toBe('claude-code');
+    expect(deriveTranscriptSource('/corpus/voice-notes/2026-06-12/xyz.md')).toBe('voice-notes');
+  });
+
+  test('null when the parent dir is not a date dir or grandparent is not a slug', () => {
+    expect(deriveTranscriptSource('/corpus/flat-file.md')).toBeNull();
+    expect(deriveTranscriptSource('/corpus/claude-code/not-a-date/abc.md')).toBeNull();
+    expect(deriveTranscriptSource('/corpus/Not A Slug/2026-06-12/abc.md')).toBeNull();
+  });
+});
+
+describe('inferContentDate', () => {
+  test('parses the | First message | row', () => {
+    expect(inferContentDate(METADATA_BLOCK)).toBe('2026-05-15');
+  });
+  test('null when absent', () => {
+    expect(inferContentDate(FILLER)).toBeNull();
+  });
+});
+
+describe('discoverTranscripts — transcriptSource + date cascade', () => {
+  test('populates transcriptSource per file; null for flat files', () => {
+    write('claude-code/2026-06-12/aaaa.md', FILLER);
+    write('2026-06-12-flat.md', FILLER);
+    const out = discoverTranscripts({ corpusDir: tmpDir, minChars: 100 });
+    const byBase = new Map(out.map(t => [t.basename, t.transcriptSource]));
+    expect(byBase.get('aaaa')).toBe('claude-code');
+    expect(byBase.get('2026-06-12-flat')).toBeNull();
+  });
+
+  test('content First-message date wins over the filename date', () => {
+    write('2026-01-01-named.md', METADATA_BLOCK + FILLER);
+    const out = discoverTranscripts({ corpusDir: tmpDir, minChars: 100 });
+    expect(out).toHaveLength(1);
+    expect(out[0].inferredDate).toBe('2026-05-15');
+  });
+
+  test('filename date remains the fallback when content has no metadata row', () => {
+    write('2026-01-01-named.md', FILLER);
+    const out = discoverTranscripts({ corpusDir: tmpDir, minChars: 100 });
+    expect(out[0].inferredDate).toBe('2026-01-01');
+  });
+
+  test('date filter matches on the content date for UUID-named transcripts', () => {
+    write('claude-code/2026-05-15/uuid-basename.md', METADATA_BLOCK + FILLER);
+    const hit = discoverTranscripts({ corpusDir: tmpDir, minChars: 100, date: '2026-05-15' });
+    expect(hit).toHaveLength(1);
+    const miss = discoverTranscripts({ corpusDir: tmpDir, minChars: 100, date: '2026-05-16' });
+    expect(miss).toHaveLength(0);
+  });
+});
+
+describe('readSingleTranscript — same metadata surface', () => {
+  test('carries transcriptSource and prefers the content date', () => {
+    const p = write('claude-code/2026-05-15/2026-01-01-single.md', METADATA_BLOCK + FILLER);
+    const t = readSingleTranscript(p, { minChars: 100 });
+    expect(t).not.toBeNull();
+    expect(t!.transcriptSource).toBe('claude-code');
+    expect(t!.inferredDate).toBe('2026-05-15');
+  });
+});

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -216,17 +216,21 @@ describe('progress reporter', () => {
   });
 
   test('only one process-level signal handler installed across many reporters', () => {
-    // Baseline: one handler already installed by prior tests in this file.
+    // Baseline: one handler already installed by prior tests in this file, and
+    // possibly live reporters from OTHER test files sharing this bun process
+    // (shard composition is not this test's invariant — assert the delta, not
+    // an absolute zero, or shard reshuffles make this fail spuriously).
     const installedBefore = __signalHandlerInstalledForTest();
+    const liveBefore = __liveReporterCountForTest();
     const { stream } = sink(false);
     for (let i = 0; i < 50; i++) {
       const p = createProgress({ mode: 'json', stream, minIntervalMs: 0, minItems: 1 });
       p.start(`phase_${i}`, 1);
       p.finish();
     }
-    // After 50 reporter lifecycles, still exactly one handler and zero leaked live entries.
+    // After 50 reporter lifecycles, still exactly one handler and zero NET leaked live entries.
     expect(__signalHandlerInstalledForTest()).toBe(installedBefore || true);
-    expect(__liveReporterCountForTest()).toBe(0);
+    expect(__liveReporterCountForTest()).toBe(liveBefore);
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {


### PR DESCRIPTION
Takeover of #2286 (credit: @brettdavies, co-authored on the commit). Fixes #2285.

The original branch was DIRTY against master and its rewritten `collectChildPutPageSlugs` hardcoded `source_id: 'default'`, regressing #1586's cycle-source scoping (a source-isolation bug for non-default cycles). This rebuild lands the same feature on top of current master with the `cycleSourceId` threading intact.

## What ships

- **`DiscoveredTranscript.transcriptSource`** — derived from the `<corpus>/<source>/<date>/<id>.md` layout during discovery (`deriveTranscriptSource`); null for ad-hoc inputs that don't match. Available to every downstream consumer.
- **Content-based date inference** — `inferredDate` now prefers the `| First message | <ISO> |` row in the transcript's `## Metadata` table (stable across rsync/Dropbox/Syncthing re-syncs that re-stamp mtime), falling back to the filename-regex date. #2286 promised this cascade in its body but never shipped the parser; it's implemented here, and the date-range filter now matches UUID-named archive transcripts on their content date.
- **Orchestrator-owned deterministic frontmatter** — each written page gets `transcript_id` (content-version suffix stripped), `transcript_hash`, `transcript_source`, `chunk` (i/n for chunked transcripts), and `date` stamped authoritatively. Subagents retain authority over type/title/tags/body; their drift on the deterministic fields is overwritten.

## How it differs from #2286's implementation

- Keeps master's #1586 source scoping: refs are stamped with the cycle's resolved source, never a hardcoded `'default'`.
- No second `engine.putPage` round-trip: the deterministic fields ride the existing #2569 `stampDreamProvenance` jsonb-merge funnel (raw object bound via `executeRawJsonb` — no stringify-into-jsonb), which already runs before `reverseWriteRefs`; the reverse-render re-reads the row, so DB and disk stay lockstep through one write path.
- `date` (position 2 in the `effective-date.ts` precedence chain) is stamped as plain `YYYY-MM-DD`; a redundant frontmatter `effective_date` key the chain never reads was dropped.

## Tests

- `test/cycle/transcript-discovery-metadata.test.ts` (new): `deriveTranscriptSource` layouts, `inferContentDate`, content-over-filename precedence, filename fallback, date-filter match on content date, `readSingleTranscript` parity.
- `test/cycle-synthesize-slug-collection.test.ts` (extended): ref↔job pairing keeps the cycle source (#1586 guard), full metadata stamp lands as queryable jsonb with subagent keys preserved, minimal stamp omits inapplicable fields.
- `bun run typecheck` clean; touched suites (`cycle-synthesize*`, `cycle-dream-output-root`, `synthesize-gateway-adapter`, e2e `dream-synthesize-pglite` + `dream-synthesize-chunking`, `v0_29-tool-surfaces`, `regression-strict-source-id`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)