### PR TITLE
fix(ci): delta-assert reporter leak test + raise shard timeout (kills the two dominant flake classes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,11 @@ jobs:
     needs: cache-check
     if: needs.cache-check.outputs.hit != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 22, not 15: under parallel PR load the PGLite WASM cold-starts stretch a
+    # shard past 15 min while every test is still passing — the timeout then
+    # cancels the job and the test-status gate reads it as a failure. 13 runs
+    # died this way on 2026-07-21/22 alone.
+    timeout-minutes: 22
     strategy:
       fail-fast: false
       matrix:

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -218,15 +218,21 @@ describe('progress reporter', () => {
   test('only one process-level signal handler installed across many reporters', () => {
     // Baseline: one handler already installed by prior tests in this file.
     const installedBefore = __signalHandlerInstalledForTest();
+    // liveReporters is module-global, so a reporter left running by ANOTHER
+    // test file in the same shard shows up here. Assert the DELTA (these 50
+    // lifecycles leak nothing) instead of an absolute zero — the absolute
+    // form flaked whenever shard composition changed and an unrelated file
+    // held a live reporter across this test.
+    const liveBefore = __liveReporterCountForTest();
     const { stream } = sink(false);
     for (let i = 0; i < 50; i++) {
       const p = createProgress({ mode: 'json', stream, minIntervalMs: 0, minItems: 1 });
       p.start(`phase_${i}`, 1);
       p.finish();
     }
-    // After 50 reporter lifecycles, still exactly one handler and zero leaked live entries.
+    // After 50 reporter lifecycles, still exactly one handler and no new live entries.
     expect(__signalHandlerInstalledForTest()).toBe(installedBefore || true);
-    expect(__liveReporterCountForTest()).toBe(0);
+    expect(__liveReporterCountForTest()).toBe(liveBefore);
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {


### PR DESCRIPTION
## Summary
Two one-line root fixes for the failure classes that dominated CI in the last 48h:

1. **`test/progress.test.ts` signal-handler test** asserted `__liveReporterCountForTest() === 0` against a **module-global** set — an unrelated test file holding a live reporter anywhere in the shard flakes it. It red-flagged ~12 PR runs and a master push, varying purely with shard composition. Now asserts the delta (these 50 lifecycles leak nothing), which is the test's actual claim.
2. **Shard job timeout 15 → 22 min**: 13 runs were cancelled mid-shard with every test passing (PGLite WASM cold-starts stretch under parallel PR load); the test-status gate reads the cancellation as failure.

## Test plan
- [x] `bun test test/progress.test.ts` green locally
- [x] Workflow edit is a single value change; actionlint-clean syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)