### PR TITLE
fix(sync): make full reconcile convergence truthful

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -177,8 +177,8 @@ function resolveSyncYieldEvery(): number {
  * extraction-lag nudge. Fires on every non-error completion — crucially
  * `first_sync` (a fresh / --full import is the BIGGEST un-extracted backlog) and
  * `up_to_date` (a no-op sync over a brain with a pre-existing backlog still
- * warrants the nudge). Excludes `dry_run` (preview) / `blocked_by_failures` /
- * `partial` (inconsistent state). Pure so D5's contract is unit-testable
+ * warrants the nudge). Excludes `dry_run` (preview), both blocked statuses,
+ * and `partial` (inconsistent state). Pure so D5's contract is unit-testable
  * without driving the CLI.
  */
 export function shouldNudgeAfterSync(status: SyncResult['status']): boolean {
@@ -186,7 +186,14 @@ export function shouldNudgeAfterSync(status: SyncResult['status']): boolean {
 }
 
 export interface SyncResult {
-  status: 'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures' | 'partial';
+  status:
+    | 'up_to_date'
+    | 'synced'
+    | 'first_sync'
+    | 'dry_run'
+    | 'blocked_by_failures'
+    | 'blocked_by_reconcile'
+    | 'partial';
   fromCommit: string | null;
   toCommit: string;
   added: number;
@@ -222,6 +229,30 @@ export interface SyncResult {
    * everything," the exact misdiagnosis in the #1794 recurrence report.
    */
   bankedFiles?: number;
+  /**
+   * Present when a full sync imported successfully but could not prove that
+   * its delete reconciliation converged. The bookmark remains unchanged and
+   * the same full sync is safe to retry.
+   */
+  reconcile?: {
+    reason: 'mass_delete_refused' | 'delete_failed' | 'reconcile_failed';
+    plannedDeletes: number;
+    completedDeletes: number;
+    failedDeletes: number;
+    message: string;
+  };
+}
+
+type FullReconcileIssue = NonNullable<SyncResult['reconcile']>;
+
+class FullReconcileBlockedError extends Error {
+  readonly issue: FullReconcileIssue;
+
+  constructor(issue: FullReconcileIssue) {
+    super(issue.message);
+    this.name = 'FullReconcileBlockedError';
+    this.issue = issue;
+  }
 }
 
 /**
@@ -3497,7 +3528,14 @@ async function performFullSync(
   const fullSucceeded = loadSyncFailures()
     .filter(e => e.source_id === fullSourceId && isSkippablePath(e.path) && !fullFailureSet.has(e.path))
     .map(e => e.path);
+  let reconciledDeletes = 0;
+  let plannedReconcileDeletes = 0;
   const advanceFull = async (): Promise<void> => {
+    // Reconciliation is part of convergence, not post-commit cleanup. Run it
+    // inside the failure gate's advance callback so import failures still
+    // block before destructive work, but the bookmark cannot move until every
+    // required delete has either completed or been deliberately preserved.
+    await reconcileBeforeAdvance();
     // Persist sync state so the next sync is incremental. Routed through
     // writeSyncAnchor so --source pins the right sources row.
     await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit, newestCommitMs(gitContextRoot));
@@ -3506,14 +3544,49 @@ async function performFullSync(
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
   };
 
-  const fullGate = await applySyncFailureGate({
-    sourceId: fullSourceId,
-    failedFiles: result.failures,
-    succeededPaths: fullSucceeded,
-    commit: headCommit,
-    skipFailed: opts.skipFailed === true,
-    advance: advanceFull,
-  });
+  let fullGate: Awaited<ReturnType<typeof applySyncFailureGate>>;
+  try {
+    fullGate = await applySyncFailureGate({
+      sourceId: fullSourceId,
+      failedFiles: result.failures,
+      succeededPaths: fullSucceeded,
+      commit: headCommit,
+      skipFailed: opts.skipFailed === true,
+      advance: advanceFull,
+    });
+  } catch (error) {
+    if (!(error instanceof FullReconcileBlockedError)) throw error;
+
+    // Keep non-bookmark operational metadata current for diagnostics, but do
+    // not write last_commit/chunker_version. The next full sync repeats the
+    // same reconciliation against the unchanged anchor.
+    try {
+      await engine.setConfig('sync.last_run', new Date().toISOString());
+      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    } catch {
+      // Diagnostic metadata is best-effort on a blocked reconcile. Never turn
+      // the structured, retryable result back into an opaque thrown error.
+    }
+    serr(
+      `\nFull sync reconciliation BLOCKED (${error.issue.reason}): ` +
+      `${error.issue.message}\n` +
+      `  Bookmark unchanged; re-run the full sync after correcting the cause.`,
+    );
+    return {
+      status: 'blocked_by_reconcile',
+      fromCommit: null,
+      toCommit: headCommit,
+      added: result.imported,
+      modified: 0,
+      deleted: error.issue.completedDeletes,
+      renamed: 0,
+      chunksCreated: result.chunksCreated,
+      embedded: 0,
+      pagesAffected: [],
+      failedFiles: result.failures.length,
+      reconcile: error.issue,
+    };
+  }
 
   if (!fullGate.advanced) {
     const codeBreakdown = formatCodeBreakdown(result.failures);
@@ -3556,8 +3629,8 @@ async function performFullSync(
   // file was deleted since the last sync. A full re-import is authoritative for
   // the whole tree, so reconcile deletes here too (this is what makes the
   // object-absent fallback at performSyncInner correct for deletes, not just
-  // imports). Runs only on an advancing full sync (we're past the
-  // !fullGate.advanced early-return).
+  // imports). It runs inside advanceFull, after the import failure gate chose
+  // to advance but before the bookmark write or failure acknowledgement.
   //
   // SAFETY — must NOT re-introduce the #1433 stale-page data loss. A page is
   // deleted ONLY when ALL three hold:
@@ -3569,11 +3642,25 @@ async function performFullSync(
   //   3. source_path ∉ current    → the backing file is genuinely gone from the
   //      working tree (collectSyncableFiles == the same enumeration runImport
   //      used, so paths are in the identical relative form as source_path).
-  // Skipped on the legacy no-sourceId path (the batch delete primitives require
-  // a sourceId; matches every other source-scoped feature).
-  let reconciledDeletes = 0;
-  if (opts.sourceId) {
-    const sid = opts.sourceId;
+  // Legacy programmatic callers that omit sourceId reconcile the seeded
+  // default source; operation/CLI callers pass their resolved source explicitly.
+  async function reconcileBeforeAdvance(): Promise<void> {
+    try {
+      await reconcileDeletes(fullSourceId);
+    } catch (error) {
+      if (error instanceof FullReconcileBlockedError) throw error;
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new FullReconcileBlockedError({
+        reason: 'reconcile_failed',
+        plannedDeletes: plannedReconcileDeletes,
+        completedDeletes: reconciledDeletes,
+        failedDeletes: Math.max(0, plannedReconcileDeletes - reconciledDeletes),
+        message: `full-sync reconciliation failed: ${detail}`,
+      });
+    }
+  }
+
+  async function reconcileDeletes(sid: string): Promise<void> {
     const reconcileSyncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;
     // collectSyncableFiles returns ABSOLUTE paths; source_path is stored
     // repo-relative (importFile uses `relative(dir, filePath)`), so relativize
@@ -3604,6 +3691,7 @@ async function performFullSync(
       currentFiles,
       p => (scopePrefix === '' || p.startsWith(scopePrefix)) && isSyncable(p, reconcileSyncOpts),
     );
+    plannedReconcileDeletes = plan.staleSlugs.length;
     if (plan.staleSlugs.length > 0 && plan.massDelete && !massReconcileAllowed()) {
       // #2828 mass-delete safety valve: a reconcile that would sweep more than
       // half of the pages this strategy manages, on a source with a non-trivial
@@ -3621,6 +3709,15 @@ async function performFullSync(
         `  If this bulk removal is genuinely intended, re-run with ` +
         `GBRAIN_ALLOW_MASS_RECONCILE=1 to restore the old behavior.`,
       );
+      throw new FullReconcileBlockedError({
+        reason: 'mass_delete_refused',
+        plannedDeletes: plan.staleSlugs.length,
+        completedDeletes: 0,
+        failedDeletes: plan.staleSlugs.length,
+        message:
+          `refused to delete ${plan.staleSlugs.length} of ${plan.reconcilableCount} ` +
+          `file-backed pages; set GBRAIN_ALLOW_MASS_RECONCILE=1 only for an intentional bulk removal`,
+      });
     } else if (plan.staleSlugs.length > 0) {
       // #2426: a stale page whose source_path was NEVER committed to git is
       // DB-only write-through (the file was written into the clone but never
@@ -3641,6 +3738,7 @@ async function performFullSync(
           else deletableSlugs.push(slug);
         }
       }
+      plannedReconcileDeletes = deletableSlugs.length;
       if (dbOnlySlugs.length > 0) {
         let reExported = 0;
         try {
@@ -3659,6 +3757,7 @@ async function performFullSync(
         );
       }
       const deleteScopedOpts = { sourceId: sid };
+      const failedDeleteSlugs = new Set<string>();
       for (let i = 0; i < deletableSlugs.length; i += DELETE_BATCH_SIZE) {
         const batch = deletableSlugs.slice(i, i + DELETE_BATCH_SIZE);
         try {
@@ -3666,12 +3765,36 @@ async function performFullSync(
           reconciledDeletes += deleted.length;
         } catch {
           // Per-slug fallback on a batch blip (mirrors the incremental delete
-          // loop). A stale page that won't delete is best-effort, not fatal.
+          // loop). Every unrecoverable slug blocks the bookmark and remains
+          // safe to retry on the next full sync.
           for (const slug of batch) {
             try { await engine.deletePage(slug, deleteScopedOpts); reconciledDeletes++; }
-            catch { /* best-effort */ }
+            catch { failedDeleteSlugs.add(slug); }
           }
         }
+      }
+      // Verify convergence from database state rather than trusting affected
+      // row counts. This catches partial batch behavior and concurrent misses.
+      const activeAfterDelete = deletableSlugs.length === 0
+        ? []
+        : await engine.executeRaw<{ slug: string }>(
+          `SELECT slug FROM pages
+            WHERE source_id = $1 AND deleted_at IS NULL AND slug = ANY($2::text[])`,
+          [sid, deletableSlugs],
+        );
+      const activeSlugs = new Set(activeAfterDelete.map(r => r.slug));
+      for (const slug of deletableSlugs) {
+        if (activeSlugs.has(slug)) failedDeleteSlugs.add(slug);
+      }
+      reconciledDeletes = deletableSlugs.length - failedDeleteSlugs.size;
+      if (failedDeleteSlugs.size > 0) {
+        throw new FullReconcileBlockedError({
+          reason: 'delete_failed',
+          plannedDeletes: deletableSlugs.length,
+          completedDeletes: reconciledDeletes,
+          failedDeletes: failedDeleteSlugs.size,
+          message: `${failedDeleteSlugs.size} of ${deletableSlugs.length} stale page delete(s) failed`,
+        });
       }
       if (reconciledDeletes > 0) {
         slog(`  Reconciled ${reconciledDeletes} stale page(s) whose source file was removed.`);
@@ -4399,6 +4522,7 @@ See also:
       if (
         result.status !== 'dry_run' &&
         result.status !== 'blocked_by_failures' &&
+        result.status !== 'blocked_by_reconcile' &&
         result.status !== 'partial'
       ) {
         manageGitignoreAtGitRoot(src.local_path!, engine.kind);
@@ -4416,6 +4540,7 @@ See also:
         !dryRun &&
         result.status !== 'dry_run' &&
         result.status !== 'up_to_date' &&
+        result.status !== 'blocked_by_reconcile' &&
         result.status !== 'partial'
       ) {
         try {
@@ -4670,6 +4795,7 @@ See also:
     if (
       result.status !== 'dry_run' &&
       result.status !== 'blocked_by_failures' &&
+      result.status !== 'blocked_by_reconcile' &&
       result.status !== 'partial'
     ) {
       const effectiveRepoPath = opts.repoPath ?? (await getDefaultSourcePath(engine));
@@ -4684,6 +4810,7 @@ See also:
       singleSourceAutoDefer &&
       result.status !== 'dry_run' &&
       result.status !== 'up_to_date' &&
+      result.status !== 'blocked_by_reconcile' &&
       result.status !== 'partial'
     ) {
       try {
@@ -4719,6 +4846,7 @@ See also:
       if (
         result.status !== 'dry_run' &&
         result.status !== 'blocked_by_failures' &&
+        result.status !== 'blocked_by_reconcile' &&
         result.status !== 'partial'
       ) {
         const effectiveRepoPath = opts.repoPath ?? (await getDefaultSourcePath(engine));
@@ -5358,6 +5486,14 @@ function printSyncResult(result: SyncResult, sink: NodeJS.WriteStream = process.
       write(`Sync BLOCKED at ${result.toCommit.slice(0, 8)}: ${result.failedFiles ?? 0} file(s) failed to parse.`);
       write(`  See ~/.gbrain/sync-failures.jsonl for details, or run 'gbrain doctor'.`);
       write(`  Fix the files then re-run 'gbrain sync', or 'gbrain sync --skip-failed' to move on.`);
+      break;
+    case 'blocked_by_reconcile':
+      write(
+        `Sync RECONCILIATION BLOCKED at ${result.toCommit.slice(0, 8)}: ` +
+        `${result.reconcile?.reason ?? 'reconcile_failed'}.`,
+      );
+      write(`  ${result.reconcile?.message ?? 'Delete reconciliation did not converge.'}`);
+      write(`  Re-run the full sync after correcting the cause (last_commit unchanged; safe to retry).`);
       break;
     case 'partial':
       // v0.41.13.0 (T7 / D-V3-5): --timeout fired before the bookmark write

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -937,7 +937,10 @@ async function runPhaseSync(
     const syncedCount = result.added + result.modified;
     return {
       phase: 'sync',
-      status: result.status === 'blocked_by_failures' ? 'warn' : 'ok',
+      status:
+        result.status === 'blocked_by_failures' || result.status === 'blocked_by_reconcile'
+          ? 'warn'
+          : 'ok',
       duration_ms: 0,
       summary: dryRun
         ? `${syncedCount} page(s) would sync, ${result.deleted} would delete`

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2586,6 +2586,7 @@ const sync_brain: Operation = {
     const { performSync } = await import('../commands/sync.ts');
     return performSync(ctx.engine, {
       repoPath: p.repo as string | undefined,
+      sourceId: ctx.sourceId,
       dryRun: ctx.dryRun || (p.dry_run as boolean) || false,
       noEmbed: (p.no_embed as boolean) || false,
       noPull: (p.no_pull as boolean) || false,

--- a/test/e2e/sync-full-reconcile-postgres.test.ts
+++ b/test/e2e/sync-full-reconcile-postgres.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Real-Postgres convergence regression for full-sync delete reconciliation.
+ * The actual operation handler must return a structured block, retain the
+ * prior bookmark, and converge on an explicit retry.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { execSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { operationsByName, type OperationContext } from '../../src/core/operations.ts';
+import type { SyncResult } from '../../src/commands/sync.ts';
+import { withEnv } from '../helpers/with-env.ts';
+import { getEngine, hasDatabase, setupDB, teardownDB } from './helpers.ts';
+
+const describeE2E = hasDatabase() ? describe : describe.skip;
+
+describeE2E('full-sync reconcile convergence on Postgres', () => {
+  let repoPath: string;
+  let brainHome: string;
+
+  beforeAll(async () => {
+    await setupDB();
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-full-reconcile-pg-'));
+    brainHome = mkdtempSync(join(tmpdir(), 'gbrain-full-reconcile-pg-home-'));
+    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'topics'), { recursive: true });
+    for (let i = 0; i < 21; i++) {
+      writeFileSync(join(repoPath, `topics/page-${String(i).padStart(2, '0')}.md`), [
+        '---', 'type: concept', `title: Page ${i}`, '---', '', `page ${i}`,
+      ].join('\n'));
+    }
+    execSync('git add -A && git commit -m "initial fixture"', { cwd: repoPath, stdio: 'pipe' });
+  }, 30_000);
+
+  afterAll(async () => {
+    await teardownDB();
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+    if (brainHome) rmSync(brainHome, { recursive: true, force: true });
+  });
+
+  function ctx(): OperationContext {
+    return {
+      engine: getEngine(),
+      config: {} as OperationContext['config'],
+      logger: { info() {}, warn() {}, error() {}, debug() {} } as OperationContext['logger'],
+      dryRun: false,
+      remote: false,
+      sourceId: 'default',
+    };
+  }
+
+  async function syncFull(): Promise<SyncResult> {
+    return withEnv({ GBRAIN_HOME: brainHome }, () =>
+      operationsByName.sync_brain.handler(ctx(), {
+        repo: repoPath,
+        full: true,
+        no_pull: true,
+        no_embed: true,
+      }) as Promise<SyncResult>,
+    );
+  }
+
+  async function bookmark(): Promise<string | null> {
+    const rows = await getEngine().executeRaw<{ last_commit: string | null }>(
+      `SELECT last_commit FROM sources WHERE id = 'default'`,
+    );
+    return rows[0]?.last_commit ?? null;
+  }
+
+  async function activePages(): Promise<number> {
+    const rows = await getEngine().executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM pages WHERE source_id = 'default' AND deleted_at IS NULL`,
+    );
+    return rows[0]?.n ?? 0;
+  }
+
+  test('mass refusal does not advance; explicit retry converges and advances', async () => {
+    expect((await syncFull()).status).toBe('first_sync');
+    const originalBookmark = await bookmark();
+    expect(await activePages()).toBe(21);
+
+    for (let i = 0; i < 11; i++) {
+      rmSync(join(repoPath, `topics/page-${String(i).padStart(2, '0')}.md`));
+    }
+    execSync('git add -A && git commit -m "bulk removal"', { cwd: repoPath, stdio: 'pipe' });
+    const deletionHead = execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf8' }).trim();
+
+    const blocked = await withEnv(
+      { GBRAIN_ALLOW_MASS_RECONCILE: undefined },
+      () => syncFull(),
+    );
+    expect(blocked.status).toBe('blocked_by_reconcile');
+    expect(blocked.reconcile).toMatchObject({
+      reason: 'mass_delete_refused',
+      plannedDeletes: 11,
+      completedDeletes: 0,
+      failedDeletes: 11,
+    });
+    expect(await bookmark()).toBe(originalBookmark);
+    expect(await activePages()).toBe(21);
+
+    const retried = await withEnv(
+      { GBRAIN_ALLOW_MASS_RECONCILE: '1' },
+      () => syncFull(),
+    );
+    expect(retried.status).toBe('first_sync');
+    expect(retried.deleted).toBe(11);
+    expect(await bookmark()).toBe(deletionHead);
+    expect(await activePages()).toBe(10);
+  }, 180_000);
+});

--- a/test/performfullsync-source-id.test.ts
+++ b/test/performfullsync-source-id.test.ts
@@ -33,10 +33,14 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runSources } from '../src/commands/sources.ts';
+import { operationsByName, type OperationContext } from '../src/core/operations.ts';
+import type { SyncResult } from '../src/commands/sync.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 let repoPath: string;
+let brainHome: string;
 
 async function pageCountBySource(): Promise<Record<string, number>> {
   const rows = await engine.executeRaw<{ source_id: string; n: number }>(
@@ -45,6 +49,17 @@ async function pageCountBySource(): Promise<Record<string, number>> {
   const out: Record<string, number> = {};
   for (const r of rows) out[r.source_id] = r.n;
   return out;
+}
+
+function operationContext(sourceId: string): OperationContext {
+  return {
+    engine,
+    config: {} as OperationContext['config'],
+    logger: { info() {}, warn() {}, error() {}, debug() {} } as OperationContext['logger'],
+    dryRun: false,
+    remote: false,
+    sourceId,
+  };
 }
 
 describe('performFullSync threads sourceId end-to-end', () => {
@@ -68,6 +83,7 @@ describe('performFullSync threads sourceId end-to-end', () => {
     }
 
     repoPath = mkdtempSync(join(tmpdir(), 'gbrain-pfs-'));
+    brainHome = mkdtempSync(join(tmpdir(), 'gbrain-pfs-home-'));
     execSync('git init', { cwd: repoPath, stdio: 'pipe' });
     execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
     execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
@@ -93,17 +109,16 @@ describe('performFullSync threads sourceId end-to-end', () => {
 
   afterEach(() => {
     if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+    if (brainHome) rmSync(brainHome, { recursive: true, force: true });
   });
 
-  test('performFullSync with --source routes pages to named source (not default)', async () => {
-    const { performSync } = await import('../src/commands/sync.ts');
-    const result = await performSync(engine, {
-      repoPath,
-      full: true,
-      sourceId: 'testsrc-pfs',
-      noPull: true,
-      noEmbed: true,
-    });
+  test('sync_brain actual handler threads ctx.sourceId into full sync', async () => {
+    const result = await withEnv({ GBRAIN_HOME: brainHome }, () =>
+      operationsByName.sync_brain.handler(
+        operationContext('testsrc-pfs'),
+        { repo: repoPath, full: true, no_pull: true, no_embed: true },
+      ) as Promise<SyncResult>,
+    );
 
     // status is 'first_sync' for fresh imports, 'synced' for incremental — accept both
     expect(['first_sync', 'synced']).toContain(result.status);
@@ -119,13 +134,15 @@ describe('performFullSync threads sourceId end-to-end', () => {
 
   test('performFullSync WITHOUT --source still targets default (back-compat preserved)', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
-    const result = await performSync(engine, {
-      repoPath,
-      full: true,
-      // no sourceId — expect default-source behavior
-      noPull: true,
-      noEmbed: true,
-    });
+    const result = await withEnv({ GBRAIN_HOME: brainHome }, () =>
+      performSync(engine, {
+        repoPath,
+        full: true,
+        // no sourceId — expect default-source behavior
+        noPull: true,
+        noEmbed: true,
+      }),
+    );
 
     // status is 'first_sync' for fresh imports, 'synced' for incremental — accept both
     expect(['first_sync', 'synced']).toContain(result.status);

--- a/test/sync-nudge-status-gate.test.ts
+++ b/test/sync-nudge-status-gate.test.ts
@@ -34,6 +34,10 @@ describe('shouldNudgeAfterSync (D5 status gate)', () => {
     expect(shouldNudgeAfterSync('blocked_by_failures')).toBe(false);
   });
 
+  test('does NOT fire on blocked_by_reconcile (bookmark unchanged)', () => {
+    expect(shouldNudgeAfterSync('blocked_by_reconcile')).toBe(false);
+  });
+
   test('does NOT fire on partial (inconsistent state)', () => {
     expect(shouldNudgeAfterSync('partial')).toBe(false);
   });

--- a/test/sync-reconcile-db-only.serial.test.ts
+++ b/test/sync-reconcile-db-only.serial.test.ts
@@ -24,15 +24,54 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
-import { listEverCommittedPaths } from '../src/commands/sync.ts';
+import { listEverCommittedPaths, type SyncResult } from '../src/commands/sync.ts';
+import { operationsByName, type OperationContext } from '../src/core/operations.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 let repoPath: string;
+let brainHome: string;
 
 function gitInit(repo: string): void {
   execSync('git init', { cwd: repo, stdio: 'pipe' });
   execSync('git config user.email "t@t.t"', { cwd: repo, stdio: 'pipe' });
   execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+}
+
+function operationContext(sourceId = 'default'): OperationContext {
+  return {
+    engine,
+    config: {} as OperationContext['config'],
+    logger: { info() {}, warn() {}, error() {}, debug() {} } as OperationContext['logger'],
+    dryRun: false,
+    remote: false,
+    sourceId,
+  };
+}
+
+async function fullSyncThroughOperation(): Promise<SyncResult> {
+  return withEnv({ GBRAIN_HOME: brainHome }, () =>
+    operationsByName.sync_brain.handler(operationContext(), {
+      repo: repoPath,
+      full: true,
+      no_pull: true,
+      no_embed: true,
+    }) as Promise<SyncResult>,
+  );
+}
+
+async function defaultSourceBookmark(): Promise<string | null> {
+  const rows = await engine.executeRaw<{ last_commit: string | null }>(
+    `SELECT last_commit FROM sources WHERE id = 'default'`,
+  );
+  return rows[0]?.last_commit ?? null;
+}
+
+async function activePageCount(): Promise<number> {
+  const rows = await engine.executeRaw<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM pages WHERE source_id = 'default' AND deleted_at IS NULL`,
+  );
+  return rows[0]?.n ?? 0;
 }
 
 describe('listEverCommittedPaths (#2426)', () => {
@@ -77,6 +116,7 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
   beforeEach(async () => {
     await resetPgliteState(engine);
     repoPath = mkdtempSync(join(tmpdir(), 'gbrain-dbonly-'));
+    brainHome = mkdtempSync(join(tmpdir(), 'gbrain-dbonly-home-'));
     gitInit(repoPath);
     mkdirSync(join(repoPath, 'topics'), { recursive: true });
     writeFileSync(join(repoPath, 'topics/keep.md'), [
@@ -90,15 +130,16 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
 
   afterEach(() => {
     if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+    if (brainHome) rmSync(brainHome, { recursive: true, force: true });
   });
 
   test('genuinely-deleted pages reconcile; never-committed pages are kept and re-exported', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
 
     // Full sync #1: both file-backed pages land.
-    const first = await performSync(engine, {
+    const first = await withEnv({ GBRAIN_HOME: brainHome }, () => performSync(engine, {
       repoPath, full: true, sourceId: 'default', noPull: true, noEmbed: true,
-    });
+    }));
     expect(['first_sync', 'synced']).toContain(first.status);
     expect(await engine.getPage('topics/keep')).not.toBeNull();
     expect(await engine.getPage('topics/gone')).not.toBeNull();
@@ -123,9 +164,9 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
     await engine.setConfig('sync.repo_path', repoPath);
 
     // Full sync #2 runs the delete-reconcile.
-    const second = await performSync(engine, {
+    const second = await withEnv({ GBRAIN_HOME: brainHome }, () => performSync(engine, {
       repoPath, full: true, sourceId: 'default', noPull: true, noEmbed: true,
-    });
+    }));
     expect(['first_sync', 'synced']).toContain(second.status);
 
     // The genuinely-deleted page is reconciled away…
@@ -139,4 +180,93 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
     // …and re-exported to the working tree so it is file-backed again.
     expect(existsSync(join(repoPath, 'memories/lost.md'))).toBe(true);
   }, 120_000);
+
+  test('actual sync_brain handler returns a retryable block and preserves bookmark on mass refusal', async () => {
+    mkdirSync(join(repoPath, 'bulk'), { recursive: true });
+    const bulkPaths: string[] = [];
+    for (let i = 0; i < 19; i++) {
+      const rel = `bulk/page-${String(i).padStart(2, '0')}.md`;
+      bulkPaths.push(rel);
+      writeFileSync(join(repoPath, rel), [
+        '---', 'type: concept', `title: Bulk ${i}`, '---', '', `bulk page ${i}`,
+      ].join('\n'));
+    }
+    execSync('git add -A && git commit -m "add bulk fixture"', { cwd: repoPath, stdio: 'pipe' });
+
+    const first = await fullSyncThroughOperation();
+    expect(first.status).toBe('first_sync');
+    const beforeRefusal = await defaultSourceBookmark();
+    expect(beforeRefusal).not.toBeNull();
+    expect(await activePageCount()).toBe(21);
+
+    // Delete 11/21 (>50%, and population >20) so the safety valve refuses.
+    rmSync(join(repoPath, 'topics/gone.md'));
+    for (const rel of bulkPaths.slice(0, 10)) rmSync(join(repoPath, rel));
+    execSync('git add -A && git commit -m "intentional mass removal"', { cwd: repoPath, stdio: 'pipe' });
+    const deletionHead = execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf8' }).trim();
+
+    const blocked = await withEnv(
+      { GBRAIN_ALLOW_MASS_RECONCILE: undefined },
+      () => fullSyncThroughOperation(),
+    );
+    expect(blocked.status).toBe('blocked_by_reconcile');
+    expect(blocked.reconcile).toMatchObject({
+      reason: 'mass_delete_refused',
+      plannedDeletes: 11,
+      completedDeletes: 0,
+      failedDeletes: 11,
+    });
+    expect(await defaultSourceBookmark()).toBe(beforeRefusal);
+    expect(await activePageCount()).toBe(21);
+
+    // The operator override retries the same convergence step and advances
+    // only after every genuine deletion is verified absent.
+    const retried = await withEnv(
+      { GBRAIN_ALLOW_MASS_RECONCILE: '1' },
+      () => fullSyncThroughOperation(),
+    );
+    expect(retried.status).toBe('first_sync');
+    expect(retried.deleted).toBe(11);
+    expect(await defaultSourceBookmark()).toBe(deletionHead);
+    expect(await activePageCount()).toBe(10);
+  }, 180_000);
+
+  test('delete failure is structured, leaves bookmark unchanged, and succeeds on retry', async () => {
+    const first = await fullSyncThroughOperation();
+    expect(first.status).toBe('first_sync');
+    const beforeFailure = await defaultSourceBookmark();
+
+    rmSync(join(repoPath, 'topics/gone.md'));
+    execSync('git add -A && git commit -m "remove gone"', { cwd: repoPath, stdio: 'pipe' });
+    const deletionHead = execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf8' }).trim();
+
+    const originalDeletePages = engine.deletePages;
+    const originalDeletePage = engine.deletePage;
+    engine.deletePages = async () => { throw new Error('injected batch delete failure'); };
+    engine.deletePage = async () => { throw new Error('injected scalar delete failure'); };
+    const blocked = await (async () => {
+      try {
+        return await fullSyncThroughOperation();
+      } finally {
+        engine.deletePages = originalDeletePages;
+        engine.deletePage = originalDeletePage;
+      }
+    })();
+
+    expect(blocked.status).toBe('blocked_by_reconcile');
+    expect(blocked.reconcile).toMatchObject({
+      reason: 'delete_failed',
+      plannedDeletes: 1,
+      completedDeletes: 0,
+      failedDeletes: 1,
+    });
+    expect(await defaultSourceBookmark()).toBe(beforeFailure);
+    expect(await engine.getPage('topics/gone')).not.toBeNull();
+
+    const retried = await fullSyncThroughOperation();
+    expect(retried.status).toBe('first_sync');
+    expect(retried.deleted).toBe(1);
+    expect(await defaultSourceBookmark()).toBe(deletionHead);
+    expect(await engine.getPage('topics/gone')).toBeNull();
+  }, 180_000);
 });

--- a/test/sync-timeout.test.ts
+++ b/test/sync-timeout.test.ts
@@ -106,8 +106,8 @@ describe('SyncResult partial envelope (v0.41.13.0 T1)', () => {
     // Compile-time only: TypeScript would reject this assignment if the
     // status union narrowed in a way that broke existing values.
     const existing: Array<
-      'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures'
-    > = ['up_to_date', 'synced', 'first_sync', 'dry_run', 'blocked_by_failures'];
-    expect(existing).toHaveLength(5);
+      'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures' | 'blocked_by_reconcile'
+    > = ['up_to_date', 'synced', 'first_sync', 'dry_run', 'blocked_by_failures', 'blocked_by_reconcile'];
+    expect(existing).toHaveLength(6);
   });
 });


### PR DESCRIPTION
## Problem

A full sync currently advances the source bookmark through the failure gate before deletion reconciliation runs. If the mass-delete safety valve refuses the deletion, or if one or more deletes fail, the command can still return first_sync with an advanced bookmark. The next ordinary sync then reports up to date even though the database did not converge to the Git tree.

This was reproduced against real Postgres with 21 committed pages and 11 committed files removed: the safety warning fired, all 21 pages remained, the bookmark advanced to the deletion commit, and the next sync reported up to date.

## Change

- Reconcile before advancing the bookmark.
- Return structured blocked_by_reconcile results for mass-delete refusal, deletion failure, and convergence mismatch.
- Keep the bookmark unchanged on every blocked path so a retry is honest.
- Verify expected deletions are absent before reporting success.
- Preserve never-committed DB-only pages.
- Thread the explicit source ID through the sync_brain full-sync path.

This is a general sync correctness fix. GraceDB consumes the structured result in immutable execution receipts, but no GraceDB-specific behavior is embedded here.

## Evidence

- Focused suite: 28 passed, 0 failed, 77 expectations.
- Real-Postgres actual-handler test: 1 passed, 0 failed, 10 expectations; proves refusal, unchanged bookmark, explicit retry, deletion, and advance.
- 30 of 31 local verify checks pass on macOS. The only remaining check is the pre-existing src// path-normalization failure on official master, isolated in PR #3198; running that fixed scanner against this branch passes.
- git diff --check passes.