### PR TITLE
fix(search): fold resolved source-boost map into query-cache knobs hash

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -15,7 +15,7 @@ import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
 import { embed, embedQuery } from '../embedding.ts';
 import { registerBackgroundWorkDrainer } from '../background-work.ts';
 import { resolveEmbeddingColumn, isCacheSafe } from './embedding-column.ts';
-import { resolveHardExcludes } from './source-boost.ts';
+import { resolveHardExcludes, resolveBoostMap } from './source-boost.ts';
 import {
   resolveAdaptiveReturn,
   applyAdaptiveReturn,
@@ -1702,6 +1702,11 @@ export async function hybridSearchCached(
     // resolves) into the cache key so a row written under one exclude
     // policy can't be served to a lookup under another.
     hardExcludes: resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes),
+    // v=13 — fold the resolved source-boost map (defaults merged with
+    // GBRAIN_SOURCE_BOOST) into the cache key. Boosts reorder results at
+    // query-build time only, so without this a ranking-policy change kept
+    // serving rows ranked under the old policy for up to cache.ttl_seconds.
+    sourceBoostMap: resolveBoostMap(),
   });
 
   // Cache decision: opts.useCache (explicit) wins over global config; global

--- a/src/core/search/mode.ts
+++ b/src/core/search/mode.ts
@@ -756,7 +756,16 @@ export function attributeKnob<K extends keyof ModeBundle>(
 // slugs written by a process without it, and vice versa. Same one-time
 // global cold-miss pattern as the bumps above; refills within
 // cache.ttl_seconds (3600s default).
-export const KNOBS_HASH_VERSION = 12;
+//
+// bump 12→13: the resolved source-boost map (DEFAULT_SOURCE_BOOSTS merged
+// with GBRAIN_SOURCE_BOOST) folds into the key via ctx.sourceBoostMap. Same
+// bug class as #2825's hard-excludes: boosts only applied at DB-query build
+// time (cache miss), so after a ranking-policy change (env tune or upgrade
+// that ships new defaults) lookups kept being served rows ranked under the
+// OLD policy for up to cache.ttl_seconds — making boost tuning appear
+// nondeterministic. Same one-time global cold-miss pattern; refills within
+// cache.ttl_seconds (3600s default).
+export const KNOBS_HASH_VERSION = 13;
 
 /**
  * v0.36 (D8 / CDX-2) — second-arg context for the cache key. The
@@ -795,6 +804,17 @@ export interface KnobsHashContext {
    * 'none' for legacy callers that don't thread excludes.
    */
   hardExcludes?: string[];
+  /**
+   * v=13: the RESOLVED effective source-boost map — the same value
+   * resolveBoostMap() produces at query-build time (DEFAULT_SOURCE_BOOSTS
+   * merged with GBRAIN_SOURCE_BOOST). Ranking priors change result ORDER,
+   * not membership, so they are invisible to the hard-exclude fold above —
+   * yet a cache row ranked under an old boost policy is exactly as stale as
+   * one filtered under an old exclude policy. Canonicalized (entries sorted
+   * by prefix) so object-key insertion order is irrelevant. Undefined falls
+   * back to the literal 'default' for legacy callers.
+   */
+  sourceBoostMap?: Record<string, number>;
 }
 
 export function knobsHash(
@@ -888,6 +908,18 @@ export function knobsHash(
     // across processes. Sorted copy so ['a/','b/'] and ['b/','a/'] hash
     // identically; undefined falls back to 'none' for legacy callers.
     `hx=${ctx?.hardExcludes ? [...ctx.hardExcludes].sort().join(',') : 'none'}`,
+    // v=13 addition (append-only): resolved source-boost map. Boost changes
+    // reorder results, so a row ranked under one policy must not be served
+    // to a lookup under another. Entries sorted by prefix so map insertion
+    // order is irrelevant; undefined falls back to 'default'.
+    `sb=${
+      ctx?.sourceBoostMap
+        ? Object.entries(ctx.sourceBoostMap)
+            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+            .map(([prefix, factor]) => `${prefix}:${factor}`)
+            .join(',')
+        : 'default'
+    }`,
   ];
   const h = createHash('sha256');
   h.update(parts.join('|'));

--- a/test/search-mode.test.ts
+++ b/test/search-mode.test.ts
@@ -410,7 +410,10 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // #2825: bumped 11→12 to fold the resolved hard-exclude prefix list
     // (hx=) — cached rows leaked GBRAIN_SEARCH_EXCLUDE'd slugs across
     // processes.
-    expect(KNOBS_HASH_VERSION).toBe(12);
+    // bumped 12→13 to fold the resolved source-boost map (sb=) — a
+    // ranking-policy change (GBRAIN_SOURCE_BOOST tune or new defaults)
+    // must not be served rows ranked under the previous policy.
+    expect(KNOBS_HASH_VERSION).toBe(13);
   });
 
   test('T1 (codex): floor_ratio set vs unset produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -575,8 +578,8 @@ describe('v0.40.4 — graph_signals knob', () => {
 });
 
 describe('v0.42.3.0 — autocut knobs', () => {
-  test('KNOBS_HASH_VERSION is 12 (11→12 hard-exclude fold, #2825)', () => {
-    expect(KNOBS_HASH_VERSION).toBe(12);
+  test('KNOBS_HASH_VERSION is 13 (12→13 source-boost map fold)', () => {
+    expect(KNOBS_HASH_VERSION).toBe(13);
   });
 
   test('bundle defaults: conservative off, balanced/tokenmax on @0.20', () => {

--- a/test/search/knobs-hash-reranker.test.ts
+++ b/test/search/knobs-hash-reranker.test.ts
@@ -27,7 +27,7 @@ import {
   MODE_BUNDLES,
   type ResolvedSearchKnobs,
 } from '../../src/core/search/mode.ts';
-import { resolveHardExcludes } from '../../src/core/search/source-boost.ts';
+import { resolveHardExcludes, resolveBoostMap } from '../../src/core/search/source-boost.ts';
 
 /** Build a baseline resolved knob set with all reranker fields filled. */
 function baseKnobs(): ResolvedSearchKnobs {
@@ -44,7 +44,7 @@ function baseKnobs(): ResolvedSearchKnobs {
 }
 
 describe('KNOBS_HASH_VERSION + version invariants', () => {
-  test('version is 12 (…; 9→10 relational recall; 10→11 asymmetric input_type #1400; 11→12 hard-excludes #2825)', () => {
+  test('version is 13 (…; 10→11 asymmetric input_type #1400; 11→12 hard-excludes #2825; 12→13 source-boost map)', () => {
     // v0.35.0.0: 1→2 to fold reranker fields. v0.35.6.0: 2→3 to fold
     // floor_ratio. v0.36 wave: piggybacks on v=3 with 7 cross-modal knobs
     // (D2) PLUS column + provider context (D8/CDX-2 cross-column isolation).
@@ -64,7 +64,9 @@ describe('KNOBS_HASH_VERSION + version invariants', () => {
     // pre-fix document-side query vectors must not be served.
     // #2825: 11→12 to fold the resolved hard-exclude prefix list (hx=) —
     // cached rows leaked GBRAIN_SEARCH_EXCLUDE'd slugs across processes.
-    expect(KNOBS_HASH_VERSION).toBe(12);
+    // 12→13 to fold the resolved source-boost map (sb=) — a ranking-policy
+    // change must not be served rows ranked under the previous policy.
+    expect(KNOBS_HASH_VERSION).toBe(13);
   });
 
   test('hash is 16 hex chars regardless of reranker config', () => {
@@ -241,6 +243,37 @@ describe('v=12 hard-exclude participation (#2825)', () => {
     // caller can never collide with a policy-carrying cache row.
     expect(knobsHash(k)).not.toBe(
       knobsHash(k, { hardExcludes: resolveHardExcludes(undefined, undefined, undefined) }),
+    );
+  });
+});
+
+describe('v=13 source-boost map participation', () => {
+  test('different boost maps → different hashes', () => {
+    const k = baseKnobs();
+    const defaults = knobsHash(k, { sourceBoostMap: resolveBoostMap(undefined) });
+    const tuned = knobsHash(k, { sourceBoostMap: resolveBoostMap('originals/:1.8,daily/:0.4') });
+    expect(defaults).not.toBe(tuned);
+  });
+
+  test('same map with different key insertion order → SAME hash (canonicalization)', () => {
+    const k = baseKnobs();
+    const a = knobsHash(k, { sourceBoostMap: { 'a/': 1.2, 'b/': 0.7 } });
+    const b = knobsHash(k, { sourceBoostMap: { 'b/': 0.7, 'a/': 1.2 } });
+    expect(a).toBe(b);
+  });
+
+  test('factor change on a single prefix changes the hash', () => {
+    const k = baseKnobs();
+    const a = knobsHash(k, { sourceBoostMap: { 'skills/': 1.2 } });
+    const b = knobsHash(k, { sourceBoostMap: { 'skills/': 1.3 } });
+    expect(a).not.toBe(b);
+  });
+
+  test('undefined sourceBoostMap is stable and distinct from an explicit map (legacy-caller fallback)', () => {
+    const k = baseKnobs();
+    expect(knobsHash(k)).toBe(knobsHash(k));
+    expect(knobsHash(k)).not.toBe(
+      knobsHash(k, { sourceBoostMap: resolveBoostMap(undefined) }),
     );
   });
 });


### PR DESCRIPTION
## Problem

The semantic query cache keys on mode knobs, embedding column/provider, schema pack, and (since #2825) the resolved hard-exclude list — but **not the source-boost map**. Boosts only apply at DB-query build time (cache miss), so after any ranking-policy change (a `GBRAIN_SOURCE_BOOST` tune, or an upgrade that ships new `DEFAULT_SOURCE_BOOSTS` — e.g. the #1777 `archive/` demote needed a manual version bump precisely because of this gap) lookups keep being served rows ranked under the **old** policy for up to `cache.ttl_seconds`.

In practice this makes boost tuning appear nondeterministic: identical queries return different rankings depending on which policy wrote the cache row. We hit this operating gbrain against a 240K-page multi-source company corpus where the default boost prefixes (`originals/`, `concepts/`, `writing/`) don't exist and `GBRAIN_SOURCE_BOOST` carries the entire ranking policy — every tune was invisibly masked by stale cache rows until the TTL expired.

## Fix (same pattern as #2825's `hardExcludes` fold)

- `KnobsHashContext` gains `sourceBoostMap?: Record<string, number>` — canonicalized (entries sorted by prefix) so map insertion order is irrelevant; `undefined` falls back to the literal `'default'` for legacy callers.
- `hybridSearchCached` threads `resolveBoostMap()` into the cache key alongside `resolveHardExcludes()`.
- `KNOBS_HASH_VERSION` **12 → 13** (one-time global cold-miss on upgrade; refills within `cache.ttl_seconds`, same as prior bumps).
- A future boost-policy default change no longer needs a manual version bump — the hash sees it directly.

## Tests

- Version-pin tests updated (12 → 13) in `test/search-mode.test.ts` + `test/search/knobs-hash-reranker.test.ts`.
- New v=13 participation suite: different maps → different hashes; same map in different insertion order → same hash; single-prefix factor change → different hash; undefined fallback stable and distinct from an explicit resolved map.
- `bun test test/search-mode.test.ts test/search/knobs-hash-reranker.test.ts test/query-cache-knobs-hash.serial.test.ts` → 105 pass / 0 fail. `tsc --noEmit` clean.