### PR TITLE
fix(schema-pack): gbrain-base-v2 capability parity, full bundled-pack listing, calibration holder config

### DIFF
--- a/src/commands/calibration.ts
+++ b/src/commands/calibration.ts
@@ -19,7 +19,7 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
-import { runPhaseCalibrationProfile } from '../core/cycle/calibration-profile.ts';
+import { resolveCalibrationHolder, runPhaseCalibrationProfile } from '../core/cycle/calibration-profile.ts';
 import { sourceScopeOpts, type OperationContext } from '../core/operations.ts';
 import type { GBrainConfig } from '../core/config.ts';
 import { GBrainError } from '../core/types.ts';
@@ -167,7 +167,7 @@ export async function runCalibration(
   config: GBrainConfig,
 ): Promise<void> {
   const { opts } = parseArgs(args);
-  const holder = opts.holder ?? 'garry';
+  const holder = await resolveCalibrationHolder(engine, opts.holder);
   // Resolve --source / GBRAIN_SOURCE / .gbrain-source so the (now reachable, #2035)
   // calibration command targets the right source in a multi-source brain instead
   // of always reading `default`. No signal → 'default' (prior behavior).
@@ -253,14 +253,14 @@ export async function getCalibrationProfileOp(
   ctx: OperationContext,
   params: { holder?: string },
 ): Promise<CalibrationProfileRow | null> {
-  const holder = params.holder ?? 'garry';
-  if (typeof holder !== 'string' || holder.length === 0) {
+  if (params.holder !== undefined && (typeof params.holder !== 'string' || params.holder.length === 0)) {
     throw new GBrainError(
       'INVALID_HOLDER',
       'get_calibration_profile.holder must be a non-empty string',
-      'pass holder="<slug>" or omit to default to "garry"',
+      'pass holder="<slug>" or omit to default to the calibration.user_holder config (then "garry")',
     );
   }
+  const holder = await resolveCalibrationHolder(ctx.engine, params.holder);
   const scope = sourceScopeOpts(ctx);
   return getLatestProfile(ctx.engine, { holder, ...scope });
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -928,6 +928,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // Emotional weight (v0.29)
   'emotional_weight.high_tags',
   'emotional_weight.user_holder',
+  // Calibration holder (#1726): persistent default for the nightly
+  // calibration_profile phase + `gbrain calibration`, symmetric with
+  // emotional_weight.user_holder. Falls back to 'garry' when unset.
+  'calibration.user_holder',
   // Cycle phase config
   'cycle.grade_takes.write_gstack_learnings',
   // Content sanity (v0.41)

--- a/src/core/cycle/calibration-profile.ts
+++ b/src/core/cycle/calibration-profile.ts
@@ -96,7 +96,7 @@ export type PatternStatementsGenerator = (input: {
 export type BiasTagsGenerator = (patterns: string[]) => Promise<string[]>;
 
 export interface CalibrationProfileOpts extends BasePhaseOpts {
-  /** Holder to generate the profile for. Default 'garry'. */
+  /** Holder to generate the profile for. Default: `calibration.user_holder` config, then 'garry'. */
   holder?: string;
   /** Inject the patterns generator (tests). */
   patternsGenerator?: PatternStatementsGenerator;
@@ -194,6 +194,26 @@ export function parseBiasTagsOutput(raw: string): string[] {
     .slice(0, 4);
 }
 
+/**
+ * #1726: resolve the calibration holder. Explicit param wins, then the
+ * persistent `calibration.user_holder` config key (symmetric with
+ * emotional_weight.user_holder), then the legacy 'garry' default. Fail-open:
+ * a missing config table / mock engine without getConfig falls through.
+ */
+export async function resolveCalibrationHolder(
+  engine: BrainEngine,
+  explicit?: string,
+): Promise<string> {
+  if (explicit) return explicit;
+  try {
+    const configured = await engine.getConfig('calibration.user_holder');
+    if (configured && configured.trim().length > 0) return configured.trim();
+  } catch {
+    // Config unavailable — use the legacy default.
+  }
+  return 'garry';
+}
+
 /** Pick the "loudest" pattern slot for the template fallback. */
 function pickFallbackSlots(scorecard: TakesScorecard): PatternStatementSlots {
   if (!scorecard || scorecard.resolved === 0) {
@@ -227,7 +247,7 @@ class CalibrationProfilePhase extends BaseCyclePhase {
     _ctx: OperationContext,
     opts: CalibrationProfileOpts,
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
-    const holder = opts.holder ?? 'garry';
+    const holder = await resolveCalibrationHolder(engine, opts.holder);
     const promptVersion = opts.promptVersion ?? CALIBRATION_PROFILE_PROMPT_VERSION;
     const modelId = opts.model ?? TIER_DEFAULTS.reasoning;
     const gradeCompletion = opts.gradeCompletion ?? 1.0;

--- a/src/core/extract-timeline-from-meetings.ts
+++ b/src/core/extract-timeline-from-meetings.ts
@@ -68,11 +68,14 @@ export async function extractTimelineFromMeetings(
   // 1. Fetch all meeting pages (one round-trip).
   const sourceFilter = opts.sourceIdFilter ? `AND source_id = $1` : '';
   const meetingParams = opts.sourceIdFilter ? [opts.sourceIdFilter] : [];
+  // #2109: gbrain-base-v2's unify-types catch-all retypes meeting pages to
+  // `note` with frontmatter.legacy_type = 'meeting'. Match both spellings so
+  // the extractor keeps working on migrated (v2) brains, not just v1 ones.
   const meetings = await engine.executeRaw<MeetingRow>(
     `SELECT slug, source_id, title, effective_date, updated_at,
             compiled_truth, COALESCE(timeline, '') AS timeline
        FROM pages
-      WHERE type = 'meeting'
+      WHERE (type = 'meeting' OR frontmatter ->> 'legacy_type' = 'meeting')
         AND deleted_at IS NULL
         ${sourceFilter}
       ORDER BY effective_date DESC NULLS LAST, slug`,
@@ -94,7 +97,7 @@ export async function extractTimelineFromMeetings(
        JOIN pages pf ON pf.id = l.from_page_id
        JOIN pages pt ON pt.id = l.to_page_id
       WHERE l.link_type = 'attended'
-        AND pf.type = 'meeting'
+        AND (pf.type = 'meeting' OR pf.frontmatter ->> 'legacy_type' = 'meeting')
         AND pf.deleted_at IS NULL
         AND pt.deleted_at IS NULL`,
   );

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4562,7 +4562,10 @@ const list_schema_packs: Operation = {
     const { existsSync, readdirSync } = await import('node:fs');
     const { join } = await import('node:path');
     const { gbrainPath } = await import('./config.ts');
-    const bundled = ['gbrain-base', 'gbrain-recommended'];
+    // #1726: derive from the locator's registry instead of a hand-copied
+    // subset (which had frozen at 2 of 7 bundled packs).
+    const { BUNDLED_PACKS } = await import('./schema-pack/load-active.ts');
+    const bundled = [...BUNDLED_PACKS];
     const installedDir = gbrainPath('schema-packs');
     const installed: string[] = [];
     if (existsSync(installedDir)) {

--- a/src/core/schema-pack/base/gbrain-base-v2.yaml
+++ b/src/core/schema-pack/base/gbrain-base-v2.yaml
@@ -41,6 +41,12 @@ migration_from:
   pack: gbrain-base
   version: "1.x"
 
+# #2117 — cycle-phase participation. `phases:` is additive and pack-gated;
+# without this key extract_atoms is silently off on v2 brains even though
+# onboard + doctor recommend it (v2 declares the `atom` type it writes).
+phases:
+  - extract_atoms
+
 page_types:
   - name: person
     primitive: entity
@@ -319,6 +325,10 @@ page_types:
     extractable: false
     expert_routing: false
 
+# #2117 — inference rules ported from gbrain-base v1 so extract-ner keeps
+# working on v2 brains (it hard-skips with pack_unavailable when no
+# link_type declares an inference.regex). Same ReDoS-guarded sketch
+# regexes v1 ships; production matchers in link-extraction.ts still apply.
 link_types:
   - name: partner_of
     inverse: partner_of
@@ -328,14 +338,24 @@ link_types:
   - name: discusses
   - name: founded
     inverse: founded_by
+    inference:
+      regex: \b(founded|founder of|co-?founded|started)\b
   - name: works_at
     inverse: employs
+    inference:
+      regex: \b(works? at|employed by|works? for|joined|hired by|ceo of|cto of|cmo of)\b
   - name: invested_in
     inverse: investor_of
+    inference:
+      regex: \b(invested in|backed|seeded|funded|wrote a check)\b
   - name: sourced_from
   - name: derived_from
   - name: supersedes
   - name: redirects_to
+  # NOTE: v1's `attended` inference is page_type-bound to `meeting`, which
+  # v2 does not declare (lint: link_types_undeclared_page_type). Meeting
+  # pages retyped by unify-types are matched via frontmatter.legacy_type
+  # in extract-timeline-from-meetings (#2109) instead.
   - name: attended
     inverse: attended_by
   - name: authored

--- a/src/core/schema-pack/load-active.ts
+++ b/src/core/schema-pack/load-active.ts
@@ -91,29 +91,33 @@ export function _resetPackLocatorForTests(): void {
  * Returns null when the pack is not found. Callers handle null by
  * throwing UnknownPackError with a paste-ready install hint.
  */
+// v0.39 T8 — bundled packs registry. gbrain-base + gbrain-recommended
+// ship in src/core/schema-pack/base/. Add a new entry here to bundle
+// additional canonical packs.
+//
+// v0.41 T4 — lens packs join the bundle: creator (atoms + concepts +
+// extract_atoms/synthesize_concepts phases), investor (theses + bet
+// resolution + 3 calibration domains), engineer (gstack-learnings bridge
+// + 3 calibration domains), everything (meta-pack stacking all three
+// via extends + borrow_from). Each ships as a real YAML at base/<name>.yaml.
+//
+// #1726: exported so reporting surfaces (list_schema_packs) derive from the
+// same list the locator resolves — no more hand-copied 2-of-7 subsets.
+export const BUNDLED_PACKS: ReadonlyArray<string> = [
+  'gbrain-base',
+  'gbrain-recommended',
+  'gbrain-creator',
+  'gbrain-investor',
+  'gbrain-engineer',
+  'gbrain-everything',
+  // v0.42 type-unification: 15-type canonical successor to gbrain-base.
+  // Ships as install default (Lane E T17) + via gbrain onboard pack
+  // upgrade flow (the unify-types Minion handler).
+  'gbrain-base-v2',
+];
+
 function defaultPackLocator(name: string): string | null {
-  // v0.39 T8 — bundled packs registry. gbrain-base + gbrain-recommended
-  // ship in src/core/schema-pack/base/. Add a new entry here to bundle
-  // additional canonical packs.
-  //
-  // v0.41 T4 — lens packs join the bundle: creator (atoms + concepts +
-  // extract_atoms/synthesize_concepts phases), investor (theses + bet
-  // resolution + 3 calibration domains), engineer (gstack-learnings bridge
-  // + 3 calibration domains), everything (meta-pack stacking all three
-  // via extends + borrow_from). Each ships as a real YAML at base/<name>.yaml.
-  const BUNDLED: ReadonlyArray<string> = [
-    'gbrain-base',
-    'gbrain-recommended',
-    'gbrain-creator',
-    'gbrain-investor',
-    'gbrain-engineer',
-    'gbrain-everything',
-    // v0.42 type-unification: 15-type canonical successor to gbrain-base.
-    // Ships as install default (Lane E T17) + via gbrain onboard pack
-    // upgrade flow (the unify-types Minion handler).
-    'gbrain-base-v2',
-  ];
-  if (BUNDLED.includes(name)) {
+  if (BUNDLED_PACKS.includes(name)) {
     // Resolve bundled YAML relative to this source file. Works in both
     // direct-bun execution and bun --compile binaries.
     const here = dirname(fileURLToPath(import.meta.url));

--- a/test/calibration-profile.test.ts
+++ b/test/calibration-profile.test.ts
@@ -32,7 +32,7 @@ interface CapturedSql {
   params: unknown[];
 }
 
-function buildMockEngine(opts: { scorecard: TakesScorecard }): {
+function buildMockEngine(opts: { scorecard: TakesScorecard; config?: Record<string, string> }): {
   engine: BrainEngine;
   captured: CapturedSql[];
 } {
@@ -41,6 +41,9 @@ function buildMockEngine(opts: { scorecard: TakesScorecard }): {
     kind: 'pglite',
     async getScorecard() {
       return opts.scorecard;
+    },
+    async getConfig(key: string) {
+      return opts.config?.[key] ?? null;
     },
     async executeRaw<T>(sql: string, params?: unknown[]): Promise<T[]> {
       captured.push({ sql, params: params ?? [] });
@@ -239,6 +242,36 @@ describe('runPhaseCalibrationProfile — phase integration', () => {
     expect(insert!.params[9]).toBe(true); // voice_gate_passed
     expect(insert!.params[10]).toBe(1); // voice_gate_attempts
     expect(insert!.params[11]).toEqual(['over-confident-geography']); // active_bias_tags
+  });
+
+  test('#1726: calibration.user_holder config drives the holder when no explicit opt', async () => {
+    const { engine, captured } = buildMockEngine({
+      scorecard: ENOUGH_RESOLVED_SCORECARD,
+      config: { 'calibration.user_holder': 'alice-example' },
+    });
+    await runPhaseCalibrationProfile(buildCtx(engine), {
+      patternsGenerator: async () => ['You call early-stage tactics well — 8 of 10 held up.'],
+      biasTagsGenerator: async () => [],
+      voiceGateJudge: passJudge,
+    });
+    const insert = captured.find(c => c.sql.includes('INSERT INTO calibration_profiles'));
+    expect(insert).toBeDefined();
+    expect(insert!.params[1]).toBe('alice-example'); // holder from config
+  });
+
+  test('#1726: explicit holder opt wins over calibration.user_holder config', async () => {
+    const { engine, captured } = buildMockEngine({
+      scorecard: ENOUGH_RESOLVED_SCORECARD,
+      config: { 'calibration.user_holder': 'alice-example' },
+    });
+    await runPhaseCalibrationProfile(buildCtx(engine), {
+      holder: 'charlie-example',
+      patternsGenerator: async () => ['You call early-stage tactics well — 8 of 10 held up.'],
+      biasTagsGenerator: async () => [],
+      voiceGateJudge: passJudge,
+    });
+    const insert = captured.find(c => c.sql.includes('INSERT INTO calibration_profiles'));
+    expect(insert!.params[1]).toBe('charlie-example');
   });
 
   test('default model is a provider-prefixed id, persisted to model_id (#2451)', async () => {

--- a/test/extract-timeline-legacy-type.test.ts
+++ b/test/extract-timeline-legacy-type.test.ts
@@ -1,0 +1,106 @@
+// #2109 — gbrain-base-v2's unify-types retypes meeting pages to `note`
+// with frontmatter.legacy_type='meeting'. extract-timeline-from-meetings
+// used to hardcode type='meeting' and silently scan 0 meetings on migrated
+// brains. These tests fail without the legacy_type fallback in both SQL
+// sites (meeting walk + attended-edge join).
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { extractTimelineFromMeetings } from '../src/core/extract-timeline-from-meetings.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function insertPage(opts: {
+  slug: string;
+  type: string;
+  title: string;
+  effectiveDate?: string;
+  legacyType?: string;
+}): Promise<number> {
+  const frontmatterLiteral = opts.legacyType
+    ? `'{"legacy_type": "${opts.legacyType}"}'::jsonb`
+    : `'{}'::jsonb`;
+  const rows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO pages (slug, source_id, type, title, compiled_truth, timeline, effective_date, frontmatter)
+     VALUES ($1, 'default', $2, $3, '', '', $4, ${frontmatterLiteral})
+     RETURNING id`,
+    [opts.slug, opts.type, opts.title, opts.effectiveDate ?? null],
+  );
+  return rows[0]!.id;
+}
+
+describe('extractTimelineFromMeetings — legacy_type fallback (#2109)', () => {
+  it('scans pages retyped to note with legacy_type=meeting and walks their attended edges', async () => {
+    const meetingId = await insertPage({
+      slug: 'meetings/2026-01-05',
+      type: 'note', // post-unify-types shape on a gbrain-base-v2 brain
+      legacyType: 'meeting',
+      title: 'Weekly sync',
+      effectiveDate: '2026-01-05',
+    });
+    const personId = await insertPage({
+      slug: 'people/alice-example',
+      type: 'person',
+      title: 'Alice Example',
+    });
+    await engine.executeRaw(
+      `INSERT INTO links (from_page_id, to_page_id, link_type) VALUES ($1, $2, 'attended')`,
+      [meetingId, personId],
+    );
+
+    const result = await extractTimelineFromMeetings(engine);
+    expect(result.meetings_scanned).toBe(1);
+    expect(result.entries_created).toBe(1);
+    expect(result.entities_touched).toBe(1);
+    expect(result.batch_errors).toBe(0);
+  });
+
+  it('still scans pre-unify pages with type=meeting (v1 behavior preserved)', async () => {
+    const meetingId = await insertPage({
+      slug: 'meetings/2026-02-01',
+      type: 'meeting',
+      title: 'Board prep',
+      effectiveDate: '2026-02-01',
+    });
+    const personId = await insertPage({
+      slug: 'people/charlie-example',
+      type: 'person',
+      title: 'Charlie Example',
+    });
+    await engine.executeRaw(
+      `INSERT INTO links (from_page_id, to_page_id, link_type) VALUES ($1, $2, 'attended')`,
+      [meetingId, personId],
+    );
+
+    const result = await extractTimelineFromMeetings(engine);
+    expect(result.meetings_scanned).toBe(1);
+    expect(result.entries_created).toBe(1);
+  });
+
+  it('does not scan unrelated note pages without legacy_type=meeting', async () => {
+    await insertPage({
+      slug: 'notes/random',
+      type: 'note',
+      title: 'Random note',
+      effectiveDate: '2026-03-01',
+    });
+    const result = await extractTimelineFromMeetings(engine);
+    expect(result.meetings_scanned).toBe(0);
+    expect(result.entries_created).toBe(0);
+  });
+});

--- a/test/operations-schema-pack.test.ts
+++ b/test/operations-schema-pack.test.ts
@@ -152,6 +152,19 @@ describe('list_schema_packs', () => {
       expect(result.installed).toContain('mine');
     });
   });
+
+  it('reports the full bundled registry, not a hand-copied subset (#1726)', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir }, async () => {
+      const { BUNDLED_PACKS } = await import('../src/core/schema-pack/load-active.ts');
+      const result = await operationsByName.list_schema_packs!.handler(ctxOf(), {}) as { bundled: string[] };
+      expect(result.bundled.slice().sort()).toEqual([...BUNDLED_PACKS].sort());
+      // The lens packs that declare extract_atoms/synthesize_concepts phases
+      // were the ones dropped by the frozen 2-pack literal.
+      for (const name of ['gbrain-creator', 'gbrain-everything', 'gbrain-base-v2']) {
+        expect(result.bundled).toContain(name);
+      }
+    });
+  });
 });
 
 // ── schema_stats ───────────────────────────────────────────────────────

--- a/test/schema-pack-base-v2-capabilities.test.ts
+++ b/test/schema-pack-base-v2-capabilities.test.ts
@@ -1,0 +1,40 @@
+// #2117 — gbrain-base-v2 shipped with no `phases:` declaration and zero
+// link_types[].inference regexes, so extract_atoms was silently pack-gated
+// off and extract-ner returned pack_unavailable on the bundled default pack.
+// These assertions fail against the pre-fix yaml.
+
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { loadPackFromFile } from '../src/core/schema-pack/loader.ts';
+import { linkTypesUndeclared } from '../src/core/schema-pack/lint-rules.ts';
+
+const V2_PATH = join(import.meta.dir, '..', 'src', 'core', 'schema-pack', 'base', 'gbrain-base-v2.yaml');
+
+describe('gbrain-base-v2 capability parity (#2117)', () => {
+  const manifest = loadPackFromFile(V2_PATH);
+
+  it('declares the extract_atoms cycle phase', () => {
+    expect(manifest.phases ?? []).toContain('extract_atoms');
+  });
+
+  it('ships at least one link_type inference regex so extract-ner is not pack_unavailable', () => {
+    // Mirrors the extract-ner hasRegex predicate exactly.
+    const hasRegex = manifest.link_types.some(
+      (lt) => lt.inference && typeof lt.inference === 'object' && 'regex' in lt.inference,
+    );
+    expect(hasRegex).toBe(true);
+  });
+
+  it('ports the v1 inference verbs it declares link types for', () => {
+    const withRegex = manifest.link_types
+      .filter((lt) => lt.inference?.regex)
+      .map((lt) => lt.name)
+      .sort();
+    expect(withRegex).toEqual(['founded', 'invested_in', 'works_at']);
+  });
+
+  it('inference rules pass the undeclared-page-type lint (no meeting-bound inference)', async () => {
+    const issues = await linkTypesUndeclared(manifest);
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
Backlog work unit c29: bundled-pack resolution + v2 pack capability gaps.

## Fixes

**Fixes #2109** — `extract-timeline-from-meetings` hardcoded `type='meeting'` in both SQL sites (meeting walk + attended-edge join). gbrain-base-v2's unify-types catch-all retypes meetings to `note` with `frontmatter.legacy_type='meeting'`, so migrated brains silently scanned 0 meetings while onboard kept recommending the job. Both sites now also match `frontmatter->>'legacy_type' = 'meeting'`; pre-unify `type='meeting'` brains behave exactly as before. New PGLite test fails without the fallback.

**Fixes #2117** — `gbrain-base-v2` shipped no `phases:` declaration and zero `link_types[].inference` regexes, so `extract_atoms` was silently pack-gated off and `extract-ner` returned `pack_unavailable` on the bundled default pack. The pack now declares `phases: [extract_atoms]` (v2 declares the `atom` type the phase writes) and ports v1's `founded`/`works_at`/`invested_in` inference regexes. v1's `attended` inference is page_type-bound to `meeting`, which v2 doesn't declare — porting it would fail the `link_types_undeclared_page_type` lint, so retyped meeting pages are covered by the #2109 legacy_type fallback instead (noted in the yaml).

**Fixes #1726** — both halves:
- (A) `list_schema_packs` hardcoded 2 of 7 bundled packs. The locator's registry is now the exported `BUNDLED_PACKS` const in `load-active.ts` and the op derives from it, so the MCP surface and the locator can't drift again.
- (B) New `calibration.user_holder` config key, symmetric with `emotional_weight.user_holder`. `resolveCalibrationHolder()` (explicit param → config → `'garry'`) is threaded through the nightly `calibration_profile` phase, the `gbrain calibration` CLI, and the `get_calibration_profile` op — a self-hosted brain owned by someone else no longer needs a per-invocation `--holder` flag for the nightly phase to find their takes. Fail-open: config lookup errors fall back to the legacy default.

## Not changed (deliberate)

- `src/core/brainstorm/orchestrator.ts` keeps its existing `emotional_weight.user_holder` fallback for calibration-profile lookup (typed config-slice plumbing; separate cleanup if wanted).
- `mutate.ts`'s `BUNDLED_PACK_NAMES` read-only guard (3 packs) untouched — different concern (mutation protection vs discovery), out of scope here.
- No `meeting` type re-added to v2 (product call); the legacy_type fallback fixes already-migrated brains with zero data migration.

## Tests

- `test/extract-timeline-legacy-type.test.ts` (new): retyped-meeting scan, v1 behavior preserved, plain notes not scanned.
- `test/schema-pack-base-v2-capabilities.test.ts` (new): phases + extract-ner `hasRegex` predicate + lint guard.
- `test/operations-schema-pack.test.ts`: bundled list equals the registry.
- `test/calibration-profile.test.ts`: config-driven holder + explicit-wins precedence.

`bun run typecheck` clean; 385 tests across the touched/neighboring suites (schema-cli, mutate, unify-types, onboard, lens-pack manifests, extract-atoms gating, calibration, e2e type-unification + onboard-full-flow) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)