### PR TITLE
feat(ai): add reranker touchpoint to LiteLLM proxy recipe

### DIFF
--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -56,6 +56,36 @@ export const litellmProxy: Recipe = {
       cost_per_1m_output_usd: undefined,
       price_last_verified: '2026-06-14',
     },
+    // LiteLLM normalizes Cohere / Voyage / Jina / etc. rerank backends to the
+    // same wire shape gbrain's gateway.rerank() already speaks (the
+    // ZeroEntropy/llama.cpp contract):
+    //   { model, query, documents, top_n } → { results: [{ index, relevance_score }] }
+    // So any rerank model the user registers in their LiteLLM config is
+    // reachable via `gbrain config set search.reranker.model litellm:<model>`
+    // with no request/response adapter — same as embeddings ride the proxy.
+    reranker: {
+      models: [], // user-provided; whatever rerank models the proxy serves
+      // No canonical default — the proxy defines its own model ids. The user
+      // sets search.reranker.model explicitly (mirrors the embedding
+      // touchpoint's user_provided_models contract).
+      default_model: '',
+      // The proxied backend bills (Cohere/Voyage/…); pricing-unknown is the
+      // honest state — same stance as this recipe's embedding/chat
+      // touchpoints and budget-tracker's deliberate litellm exclusion from
+      // the free-provider sets.
+      cost_per_1m_tokens_usd: undefined,
+      price_last_verified: '2026-06-27',
+      max_payload_bytes: 5_000_000,
+      // LEAF path only (matches llama-server-reranker's convention). LiteLLM
+      // serves both `/rerank` and `/v1/rerank`, and LITELLM_BASE_URL may be
+      // set with or without the `/v1` suffix (the setup_hint allows both), so
+      // the leaf form yields a valid route either way:
+      //   http://localhost:4000    + /rerank → /rerank        ✓
+      //   http://localhost:4000/v1 + /rerank → /v1/rerank     ✓
+      // Pinning '/v1/rerank' here would double to /v1/v1/rerank → 404 on
+      // /v1-suffixed bases.
+      path: '/rerank',
+    },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL (include the /v1 suffix if your proxy serves the OpenAI route there, e.g. http://localhost:4000/v1) + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL (include the /v1 suffix if your proxy serves the OpenAI route there, e.g. http://localhost:4000/v1) + pass --embedding-model litellm:<model> and --embedding-dimensions <N>. For rerank: register a rerank model in LiteLLM and set search.reranker.model litellm:<model-name>.',
 };

--- a/test/ai/recipe-litellm-reranker.test.ts
+++ b/test/ai/recipe-litellm-reranker.test.ts
@@ -1,0 +1,88 @@
+/**
+ * litellm-proxy reranker touchpoint smoke.
+ *
+ * Sibling of recipe-llama-server-reranker.test.ts. Pins the reranker
+ * touchpoint on the LiteLLM proxy recipe so:
+ *  - the touchpoint exists with the LEAF '/rerank' path (LiteLLM serves both
+ *    /rerank and /v1/rerank, so the leaf form is valid whether or not the
+ *    user's LITELLM_BASE_URL carries the /v1 suffix the setup_hint allows)
+ *  - a /v1-suffixed base URL does NOT produce /v1/v1/rerank (the original
+ *    community PR pinned '/v1/rerank' which 404s on /v1-suffixed bases)
+ *  - models: [] (user-provided; proxy defines the model ids)
+ *  - pricing stays undefined (proxy can front a paid provider — same honest
+ *    pricing-unknown stance as the embedding/chat touchpoints)
+ *
+ * The gateway.rerank() URL tests drive the real URL builder via the stubbed
+ * transport (same seam as test/ai/rerank.test.ts).
+ */
+
+import { describe, expect, test, afterEach } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import {
+  configureGateway,
+  resetGateway,
+  rerank,
+  __setRerankTransportForTests,
+} from '../../src/core/ai/gateway.ts';
+
+afterEach(() => {
+  __setRerankTransportForTests(null);
+  resetGateway();
+});
+
+describe('recipe: litellm reranker touchpoint', () => {
+  test('declares reranker touchpoint with leaf /rerank path', () => {
+    const r = getRecipe('litellm')!;
+    const tp = r.touchpoints.reranker;
+    expect(tp).toBeDefined();
+    expect(tp!.path).toBe('/rerank');
+    expect(tp!.max_payload_bytes).toBe(5_000_000);
+  });
+
+  test('reranker touchpoint uses empty models[] for user-provided model ids', () => {
+    const r = getRecipe('litellm')!;
+    expect(r.touchpoints.reranker!.models).toEqual([]);
+  });
+
+  test('pricing stays undefined — proxy can front a paid provider', () => {
+    const r = getRecipe('litellm')!;
+    expect(r.touchpoints.reranker!.cost_per_1m_tokens_usd).toBeUndefined();
+  });
+
+  test('setup_hint keeps the /v1-suffix guidance AND mentions rerank', () => {
+    const r = getRecipe('litellm')!;
+    expect(r.setup_hint).toMatch(/\/v1 suffix/);
+    expect(r.setup_hint).toMatch(/search\.reranker\.model litellm:/);
+  });
+});
+
+describe('gateway.rerank() URL via litellm recipe', () => {
+  async function capturedRerankUrl(baseUrl?: string): Promise<string> {
+    configureGateway({
+      reranker_model: 'litellm:my-reranker',
+      env: {},
+      ...(baseUrl ? { base_urls: { litellm: baseUrl } } : {}),
+    });
+    let capturedUrl = '';
+    __setRerankTransportForTests(async (url) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({ results: [{ index: 0, relevance_score: 0.9 }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    await rerank({ query: 'q', documents: ['d'] });
+    return capturedUrl;
+  }
+
+  test('default base (no /v1 suffix) → /rerank', async () => {
+    const url = await capturedRerankUrl();
+    expect(url).toBe('http://localhost:4000/rerank');
+  });
+
+  test('/v1-suffixed base → /v1/rerank, NOT /v1/v1/rerank', async () => {
+    const url = await capturedRerankUrl('http://localhost:4000/v1');
+    expect(url).toBe('http://localhost:4000/v1/rerank');
+    expect(url).not.toContain('/v1/v1/');
+  });
+});


### PR DESCRIPTION
Takeover of #2455 (credit: @ozp, co-authored on the commit).

Adds a `reranker` touchpoint to the LiteLLM proxy recipe so any rerank model registered in the user's LiteLLM config is reachable via `gbrain config set search.reranker.model litellm:<model>` — LiteLLM normalizes Cohere/Voyage/Jina to the `{model, query, documents, top_n} → {results: [{index, relevance_score}]}` shape `gateway.rerank()` already speaks, no adapter needed.

Repairs vs the original PR:

- **Leaf path `/rerank`, not `/v1/rerank`.** Master's setup_hint (updated after #2455 branched) allows `LITELLM_BASE_URL` with or without the `/v1` suffix. The PR's pinned `/v1/rerank` doubled to `/v1/v1/rerank` → 404 on `/v1`-suffixed bases, and its test only covered the suffix-less default. LiteLLM serves both `/rerank` and `/v1/rerank`, so the leaf form (the same convention `llama-server-reranker` uses) is valid either way.
- **setup_hint appends instead of replaces.** The original replacement line was based on the pre-`/v1`-suffix hint and would have dropped that guidance.
- **`cost_per_1m_tokens_usd` stays `undefined`.** A proxy can front a paid provider, so pricing-unknown is the honest state — matching this recipe's embedding/chat touchpoints and budget-tracker's deliberate exclusion of litellm from the free-provider sets (the touchpoint cost field isn't consumed by rerank pricing anyway; `FREE_LOCAL_RERANK_PROVIDERS` is).

Test (`test/ai/recipe-litellm-reranker.test.ts`) pins the recipe shape and drives `gateway.rerank()`'s real URL builder through the stubbed transport for both base-URL forms; the `/v1`-suffixed case fails with the original PR's path.

Gates: `bun run typecheck` exit 0; new + sibling reranker/gateway tests pass (106 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)