### PR TITLE
docs: clarify HTTP localOnly boundary (takeover of #1679)

### DIFF
--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -191,7 +191,7 @@ filesystem surface area.
 |-------|---------------|
 | `read` | `search`, `query`, `get_page`, `list_pages`, graph traversal |
 | `write` | `put_page`, `delete_page`, `add_link`, `add_timeline_entry` |
-| `admin` | Client management, token revocation, sweep, local-only ops |
+| `admin` | Client management, token revocation, sweep, remote-safe admin ops |
 
 ## Legacy Bearer Token Setup
 
@@ -243,15 +243,16 @@ gbrain auth test \
 
 ## Operations
 
-All 30 GBrain operations are available remotely, including `sync_brain` and
-`file_upload` (no timeout limits with self-hosted server).
+HTTP exposes the scoped, non-`localOnly` operation set. `sync_brain`,
+`file_upload`, `file_list`, and `file_url` are intentionally hidden from remote
+MCP clients even when the client has `admin` scope. Use the local stdio server
+or CLI for those local filesystem surfaces.
 
-**Security note on `file_upload`:** remote MCP callers are confined to the working
-directory where `gbrain serve` was launched. Symlinks, `..` traversal, and absolute
-paths outside cwd are rejected. Page slugs and filenames are allowlist-validated
-(alphanumeric + hyphens; no control chars, RTL overrides, or backslashes). Local
-CLI callers (`gbrain file upload ...`) keep unrestricted filesystem access since
-the user owns the machine.
+Remote callers can still read and write brain content through the normal scoped
+operations (`get_page`, `put_page`, `search`, `query`, links, timeline entries,
+OAuth/admin management, and other non-`localOnly` tools). Self-hosting removes
+third-party MCP timeout ceilings, but it does not relax the local filesystem
+trust boundary.
 
 ## Deployment Options
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3835,7 +3835,7 @@ filesystem surface area.
 |-------|---------------|
 | `read` | `search`, `query`, `get_page`, `list_pages`, graph traversal |
 | `write` | `put_page`, `delete_page`, `add_link`, `add_timeline_entry` |
-| `admin` | Client management, token revocation, sweep, local-only ops |
+| `admin` | Client management, token revocation, sweep, remote-safe admin ops |
 
 ## Legacy Bearer Token Setup
 
@@ -3887,15 +3887,16 @@ gbrain auth test \
 
 ## Operations
 
-All 30 GBrain operations are available remotely, including `sync_brain` and
-`file_upload` (no timeout limits with self-hosted server).
+HTTP exposes the scoped, non-`localOnly` operation set. `sync_brain`,
+`file_upload`, `file_list`, and `file_url` are intentionally hidden from remote
+MCP clients even when the client has `admin` scope. Use the local stdio server
+or CLI for those local filesystem surfaces.
 
-**Security note on `file_upload`:** remote MCP callers are confined to the working
-directory where `gbrain serve` was launched. Symlinks, `..` traversal, and absolute
-paths outside cwd are rejected. Page slugs and filenames are allowlist-validated
-(alphanumeric + hyphens; no control chars, RTL overrides, or backslashes). Local
-CLI callers (`gbrain file upload ...`) keep unrestricted filesystem access since
-the user owns the machine.
+Remote callers can still read and write brain content through the normal scoped
+operations (`get_page`, `put_page`, `search`, `query`, links, timeline entries,
+OAuth/admin management, and other non-`localOnly` tools). Self-hosting removes
+third-party MCP timeout ceilings, but it does not relax the local filesystem
+trust boundary.
 
 ## Deployment Options
 

--- a/test/autopilot-install.test.ts
+++ b/test/autopilot-install.test.ts
@@ -108,7 +108,7 @@ describe('autopilot wrapper script — env source order (v0.36.1.x #966)', () =>
 // operators put in ~/.bashrc never reach this subprocess. Without the
 // explicit export the wrapper silently dies with `env: bun: No such file
 // or directory`, leaves a stale lockfile, and blocks every subsequent tick
-// for the 10-min stale-lock window. Regression: see Hermes `cron doctor`
+// for the 10-min stale-lock window. Regression: see agent-fork `cron doctor`
 // reports — this caused a 1-week nightly-cycle outage on at least one
 // operator machine before being diagnosed.
 describe('autopilot wrapper script — bun PATH export (v0.42.x regression)', () => {


### PR DESCRIPTION
Supersedes #1679 (fork PR by @TheLordArgus, applied with co-author credit). Fixes #1612.

The Operations section of `docs/mcp/DEPLOY.md` still claimed all operations are available remotely, including `sync_brain` and `file_upload`, contradicting the Scopes section and `serve-http.ts`'s `localOnly` filtering. This updates that stale section so the doc consistently says:

- HTTP exposes the scoped, non-`localOnly` operation set
- `sync_brain`, `file_upload`, `file_list`, and `file_url` are hidden from remote MCP clients even with `admin` scope
- local stdio/CLI remains the path for local filesystem surfaces
- the scope table's `admin` row now reads "remote-safe admin ops" instead of "local-only ops"

Takeover additions:
- rebased onto current master (applied cleanly)
- regenerated `llms.txt` / `llms-full.txt` via `bun run build:llms` (freshness test `test/build-llms.test.ts` passes: 12/12)
- `bun run typecheck` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)