### PR TITLE
fix(ai): Ollama local-provider compatibility fixes (takeover of #1854)

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -33,6 +33,20 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
+    expansion: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
   },
   setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
 };

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -361,6 +361,11 @@ function isAxisScoreInRange(n: unknown): n is number {
 function validateIdeaShape(raw: unknown): { id: string; scores: JudgeAxisScores; note: string } | null {
   if (typeof raw !== 'object' || raw === null) return null;
   const r = raw as Record<string, unknown>;
+  // Some models (e.g. Kimi K2) return numeric ids instead of string ids like "Idea 01".
+  // Coerce to string for compatibility.
+  if (typeof r.id === 'number') {
+    r.id = 'Idea ' + String(r.id).padStart(2, '0');
+  }
   if (typeof r.id !== 'string') return null;
   const note = typeof r.note === 'string' ? r.note : '';
   const s = r.scores;

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -156,6 +156,20 @@ const FREE_LOCAL_EMBED_PROVIDERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Provider id prefixes whose chat models run on local inference (electricity,
+ * not API tokens) and so price at $0. Without this, a `--max-cost`-bounded
+ * brainstorm/lsd configured for a local chat provider TX2 hard-fails because
+ * lookupPricing has no entry for them. Matched against the provider half
+ * of the `provider:model` string.
+ *
+ * Sibling to FREE_LOCAL_EMBED_PROVIDERS and FREE_LOCAL_RERANK_PROVIDERS.
+ */
+const FREE_LOCAL_CHAT_PROVIDERS: ReadonlySet<string> = new Set([
+  'ollama',
+  'llama-server',
+]);
+
+/**
  * Look up `modelId` in the chat or embedding pricing maps. Returns a
  * per-1M-token price tuple, or null when unknown.
  *
@@ -199,6 +213,9 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   // under `--max-cost`. Only the rerank kind — chat/embed already have
   // their own provider-specific pricing surfaces.
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
+    return { input: 0, output: 0 };
+  }
+  if (kind === 'chat' && providerId && FREE_LOCAL_CHAT_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
   return null;

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -460,6 +460,9 @@ export async function runThink(
       // problems when the real cause was a model id the recipe didn't know
       // (e.g. a tier-configured model newer than the recipe list). The re-probe
       // is pure and cheap (no IO): same predicate tryBuildGatewayClient used.
+      // NO_ANTHROPIC_API_KEY only fires for the anthropic provider (probe reason
+      // 'unavailable' is anthropic-no-key by construction) — non-Anthropic
+      // providers (Ollama, OpenRouter) never see the false warning (#1854).
       const probe = probeChatModel(normalizeModelId(modelUsed));
       const modelProblem = !probe.ok && probe.reason !== 'unavailable';
       warnings.push(
@@ -781,7 +784,7 @@ function buildGracefulMessage(modelStr: string): {
     type: 'message',
     role: 'assistant',
     model: modelStr,
-    content: [{ type: 'text', text: '(no LLM available — set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env)' }],
+    content: [{ type: 'text', text: '(no LLM available — set chat_model, expansion_model, or anthropic_api_key via gbrain config)' }],
     usage: { input_tokens: 0, output_tokens: 0 },
     stop_reason: 'end_turn',
   };

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -53,9 +53,16 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('embedding-only providers (voyage) do NOT declare chat', () => {
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
+  });
+
+  test('ollama declares a zero-cost local chat touchpoint (#1854)', () => {
+    const chat = getRecipe('ollama')!.touchpoints.chat;
+    expect(chat).toBeDefined();
+    expect(chat!.models.length).toBeGreaterThan(0);
+    expect(chat!.cost_per_1m_input_usd).toBe(0);
+    expect(chat!.cost_per_1m_output_usd).toBe(0);
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
@@ -112,8 +119,10 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
       .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
-      .toThrow(AIConfigError);
+    // ollama gained a chat touchpoint (#1854); openai-compat tier accepts
+    // arbitrary models, so it no longer rejects here.
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'llama3.3'))
+      .not.toThrow();
   });
 
   test('assertTouchpoint rejects unknown native model with the model list in the fix hint', () => {

--- a/test/autopilot-install.test.ts
+++ b/test/autopilot-install.test.ts
@@ -108,7 +108,7 @@ describe('autopilot wrapper script — env source order (v0.36.1.x #966)', () =>
 // operators put in ~/.bashrc never reach this subprocess. Without the
 // explicit export the wrapper silently dies with `env: bun: No such file
 // or directory`, leaves a stale lockfile, and blocks every subsequent tick
-// for the 10-min stale-lock window. Regression: see Hermes `cron doctor`
+// for the 10-min stale-lock window. Regression: see a downstream agent fork's `cron doctor`
 // reports — this caused a 1-week nightly-cycle outage on at least one
 // operator machine before being diagnosed.
 describe('autopilot wrapper script — bun PATH export (v0.42.x regression)', () => {


### PR DESCRIPTION
Takeover of #1854 by @starm2010 (fork branch, CONFLICTING with master). Supersedes #1854.

## What landed (rebased onto current master)

1. **`FREE_LOCAL_CHAT_PROVIDERS`** in `src/core/budget/budget-tracker.ts` — local chat providers (`ollama`, `llama-server`) return zero pricing, so `--max-cost`-bounded brainstorm/lsd no longer hard-fails on a `lookupPricing` miss. Sibling to the existing `FREE_LOCAL_EMBED_PROVIDERS` / `FREE_LOCAL_RERANK_PROVIDERS` sets.
2. **Numeric idea-id coercion** in `validateIdeaShape` (`src/core/brainstorm/judges.ts`) — models like Kimi K2 return numeric `id` fields; `5` is coerced to `"Idea 05"` before the string type check.
3. **Ollama recipe chat + expansion touchpoints** (`src/core/ai/recipes/ollama.ts`) — `llama3.3` / `qwen3` / `deepseek-r1`, `supports_tools: true`, zero cost, so the recipe system can route reasoning calls to Ollama.
4. **Graceful "no LLM available" message** (`src/core/think/index.ts`) now mentions `chat_model` / `expansion_model` config, not just `anthropic_api_key`.

## What was dropped as superseded

The original PR scoped the `NO_ANTHROPIC_API_KEY` warning to `providerId === 'anthropic'`. Master's #1698 probe-based warning already does this more robustly: `probeChatModel` returns reason `'unavailable'` only for anthropic-without-key, and every other failure is labeled `MODEL_NOT_USABLE:<reason>`. Resolved the conflict by keeping master's version and adding a comment documenting the invariant; the now-unused `splitProviderModelId` import was dropped.

## Testing

- `bun run typecheck` exit 0
- `bun test` on `budget-tracker`, `brainstorm/`, `think-gateway-adapter`, `think-pipeline.serial`, `think-ab`, `model-pricing`, `gateway-model-messages`, `gateway-tier-extended-models`: 195 pass / 0 fail

Co-authored-by credit to @starm2010 is in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)