### PR TITLE
fix(search): honor sources.config.federated in unqualified local CLI search/query

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -808,12 +808,20 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
   // 'default'. Wrapped in try/catch so a doctor / single-source brain that
   // never set up sources still returns 'default' silently.
   let sourceId: string | undefined;
+  // #2561: when the source resolved via a NON-explicit tier (path-match /
+  // brain default / sole-non-default / seed default), unqualified search-shaped
+  // reads span every `config.federated = true` source. Computed here (the
+  // trusted local boundary) and consumed by federatedSearchScope in
+  // operations.ts, which additionally gates on ctx.remote === false.
+  let localFederated: string[] | undefined;
   try {
-    const { resolveSourceId } = await import('./core/source-resolver.ts');
+    const { resolveSourceWithTier, localFederatedSourceIds } = await import('./core/source-resolver.ts');
     // params.source is set when a CLI flag was parsed for the op (rare; most
     // CLI ops don't take --source). Falls through to env/dotfile/path-match.
     const explicit = (params.source as string | undefined) ?? null;
-    sourceId = await resolveSourceId(engine, explicit);
+    const resolved = await resolveSourceWithTier(engine, explicit);
+    sourceId = resolved.source_id;
+    localFederated = await localFederatedSourceIds(engine, resolved.source_id, resolved.tier);
   } catch {
     // Source resolution failed (e.g. sources table doesn't exist on a fresh
     // pre-init brain). Leave sourceId unset; engine read methods fall through
@@ -834,6 +842,7 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
     // table). Matches dispatch.ts's auto-fill so the contract holds across
     // every transport.
     sourceId: sourceId ?? 'default',
+    ...(localFederated ? { localFederatedSourceIds: localFederated } : {}),
   };
 }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -424,6 +424,23 @@ export interface OperationContext {
    * satisfied even on single-source brains.
    */
   sourceId: string;
+  /**
+   * #2561 — federated read scope for UNQUALIFIED local CLI reads.
+   *
+   * Set ONLY by the local CLI's context builder (src/cli.ts makeContext), and
+   * only when the source resolved via a non-explicit tier (local_path /
+   * brain_default / sole_non_default / seed_default — NOT --source, NOT
+   * GBRAIN_SOURCE, NOT a .gbrain-source dotfile). Contains the resolved
+   * source first, then every other `config.federated = true` source, so an
+   * unqualified `gbrain search "X"` spans federated sources as
+   * docs/guides/multi-source-brains.md promises.
+   *
+   * Consumed exclusively by `federatedSearchScope` and ONLY when
+   * `ctx.remote === false` — a remote caller's scope stays governed by
+   * `ctx.auth.allowedSources` / scalar `ctx.sourceId` (source-isolation
+   * invariant, fail-closed).
+   */
+  localFederatedSourceIds?: string[];
 }
 
 /**
@@ -537,6 +554,45 @@ export function resolveRequestedScope(
     return { sourceId: sourceIdParam };
   }
   return sourceScopeOpts(ctx);
+}
+
+/**
+ * #2561 — source scope for the search-shaped read ops (`search`, `query`).
+ *
+ * Delegates to `resolveRequestedScope` (the single trust+grant resolver), then
+ * widens an UNQUALIFIED trusted-local scalar scope to the CLI-computed
+ * federated set (`ctx.localFederatedSourceIds`, resolved source first). This is
+ * what makes `sources add --federated` mean something for local search: a
+ * federated source participates in unqualified `gbrain search "X"` results.
+ *
+ * The expansion NEVER applies when:
+ *   - the caller is not strictly trusted-local (`ctx.remote !== false`) —
+ *     remote scope stays grant-governed (fail-closed source isolation);
+ *   - a per-call `source_id` was passed (explicit wins, including `__all__`);
+ *   - the resolver already produced a federated array (OAuth grant);
+ *   - the CLI resolved the source from an explicit signal (--source / env /
+ *     dotfile) — makeContext leaves `localFederatedSourceIds` unset then.
+ *
+ * Deliberately NOT inside `sourceScopeOpts`: code-intel ops collapse a
+ * multi-element scope to an error (`resolveCodeIntelScope`), and non-search
+ * reads (get_page, get_links, …) keep their long-standing scalar behavior.
+ */
+export function federatedSearchScope(
+  ctx: OperationContext,
+  sourceIdParam?: string,
+): { sourceId?: string; sourceIds?: string[] } {
+  const scope = resolveRequestedScope(ctx, sourceIdParam);
+  if (
+    ctx.remote === false &&
+    sourceIdParam === undefined &&
+    scope.sourceId !== undefined &&
+    scope.sourceIds === undefined &&
+    ctx.localFederatedSourceIds !== undefined &&
+    ctx.localFederatedSourceIds.length > 1
+  ) {
+    return { sourceIds: ctx.localFederatedSourceIds };
+  }
+  return scope;
 }
 
 /**
@@ -1448,7 +1504,8 @@ const search: Operation = {
     const queryText = p.query as string;
     const limit = (p.limit as number) || 20;
     const offset = (p.offset as number) || 0;
-    const scope = sourceScopeOpts(ctx);
+    // #2561: unqualified trusted-local search spans federated sources.
+    const scope = federatedSearchScope(ctx);
 
     // T4/D5 — per-call mode honored ONLY for trusted/local callers so a remote
     // OAuth client can't escalate to the costly tokenmax bundle. Local + unknown
@@ -1610,7 +1667,9 @@ const query: Operation = {
     // is spread into BOTH the image-similarity searchVector path and the text
     // hybridSearch path below, so both honor the same grant.
     const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
-    const querySourceScope = resolveRequestedScope(ctx, sourceIdParam);
+    // #2561: unqualified trusted-local query spans federated sources (per-call
+    // source_id / remote grants still resolve through resolveRequestedScope).
+    const querySourceScope = federatedSearchScope(ctx, sourceIdParam);
 
     // v0.27.1: image-similarity branch. Bypasses hybridSearch (which is
     // text-only); embeds the image via embedMultimodal and runs a direct

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -353,6 +353,45 @@ export async function resolveSourceWithTier(
   return { source_id: 'default', tier: 'seed_default' };
 }
 
+/**
+ * #2561 — compute the federated read scope for an UNQUALIFIED local CLI call.
+ *
+ * `sources add --federated` promises that a `config.federated = true` source
+ * "participates in unqualified `gbrain search` results"
+ * (docs/guides/multi-source-brains.md). This helper turns that promise into a
+ * scope: given the resolved source and WHICH tier resolved it, return
+ * `[resolvedSource, ...other federated source ids]` — or `undefined` when the
+ * expansion must not apply:
+ *
+ *   - explicit tiers (`flag` / `env` / `dotfile`): the user named a source;
+ *     scalar scope stands (that IS the qualified case);
+ *   - no other federated source exists: keep the scalar fast path unchanged.
+ *
+ * Archived sources are excluded (same rationale as pickSoleNonDefaultSource);
+ * the archived column is v34+, so fall back to the un-archived query on older
+ * brains. Callers put the result on `OperationContext.localFederatedSourceIds`
+ * — consumed only by `federatedSearchScope` and only when `remote === false`.
+ */
+export async function localFederatedSourceIds(
+  engine: BrainEngine,
+  sourceId: string,
+  tier: SourceTier,
+): Promise<string[] | undefined> {
+  if (tier === 'flag' || tier === 'env' || tier === 'dotfile') return undefined;
+  let rows: Array<{ id: string }>;
+  try {
+    rows = await engine.executeRaw<{ id: string }>(
+      `SELECT id FROM sources WHERE config->>'federated' = 'true' AND archived = false ORDER BY id`,
+    );
+  } catch {
+    rows = await engine.executeRaw<{ id: string }>(
+      `SELECT id FROM sources WHERE config->>'federated' = 'true' ORDER BY id`,
+    );
+  }
+  const ids = [sourceId, ...rows.map((r) => r.id).filter((id) => id !== sourceId)];
+  return ids.length > 1 ? ids : undefined;
+}
+
 /** Exposed for tests. */
 export const __testing = {
   readDotfileWalk,

--- a/test/local-federated-search-scope.test.ts
+++ b/test/local-federated-search-scope.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #2561 — sources.config.federated participates in UNQUALIFIED local CLI
+ * search/query.
+ *
+ * Pre-fix: the local CLI always emitted a scalar `{sourceId}` scope (required
+ * field, auto-filled 'default'), so a source registered with
+ * `gbrain sources add --federated` was invisible to an unqualified
+ * `gbrain search "X"` — contradicting docs/guides/multi-source-brains.md
+ * ("Source participates in unqualified `gbrain search` results").
+ *
+ * Fix: the CLI context builder computes `ctx.localFederatedSourceIds`
+ * (resolved source + every other federated source) whenever the source
+ * resolved via a NON-explicit tier; `federatedSearchScope` widens the scalar
+ * scope to that set for the `search` / `query` ops — trusted-local only
+ * (`ctx.remote === false`), never for remote callers, never when a per-call
+ * `source_id` or an explicit --source/env/dotfile was given.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { localFederatedSourceIds } from '../src/core/source-resolver.ts';
+import {
+  federatedSearchScope,
+  operations,
+  type OperationContext,
+} from '../src/core/operations.ts';
+
+let engine: PGLiteEngine;
+const search = operations.find((o) => o.name === 'search')!;
+
+function ctxOf(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine: engine as any,
+    config: {} as any,
+    logger: console as any,
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  // Seeded 'default' source is federated=true. Add:
+  //   wiki    — federated (must join unqualified search)
+  //   private — NOT federated (must stay invisible unless explicitly named)
+  //   oldnews — federated but archived (must stay excluded)
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ('wiki', 'wiki', '/tmp/wiki', '{"federated": true}'::jsonb)`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ('private', 'private', '/tmp/private', '{}'::jsonb)`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config, archived) VALUES ('oldnews', 'oldnews', '/tmp/oldnews', '{"federated": true}'::jsonb, true)`,
+  );
+  const pages: Array<[slug: string, sourceId: string, where: string]> = [
+    ['notes/home', 'default', 'default'],
+    ['wiki/topic', 'wiki', 'wiki'],
+    ['private/topic', 'private', 'private'],
+    ['old/topic', 'oldnews', 'oldnews'],
+  ];
+  for (const [slug, sourceId, where] of pages) {
+    await engine.putPage(slug, {
+      type: 'note', title: `Topic in ${where}`, compiled_truth: `the zebra telescope in ${where}`, frontmatter: {},
+    }, { sourceId });
+    await engine.upsertChunks(slug, [
+      { chunk_index: 0, chunk_text: `the zebra telescope in ${where}`, chunk_source: 'compiled_truth' },
+    ], { sourceId });
+  }
+  // Keyword-only search path: no embedding provider needed in tests.
+  await engine.setConfig('search.mcp_keyword_only', 'true');
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+describe('localFederatedSourceIds — CLI-side scope computation', () => {
+  test('non-explicit tier: resolved source first, then other federated, archived excluded', async () => {
+    expect(await localFederatedSourceIds(engine, 'default', 'seed_default')).toEqual(['default', 'wiki']);
+  });
+
+  test('non-federated resolved source still joins its own scope', async () => {
+    expect(await localFederatedSourceIds(engine, 'private', 'brain_default')).toEqual(['private', 'default', 'wiki']);
+  });
+
+  test('explicit tiers (--source / env / dotfile) never expand', async () => {
+    expect(await localFederatedSourceIds(engine, 'default', 'flag')).toBeUndefined();
+    expect(await localFederatedSourceIds(engine, 'default', 'env')).toBeUndefined();
+    expect(await localFederatedSourceIds(engine, 'default', 'dotfile')).toBeUndefined();
+  });
+
+  test('single federated source (the resolved one) keeps the scalar fast path', async () => {
+    const solo = { executeRaw: async () => [{ id: 'default' }] } as any;
+    expect(await localFederatedSourceIds(solo, 'default', 'seed_default')).toBeUndefined();
+  });
+});
+
+describe('federatedSearchScope — trust + explicitness matrix', () => {
+  test('trusted local + unqualified widens to the federated set', () => {
+    const ctx = ctxOf({ localFederatedSourceIds: ['default', 'wiki'] });
+    expect(federatedSearchScope(ctx)).toEqual({ sourceIds: ['default', 'wiki'] });
+  });
+
+  test('remote caller NEVER widens (fail-closed), even if the field is set', () => {
+    const ctx = ctxOf({ remote: true, localFederatedSourceIds: ['default', 'wiki'] });
+    expect(federatedSearchScope(ctx)).toEqual({ sourceId: 'default' });
+  });
+
+  test('per-call source_id wins over the federated set', () => {
+    const ctx = ctxOf({ localFederatedSourceIds: ['default', 'wiki'] });
+    expect(federatedSearchScope(ctx, 'wiki')).toEqual({ sourceId: 'wiki' });
+  });
+
+  test('per-call __all__ keeps the whole-brain semantics for trusted local', () => {
+    const ctx = ctxOf({ localFederatedSourceIds: ['default', 'wiki'] });
+    expect(federatedSearchScope(ctx, '__all__')).toEqual({});
+  });
+
+  test('a federated OAuth grant wins over the local set', () => {
+    const ctx = ctxOf({
+      localFederatedSourceIds: ['default', 'wiki'],
+      auth: { allowedSources: ['a', 'b'] } as OperationContext['auth'],
+    });
+    expect(federatedSearchScope(ctx)).toEqual({ sourceIds: ['a', 'b'] });
+  });
+
+  test('no local federated set → unchanged scalar scope', () => {
+    expect(federatedSearchScope(ctxOf())).toEqual({ sourceId: 'default' });
+  });
+});
+
+describe('search op — unqualified local search spans federated sources', () => {
+  test('federated source results appear; non-federated + archived stay invisible', async () => {
+    const ctx = ctxOf({
+      localFederatedSourceIds: await localFederatedSourceIds(engine, 'default', 'seed_default'),
+    });
+    const results = (await search.handler(ctx, { query: 'zebra telescope' })) as Array<{ slug: string }>;
+    const slugs = results.map((r) => r.slug);
+    expect(slugs).toContain('notes/home');
+    expect(slugs).toContain('wiki/topic'); // pre-#2561 this was missing
+    expect(slugs).not.toContain('private/topic');
+    expect(slugs).not.toContain('old/topic');
+  });
+
+  test('explicit source resolution (no federated set on ctx) stays single-source', async () => {
+    const results = (await search.handler(ctxOf(), { query: 'zebra telescope' })) as Array<{ slug: string }>;
+    const slugs = results.map((r) => r.slug);
+    expect(slugs).toEqual(['notes/home']);
+  });
+});


### PR DESCRIPTION
Fixes #2561

## Problem

`gbrain sources add --federated` promises (docs/guides/multi-source-brains.md) that a `config.federated = true` source "participates in unqualified `gbrain search` results" — but nothing on the local read path ever consulted the flag. The local CLI always emitted a scalar `{sourceId}` scope (required field, auto-filled `default`), so a federated source stayed invisible unless explicitly named via `--source`.

## Fix

Expansion happens at the trusted-local boundary only:

- **`src/cli.ts` makeContext** now resolves the source WITH its tier (`resolveSourceWithTier`) and, when the tier is non-explicit (`local_path` / `brain_default` / `sole_non_default` / `seed_default` — NOT `--source`, NOT `GBRAIN_SOURCE`, NOT a `.gbrain-source` dotfile), computes `ctx.localFederatedSourceIds = [resolvedSource, ...other federated source ids]` (archived sources excluded; single-source brains keep the scalar fast path).
- **`federatedSearchScope`** (operations.ts) delegates to `resolveRequestedScope` (the single trust+grant resolver), then widens an unqualified trusted-local scalar scope to that set. Wired into the `search` and `query` handlers only.

## Source-isolation invariant (fail-closed)

The expansion NEVER applies when:
- `ctx.remote !== false` — remote scope stays governed by `ctx.auth.allowedSources` / scalar `ctx.sourceId`;
- a per-call `source_id` (including `__all__`) was passed — explicit wins;
- an OAuth federated grant is present — the grant array wins;
- the source was named explicitly (flag/env/dotfile) — the field is never set.

Deliberately NOT inside `sourceScopeOpts`: code-intel ops collapse multi-element scopes to an error (`resolveCodeIntelScope`), and non-search reads (get_page, get_links, …) keep their long-standing scalar behavior. Query-cache contamination is already handled — `cacheScopeKey` folds `sourceIds` sets into the cache key.

## Tests

`test/local-federated-search-scope.test.ts` (fails without the fix):
- `localFederatedSourceIds` tier gating + archived exclusion + scalar fast path;
- `federatedSearchScope` trust/explicitness matrix (remote never widens);
- PGLite integration: unqualified `search` op returns the federated source's page, excludes non-federated + archived sources; explicit resolution stays single-source.

Gates: `bun run typecheck` exit 0; new + neighboring suites (source-scope-resolver, get-page-federated-scope, operations-fuzzy-source-scope, sources, e2e/source-isolation-pglite, all 4 source-resolver suites) all pass; jsonb guard scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)