### PR TITLE
fix(extract): resolve cross-directory wikilinks via sync-consistent slugification

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -43,7 +43,7 @@ import {
 } from '../core/link-extraction.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
-import { pathToSlug, pruneDir, isSyncable } from '../core/sync.ts';
+import { pathToSlug, slugifyPath, pruneDir, isSyncable } from '../core/sync.ts';
 // v0.41.18.0: withRetry + isRetryableConnError + WithRetryOpts moved to
 // src/core/retry.ts as the canonical primitive. Engine methods
 // (addLinksBatch/addTimelineEntriesBatch/upsertChunks) now self-retry via
@@ -269,14 +269,24 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
 export function resolveSlug(fileDir: string, relTarget: string, allSlugs: Set<string>): string | null {
   const targetNoExt = relTarget.endsWith('.md') ? relTarget.slice(0, -3) : relTarget;
 
-  const s1 = join(fileDir, targetNoExt);
-  if (allSlugs.has(s1)) return s1;
+  // Issue #1964: wikilinks carry raw Obsidian paths (`[[llm-wiki/entities/AI 3.0]]`)
+  // but allSlugs holds sync-slugified slugs (`llm-wiki/entities/ai-3.0`). Try the
+  // raw candidate first (back-compat), then the sync-consistent slugified form.
+  const hit = (candidate: string): string | null => {
+    if (allSlugs.has(candidate)) return candidate;
+    const slugified = slugifyPath(candidate);
+    if (slugified !== candidate && allSlugs.has(slugified)) return slugified;
+    return null;
+  };
+
+  const s1 = hit(join(fileDir, targetNoExt));
+  if (s1) return s1;
 
   const parts = fileDir.split('/').filter(Boolean);
   for (let strip = 1; strip <= parts.length; strip++) {
     const ancestor = parts.slice(0, parts.length - strip).join('/');
-    const candidate = ancestor ? join(ancestor, targetNoExt) : targetNoExt;
-    if (allSlugs.has(candidate)) return candidate;
+    const candidate = hit(ancestor ? join(ancestor, targetNoExt) : targetNoExt);
+    if (candidate) return candidate;
   }
 
   return null;

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -14,6 +14,7 @@
 import type { BrainEngine } from './engine.ts';
 import type { PageType } from './types.ts';
 import { ensureWellFormed } from './text-safe.ts';
+import { slugifyPath } from './sync.ts';
 
 /**
  * v0.42.7 — link-extraction version stamp. Bump this ISO timestamp whenever the
@@ -482,14 +483,29 @@ export async function extractPageLinks(
     // pre-v0.40.8.2 behavior of dropping bare wikilinks outside
     // DIR_PATTERN.
     if (ref.needsResolution) {
-      if (!opts.globalBasename || typeof resolver.resolveBasenameMatches !== 'function') {
-        continue;
-      }
+      if (typeof resolver.resolveBasenameMatches !== 'function') continue;
       // Issue #972 (codex): resolve by the wikilink TARGET (ref.slug — the
       // text inside `[[...]]` before any `|`), NOT the display alias
       // (ref.name = match[2]). `[[struktura|the project]]` must resolve
       // `struktura`, not "the project". The display text is for context only.
-      const matches = await resolver.resolveBasenameMatches(ref.slug);
+      //
+      // Issue #1964: a dir-qualified wikilink (`[[llm-wiki/entities/AI 3.0]]`)
+      // carries a raw Obsidian path while page slugs are sync-slugified
+      // (`llm-wiki/entities/ai-3.0`). Slugify the path the same way sync does,
+      // then match by exact slug or path-suffix (wiki-root-relative authoring).
+      // This runs regardless of global_basename — it's dir-qualified, so the
+      // cross-dir false-positive risk the flag guards against doesn't apply.
+      // Mirrors the FS path's resolveSlug ancestor walk. Bare `[[name]]`
+      // wikilinks still require the global_basename flag.
+      let matches: string[] = [];
+      const slugified = ref.slug.includes('/') ? slugifyPath(ref.slug) : '';
+      if (slugified.includes('/')) {
+        const tail = slugified.slice(slugified.lastIndexOf('/') + 1);
+        matches = (await resolver.resolveBasenameMatches(tail))
+          .filter(m => m === slugified || m.endsWith(`/${slugified}`));
+      } else if (opts.globalBasename) {
+        matches = await resolver.resolveBasenameMatches(ref.slug);
+      }
       if (matches.length === 0) continue;
       const idx = content.indexOf(ref.slug);
       const context = idx >= 0 ? excerpt(content, idx, 240) : ref.name;

--- a/test/extract-fs.test.ts
+++ b/test/extract-fs.test.ts
@@ -389,6 +389,33 @@ describe('resolveSlugAll', () => {
   });
 });
 
+// ─── issue #1964: cross-directory wikilinks — slug/path mismatch ──────────
+
+describe('issue #1964: raw Obsidian wikilink paths resolve to sync-slugified slugs', () => {
+  test('resolveSlug slugifies the candidate (sync-consistent), no flag needed', () => {
+    const all = new Set(['llm-wiki/entities/ai-3.0']);
+    // Wikilink literal `[[llm-wiki/entities/AI 3.0]]` — spaces + uppercase.
+    expect(resolveSlug('llm-wiki/notes', 'llm-wiki/entities/AI 3.0.md', all))
+      .toBe('llm-wiki/entities/ai-3.0');
+  });
+
+  test('resolveSlug slugifies raw (unslugified) fileDir too', () => {
+    const all = new Set(['llm-wiki/entities/ai-3.0']);
+    // fileDir comes from dirname(relPath) — the raw on-disk directory.
+    expect(resolveSlug('LLM Wiki/Notes', 'entities/AI 3.0.md', all))
+      .toBe('llm-wiki/entities/ai-3.0');
+  });
+
+  test('extractLinksFromFile resolves cross-directory wikilink with flag OFF as a typed edge', async () => {
+    const allSlugs = new Set(['llm-wiki/entities/ai-3.0', 'llm-wiki/notes/roadmap']);
+    const content = '---\ntitle: Roadmap\ntype: concept\n---\n\nSee [[llm-wiki/entities/AI 3.0]].\n';
+    const links = await extractLinksFromFile(content, 'llm-wiki/notes/roadmap.md', allSlugs);
+    expect(links.map(l => l.to_slug)).toEqual(['llm-wiki/entities/ai-3.0']);
+    // Dir-qualified path resolution is exact, NOT the basename fallback.
+    expect(links[0].link_type).not.toBe('wikilink_basename');
+  });
+});
+
 describe('issue #972 repro: bare wikilinks resolve when flag is on', () => {
   // End-to-end: reproduces the issue's exact repro inside a tempdir +
   // PGLite, then asserts edge count under both flag states.

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -9,6 +9,8 @@ import {
   parseTimelineEntries,
   isAutoLinkEnabled,
   FRONTMATTER_LINK_MAP,
+  buildBasenameIndex,
+  queryBasenameIndex,
   type SlugResolver,
 } from '../src/core/link-extraction.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
@@ -422,6 +424,46 @@ describe('extractPageLinks', () => {
     expect(alice!.linkType).not.toBe('wikilink_basename'); // verb-inferred
     expect(strk).toBeDefined();
     expect(strk!.linkType).toBe('wikilink_basename');
+  });
+
+  // ─── issue #1964: dir-qualified wikilinks with raw Obsidian paths ────────
+
+  test('#1964: dir-qualified wikilink resolves via sync-consistent slugification (flag OFF)', async () => {
+    // `[[llm-wiki/entities/AI 3.0]]` is a raw Obsidian path; the page slug
+    // is the sync-slugified `llm-wiki/entities/ai-3.0`. Must resolve WITHOUT
+    // global_basename (it's dir-qualified) and must NOT leak to a same-tail
+    // page in a different directory.
+    const resolver: SlugResolver = {
+      resolve: async () => null,
+      resolveBasenameMatches: async (name) =>
+        name === 'ai-3.0' ? ['other/ai-3.0', 'llm-wiki/entities/ai-3.0'] : [],
+    };
+    const { candidates } = await extractPageLinks(
+      'llm-wiki/notes/roadmap',
+      'See [[llm-wiki/entities/AI 3.0]] for the model.',
+      {}, 'concept', resolver,
+      // opts.globalBasename omitted (= false) — path is dir-qualified
+    );
+    expect(candidates.map(c => c.targetSlug)).toEqual(['llm-wiki/entities/ai-3.0']);
+    expect(candidates[0].linkType).toBe('wikilink_basename');
+    expect(candidates[0].linkSource).toBe('wikilink-resolved');
+  });
+
+  test('#1964: path-suffix match resolves wiki-root-relative paths against a real index', async () => {
+    // Author writes `[[llm-wiki/entities/AI 3.0]]` but the brain nests the
+    // wiki under a vault dir. Suffix match rescues it; queried through the
+    // REAL basename index so the tail-key lookup is exercised end to end.
+    const idx = buildBasenameIndex(['vault/llm-wiki/entities/ai-3.0', 'people/ai-3.0']);
+    const resolver: SlugResolver = {
+      resolve: async () => null,
+      resolveBasenameMatches: async (name) => queryBasenameIndex(idx, name),
+    };
+    const { candidates } = await extractPageLinks(
+      'vault/llm-wiki/notes/roadmap',
+      'See [[llm-wiki/entities/AI 3.0]].',
+      {}, 'concept', resolver,
+    );
+    expect(candidates.map(c => c.targetSlug)).toEqual(['vault/llm-wiki/entities/ai-3.0']);
   });
 
   test('opts.skipFrontmatter suppresses the frontmatter pass', async () => {


### PR DESCRIPTION
## Work unit c42: wikilink extraction & orphans (Obsidian/PARA brains)

Fixes #1964

Raw Obsidian wikilink paths (`[[llm-wiki/entities/AI 3.0]]`) never matched sync-slugified slugs (`llm-wiki/entities/ai-3.0`) on either extraction path, so cross-directory wikilinks silently produced no edges (and their targets showed up as orphans).

### FS path (`src/commands/extract.ts`)
`resolveSlug` did raw path-equality against `allSlugs` — no slugification — so the ancestor walk always missed. It now slugifies each candidate with `slugifyPath` (the exact function sync uses to mint slugs) when the raw check misses, in both the direct join and the ancestor walk. This also covers a raw (unslugified) `fileDir`, since `dirname(relPath)` is the on-disk directory. Dir-qualified wikilinks now resolve as typed edges by default — no `global_basename` opt-in needed.

### DB path (`src/core/link-extraction.ts`)
`extractPageLinks` passed the full path literal to `resolveBasenameMatches`, whose index is keyed by slug *tails* — a path-containing wikilink could never match anything. Dir-qualified generic wikilinks now resolve by slugifying the path and matching by exact slug or path suffix (wiki-root-relative authoring) against the basename index. This runs regardless of `global_basename`: the flag guards bare-name cross-directory ambiguity, which doesn't apply to dir-qualified paths. The suffix filter compares slugified-to-slugified, so a same-tail page in a different directory is filtered out rather than matched.

### Tests
- `test/extract-fs.test.ts`: 3 new tests (pure `resolveSlug` slugification, raw fileDir, end-to-end `extractLinksFromFile` with flag OFF → typed edge).
- `test/link-extraction.test.ts`: 2 new tests (dir-qualified resolution with flag OFF + cross-dir filtering; path-suffix match through the real basename index).
- All 5 fail without the fix; full `link-extraction` + `extract-*` + `backlinks` suites green with it. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)