### PR TITLE
fix(sync): keep the expected discover_git_root probe failure off stderr

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -918,12 +918,28 @@ export function buildAutoEmbedArgs(slugs: string[], sourceId?: string): string[]
  *
  * 100 MiB is generous but still bounded — a 100K-file diff with long
  * paths tops out around 10–20 MiB in practice.
+ *
+ * `silenceStderr`: Node's `execFileSync` writes the child's stderr straight
+ * through to the parent's real stderr by default (in addition to attaching
+ * it to the thrown error's `.stderr`) *unless* an explicit `stdio` array is
+ * given. Callers that treat a failure as an expected, self-handled outcome
+ * (rather than a crash to surface) pass `silenceStderr: true` so git's raw
+ * `fatal: ...` line never reaches the process's own stderr — only the
+ * caller's own (usually friendlier) handling of the caught error does.
+ * Default `false` preserves today's passthrough for every other call site.
  */
-function git(repoPath: string, args: string[], configs: string[] = [], timeoutMs = 30000): string {
+function git(
+  repoPath: string,
+  args: string[],
+  configs: string[] = [],
+  timeoutMs = 30000,
+  { silenceStderr = false }: { silenceStderr?: boolean } = {},
+): string {
   return execFileSync('git', buildGitInvocation(repoPath, args, configs), {
     encoding: 'utf-8',
     timeout: timeoutMs,
     maxBuffer: 100 * 1024 * 1024,
+    ...(silenceStderr ? { stdio: ['ignore', 'pipe', 'pipe'] as const } : {}),
   }).trim();
 }
 
@@ -932,10 +948,19 @@ function git(repoPath: string, args: string[], configs: string[] = [], timeoutMs
  * `git -C <path> rev-parse --show-toplevel`. Handles worktrees and submodules
  * natively (git itself resolves them). Throws a user-friendly error when no
  * git repo is found.
+ *
+ * The probe's failure is expected and routine (a non-git-yet brain dir, a
+ * scratch dir, a caller checking "is this a repo?") — `sync.ts` self-heals
+ * it (git-init) or surfaces the message below, never the raw git stderr.
+ * `silenceStderr: true` keeps git's own `fatal: not a git repository ...`
+ * off the process's real stderr so operator log-scanning for `fatal:` as a
+ * crash signature doesn't false-alarm on every routine probe miss (#2964
+ * auto-recovery made the *outcome* self-healing; this keeps the *log* quiet
+ * about the expected miss that triggered it).
  */
 export function discoverGitRoot(inputPath: string): string {
   try {
-    return git(inputPath, ['rev-parse', '--show-toplevel']);
+    return git(inputPath, ['rev-parse', '--show-toplevel'], [], 30000, { silenceStderr: true });
   } catch {
     throw new Error(
       `Not inside a git repository: ${inputPath}. GBrain sync requires a git-initialized repo (or a subdirectory of one).`,

--- a/test/sync-discover-git-root-stderr.test.ts
+++ b/test/sync-discover-git-root-stderr.test.ts
@@ -1,0 +1,84 @@
+/**
+ * discoverGitRoot's `rev-parse --show-toplevel` probe fails routinely (a
+ * scratch dir, a not-yet-git-initialized brain dir, `#2964` auto-recovery's
+ * own probe). Node's `execFileSync` writes the child's stderr straight
+ * through to the parent's real stderr by default, so every one of these
+ * *expected* misses used to dump git's raw `fatal: not a git repository
+ * (or any of the parent directories): .git` line onto gbrain's own stderr —
+ * indistinguishable, to an operator grepping logs for `fatal:` as a crash
+ * signature, from an actual crash. `discoverGitRoot` already handles the
+ * failure (throws a friendlier `Error`, or `sync.ts`'s `#2964` auto-recovery
+ * catches it and git-inits); only the process-level stderr leak was the bug.
+ *
+ * These tests spawn a real `bun` subprocess (rather than monkeypatching
+ * `process.stderr.write` in-process) because the leak happens at the OS file
+ * descriptor level — `execFileSync`'s default `stdio: 'inherit'`-for-stderr
+ * behavior writes directly to fd 2 of whichever process calls it, bypassing
+ * `process.stderr.write()` entirely. A subprocess is the only way to observe
+ * (or fail to observe) that write from the test.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+
+const SYNC_MODULE = join(import.meta.dir, '..', 'src', 'commands', 'sync.ts');
+
+function runDiscoverGitRootProbe(targetDir: string) {
+  return spawnSync(
+    'bun',
+    [
+      '-e',
+      `
+      import { discoverGitRoot } from ${JSON.stringify(SYNC_MODULE)};
+      try {
+        // Success path prints to STDOUT only — stderr must stay untouched
+        // by both the probe itself and this harness so the tests can make
+        // a clean "nothing on stderr" assertion.
+        console.log('OK:' + discoverGitRoot(${JSON.stringify(targetDir)}));
+      } catch (e) {
+        console.error('CAUGHT:' + e.message);
+      }
+      `,
+    ],
+    { encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } },
+  );
+}
+
+describe('discoverGitRoot probe stderr hygiene', () => {
+  test('an expected probe failure (non-git dir) never leaks git\'s raw "fatal:" line to stderr', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-nogit-'));
+    try {
+      const res = runDiscoverGitRootProbe(dir);
+      expect(res.status).toBe(0);
+      // The caller's own friendly error still surfaces...
+      expect(res.stderr).toContain('CAUGHT:Not inside a git repository');
+      // ...but git's own raw stderr line must not reach the process stderr.
+      expect(res.stderr).not.toMatch(/fatal:/i);
+      expect(res.stderr).not.toContain('not a git repository (or any of the parent directories)');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a successful probe (real git repo) still returns the toplevel and prints nothing to stderr', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-git-'));
+    try {
+      spawnSync('git', ['init', '--quiet'], { cwd: dir });
+      const res = runDiscoverGitRootProbe(dir);
+      expect(res.status).toBe(0);
+      // The resolved toplevel path lands on stdout, proving the probe
+      // actually succeeded (not just "didn't throw"). Compare by basename
+      // only — macOS resolves `/tmp`/`/var` symlinks (e.g. to
+      // `/private/tmp/...`), so the raw `dir` string may not appear verbatim
+      // in git's `--show-toplevel` output even on a clean success.
+      expect(res.stdout).toContain('OK:');
+      expect(res.stdout).toContain(basename(dir));
+      expect(res.stderr).toBe('');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

`discoverGitRoot()` probes `git rev-parse --show-toplevel` to locate the repo
root. A probe miss is expected/routine — a brain dir that hasn't been
`git init`-ed yet, a scratch dir, etc. — and #2964's auto-recovery already
self-heals it (git-init in place) or the caller surfaces a friendlier
`Error`.

Node's `execFileSync` writes the child process's stderr straight through to
the parent's **real** stderr by default (in addition to attaching it to the
thrown error's `.stderr`) *unless* an explicit `stdio` array is given. So
every routine probe miss was dumping git's raw

```
fatal: not a git repository (or any of the parent directories): .git
```

onto gbrain's own operator logs — indistinguishable, to anyone log-scanning
for `fatal:` as a crash signature, from an actual crash.

### Dogfooding evidence (production brain, 2026-07-22 dream cycle)

```
[gbrain phase] sync.discover_git_root
fatal: not a git repository (or any of the parent directories): .git
[gbrain] auto-recovery: git-initializing brain dir /Users/masa-ws1/.gbrain/brain-pages (no git repo found).
```

The self-heal (#2964) worked correctly — the sync recovered fine — but the
stray `fatal:` line between the phase marker and the auto-recovery message
tripped a nightly log-monitor's crash-signature grep.

## Fix

Added an opt-in `silenceStderr` param to the shared `git()` helper. When set,
it passes an explicit `stdio: ['ignore', 'pipe', 'pipe']` to `execFileSync`,
which disables the implicit stderr-passthrough-to-parent behavior (stdout is
still captured and returned as before; the failure's message is still
attached to the thrown error for anyone who wants it).

`discoverGitRoot()`'s internal probe call is the only call site that passes
`silenceStderr: true`. Every other `git()` call in `sync.ts` is untouched —
default `silenceStderr: false` preserves today's passthrough behavior, so
genuinely unexpected git failures elsewhere in the sync pipeline still surface
their raw stderr as before.

## Testing

Added `test/sync-discover-git-root-stderr.test.ts` — spawns a real `bun`
subprocess (the leak happens at the OS file-descriptor level, so it can only
be observed from outside the process) and asserts:

- A non-git dir: the friendly caught error still surfaces, but git's raw
  `fatal:` line does not reach stderr.
- A real git repo: the probe succeeds (stdout carries the resolved path) and
  stderr is empty.

Revert-check: stashed the `src/commands/sync.ts` change and confirmed the new
test fails exactly on the leaked `fatal:` line (red), then restored the fix
(green).

```
bun test test/sync.test.ts test/sync-git-autoinit.test.ts \
  test/sync-monorepo.test.ts test/sync-discover-git-root-stderr.test.ts
# 97 pass, 0 fail

bun run typecheck
# clean
```

Related to #2964, which introduced the auto-recovery this probe feeds.

## Review

Two rounds of Codex review (`gpt-5.6-sol`, high reasoning effort) on the
diff + new test file, scoped to just those two files:

- Round 1: no P1s. One P2 — the success-path test's harness script wrote
  `'UNEXPECTED_SUCCESS'` to stderr on the success branch, undermining its own
  "prints nothing to stderr" assertion. Fixed by moving the success signal to
  stdout (`console.log('OK:' + result)`) and asserting `stderr === ''`.
- Round 2: confirmed the fix, no remaining P1/P2/P3s. Codex also
  independently reproduced the underlying Node `stdio` behavior difference
  in a scratch script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
