### PR TITLE
fix(eval): raise contradiction judge token cap for thinking models

### DIFF
--- a/src/core/eval-contradictions/judge.ts
+++ b/src/core/eval-contradictions/judge.ts
@@ -348,7 +348,7 @@ export async function judgeContradiction(input: JudgeInput): Promise<JudgeOutput
   const result = await callFn({
     model: input.model,
     messages: [{ role: 'user', content: prompt }],
-    maxTokens: 200,
+    maxTokens: 1024,
     abortSignal: input.abortSignal,
   });
   if (isRefusalResponse(result)) {


### PR DESCRIPTION
## Summary

`judgeContradiction` caps the judge chat call at `maxTokens: 200` (`src/core/eval-contradictions/judge.ts`). Thinking-capable judge models (e.g. Gemini 2.5 Flash) spend a chunk of that budget on reasoning tokens before emitting the verdict JSON, so the response comes back with `finishReason: length` and unparseable JSON — which the probe counts as a `parse_fail` judge error (0 findings). Non-thinking judges stop well under 1024 tokens, so they pay nothing extra.

## The fix

- Raise the judge `maxTokens` from 200 to 1024, enough headroom for a thinking model to reason and still emit the verdict JSON.
