### PR TITLE
fix(gateway): refresh eval cross-modal defaults + native chat allowlists

### DIFF
--- a/src/commands/eval-cross-modal.ts
+++ b/src/commands/eval-cross-modal.ts
@@ -76,9 +76,9 @@ FLAGS:
                            dimensions (goal, depth, sourcing, specificity, useful).
   --cycles N               1-3. Default: 3 in TTY, 1 in non-TTY (T11). Each
                            cycle is 3 model calls; verdict aggregates over them.
-  --slot-a-model <id>      Override default 'openai:gpt-4o'.
-  --slot-b-model <id>      Override default 'anthropic:claude-opus-4-7'.
-  --slot-c-model <id>      Override default 'google:gemini-1.5-pro'.
+  --slot-a-model <id>      Override default 'openai:gpt-5.2'.
+  --slot-b-model <id>      Override default 'anthropic:claude-opus-4-8'.
+  --slot-c-model <id>      Override default 'google:gemini-3-pro'.
   --receipt-dir <path>     Default: gbrainPath('eval-receipts').
   --max-tokens N           Output token budget per call. Default: 4000.
   --json                   Emit final aggregate as JSON to stdout (progress to stderr).

--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -23,11 +23,20 @@ export const google: Recipe = {
       price_last_verified: '2026-04-20',
     },
     chat: {
-      models: ['gemini-2.0-flash-exp', 'gemini-2.0-flash', 'gemini-1.5-pro'],
+      // gemini-1.5-pro and gemini-2.0-flash-exp 404 at the live API for new
+      // keys (#1607); gemini-2.0-flash kept for existing keys. gemini-3-pro
+      // matches the registry alias in model-config.ts:DEFAULT_ALIASES.
+      models: [
+        'gemini-3-pro',
+        'gemini-2.5-pro',
+        'gemini-2.5-flash',
+        'gemini-flash-latest',
+        'gemini-2.0-flash',
+      ],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,
-      max_context_tokens: 1000000, // Gemini 1.5 Pro
+      max_context_tokens: 1000000, // Gemini 2.5/3 Pro
       cost_per_1m_input_usd: 0.30,
       cost_per_1m_output_usd: 1.20,
       price_last_verified: '2026-04-20',

--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -30,7 +30,9 @@ export const openai: Recipe = {
       price_last_verified: '2026-04-20',
     },
     chat: {
-      models: ['gpt-5.2', 'gpt-4o-mini'],
+      // gpt-5 matches the registry alias in model-config.ts:DEFAULT_ALIASES;
+      // gpt-4o/gpt-5.5 are live API models carried in model-pricing.ts (#1607).
+      models: ['gpt-5.2', 'gpt-5.5', 'gpt-5', 'gpt-4o', 'gpt-4o-mini'],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,

--- a/src/core/cross-modal-eval/runner.ts
+++ b/src/core/cross-modal-eval/runner.ts
@@ -44,9 +44,9 @@ export const DEFAULT_DIMENSIONS: string[] = [
  * `--slot-a-model`, `--slot-b-model`, `--slot-c-model` on the CLI.
  */
 export const DEFAULT_SLOTS: SlotConfig[] = [
-  { id: 'A', model: 'openai:gpt-4o' },
-  { id: 'B', model: 'anthropic:claude-opus-4-7' },
-  { id: 'C', model: 'google:gemini-1.5-pro' },
+  { id: 'A', model: 'openai:gpt-5.2' },
+  { id: 'B', model: 'anthropic:claude-opus-4-8' },
+  { id: 'C', model: 'google:gemini-3-pro' },
 ];
 
 export interface SlotConfig {

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -76,9 +76,13 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   'openai:gpt-4o-mini':                   { input:  0.15, output:  0.60 },
   'openai:gpt-5':                         { input:  5.00, output: 20.00 },
   'openai:gpt-5.5':                       { input:  4.00, output: 16.00 },
+  // gpt-5.2 baseline — matches the openai recipe's chat cost anchors.
+  'openai:gpt-5.2':                       { input:  1.25, output: 10.00 },
 
   // ── Google ─────────────────────────────────────────────────────────────
   'google:gemini-1.5-pro':                { input:  1.25, output:  5.00 },
+  // Gemini 3 Pro (≤200K context rate) — the cross-modal slot C default.
+  'google:gemini-3-pro':                  { input:  2.00, output: 12.00 },
   // Gemini 2.0 Flash: $0.10 in / $0.40 out (verified 2026-06-03). Reconciled
   // from a stale $0.30/$1.20 entry that had drifted in takes-quality-eval.
   // `gemini-2-flash` kept as an alias for the legacy id spelling.

--- a/test/e2e/cross-modal-eval.test.ts
+++ b/test/e2e/cross-modal-eval.test.ts
@@ -45,7 +45,7 @@ afterEach(() => {
 
 function makeChatStub(scoresBySlot: Record<string, number[]>) {
   let callIdx = 0;
-  const order = ['openai:gpt-4o', 'anthropic:claude-opus-4-7', 'google:gemini-1.5-pro'];
+  const order = ['openai:gpt-5.2', 'anthropic:claude-opus-4-8', 'google:gemini-3-pro'];
   return mock(async (opts: { model?: string }) => {
     const model = opts.model ?? '';
     callIdx++;
@@ -74,9 +74,9 @@ function makeChatStub(scoresBySlot: Record<string, number[]>) {
 describe('gbrain eval cross-modal — runner verdict contract', () => {
   test('PASS: 3 happy responses, all dims >=7', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 8],
-      'anthropic:claude-opus-4-7': [8, 7],
-      'google:gemini-1.5-pro': [8, 8],
+      'openai:gpt-5.2': [9, 8],
+      'anthropic:claude-opus-4-8': [8, 7],
+      'google:gemini-3-pro': [8, 8],
     });
     mock.module('../../src/core/ai/gateway.ts', () => ({
       chat: chatStub,
@@ -105,9 +105,9 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('FAIL: one dim mean below 7', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 6],
-      'anthropic:claude-opus-4-7': [8, 6],
-      'google:gemini-1.5-pro': [8, 6],
+      'openai:gpt-5.2': [9, 6],
+      'anthropic:claude-opus-4-8': [8, 6],
+      'google:gemini-3-pro': [8, 6],
     });
     mock.module('../../src/core/ai/gateway.ts', () => ({
       chat: chatStub,
@@ -130,9 +130,9 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('FAIL: min-score floor caught when one model scores <5 (Q2)', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 8],
-      'anthropic:claude-opus-4-7': [8, 8],
-      'google:gemini-1.5-pro': [4, 8], // goal=4 trips the floor
+      'openai:gpt-5.2': [9, 8],
+      'anthropic:claude-opus-4-8': [8, 8],
+      'google:gemini-3-pro': [4, 8], // goal=4 trips the floor
     });
     mock.module('../../src/core/ai/gateway.ts', () => ({
       chat: chatStub,
@@ -155,7 +155,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('INCONCLUSIVE: 2 of 3 mock 5xx -> exit 2 contract (Q3)', async () => {
     const chatStub = mock(async (opts: { model?: string }) => {
-      if (opts.model === 'openai:gpt-4o') {
+      if (opts.model === 'openai:gpt-5.2') {
         return {
           text: JSON.stringify({
             scores: { goal: { score: 8 } },

--- a/test/model-defaults-in-allowlists.test.ts
+++ b/test/model-defaults-in-allowlists.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Anti-rot guard (#1607): every hardcoded default model string shipped in
+ * source code must pass the native-recipe chat allowlist. Hardcoded defaults
+ * do NOT get the config `extendedModels` escape hatch in assertTouchpoint,
+ * so a default that drifts out of its recipe's allowlist throws "not listed"
+ * at runtime — exactly how the eval cross-modal defaults rotted (gpt-4o was
+ * the shipped slot-A default while the openai chat allowlist rejected it).
+ *
+ * Covers: cross-modal DEFAULT_SLOTS, model-config DEFAULT_ALIASES and
+ * TIER_DEFAULTS. Also asserts DEFAULT_SLOTS models are priced from the
+ * canonical table so cost estimates don't silently go blind.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { DEFAULT_SLOTS } from '../src/core/cross-modal-eval/runner.ts';
+import { DEFAULT_ALIASES, TIER_DEFAULTS } from '../src/core/model-config.ts';
+import { resolveRecipe, assertTouchpoint } from '../src/core/ai/model-resolver.ts';
+import { canonicalLookup } from '../src/core/model-pricing.ts';
+
+function expectInChatAllowlist(model: string, label: string) {
+  const { parsed, recipe } = resolveRecipe(model);
+  expect(
+    () => assertTouchpoint(recipe, 'chat', parsed.modelId),
+    `${label} default "${model}" is not in the ${recipe.id} chat allowlist`,
+  ).not.toThrow();
+}
+
+describe('shipped default models pass native chat allowlists (#1607)', () => {
+  test('eval cross-modal DEFAULT_SLOTS', () => {
+    for (const slot of DEFAULT_SLOTS) {
+      expectInChatAllowlist(slot.model, `slot ${slot.id}`);
+    }
+  });
+
+  test('eval cross-modal DEFAULT_SLOTS are priced from canonical', () => {
+    for (const slot of DEFAULT_SLOTS) {
+      expect(canonicalLookup(slot.model), `${slot.model} has no canonical pricing`).toBeDefined();
+    }
+  });
+
+  test('model-config DEFAULT_ALIASES', () => {
+    for (const [alias, model] of Object.entries(DEFAULT_ALIASES)) {
+      expectInChatAllowlist(model, `alias "${alias}"`);
+    }
+  });
+
+  test('model-config TIER_DEFAULTS', () => {
+    for (const [tier, model] of Object.entries(TIER_DEFAULTS)) {
+      expectInChatAllowlist(model, `tier "${tier}"`);
+    }
+  });
+});

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -118,10 +118,13 @@ describe('DRIFT GUARD — derived views stay equal to canonical (re-hardcode tri
     for (const id of [
       'openai:gpt-4o',
       'openai:gpt-4o-mini',
+      'openai:gpt-5.2',
       'anthropic:claude-opus-4-7',
+      'anthropic:claude-opus-4-8',
       'anthropic:claude-sonnet-4-6',
       'google:gemini-1.5-pro',
       'google:gemini-2.0-flash',
+      'google:gemini-3-pro',
       'together:meta-llama/Llama-3.3-70B-Instruct-Turbo',
       'deepseek:deepseek-chat',
     ]) {


### PR DESCRIPTION
Fixes #1607 (points 1 and 2 — the halves adversarially confirmed on current master).

## What changed

- **`eval cross-modal` default slots were all dead out of the box** (`openai:gpt-4o` rejected by gbrain's own openai chat allowlist; `anthropic:claude-opus-4-7` and `google:gemini-1.5-pro` deprecated upstream). Defaults now resolve to models present in each recipe's current chat allowlist: `openai:gpt-5.2` / `anthropic:claude-opus-4-8` / `google:gemini-3-pro`. Help text updated to match.
- **Google chat allowlist refreshed**: adds `gemini-3-pro` (now agrees with the registry alias in `model-config.ts:DEFAULT_ALIASES`), `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-flash-latest`; drops ids no longer served to new keys (`gemini-1.5-pro`, `gemini-2.0-flash-exp`). `gemini-2.0-flash` kept for existing keys. Config-derived models still bypass the allowlist via `extendedModels`, so nobody's existing config breaks.
- **OpenAI chat allowlist** adds `gpt-5` (matches `DEFAULT_ALIASES.gpt`, which the allowlist was contradicting), `gpt-5.5`, and `gpt-4o` — all live API models already carried in canonical pricing.
- **Canonical pricing** gains `openai:gpt-5.2` and `google:gemini-3-pro` rows so the new defaults keep working cost estimates (single-table rule respected; consumers untouched).

## Anti-rot guard

New `test/model-defaults-in-allowlists.test.ts`: every hardcoded default model string (cross-modal `DEFAULT_SLOTS`, `DEFAULT_ALIASES`, `TIER_DEFAULTS`) must pass `assertTouchpoint` against its recipe's chat allowlist, and `DEFAULT_SLOTS` must be priced from canonical. Hardcoded defaults don't get the config `extendedModels` escape hatch, so this is exactly the drift class that produced the bug — the test fails on pre-fix master.

## Not addressed here (issue points 3 and 4)

- Native-Anthropic gateway 404 on a valid key+model: filed at v0.41.23, not reproducible from a code snapshot — needs a live re-test against current `@ai-sdk/anthropic` before any change.
- `providers list` reporting unvalidated keys as ready: a real ergonomics gap, but adding an auth probe is a product decision (cost/latency of probing on list), left open on #1607.

## Verification

- `bun run typecheck` exit 0
- `bun test` on the 8 touched/adjacent files: 154 pass / 0 fail (`model-defaults-in-allowlists`, `model-pricing`, `cross-modal-phase1`, `cross-modal-eval-cli`, `eval-cross-modal-batch`, `ai/gateway-chat`, `model-config.serial`, `anthropic-model-ids`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)