### PR TITLE
fix(readme): correct broken OpenClaw and Hermes project links (takeover of #1961)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ GBrain is designed to be installed and operated by an AI agent. The fastest path
 
 If you don't already have an AI agent platform running, start with one of these. Both are designed to read GBrain's install protocol and execute it:
 
-- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
-- **[Hermes](https://github.com/openclawagents/hermes)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
+- **[OpenClaw](https://github.com/openclaw/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[Hermes](https://github.com/NousResearch/hermes-agent)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Then paste this into your agent:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1565,8 +1565,8 @@ GBrain is designed to be installed and operated by an AI agent. The fastest path
 
 If you don't already have an AI agent platform running, start with one of these. Both are designed to read GBrain's install protocol and execute it:
 
-- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
-- **[Hermes](https://github.com/openclawagents/hermes)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
+- **[OpenClaw](https://github.com/openclaw/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[Hermes](https://github.com/NousResearch/hermes-agent)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Then paste this into your agent:
 


### PR DESCRIPTION
Supersedes #1961 (fork branch by @jessems, rebased onto current master with llms regeneration).

## What

The **Have your agent install it (recommended)** section of the README links the OpenClaw and Hermes project names to repos under an `openclawagents` org that doesn't exist (both 404).

## Fix

- **OpenClaw** → `https://github.com/openclaw/openclaw`
- **Hermes** → `https://github.com/NousResearch/hermes-agent`

Deploy targets (AlphaClaw on Render, the Railway template) already resolve and are unchanged. `llms-full.txt` regenerated via `bun run build:llms` in the same commit (README is inlined in the bundle; freshness test `test/build-llms.test.ts` passes 12/12).

Gates: `bun run typecheck` exit 0; `bun test test/build-llms.test.ts` exit 0.

Credit: original diff and link verification by @jessems in #1961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)