### PR TITLE
fix(embed): dynamic embedding column write target — upsertChunks + stale scans (#1262)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,6 +1,7 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { embedBatch, currentEmbeddingSignature } from '../core/embedding.ts';
-import type { ChunkInput } from '../core/types.ts';
+import type { ChunkInput, ResolvedColumn } from '../core/types.ts';
+import { resolveWriteColumnForEngine } from '../core/search/embedding-column.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
@@ -183,8 +184,13 @@ export class EmbeddingDimMismatchError extends Error {
  * fresh-install bug class at the very first invocation instead of letting
  * the worker pool hammer N pages with raw 22000 errors.
  */
-async function preflightDimMismatch(engine: BrainEngine, dryRun: boolean): Promise<void> {
+async function preflightDimMismatch(engine: BrainEngine, dryRun: boolean, embeddingColumn?: ResolvedColumn): Promise<void> {
   if (dryRun) return; // dry-run never embeds, no risk
+  // #1262: an alt-column brain writes to `embeddingColumn`, not the legacy
+  // `embedding` column — the legacy column's dims are irrelevant, and the
+  // registry entry (validated at resolve time) pins the target's dims. Only
+  // the legacy default path needs the schema-vs-gateway dim comparison.
+  if (embeddingColumn && embeddingColumn.name !== 'embedding') return;
   const { readContentChunksEmbeddingDim, embeddingMismatchMessage } = await import('../core/embedding-dim-check.ts');
   const { getEmbeddingDimensions, getEmbeddingModel } = await import('../core/ai/gateway.ts');
   let existing;
@@ -238,7 +244,12 @@ export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promis
   // v0.37.11.0 (Lane D.2): pre-flight dim-mismatch check. Catches the headline
   // fresh-install bug class before the worker pool spends 20 parallel calls
   // hitting raw Postgres dimension errors.
-  await preflightDimMismatch(engine, !!opts.dryRun);
+  // #1262: resolve the write-side embedding column ONCE at the boundary
+  // (merged config + gateway model) and thread the descriptor through every
+  // upsertChunks / stale-scan below. undefined => legacy `embedding` column.
+  const embeddingColumn = await resolveWriteColumnForEngine(engine);
+
+  await preflightDimMismatch(engine, !!opts.dryRun, embeddingColumn);
 
   const result: EmbedResult = {
     embedded: 0,
@@ -253,7 +264,7 @@ export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promis
     for (const s of opts.slugs) {
       if (isAborted(opts.signal)) break; // #1737: stop the per-slug loop on abort
       try {
-        await embedPage(engine, s, !!opts.dryRun, result, opts.sourceId, opts.signal);
+        await embedPage(engine, s, !!opts.dryRun, result, opts.sourceId, opts.signal, embeddingColumn);
       } catch (e: unknown) {
         serr(`  Error embedding ${s}: ${e instanceof Error ? e.message : e}`);
       }
@@ -347,7 +358,7 @@ export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promis
         catchUp: opts.catchUp,
         pacer,
         paceMaxConcurrency,
-      }, opts.signal);
+      }, opts.signal, embeddingColumn);
     } finally {
       // E1: surface pacing telemetry (human + structured) when pacing was on.
       const snap = pacer.snapshot();
@@ -376,7 +387,7 @@ export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promis
     return result;
   }
   if (opts.slug) {
-    await embedPage(engine, opts.slug, !!opts.dryRun, result, opts.sourceId, opts.signal);
+    await embedPage(engine, opts.slug, !!opts.dryRun, result, opts.sourceId, opts.signal, embeddingColumn);
     return result;
   }
   throw new Error('No embed target specified. Pass { slug }, { slugs }, { all }, or { stale }.');
@@ -521,8 +532,13 @@ async function embedPage(
   result: EmbedResult,
   sourceId?: string,
   signal?: AbortSignal,
+  embeddingColumn?: ResolvedColumn,
 ) {
   const opts = sourceId ? { sourceId } : undefined;
+  // #1262: write-side descriptor rides only on WRITE calls (upsertChunks).
+  const chunkOpts = (sourceId || embeddingColumn)
+    ? { ...(sourceId && { sourceId }), ...(embeddingColumn && { embeddingColumn }) }
+    : undefined;
   const page = await engine.getPage(slug, opts);
   if (!page) {
     throw new Error(`Page not found: ${slug}`);
@@ -554,7 +570,7 @@ async function embedPage(
     }
 
     if (inputs.length > 0) {
-      await engine.upsertChunks(slug, inputs, opts);
+      await engine.upsertChunks(slug, inputs, chunkOpts);
       chunks = await engine.getChunks(slug, opts);
     }
   }
@@ -589,7 +605,7 @@ async function embedPage(
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
-  await engine.upsertChunks(slug, updated, opts);
+  await engine.upsertChunks(slug, updated, chunkOpts);
   // v0.41.31: stamp provenance so a later model/dims swap is detectable as
   // stale. embedPage is the per-slug path used by `gbrain embed <slug>` AND
   // by `gbrain sync`'s post-import embed step (runEmbedCore({slugs})).
@@ -622,6 +638,7 @@ async function embedAll(
     paceMaxConcurrency?: number;
   },
   signal?: AbortSignal,
+  embeddingColumn?: ResolvedColumn,
 ) {
   // v0.41.31: current embedding provenance signature. Stamped onto pages
   // when their chunks are (re)embedded so a later model/dimension swap is
@@ -644,7 +661,7 @@ async function embedAll(
     // D7: thread sourceId so `gbrain embed --stale --source X` actually scopes.
     // v0.41.18.0 (A13): thread batchSize/priority/catchUp into the stale path.
     // #1737: thread the external abort signal so the cycle embed phase bails.
-    return await embedAllStale(engine, sourceId, dryRun, result, onProgress, staleOpts, signature, signal);
+    return await embedAllStale(engine, sourceId, dryRun, result, onProgress, staleOpts, signature, signal, embeddingColumn);
   }
 
   // --all path: pacer (no-op when off). E-1: lower the worker count to the
@@ -725,7 +742,10 @@ async function embedAll(
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await observed(pacer, () => engine.upsertChunks(page.slug, updated, pageOpts));
+      await observed(pacer, () => engine.upsertChunks(page.slug, updated, {
+        ...(pageSourceId && { sourceId: pageSourceId }),
+        ...(embeddingColumn && { embeddingColumn }),
+      }));
       // v0.41.31: stamp embedding provenance so a later model swap is
       // detectable as stale.
       await observed(pacer, () =>
@@ -805,10 +825,16 @@ async function embedAllStale(
   },
   signature?: string,
   externalSignal?: AbortSignal,
+  embeddingColumn?: ResolvedColumn,
 ) {
   // D7: thread sourceId so source-scoped runs only count + visit
   // that source's NULL embeddings.
-  const sourceOpt = sourceId ? { sourceId } : undefined;
+  // #1262: the stale predicate follows the write-side column — without it an
+  // alt-column brain would perpetually re-select (and re-pay for) chunks whose
+  // target column is already populated.
+  const sourceOpt = (sourceId || embeddingColumn)
+    ? { ...(sourceId && { sourceId }), ...(embeddingColumn && { embeddingColumn }) }
+    : undefined;
 
   // v0.41.31: re-embed pages whose embedding_signature drifted (model/dims
   // swap). dry-run must NOT mutate, so it counts signature-stale via the
@@ -967,6 +993,7 @@ async function embedAllStale(
             afterUpdatedAt,
           }),
           ...(sourceId && { sourceId }),
+          ...(embeddingColumn && { embeddingColumn }),
         }),
       );
       if (batch.length === 0) {
@@ -1019,7 +1046,10 @@ async function embedAllStale(
             embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
             token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
           }));
-          await observed(pacer, () => engine.upsertChunks(slug, merged, { sourceId: keySourceId }));
+          await observed(pacer, () => engine.upsertChunks(slug, merged, {
+            sourceId: keySourceId,
+            ...(embeddingColumn && { embeddingColumn }),
+          }));
           // v0.41.31: stamp provenance after the page's chunks are embedded —
           // but only when EVERY chunk was stale (fully re-embedded this pass).
           // A partially-stale page keeps preserved chunks of unknown/old
@@ -1090,7 +1120,7 @@ async function embedAllStale(
   // as a clean run — re-running won't help until the underlying failure is fixed.
   if (staleOpts?.catchUp && !effectiveSignal.aborted && embedFailures > 0) {
     const remaining = await engine.countStaleChunks(
-      signature ? { signature, ...(sourceId ? { sourceId } : {}) } : (sourceId ? { sourceId } : undefined),
+      signature ? { signature, ...sourceOpt } : sourceOpt,
     );
     if (remaining > 0) {
       serr(`\n  [embed] catch-up finished but ${remaining} chunk(s) remain stale after ${embedFailures} embed failure(s). These are not embeddable as-is; re-running won't clear them until the underlying error is resolved.`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -576,9 +576,16 @@ async function runInlineCostGate(
 
   // Stale backlog: cheap single SQL; fail-open to 0 so a transient DB hiccup
   // never blocks the sync. Signature-aware (model/dims swap surfaces here).
+  // #1262: follow the write-side embedding column — otherwise an alt-column
+  // brain's fully-embedded corpus counts as phantom backlog on every gate.
   let staleChars = 0;
   try {
-    staleChars = await engine.sumStaleChunkChars({ signature: currentEmbeddingSignature() });
+    const { resolveWriteColumnForEngine } = await import('../core/search/embedding-column.ts');
+    const embeddingColumn = await resolveWriteColumnForEngine(engine);
+    staleChars = await engine.sumStaleChunkChars({
+      signature: currentEmbeddingSignature(),
+      ...(embeddingColumn && { embeddingColumn }),
+    });
   } catch {
     staleChars = 0;
   }

--- a/src/core/contextual-retrieval-service.ts
+++ b/src/core/contextual-retrieval-service.ts
@@ -61,6 +61,7 @@ import {
   type SynopsisFailureKind,
 } from './audit-synopsis.ts';
 import type { BrainEngine } from './engine.ts';
+import { resolveWriteColumnForEngine } from './search/embedding-column.ts';
 import type { ChunkInput, CRMode, Page } from './types.ts';
 import type { SourceRow } from './sources-ops.ts';
 
@@ -286,9 +287,13 @@ export async function reembedPageWithContextualRetrieval(
 
       // ── PHASE 2: single DB transaction ───────────────────────────
       try {
+        // #1262: contextual re-embeds write TEXT embeddings — thread the
+        // caller-resolved write column like every other embed path.
+        const embeddingColumn = await resolveWriteColumnForEngine(args.engine);
         await args.engine.transaction(async (tx) => {
           await tx.upsertChunks(args.pageSlug, phase1.embeddedChunks, {
             sourceId: args.sourceId,
+            ...(embeddingColumn && { embeddingColumn }),
           });
           await tx.updatePageContextualRetrievalState(
             args.pageSlug,

--- a/src/core/embed-stale.ts
+++ b/src/core/embed-stale.ts
@@ -18,7 +18,7 @@
  */
 
 import type { BrainEngine } from './engine.ts';
-import type { ChunkInput } from './types.ts';
+import type { ChunkInput, ResolvedColumn } from './types.ts';
 import { embedBatchWithBackoff } from '../commands/embed.ts';
 import { type DbPacer, createNoopPacer, observed } from './db-pacer.ts';
 import { AbortError } from './abort-check.ts';
@@ -61,6 +61,13 @@ export interface EmbedStaleOpts {
    * Omit to keep the legacy `embedding IS NULL`-only behavior.
    */
   embeddingSignature?: string;
+  /**
+   * #1262: caller-resolved write-side embedding column. Threaded into BOTH
+   * listStaleChunks (staleness predicate) and upsertChunks (write target) so
+   * an alt-column brain converges instead of re-selecting embedded rows.
+   * Resolve at the boundary via `resolveWriteColumnForEngine()`.
+   */
+  embeddingColumn?: ResolvedColumn;
   /**
    * DB-contention pacer (paced-backfill). When enabled it (a) supplies the
    * worker count via the caller passing `concurrency = bundle.maxConcurrency`
@@ -156,6 +163,7 @@ export async function embedStaleForSource(
         afterPageId,
         afterChunkIndex,
         sourceId,
+        ...(opts.embeddingColumn && { embeddingColumn: opts.embeddingColumn }),
       }),
     );
     if (batch.length === 0) {
@@ -223,7 +231,10 @@ export async function embedStaleForSource(
           doc_comment: c.doc_comment ?? undefined,
           symbol_name_qualified: c.symbol_name_qualified ?? undefined,
         }));
-        await observed(pacer, () => engine.upsertChunks(slug, merged, { sourceId: keySourceId }));
+        await observed(pacer, () => engine.upsertChunks(slug, merged, {
+          sourceId: keySourceId,
+          ...(opts.embeddingColumn && { embeddingColumn: opts.embeddingColumn }),
+        }));
         // v0.41.31: stamp provenance only when EVERY chunk was stale (fully
         // re-embedded this pass) — a partially-stale page keeps preserved
         // chunks of unknown provenance, so don't claim current. After the

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -12,6 +12,7 @@ import type {
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
+  ResolvedColumn,
   CodeEdgeInput, CodeEdgeResult,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
@@ -987,8 +988,13 @@ export interface BrainEngine {
    * — Postgres rolls back automatically on conn drop, so commit-ambiguous
    * failure replays to the same end state. Callers MUST NOT wrap externally;
    * see {@link BatchOpts} retry-contract block.
+   *
+   * `opts.embeddingColumn` (optional) selects the content_chunks column that
+   * receives TEXT embeddings (#1262). The caller resolves the descriptor at
+   * the import/embed boundary via `resolveWriteColumn()`; engines never read
+   * config or choose columns themselves. Omitted => legacy `embedding`.
    */
-  upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string } & BatchOpts): Promise<void>;
+  upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string; embeddingColumn?: ResolvedColumn } & BatchOpts): Promise<void>;
   /**
    * Read every chunk for a page. `opts.sourceId` source-scopes the page
    * lookup; without it, multi-source brains return chunks from every
@@ -1005,8 +1011,13 @@ export interface BrainEngine {
    * counts across every source in the brain. Operators running
    * `gbrain embed --stale --source media-corpus` expect only that
    * source's NULLs touched; the caller threads `sourceId` here.
+   *
+   * `opts.embeddingColumn` switches the staleness predicate from the legacy
+   * `embedding` column to the resolved write-side column, so alt-column
+   * brains do not perpetually re-select rows whose target column is already
+   * populated (#1262). Must match the eventual upsertChunks target.
    */
-  countStaleChunks(opts?: { sourceId?: string; signature?: string }): Promise<number>;
+  countStaleChunks(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number>;
   /**
    * Sum of LENGTH(chunk_text) over stale chunks — the character-count
    * backlog the embed phase / embed-backfill will process. Sibling of
@@ -1069,6 +1080,9 @@ export interface BrainEngine {
     // both round-trip TIMESTAMPTZ as Date | string; ISO string is the
     // common denominator on the wire).
     afterUpdatedAt?: string | null;
+    // #1262: staleness predicate targets this column when set (must match
+    // countStaleChunks and the eventual upsertChunks write target).
+    embeddingColumn?: ResolvedColumn;
   }): Promise<StaleChunkRow[]>;
   /**
    * Delete every chunk for a page. Internal page-id lookup is sourceId-scoped

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1031,8 +1031,13 @@ export interface BrainEngine {
    * model signature (a model/dims swap). NULL signature is GRANDFATHERED
    * (never counted) so the post-migration corpus isn't flagged en masse.
    * Omit `signature` for the legacy `embedding IS NULL`-only count.
+   *
+   * `opts.embeddingColumn` switches the staleness predicate to the resolved
+   * write-side column (#1262) — same contract as countStaleChunks — so the
+   * sync cost gate doesn't count an alt-column brain's fully-embedded corpus
+   * as phantom backlog.
    */
-  sumStaleChunkChars(opts?: { sourceId?: string; signature?: string }): Promise<number>;
+  sumStaleChunkChars(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number>;
   /**
    * Stamp `pages.embedding_signature = signature` for one page. Called after
    * a page's chunks are (re)embedded so a later model swap can detect it as

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -10,7 +10,8 @@ import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
 import { embedBatch, embedMultimodal, currentEmbeddingSignature } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath } from './sync.ts';
-import type { ChunkInput, PageInput, PageType } from './types.ts';
+import type { ChunkInput, PageInput, PageType, ResolvedColumn } from './types.ts';
+import { resolveWriteColumnForEngine } from './search/embedding-column.ts';
 import { computeEffectiveDate } from './effective-date.ts';
 import { MARKDOWN_CHUNKER_VERSION } from './chunkers/recursive.ts';
 import { logSlugFallback } from './audit-slug-fallback.ts';
@@ -740,6 +741,14 @@ export async function importFromContent(
   // schema DEFAULT — required for multi-source brains; harmless ('default')
   // for single-source callers.
   const txOpts = sourceId ? { sourceId } : undefined;
+  // #1262: resolve the write-side embedding column once (merged config +
+  // gateway model) BEFORE the transaction; the descriptor rides only on
+  // upsertChunks so text embeddings land in the registered column.
+  const chunkWriteColumn = await resolveWriteColumnForEngine(engine);
+  const chunkOpts: { sourceId?: string; embeddingColumn?: ResolvedColumn } | undefined =
+    (sourceId || chunkWriteColumn)
+      ? { ...(sourceId && { sourceId }), ...(chunkWriteColumn && { embeddingColumn: chunkWriteColumn }) }
+      : undefined;
   await engine.transaction(async (tx) => {
     if (existing) await tx.createVersion(slug, txOpts);
 
@@ -824,7 +833,7 @@ export async function importFromContent(
     }
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks, txOpts);
+      await tx.upsertChunks(slug, chunks, chunkOpts);
       // v0.41.31: stamp embedding provenance when this import actually
       // embedded (not --no-embed), so a later model/dims swap is detectable
       // as stale via embed --stale. The deferred/backfill + per-slug embed
@@ -1064,6 +1073,12 @@ export async function importCodeFile(
   const title = `${relativePath} (${lang})`;
   const sourceId = opts.sourceId;
   const txOpts = sourceId ? { sourceId } : undefined;
+  // #1262: write-side embedding column descriptor (rides only on upsertChunks).
+  const chunkWriteColumn = await resolveWriteColumnForEngine(engine);
+  const chunkOpts: { sourceId?: string; embeddingColumn?: ResolvedColumn } | undefined =
+    (sourceId || chunkWriteColumn)
+      ? { ...(sourceId && { sourceId }), ...(chunkWriteColumn && { embeddingColumn: chunkWriteColumn }) }
+      : undefined;
 
   const byteLength = Buffer.byteLength(content, 'utf-8');
   if (byteLength > MAX_FILE_SIZE) {
@@ -1183,7 +1198,7 @@ export async function importCodeFile(
     await tx.addTag(slug, lang, txOpts);
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks, txOpts);
+      await tx.upsertChunks(slug, chunks, chunkOpts);
       // v0.41.31: stamp embedding provenance ONLY when every chunk was
       // freshly embedded with the current model this call (no reuse-by-hash
       // carrying old-model vectors). Mixed pages stay unstamped rather than
@@ -1332,6 +1347,12 @@ export async function withImportTransaction(
 ): Promise<void> {
   const sourceId = spec.sourceId ?? 'default';
   const txOpts = spec.sourceId ? { sourceId: spec.sourceId } : undefined;
+  // #1262: write-side embedding column descriptor (rides only on upsertChunks).
+  const chunkWriteColumn = await resolveWriteColumnForEngine(engine);
+  const chunkOpts: { sourceId?: string; embeddingColumn?: ResolvedColumn } | undefined =
+    (spec.sourceId || chunkWriteColumn)
+      ? { ...(spec.sourceId && { sourceId: spec.sourceId }), ...(chunkWriteColumn && { embeddingColumn: chunkWriteColumn }) }
+      : undefined;
   await engine.transaction(async (tx) => {
     if (spec.hadExisting) await tx.createVersion(spec.slug, txOpts);
     await tx.putPage(spec.slug, spec.page, txOpts);
@@ -1347,7 +1368,7 @@ export async function withImportTransaction(
     }
     if (spec.chunks !== undefined) {
       if (spec.chunks.length > 0) {
-        await tx.upsertChunks(spec.slug, spec.chunks, txOpts);
+        await tx.upsertChunks(spec.slug, spec.chunks, chunkOpts);
       } else {
         await tx.deleteChunks(spec.slug, txOpts);
       }

--- a/src/core/minions/handlers/embed-backfill.ts
+++ b/src/core/minions/handlers/embed-backfill.ts
@@ -35,6 +35,7 @@ import { tryAcquireDbLock } from '../../db-lock.ts';
 import { BudgetTracker, BudgetExhausted } from '../../budget/budget-tracker.ts';
 import { withBudgetTracker } from '../../ai/gateway.ts';
 import { embedStaleForSource } from '../../embed-stale.ts';
+import { resolveWriteColumnForEngine } from '../../search/embedding-column.ts';
 import { currentEmbeddingSignature } from '../../embedding.ts';
 import { type DbPacer, createDbPacer, createNoopPacer } from '../../db-pacer.ts';
 import { resolvePaceMode, loadPaceModeConfig, readPaceEnv } from '../../pace-mode.ts';
@@ -164,12 +165,16 @@ export function makeEmbedBackfillHandler(engine: BrainEngine) {
     // the supervisor, so pacing it is the headline win.
     const { pacer, concurrency } = await resolveBackfillPacer(engine, job.data);
 
+    // #1262: resolve the write-side embedding column once at the job boundary.
+    const embeddingColumn = await resolveWriteColumnForEngine(engine);
+
     try {
       const result = await withBudgetTracker(tracker, async () =>
         embedStaleForSource(engine, sourceId, {
           batchSize,
           signal: job.signal,
           pacer,
+          ...(embeddingColumn && { embeddingColumn }),
           ...(concurrency !== undefined && { concurrency }),
           // v0.41.31: re-embed pages whose model signature drifted + stamp
           // provenance as chunks land.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2424,7 +2424,7 @@ export class PGLiteEngine implements BrainEngine {
     return Number(count);
   }
 
-  async sumStaleChunkChars(opts?: { sourceId?: string; signature?: string }): Promise<number> {
+  async sumStaleChunkChars(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number> {
     // Sibling of countStaleChunks: same stale predicate, summing chunk_text
     // length for the sync cost preview. ::bigint guards int4 overflow.
     const { where, params } = this.buildStaleChunkWhere(opts);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -40,6 +40,7 @@ import type {
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
+  ResolvedColumn,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
   SalienceOpts, SalienceResult, AnomaliesOpts, AnomalyResult,
@@ -2230,12 +2231,20 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string } & BatchOpts): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string; embeddingColumn?: ResolvedColumn } & BatchOpts): Promise<void> {
     return this.batchRetry(opts?.auditSite ?? 'upsertChunks', opts?.signal, () => this._upsertChunksOnce(slug, chunks, opts), chunks.length);
   }
 
-  private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
+  private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string; embeddingColumn?: ResolvedColumn }): Promise<void> {
     const sourceId = opts?.sourceId ?? 'default';
+    // #1262: caller-resolved write target for TEXT embeddings. Descriptor
+    // names are identifier-validated + quoted by buildVectorCastFragment;
+    // omitted => legacy `embedding vector`. Mirrors postgres-engine.ts.
+    const targetFragment = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn)
+      : undefined;
+    const targetCol = targetFragment?.col ?? 'embedding';
+    const embeddingCast = targetFragment?.castSql.replace('$1::', '') ?? 'vector';
 
     // Source-scope the page-id lookup so duplicate slugs in different sources
     // do not return multiple rows or target the wrong page.
@@ -2270,7 +2279,7 @@ export class PGLiteEngine implements BrainEngine {
     // list. Image chunks pass embedding=null + embedding_image=Float32Array
     // (1024-dim Voyage). Text/code chunks pass embedding=Float32Array +
     // embedding_image=null. Default modality='text' when omitted.
-    const cols = '(page_id, chunk_index, chunk_text, chunk_source, embedding, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)';
+    const cols = `(page_id, chunk_index, chunk_text, chunk_source, ${targetCol}, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)`;
     const rowParts: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;
@@ -2288,7 +2297,7 @@ export class PGLiteEngine implements BrainEngine {
       const modality = chunk.modality ?? 'text';
 
       // Inline ::vector NULL literals to avoid a per-branch placeholder.
-      const embeddingPh = embeddingStr ? `$${paramIdx++}::vector` : 'NULL';
+      const embeddingPh = embeddingStr ? `$${paramIdx++}::${embeddingCast}` : 'NULL';
       const embeddedAtPh = embeddingStr ? 'now()' : 'NULL';
       const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}::vector` : 'NULL';
 
@@ -2327,19 +2336,19 @@ export class PGLiteEngine implements BrainEngine {
        ON CONFLICT (page_id, chunk_index) DO UPDATE SET
          chunk_text = EXCLUDED.chunk_text,
          chunk_source = EXCLUDED.chunk_source,
-         embedding = CASE
-           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text THEN EXCLUDED.embedding
-           WHEN content_chunks.embedding IS NULL THEN EXCLUDED.embedding
+         ${targetCol} = CASE
+           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text THEN EXCLUDED.${targetCol}
+           WHEN content_chunks.${targetCol} IS NULL THEN EXCLUDED.${targetCol}
            WHEN EXCLUDED.embedded_at IS NOT NULL
                 AND (content_chunks.embedded_at IS NULL OR EXCLUDED.embedded_at > content_chunks.embedded_at)
-                THEN EXCLUDED.embedding
-           ELSE content_chunks.embedding
+                THEN EXCLUDED.${targetCol}
+           ELSE content_chunks.${targetCol}
          END,
          model = COALESCE(EXCLUDED.model, content_chunks.model),
          token_count = EXCLUDED.token_count,
          embedded_at = CASE
-           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text AND EXCLUDED.embedding IS NULL THEN NULL
-           WHEN content_chunks.embedding IS NULL AND EXCLUDED.embedding IS NOT NULL THEN EXCLUDED.embedded_at
+           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text AND EXCLUDED.${targetCol} IS NULL THEN NULL
+           WHEN content_chunks.${targetCol} IS NULL AND EXCLUDED.${targetCol} IS NOT NULL THEN EXCLUDED.embedded_at
            WHEN EXCLUDED.embedded_at IS NOT NULL
                 AND (content_chunks.embedded_at IS NULL OR EXCLUDED.embedded_at > content_chunks.embedded_at)
                 THEN EXCLUDED.embedded_at
@@ -2377,14 +2386,19 @@ export class PGLiteEngine implements BrainEngine {
    * drift (NULL grandfathered → never stale). Shared by countStaleChunks +
    * sumStaleChunkChars so they can't drift.
    */
-  private buildStaleChunkWhere(opts?: { sourceId?: string; signature?: string }): { where: string; params: unknown[] } {
+  private buildStaleChunkWhere(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): { where: string; params: unknown[] } {
+    // #1262: staleness targets the caller-resolved write column when set
+    // (identifier-validated + quoted); legacy `embedding` otherwise.
+    const staleCol = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn).col
+      : 'embedding';
     const params: unknown[] = [];
     const conds: string[] = [];
     if (opts?.signature !== undefined) {
       params.push(opts.signature);
-      conds.push(`(cc.embedding IS NULL OR (p.embedding_signature IS NOT NULL AND p.embedding_signature <> $${params.length}))`);
+      conds.push(`(cc.${staleCol} IS NULL OR (p.embedding_signature IS NOT NULL AND p.embedding_signature <> $${params.length}))`);
     } else {
-      conds.push(`cc.embedding IS NULL`);
+      conds.push(`cc.${staleCol} IS NULL`);
     }
     conds.push(`NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')`);
     if (opts?.sourceId !== undefined) {
@@ -2394,7 +2408,7 @@ export class PGLiteEngine implements BrainEngine {
     return { where: conds.join(' AND '), params };
   }
 
-  async countStaleChunks(opts?: { sourceId?: string; signature?: string }): Promise<number> {
+  async countStaleChunks(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number> {
     // D7: source-scoped count for `gbrain embed --stale --source X`. Always
     // JOIN pages so embed-skip + signature predicates apply. PGLite is
     // PostgreSQL 17.5 in WASM and supports the full JSONB operator set.
@@ -2463,11 +2477,17 @@ export class PGLiteEngine implements BrainEngine {
     sourceId?: string;
     orderBy?: 'page_id' | 'updated_desc';
     afterUpdatedAt?: string | null;
+    embeddingColumn?: ResolvedColumn;
   }): Promise<StaleChunkRow[]> {
     const limit = opts?.batchSize ?? 2000;
     const afterPid = opts?.afterPageId ?? 0;
     const afterIdx = opts?.afterChunkIndex ?? -1;
     const orderBy = opts?.orderBy ?? 'page_id';
+    // #1262: staleness follows the caller-resolved write column (validated +
+    // quoted identifier); legacy `embedding` otherwise.
+    const staleCol = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn).col
+      : 'embedding';
 
     // v0.41.18.0 (A13, codex #9): --priority recent path. See postgres-engine
     // sibling for full rationale. Same composite cursor + ORDER BY.
@@ -2481,7 +2501,7 @@ export class PGLiteEngine implements BrainEngine {
                   p.updated_at
              FROM content_chunks cc
              JOIN pages p ON p.id = cc.page_id
-            WHERE cc.embedding IS NULL
+            WHERE cc.${staleCol} IS NULL
               AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             ORDER BY p.updated_at DESC NULLS LAST, p.id ASC, cc.chunk_index ASC
             LIMIT $1`,
@@ -2492,7 +2512,7 @@ export class PGLiteEngine implements BrainEngine {
                   p.updated_at
              FROM content_chunks cc
              JOIN pages p ON p.id = cc.page_id
-            WHERE cc.embedding IS NULL
+            WHERE cc.${staleCol} IS NULL
               AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
               AND (
                 p.updated_at < $1::timestamptz
@@ -2511,7 +2531,7 @@ export class PGLiteEngine implements BrainEngine {
                 p.updated_at
            FROM content_chunks cc
            JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE cc.${staleCol} IS NULL
             AND p.source_id = $1
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
           ORDER BY p.updated_at DESC NULLS LAST, p.id ASC, cc.chunk_index ASC
@@ -2523,7 +2543,7 @@ export class PGLiteEngine implements BrainEngine {
                 p.updated_at
            FROM content_chunks cc
            JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE cc.${staleCol} IS NULL
             AND p.source_id = $1
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             AND (
@@ -2548,7 +2568,7 @@ export class PGLiteEngine implements BrainEngine {
                 cc.model, cc.token_count, p.source_id, cc.page_id
            FROM content_chunks cc
            JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE cc.${staleCol} IS NULL
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             AND (cc.page_id, cc.chunk_index) > ($1, $2)
           ORDER BY cc.page_id, cc.chunk_index
@@ -2562,7 +2582,7 @@ export class PGLiteEngine implements BrainEngine {
               cc.model, cc.token_count, p.source_id, cc.page_id
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
-        WHERE cc.embedding IS NULL
+        WHERE cc.${staleCol} IS NULL
           AND p.source_id = $1
           AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
           AND (cc.page_id, cc.chunk_index) > ($2, $3)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -50,6 +50,7 @@ import type {
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
+  ResolvedColumn,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
   SalienceOpts, SalienceResult, AnomaliesOpts, AnomalyResult,
@@ -2380,13 +2381,21 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string } & BatchOpts): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string; embeddingColumn?: ResolvedColumn } & BatchOpts): Promise<void> {
     return this.batchRetry(opts?.auditSite ?? 'upsertChunks', opts?.signal, () => this._upsertChunksOnce(slug, chunks, opts), chunks.length);
   }
 
-  private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
+  private async _upsertChunksOnce(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string; embeddingColumn?: ResolvedColumn }): Promise<void> {
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
+    // #1262: caller-resolved write target for TEXT embeddings. Descriptor
+    // names are identifier-validated + quoted by buildVectorCastFragment;
+    // omitted => legacy `embedding vector`.
+    const targetFragment = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn)
+      : undefined;
+    const targetCol = targetFragment?.col ?? 'embedding';
+    const embeddingCast = targetFragment?.castSql.replace('$1::', '') ?? 'vector';
 
     // Source-scope the page-id lookup. Without this filter, multi-source
     // brains where the slug exists in 2+ sources return >1 row and the
@@ -2413,7 +2422,7 @@ export class PostgresEngine implements BrainEngine {
     // scope metadata through upserts.
     // v0.27.1 (Phase 8): added `modality` + `embedding_image` to the column
     // list. Image chunks pass embedding=null + embedding_image=Float32Array.
-    const cols = '(page_id, chunk_index, chunk_text, chunk_source, embedding, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)';
+    const cols = `(page_id, chunk_index, chunk_text, chunk_source, ${targetCol}, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)`;
     const rows: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;
@@ -2430,7 +2439,7 @@ export class PostgresEngine implements BrainEngine {
         : null;
       const modality = chunk.modality ?? 'text';
 
-      const embeddingPh = embeddingStr ? `$${paramIdx++}::vector` : 'NULL';
+      const embeddingPh = embeddingStr ? `$${paramIdx++}::${embeddingCast}` : 'NULL';
       const embeddedAtPh = embeddingStr ? 'now()' : 'NULL';
       const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}::vector` : 'NULL';
 
@@ -2478,19 +2487,19 @@ export class PostgresEngine implements BrainEngine {
        ON CONFLICT (page_id, chunk_index) DO UPDATE SET
          chunk_text = EXCLUDED.chunk_text,
          chunk_source = EXCLUDED.chunk_source,
-         embedding = CASE
-           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text THEN EXCLUDED.embedding
-           WHEN content_chunks.embedding IS NULL THEN EXCLUDED.embedding
+         ${targetCol} = CASE
+           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text THEN EXCLUDED.${targetCol}
+           WHEN content_chunks.${targetCol} IS NULL THEN EXCLUDED.${targetCol}
            WHEN EXCLUDED.embedded_at IS NOT NULL
                 AND (content_chunks.embedded_at IS NULL OR EXCLUDED.embedded_at > content_chunks.embedded_at)
-                THEN EXCLUDED.embedding
-           ELSE content_chunks.embedding
+                THEN EXCLUDED.${targetCol}
+           ELSE content_chunks.${targetCol}
          END,
          model = COALESCE(EXCLUDED.model, content_chunks.model),
          token_count = EXCLUDED.token_count,
          embedded_at = CASE
-           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text AND EXCLUDED.embedding IS NULL THEN NULL
-           WHEN content_chunks.embedding IS NULL AND EXCLUDED.embedding IS NOT NULL THEN EXCLUDED.embedded_at
+           WHEN EXCLUDED.chunk_text != content_chunks.chunk_text AND EXCLUDED.${targetCol} IS NULL THEN NULL
+           WHEN content_chunks.${targetCol} IS NULL AND EXCLUDED.${targetCol} IS NOT NULL THEN EXCLUDED.embedded_at
            WHEN EXCLUDED.embedded_at IS NOT NULL
                 AND (content_chunks.embedded_at IS NULL OR EXCLUDED.embedded_at > content_chunks.embedded_at)
                 THEN EXCLUDED.embedded_at
@@ -2530,14 +2539,19 @@ export class PostgresEngine implements BrainEngine {
    * embedding_signature drift (NULL grandfathered). Shared by
    * countStaleChunks + sumStaleChunkChars (parity with the PGLite sibling).
    */
-  private buildStaleChunkWhere(opts?: { sourceId?: string; signature?: string }): { where: string; params: unknown[] } {
+  private buildStaleChunkWhere(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): { where: string; params: unknown[] } {
+    // #1262: staleness targets the caller-resolved write column when set
+    // (identifier-validated + quoted); legacy `embedding` otherwise.
+    const staleCol = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn).col
+      : 'embedding';
     const params: unknown[] = [];
     const conds: string[] = [];
     if (opts?.signature !== undefined) {
       params.push(opts.signature);
-      conds.push(`(cc.embedding IS NULL OR (p.embedding_signature IS NOT NULL AND p.embedding_signature <> $${params.length}))`);
+      conds.push(`(cc.${staleCol} IS NULL OR (p.embedding_signature IS NOT NULL AND p.embedding_signature <> $${params.length}))`);
     } else {
-      conds.push(`cc.embedding IS NULL`);
+      conds.push(`cc.${staleCol} IS NULL`);
     }
     conds.push(`NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')`);
     if (opts?.sourceId !== undefined) {
@@ -2547,7 +2561,7 @@ export class PostgresEngine implements BrainEngine {
     return { where: conds.join(' AND '), params };
   }
 
-  async countStaleChunks(opts?: { sourceId?: string; signature?: string }): Promise<number> {
+  async countStaleChunks(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number> {
     // Always JOIN pages so the embed_skip + signature predicates apply.
     // D7: source_id scoping. v0.41.31: optional signature widens staleness
     // to embedding_signature drift (NULL grandfathered).
@@ -2618,11 +2632,18 @@ export class PostgresEngine implements BrainEngine {
     sourceId?: string;
     orderBy?: 'page_id' | 'updated_desc';
     afterUpdatedAt?: string | null;
+    embeddingColumn?: ResolvedColumn;
   }): Promise<StaleChunkRow[]> {
     const limit = opts?.batchSize ?? 2000;
     const afterPid = opts?.afterPageId ?? 0;
     const afterIdx = opts?.afterChunkIndex ?? -1;
     const orderBy = opts?.orderBy ?? 'page_id';
+    // #1262: staleness follows the caller-resolved write column (validated +
+    // quoted identifier); legacy `embedding` otherwise. Interpolated below as
+    // an unsafe FRAGMENT (identifiers can't be bound parameters).
+    const staleCol = opts?.embeddingColumn
+      ? buildVectorCastFragment(opts.embeddingColumn).col
+      : 'embedding';
 
     // RLS scope binding (opt-in via GBRAIN_RLS_SCOPE_BINDING).
     return await this.withScopedReadTransaction(undefined, opts?.sourceId, async (tx) => {
@@ -2639,7 +2660,7 @@ export class PostgresEngine implements BrainEngine {
                    p.updated_at
             FROM content_chunks cc
             JOIN pages p ON p.id = cc.page_id
-            WHERE cc.embedding IS NULL
+            WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
               AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             ORDER BY p.updated_at DESC NULLS LAST, p.id ASC, cc.chunk_index ASC
             LIMIT ${limit}
@@ -2649,7 +2670,7 @@ export class PostgresEngine implements BrainEngine {
                    p.updated_at
             FROM content_chunks cc
             JOIN pages p ON p.id = cc.page_id
-            WHERE cc.embedding IS NULL
+            WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
               AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
               AND (
                 p.updated_at < ${afterUpdated}::timestamptz
@@ -2667,7 +2688,7 @@ export class PostgresEngine implements BrainEngine {
                  p.updated_at
           FROM content_chunks cc
           JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
             AND p.source_id = ${opts.sourceId}
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
           ORDER BY p.updated_at DESC NULLS LAST, p.id ASC, cc.chunk_index ASC
@@ -2678,7 +2699,7 @@ export class PostgresEngine implements BrainEngine {
                  p.updated_at
           FROM content_chunks cc
           JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
             AND p.source_id = ${opts.sourceId}
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             AND (
@@ -2698,7 +2719,7 @@ export class PostgresEngine implements BrainEngine {
                  cc.model, cc.token_count, p.source_id, cc.page_id
           FROM content_chunks cc
           JOIN pages p ON p.id = cc.page_id
-          WHERE cc.embedding IS NULL
+          WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
             AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
             AND (cc.page_id, cc.chunk_index) > (${afterPid}, ${afterIdx})
           ORDER BY cc.page_id, cc.chunk_index
@@ -2711,7 +2732,7 @@ export class PostgresEngine implements BrainEngine {
                cc.model, cc.token_count, p.source_id, cc.page_id
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
-        WHERE cc.embedding IS NULL
+        WHERE ${tx.unsafe(`cc.${staleCol} IS NULL`)}
           AND p.source_id = ${opts.sourceId}
           AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
           AND (cc.page_id, cc.chunk_index) > (${afterPid}, ${afterIdx})

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2579,7 +2579,7 @@ export class PostgresEngine implements BrainEngine {
     });
   }
 
-  async sumStaleChunkChars(opts?: { sourceId?: string; signature?: string }): Promise<number> {
+  async sumStaleChunkChars(opts?: { sourceId?: string; signature?: string; embeddingColumn?: ResolvedColumn }): Promise<number> {
     // Sibling of countStaleChunks: same stale predicate, summing chunk_text
     // length for the sync cost preview. ::bigint guards int4 overflow.
     const { where, params } = this.buildStaleChunkWhere(opts);

--- a/src/core/search/embedding-column.ts
+++ b/src/core/search/embedding-column.ts
@@ -444,6 +444,80 @@ export function resolveEmbeddingColumn(
 }
 
 /**
+ * Resolves the WRITE-side embedding column for the currently configured
+ * embedding model (#1262). The read-side resolver above answers "which
+ * column does this query search?"; this one answers "which column should
+ * newly produced text embeddings land in?".
+ *
+ * Unlike read-side search, writes take no per-call column override. The
+ * import/embed boundary resolves once from merged config + gateway state
+ * and passes the descriptor into `engine.upsertChunks`; engines stay
+ * config-free (same contract as the read-side descriptor).
+ *
+ * Behavior:
+ *   - no user-declared `embedding_columns` => undefined (legacy brain,
+ *     writes keep targeting the default `embedding` column)
+ *   - a user-declared entry whose `provider` matches the current
+ *     embedding model => that entry's descriptor
+ *   - no provider match => undefined (fall back to legacy `embedding`)
+ *
+ * Only USER-declared entries are consulted — never the cfg-derived
+ * builtins. The `embedding_image` builtin's provider is the multimodal
+ * model; matching it here would misroute text embeddings into the image
+ * column. The no-match fallback is intentional: switching models before
+ * registering a matching column must not silently write vectors into an
+ * arbitrary column.
+ */
+export function resolveWriteColumn(cfg: GBrainConfig): ResolvedColumn | undefined {
+  const userColumns = cfg.embedding_columns;
+  if (
+    !userColumns ||
+    typeof userColumns !== 'object' ||
+    Array.isArray(userColumns) ||
+    Object.keys(userColumns).length === 0
+  ) {
+    return undefined;
+  }
+
+  // Same model-resolution chain as the registry builtin: cfg > gateway > default.
+  let gwModel: string | undefined;
+  try {
+    const gw = require('../ai/gateway.ts') as typeof import('../ai/gateway.ts');
+    gwModel = gw.getEmbeddingModel();
+  } catch {
+    // Gateway unconfigured — fall through to the canonical default.
+  }
+  const currentModel = cfg.embedding_model ?? gwModel ?? DEFAULT_EMBEDDING_MODEL;
+
+  for (const [name, entry] of Object.entries(userColumns)) {
+    if (!entry) continue;
+    validateColumnKey(name);
+    validateColumnConfig(name, entry);
+    if (entry.provider !== currentModel) continue;
+    return {
+      name,
+      type: entry.type,
+      dimensions: entry.dimensions,
+      embeddingModel: entry.provider,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Engine-boundary convenience: merged config (file/env + DB plane) →
+ * resolveWriteColumn. Dynamic import keeps config.ts out of this module's
+ * static graph (mirrors the gateway require above).
+ */
+export async function resolveWriteColumnForEngine(
+  engine: { getConfig(key: string): Promise<string | null | undefined> },
+): Promise<ResolvedColumn | undefined> {
+  const { loadConfigWithEngine } = await import('../config.ts');
+  const cfg = await loadConfigWithEngine(engine);
+  return cfg ? resolveWriteColumn(cfg) : undefined;
+}
+
+/**
  * True when the resolved column is the default `embedding` name.
  * Name-based check; does not compare embedding space.
  */

--- a/test/e2e/embedding-column-pglite.test.ts
+++ b/test/e2e/embedding-column-pglite.test.ts
@@ -241,3 +241,133 @@ describe('buildVectorCastFragment — engine SQL composer (D3)', () => {
     expect(castSql).toBe('$1::halfvec(2560)');
   });
 });
+
+describe('PGLite engine: upsertChunks write-side ResolvedColumn descriptor (#1262)', () => {
+  test('halfvec descriptor writes the text embedding to the alternate column, not legacy embedding', async () => {
+    await engine.putPage('docs/write-alt-pglite', {
+      type: 'concept',
+      title: 'Write alt column PGLite',
+      compiled_truth: 'PGLite write-side alternate embedding column test.',
+    });
+
+    const descriptor: ResolvedColumn = {
+      name: 'embedding_ze',
+      type: 'halfvec',
+      dimensions: 2560,
+      embeddingModel: 'zeroentropyai:zembed-1',
+    };
+    await engine.upsertChunks('docs/write-alt-pglite', [
+      {
+        chunk_index: 0,
+        chunk_text: 'PGLite write-side alternate embedding column test.',
+        chunk_source: 'compiled_truth',
+        embedding: new Float32Array(2560).fill(0.25),
+      },
+    ], { embeddingColumn: descriptor });
+
+    const rows = await engine.executeRaw<{
+      has_default: boolean;
+      has_ze: boolean;
+      has_embedded_at: boolean;
+    }>(
+      `SELECT embedding IS NOT NULL AS has_default,
+              embedding_ze IS NOT NULL AS has_ze,
+              embedded_at IS NOT NULL AS has_embedded_at
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = 'docs/write-alt-pglite'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].has_default).toBe(false);
+    expect(rows[0].has_ze).toBe(true);
+    expect(rows[0].has_embedded_at).toBe(true);
+  });
+
+  test('text-unchanged re-upsert without a vector preserves the alternate-column embedding', async () => {
+    const descriptor: ResolvedColumn = {
+      name: 'embedding_ze',
+      type: 'halfvec',
+      dimensions: 2560,
+      embeddingModel: 'zeroentropyai:zembed-1',
+    };
+    // Same chunk_text, no embedding: the ON CONFLICT CASE must keep the
+    // existing alternate-column vector (D24 semantics follow the column).
+    await engine.upsertChunks('docs/write-alt-pglite', [
+      {
+        chunk_index: 0,
+        chunk_text: 'PGLite write-side alternate embedding column test.',
+        chunk_source: 'compiled_truth',
+      },
+    ], { embeddingColumn: descriptor });
+    const rows = await engine.executeRaw<{ has_ze: boolean }>(
+      `SELECT embedding_ze IS NOT NULL AS has_ze
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = 'docs/write-alt-pglite'`,
+    );
+    expect(rows).toEqual([{ has_ze: true }]);
+  });
+});
+
+describe('PGLite: embed --stale converges on an alt-column brain (#1262)', () => {
+  test('boundary resolves the write column; stale scan does not re-select embedded rows', async () => {
+    const { runEmbedCore } = await import('../../src/commands/embed.ts');
+    const local = new PGLiteEngine();
+    const previousHome = process.env.GBRAIN_HOME;
+    process.env.GBRAIN_HOME = `/tmp/gbrain-write-col-stale-${Date.now()}`;
+    try {
+      await local.connect({});
+      await local.initSchema();
+      await (local as any).db.exec(
+        `ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS embedding_ze halfvec(2560)`,
+      );
+
+      const descriptor: ResolvedColumn = {
+        name: 'embedding_ze',
+        type: 'halfvec',
+        dimensions: 2560,
+        embeddingModel: 'zeroentropyai:zembed-1',
+      };
+      await local.setConfig('embedding_columns', JSON.stringify({
+        embedding_ze: { provider: 'zeroentropyai:zembed-1', dimensions: 2560, type: 'halfvec' },
+      }));
+      configureGateway({
+        embedding_model: 'zeroentropyai:zembed-1',
+        embedding_dimensions: 2560,
+        env: {},
+      });
+
+      await local.putPage('docs/stale-alt-pglite', {
+        type: 'concept',
+        title: 'Dynamic stale column',
+        compiled_truth: 'A chunk that is embedded only in the dynamic column.',
+      });
+      await local.upsertChunks('docs/stale-alt-pglite', [
+        {
+          chunk_index: 0,
+          chunk_text: 'A chunk that is embedded only in the dynamic column.',
+          chunk_source: 'compiled_truth',
+          embedding: new Float32Array(2560).fill(0.25),
+        },
+      ], { embeddingColumn: descriptor });
+
+      // Engine-level contrast: legacy predicate still sees the row as stale;
+      // the alt-column predicate does not.
+      expect(await local.countStaleChunks()).toBe(1);
+      expect(await local.countStaleChunks({ embeddingColumn: descriptor })).toBe(0);
+      expect(await local.listStaleChunks({ embeddingColumn: descriptor, batchSize: 100 })).toHaveLength(0);
+      expect(await local.listStaleChunks({ batchSize: 100 })).toHaveLength(1);
+
+      // Boundary-level: `embed --stale --dry-run` resolves the write column
+      // from merged config + gateway and reports NOTHING to embed. Without
+      // the fix this reports 1 (perpetual re-embed loop).
+      const result = await runEmbedCore(local, { stale: true, dryRun: true });
+      expect(result.would_embed).toBe(0);
+    } finally {
+      await local.disconnect();
+      if (previousHome === undefined) delete process.env.GBRAIN_HOME;
+      else process.env.GBRAIN_HOME = previousHome;
+      resetGateway();
+    }
+  });
+});

--- a/test/e2e/embedding-column-pglite.test.ts
+++ b/test/e2e/embedding-column-pglite.test.ts
@@ -355,6 +355,9 @@ describe('PGLite: embed --stale converges on an alt-column brain (#1262)', () =>
       // the alt-column predicate does not.
       expect(await local.countStaleChunks()).toBe(1);
       expect(await local.countStaleChunks({ embeddingColumn: descriptor })).toBe(0);
+      // sumStaleChunkChars feeds the sync cost gate — same predicate contract.
+      expect(await local.sumStaleChunkChars()).toBeGreaterThan(0);
+      expect(await local.sumStaleChunkChars({ embeddingColumn: descriptor })).toBe(0);
       expect(await local.listStaleChunks({ embeddingColumn: descriptor, batchSize: 100 })).toHaveLength(0);
       expect(await local.listStaleChunks({ batchSize: 100 })).toHaveLength(1);
 

--- a/test/e2e/embedding-column-postgres.test.ts
+++ b/test/e2e/embedding-column-postgres.test.ts
@@ -224,4 +224,54 @@ if (!dbUrl) {
       await engine.executeRaw(`UPDATE content_chunks SET embedding_voyage = '${v}'::vector WHERE id = ${dogId}`);
     });
   });
+
+  describe('Postgres: upsertChunks write-side ResolvedColumn descriptor (#1262)', () => {
+    const descriptor: ResolvedColumn = {
+      name: 'embedding_ze',
+      type: 'halfvec',
+      dimensions: 2560,
+      embeddingModel: 'zeroentropyai:zembed-1',
+    };
+
+    test('halfvec descriptor writes the text embedding to the alternate column, not legacy embedding', async () => {
+      await engine.putPage('docs/write-alt-postgres', {
+        type: 'concept',
+        title: 'Write alt column Postgres',
+        compiled_truth: 'Postgres write-side alternate embedding column test.',
+      });
+      await engine.upsertChunks('docs/write-alt-postgres', [
+        {
+          chunk_index: 0,
+          chunk_text: 'Postgres write-side alternate embedding column test.',
+          chunk_source: 'compiled_truth',
+          embedding: new Float32Array(2560).fill(0.25),
+        },
+      ], { embeddingColumn: descriptor });
+
+      const rows = await engine.executeRaw<{
+        has_default: boolean;
+        has_ze: boolean;
+      }>(
+        `SELECT embedding IS NOT NULL AS has_default,
+                embedding_ze IS NOT NULL AS has_ze
+           FROM content_chunks cc
+           JOIN pages p ON p.id = cc.page_id
+          WHERE p.slug = 'docs/write-alt-postgres'`,
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].has_default).toBe(false);
+      expect(rows[0].has_ze).toBe(true);
+    }, 30_000);
+
+    test('stale scan follows the write-side column (count + list parity with the write target)', async () => {
+      // Legacy predicate: cat/dog/write-alt rows all have embedding NULL.
+      expect(await engine.countStaleChunks()).toBeGreaterThan(0);
+      // Alt-column predicate: every chunk has embedding_ze populated.
+      expect(await engine.countStaleChunks({ embeddingColumn: descriptor })).toBe(0);
+      expect(await engine.listStaleChunks({ embeddingColumn: descriptor, batchSize: 100 })).toHaveLength(0);
+      expect((await engine.listStaleChunks({ batchSize: 100 })).length).toBeGreaterThan(0);
+      // updated_desc arm uses the same predicate.
+      expect(await engine.listStaleChunks({ embeddingColumn: descriptor, orderBy: 'updated_desc', batchSize: 100 })).toHaveLength(0);
+    }, 30_000);
+  });
 }

--- a/test/search/embedding-column.serial.test.ts
+++ b/test/search/embedding-column.serial.test.ts
@@ -13,9 +13,10 @@
  *     throw on unknown string.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterAll, afterEach } from 'bun:test';
 import {
   resolveEmbeddingColumn,
+  resolveWriteColumn,
   getEmbeddingColumnRegistry,
   buildVectorCastFragment,
   quoteIdentifier,
@@ -34,6 +35,28 @@ import {
 } from '../../src/core/search/embedding-column.ts';
 import type { GBrainConfig } from '../../src/core/config.ts';
 import type { ResolvedColumn } from '../../src/core/types.ts';
+import { configureGateway, resetGateway } from '../../src/core/ai/gateway.ts';
+
+/**
+ * Teardown: reset AND re-apply the legacy preload config
+ * (test/helpers/legacy-embedding-preload.ts). A bare resetGateway() would
+ * leave the slot empty for the NEXT file's beforeAll (the preload's
+ * per-test beforeEach only fires before tests, not before beforeAll), which
+ * would make sibling PGLite fixtures initSchema at the 1280 default instead
+ * of the legacy 1536 their seed vectors assume.
+ */
+function restorePreloadGateway() {
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { ...process.env },
+  });
+}
+
+afterAll(() => {
+  restorePreloadGateway();
+});
 
 function cfg(overrides: Partial<GBrainConfig> = {}): GBrainConfig {
   return { engine: 'pglite', ...overrides };
@@ -520,5 +543,91 @@ describe('codex /ship #4 — isCacheSafe (embedding-space-based skip)', () => {
       embeddingModel: 'openai:text-embedding-3-large',
     };
     expect(isCacheSafe(r, cfg())).toBe(true);
+  });
+});
+
+describe('resolveWriteColumn — write-side boundary resolution (#1262)', () => {
+  afterEach(() => {
+    restorePreloadGateway();
+  });
+
+  test('no registry / empty registry returns undefined (legacy single-column brain)', () => {
+    expect(resolveWriteColumn(cfg())).toBeUndefined();
+    expect(resolveWriteColumn(cfg({ embedding_columns: {} }))).toBeUndefined();
+  });
+
+  test('provider match via cfg.embedding_model returns the descriptor', () => {
+    const r = resolveWriteColumn(cfg({
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_dimensions: 1024,
+      embedding_columns: {
+        embedding_voyage: { provider: 'voyage:voyage-3-large', dimensions: 1024, type: 'vector' },
+      },
+    }));
+    expect(r).toEqual({
+      name: 'embedding_voyage',
+      type: 'vector',
+      dimensions: 1024,
+      embeddingModel: 'voyage:voyage-3-large',
+    });
+  });
+
+  test('provider match via gateway state (cfg.embedding_model unset) returns descriptor', () => {
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 2560,
+      env: {},
+    });
+    const r = resolveWriteColumn(cfg({
+      embedding_columns: {
+        embedding_ze: { provider: 'zeroentropyai:zembed-1', dimensions: 2560, type: 'halfvec' },
+      },
+    }));
+    expect(r).toEqual({
+      name: 'embedding_ze',
+      type: 'halfvec',
+      dimensions: 2560,
+      embeddingModel: 'zeroentropyai:zembed-1',
+    });
+  });
+
+  test('no provider match returns undefined instead of guessing a column', () => {
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 2560,
+      env: {},
+    });
+    const r = resolveWriteColumn(cfg({
+      embedding_columns: {
+        embedding_voyage: { provider: 'voyage:voyage-3-large', dimensions: 1024, type: 'vector' },
+      },
+    }));
+    expect(r).toBeUndefined();
+  });
+
+  test('only USER-declared columns are consulted — multimodal builtin never captures text writes', () => {
+    // Current model equals the embedding_image BUILTIN's provider; a registry
+    // walk that consulted builtins would misroute text writes into the image
+    // column. resolveWriteColumn must return undefined here.
+    configureGateway({
+      embedding_model: 'voyage:voyage-multimodal-3',
+      embedding_dimensions: 1024,
+      env: {},
+    });
+    const r = resolveWriteColumn(cfg({
+      embedding_columns: {
+        embedding_other: { provider: 'openai:text-embedding-3-large', dimensions: 1536, type: 'vector' },
+      },
+    }));
+    expect(r).toBeUndefined();
+  });
+
+  test('malformed registry entry throws loud (same validation as the read side)', () => {
+    expect(() => resolveWriteColumn(cfg({
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_columns: {
+        'bad"col': { provider: 'voyage:voyage-3-large', dimensions: 1024, type: 'vector' },
+      } as never,
+    }))).toThrow(EmbeddingColumnConfigError);
   });
 });


### PR DESCRIPTION
Fixes #1262
Takeover of #1263 (rebased onto current master; credit to @DmitryBMsk, co-authored on the commit)

## Problem

`upsertChunks` in BOTH engines hardcoded the legacy `embedding` column — the INSERT column list, the `::vector` cast, and every ON CONFLICT clause. The `embedding_columns` registry had read-side consumers only (PR #1164), so a brain configured with a registered alternate column (e.g. `halfvec(2560)`) could *search* the right column but failed every `put_page`/`import`/`sync`/`embed` write with a dimension mismatch.

## Fix (write-side symmetric to the read-side resolver)

- **`resolveWriteColumn(cfg)` / `resolveWriteColumnForEngine(engine)`** (`src/core/search/embedding-column.ts`): a user-declared registry entry whose `provider` matches the current embedding model resolves to a descriptor; no registry / no match ⇒ `undefined` (legacy `embedding`, no behavior change). Builtins are never consulted, so the multimodal builtin can't capture text writes.
- **`upsertChunks` accepts a caller-resolved `embeddingColumn`** in `postgres-engine.ts` AND `pglite-engine.ts` (lockstep): target column, cast (`::vector` / `::halfvec(N)`), and the v0.40.3.0 D24 ON CONFLICT race-fix CASE arms all follow the column. Engines stay config-free — the boundary resolves, same contract as the read side.
- **Stale scans follow the write column**: `countStaleChunks`, `listStaleChunks` (both cursor arms), and the shared `buildStaleChunkWhere` accept the descriptor. Without this an alt-column brain re-selects (and re-pays for) already-embedded chunks on every `embed --stale` run, forever.
- **Boundary threading**: `runEmbedCore` (embedPage / embedAll / embedAllStale), `embedStaleForSource` + the `embed-backfill` Minion handler, `importFromContent` / `importCodeFile` / `withImportTransaction`, and the contextual-retrieval re-embed transaction resolve once and pass the descriptor to every write.
- **`preflightDimMismatch`** skips the legacy-column dim comparison when a non-default write column resolved — it would otherwise hard-block `gbrain embed` on alt-column brains even after the write fix.

## What changed vs #1263

The original PR was correct in approach but targeted v0.37.6.0; the patched region was rewritten since (D24 ON CONFLICT race fix, batchRetry wrapper, signature-stale machinery, embed-backfill/keyset re-entry, updated_desc cursor arm). This re-threads the same design through the current code: D24 CASE semantics preserved per-column, both `listStaleChunks` cursor orders covered, `embed-stale.ts` + the Minion handler included, and the preflight dim-check made column-aware.

## Tests

- `test/search/embedding-column.serial.test.ts` — `resolveWriteColumn` unit coverage (no registry, cfg-model match, gateway-model match, no-match fallback, builtin-never-matches, malformed entry throws).
- `test/e2e/embedding-column-pglite.test.ts` — write lands in the alternate halfvec column (legacy stays NULL), text-unchanged re-upsert preserves the alt-column vector (D24 follows the column), stale count/list contrast, and an `embed --stale --dry-run` integration proving boundary resolution + convergence (reports 1-chunk perpetual backlog without the fix).
- `test/e2e/embedding-column-postgres.test.ts` — DATABASE_URL-gated twins for real pgvector.

All three fail without the src changes (verified by stashing src/): 3 fail → 0 fail.

Gates: `bun run typecheck` exit 0; touched test batch (17 files, 195 pass / 0 fail) + import/sync sanity batch (7 files, 70 pass / 0 fail); JSONB pattern + params guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)