### PR TITLE
fix(cli): route init --help to its own usage text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgra
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
 const CLI_ONLY_SELF_HELP = new Set([
+  'init',
   'upgrade', 'post-upgrade', 'check-update',
   'embed', 'config',
   'skillpack', 'skillpack-check',


### PR DESCRIPTION
## Summary

`gbrain init --help` prints the generic one-line CLI-only short-circuit (`printCliOnlyHelp`) instead of `init`'s own usage. In `src/cli.ts`, `init` is in `CLI_ONLY` but not in `CLI_ONLY_SELF_HELP` — and the dispatcher fires the generic short-circuit for any `CLI_ONLY` command that isn't in the self-help set, so `init`'s detailed usage is unreachable.

## The fix

- Add `'init'` to `CLI_ONLY_SELF_HELP` so `init --help` routes to its own usage text (same treatment the other self-documenting CLI-only commands already get).
