### PR TITLE
fix(ci): normalize scanner roots on macOS

### DIFF
--- a/scripts/check-operations-filter-bypass.sh
+++ b/scripts/check-operations-filter-bypass.sh
@@ -70,7 +70,7 @@ PATTERN='import[[:space:]]+(\*[[:space:]]+as[[:space:]]+[a-zA-Z_$][a-zA-Z0-9_$]*
 FOUND_FILES=""
 while IFS= read -r f; do
   [ -n "$f" ] && FOUND_FILES="$FOUND_FILES$f"$'\n'
-done < <(grep -rlE --include='*.ts' "$PATTERN" src/ 2>/dev/null | sort -u || true)
+done < <(grep -rlE --include='*.ts' "$PATTERN" src 2>/dev/null | sort -u || true)
 
 FAIL=0
 

--- a/scripts/check-test-real-names.sh
+++ b/scripts/check-test-real-names.sh
@@ -100,9 +100,9 @@ IFS='|' eval 'PATTERN="${PATTERN_PARTS[*]}"'
 
 # Find tool.
 if command -v rg >/dev/null 2>&1; then
-  matches="$(rg -niH --no-heading -t ts "$PATTERN" test/ 2>/dev/null || true)"
+  matches="$(rg -niH --no-heading -t ts "$PATTERN" test 2>/dev/null || true)"
 elif command -v grep >/dev/null 2>&1; then
-  matches="$(grep -rniE --include='*.test.ts' "$PATTERN" test/ 2>/dev/null || true)"
+  matches="$(grep -rniE --include='*.test.ts' "$PATTERN" test 2>/dev/null || true)"
 else
   echo "check-test-real-names: ERROR: neither rg nor grep available." >&2
   exit 2


### PR DESCRIPTION
## Context

On macOS, find invoked with a trailing-slash root emits paths such as src//cli.ts. The operations trust-boundary scanner compares those paths against normalized allow-list entries such as src/cli.ts, so an unchanged checkout fails the local verify gate. The real-name scanner has the same cross-platform path-shape problem.

This removes the trailing slash from the scanner roots. It does not change runtime behavior or scanner policy; it only makes path identity consistent across macOS and Linux.

## Evidence

- Reproduced on official master d9eb027b with Bun 1.3.14: 30 of 31 verify checks passed; check:operations-filter-bypass failed only on src// path mismatches.
- With this patch on the same master: bun run verify passed all 31 checks.
- git diff --check passed.

This was found while preparing small downstream embedding fixes for GraceDB; landing it independently keeps those later PRs free of duplicated CI-only changes.