### PR TITLE
fix(gateway): API-key & gateway-config plumbing — file-plane key writes, config-aware secret checks, brainstorm chat_model

### DIFF
--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -6,14 +6,14 @@ description: Twitter timeline, mentions, and keyword monitoring flow into brain 
 category: sense
 requires: []
 secrets:
-  - name: X_BEARER_TOKEN
+  - name: X_API_BEARER_TOKEN
     description: X API v2 Bearer token (Basic tier minimum, $200/mo for full archive search)
     where: https://developer.x.com/en/portal/dashboard — create a project + app, copy the Bearer Token from "Keys and tokens"
 health_checks:
   - type: http
     url: "https://api.x.com/2/users/me"
     auth: bearer
-    auth_token: "$X_BEARER_TOKEN"
+    auth_token: "$X_API_BEARER_TOKEN"
     label: "X API"
 setup_time: 15 min
 cost_estimate: "$0-200/mo (Free tier: 1 app, read-only. Basic: $200/mo for search + higher limits)"
@@ -117,7 +117,7 @@ gives search/recent endpoint and higher limits. Pro tier gets full archive searc
 
 Validate immediately:
 ```bash
-curl -sf -H "Authorization: Bearer $X_BEARER_TOKEN" \
+curl -sf -H "Authorization: Bearer $X_API_BEARER_TOKEN" \
   "https://api.x.com/2/users/me" \
   && echo "PASS: X API connected" \
   || echo "FAIL: X API token invalid"
@@ -133,7 +133,7 @@ starting with 'AAA...', (3) if you just created the app, the token is valid imme
 
 ```bash
 # Look up the user's X user ID from their handle
-curl -sf -H "Authorization: Bearer $X_BEARER_TOKEN" \
+curl -sf -H "Authorization: Bearer $X_API_BEARER_TOKEN" \
   "https://api.x.com/2/users/by/username/USERNAME" | grep -o '"id":"[^"]*"'
 ```
 

--- a/src/commands/brainstorm.ts
+++ b/src/commands/brainstorm.ts
@@ -41,6 +41,8 @@ export interface BrainstormCliArgs {
   maxFarSet?: number;
   /** When true, abort mid-run if running spend exceeds 5× estimate. */
   strictBudget?: boolean;
+  /** #1307: Override the model used for cross-generation (defaults to configured chat_model). */
+  model?: string;
   /** Override the model used for the judge phase. */
   judgeModel?: string;
   /** Max ideas per judge LLM call. Default 100. */
@@ -97,6 +99,13 @@ export function parseBrainstormArgs(args: string[]): BrainstormCliArgs {
       out.maxFarSet = n;
     } else if (arg === '--strict-budget') {
       out.strictBudget = true;
+    } else if (arg === '--model') {
+      const v = args[++i];
+      if (!v || v.startsWith('--')) {
+        out.error = `--model requires a model id (e.g. openai:gpt-4o or anthropic:claude-sonnet-4-6)`;
+        return out;
+      }
+      out.model = v;
     } else if (arg === '--judge-model') {
       const v = args[++i];
       if (!v) {
@@ -153,6 +162,7 @@ Options:
   --max-cost USD                  Abort if estimated cost exceeds USD (default 5)
   --max-far-set N                 Cap domain bank prefix sampling (default 50)
   --strict-budget                 Abort if running cost exceeds 5× the estimate
+  --model MODEL                   Override the cross-generation LLM (default: configured chat_model)
   --judge-model MODEL             Override the judge LLM (larger-context for big runs)
   --max-ideas-per-judge-call N    Max ideas per judge LLM call (default 100)
   --resume RUN_ID                 Resume a previously-crashed run (uses --list-runs ids)
@@ -188,6 +198,7 @@ Options:
   --max-cost USD                  Abort if estimated cost exceeds USD (default 5)
   --max-far-set N                 Cap domain bank prefix sampling (default 50)
   --strict-budget                 Abort if running cost exceeds 5× the estimate
+  --model MODEL                   Override the cross-generation LLM (default: configured chat_model)
   --judge-model MODEL             Override the judge LLM (larger-context for big runs)
   --max-ideas-per-judge-call N    Max ideas per judge LLM call (default 100)
   --resume RUN_ID                 Resume a previously-crashed run (uses --list-runs ids)
@@ -274,6 +285,7 @@ async function runBrainstormCli(
       maxCostUsd: parsed.maxCost,
       maxFarSet: parsed.maxFarSet,
       strictBudget: parsed.strictBudget,
+      modelOverride: parsed.model,
       judgeModel: parsed.judgeModel,
       maxIdeasPerJudgeCall: parsed.maxIdeasPerJudgeCall,
       resumeRunId: parsed.resume,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -35,6 +35,19 @@ export function redactConfigValue(key: string, value: string): string {
   return value;
 }
 
+/**
+ * #2119: provider API keys the runtime only ever reads from the env/file
+ * plane (see src/core/ai/build-gateway-config.ts). `config set` for these
+ * writes ~/.gbrain/config.json instead of the DB plane, which nothing reads
+ * for keys. Exported for tests.
+ */
+export const API_KEY_FILE_PLANE_KEYS = [
+  'openai_api_key',
+  'anthropic_api_key',
+  'zeroentropy_api_key',
+  'openrouter_api_key',
+];
+
 export async function runConfig(engine: BrainEngine, args: string[]) {
   const action = args[0];
 
@@ -83,6 +96,19 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
     if (!key) {
       console.error('Usage: gbrain config unset <key> | --pattern <prefix>');
       process.exit(1);
+    }
+    // #2119: API keys live in the file plane — remove them there (and clear
+    // any stale DB-plane row left by the pre-fix no-op write).
+    if (API_KEY_FILE_PLANE_KEYS.includes(key)) {
+      const { loadConfigFileOnly, saveConfig } = await import('../core/config.ts');
+      const fileCfg = loadConfigFileOnly() as Record<string, unknown> | null;
+      if (fileCfg && fileCfg[key] !== undefined) {
+        delete fileCfg[key];
+        saveConfig(fileCfg as unknown as Parameters<typeof saveConfig>[0]);
+        await engine.unsetConfig(key).catch(() => 0);
+        console.log(`Unset ${key} (file plane)`);
+        return;
+      }
     }
     const n = await engine.unsetConfig(key);
     if (n > 0) {
@@ -155,6 +181,22 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
       console.error(`[config]`);
       console.error(`[config] No --force escape: silently writing a no-op preserves the bug class this rejection closes.`);
       process.exit(1);
+    }
+
+    // #2119: *_api_key fields are file-plane canonical. The gateway resolves
+    // keys from process.env + ~/.gbrain/config.json only (buildGatewayConfig
+    // folds them into the gateway env); reconfigureGatewayWithEngine re-resolves
+    // models, never keys — so a DB-plane write was a silent no-op that the
+    // no-key error hint itself recommended. Redirect the write to the file
+    // plane so `gbrain config set anthropic_api_key ...` actually works.
+    if (API_KEY_FILE_PLANE_KEYS.includes(key)) {
+      const { loadConfigFileOnly, saveConfig, configPath } = await import('../core/config.ts');
+      const fileCfg = (loadConfigFileOnly() ?? {}) as Record<string, unknown>;
+      fileCfg[key] = value;
+      saveConfig(fileCfg as unknown as Parameters<typeof saveConfig>[0]);
+      console.log(`Set ${key} = ${redactConfigValue(key, value)}`);
+      console.error(`[config] API keys live in the file plane — wrote ${configPath()} (the gateway never reads the DB plane for keys). Env vars still win at runtime.`);
+      return;
     }
 
     // v0.37.10.0 (D6): strict unknown-key rejection with --force escape hatch.

--- a/src/commands/features.ts
+++ b/src/commands/features.ts
@@ -42,7 +42,7 @@ interface FeatureScanResult {
 const RECIPE_META = [
   { id: 'email-to-brain', name: 'Email to Brain', secrets: ['GMAIL_APP_PASSWORD'] },
   { id: 'calendar-to-brain', name: 'Calendar Sync', secrets: ['GOOGLE_CALENDAR_API_KEY'] },
-  { id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_BEARER_TOKEN'] },
+  { id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_API_BEARER_TOKEN'] },
   { id: 'twilio-voice-brain', name: 'Voice to Brain', secrets: ['TWILIO_AUTH_TOKEN'] },
   { id: 'meeting-sync', name: 'Meeting Sync', secrets: ['CIRCLEBACK_API_KEY'] },
   { id: 'credential-gateway', name: 'Credential Gateway', secrets: ['OAUTH_CLIENT_SECRET'] },

--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -23,7 +23,8 @@ import matter from 'gray-matter';
 import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
-import { gbrainPath } from '../core/config.ts';
+import { gbrainPath, loadConfig } from '../core/config.ts';
+import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
 import { execSync } from 'child_process';
 
 // --- Types ---
@@ -122,9 +123,28 @@ export function isUnsafeHealthCheck(check: string): boolean {
   return /[;&|`$(){}\\<>\n]/.test(check);
 }
 
-/** Expand $VAR references with process.env values */
+/**
+ * #2789: resolve a secret the way the gateway does — process.env first,
+ * then the ~/.gbrain/config.json keys buildGatewayConfig folds into the
+ * gateway env (same seam every runtime provider uses). Without the config
+ * fold, creds stored via `gbrain config set *_api_key` reported [missing]
+ * in show/status even though the integration worked.
+ */
+export function secretValue(name: string): string | undefined {
+  const fromEnv = process.env[name];
+  if (fromEnv) return fromEnv;
+  try {
+    const cfg = loadConfig();
+    if (cfg) return buildGatewayConfig(cfg).env?.[name] || undefined;
+  } catch {
+    // config unreadable → env-only resolution
+  }
+  return undefined;
+}
+
+/** Expand $VAR references with env/config-resolved secret values */
 export function expandVars(s: string): string {
-  return s.replace(/\$([A-Z_][A-Z0-9_]*)/g, (_, name) => process.env[name] || '');
+  return s.replace(/\$([A-Z_][A-Z0-9_]*)/g, (_, name) => secretValue(name) || '');
 }
 
 // --- SSRF Protection ---
@@ -249,7 +269,7 @@ export async function executeHealthCheck(
     }
 
     case 'env_exists': {
-      const val = process.env[check.name];
+      const val = secretValue(check.name);
       return {
         ...base,
         status: val ? 'ok' : 'fail',
@@ -461,7 +481,7 @@ function checkSecrets(secrets: RecipeSecret[]): { set: string[]; missing: Recipe
   const set: string[] = [];
   const missing: RecipeSecret[] = [];
   for (const s of secrets) {
-    if (process.env[s.name]) {
+    if (secretValue(s.name)) {
       set.push(s.name);
     } else {
       missing.push(s);
@@ -608,7 +628,7 @@ function cmdShow(args: string[]): void {
 
   console.log('\nSecrets needed:');
   for (const s of f.secrets) {
-    const isSet = process.env[s.name] ? '  [set]' : '  [missing]';
+    const isSet = secretValue(s.name) ? '  [set]' : '  [missing]';
     console.log(`  ${s.name}${isSet}`);
     console.log(`    ${s.description}`);
     console.log(`    Get it: ${s.where}`);

--- a/src/core/brainstorm/orchestrator.ts
+++ b/src/core/brainstorm/orchestrator.ts
@@ -32,7 +32,7 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
-import { chat as defaultChat, embedQuery, type ChatResult, type ChatOpts } from '../ai/gateway.ts';
+import { chat as defaultChat, embedQuery, getChatModel, type ChatResult, type ChatOpts } from '../ai/gateway.ts';
 import { hybridSearch, hybridSearchCached } from '../search/hybrid.ts';
 import { fetchFar, type CloseRef, type FarPage } from './domain-bank.ts';
 import { StructuredAgentError } from '../errors.ts';
@@ -527,6 +527,23 @@ async function runBrainstormImpl(
   return withBudgetTracker(_runTracker, () => _runBrainstormInner(engine, config, opts));
 }
 
+/**
+ * #1307: model used for cross-generation (and the cost preview). Explicit
+ * override wins; otherwise the gateway's configured chat_model — NOT a
+ * hardcoded Anthropic id, which made brainstorm/lsd ignore `chat_model` on
+ * non-Anthropic installs. try/catch because tests drive the orchestrator
+ * through the chatFn seam without configureGateway (same pattern as
+ * judges.ts resolveOutputCap). Exported for tests.
+ */
+export function resolveBrainstormModel(override?: string): string {
+  if (override) return override;
+  try {
+    return getChatModel();
+  } catch {
+    return 'anthropic:claude-sonnet-4-6';
+  }
+}
+
 async function _runBrainstormInner(
   engine: BrainEngine,
   config: { embedding_model?: string; emotional_weight?: { user_holder?: string } },
@@ -538,7 +555,7 @@ async function _runBrainstormInner(
   const embedFn = opts.embedQueryFn ?? embedQuery;
 
   // ---- Phase 0: cost preview + TTY grace ----
-  const modelStr = opts.modelOverride ?? 'anthropic:claude-sonnet-4-6';
+  const modelStr = resolveBrainstormModel(opts.modelOverride);
   const { aborted, estimate } = await previewCostAndWait({
     profile,
     model: modelStr,
@@ -746,7 +763,7 @@ async function _runBrainstormInner(
       far: cross.far,
     });
     const chatOpts: ChatOpts = {
-      model: opts.modelOverride,
+      model: modelStr,
       system,
       messages: [{ role: 'user', content: user }],
       maxTokens: 1500,

--- a/src/core/resolvers/builtin/x-api/handle-to-tweet.ts
+++ b/src/core/resolvers/builtin/x-api/handle-to-tweet.ts
@@ -350,6 +350,10 @@ function getBearerToken(ctx: ResolverContext): string | null {
   if (typeof fromConfig === 'string' && fromConfig.length > 0) return fromConfig;
   const fromEnv = process.env.X_API_BEARER_TOKEN;
   if (fromEnv && fromEnv.length > 0) return fromEnv;
+  // #2789: the x-to-brain recipe historically instructed users to export
+  // X_BEARER_TOKEN. Accept it so pre-rename setups keep working.
+  const legacy = process.env.X_BEARER_TOKEN;
+  if (legacy && legacy.length > 0) return legacy;
   return null;
 }
 

--- a/test/brainstorm/model-resolution.test.ts
+++ b/test/brainstorm/model-resolution.test.ts
@@ -1,0 +1,41 @@
+/**
+ * #1307: brainstorm/lsd cross-generation must honor the configured
+ * chat_model (not a hardcoded Anthropic id) and expose a --model flag.
+ */
+import { describe, test, expect, afterAll } from 'bun:test';
+import { configureGateway, resetGateway } from '../../src/core/ai/gateway.ts';
+import { resolveBrainstormModel } from '../../src/core/brainstorm/orchestrator.ts';
+import { parseBrainstormArgs } from '../../src/commands/brainstorm.ts';
+
+afterAll(() => {
+  resetGateway();
+});
+
+describe('resolveBrainstormModel (#1307)', () => {
+  test('explicit override wins', () => {
+    expect(resolveBrainstormModel('openai:gpt-4o')).toBe('openai:gpt-4o');
+  });
+
+  test('falls back to the configured chat_model, not hardcoded anthropic', () => {
+    configureGateway({ chat_model: 'deepseek:deepseek-chat', env: {} });
+    expect(resolveBrainstormModel()).toBe('deepseek:deepseek-chat');
+  });
+
+  test('unconfigured gateway degrades to the historical default', () => {
+    resetGateway();
+    expect(resolveBrainstormModel()).toBe('anthropic:claude-sonnet-4-6');
+  });
+});
+
+describe('--model CLI flag (#1307)', () => {
+  test('parses into args.model', () => {
+    const parsed = parseBrainstormArgs(['why?', '--model', 'openai:gpt-4o']);
+    expect(parsed.model).toBe('openai:gpt-4o');
+    expect(parsed.error).toBeUndefined();
+  });
+
+  test('missing value errors', () => {
+    const parsed = parseBrainstormArgs(['why?', '--model']);
+    expect(parsed.error).toContain('--model requires a model id');
+  });
+});

--- a/test/config-api-key-file-plane.test.ts
+++ b/test/config-api-key-file-plane.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #2119: `gbrain config set <provider>_api_key` must write the file plane
+ * (~/.gbrain/config.json) — the only plane the gateway reads keys from
+ * (src/core/ai/build-gateway-config.ts) — never the DB plane, which was a
+ * silent no-op. `config unset` for the same keys must remove the file-plane
+ * value.
+ */
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runConfig, API_KEY_FILE_PLANE_KEYS } from '../src/commands/config.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+const originalHome = process.env.GBRAIN_HOME;
+let home: string;
+let configJson: string;
+let setConfigCalls: Array<[string, string]>;
+let unsetConfigCalls: string[];
+
+const stubEngine = {
+  setConfig: async (k: string, v: string) => { setConfigCalls.push([k, v]); },
+  unsetConfig: async (k: string) => { unsetConfigCalls.push(k); return 0; },
+  getConfig: async () => null,
+  listConfigKeys: async () => [],
+} as unknown as BrainEngine;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-apikey-'));
+  process.env.GBRAIN_HOME = home;
+  configJson = join(home, '.gbrain', 'config.json');
+  setConfigCalls = [];
+  unsetConfigCalls = [];
+});
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = originalHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('config set *_api_key writes the file plane (#2119)', () => {
+  test('anthropic_api_key lands in ~/.gbrain/config.json, not the DB plane', async () => {
+    await runConfig(stubEngine, ['set', 'anthropic_api_key', 'sk-ant-test-123']);
+    const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
+    expect(saved.anthropic_api_key).toBe('sk-ant-test-123');
+    expect(setConfigCalls).toEqual([]); // DB plane untouched — nothing reads keys there
+  });
+
+  test('preserves existing file-plane fields', async () => {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(configJson, JSON.stringify({ engine: 'pglite', database_path: '/x' }));
+    await runConfig(stubEngine, ['set', 'openai_api_key', 'sk-oai-test']);
+    const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
+    expect(saved.engine).toBe('pglite');
+    expect(saved.openai_api_key).toBe('sk-oai-test');
+  });
+
+  test('unset removes the file-plane key and clears any stale DB row', async () => {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(configJson, JSON.stringify({ anthropic_api_key: 'sk-old' }));
+    await runConfig(stubEngine, ['unset', 'anthropic_api_key']);
+    const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
+    expect(saved.anthropic_api_key).toBeUndefined();
+    expect(unsetConfigCalls).toEqual(['anthropic_api_key']);
+  });
+
+  test('key list covers every key buildGatewayConfig folds into gateway env', () => {
+    expect(API_KEY_FILE_PLANE_KEYS.sort()).toEqual([
+      'anthropic_api_key', 'openai_api_key', 'openrouter_api_key', 'zeroentropy_api_key',
+    ]);
+  });
+});

--- a/test/config-api-key-file-plane.test.ts
+++ b/test/config-api-key-file-plane.test.ts
@@ -5,14 +5,14 @@
  * silent no-op. `config unset` for the same keys must remove the file-plane
  * value.
  */
-import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { withEnv } from './helpers/with-env.ts';
 import { runConfig, API_KEY_FILE_PLANE_KEYS } from '../src/commands/config.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
-const originalHome = process.env.GBRAIN_HOME;
 let home: string;
 let configJson: string;
 let setConfigCalls: Array<[string, string]>;
@@ -27,21 +27,16 @@ const stubEngine = {
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'gbrain-apikey-'));
-  process.env.GBRAIN_HOME = home;
   configJson = join(home, '.gbrain', 'config.json');
   setConfigCalls = [];
   unsetConfigCalls = [];
 });
 
-afterAll(() => {
-  if (originalHome === undefined) delete process.env.GBRAIN_HOME;
-  else process.env.GBRAIN_HOME = originalHome;
-  rmSync(home, { recursive: true, force: true });
-});
-
 describe('config set *_api_key writes the file plane (#2119)', () => {
   test('anthropic_api_key lands in ~/.gbrain/config.json, not the DB plane', async () => {
-    await runConfig(stubEngine, ['set', 'anthropic_api_key', 'sk-ant-test-123']);
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await runConfig(stubEngine, ['set', 'anthropic_api_key', 'sk-ant-test-123']);
+    });
     const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
     expect(saved.anthropic_api_key).toBe('sk-ant-test-123');
     expect(setConfigCalls).toEqual([]); // DB plane untouched — nothing reads keys there
@@ -50,7 +45,9 @@ describe('config set *_api_key writes the file plane (#2119)', () => {
   test('preserves existing file-plane fields', async () => {
     mkdirSync(join(home, '.gbrain'), { recursive: true });
     writeFileSync(configJson, JSON.stringify({ engine: 'pglite', database_path: '/x' }));
-    await runConfig(stubEngine, ['set', 'openai_api_key', 'sk-oai-test']);
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await runConfig(stubEngine, ['set', 'openai_api_key', 'sk-oai-test']);
+    });
     const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
     expect(saved.engine).toBe('pglite');
     expect(saved.openai_api_key).toBe('sk-oai-test');
@@ -59,7 +56,9 @@ describe('config set *_api_key writes the file plane (#2119)', () => {
   test('unset removes the file-plane key and clears any stale DB row', async () => {
     mkdirSync(join(home, '.gbrain'), { recursive: true });
     writeFileSync(configJson, JSON.stringify({ anthropic_api_key: 'sk-old' }));
-    await runConfig(stubEngine, ['unset', 'anthropic_api_key']);
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await runConfig(stubEngine, ['unset', 'anthropic_api_key']);
+    });
     const saved = JSON.parse(readFileSync(configJson, 'utf-8'));
     expect(saved.anthropic_api_key).toBeUndefined();
     expect(unsetConfigCalls).toEqual(['anthropic_api_key']);

--- a/test/integrations-config-secrets.test.ts
+++ b/test/integrations-config-secrets.test.ts
@@ -1,0 +1,66 @@
+/**
+ * #2789: integrations show/status must resolve secrets the way the gateway
+ * does — process.env overlaid on the ~/.gbrain/config.json keys that
+ * buildGatewayConfig folds into the gateway env. Also pins the X recipe's
+ * secret name to the env var the x-api resolver actually reads.
+ */
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import matter from 'gray-matter';
+import { secretValue } from '../src/commands/integrations.ts';
+
+const originalHome = process.env.GBRAIN_HOME;
+const originalKey = process.env.ANTHROPIC_API_KEY;
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-secrets-'));
+  process.env.GBRAIN_HOME = home;
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = originalHome;
+  if (originalKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = originalKey;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('secretValue folds config-stored creds (#2789)', () => {
+  test('config.json anthropic_api_key resolves when env is unset', () => {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'pglite', database_path: '/x', anthropic_api_key: 'sk-cfg-only' }),
+    );
+    expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-cfg-only');
+  });
+
+  test('process.env wins over config.json', () => {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'pglite', database_path: '/x', anthropic_api_key: 'sk-cfg' }),
+    );
+    process.env.ANTHROPIC_API_KEY = 'sk-env';
+    expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-env');
+  });
+
+  test('missing everywhere resolves undefined', () => {
+    expect(secretValue('DEFINITELY_NOT_SET_ANYWHERE_XYZ')).toBeUndefined();
+  });
+});
+
+describe('x-to-brain secret name matches the resolver (#2789)', () => {
+  test('recipe frontmatter declares X_API_BEARER_TOKEN (the env var handle-to-tweet reads)', () => {
+    const recipe = matter(readFileSync(join(import.meta.dir, '..', 'recipes', 'x-to-brain.md'), 'utf-8'));
+    const names = (recipe.data.secrets as Array<{ name: string }>).map(s => s.name);
+    expect(names).toContain('X_API_BEARER_TOKEN');
+    expect(names).not.toContain('X_BEARER_TOKEN');
+    // The recipe body's curl validation steps must use the same var.
+    expect(recipe.content).not.toContain('$X_BEARER_TOKEN');
+  });
+});

--- a/test/integrations-config-secrets.test.ts
+++ b/test/integrations-config-secrets.test.ts
@@ -4,53 +4,47 @@
  * buildGatewayConfig folds into the gateway env. Also pins the X recipe's
  * secret name to the env var the x-api resolver actually reads.
  */
-import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import matter from 'gray-matter';
+import { withEnv } from './helpers/with-env.ts';
 import { secretValue } from '../src/commands/integrations.ts';
 
-const originalHome = process.env.GBRAIN_HOME;
-const originalKey = process.env.ANTHROPIC_API_KEY;
 let home: string;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'gbrain-secrets-'));
-  process.env.GBRAIN_HOME = home;
-  delete process.env.ANTHROPIC_API_KEY;
-});
-
-afterAll(() => {
-  if (originalHome === undefined) delete process.env.GBRAIN_HOME;
-  else process.env.GBRAIN_HOME = originalHome;
-  if (originalKey === undefined) delete process.env.ANTHROPIC_API_KEY;
-  else process.env.ANTHROPIC_API_KEY = originalKey;
-  rmSync(home, { recursive: true, force: true });
 });
 
 describe('secretValue folds config-stored creds (#2789)', () => {
-  test('config.json anthropic_api_key resolves when env is unset', () => {
+  test('config.json anthropic_api_key resolves when env is unset', async () => {
     mkdirSync(join(home, '.gbrain'), { recursive: true });
     writeFileSync(
       join(home, '.gbrain', 'config.json'),
       JSON.stringify({ engine: 'pglite', database_path: '/x', anthropic_api_key: 'sk-cfg-only' }),
     );
-    expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-cfg-only');
+    await withEnv({ GBRAIN_HOME: home, ANTHROPIC_API_KEY: undefined }, () => {
+      expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-cfg-only');
+    });
   });
 
-  test('process.env wins over config.json', () => {
+  test('process.env wins over config.json', async () => {
     mkdirSync(join(home, '.gbrain'), { recursive: true });
     writeFileSync(
       join(home, '.gbrain', 'config.json'),
       JSON.stringify({ engine: 'pglite', database_path: '/x', anthropic_api_key: 'sk-cfg' }),
     );
-    process.env.ANTHROPIC_API_KEY = 'sk-env';
-    expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-env');
+    await withEnv({ GBRAIN_HOME: home, ANTHROPIC_API_KEY: 'sk-env' }, () => {
+      expect(secretValue('ANTHROPIC_API_KEY')).toBe('sk-env');
+    });
   });
 
-  test('missing everywhere resolves undefined', () => {
-    expect(secretValue('DEFINITELY_NOT_SET_ANYWHERE_XYZ')).toBeUndefined();
+  test('missing everywhere resolves undefined', async () => {
+    await withEnv({ GBRAIN_HOME: home, ANTHROPIC_API_KEY: undefined }, () => {
+      expect(secretValue('DEFINITELY_NOT_SET_ANYWHERE_XYZ')).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
API-key & gateway-config plumbing fixes (backlog unit c39-f1, gateway component).

Fixes #2119 — `config set anthropic_api_key` (and openai/zeroentropy/openrouter) wrote the DB config plane, which the runtime never reads for keys (`buildGatewayConfig` resolves keys from env + `~/.gbrain/config.json` only; `reconfigureGatewayWithEngine` re-resolves models, never keys). The no-key error hint recommended that exact no-op command. `config set`/`unset` for `*_api_key` now write/remove the file plane directly (mirroring the `embedding_model` file-plane-canonical treatment), so the documented command — and the error-hint recipe — actually works. `unset` also clears any stale DB-plane row left by pre-fix writes.

Fixes #2789 — `gbrain integrations show/status` (and the doctor `env_exists` check + `$VAR` health-check interpolation) tested `process.env` only, so creds stored via `gbrain config set *_api_key` reported `[missing]` even though the integration worked. Secret resolution now folds `buildGatewayConfig(loadConfig()).env` — the same seam every runtime provider uses. Also fixes the X secret-name mismatch: the `x-to-brain` recipe and `features.ts` pinned `X_BEARER_TOKEN` while the x-api resolver reads only `X_API_BEARER_TOKEN`; both now use the canonical `X_API_BEARER_TOKEN`, and the resolver accepts the legacy name so pre-rename setups keep working.

Fixes #1307 — brainstorm/lsd cross-generation (cost preview + chat calls) hardcoded `anthropic:claude-sonnet-4-6` and the CLI wired only `--judge-model`, so the configured `chat_model` was ignored. The fallback now resolves through `getChatModel()` (with the judges.ts try/catch pattern for unconfigured-gateway test contexts), and a new `--model` flag on both `gbrain brainstorm` and `gbrain lsd` wires `modelOverride` from the CLI.

Skipped #2088 — already fixed on master by merged PR #2125 (f529eaa2): the jobs worker re-stamps the gateway before queued AI work, and `propose-takes.ts` resolves `opts.model ?? getChatModel()`.

Tests: `test/config-api-key-file-plane.test.ts`, `test/integrations-config-secrets.test.ts` (includes a recipe/resolver secret-name drift pin), `test/brainstorm/model-resolution.test.ts`. All fail without their fix. `bun run typecheck` exits 0; new + related suites (config, integrations, features, resolvers, brainstorm — 384 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)