### PR TITLE
fix(test): baseline live-reporter count in the signal-handler singleton test — shard-composition flake

### DIFF
--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -218,15 +218,22 @@ describe('progress reporter', () => {
   test('only one process-level signal handler installed across many reporters', () => {
     // Baseline: one handler already installed by prior tests in this file.
     const installedBefore = __signalHandlerInstalledForTest();
+    // Baseline the live count too. Other test files sharing this shard process
+    // may legitimately hold reporters open while this test runs, and shard
+    // composition (which shifts whenever any PR adds or removes a test file)
+    // decides who those neighbors are. Asserting the absolute count made this
+    // test fail on unrelated PRs; the invariant this test owns is that its own
+    // 50 lifecycles leak nothing — a net-zero delta.
+    const liveBefore = __liveReporterCountForTest();
     const { stream } = sink(false);
     for (let i = 0; i < 50; i++) {
       const p = createProgress({ mode: 'json', stream, minIntervalMs: 0, minItems: 1 });
       p.start(`phase_${i}`, 1);
       p.finish();
     }
-    // After 50 reporter lifecycles, still exactly one handler and zero leaked live entries.
+    // After 50 reporter lifecycles, still exactly one handler and no net leak.
     expect(__signalHandlerInstalledForTest()).toBe(installedBefore || true);
-    expect(__liveReporterCountForTest()).toBe(0);
+    expect(__liveReporterCountForTest()).toBe(liveBefore);
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {


### PR DESCRIPTION
## Summary

The signal-handler singleton test in test/progress.test.ts asserts `__liveReporterCountForTest()` is exactly `0` — an absolute assertion on a process-global registry (`liveReporters`) shared by every test file in the shard process. Any neighboring file legitimately holding a live reporter when this test runs fails it, and shard composition reshuffles whenever **any** PR adds or removes a test file. Result: unrelated PRs go red on shard CI while master stays green.

Observed on two independent PRs, both of which merely add a test file and touch no progress code:

- #3074 — `test (5)`: `Expected: 0, Received: 1` at test/progress.test.ts:229, both in-run retries fail identically
- #2692 — `test (5)`: same assertion, same values, both retries

Deterministic for a given shard composition (retries don't help); invisible on master because its current composition happens to be safe.

## Minimal repro

Run progress.test.ts in one process together with any file that starts a reporter without finishing it:

```ts
// leaky-neighbor.test.ts
import { test, expect } from 'bun:test';
import { createProgress } from '../src/core/progress.ts';
import { Writable } from 'node:stream';

test('neighbor holds a live reporter open', () => {
  const stream = new Writable({ write(_c, _e, cb) { cb(); } });
  const p = createProgress({ mode: 'json', stream: stream as any, minIntervalMs: 0, minItems: 1 });
  p.start('leaky_phase', 1);
  // intentionally no finish()
  expect(true).toBe(true);
});
```

```
bun test leaky-neighbor.test.ts test/progress.test.ts
# → (fail) progress reporter > only one process-level signal handler installed across many reporters
```

## Change

Baseline the live count at test start and assert a **net-zero delta** after the 50 reporter lifecycles. The invariant the test owns — its own lifecycles leak nothing — is preserved; neighbors' state is no longer inherited. Test-only, no runtime code touched.

Note: neighbors holding reporters open across test boundaries may themselves be worth a cleanup pass, but that is separable — this PR is about the singleton test failing PRs it has no relationship with.

## Verification

- Repro above: fails before this change, passes after.
- Standalone `bun test test/progress.test.ts`: 17 pass / 0 fail, unchanged.
- `bun run typecheck`: exit 0.
