### PR TITLE
fix(skillopt): emit proposed.md in no-mutate mode (#2635) [takeover of #2719]

### DIFF
--- a/docs/tutorials/improving-skills-with-skillopt.md
+++ b/docs/tutorials/improving-skills-with-skillopt.md
@@ -233,13 +233,14 @@ keep it or `git checkout` to throw it away. Nothing is committed for you.
 
 **For a skill that ships with gbrain** (anything under the gbrain repo's own
 `skills/`): SkillOpt refuses to overwrite it by default and writes the winner to
-`skills/<name>/skillopt/best.md` instead, so an optimization pass can never
-silently mutate a skill other people depend on. Two ways to handle that:
+`skills/<name>/skillopt/proposed.md` instead (while keeping `best.md` as the
+optimizer's current-best pointer), so an optimization pass can never silently
+mutate a skill other people depend on. Two ways to handle that:
 
 ```bash
 # See the proposed improvement without touching SKILL.md (works for ANY skill):
 gbrain skillopt meeting-prep --split 1:1:1 --no-mutate
-# → writes skills/meeting-prep/skillopt/best.md (the proposed rewrite), prints its path. Copy what you want.
+# → writes skills/meeting-prep/skillopt/proposed.md, updates best.md, and prints the proposal path.
 
 # Actually rewrite a bundled skill (explicit opt-in + an independent held-out set):
 gbrain skillopt brain-ops --split 1:1:1 --allow-mutate-bundled \

--- a/src/core/skillopt/orchestrator.ts
+++ b/src/core/skillopt/orchestrator.ts
@@ -93,7 +93,13 @@ import { resolveLrSchedule } from './lr-schedule.ts';
 import { preflight, formatPreflightReport } from './preflight.ts';
 import { isRejected, loadRejectedBuffer, makeRejectedEntry, saveRejectedBuffer } from './rejected-buffer.ts';
 import { runReflect, runOneShotRewrite, describeJudges } from './reflect.ts';
-import { acceptCandidate, bestPath, revertAllPending, skillPath, writeProposed } from './version-store.ts';
+import {
+  acceptCandidate,
+  proposedPath as proposedFilePath,
+  revertAllPending,
+  skillPath,
+  writeProposed,
+} from './version-store.ts';
 import { runValidationGate, scoreSkillOnTasks } from './validate-gate.ts';
 import { ROLLOUT_SUCCESS_THRESHOLD } from './types.ts';
 import type { SkillOptOpts, EditOp, RunReceipt, BenchmarkTask } from './types.ts';
@@ -702,9 +708,9 @@ async function runOptimizationLoop(
   // to the catch's assignment values only (it can't prove the async callback ran).
   const finalOutcome = outcome as 'accepted' | 'no_improvement' | 'aborted' | 'errored';
   if (!mutateDecision.mutate && finalOutcome === 'accepted') {
-    // best.md was written by writeProposed() in the accept branch (no-mutate
-    // path); it doubles as proposed.md for human review. SKILL.md untouched.
-    proposedPath = bestPath(skillsDir, skillName);
+    // writeProposed() emitted both the best pointer and the stable review
+    // artifact in the accept branch. SKILL.md remains untouched.
+    proposedPath = proposedFilePath(skillsDir, skillName);
   } else if (mutateDecision.mutate) {
     mutatedSkillFile = finalOutcome === 'accepted';
   }

--- a/src/core/skillopt/version-store.ts
+++ b/src/core/skillopt/version-store.ts
@@ -23,6 +23,7 @@
  *
  *   history.json
  *   best.md
+ *   proposed.md
  *   versions/
  *     v0001_e1_s1.md
  *     v0002_e1_s2.md
@@ -50,6 +51,10 @@ export function historyPath(skillsDir: string, skillName: string): string {
 
 export function bestPath(skillsDir: string, skillName: string): string {
   return path.join(skilloptDir(skillsDir, skillName), 'best.md');
+}
+
+export function proposedPath(skillsDir: string, skillName: string): string {
+  return path.join(skilloptDir(skillsDir, skillName), 'proposed.md');
 }
 
 export function skillPath(skillsDir: string, skillName: string): string {
@@ -171,17 +176,18 @@ export function acceptCandidate(input: AcceptInput): AcceptResult {
 }
 
 /**
- * Write the candidate to `best.md` (which doubles as `proposed.md`) WITHOUT
- * touching SKILL.md or the history ledger. Used by the `--no-mutate` /
- * bundled-without-allow paths: the optimizer found a better candidate but the
- * caller opted out of in-place mutation, so we surface it for human review.
- * Returns the path written. Atomic (.tmp + rename).
+ * Write the candidate to both `best.md` and `proposed.md` WITHOUT touching
+ * SKILL.md or the history ledger. `best.md` remains the optimizer's current
+ * best pointer; `proposed.md` is the stable human-review artifact promised by
+ * `--no-mutate`. Returns the proposal path. Each write is atomic (.tmp + rename).
  */
 export function writeProposed(skillsDir: string, skillName: string, candidateText: string): string {
-  const p = bestPath(skillsDir, skillName);
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  atomicWrite(p, candidateText);
-  return p;
+  const best = bestPath(skillsDir, skillName);
+  const proposed = proposedPath(skillsDir, skillName);
+  fs.mkdirSync(path.dirname(best), { recursive: true });
+  atomicWrite(best, candidateText);
+  atomicWrite(proposed, candidateText);
+  return proposed;
 }
 
 /**

--- a/test/e2e/skillopt-loop.serial.test.ts
+++ b/test/e2e/skillopt-loop.serial.test.ts
@@ -39,6 +39,7 @@ import { runSkillOpt } from '../../src/core/skillopt/orchestrator.ts';
 import {
   bestPath,
   loadHistory,
+  proposedPath,
   skillPath,
 } from '../../src/core/skillopt/version-store.ts';
 import { loadRejectedBuffer } from '../../src/core/skillopt/rejected-buffer.ts';
@@ -741,7 +742,7 @@ describe('skillopt T3 — F11 held-out gate, ablation opts, no-DB-pollution', ()
     } finally { fixture.cleanup(); }
   });
 
-  test('--no-mutate writes proposed.md (best.md), leaves SKILL.md untouched', async () => {
+  test('--no-mutate writes proposed.md and best.md, leaves SKILL.md untouched', async () => {
     const fixture = setupFixture(SKILL_PEOPLE_ONLY, CITATIONS_BENCHMARK);
     try {
       installStub({
@@ -753,10 +754,9 @@ describe('skillopt T3 — F11 held-out gate, ablation opts, no-DB-pollution', ()
           const result = await runOnce(fixture, { noMutate: true });
           expect(result.outcome).toBe('accepted');
           expect(result.mutatedSkillFile).toBe(false);
-          expect(result.proposedPath).toBeDefined();
-          // proposed.md (best.md) exists and carries the improvement.
-          expect(fs.existsSync(result.proposedPath!)).toBe(true);
+          expect(result.proposedPath).toBe(proposedPath(fixture.skillsDir, SKILL));
           expect(fs.readFileSync(result.proposedPath!, 'utf8')).toContain('## Citations');
+          expect(fs.readFileSync(bestPath(fixture.skillsDir, SKILL), 'utf8')).toContain('## Citations');
           // SKILL.md on disk is UNCHANGED (still People-only).
           const skill = fs.readFileSync(skillPath(fixture.skillsDir, SKILL), 'utf8');
           expect(skill).not.toContain('## Citations');

--- a/test/skillopt/version-store.test.ts
+++ b/test/skillopt/version-store.test.ts
@@ -12,9 +12,11 @@ import {
   bestPath,
   historyPath,
   loadHistory,
+  proposedPath,
   revertAllPending,
   skillPath,
   versionsDir,
+  writeProposed,
 } from '../../src/core/skillopt/version-store.ts';
 
 let tmpDir: string;
@@ -76,6 +78,19 @@ describe('acceptCandidate (D8 two-phase commit)', () => {
     expect(r1.versionN).toBe(1);
     expect(r2.versionN).toBe(2);
     expect(loadHistory(tmpDir, SKILL)).toHaveLength(2);
+  });
+});
+
+describe('writeProposed', () => {
+  test('writes distinct best and proposed artifacts without mutating SKILL.md (#2635)', () => {
+    const candidate = '---\nname: test\n---\nproposed body\n';
+
+    const written = writeProposed(tmpDir, SKILL, candidate);
+
+    expect(written).toBe(proposedPath(tmpDir, SKILL));
+    expect(fs.readFileSync(bestPath(tmpDir, SKILL), 'utf8')).toBe(candidate);
+    expect(fs.readFileSync(proposedPath(tmpDir, SKILL), 'utf8')).toBe(candidate);
+    expect(fs.readFileSync(skillPath(tmpDir, SKILL), 'utf8')).toContain('baseline body');
   });
 });
 


### PR DESCRIPTION
Supersedes #2719 (fork head by @RerankerGuo; re-applied onto current master with co-author credit).

## Summary

- `writeProposed` now emits a physical `skillopt/proposed.md` for accepted `--no-mutate` runs, alongside `best.md` (which stays the optimizer's current-best pointer). `SKILL.md` untouched.
- Orchestrator returns the real proposal path (`proposedPath`) instead of describing `best.md` as `proposed.md`.
- SkillOpt tutorial updated to match.

Fixes #2635

## Validation (this branch, on top of master)

- `bun run typecheck` — exit 0
- `bun test test/skillopt/version-store.test.ts test/build-llms.test.ts` — 18 pass / 0 fail
- `bun test test/e2e/skillopt-loop.serial.test.ts` — 17 pass / 0 fail
- `bun run build:llms` — ran clean; no bundle diff (the tutorial is not inlined in llms bundles), so freshness gate holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)