### PR TITLE
docs(todos): drop the completed #2684-residual entry (landed via #2973)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,14 +2,6 @@
 
 ## community fix-wave follow-ups (filed v0.42.60.0)
 
-- [ ] **P1 — take-writes source scoping fails open when source resolution errors (#2684 residual).**
-  `resolveTakesSourceId` (src/commands/takes.ts) swallows resolution errors and returns
-  `undefined`, which falls back to the unscoped slug-only page lookup — so an invalid
-  `GBRAIN_SOURCE` (or a broken dotfile chain) silently restores the pre-#2698 cross-source
-  write behavior on multi-source brains. Decide fail-closed semantics: error out when a
-  source was explicitly requested but doesn't resolve; keep the unscoped fallback only for
-  brains with no source configuration at all. Add a regression test for the invalid-source
-  path. Found by cross-model adversarial review during the v0.42.60.0 release ship.
 - [ ] **P2 — cherry-pick #2112's uncovered doctor.ts hunk.** Fix-wave A (#2820) superseded
   most of #2112 but not its `checkSubagentCapability` fix (check explicit `models.subagent`
   before `models.tier.subagent`). Refile or cherry-pick; the rest of that PR is covered.


### PR DESCRIPTION
## What

Removes the completed `P1 — take-writes source scoping fails open (#2684 residual)` entry from TODOS.md.

## Why it is done

The entry asked for fail-closed semantics in `resolveTakesSourceId` (src/commands/takes.ts) plus a regression test for the invalid-source path. Both shipped in #2973 (merged 2026-07-20): the function now delegates straight to `resolveSourceId` with no catch-and-fallback, so an unresolvable explicit source (invalid `GBRAIN_SOURCE`, broken dotfile chain) throws instead of silently restoring the pre-#2698 unscoped cross-source write behavior.

Verified against current master before removal: `resolveTakesSourceId` is a two-line delegation with no error swallowing (src/commands/takes.ts:114-116).

## Scope

Docs-only, one hunk. The sibling `P2 — cherry-pick #2112` entry is intentionally left in place (being addressed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
