### PR TITLE
fix(doctor): checkSubagentCapability honors explicit models.subagent before tier resolution (#2112 residual)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,10 +2,6 @@
 
 ## community fix-wave follow-ups (filed v0.42.60.0)
 
-- [ ] **P2 — cherry-pick #2112's uncovered doctor.ts hunk.** Fix-wave A (#2820) superseded
-  most of #2112 but not its `checkSubagentCapability` fix (check explicit `models.subagent`
-  before `models.tier.subagent`). Refile or cherry-pick; the rest of that PR is covered.
-
 ## v0.42.59.0 follow-ups (five-fix rollup #2735–#2739)
 
 Filed as follow-ups from v0.42.59.0 (bootstrap probe for

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3046,7 +3046,11 @@ export async function checkSubagentCapability(engine: BrainEngine): Promise<Chec
             `${source} is "${resolved}" — provider does not support prompt caching. ` +
             `The subagent loop runs hot (cost scales linearly with conversation length). ` +
             `For lower cost on long loops, use an Anthropic model: ` +
-            `\`gbrain config set ${source} anthropic:claude-sonnet-4-6\`.`,
+            // Always recommend the scoped `models.subagent` override here (not
+            // `${source}`) — when source is `models.default`, `${source}`
+            // would recommend rewriting the global default model for every
+            // workload instead of just the subagent loop.
+            `\`gbrain config set models.subagent anthropic:claude-sonnet-4-6\`.`,
         };
       }
       return null;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3011,6 +3011,7 @@ async function checkEmbeddingEnvOverride(engine: BrainEngine): Promise<Check> {
 export async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
   try {
     const { classifyCapabilities } = await import('../core/ai/capabilities.ts');
+    const explicitSubagent = await engine.getConfig('models.subagent');
     const tierSubagent = await engine.getConfig('models.tier.subagent');
     const modelsDefault = await engine.getConfig('models.default');
 
@@ -3045,13 +3046,16 @@ export async function checkSubagentCapability(engine: BrainEngine): Promise<Chec
             `${source} is "${resolved}" — provider does not support prompt caching. ` +
             `The subagent loop runs hot (cost scales linearly with conversation length). ` +
             `For lower cost on long loops, use an Anthropic model: ` +
-            `\`gbrain config set models.tier.subagent anthropic:claude-sonnet-4-6\`.`,
+            `\`gbrain config set ${source} anthropic:claude-sonnet-4-6\`.`,
         };
       }
       return null;
     };
 
-    if (tierSubagent) {
+    if (explicitSubagent) {
+      const issue = explain(explicitSubagent, 'models.subagent');
+      if (issue) return issue;
+    } else if (tierSubagent) {
       const issue = explain(tierSubagent, 'models.tier.subagent');
       if (issue) return issue;
     } else if (modelsDefault) {
@@ -3089,9 +3093,11 @@ export async function checkSubagentCapability(engine: BrainEngine): Promise<Chec
     return {
       name: 'subagent_capability',
       status: 'ok',
-      message: tierSubagent
-        ? `Subagent tier resolves to "${tierSubagent}" with full tool-loop capability`
-        : `Subagent tier resolves to default (claude-sonnet-4-6) — full tool-loop capability`,
+      message: explicitSubagent
+        ? `Subagent model resolves to "${explicitSubagent}" with full tool-loop capability`
+        : tierSubagent
+          ? `Subagent tier resolves to "${tierSubagent}" with full tool-loop capability`
+          : `Subagent tier resolves to default (claude-sonnet-4-6) — full tool-loop capability`,
     };
   } catch (e) {
     return {

--- a/test/doctor-subagent-capability.test.ts
+++ b/test/doctor-subagent-capability.test.ts
@@ -1,0 +1,73 @@
+// v0.42.x — `subagent_capability` doctor check: explicit `models.subagent`
+// precedence over `models.tier.subagent` (residual hunk from #2112; fix-wave A
+// / #2820 superseded the rest of that PR but not this one).
+//
+// Pinned contracts:
+//   - explicit `models.subagent` set (bad model) + `models.tier.subagent` set
+//     (good model) → warn attributed to `models.subagent` (explicit wins,
+//     doesn't fall through to the tier value).
+//   - explicit `models.subagent` unset, `models.tier.subagent` set (bad model)
+//     → warn attributed to `models.tier.subagent` (unchanged fallback order).
+//   - explicit `models.subagent` set (good model) → ok, message references
+//     the explicit model.
+//
+// Hermetic: PGLite, per CLAUDE.md R1/R3/R4.
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { checkSubagentCapability } from '../src/commands/doctor.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+describe('subagent_capability: explicit models.subagent precedence (#2112 residual)', () => {
+  test('explicit models.subagent (bad) wins over models.tier.subagent (good) → warn attributed to models.subagent', async () => {
+    await engine.setConfig('models.subagent', 'bogus-provider:not-a-real-model');
+    await engine.setConfig('models.tier.subagent', 'anthropic:claude-sonnet-4-6');
+
+    const check = await checkSubagentCapability(engine);
+
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('models.subagent');
+    expect(check.message).toContain('bogus-provider:not-a-real-model');
+    // Must be attributed to the explicit key, not silently fall through to
+    // the (good) tier value's source label instead.
+    expect(check.message).not.toContain('models.tier.subagent');
+  });
+
+  test('models.subagent unset, models.tier.subagent (bad) → warn attributed to models.tier.subagent (unchanged fallback)', async () => {
+    await engine.setConfig('models.tier.subagent', 'bogus-provider:not-a-real-model');
+
+    const check = await checkSubagentCapability(engine);
+
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('models.tier.subagent');
+    expect(check.message).toContain('bogus-provider:not-a-real-model');
+  });
+
+  test('explicit models.subagent (good) → ok, message references the explicit model', async () => {
+    await engine.setConfig('models.subagent', 'anthropic:claude-sonnet-4-6');
+    // Tier left unset entirely, and modelsDefault unset, so if precedence were
+    // wrong (fell through past explicit) the ok message would say "default"
+    // instead of naming the explicit model.
+
+    const check = await checkSubagentCapability(engine);
+
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('Subagent model resolves to "anthropic:claude-sonnet-4-6"');
+  });
+});

--- a/test/doctor-subagent-capability.test.ts
+++ b/test/doctor-subagent-capability.test.ts
@@ -70,4 +70,19 @@ describe('subagent_capability: explicit models.subagent precedence (#2112 residu
     expect(check.status).toBe('ok');
     expect(check.message).toContain('Subagent model resolves to "anthropic:claude-sonnet-4-6"');
   });
+
+  test('degraded:no_caching via models.default → fix hint recommends scoped models.subagent, not models.default', async () => {
+    // openai:gpt-5.2 supports tool calling but not prompt caching → degraded:no_caching.
+    // Neither models.subagent nor models.tier.subagent set, so this falls through to
+    // models.default. The fix hint must not tell the operator to overwrite the global
+    // default model — it should recommend the scoped models.subagent override instead.
+    await engine.setConfig('models.default', 'openai:gpt-5.2');
+
+    const check = await checkSubagentCapability(engine);
+
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('models.default is "openai:gpt-5.2"');
+    expect(check.message).toContain('gbrain config set models.subagent anthropic:claude-sonnet-4-6');
+    expect(check.message).not.toContain('gbrain config set models.default');
+  });
 });


### PR DESCRIPTION
## Summary

Fix-wave A (#2820) superseded most of #2112 but missed its `doctor.ts` hunk: `checkSubagentCapability` never consulted the explicit `models.subagent` override — it only read `models.tier.subagent` and `models.default`. Implemented per the maintainer's TODOS.md entry ("P2 — cherry-pick #2112's uncovered doctor.ts hunk").

- Resolution order is now `models.subagent` (explicit) > `models.tier.subagent` > `models.default`, matching the runtime resolver's own precedence (which already honors `models.subagent` above the tier value) — the doctor check was silently out of sync with what actually runs.
- The `ok`-path message now names the explicit model when it's the source of resolution.
- The `degraded:no_caching` fix hint is hardcoded to recommend the scoped `models.subagent` override (not the triggering `${source}` label) — otherwise a warning that originated from `models.default` would tell the operator to rewrite the global default model for every workload just to fix a subagent-only cost concern. Caught in codex review round 1 (P2), fixed + regression-tested in round 2.
- Removes the now-completed P2 entry from `TODOS.md`.

## Test plan

New `test/doctor-subagent-capability.test.ts` (4 cases, PGLite-hermetic):
- explicit `models.subagent` (bad model) wins over `models.tier.subagent` (good model) → warn attributed to `models.subagent`.
- `models.subagent` unset, `models.tier.subagent` (bad) → warn attributed to `models.tier.subagent` (unchanged fallback order).
- explicit `models.subagent` (good) → ok, message names the explicit model.
- `degraded:no_caching` reached via `models.default` → fix hint recommends `models.subagent`, never `models.default`.

Verified red-before-green: stashed the `src/commands/doctor.ts` change (keeping the new test), confirmed 2 of 4 cases fail against pre-fix code, then restored the fix and confirmed all 4 pass.

- [x] `bun test test/doctor-subagent-capability.test.ts` — 4 pass
- [x] `bun test test/doctor.test.ts test/doctor-embedding-env-override.test.ts test/doctor-subagent-health.test.ts` — no regressions (100 pass across the 4 files combined)
- [x] `bun run typecheck` — clean
- [x] Two rounds of `codex exec` (gpt-5.6-sol, high reasoning) review: round 1 flagged a P2 (the `${source}` caching-hint issue above), fixed and re-tested; round 2 — no remaining findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
