### PR TITLE
fix(embedding,sources,files): Ollama per-model dims, config-repair array guard, upload-raw persistence

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -196,13 +196,45 @@ async function uploadRaw(engine: BrainEngine, args: string[]) {
   const needsCloud = stat.size >= SIZE_THRESHOLD || isMedia;
 
   if (!needsCloud) {
-    // Small text/PDF files stay in git
+    // Small text/PDF files stay in git — copy into the brain repo's `.raw/`
+    // sidecar (the shape documented in skills/_brain-filing-rules.md) and
+    // record a files row. #2297: this branch used to print success and
+    // persist NOTHING (the reported path was the caller's input file), so
+    // provenance was silently lost.
+    const { getDefaultSourcePath } = await import('../core/source-resolver.ts');
+    const repoPath = await getDefaultSourcePath(engine);
+    if (!repoPath) {
+      console.error('No brain repo configured — cannot preserve the raw file in git.');
+      console.error('Set a source local_path (`gbrain sources add <id> --path <repo>`) or configure sync.repo_path.');
+      process.exit(1);
+    }
+    const content = readFileSync(filePath);
+    const hash = createHash('sha256').update(content).digest('hex');
+    const relPath = join(pageSlug ?? 'unsorted', '.raw', filename);
+    const destPath = join(repoPath, relPath);
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, content);
+
+    await executeRawJsonb(
+      engine,
+      `INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+       ON CONFLICT (storage_path) DO UPDATE SET
+         content_hash = EXCLUDED.content_hash,
+         size_bytes = EXCLUDED.size_bytes,
+         mime_type = EXCLUDED.mime_type`,
+      [pageSlug, filename, relPath, mimeType, stat.size, 'sha256:' + hash],
+      [{ type: fileType, storage: 'git' }],
+    );
+
     console.log(JSON.stringify({
       success: true,
       storage: 'git',
-      path: filePath,
+      path: destPath,
+      storagePath: relPath,
       size: stat.size,
       size_human: humanSize(stat.size),
+      hash: `sha256:${hash}`,
     }));
     return;
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import { saveConfig, loadConfig, loadConfigFileOnly, toEngineConfig, gbrainPath,
 import { createEngine } from '../core/engine-factory.ts';
 import { discoverOAuth, mintClientCredentialsToken, smokeTestMcp } from '../core/remote-mcp-probe.ts';
 import { runInitEmbedCheck } from '../core/init-embed-check.ts';
+import { effectiveDefaultDims } from '../core/embedding-dim-check.ts';
 
 export async function runInit(args: string[]) {
   // Help guard: cli.ts only routes --help to printOpHelp() for shared-op
@@ -246,7 +247,7 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     out.embedding_model = `${shorthand}:${firstModel}`;
-    out.embedding_dimensions = recipe.touchpoints.embedding!.default_dims;
+    out.embedding_dimensions = effectiveDefaultDims(recipe.touchpoints.embedding!, firstModel);
   }
 
   if (dimsArg !== null && !Number.isNaN(dimsArg) && dimsArg > 0) {
@@ -271,7 +272,11 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     if (recipe?.touchpoints.embedding?.default_dims) {
-      out.embedding_dimensions = recipe.touchpoints.embedding.default_dims;
+      // #2170: resolve the SELECTED model's native width (e.g. ollama:bge-m3 →
+      // 1024), not the provider-wide default_dims, so the schema isn't sized
+      // wrong when no --embedding-dimensions was passed.
+      const modelId = out.embedding_model.slice(providerId.length + 1);
+      out.embedding_dimensions = effectiveDefaultDims(recipe.touchpoints.embedding, modelId);
     }
   }
 
@@ -436,7 +441,7 @@ async function resolveEmbeddingByEnv(out: ResolvedAIOptions, nonInteractive: boo
         await import('../core/ai/defaults.ts');
       const dims = fullModel === DEFAULT_EMBEDDING_MODEL
         ? DEFAULT_EMBEDDING_DIMENSIONS
-        : tp.default_dims;
+        : effectiveDefaultDims(tp, model);
       out.embedding_model = fullModel;
       out.embedding_dimensions = dims;
       console.error(

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -14,19 +14,29 @@ export const ollama: Recipe = {
   touchpoints: {
     embedding: {
       // #2271: modern local embed models added so assertTouchpoint accepts them.
-      // Each carries its own native dim (qwen3-embed-8b=4096, arctic-l-v2=1024);
-      // the recipe-wide default_dims below is only the nomic fallback, so users
-      // of the larger models pass --embedding-dimensions (allowed via
-      // trust_custom_dims). Per-model dims metadata is a tracked follow-up.
       models: [
         'nomic-embed-text',
+        'bge-m3',
         'mxbai-embed-large',
         'all-minilm',
         'qwen3-embed-8b',
         'snowflake-arctic-embed-l-v2',
       ],
-      default_dims: 768, // nomic-embed-text native dim
-      trust_custom_dims: true, // #2271: local models carry varied native dims
+      default_dims: 768, // nomic-embed-text native dim (fallback for models absent from model_dims)
+      // #2170: Ollama models emit DIFFERENT fixed native widths, but one
+      // provider-wide default_dims silently built a 768d schema for 1024d
+      // models (bge-m3, mxbai-embed-large) → `gbrain embed` then failed with a
+      // dim mismatch. Declare each model's real native width so the schema is
+      // sized correctly with no --embedding-dimensions flag.
+      model_dims: {
+        'nomic-embed-text': 768,
+        'bge-m3': 1024,
+        'mxbai-embed-large': 1024,
+        'all-minilm': 384,
+        'qwen3-embed-8b': 4096,
+        'snowflake-arctic-embed-l-v2': 1024,
+      },
+      trust_custom_dims: true, // #2271: locally-pulled model variants may carry non-listed dims
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -28,6 +28,18 @@ export interface EmbeddingTouchpoint {
   models: string[];
   default_dims: number;
   dims_options?: number[]; // for Matryoshka-aware providers
+  /**
+   * #2170: per-model native embedding width, for providers whose models emit
+   * DIFFERENT fixed dimensions under one recipe (e.g. Ollama: nomic-embed-text
+   * = 768, bge-m3 = 1024, all-minilm = 384). When a model is named here, this
+   * width overrides the provider-wide `default_dims` for schema-column sizing
+   * (resolved via `effectiveDefaultDims` in embedding-dim-check.ts); models
+   * absent from the map fall back to `default_dims`. Keys MUST be a subset of
+   * `models` (pinned by test/embedding-dim-check.test.ts). Distinct from
+   * `dims_options` (a set of *choosable* Matryoshka widths for ONE flexible
+   * model) — `model_dims` is each model's single, fixed native width.
+   */
+  model_dims?: Record<string, number>;
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string; // ISO date
   /**

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -17,7 +17,7 @@ import type { BrainEngine } from './engine.ts';
 import { PGVECTOR_HNSW_VECTOR_MAX_DIMS } from './vector-index.ts';
 import { gbrainPath } from './config.ts';
 import { resolveRecipe } from './ai/model-resolver.ts';
-import type { Recipe } from './ai/types.ts';
+import type { Recipe, EmbeddingTouchpoint } from './ai/types.ts';
 import { AIConfigError } from './ai/errors.ts';
 import {
   supportsVoyageOutputDimension,
@@ -275,6 +275,17 @@ export interface ResolveSchemaEmbeddingDimOpts {
  *     `dims_options` list (Matryoshka providers). Otherwise reject — the
  *     user picked a model that doesn't support custom dims.
  */
+/**
+ * The embedding width a specific model actually emits: its per-model override
+ * from `model_dims` (e.g. Ollama `bge-m3` -> 1024) when present, else the
+ * recipe's provider-wide `default_dims`. Single source of truth for "what
+ * width will this model's schema column be" — schema/gateway dim sites resolve
+ * through it instead of reading `default_dims` directly (#2170).
+ */
+export function effectiveDefaultDims(tp: EmbeddingTouchpoint, modelId: string): number {
+  return tp.model_dims?.[modelId] ?? tp.default_dims;
+}
+
 export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): ResolveSchemaDimResult {
   try {
     const { recipe, parsed } = resolveRecipe(opts.embedding_model);
@@ -287,7 +298,7 @@ export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): 
           `Pick a recipe with an embedding touchpoint (gbrain providers list).`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp, opts.embedding_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -338,7 +349,7 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
           `Pick a multimodal-capable model from this provider.`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_multimodal_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp, opts.embedding_multimodal_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -365,13 +376,13 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
 function validateDimAgainstTouchpoint(
   modelId: string,
   recipe: Recipe,
-  defaultDims: number,
-  dimsOptions: number[] | undefined,
+  tp: EmbeddingTouchpoint,
   requestedDims: number | undefined,
 ): ResolveSchemaDimResult {
+  const dimsOptions = tp.dims_options;
   const nvidiaNaturalDims = recipe.id === 'nvidia' ? nvidiaEmbeddingDim(modelId) : undefined;
-  const effectiveDefaultDims = nvidiaNaturalDims ?? defaultDims;
-  const dim = requestedDims ?? effectiveDefaultDims;
+  const modelDefaultDims = nvidiaNaturalDims ?? effectiveDefaultDims(tp, modelId);
+  const dim = requestedDims ?? modelDefaultDims;
 
   if (!Number.isInteger(dim) || dim <= 0) {
     return {
@@ -388,7 +399,7 @@ function validateDimAgainstTouchpoint(
     };
   }
 
-  if (requestedDims !== undefined && requestedDims !== defaultDims) {
+  if (requestedDims !== undefined && requestedDims !== modelDefaultDims) {
     // User asked for a non-default dim. Walk the precedence chain.
     const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
     if (!customDimOk.valid) {
@@ -401,7 +412,7 @@ function validateDimAgainstTouchpoint(
     dim,
     model: `${recipe.id}:${modelId}`,
     provider: recipe.id,
-    recipeDefault: effectiveDefaultDims,
+    recipeDefault: modelDefaultDims,
   };
 }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1442,9 +1442,15 @@ export class PostgresEngine implements BrainEngine {
                END
              WHEN jsonb_typeof(config) = 'array'
                THEN COALESCE(
+                 -- #2251: skip non-object elements (the in-the-wild bad shape
+                 -- mixes double-encoded strings with patch objects); jsonb_each
+                 -- on a non-object raises and would fail the whole UPDATE,
+                 -- permanently blocking last_full_cycle_at writes. The CASE
+                 -- guard (not a WHERE) guarantees jsonb_each never sees a
+                 -- non-object regardless of qual-evaluation order.
                  (SELECT jsonb_object_agg(kv.key, kv.value)
                     FROM jsonb_array_elements(config) elem,
-                         jsonb_each(elem) kv),
+                         jsonb_each(CASE WHEN jsonb_typeof(elem) = 'object' THEN elem ELSE '{}'::jsonb END) kv),
                  '{}'::jsonb
                )
              ELSE '{}'::jsonb

--- a/test/e2e/list-all-sources-postgres.test.ts
+++ b/test/e2e/list-all-sources-postgres.test.ts
@@ -160,4 +160,33 @@ describeIfDB('Postgres parity — updateSourceConfig', () => {
     expect(rows[0]?.typeof).toBe('object');
     expect(rows[0]?.value).toBe('2026-05-22T12:00:00.000Z');
   });
+
+  test('array config with non-object elements is repaired, not fatal (#2251)', async () => {
+    await seedSource('echo');
+    // In-the-wild bad shape (#2251): a leading double-encoded STRING element
+    // mixed with patch objects. jsonb_each on the string element used to raise
+    // "cannot call jsonb_each on a non-object", failing the whole UPDATE —
+    // last_full_cycle_at never wrote and the dream cycle re-ran the source
+    // forever. Non-object elements must be skipped, object elements flattened.
+    await engine.executeRaw(
+      `UPDATE sources
+          SET config = '["{\\"double\\": true}", {"remote_url": "https://x"}, {"stale_key": "keep"}]'::jsonb
+        WHERE id = 'echo'`,
+    );
+    const updated = await engine.updateSourceConfig('echo', {
+      last_full_cycle_at: '2026-05-22T13:00:00.000Z',
+    });
+    expect(updated).toBe(true);
+    const rows = await engine.executeRaw<{ typeof: string; value: string | null; remote: string | null; stale: string | null }>(
+      `SELECT jsonb_typeof(config) AS typeof,
+              config->>'last_full_cycle_at' AS value,
+              config->>'remote_url' AS remote,
+              config->>'stale_key' AS stale
+         FROM sources WHERE id = 'echo'`,
+    );
+    expect(rows[0]?.typeof).toBe('object');
+    expect(rows[0]?.value).toBe('2026-05-22T13:00:00.000Z');
+    expect(rows[0]?.remote).toBe('https://x');
+    expect(rows[0]?.stale).toBe('keep');
+  });
 });

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -20,6 +20,7 @@ import {
   PGVECTOR_COLUMN_MAX_DIMS,
 } from '../src/core/embedding-dim-check.ts';
 import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+import { RECIPES } from '../src/core/ai/recipes/index.ts';
 
 // Canonical pattern: single engine per file, init once, disconnect once.
 // The two tests below diverge in whether they want a migrated brain or a
@@ -357,6 +358,104 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) {
       expect(got.dim).toBe(1536);
       expect(got.model).toBe('openai:text-embedding-3-large');
+    }
+  });
+});
+
+describe('resolveSchemaEmbeddingDim — Ollama per-model native dims (#2170)', () => {
+  test('bge-m3 resolves at its native 1024 (not the provider default 768)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3' });
+    expect(got).toEqual({
+      ok: true,
+      dim: 1024,
+      model: 'ollama:bge-m3',
+      provider: 'ollama',
+      recipeDefault: 1024,
+    });
+  });
+
+  test('mxbai-embed-large resolves at its native 1024', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:mxbai-embed-large' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('nomic-embed-text resolves at 768 (the provider default)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:nomic-embed-text' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(768);
+  });
+
+  test('all-minilm resolves at 384', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:all-minilm' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(384);
+  });
+
+  test('qwen3-embed-8b resolves at 4096', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:qwen3-embed-8b' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(4096);
+  });
+
+  test('explicit --embedding-dimensions matching the native width (bge-m3 @ 1024) is accepted', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3', embedding_dimensions: 1024 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('explicit non-native dim is still trusted for local recipes (trust_custom_dims, #2271)', () => {
+    // Ollama users may run custom/quantized variants under a listed name; the
+    // #2271 passthrough tier keeps an explicit dim authoritative. The runtime
+    // response-dim validation catches a genuine mismatch pre-storage.
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3', embedding_dimensions: 768 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(768);
+  });
+
+  test('regression (#2170): ollama:bge-m3 no longer silently sizes a 768 schema', () => {
+    // Before the per-model fix this resolved to 768, then `gbrain embed`
+    // failed at runtime ("model bge-m3 returned 1024 but schema expects 768").
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+});
+
+describe('resolveSchemaEmbeddingDim — user-provided-model local providers (#2170)', () => {
+  test('llama-server accepts an explicit --embedding-dimensions (1024)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:my-embed', embedding_dimensions: 1024 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('litellm accepts an explicit --embedding-dimensions (1536)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'litellm:some-proxy-model', embedding_dimensions: 1536 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1536);
+  });
+
+  test('llama-server accepts a non-standard width (e.g. 896) — user knows their backend', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:qwen-embed', embedding_dimensions: 896 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(896);
+  });
+
+  test('llama-server WITHOUT an explicit dimension is rejected (default_dims: 0)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:my-embed' });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
+});
+
+describe('recipe contract — model_dims keys are a subset of models (#2170)', () => {
+  test('every recipe that declares model_dims only maps models it lists', () => {
+    for (const recipe of RECIPES.values()) {
+      const tp = recipe.touchpoints.embedding;
+      if (!tp?.model_dims) continue;
+      for (const modelId of Object.keys(tp.model_dims)) {
+        expect(tp.models).toContain(modelId);
+      }
     }
   });
 });

--- a/test/files-upload-raw.test.ts
+++ b/test/files-upload-raw.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #2297 — `gbrain files upload-raw` small-file (git) branch.
+ *
+ * The !needsCloud branch used to print `{success:true, storage:'git',
+ * path:<caller's input path>}` and return WITHOUT copying anything into the
+ * brain repo or inserting a files row — provenance silently lost while
+ * reporting success. These tests pin the fixed behavior: the file lands in
+ * the documented `<page-slug>/.raw/<filename>` sidecar (unsorted/.raw
+ * without --page) and a files row records it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runFiles } from '../src/commands/files.ts';
+
+let engine: PGLiteEngine;
+let repoDir: string;
+let srcDir: string;
+let savedEnvSource: string | undefined;
+
+beforeAll(async () => {
+  // resolveSourceId env tier could leak from the harness — pin it off.
+  savedEnvSource = process.env.GBRAIN_SOURCE;
+  delete process.env.GBRAIN_SOURCE;
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  repoDir = mkdtempSync(join(tmpdir(), 'gbrain-raw-repo-'));
+  srcDir = mkdtempSync(join(tmpdir(), 'gbrain-raw-src-'));
+  // Legacy-tier brain repo resolution (getDefaultSourcePath fallback).
+  await engine.setConfig('sync.repo_path', repoDir);
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  rmSync(repoDir, { recursive: true, force: true });
+  rmSync(srcDir, { recursive: true, force: true });
+  if (savedEnvSource !== undefined) process.env.GBRAIN_SOURCE = savedEnvSource;
+});
+
+describe('files upload-raw — small text file stays in git (#2297)', () => {
+  test('copies into <page-slug>/.raw/ in the brain repo and records a files row', async () => {
+    const input = join(srcDir, 'notes.txt');
+    writeFileSync(input, 'raw provenance content');
+
+    await runFiles(engine, ['upload-raw', input, '--page', 'people/alice-example', '--type', 'notes']);
+
+    const dest = join(repoDir, 'people/alice-example/.raw/notes.txt');
+    expect(existsSync(dest)).toBe(true);
+    expect(readFileSync(dest, 'utf8')).toBe('raw provenance content');
+
+    const rows = await engine.executeRaw<{ storage_path: string; page_slug: string | null; metadata: Record<string, unknown> }>(
+      `SELECT storage_path, page_slug, metadata FROM files WHERE filename = 'notes.txt'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].storage_path).toBe('people/alice-example/.raw/notes.txt');
+    expect(rows[0].page_slug).toBe('people/alice-example');
+    expect(rows[0].metadata).toMatchObject({ type: 'notes', storage: 'git' });
+  });
+
+  test('without --page falls back to unsorted/.raw/', async () => {
+    const input = join(srcDir, 'loose.txt');
+    writeFileSync(input, 'loose content');
+
+    await runFiles(engine, ['upload-raw', input]);
+
+    expect(existsSync(join(repoDir, 'unsorted/.raw/loose.txt'))).toBe(true);
+    const rows = await engine.executeRaw<{ storage_path: string }>(
+      `SELECT storage_path FROM files WHERE filename = 'loose.txt'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].storage_path).toBe('unsorted/.raw/loose.txt');
+  });
+
+  test('re-upload of the same file is idempotent (ON CONFLICT upsert)', async () => {
+    const input = join(srcDir, 'notes.txt');
+    writeFileSync(input, 'raw provenance content v2');
+
+    await runFiles(engine, ['upload-raw', input, '--page', 'people/alice-example']);
+
+    const dest = join(repoDir, 'people/alice-example/.raw/notes.txt');
+    expect(readFileSync(dest, 'utf8')).toBe('raw provenance content v2');
+    const rows = await engine.executeRaw<{ id: number }>(
+      `SELECT id FROM files WHERE storage_path = 'people/alice-example/.raw/notes.txt'`,
+    );
+    expect(rows.length).toBe(1);
+  });
+});

--- a/test/files-upload-raw.test.ts
+++ b/test/files-upload-raw.test.ts
@@ -15,16 +15,17 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runFiles } from '../src/commands/files.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 let repoDir: string;
 let srcDir: string;
-let savedEnvSource: string | undefined;
+
+// resolveSourceId env tier could leak from the harness — pin it off per call.
+const runFilesNoEnvSource = (engine: PGLiteEngine, args: string[]) =>
+  withEnv({ GBRAIN_SOURCE: undefined }, () => runFiles(engine, args));
 
 beforeAll(async () => {
-  // resolveSourceId env tier could leak from the harness — pin it off.
-  savedEnvSource = process.env.GBRAIN_SOURCE;
-  delete process.env.GBRAIN_SOURCE;
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
@@ -38,7 +39,6 @@ afterAll(async () => {
   await engine.disconnect();
   rmSync(repoDir, { recursive: true, force: true });
   rmSync(srcDir, { recursive: true, force: true });
-  if (savedEnvSource !== undefined) process.env.GBRAIN_SOURCE = savedEnvSource;
 });
 
 describe('files upload-raw — small text file stays in git (#2297)', () => {
@@ -46,7 +46,7 @@ describe('files upload-raw — small text file stays in git (#2297)', () => {
     const input = join(srcDir, 'notes.txt');
     writeFileSync(input, 'raw provenance content');
 
-    await runFiles(engine, ['upload-raw', input, '--page', 'people/alice-example', '--type', 'notes']);
+    await runFilesNoEnvSource(engine, ['upload-raw', input, '--page', 'people/alice-example', '--type', 'notes']);
 
     const dest = join(repoDir, 'people/alice-example/.raw/notes.txt');
     expect(existsSync(dest)).toBe(true);
@@ -65,7 +65,7 @@ describe('files upload-raw — small text file stays in git (#2297)', () => {
     const input = join(srcDir, 'loose.txt');
     writeFileSync(input, 'loose content');
 
-    await runFiles(engine, ['upload-raw', input]);
+    await runFilesNoEnvSource(engine, ['upload-raw', input]);
 
     expect(existsSync(join(repoDir, 'unsorted/.raw/loose.txt'))).toBe(true);
     const rows = await engine.executeRaw<{ storage_path: string }>(
@@ -79,7 +79,7 @@ describe('files upload-raw — small text file stays in git (#2297)', () => {
     const input = join(srcDir, 'notes.txt');
     writeFileSync(input, 'raw provenance content v2');
 
-    await runFiles(engine, ['upload-raw', input, '--page', 'people/alice-example']);
+    await runFilesNoEnvSource(engine, ['upload-raw', input, '--page', 'people/alice-example']);
 
     const dest = join(repoDir, 'people/alice-example/.raw/notes.txt');
     expect(readFileSync(dest, 'utf8')).toBe('raw provenance content v2');


### PR DESCRIPTION
Backlog fix wave, work unit c37-1-f1 (embedding preflight & dims: local providers) + two verified P1s.

### 1. Per-model native dims for Ollama local embed models
Fixes #2170. Takeover of #2642 (rebased onto #2271's `trust_custom_dims`; credit to @Willisbest, co-author on the commit).

The Ollama recipe declared one provider-wide `default_dims: 768`, so the flagless path (`gbrain init --embedding-model ollama:bge-m3` or `ollama:mxbai-embed-large`) sized a 768d schema for 1024d models and `gbrain embed` failed at runtime. #2271 fixed only the explicit `--embedding-dimensions` path.

- `EmbeddingTouchpoint.model_dims` — per-model native width map (keys pinned as a subset of `models` by a contract test).
- `effectiveDefaultDims(tp, modelId)` in `embedding-dim-check.ts` — single source of truth; `validateDimAgainstTouchpoint` now takes the touchpoint and resolves the SELECTED model's width (NVIDIA natural dims keep precedence).
- `init.ts` routes all three default-dims sites (shorthand pick, verbose model without dims, env auto-detect) through it.
- Ollama recipe: adds `bge-m3` and declares native widths for all six listed models.

#2642's Tier-1.5 hunk (accept any explicit dim for `user_provided_models`) was dropped — fully superseded by master's `trust_custom_dims` — but its llama-server/litellm explicit-dims regression tests are kept.

### 2. updateSourceConfig array-branch repair no longer fatal on mixed shapes
Fixes #2251. The Postgres config-shape repair ran `jsonb_each(elem)` over every array element; a non-object element (the documented in-the-wild shape: double-encoded string + timestamp objects) raised `cannot call jsonb_each on a non-object`, failing the whole UPDATE — `last_full_cycle_at` never wrote and the dream cycle re-ran the source forever. The element is now guarded with a `CASE` (not a `WHERE` qual) so `jsonb_each` never sees a non-object regardless of qual-evaluation order. Postgres-only by design (the CASE repair exists only in postgres-engine). Expression semantics verified against Postgres 17.5 (PGLite) with the mixed `["str", {...}, 42, null]` shape; DATABASE_URL-gated e2e test added.

### 3. files upload-raw small-file branch actually persists
Fixes #2297. The `!needsCloud` branch printed `{success:true, storage:'git', path:<caller's input file>}` and returned without copying anything into the brain repo or inserting a files row. It now copies the file to the documented `<page-slug>/.raw/<filename>` sidecar (`unsorted/.raw/` without `--page`), records a files row (executeRawJsonb upsert on storage_path), reports the real destination, and fails loudly when no brain repo is configured.

### Tests
- `test/embedding-dim-check.test.ts` — per-model dim resolution (all six Ollama models, explicit-dim paths, trust_custom_dims passthrough), llama-server/litellm explicit dims, model_dims⊆models contract. New tests fail without the fix (bge-m3 resolved 768 before).
- `test/e2e/list-all-sources-postgres.test.ts` — mixed-array config repaired, patch merged, non-object elements skipped (DATABASE_URL-gated).
- `test/files-upload-raw.test.ts` — new: sidecar copy + files row + unsorted fallback + idempotent re-upload (fails without the fix: nothing persisted).

Gates: `bun run typecheck` exit 0; touched test files 149 pass / 0 fail; `check-jsonb-pattern.sh` + `check-jsonb-params.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)