### PR TITLE
fix(openclaw): declare gbrain plugin manifest entry (takeover of #2551)

### DIFF
--- a/docs/guides/skillpacks-as-scaffolding.md
+++ b/docs/guides/skillpacks-as-scaffolding.md
@@ -131,7 +131,9 @@ into gbrain so other clients can scaffold it. Default behavior:
   `~/.gbrain/harvest-private-patterns.txt` plus built-in defaults
   (canonical private fork name, common email regex, Slack channel pattern). Any
   match → rollback (delete the harvested files) and exit non-zero.
-- `openclaw.plugin.json` updated with the new slug, sorted.
+- `openclaw.plugin.json` updated with the new slug, sorted. Harvest must preserve
+  the top-level OpenClaw-native plugin fields (`id`, `configSchema`, `contracts`)
+  because OpenClaw validates those before it can install the package.
 - `--no-lint` bypasses the linter (after a manual editorial scrub).
 
 Use the `skillpack-harvest` skill (its companion editorial workflow)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,4 +1,5 @@
 {
+  "id": "gbrain-context-engine",
   "name": "gbrain",
   "version": "0.32.3.0",
   "description": "Personal knowledge brain with Postgres + pgvector hybrid search",

--- a/skills/skillpack-harvest/SKILL.md
+++ b/skills/skillpack-harvest/SKILL.md
@@ -266,4 +266,5 @@ editorial pass.
   (e.g. `src/commands/<slug>.ts` if the host SKILL.md declares it
   in frontmatter)
 - gbrain's `openclaw.plugin.json` — adds the slug to `skills:`
-  array, sorted alphabetically
+  array, sorted alphabetically, without removing OpenClaw-native plugin fields
+  like `id`, `configSchema`, or `contracts`

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -57,6 +57,8 @@ This mode guarantees:
 - `skills/manifest.json` lists every skill directory
 - `skills/RESOLVER.md` references every skill in the manifest
 - `openclaw.plugin.json` `skills[]` round-trips with both
+- `openclaw.plugin.json` keeps OpenClaw install-required native plugin fields
+  (`id`, object `configSchema`, and `contracts.contextEngines` when applicable)
 - No MECE violations (duplicate triggers across skills)
 
 ### Phases
@@ -72,7 +74,7 @@ This mode guarantees:
 ### Automation
 
 ```bash
-bun test test/skills-conformance.test.ts test/resolver.test.ts
+bun test test/skills-conformance.test.ts test/resolver.test.ts test/openclaw-plugin-manifest.test.ts
 ```
 
 The CI-gated check is the package.json `test` script.

--- a/src/openclaw-context-engine.ts
+++ b/src/openclaw-context-engine.ts
@@ -63,25 +63,26 @@ interface PluginCtx {
   [key: string]: unknown;
 }
 
+export function register(api: PluginApi) {
+  api.registerContextEngine(ENGINE_ID, (ctx: PluginCtx) => {
+    const hostResolver =
+      typeof ctx.resolveEntities === 'function'
+        ? ctx.resolveEntities
+        : typeof ctx.brainQuery === 'function'
+          ? ctx.brainQuery
+          : undefined;
+    return createGBrainContextEngine({
+      workspaceDir: ctx.workspaceDir,
+      resolveEntities: hostResolver,
+    });
+  });
+}
+
 const entry: PluginEntry = {
   id: 'gbrain-context-engine',
   name: 'GBrain Context Engine',
   description: 'Deterministic temporal/spatial context injection on every turn',
-
-  register(api: PluginApi) {
-    api.registerContextEngine(ENGINE_ID, (ctx: PluginCtx) => {
-      const hostResolver =
-        typeof ctx.resolveEntities === 'function'
-          ? ctx.resolveEntities
-          : typeof ctx.brainQuery === 'function'
-            ? ctx.brainQuery
-            : undefined;
-      return createGBrainContextEngine({
-        workspaceDir: ctx.workspaceDir,
-        resolveEntities: hostResolver,
-      });
-    });
-  },
+  register,
 };
 
 export default entry;

--- a/test/openclaw-plugin-manifest.test.ts
+++ b/test/openclaw-plugin-manifest.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('root OpenClaw plugin manifest', () => {
+  it('declares the id required by OpenClaw plugin installs', () => {
+    const manifest = JSON.parse(readFileSync(join(import.meta.dir, '..', 'openclaw.plugin.json'), 'utf8'));
+    const entrySource = readFileSync(join(import.meta.dir, '..', 'src', 'openclaw-context-engine.ts'), 'utf8');
+    const entryId = entrySource.match(/id:\s*'([^']+)'/)?.[1];
+
+    expect(manifest.id).toBe(entryId);
+    expect(manifest.configSchema).toBeDefined();
+    expect(typeof manifest.configSchema).toBe('object');
+    expect(manifest.contracts?.contextEngines).toContain('gbrain-context');
+    expect(entrySource).toContain('export function register');
+  });
+});


### PR DESCRIPTION
Supersedes #2551 (fork branch rebased onto current master as a takeover).

## Summary
- Add the OpenClaw-required top-level `id` (`gbrain-context-engine`) to `openclaw.plugin.json`
- Export a direct `register(api)` entrypoint from `src/openclaw-context-engine.ts`; default plugin object reuses it
- Add `test/openclaw-plugin-manifest.test.ts` regression test (manifest id matches entry id, object `configSchema`, `contracts.contextEngines`)
- Document that skillpack harvest must preserve OpenClaw-native manifest fields (`id`, `configSchema`, `contracts`)

## Verification
- `bun test test/openclaw-plugin-manifest.test.ts test/skills-conformance.test.ts test/resolver.test.ts` — 370 pass / 0 fail
- `bun run typecheck` — exit 0
- `bun run build:llms` regenerated with no content drift; `bun test test/build-llms.test.ts` — 12 pass / 0 fail

Original author: @FilipHarald (credited via Co-authored-by).

🤖 Generated with [Claude Code](https://claude.com/claude-code)