### PR TITLE
fix(pricing): add the zeroentropyai:zerank-2 reranker entry the budget tracker needs (#3223)

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -166,9 +166,13 @@ const FREE_LOCAL_EMBED_PROVIDERS: ReadonlySet<string> = new Set([
  *     local-inference providers (FREE_LOCAL_EMBED_PROVIDERS) price at $0 so
  *     `--max-cost` callers don't hard-fail.
  *   - Rerank: try ANTHROPIC_PRICING (legacy path for any Claude-priced
- *     rerank); else if the provider half is in FREE_LOCAL_RERANK_PROVIDERS,
- *     return zero pricing so `--max-cost` callers don't TX2 hard-fail on
- *     local inference recipes (electricity, not tokens); else unknown.
+ *     rerank); else try lookupEmbeddingPrice — paid rerank providers (e.g.
+ *     ZeroEntropy's zerank-2) share the same provider:model-keyed,
+ *     $/1M-token table as their embedding siblings, so it's reused here
+ *     rather than duplicated into a third table; else if the provider half
+ *     is in FREE_LOCAL_RERANK_PROVIDERS, return zero pricing so `--max-cost`
+ *     callers don't TX2 hard-fail on local inference recipes (electricity,
+ *     not tokens); else unknown.
  */
 function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   if (kind === 'embed') {
@@ -193,6 +197,14 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   if (modelTail) {
     const tailHit = ANTHROPIC_PRICING[modelTail];
     if (tailHit) return tailHit;
+  }
+  // Paid rerank providers (e.g. ZeroEntropy's zerank-2) aren't Claude-priced,
+  // so they miss the ANTHROPIC_PRICING checks above. Reuse the embedding
+  // pricing table (issue #3223) — same provider:model key shape, same
+  // $/1M-token unit — instead of hand-copying a third pricing surface.
+  if (kind === 'rerank') {
+    const hit = lookupEmbeddingPrice(modelId);
+    if (hit.kind === 'known') return { input: hit.pricePerMTok, output: 0 };
   }
   // v0.40.6.1: zero-price local-inference rerank providers so the budget
   // tracker's TX2 hard-fail doesn't trip on `llama-server-reranker:<model>`

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -37,6 +37,10 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   'voyage:voyage-4-large':         { pricePerMTok: 0.18 },
   // ZeroEntropy (https://zeroentropy.dev/pricing — zembed-1)
   'zeroentropyai:zembed-1':        { pricePerMTok: 0.05 },
+  // ZeroEntropy reranker (docs/ai-providers/zeroentropy.md — $0.025/1M tokens).
+  // Reused here (not a separate rerank table) because budget-tracker.ts's
+  // rerank-kind lookup falls back to this same table for paid providers.
+  'zeroentropyai:zerank-2':        { pricePerMTok: 0.025 },
   // Mistral (https://mistral.ai/pricing/api/, verified 2026-07-19)
   'mistral:mistral-embed':         { pricePerMTok: 0.10 },
   'mistral:mistral-embed-2312':    { pricePerMTok: 0.10 },

--- a/test/core/budget/budget-tracker.test.ts
+++ b/test/core/budget/budget-tracker.test.ts
@@ -248,6 +248,37 @@ describe('BudgetTracker.reserve', () => {
     expect((caught as BudgetExhausted).reason).toBe('no_pricing');
   });
 
+  test('#3223: rerank kind for zeroentropyai:zerank-2 prices from the embedding table (no TX2 throw under --max-cost)', () => {
+    // Pre-fix: `search_mode: tokenmax` defaults the zerank-2 reranker ON
+    // (docs/ai-providers/zeroentropy.md), but lookupPricing's rerank branch
+    // never consulted the embedding pricing table (where ZeroEntropy's
+    // provider:model-keyed prices live) — so any --max-cost run that
+    // reranked TX2 hard-failed with "no pricing entry" even after adding
+    // the entry to EMBEDDING_PRICING alone. Fixed by wiring the rerank
+    // branch to fall back to lookupEmbeddingPrice.
+    const t = new BudgetTracker({ maxCostUsd: 0.0001, label: 'test', auditPath });
+    expect(() =>
+      t.reserve({
+        modelId: 'zeroentropyai:zerank-2',
+        estimatedInputTokens: 3000,
+        maxOutputTokens: 0,
+        kind: 'rerank',
+      }),
+    ).not.toThrow();
+    expect(t.totalSpent).toBe(0); // reserve() only projects; record() below banks it.
+    expect(() =>
+      t.record({
+        modelId: 'zeroentropyai:zerank-2',
+        inputTokens: 3000,
+        outputTokens: 0,
+        kind: 'rerank',
+      }),
+    ).not.toThrow();
+    // $0.025/1M * 3000 tokens = $0.000075, under the $0.0001 cap — proves the
+    // real ZeroEntropy price was used, not a $0 fallback.
+    expect(t.totalSpent).toBeCloseTo(0.000075, 9);
+  });
+
   test('v0.40.x: local embed providers price at $0 (no TX2 throw under --max-cost)', () => {
     // FREE_LOCAL_EMBED_PROVIDERS — ollama / llama-server run on local inference
     // (electricity, not tokens). Pre-fix a --max-cost embed/reindex job


### PR DESCRIPTION
## Summary

`search_mode: tokenmax` defaults the `zerank-2` reranker ON (per `docs/ai-providers/zeroentropy.md`), but it had no pricing entry. Any `--max-cost`-capped operation that reranks TX2 hard-fails in `BudgetTracker.reserve()` with `no pricing entry for model "zeroentropyai:zerank-2"`.

Thanks to @WilliamCourterWelch for the clear diagnosis — the report correctly traced this to the same shape of bug fixed for `llama-server-reranker` in v0.40.6.1.

## Why this is more than the one-line fix the issue proposed

The issue suggested adding `'zeroentropyai:zerank-2': { pricePerMTok: 0.025 }` to `EMBEDDING_PRICING` in `src/core/embedding-pricing.ts`. I reproduced the hard-fail first, then added *only* that entry and re-ran the repro — it still threw. Tracing `lookupPricing()` in `src/core/budget/budget-tracker.ts` shows the `rerank` branch never consults the embedding pricing table at all; it only checks `ANTHROPIC_PRICING` (bare key, then provider-tail key) and then the `FREE_LOCAL_RERANK_PROVIDERS` zero-price set. So a pricing-table-only fix would sit unused for any paid rerank provider.

## Fix

- `src/core/embedding-pricing.ts`: add the `zeroentropyai:zerank-2` entry at `$0.025/1M` tokens (cited from `docs/ai-providers/zeroentropy.md`), reusing the existing table rather than introducing a third pricing surface.
- `src/core/budget/budget-tracker.ts`: wire the `rerank` branch of `lookupPricing()` to fall back to `lookupEmbeddingPrice()` for providers not in `ANTHROPIC_PRICING`, mirroring the existing `FREE_LOCAL_RERANK_PROVIDERS` pattern in the same function. Paid rerank providers share the same `provider:model` key shape and `$`/1M-token unit as embedding providers, so this reuses the table instead of duplicating prices.
- `test/core/budget/budget-tracker.test.ts`: new regression test exercising `reserve()` (no TX2 throw under a tight cap) followed by `record()` (asserts the actual $0.025/1M price is banked, not a $0 fallback). Verified this test fails against the pre-fix code via a stash-based revert-check.

## Scope note (left as an open question, not addressed here)

The issue also asks: "consider whether an unknown *reranker* model should hard-fail the budget tracker at all, or warn and bill zero." That's a semantics change to the TX2 contract for `--max-cost`, not a pricing-table gap, so I left it out of this fix to keep the change minimal and reviewable. Happy to follow up separately if maintainers want to pursue it.

## Testing

- `bun test test/core/budget/budget-tracker.test.ts test/embedding-pricing.test.ts` — 38 pass, 0 fail.
- `bun run typecheck` — clean.
- Revert-check: stashed the two `src/` changes, re-ran the new test — it fails red against pre-fix code, confirming it's a real regression test and not a tautology.

## Dogfooding note

My own production brain runs the ZeroEntropy hosted reranker under `tokenmax` with `--max-cost`-bounded ideation ops, so this bug directly affects my daily usage — that's what surfaced the gap between the issue's suggested fix and what actually needed to change.

Addresses the report in #3223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
