### PR TITLE
feat(operations): include source_id in list_pages rows

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1422,6 +1422,7 @@ const list_pages: Operation = {
     });
     return pages.map(pg => ({
       slug: pg.slug,
+      source_id: pg.source_id,
       type: pg.type,
       title: pg.title,
       updated_at: pg.updated_at,


### PR DESCRIPTION
## Summary

The `list_pages` operation returns `slug` / `type` / `title` / `updated_at` / `deleted_at` per row but omits `source_id` (`src/core/operations.ts`). On a federated/multi-source brain that makes it impossible to disambiguate same-slug pages across sources, or to target the right source for a follow-up op, from a `list_pages` result alone. The underlying row already carries `source_id`.

## The fix

- Add `source_id: pg.source_id` to the returned row map. Additive — existing consumers are unaffected.
