### PR TITLE
fix(import): normalize mixed-case slugs before chunk upsert

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -36,7 +36,7 @@ import {
 } from './embedding-context.ts';
 import { loadSearchModeConfig, resolveSearchMode } from './search/mode.ts';
 import { normalizeAliasList } from './search/alias-normalize.ts';
-import { isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { isUndefinedTableError, warnOncePerProcess, validateSlug } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { runGuardrails } from './guardrails.ts';
 
@@ -295,6 +295,12 @@ export async function importFromContent(
     remote?: boolean;
   } = {},
 ): Promise<ImportResult> {
+  // Normalize BEFORE any tx write: putPage lowercases via validateSlug but
+  // upsertChunks used to query by the caller's raw slug, so a mixed-case slug
+  // created the page row then failed the chunk upsert with "Page not found",
+  // rolling back the whole import (#430).
+  slug = validateSlug(slug);
+
   // v0.18.0+ multi-source: when caller is syncing under a non-default source,
   // every per-page tx call must carry `sourceId` so writes target the right
   // (source_id, slug) row. Pre-fix, putPage relied on the schema DEFAULT and

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2235,6 +2235,9 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
+    // Normalize the same way putPage does — pages.slug is stored lowercased,
+    // so a raw mixed-case slug here would miss the row it just wrote (#430).
+    slug = validateSlug(slug);
     const sourceId = opts?.sourceId ?? 'default';
 
     // Source-scope the page-id lookup so duplicate slugs in different sources

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2385,6 +2385,9 @@ export class PostgresEngine implements BrainEngine {
   }
 
   private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
+    // Normalize the same way putPage does — pages.slug is stored lowercased,
+    // so a raw mixed-case slug here would miss the row it just wrote (#430).
+    slug = validateSlug(slug);
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
 

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importFromContent } from '../src/core/import-file.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 import type { PageInput, ChunkInput } from '../src/core/types.ts';
 
@@ -180,6 +181,24 @@ describe('PGLiteEngine: Pages', () => {
   test('validateSlug normalizes to lowercase', async () => {
     const page = await engine.putPage('Test/UPPER', testPage);
     expect(page.slug).toBe('test/upper');
+  });
+
+  test('importFromContent normalizes mixed-case slugs before all tx writes (#430)', async () => {
+    const result = await importFromContent(
+      engine,
+      'TestNamespace/Page-Name',
+      '---\ntype: note\ntitle: Mixed Case\n---\n\nbody text',
+      { noEmbed: true },
+    );
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('testnamespace/page-name');
+
+    const page = await engine.getPage('testnamespace/page-name');
+    expect(page).not.toBeNull();
+    expect(page!.title).toBe('Mixed Case');
+
+    const chunks = await engine.getChunks('testnamespace/page-name');
+    expect(chunks.length).toBeGreaterThan(0);
   });
 });
 
@@ -362,6 +381,17 @@ describe('PGLiteEngine: Chunks', () => {
     expect(chunks.length).toBe(2);
     expect(chunks[0].chunk_text).toBe('Chunk zero');
     expect(chunks[1].chunk_text).toBe('Chunk one');
+  });
+
+  test('upsertChunks normalizes mixed-case slugs like putPage (#430)', async () => {
+    await engine.putPage('Test/ChunkCase', testPage);
+    await engine.upsertChunks('Test/ChunkCase', [
+      { chunk_index: 0, chunk_text: 'Mixed-case chunk', chunk_source: 'compiled_truth' },
+    ]);
+
+    const chunks = await engine.getChunks('test/chunkcase');
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].chunk_text).toBe('Mixed-case chunk');
   });
 
   test('upsertChunks removes orphan chunks', async () => {


### PR DESCRIPTION
## Items

- Fixes #430 — `put_page` with a mixed-case slug created the page row lowercased (putPage → validateSlug) but `upsertChunks` queried `WHERE slug = <raw slug>`, threw `Page not found`, and rolled back the whole import.
- Takeover of #855 — same approach as the original PR (credit: @Kage18, co-authored on the commit), rebased onto current master: the postgres `upsertChunks` is now a `batchRetry` wrapper delegating to `_upsertChunksOnce`, and `importFromContent`'s opts block was rewritten since that branch. Not closing #855 here.

## Fix

- `slug = validateSlug(slug)` at the top of `importFromContent` (src/core/import-file.ts) so every tx write inside one import sees the same normalized slug.
- Same normalization inside `_upsertChunksOnce` in BOTH `postgres-engine.ts` and `pglite-engine.ts` (engine parity), matching what `putPage` already does.

## Tests

Two regression tests in `test/pglite-engine.test.ts` (`upsertChunks` direct + `importFromContent` end-to-end). Both fail on master without the fix, pass with it. `bun run typecheck` clean; full `test/pglite-engine.test.ts` suite 102/102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)