### PR TITLE
feat(facts): owner-trusted local fact reads via facts.trust_local_reads (takeover of #2427)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -908,6 +908,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'facts.extraction_model',
   // #2113: output-token cap for the per-turn facts extractor (default 4000).
   'facts.extraction_max_tokens',
+  // Owner opt-in: let the local stdio MCP pipe read this owner's private facts
+  // (find_trajectory / recall). Default off; HTTP transport ignores it. See
+  // src/core/facts/reader-trust.ts.
+  'facts.trust_local_reads',
   // Dream cycle config
   'dream.synthesize.session_corpus_dir',
   'dream.synthesize.meeting_transcripts_dir',

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -591,6 +591,8 @@ export interface TrajectoryOpts {
   sourceIds?: string[];
   /** When true, filters to visibility='world' only. Set by MCP layer from ctx.remote. */
   remote?: boolean;
+  /** Owner opt-in: read private facts despite `remote`. See facts/reader-trust.ts. */
+  trustedFactReads?: boolean;
   /** Metric filter. When set, only facts with this canonical metric label participate. */
   metric?: string;
   /**

--- a/src/core/facts/meta-hook.ts
+++ b/src/core/facts/meta-hook.ts
@@ -17,6 +17,7 @@
 import type { OperationContext } from './../operations.ts';
 import type { FactRow } from './../engine.ts';
 import { effectiveConfidence } from './decay.ts';
+import { readableFactVisibilities } from './reader-trust.ts';
 
 const DEFAULT_TTL_MS = 30_000;
 const DEFAULT_TOP_K = 10;
@@ -61,9 +62,9 @@ export async function getBrainHotMemoryMeta(
     return cached.payload;
   }
 
-  // Build a fresh payload. Visibility tier: remote → world-only;
-  // local → all rows.
-  const visibility = ctx.remote === false ? undefined : ['world'] as ('world' | 'private')[];
+  // Build a fresh payload. Visibility tier: untrusted remote → world-only;
+  // trusted local + owner-trusted reads → all rows.
+  const visibility = readableFactVisibilities(ctx);
 
   let rows: FactRow[] = [];
   if (sessionId) {

--- a/src/core/facts/meta-hook.ts
+++ b/src/core/facts/meta-hook.ts
@@ -51,7 +51,13 @@ export async function getBrainHotMemoryMeta(
   const sessionId = (ctx as { source_session?: string }).source_session
     ?? null;
   const allowListHash = hashAllowList(ctx.takesHoldersAllowList);
-  const cacheKey = `${sourceId}::${sessionId ?? '_'}::${allowListHash}`;
+  // Visibility tier: untrusted remote → world-only; trusted local +
+  // owner-trusted reads → all rows. Folded into the cache key (the header's
+  // "cache entries don't bleed across tiers" invariant): trustedFactReads is
+  // re-read from config per call, so a mid-session opt-out must not keep
+  // serving a private-inclusive cached payload for the TTL window.
+  const visibility = readableFactVisibilities(ctx);
+  const cacheKey = `${sourceId}::${sessionId ?? '_'}::${allowListHash}::${visibility ? 'world' : 'all'}`;
 
   const ttl = Math.max(1000, opts.ttlMs ?? DEFAULT_TTL_MS);
   const topK = Math.max(1, Math.min(opts.topK ?? DEFAULT_TOP_K, 25));
@@ -61,10 +67,6 @@ export async function getBrainHotMemoryMeta(
   if (cached && cached.expiresAt > Date.now()) {
     return cached.payload;
   }
-
-  // Build a fresh payload. Visibility tier: untrusted remote → world-only;
-  // trusted local + owner-trusted reads → all rows.
-  const visibility = readableFactVisibilities(ctx);
 
   let rows: FactRow[] = [];
   if (sessionId) {

--- a/src/core/facts/reader-trust.ts
+++ b/src/core/facts/reader-trust.ts
@@ -1,0 +1,48 @@
+/**
+ * Fact-read visibility trust.
+ *
+ * Fact rows are tagged `private` | `world`. Remote/untrusted callers
+ * (`remote === true`) see only `world` rows — the posture that keeps a
+ * published or HTTP-served brain from leaking private claims to strangers.
+ *
+ * But the stdio MCP server is an unauthenticated LOCAL pipe: on a single-owner
+ * machine the caller IS the owner, yet it still defaults `remote: true` for
+ * safety, so the owner's own agent is denied the owner's own private facts
+ * (e.g. `find_trajectory` returns empty over MCP even though the facts exist).
+ *
+ * `trustedFactReads` is a narrow, READ-ONLY trust elevation, deliberately
+ * DECOUPLED from `remote` so every other remote protection — file_upload
+ * confinement, source isolation, fence stripping, takes-holder scoping — stays
+ * fully in force. The stdio MCP server sets it ONLY when the brain owner opts
+ * in via the `facts.trust_local_reads` config (default off). The HTTP/published
+ * transport never sets it, so a served brain stays world-only regardless.
+ */
+export interface FactReaderTrust {
+  /**
+   * Mirrors OperationContext.remote. FAIL-CLOSED: anything not strictly
+   * `false` is treated as remote/untrusted (CLAUDE.md trust invariant).
+   */
+  remote?: boolean;
+  /** Owner opt-in: this remote caller may read private facts. */
+  trustedFactReads?: boolean;
+}
+
+/**
+ * True when the reader is restricted to `visibility = 'world'` rows.
+ * Fail-closed: an unset/undefined `remote` is untrusted — only an explicit
+ * `remote: false` (trusted local CLI) or an explicit owner opt-in
+ * (`trustedFactReads: true`) reads private rows.
+ */
+export function factsWorldOnly(t: FactReaderTrust): boolean {
+  return t.remote !== false && t.trustedFactReads !== true;
+}
+
+/**
+ * Visibility filter for list-style fact reads: `['world']` when the reader is
+ * world-only, `undefined` (no filter — all rows) when it is trusted.
+ */
+export function readableFactVisibilities(
+  t: FactReaderTrust,
+): ('private' | 'world')[] | undefined {
+  return factsWorldOnly(t) ? ['world'] : undefined;
+}

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -18,6 +18,7 @@ import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from '
 import type { HybridSearchMeta } from './types.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isGlobalBasenameEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import { isFactsBackstopEligible } from './facts/eligibility.ts';
+import { readableFactVisibilities } from './facts/reader-trust.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
 import { getContentFlag } from './quarantine.ts';
@@ -332,6 +333,15 @@ export interface OperationContext {
    * remote/untrusted (defense in depth in case the type is bypassed via cast).
    */
   remote: boolean;
+  /**
+   * Owner opt-in (`facts.trust_local_reads`): allow this remote caller to read
+   * `private` facts. A NARROW, read-only trust elevation decoupled from
+   * `remote` — every other remote protection (file confinement, source
+   * isolation, fence stripping, takes scoping) stays in force. Set ONLY by the
+   * stdio MCP server when the config is on; the HTTP transport never sets it.
+   * Consulted via `src/core/facts/reader-trust.ts`.
+   */
+  trustedFactReads?: boolean;
   /**
    * Subagent runtime context (v0.16+). Set by the subagent tool dispatcher when
    * dispatching an op as a tool call from an LLM loop. Used to enforce per-op
@@ -3629,6 +3639,7 @@ const find_trajectory: Operation = {
       entitySlug: p.entity_slug,
       ...scope,
       remote: ctx.remote === true,
+      trustedFactReads: ctx.trustedFactReads === true,
       metric,
       kind,
       since,
@@ -3989,13 +4000,9 @@ const recall: Operation = {
     const includeExpired = p.include_expired === true;
     const grep = typeof p.grep === 'string' ? p.grep.toLowerCase() : null;
 
-    // Visibility filter: remote callers see world-only unless their token
-    // grants elevated visibility (future-proofing; v0.31 ships world-only
-    // for remote, all for local CLI).
-    const visibility =
-      ctx.remote === false
-        ? undefined
-        : ['world'] as ('private' | 'world')[];
+    // Visibility filter: world-only for untrusted remote callers; all rows for
+    // trusted local CLI and owner-trusted reads (facts.trust_local_reads).
+    const visibility = readableFactVisibilities(ctx);
 
     let rows: Awaited<ReturnType<typeof ctx.engine.listFactsByEntity>> = [];
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -18,6 +18,7 @@ import type {
 } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
+import { factsWorldOnly } from './facts/reader-trust.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
@@ -4318,7 +4319,10 @@ export class PGLiteEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    // Direct-engine contract: unset `remote` here means a trusted in-process
+    // caller (CLI/tests) — the fail-closed default lives in the op layer, which
+    // always passes explicit booleans. Normalize before the fail-closed helper.
+    const remoteFilter = factsWorldOnly({ remote: opts.remote === true, trustedFactReads: opts.trustedFactReads === true });
 
     // Build SQL dynamically. PGLite uses $N positional params; we
     // assemble the WHERE clauses + params array in tandem to keep them

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -14,6 +14,7 @@ import type {
   SourceRow,
 } from './engine.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
+import { factsWorldOnly } from './facts/reader-trust.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
@@ -4532,7 +4533,10 @@ export class PostgresEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    // Direct-engine contract: unset `remote` here means a trusted in-process
+    // caller (CLI/tests) — the fail-closed default lives in the op layer, which
+    // always passes explicit booleans. Normalize before the fail-closed helper.
+    const remoteFilter = factsWorldOnly({ remote: opts.remote === true, trustedFactReads: opts.trustedFactReads === true });
 
     // Source-scope predicate: array path (federated) wins over scalar.
     // Engine.ts contract: returns chronological points; regressions +

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -30,6 +30,13 @@ export interface ToolResult {
 export interface DispatchOpts {
   /** Defaults to true (remote/untrusted). Local CLI callers (`gbrain call`) pass false. */
   remote?: boolean;
+  /**
+   * Owner opt-in (`facts.trust_local_reads`): let this remote caller read
+   * `private` facts. Set ONLY by the stdio MCP server; the HTTP transport
+   * leaves it unset so a served brain stays world-only. See
+   * `src/core/facts/reader-trust.ts`.
+   */
+  trustedFactReads?: boolean;
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
   /**
@@ -203,6 +210,7 @@ export function buildOperationContext(
     logger: opts.logger || stderrLogger,
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
+    trustedFactReads: opts.trustedFactReads === true,
     takesHoldersAllowList: opts.takesHoldersAllowList,
     // v0.34 D4: sourceId is REQUIRED at the type level. Auto-fill 'default'
     // for single-source brains and any caller who didn't resolve a sourceId.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,16 @@ export async function startMcpServer(engine: BrainEngine) {
   // shape and cast through `any` (the SDK accepts it via the ServerResult union).
   server.setRequestHandler(CallToolRequestSchema, async (request: any): Promise<any> => {
     const { name, arguments: params } = request.params;
+    // Owner opt-in: the stdio pipe is local + unauthenticated, so on a
+    // single-owner machine its caller is the owner. When facts.trust_local_reads
+    // is on, let fact reads (find_trajectory / recall) see this owner's own
+    // private facts. Narrow + read-only — every other remote protection stays
+    // on (remote stays true). HTTP transport never sets this. Best-effort: a
+    // config read blip falls back to the safe world-only default.
+    let trustedFactReads = false;
+    try {
+      trustedFactReads = (await engine.getConfig('facts.trust_local_reads')) === 'true';
+    } catch { /* keep world-only default */ }
     // v0.28: stdio MCP has no per-token auth (local pipe). Default the
     // takes-holder allow-list to ['world'] so agent-facing callers don't
     // see private hunches via takes_list / takes_search / query. Operators
@@ -42,6 +52,7 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      trustedFactReads,
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/engine-find-trajectory.test.ts
+++ b/test/engine-find-trajectory.test.ts
@@ -165,6 +165,22 @@ describe('findTrajectory — visibility filter (D-CDX-1 / R6)', () => {
     const all = await engine.findTrajectory({ entitySlug: 'traj-vis-default' });
     expect(all.length).toBe(2);
   });
+
+  test('remote=true + trustedFactReads bypasses world-only (owner-trusted reads)', async () => {
+    await insertTyped({ entity_slug: 'traj-vis-trusted', metric: 'mrr', value: 50000, visibility: 'private', valid_from: new Date('2026-01-15') });
+    await insertTyped({ entity_slug: 'traj-vis-trusted', metric: 'mrr', value: 99999, visibility: 'world',   valid_from: new Date('2026-04-12') });
+
+    // Untrusted remote: world only.
+    const untrusted = await engine.findTrajectory({ entitySlug: 'traj-vis-trusted', remote: true });
+    expect(untrusted.length).toBe(1);
+    expect(untrusted[0].value).toBe(99999);
+
+    // Owner-trusted remote: sees the private point too. remote stays true — only
+    // fact-read visibility is elevated.
+    const trusted = await engine.findTrajectory({ entitySlug: 'traj-vis-trusted', remote: true, trustedFactReads: true });
+    expect(trusted.length).toBe(2);
+    expect(trusted.map(p => p.value).sort((a, b) => (a! - b!))).toEqual([50000, 99999]);
+  });
 });
 
 describe('findTrajectory — metric + since + until filters', () => {

--- a/test/facts-reader-trust.test.ts
+++ b/test/facts-reader-trust.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  factsWorldOnly,
+  readableFactVisibilities,
+} from '../src/core/facts/reader-trust.ts';
+
+describe('factsWorldOnly', () => {
+  test('FAIL-CLOSED: unset remote is untrusted (world-only)', () => {
+    expect(factsWorldOnly({})).toBe(true);
+    expect(factsWorldOnly({ remote: undefined })).toBe(true);
+    expect(factsWorldOnly({ trustedFactReads: false })).toBe(true);
+  });
+
+  test('explicit remote=false (trusted local CLI) sees all', () => {
+    expect(factsWorldOnly({ remote: false })).toBe(false);
+    expect(factsWorldOnly({ remote: false, trustedFactReads: false })).toBe(false);
+  });
+
+  test('untrusted remote callers are world-only', () => {
+    expect(factsWorldOnly({ remote: true })).toBe(true);
+    expect(factsWorldOnly({ remote: true, trustedFactReads: false })).toBe(true);
+  });
+
+  test('owner-trusted remote reads bypass the world-only filter', () => {
+    expect(factsWorldOnly({ remote: true, trustedFactReads: true })).toBe(false);
+  });
+
+  test('trustedFactReads is a no-op for an already-trusted local caller', () => {
+    expect(factsWorldOnly({ remote: false, trustedFactReads: true })).toBe(false);
+  });
+});
+
+describe('readableFactVisibilities', () => {
+  test("world-only readers get the ['world'] filter (incl. unset remote)", () => {
+    expect(readableFactVisibilities({ remote: true })).toEqual(['world']);
+    expect(readableFactVisibilities({})).toEqual(['world']);
+  });
+
+  test('trusted readers get undefined (no filter — all rows)', () => {
+    expect(readableFactVisibilities({ remote: false })).toBeUndefined();
+    expect(readableFactVisibilities({ remote: true, trustedFactReads: true })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Takeover of #2427 (credit: @jeanpierre121, co-authored on the commit). Salvages the owner-trusted-reads feature with its trust regression repaired; references #2427 but closes nothing.

## What

Fact rows are `private` | `world`; remote callers are world-only. The stdio MCP server is a local, unauthenticated pipe — on a single-owner machine its caller IS the owner — yet it defaults `remote: true`, so the owner's own agent got an empty `find_trajectory` and world-only `recall` over MCP.

This adds `trustedFactReads`: a narrow, READ-ONLY trust elevation decoupled from `remote`, so every other remote protection (file confinement, source isolation, fence stripping, takes-holder scoping) stays fully in force. Opt-in via the new `facts.trust_local_reads` config key (default off). Only the stdio server sets it; HTTP dispatch never does, so a served brain stays world-only regardless.

- `src/core/facts/reader-trust.ts` (new): `factsWorldOnly` / `readableFactVisibilities` — single decision point for fact-read visibility.
- All four visibility sites route through it: `findTrajectory` (postgres + pglite engines, in lockstep), the recall op, and the facts meta-hook.
- `OperationContext.trustedFactReads` + `TrajectoryOpts.trustedFactReads`; `dispatch.ts` threads the flag; stdio `server.ts` reads the config best-effort (a config blip falls back to world-only).

## Repair vs #2427 as submitted

#2427's `factsWorldOnly` was **fail-open** (`remote === true && …`): an unset `remote` read private rows. It replaced two fail-closed sites (recall's visibility filter and the facts meta-hook, both `ctx.remote === false ? undefined : ['world']` on master), and its own test codified the regression (`factsWorldOnly({}) === false`), violating the CLAUDE.md trust invariant ("anything not strictly `false` is remote/untrusted").

Repaired: `factsWorldOnly` is now fail-closed (`t.remote !== false && t.trustedFactReads !== true`) and the truth-table test pins it. The two engine `findTrajectory` call sites keep the direct-engine default-local contract (unset `remote` at the engine layer = trusted in-process caller, matching master's `opts.remote === true` filter) by normalizing to explicit booleans before calling the helper.

## Dropped from #2427

The claim-time fact dating half (`segmentValidFrom`) already landed on master via #2958 (`seg.startIso` with the epoch guard) — not re-applied.

## Tests

- `test/facts-reader-trust.test.ts`: fail-closed truth table for both helpers (fails against #2427's version — `factsWorldOnly({})` must be `true`).
- `test/engine-find-trajectory.test.ts`: new case — `remote=true + trustedFactReads` returns private points while plain `remote=true` stays world-only.
- `bun run typecheck` exit 0; touched suites green (85 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)