### PR TITLE
fix(orphans): exclude life/events/ chronicle volume from orphan_ratio (#2264)

### DIFF
--- a/src/core/orphan-policy.ts
+++ b/src/core/orphan-policy.ts
@@ -27,6 +27,10 @@ const DENY_PREFIXES = [
   '_templates/',
   'openclaw/config/',
   'extracts/',
+  // auto_chronicle event volume (life/events/<day>-<hash>) — machine leaf, no
+  // inbound links by design. Deny-prefix (not whole `life/` first-segment) so
+  // human-authored life/diary/ stays IN the orphan denominator. (#2264)
+  'life/events/',
 ];
 
 const FIRST_SEGMENT_EXCLUSIONS = new Set([

--- a/test/doctor-orphan-ratio.test.ts
+++ b/test/doctor-orphan-ratio.test.ts
@@ -177,6 +177,38 @@ describe('runDoctor — orphan_ratio check (local surface, D5)', () => {
     expect(check!.message).toContain('gbrain extract links --by-mention');
   });
 
+  test('#2264 — auto_chronicle life/events/ volume is excluded, so it does not trip orphan_ratio', async () => {
+    // Healthy knowledge graph: 100 fully-linked entity pages (no real decay).
+    for (let i = 0; i < 100; i++) {
+      await engine.putPage(`people/person-${i}`, {
+        type: 'person', title: `Person ${i}`, compiled_truth: 'b', timeline: '', frontmatter: {},
+      });
+    }
+    await engine.putPage('writing/index', {
+      type: 'note', title: 'Index', compiled_truth: 'index', timeline: '', frontmatter: {},
+    });
+    const links = [];
+    for (let i = 0; i < 100; i++) {
+      links.push({
+        from_slug: 'writing/index',
+        to_slug: `people/person-${i}`,
+        link_type: 'mentions', link_source: 'markdown', context: '',
+      });
+    }
+    await engine.addLinksBatch(links);
+    // Machine chronicle volume: 500 life/events/ pages, no inbound links by
+    // design. Without the exclusion these swamp the denominator (~83% orphan
+    // → FAIL); excluded, orphan_ratio reflects the healthy knowledge graph.
+    for (let i = 0; i < 500; i++) {
+      await engine.putPage(`life/events/2026-08-${i}-evt`, {
+        type: 'event', title: `Event ${i}`, compiled_truth: 'e', timeline: '', frontmatter: {},
+      });
+    }
+    const report = await runDoctorJson();
+    const check = findCheck(report, 'orphan_ratio');
+    expect(check!.status).toBe('ok');
+  });
+
   test('zero entity pages → vacuous status ok', async () => {
     const report = await runDoctorJson();
     const check = findCheck(report, 'orphan_ratio');

--- a/test/orphans-pure-fn.test.ts
+++ b/test/orphans-pure-fn.test.ts
@@ -177,6 +177,8 @@ describe('shouldExclude — orphan filter regression (preserve curation)', () =>
     expect(shouldExclude('dashboards/_index')).toBe(true);
     expect(shouldExclude('scripts/build')).toBe(true);
     expect(shouldExclude('output/foo')).toBe(true);
+    // #2264 — auto_chronicle event volume (life/events/…) is a machine leaf.
+    expect(shouldExclude('life/events/2026-08-01-abc123')).toBe(true);
   });
 
   test('first-segment exclusions fire', () => {
@@ -206,6 +208,12 @@ describe('shouldExclude — orphan filter regression (preserve curation)', () =>
     expect(shouldExclude('companies/acme')).toBe(false);
     expect(shouldExclude('writing/post-1')).toBe(false);
     expect(shouldExclude('agents/arya/qa-reports/launch-review')).toBe(false);
+    // #2264 — knowledge classes must STAY in the denominator so real graph decay still trips.
+    expect(shouldExclude('concepts/information-architecture')).toBe(false);
+    expect(shouldExclude('notes/some-note')).toBe(false);
+    expect(shouldExclude('projects/proj-x')).toBe(false);
+    // #2264 — only life/events/ is excluded; human-authored life/diary/ stays counted.
+    expect(shouldExclude('life/diary/2026-08-01-xyz')).toBe(false);
   });
 });
 


### PR DESCRIPTION
**Impact:** on brains with `auto_chronicle` on, machine-generated chronicle events swamp the `orphan_ratio` denominator — they have no inbound links by design — so the one metric that should flag real link decay sits pinned red and un-actionable (this issue's point, corroborated by the 7k/9.2k-brain reports in the thread).

**Root cause:** the shipped exclusion policy already covers `raw`/`atoms`/`skills`/`dreaming`/`daily` and `extracts/` — but **`life/events/<day>-<hash>`** (written per eligible event) is still counted. On a 1,657-page auto_chronicle brain, `life/events/` was ~72% of the orphan mass — enough to hold the ratio at FAIL on its own.

**Fix:** add `'life/events/'` to `DENY_PREFIXES`. Deliberately a **scoped prefix, not the whole `life/` first-segment**: `life/` also holds human-authored `life/diary/` (`gbrain capture --type diary`), which should stay **in** the denominator — only the machine `life/events/` volume is excluded. Same shipped hardcoded-class mechanism as the existing entries; not the user-config route from #2215 (closed `not_planned`). Knowledge classes (`concepts/`, `people/`, `notes/`, `projects/`) also stay in, so genuine graph decay still trips the check.

**Verified** (hermetic PGLite, no DB gate):
- `test/orphans-pure-fn.test.ts` (pure-fn): `shouldExclude('life/events/…')` now true — **fails before, passes after**; `life/diary/…`, `concepts/`, `notes/`, `projects/` pinned as **still-counted** (the denominator invariants).
- `test/doctor-orphan-ratio.test.ts` (metric-level): a healthy 100-entity graph + 500 orphaned `life/events/` pages reads **FAIL before → ok after** the exclusion — proves the fix at the doctor `orphan_ratio` surface itself, not just the pure fn. (`orphan_ratio` runs the same `shouldExclude` path — `getOrphansData`, local `doctor.ts` + the `doctor-remote` MCP op.)
- `bun run verify` 31/31 (typecheck + guards).

Blast radius: 1 shipped-code line (`'life/events/'`) + test assertions (pure-fn + one doctor fixture). No schema, API, or doctor-message change.

Fixes #2264.