### PR TITLE
fix(sync): report the pinned commit after resumed sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3392,7 +3392,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   return {
     status: 'synced',
     fromCommit: lastCommit,
-    toCommit: headCommit,
+    toCommit: pin,
     added: filtered.added.length,
     modified: filtered.modified.length,
     deleted: filtered.deleted.length,

--- a/test/sync-resumable-import.serial.test.ts
+++ b/test/sync-resumable-import.serial.test.ts
@@ -203,15 +203,18 @@ describe('#1794 — resumable incremental sync (pinned target)', () => {
     // Run 1: drains C0..C1 only, advances to the PIN (C1), not live HEAD (C2).
     const r1 = await performSync(engine, { repoPath, noPull: true, noEmbed: true });
     expect(r1.status).toBe('synced');
+    expect(r1.toCommit).toBe(c1);
+    expect(r1.toCommit).not.toBe(c2);
     expect(await engine.getPage('notes/x')).not.toBeNull();
     expect(await engine.getPage('notes/y')).toBeNull(); // past the pin, not yet
-    expect(await lastCommitConfig()).toBe(c1);
+    expect(await lastCommitConfig()).toBe(r1.toCommit);
 
     // Run 2: now anchored at C1, diff C1..C2 picks up y.
     const r2 = await performSync(engine, { repoPath, noPull: true, noEmbed: true });
     expect(r2.status).toBe('synced');
+    expect(r2.toCommit).toBe(c2);
     expect(await engine.getPage('notes/y')).not.toBeNull();
-    expect(await lastCommitConfig()).toBe(c2);
+    expect(await lastCommitConfig()).toBe(r2.toCommit);
   }, 60_000);
 
   // ── D. Rewrite of the pin → discard checkpoint, re-pin to HEAD ─────────────


### PR DESCRIPTION
## Problem

The resumable incremental-sync path correctly pins a target commit and advances the bookmark to that pin, but its final synced result reports the live headCommit. If HEAD advances while the pinned batch is being drained, the result claims a commit that was not processed and disagrees with the stored bookmark.

## Change

Return the pinned target as toCommit on the successful resumable path. Other result paths are unchanged.

This matters to any caller that records an immutable sync receipt or decides whether a follow-up sync is required. GraceDB rejects a receipt when the native result commit differs from its immutable source snapshot, but the invariant is general to gbrain.

## Evidence

- Resumable-sync suite: 13 passed, 0 failed, 99 expectations.
- The regression advances the repository from C1 to C2 while C1 is pinned, asserts the first result and bookmark both report C1, then proves the next sync processes and reports C2.
- 30 of 31 local verify checks pass on macOS; the sole official-master src// scanner issue is isolated in PR #3198, and its fixed scanner passes against this branch.
- git diff --check passes.