### PR TITLE
fix(migrate): tolerate non-superuser roles lacking BYPASSRLS

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -906,13 +906,14 @@ export const MIGRATIONS: Migration[] = [
       BEGIN
         SELECT EXISTS (SELECT 1 FROM pg_roles pr WHERE pg_has_role(current_user, pr.oid, 'USAGE') AND (pr.rolbypassrls OR pr.rolsuper)) INTO has_bypass; -- #1385: superuser + inherited-role BYPASSRLS, not just the role's own rolbypassrls
         IF NOT has_bypass THEN
-          -- Fail the migration loudly instead of WARNING + version-bump.
-          -- The runner unconditionally records schema_version on success,
-          -- so a silent WARNING here would permanently lock the backfill out
-          -- on future runs even after switching to a bypass role. Raising
-          -- aborts the transaction, leaves schema_version at the prior value,
-          -- and lets the next invocation retry after the role is fixed.
-          RAISE EXCEPTION 'v24 rls_backfill_missing_tables: role % does not have BYPASSRLS privilege — cannot enable RLS safely. Re-run as postgres (or another BYPASSRLS role). The migration will retry automatically on the next initSchema call.', current_user;
+          -- A non-superuser table OWNER (e.g. the app role on managed
+          -- Postgres) can never hold BYPASSRLS, but it OWNS these tables and
+          -- gbrain sets no FORCE ROW LEVEL SECURITY and no policies, so the
+          -- owner is exempt and enabling RLS is a harmless no-op. Aborting
+          -- would permanently wedge the migration chain on such instances.
+          -- Still fail-closed: the ALTERs below require ownership, so a
+          -- non-owner role aborts this block with schema_version unbumped.
+          RAISE WARNING 'v24 rls_backfill_missing_tables: role % lacks BYPASSRLS — enabling RLS anyway (owner-exempt; safe on a single-owner DB).', current_user;
         END IF;
 
         -- These 8 are guaranteed to exist: schema.sql creates them (idempotent
@@ -1195,7 +1196,8 @@ export const MIGRATIONS: Migration[] = [
         BEGIN
           SELECT EXISTS (SELECT 1 FROM pg_roles pr WHERE pg_has_role(current_user, pr.oid, 'USAGE') AND (pr.rolbypassrls OR pr.rolsuper)) INTO has_bypass; -- #1385: superuser + inherited-role BYPASSRLS, not just the role's own rolbypassrls
           IF NOT has_bypass THEN
-            RAISE EXCEPTION 'v29 cathedral_ii_code_edges_rls: role % does not have BYPASSRLS privilege — cannot enable RLS safely. Re-run as postgres (or another BYPASSRLS role). The migration will retry automatically on the next initSchema call.', current_user;
+            -- Owner-exempt: warn + proceed rather than abort (see v24).
+            RAISE WARNING 'v29 cathedral_ii_code_edges_rls: role % lacks BYPASSRLS — enabling RLS anyway (owner-exempt; safe on a single-owner DB).', current_user;
           END IF;
 
           ALTER TABLE code_edges_chunk ENABLE ROW LEVEL SECURITY;
@@ -1424,7 +1426,8 @@ export const MIGRATIONS: Migration[] = [
         BEGIN
           SELECT EXISTS (SELECT 1 FROM pg_roles pr WHERE pg_has_role(current_user, pr.oid, 'USAGE') AND (pr.rolbypassrls OR pr.rolsuper)) INTO has_bypass; -- #1385: superuser + inherited-role BYPASSRLS, not just the role's own rolbypassrls
           IF NOT has_bypass THEN
-            RAISE EXCEPTION 'v31 eval_capture_tables: role % does not have BYPASSRLS privilege — cannot enable RLS safely. Re-run as postgres (or another BYPASSRLS role). The migration will retry automatically on the next initSchema call.', current_user;
+            -- Owner-exempt: warn + proceed rather than abort (see v24).
+            RAISE WARNING 'v31 eval_capture_tables: role % lacks BYPASSRLS — enabling RLS anyway (owner-exempt; safe on a single-owner DB).', current_user;
           END IF;
 
           CREATE TABLE IF NOT EXISTS eval_candidates (
@@ -1764,9 +1767,8 @@ export const MIGRATIONS: Migration[] = [
         BEGIN
           SELECT EXISTS (SELECT 1 FROM pg_roles pr WHERE pg_has_role(current_user, pr.oid, 'USAGE') AND (pr.rolbypassrls OR pr.rolsuper)) INTO has_bypass; -- #1385: superuser + inherited-role BYPASSRLS, not just the role's own rolbypassrls
           IF NOT has_bypass THEN
-            -- Same posture as v24: raise to abort the migration so the runner
-            -- leaves config.version unbumped and retries on the next call.
-            RAISE EXCEPTION 'v35 auto_rls_event_trigger backfill: role % does not have BYPASSRLS — cannot enable RLS safely. Re-run as postgres (or another BYPASSRLS role).', current_user;
+            -- Owner-exempt: warn + proceed rather than abort (see v24).
+            RAISE WARNING 'v35 auto_rls_event_trigger backfill: role % lacks BYPASSRLS — enabling RLS anyway (owner-exempt; safe on a single-owner DB).', current_user;
           END IF;
 
           FOR r IN

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -442,16 +442,30 @@ describe('migration v24 — rls_backfill_missing_tables', () => {
     );
   });
 
-  // Codex found: if v24 RAISE WARNINGs instead of raising on non-BYPASSRLS,
-  // the migration runner still bumps schema_version to 24, permanently
-  // skipping the backfill on future runs even after the role is fixed.
-  // The fix is to raise loudly so the transaction aborts, version stays
-  // at 23, and the next initSchema call retries after role reassignment.
-  test('fails loudly on non-BYPASSRLS roles instead of silently bumping version', () => {
+  // Warn + PROCEED on a non-BYPASSRLS role, not abort. A non-superuser table
+  // OWNER (the app role on managed Postgres) can never hold BYPASSRLS, and
+  // gbrain sets no FORCE ROW LEVEL SECURITY and no policies, so the owner is
+  // exempt and enabling RLS is a harmless no-op; aborting permanently wedges
+  // the upgrade chain on those instances.
+  //
+  // The hazard Codex originally found (WARNING + schema_version bump = the
+  // backfill silently skipped forever) does NOT apply, because the ALTERs run
+  // unconditionally OUTSIDE the guard: the run that warns is the run that
+  // actually enables RLS. Fail-closed is preserved by ownership rather than by
+  // BYPASSRLS - ENABLE ROW LEVEL SECURITY requires ownership, so a non-owner
+  // role aborts the DO block and leaves schema_version unbumped.
+  test('warns and proceeds on non-BYPASSRLS roles, enabling RLS in the same run', () => {
     const v24 = MIGRATIONS.find(m => m.version === 24);
     const sql = v24!.sql || '';
-    expect(sql).toMatch(/RAISE EXCEPTION[^;]*BYPASSRLS/);
-    expect(sql).not.toMatch(/RAISE WARNING[^;]*BYPASSRLS/);
+    expect(sql).toMatch(/RAISE WARNING[^;]*BYPASSRLS/);
+    expect(sql).not.toMatch(/RAISE EXCEPTION[^;]*BYPASSRLS/);
+    // warn-and-proceed, never warn-and-skip: the ALTERs must sit AFTER the
+    // guard's END IF, not inside the IF NOT has_bypass branch.
+    const guardEnd = sql.indexOf('END IF;');
+    expect(guardEnd).toBeGreaterThan(-1);
+    expect(sql.indexOf('ALTER TABLE access_tokens ENABLE ROW LEVEL SECURITY')).toBeGreaterThan(
+      guardEnd,
+    );
   });
 
   test('LATEST_VERSION has caught up to 24', () => {
@@ -1339,11 +1353,14 @@ describe('migration v31 — eval_capture_tables', () => {
     }
   });
 
-  test('Postgres variant gates RLS on BYPASSRLS and fails loudly', () => {
+  test('Postgres variant gates RLS on BYPASSRLS and warns without aborting', () => {
     const pgSql = MIGRATIONS.find(m => m.version === 31)!.sqlFor!.postgres!;
     expect(pgSql).toContain('rolbypassrls');
     expect(pgSql).toMatch(/IF NOT has_bypass/);
-    expect(pgSql).toMatch(/RAISE EXCEPTION[^;]*BYPASSRLS/);
+    // Same warn-and-proceed contract as v24: a non-superuser owner is exempt,
+    // so warn instead of aborting the upgrade chain.
+    expect(pgSql).toMatch(/RAISE WARNING[^;]*BYPASSRLS/);
+    expect(pgSql).not.toMatch(/RAISE EXCEPTION[^;]*BYPASSRLS/);
     expect(pgSql).toContain('ALTER TABLE eval_candidates ENABLE ROW LEVEL SECURITY');
     expect(pgSql).toContain('ALTER TABLE eval_capture_failures ENABLE ROW LEVEL SECURITY');
   });


### PR DESCRIPTION
## Summary

The RLS-backfill migrations v24 / v29 / v31 / v35 (`src/core/migrate.ts`) `RAISE EXCEPTION` when the current role lacks `BYPASSRLS`, aborting the migration. On managed Postgres (e.g. Cloud SQL) the application role is a non-superuser that cannot hold `BYPASSRLS` but still **owns** the tables. Since gbrain ships no policies and no `FORCE ROW LEVEL SECURITY`, the owner is exempt from RLS and `ENABLE ROW LEVEL SECURITY` is a harmless no-op. The hard abort permanently wedges the migration chain on such instances — the runner never advances past the failing version.

## The fix

- In the four `IF NOT has_bypass` guards, change `RAISE EXCEPTION` to `RAISE WARNING` and fall through to the `ENABLE ROW LEVEL SECURITY` statements. A `BYPASSRLS` role behaves exactly as before; a non-superuser owner now warns and proceeds (safe on a single-owner database) instead of wedging.
