### PR TITLE
fix(cycle+migrations): extract_facts legacy-row guard counts only active rows + v0_32_2 drift-repair lane (#2646)

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -261,6 +261,56 @@ function printDryRun(plan: Plan, installed: string): void {
   }
 }
 
+/**
+ * #2646: verdict for a finished v0.32.2 drift-repair run. Pure so the
+ * exit-code semantics are unit-testable (codex P2/P3).
+ *
+ * - status failed/partial, or an unverifiable remainder (null after a
+ *   run that just held the DB) → treated as failure (exit 1); the
+ *   ledger stays untouched and progress is preserved for a re-run.
+ * - status complete + remaining 0 → success.
+ * - status complete + remaining > 0 → success WITH a loud warning, not
+ *   an error: rows can legitimately stay behind (skipped_no_local_path
+ *   on thin-client sources). Failing here would make every subsequent
+ *   `apply-migrations --yes` — including postinstall — exit 1 forever
+ *   for those users.
+ */
+function evaluateV0_32_2RepairOutcome(
+  status: 'complete' | 'partial' | 'failed',
+  remaining: number | null,
+): { failed: boolean; message: string } {
+  if (status === 'failed') {
+    return { failed: true, message: 'v0.32.2 drift repair reported status=failed. Fix the reported phase and re-run.' };
+  }
+  if (status === 'partial') {
+    return {
+      failed: true,
+      message: 'v0.32.2 drift repair finished as PARTIAL. Progress is preserved; ' +
+        'resolve the reported phase detail and re-run `gbrain apply-migrations --yes`.',
+    };
+  }
+  if (remaining === null) {
+    return {
+      failed: true,
+      message: 'v0.32.2 drift repair ran, but the remaining backlog could not be verified ' +
+        '(brain unreachable). Re-run `gbrain apply-migrations --yes` to confirm.',
+    };
+  }
+  if (remaining > 0) {
+    return {
+      failed: false,
+      message: `Drift repair finished with ${remaining} active legacy row(s) still pending ` +
+        `(see the fence_facts detail — e.g. skipped_no_local_path). Progress is ` +
+        `preserved; re-run \`gbrain apply-migrations --yes\` after resolving.`,
+    };
+  }
+  return {
+    failed: false,
+    message: 'Drift repair complete: no active legacy rows remain. ' +
+      'The extract_facts guard will release on the next cycle.',
+  };
+}
+
 function orchestratorOptsFrom(cli: ApplyMigrationsArgs): OrchestratorOpts {
   return {
     yes: cli.yes || cli.nonInteractive,
@@ -559,23 +609,13 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     );
     try {
       const result = await v0_32_2.orchestrator(orchestratorOptsFrom(cli));
-      if (result.status === 'failed') {
-        console.error('v0.32.2 drift repair reported status=failed. Fix the reported phase and re-run.');
+      const remaining = result.status === 'complete' ? await detectV0_32_2Drift() : null;
+      const verdict = evaluateV0_32_2RepairOutcome(result.status, remaining);
+      if (verdict.failed) {
+        console.error(verdict.message);
         failed = true;
       } else {
-        const remaining = await detectV0_32_2Drift();
-        if (remaining !== null && remaining > 0) {
-          console.log(
-            `Drift repair finished with ${remaining} active legacy row(s) still pending ` +
-            `(see the fence_facts detail — e.g. skipped_no_local_path). Progress is ` +
-            `preserved; re-run \`gbrain apply-migrations --yes\` after resolving.`,
-          );
-        } else {
-          console.log(
-            'Drift repair complete: no active legacy rows remain. ' +
-            'The extract_facts guard will release on the next cycle.',
-          );
-        }
+        console.log(verdict.message);
       }
     } catch (e) {
       console.error(`v0.32.2 drift repair threw: ${e instanceof Error ? e.message : String(e)}`);
@@ -592,4 +632,5 @@ export const __testing = {
   buildPlan,
   indexCompleted,
   statusForVersion,
+  evaluateV0_32_2RepairOutcome,
 };

--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -16,6 +16,7 @@ import { VERSION } from '../version.ts';
 import { loadConfig } from '../core/config.ts';
 import { loadCompletedMigrations, appendCompletedMigration, type CompletedMigrationEntry } from '../core/preferences.ts';
 import { migrations, compareVersions, type Migration, type OrchestratorOpts } from './migrations/index.ts';
+import { v0_32_2, detectV0_32_2Drift } from './migrations/v0_32_2.ts';
 
 /** Bug 3 — max consecutive partials before we wedge a migration. */
 const MAX_CONSECUTIVE_PARTIALS = 3;
@@ -397,6 +398,24 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
   const idx = indexCompleted(completed);
   const plan = buildPlan(idx, installed, cli.specificMigration);
 
+  // ── Targeted drift-repair lane (#2646) ─────────────────────────
+  // "v0.32.2 complete" is a statement about the ledger, not a permanent
+  // DB post-condition: a lingering pre-fence writer can insert
+  // v0.31-shape rows AFTER the backfill completed. Those rows trip the
+  // extract_facts legacy-row guard forever, and the completed marker
+  // means a normal run no-ops. When the migration is complete AND
+  // active legacy rows exist, re-run the v0_32_2 orchestrator as a
+  // REPAIR. The ledger is never touched: completion and drift are
+  // different concepts. Detection is best-effort (null = unreachable
+  // DB / no override) and scoped to runs that would consider v0.32.2
+  // at all (no --migration filter pointing elsewhere).
+  let v0_32_2RepairDrift = 0;
+  const considers0322 = !cli.specificMigration || cli.specificMigration === '0.32.2';
+  if (considers0322 && statusForVersion('0.32.2', idx) === 'complete') {
+    const drift = await detectV0_32_2Drift();
+    if (drift !== null && drift > 0) v0_32_2RepairDrift = drift;
+  }
+
   // Bug 3 — surface wedged migrations as a loud, actionable error.
   if (plan.wedged.length > 0) {
     for (const m of plan.wedged) {
@@ -415,13 +434,35 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     process.exit(2);
   }
 
-  if (cli.list) { printList(plan, installed); process.exit(0); }
-  if (cli.dryRun) { printDryRun(plan, installed); process.exit(0); }
+  if (cli.list) {
+    printList(plan, installed);
+    if (v0_32_2RepairDrift > 0) {
+      console.log(
+        `\nDrift repair needed: v0.32.2 is applied, but ${v0_32_2RepairDrift} active legacy ` +
+        `fact row(s) postdate the backfill (a pre-fence writer inserted them after the ` +
+        `migration ran). Run \`gbrain apply-migrations --yes\` to repair.`,
+      );
+    }
+    process.exit(0);
+  }
+  if (cli.dryRun) {
+    printDryRun(plan, installed);
+    if (v0_32_2RepairDrift > 0) {
+      console.log(
+        `Would REPAIR: v0.32.2 backfill drift — ${v0_32_2RepairDrift} active legacy fact ` +
+        `row(s) postdate the completed migration (ledger marker stays untouched).`,
+      );
+    }
+    process.exit(0);
+  }
 
   const toRun: Migration[] = [...plan.partial, ...plan.pending];
-  if (toRun.length === 0) {
+  if (toRun.length === 0 && v0_32_2RepairDrift === 0) {
     console.log('All migrations up to date.');
     process.exit(0);
+  }
+  if (toRun.length === 0) {
+    console.log('All migrations applied; running v0.32.2 drift repair only.');
   }
 
   // Run each orchestrator in registry order. An orchestrator failure aborts
@@ -499,6 +540,46 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
       } catch { /* swallow ledger-write failure on throw path */ }
       failed = true;
       break;
+    }
+  }
+
+  // ── Run the v0.32.2 drift repair (#2646) ───────────────────────
+  // After the normal chain so a pending/partial v0.32.2 run (which
+  // does the same work and DOES own the ledger) always wins. The
+  // repair reuses the orchestrator verbatim — phase B is idempotent
+  // and active-only — but never writes the ledger: the migration
+  // stays 'complete' throughout; only the DB post-condition is being
+  // re-established. A repair that leaves rows behind (dirty tree,
+  // missing local_path, interruption) just reports the remainder —
+  // the next run picks it up from the drift check.
+  if (!failed && v0_32_2RepairDrift > 0) {
+    console.log(
+      `\n=== Repairing v0.32.2 backfill drift: ${v0_32_2RepairDrift} active legacy ` +
+      `fact row(s) postdate the completed migration ===`,
+    );
+    try {
+      const result = await v0_32_2.orchestrator(orchestratorOptsFrom(cli));
+      if (result.status === 'failed') {
+        console.error('v0.32.2 drift repair reported status=failed. Fix the reported phase and re-run.');
+        failed = true;
+      } else {
+        const remaining = await detectV0_32_2Drift();
+        if (remaining !== null && remaining > 0) {
+          console.log(
+            `Drift repair finished with ${remaining} active legacy row(s) still pending ` +
+            `(see the fence_facts detail — e.g. skipped_no_local_path). Progress is ` +
+            `preserved; re-run \`gbrain apply-migrations --yes\` after resolving.`,
+          );
+        } else {
+          console.log(
+            'Drift repair complete: no active legacy rows remain. ' +
+            'The extract_facts guard will release on the next cycle.',
+          );
+        }
+      }
+    } catch (e) {
+      console.error(`v0.32.2 drift repair threw: ${e instanceof Error ? e.message : String(e)}`);
+      failed = true;
     }
   }
 

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -660,15 +660,20 @@ async function orchestrator(opts: OrchestratorOpts): Promise<OrchestratorResult>
   return finalizeResult(phases, overallStatus, engine);
 }
 
-function finalizeResult(
+async function finalizeResult(
   phases: OrchestratorPhaseResult[],
   status: 'complete' | 'partial' | 'failed',
   engine: BrainEngine | null,
-): OrchestratorResult {
+): Promise<OrchestratorResult> {
   // Best-effort disconnect of the engine we created. testEngineOverride
-  // is owned by the test, never disconnected here.
+  // is owned by the test, never disconnected here. AWAITED (#2646 codex
+  // round-2 P2): the apply-migrations repair lane opens another engine
+  // right after the orchestrator returns (the post-repair recount); a
+  // fire-and-forget disconnect races the PGLite single-writer lock
+  // release and can turn a successful repair into a false
+  // "could not be verified" exit 1.
   if (engine && !testEngineOverride) {
-    engine.disconnect().catch(() => { /* best-effort */ });
+    try { await engine.disconnect(); } catch { /* best-effort */ }
   }
   return {
     version: '0.32.2',

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -54,7 +54,7 @@ import type {
 import type { BrainEngine } from '../../core/engine.ts';
 import { loadConfig, toEngineConfig } from '../../core/config.ts';
 import { createEngine } from '../../core/engine-factory.ts';
-import { upsertFactRow, parseFactsFence } from '../../core/facts-fence.ts';
+import { upsertFactRow, parseFactsFence, renderFactsTable } from '../../core/facts-fence.ts';
 
 let testEngineOverride: BrainEngine | null = null;
 export function __setTestEngineOverride(engine: BrainEngine | null): void {
@@ -148,6 +148,13 @@ interface PhaseBOutcome {
    * preserving the row as a record.
    */
   expired_duplicates: number;
+  /**
+   * #2646 (codex P1): fence rows removed again because a concurrent
+   * forget_fact expired their DB row between fetch and stamp — the
+   * committed fence row was unbacked and would have resurrected a
+   * freshly-forgotten claim on the next extract_facts cycle.
+   */
+  raced_forgets: number;
   pages_touched: number;
   failed_pages: string[];
 }
@@ -189,7 +196,11 @@ export async function detectV0_32_2Drift(): Promise<number | null> {
     return null;
   } finally {
     if (!testEngineOverride) {
-      engine.disconnect().catch(() => { /* best-effort */ });
+      // AWAIT the disconnect (codex P2): the caller may open another
+      // engine immediately (the repair itself); a fire-and-forget
+      // disconnect races the PGLite single-writer lock release — the
+      // same race the runner's pre-flight deliberately avoids.
+      try { await engine.disconnect(); } catch { /* best-effort */ }
     }
   }
 }
@@ -275,6 +286,7 @@ async function phaseBFenceFacts(
       skipped_no_entity: parseInt(noEntityRows[0]?.n ?? '0', 10),
       skipped_no_local_path: 0,
       expired_duplicates: 0,
+      raced_forgets: 0,
       pages_touched: 0,
       failed_pages: [],
     };
@@ -443,13 +455,59 @@ async function phaseBFenceFacts(
         // #2646: the `row_num IS NULL AND expired_at IS NULL` guard makes
         // the stamp race-safe against a concurrent forget_fact — a row
         // expired between our fetch and this UPDATE stays expired-legacy
-        // instead of being revived as an active fence row.
+        // instead of being revived as an active fence row. RETURNING id
+        // tells us whether the stamp actually landed.
+        const unbackedRowNums: number[] = [];
+        let stampedCount = 0;
         for (const a of assignments) {
-          await engine.executeRaw(
+          const stamped = await engine.executeRaw<{ id: string }>(
             `UPDATE facts SET row_num = $1, source_markdown_slug = $2
-              WHERE id = $3 AND row_num IS NULL AND expired_at IS NULL`,
+              WHERE id = $3 AND row_num IS NULL AND expired_at IS NULL
+              RETURNING id`,
             [a.row_num, entitySlug, a.id],
           );
+          if (stamped.length > 0) { stampedCount += 1; continue; }
+          // Zero rows stamped: the row changed under us between fetch
+          // and stamp. If it is now expired (a concurrent forget_fact
+          // won the race), the fence row we just committed is unbacked
+          // AND represents a claim the operator explicitly removed —
+          // leaving it would let the next extract_facts cycle
+          // resurrect the forgotten fact from markdown (codex P1).
+          // Collect it for removal below. If instead the row was
+          // stamped by a concurrent run, the fence row IS backed —
+          // leave it alone.
+          const current = await engine.executeRaw<{ row_num: number | string | null; expired_at: Date | null }>(
+            `SELECT row_num, expired_at FROM facts WHERE id = $1`,
+            [a.id],
+          );
+          const cur = current[0];
+          if (cur && cur.row_num === null && cur.expired_at !== null) {
+            unbackedRowNums.push(a.row_num);
+          }
+        }
+
+        // Remove fence rows orphaned by a raced forget: re-read the
+        // canonical file, drop those row_nums, and rewrite with the
+        // same atomic .tmp + parse + rename primitive.
+        if (unbackedRowNums.length > 0) {
+          const unbackedSet = new Set(unbackedRowNums);
+          const currentBody = readFileSync(filePath, 'utf-8');
+          const currentParsed = parseFactsFence(currentBody);
+          const kept = currentParsed.facts.filter(f => !unbackedSet.has(f.rowNum));
+          const newFence = renderFactsTable(kept);
+          const begin = currentBody.indexOf('<!--- gbrain:facts:begin -->');
+          const end   = currentBody.indexOf('<!--- gbrain:facts:end -->', begin + 1);
+          if (begin !== -1 && end !== -1) {
+            const cleanedBody =
+              currentBody.slice(0, begin) + newFence +
+              currentBody.slice(end + '<!--- gbrain:facts:end -->'.length);
+            writeFileSync(tmpPath, cleanedBody, 'utf-8');
+            const cleanedParsed = parseFactsFence(readFileSync(tmpPath, 'utf-8'));
+            if (cleanedParsed.warnings.length === 0) {
+              renameSync(tmpPath, filePath);
+            }
+          }
+          outcome.raced_forgets += unbackedRowNums.length;
         }
         // #2646: soft-expire duplicate legacy rows (same guard — an
         // already-expired or already-stamped row is left alone).
@@ -461,7 +519,7 @@ async function phaseBFenceFacts(
           );
         }
         outcome.expired_duplicates += duplicateIds.length;
-        outcome.fenced += assignments.length;
+        outcome.fenced += stampedCount;
         outcome.pages_touched += 1;
         touchedPages.push(key);
       } catch (err) {
@@ -474,6 +532,7 @@ async function phaseBFenceFacts(
       `pages=${outcome.pages_touched} skipped_no_entity=${outcome.skipped_no_entity} ` +
       `skipped_no_local_path=${outcome.skipped_no_local_path}` +
       (outcome.expired_duplicates > 0 ? ` expired_duplicates=${outcome.expired_duplicates}` : '') +
+      (outcome.raced_forgets > 0 ? ` raced_forgets=${outcome.raced_forgets}` : '') +
       (outcome.failed_pages.length > 0 ? ` failed=${outcome.failed_pages.length}` : '');
 
     if (outcome.failed_pages.length > 0) {

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -16,16 +16,32 @@
  *                     mismatch.
  *   D. Record       — runner-owned ledger write (apply-migrations.ts).
  *
- * Idempotency: phase B only touches rows with row_num IS NULL. Re-runs
- * after a partial completion pick up where the previous run stopped.
- * Per-page atomic (.tmp + parse + rename, same primitive as
- * fence-write.ts). Dirty-tree refusal mirrors src/core/dry-fix.ts so
- * the user can review the diff before committing.
+ * Idempotency: phase B only touches ACTIVE rows with row_num IS NULL
+ * (#2646: the backfill predicate is `row_num IS NULL AND expired_at IS
+ * NULL` everywhere — dry-run counts, the phase B fetch, the DB stamp,
+ * and the drift detection below all agree). Soft-expired legacy rows
+ * (what `forget_fact` leaves behind) are never fenced: writing a
+ * forgotten claim into a page's fence as an active row would resurrect
+ * it in markdown. Re-runs after a partial completion pick up where the
+ * previous run stopped. Per-page atomic (.tmp + parse + rename, same
+ * primitive as fence-write.ts). Dirty-tree refusal mirrors
+ * src/core/dry-fix.ts so the user can review the diff before
+ * committing.
  *
  * Facts with NULL entity_slug are structurally unfenceable (no page to
  * fence onto). They're skipped with a warning; the operator decides
  * whether to hand-curate or delete them. Their row_num stays NULL
  * forever; they live in the legacy keyspace permanently.
+ *
+ * Drift repair (#2646): rows matching the backfill predicate can exist
+ * AFTER this migration completed — a lingering pre-fence writer keeps
+ * inserting v0.31-shape rows, which the completed backfill never saw,
+ * and which permanently trip the extract_facts legacy-row guard.
+ * `detectV0_32_2Drift` + the apply-migrations repair lane re-run this
+ * orchestrator as a REPAIR when that happens. The completed-migration
+ * ledger marker is never touched: "the migration ran" (ledger) and
+ * "the DB currently satisfies the post-condition" (drift check) are
+ * different statements.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'node:fs';
@@ -124,8 +140,58 @@ interface PhaseBOutcome {
   fenced: number;
   skipped_no_entity: number;
   skipped_no_local_path: number;
+  /**
+   * #2646: active legacy rows whose (claim, source) duplicates a row
+   * already assigned on the same page. A fence row_num can only back
+   * ONE DB row (partial UNIQUE index), so extras are soft-expired —
+   * never hard-deleted — which drains the extract_facts guard while
+   * preserving the row as a record.
+   */
+  expired_duplicates: number;
   pages_touched: number;
   failed_pages: string[];
+}
+
+/**
+ * #2646: the single backfill-target predicate. Active (not
+ * soft-expired) legacy rows only — `forget_fact` soft-expires, so an
+ * expired row is an operator's explicit removal and must never be
+ * fenced back into markdown. Kept in one place so the dry-run count,
+ * the phase B fetch, and the drift detection can never disagree.
+ */
+const ACTIVE_LEGACY_PREDICATE =
+  `row_num IS NULL AND entity_slug IS NOT NULL AND expired_at IS NULL`;
+
+/**
+ * Count rows that the v0_32_2 backfill still needs to fence. Exported
+ * for the apply-migrations drift-repair lane (#2646) and reused by the
+ * dry-run report.
+ */
+export async function countActiveLegacyRows(engine: BrainEngine): Promise<number> {
+  const rows = await engine.executeRaw<{ n: string }>(
+    `SELECT COUNT(*) AS n FROM facts WHERE ${ACTIVE_LEGACY_PREDICATE}`,
+  );
+  return parseInt(rows[0]?.n ?? '0', 10);
+}
+
+/**
+ * Drift detection for the apply-migrations repair lane (#2646).
+ * Returns the active-legacy count, or null when no brain is
+ * configured / reachable (detection is best-effort; a missing engine
+ * must never block the migration runner).
+ */
+export async function detectV0_32_2Drift(): Promise<number | null> {
+  const engine = await getEngine();
+  if (!engine) return null;
+  try {
+    return await countActiveLegacyRows(engine);
+  } catch {
+    return null;
+  } finally {
+    if (!testEngineOverride) {
+      engine.disconnect().catch(() => { /* best-effort */ });
+    }
+  }
 }
 
 /**
@@ -151,23 +217,22 @@ function isLocalPathDirty(localPath: string): boolean {
 async function phaseBFenceFacts(
   engine: BrainEngine | null,
   opts: OrchestratorOpts,
-): Promise<OrchestratorPhaseResult> {
+): Promise<OrchestratorPhaseResult & { touchedPages?: string[] }> {
   if (opts.dryRun) {
     // Dry-run: report what WOULD happen without touching FS or DB.
     if (!engine) return { name: 'fence_facts', status: 'skipped', detail: 'no_brain_configured' };
     try {
-      const counts = await engine.executeRaw<{ n: string }>(
-        `SELECT COUNT(*) AS n FROM facts WHERE row_num IS NULL`,
-      );
-      const total = parseInt(counts[0]?.n ?? '0', 10);
+      // #2646: same active-only predicate as the real fetch below.
+      const fenceable = await countActiveLegacyRows(engine);
       const noEntity = await engine.executeRaw<{ n: string }>(
-        `SELECT COUNT(*) AS n FROM facts WHERE row_num IS NULL AND entity_slug IS NULL`,
+        `SELECT COUNT(*) AS n FROM facts
+          WHERE row_num IS NULL AND entity_slug IS NULL AND expired_at IS NULL`,
       );
       const noEntityCount = parseInt(noEntity[0]?.n ?? '0', 10);
       return {
         name: 'fence_facts',
         status: 'skipped',
-        detail: `dry-run: would fence ${total - noEntityCount} rows; ${noEntityCount} unfenceable (NULL entity_slug)`,
+        detail: `dry-run: would fence ${fenceable} rows; ${noEntityCount} unfenceable (NULL entity_slug)`,
       };
     } catch (e) {
       return { name: 'fence_facts', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
@@ -186,21 +251,30 @@ async function phaseBFenceFacts(
     const localPathById = new Map<string, string | null>();
     for (const s of sources) localPathById.set(s.id, s.local_path);
 
-    // Walk legacy rows in (source_id, entity_slug) groups for per-page
-    // atomic writes.
+    // Walk ACTIVE legacy rows (#2646: soft-expired rows are an
+    // operator's explicit removal — never fence them back) in
+    // (source_id, entity_slug) groups for per-page atomic writes.
     const legacy = await engine.executeRaw<LegacyFactRow>(
       `SELECT id, source_id, entity_slug, fact, kind, visibility, notability,
               context, valid_from, valid_until, source, confidence
          FROM facts
-        WHERE row_num IS NULL
+        WHERE ${ACTIVE_LEGACY_PREDICATE}
         ORDER BY source_id, entity_slug, id`,
+    );
+    // NULL-entity rows are excluded from the fetch by the predicate;
+    // count them separately (active only) so the report still names
+    // the structurally-unfenceable backlog.
+    const noEntityRows = await engine.executeRaw<{ n: string }>(
+      `SELECT COUNT(*) AS n FROM facts
+        WHERE row_num IS NULL AND entity_slug IS NULL AND expired_at IS NULL`,
     );
 
     const outcome: PhaseBOutcome = {
       scanned: legacy.length,
       fenced: 0,
-      skipped_no_entity: 0,
+      skipped_no_entity: parseInt(noEntityRows[0]?.n ?? '0', 10),
       skipped_no_local_path: 0,
+      expired_duplicates: 0,
       pages_touched: 0,
       failed_pages: [],
     };
@@ -209,10 +283,6 @@ async function phaseBFenceFacts(
     // atomically with all its legacy rows.
     const groups = new Map<string, LegacyFactRow[]>();
     for (const row of legacy) {
-      if (row.entity_slug === null) {
-        outcome.skipped_no_entity += 1;
-        continue;
-      }
       const localPath = localPathById.get(row.source_id);
       if (!localPath) {
         outcome.skipped_no_local_path += 1;
@@ -238,6 +308,13 @@ async function phaseBFenceFacts(
         };
       }
     }
+
+    // #2646: pages this run actually rewrote, as `source_id\0slug` keys.
+    // Phase C scopes its verification to these (verdict: the migration's
+    // post-condition is about the pages IT touched, not every fenced
+    // page in the brain — unrelated pre-existing drift belongs to
+    // doctor, and failing verify on it wedged legitimate runs).
+    const touchedPages: string[] = [];
 
     for (const [key, group] of groups) {
       const [sourceId, entitySlug] = key.split('\0');
@@ -270,22 +347,63 @@ async function phaseBFenceFacts(
         // a partial-completion re-run, parseFactsFence will see the
         // existing row and append a duplicate. We dedup on (claim,
         // source) before append to handle this.
+        //
+        // #2646: each existing fence row_num is a QUEUE consumed at
+        // most once. The old find()-based lookup handed the SAME
+        // row_num to every DB row sharing a (claim, source) key, and
+        // the second UPDATE then violated the partial UNIQUE index on
+        // (source_id, source_markdown_slug, row_num) — leaving the
+        // group permanently half-stamped. Rows left over once their
+        // key's queue is exhausted AND the key was already assigned
+        // this run are true duplicates: soft-expired (never
+        // hard-deleted), which drains the extract_facts guard while
+        // preserving the row as a record.
         const existingFence = parseFactsFence(body);
-        const existingKeySet = new Set(existingFence.facts.map(f => `${f.claim}\0${f.source ?? ''}`));
+
+        // Fence row_nums already claimed by a stamped DB row are NOT
+        // available — handing one out again would collide on the
+        // partial UNIQUE index (the mid-stamp interruption case: the
+        // rename committed, some rows stamped, the process died).
+        // Their keys still count as "already assigned" so a leftover
+        // duplicate legacy row is expired, not re-appended.
+        const takenRows = await engine.executeRaw<{ row_num: number | string }>(
+          `SELECT row_num FROM facts
+            WHERE source_id = $1 AND source_markdown_slug = $2 AND row_num IS NOT NULL`,
+          [sourceId, entitySlug],
+        );
+        const takenRowNums = new Set(takenRows.map(r => Number(r.row_num)));
+
+        const availableByKey = new Map<string, number[]>();
+        const backedKeys = new Set<string>();
+        for (const f of existingFence.facts) {
+          const key = `${f.claim}\0${f.source ?? ''}`;
+          if (takenRowNums.has(f.rowNum)) {
+            backedKeys.add(key);
+            continue;
+          }
+          const queue = availableByKey.get(key) ?? [];
+          queue.push(f.rowNum);
+          availableByKey.set(key, queue);
+        }
 
         const assignments: Array<{ id: string; row_num: number }> = [];
+        const duplicateIds: string[] = [];
+        const assignedKeys = new Set<string>(backedKeys);
         for (const row of group) {
           const key = `${row.fact}\0${row.source ?? ''}`;
-          if (existingKeySet.has(key)) {
-            // Already fenced (idempotent re-run). Find the existing
-            // row_num and assign it to this DB row.
-            const existing = existingFence.facts.find(f =>
-              f.claim === row.fact && (f.source ?? '') === (row.source ?? ''),
-            );
-            if (existing) {
-              assignments.push({ id: row.id, row_num: existing.rowNum });
-              continue;
-            }
+          const queue = availableByKey.get(key);
+          if (queue && queue.length > 0) {
+            // Already fenced (idempotent re-run) — consume one fence
+            // row_num for this DB row.
+            assignments.push({ id: row.id, row_num: queue.shift()! });
+            assignedKeys.add(key);
+            continue;
+          }
+          if (assignedKeys.has(key)) {
+            // Duplicate legacy row: its (claim, source) is already
+            // backed by a DB row this run. Soft-expire below.
+            duplicateIds.push(row.id);
+            continue;
           }
           // Append a new row.
           const validFromStr = (row.valid_from instanceof Date ? row.valid_from : new Date(row.valid_from))
@@ -306,7 +424,7 @@ async function phaseBFenceFacts(
             context:    row.context ?? undefined,
           });
           body = updated;
-          existingKeySet.add(key);
+          assignedKeys.add(key);
           assignments.push({ id: row.id, row_num: rowNum });
         }
 
@@ -322,14 +440,30 @@ async function phaseBFenceFacts(
         renameSync(tmpPath, filePath);
 
         // UPDATE the DB rows with their new row_nums + source_markdown_slug.
+        // #2646: the `row_num IS NULL AND expired_at IS NULL` guard makes
+        // the stamp race-safe against a concurrent forget_fact — a row
+        // expired between our fetch and this UPDATE stays expired-legacy
+        // instead of being revived as an active fence row.
         for (const a of assignments) {
           await engine.executeRaw(
-            `UPDATE facts SET row_num = $1, source_markdown_slug = $2 WHERE id = $3`,
+            `UPDATE facts SET row_num = $1, source_markdown_slug = $2
+              WHERE id = $3 AND row_num IS NULL AND expired_at IS NULL`,
             [a.row_num, entitySlug, a.id],
           );
         }
+        // #2646: soft-expire duplicate legacy rows (same guard — an
+        // already-expired or already-stamped row is left alone).
+        for (const id of duplicateIds) {
+          await engine.executeRaw(
+            `UPDATE facts SET expired_at = now()
+              WHERE id = $1 AND row_num IS NULL AND expired_at IS NULL`,
+            [id],
+          );
+        }
+        outcome.expired_duplicates += duplicateIds.length;
         outcome.fenced += assignments.length;
         outcome.pages_touched += 1;
+        touchedPages.push(key);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         outcome.failed_pages.push(`${entitySlug} (${msg})`);
@@ -339,6 +473,7 @@ async function phaseBFenceFacts(
     const detail = `scanned=${outcome.scanned} fenced=${outcome.fenced} ` +
       `pages=${outcome.pages_touched} skipped_no_entity=${outcome.skipped_no_entity} ` +
       `skipped_no_local_path=${outcome.skipped_no_local_path}` +
+      (outcome.expired_duplicates > 0 ? ` expired_duplicates=${outcome.expired_duplicates}` : '') +
       (outcome.failed_pages.length > 0 ? ` failed=${outcome.failed_pages.length}` : '');
 
     if (outcome.failed_pages.length > 0) {
@@ -346,9 +481,10 @@ async function phaseBFenceFacts(
         name: 'fence_facts',
         status: 'failed',
         detail: `${detail} :: ${outcome.failed_pages.slice(0, 3).join(' | ')}${outcome.failed_pages.length > 3 ? '...' : ''}`,
+        touchedPages,
       };
     }
-    return { name: 'fence_facts', status: 'complete', detail };
+    return { name: 'fence_facts', status: 'complete', detail, touchedPages };
   } catch (e) {
     return { name: 'fence_facts', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }
@@ -359,6 +495,7 @@ async function phaseBFenceFacts(
 async function phaseCVerify(
   engine: BrainEngine | null,
   opts: OrchestratorOpts,
+  touchedPages?: string[],
 ): Promise<OrchestratorPhaseResult> {
   if (opts.dryRun) return { name: 'verify', status: 'skipped', detail: 'dry-run' };
   if (!engine) return { name: 'verify', status: 'skipped', detail: 'no_brain_configured' };
@@ -366,18 +503,29 @@ async function phaseCVerify(
   try {
     // Per touched page (= any page with a fenced row in the DB), re-parse
     // the fence from disk and compare row counts to the DB.
+    //
+    // #2646: when the caller passes the pages phase B actually rewrote,
+    // verification is scoped to THOSE — the migration's post-condition
+    // is about what it touched this run. Pre-existing drift on
+    // unrelated pages belongs to doctor; failing verify on it turned
+    // legitimate (re)runs partial forever. Callers that pass nothing
+    // (legacy tests, standalone use) keep the full-brain walk.
     const sources = await engine.executeRaw<SourceLookup>(
       `SELECT id, local_path FROM sources`,
     );
     const localPathById = new Map<string, string | null>();
     for (const s of sources) localPathById.set(s.id, s.local_path);
 
-    const groups = await engine.executeRaw<{ source_id: string; source_markdown_slug: string; n: string }>(
+    const allGroups = await engine.executeRaw<{ source_id: string; source_markdown_slug: string; n: string }>(
       `SELECT source_id, source_markdown_slug, COUNT(*) AS n
          FROM facts
         WHERE row_num IS NOT NULL
         GROUP BY source_id, source_markdown_slug`,
     );
+    const touchedSet = touchedPages !== undefined ? new Set(touchedPages) : null;
+    const groups = touchedSet === null
+      ? allGroups
+      : allGroups.filter(g => touchedSet.has(`${g.source_id}\0${g.source_markdown_slug}`));
 
     const mismatches: string[] = [];
     let pagesChecked = 0;
@@ -407,7 +555,17 @@ async function phaseCVerify(
         detail: `${mismatches.length} pages drifted: ${mismatches.slice(0, 3).join(' | ')}${mismatches.length > 3 ? '...' : ''}`,
       };
     }
-    return { name: 'verify', status: 'complete', detail: `pages_checked=${pagesChecked}` };
+    // #2646: surface the remaining active-legacy backlog as part of the
+    // post-condition report. Non-zero is NOT a failure here — rows can
+    // legitimately remain (skipped_no_local_path) — but the repair lane
+    // and the operator need the number to know whether the
+    // extract_facts guard will release.
+    const remaining = await countActiveLegacyRows(engine);
+    return {
+      name: 'verify',
+      status: 'complete',
+      detail: `pages_checked=${pagesChecked} active_legacy_remaining=${remaining}`,
+    };
   } catch (e) {
     return { name: 'verify', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }
@@ -429,10 +587,12 @@ async function orchestrator(opts: OrchestratorOpts): Promise<OrchestratorResult>
   if (a.status === 'failed') return finalizeResult(phases, 'failed', engine);
 
   const b = await phaseBFenceFacts(engine, opts);
-  phases.push(b);
+  // Strip the internal touchedPages field before the result reaches the
+  // ledger — it's a phase-B→C wiring detail, not a persisted record.
+  phases.push({ name: b.name, status: b.status, detail: b.detail });
   if (b.status === 'failed') return finalizeResult(phases, 'failed', engine);
 
-  const c = await phaseCVerify(engine, opts);
+  const c = await phaseCVerify(engine, opts, b.touchedPages);
   phases.push(c);
 
   const overallStatus: 'complete' | 'partial' | 'failed' =

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -23,11 +23,12 @@
  * page coordinate only; legacy NULL-source_markdown_slug rows survive
  * because deleteFactsForPage targets source_markdown_slug = slug only.
  *
- * Empty-fence guard (Codex R2-#7; #2484): the phase refuses to do its
- * destructive reconciliation pass when genuinely-backfillable legacy
+ * Empty-fence guard (Codex R2-#7; #2484; #2646): the phase refuses to do
+ * its destructive reconciliation pass when genuinely-backfillable legacy
  * rows still exist — `row_num IS NULL` (never fenced) AND `entity_slug`
  * resolves to a live page in this source (so the v0_32_2 migration's
- * Phase B could fence them). Status returns `warn` with a hint to run
+ * Phase B could fence them) AND the row is not soft-expired
+ * (`expired_at IS NULL`). Status returns `warn` with a hint to run
  * `gbrain apply-migrations --yes`. Without the guard, an interrupted
  * upgrade where v0_32_2 hasn't run could leave the cycle silently
  * misreporting "0 facts on people/alice" while legacy rows linger.
@@ -41,6 +42,10 @@
  * the phase jams forever (~16/day observed). Requiring a backing page
  * keeps genuine pre-v0.32.2 rows (whose entity page exists) gating
  * while excluding the inline-writer's permanent-unfenceable rows.
+ *
+ * Soft-expired rows don't count either (#2646): they're what
+ * `forget_fact` produces, so excluding them lets operators drain the
+ * backlog through the sanctioned removal path instead of raw SQL.
  */
 
 import type { BrainEngine } from '../engine.ts';
@@ -173,7 +178,7 @@ export async function runExtractFacts(
     phantomsMorePending: false,
   };
 
-  // ── Empty-fence guard (Codex R2-#7; #2484) ─────────────────────
+  // ── Empty-fence guard (Codex R2-#7; #2484; #2646) ──────────────
   // Pre-check: if any genuinely-backfillable legacy fact rows exist,
   // refuse to run the destructive reconciliation pass — the v0_32_2
   // orchestrator must fence them first.
@@ -181,12 +186,13 @@ export async function runExtractFacts(
   // A row is a real backfill candidate only when `row_num IS NULL`
   // (never fenced) AND its `entity_slug` resolves to a LIVE page in
   // this source (the migration's Phase B only fences rows whose
-  // entity_slug maps to a writable page). #2484: the original
-  // predicate was just `row_num IS NULL AND entity_slug IS NOT NULL`,
-  // which ALSO matched structurally-unfenceable hot-memory rows the
-  // inline writer keeps producing post-migration: the legacy DB-only
-  // fallback (backstop.ts) writes `entity_slug` (a resolved slug, e.g.
-  // a slugify-floor or stub-guard-blocked unprefixed slug like
+  // entity_slug maps to a writable page) AND it is not soft-expired.
+  // #2484: the original predicate was just `row_num IS NULL AND
+  // entity_slug IS NOT NULL`, which ALSO matched
+  // structurally-unfenceable hot-memory rows the inline writer keeps
+  // producing post-migration: the legacy DB-only fallback
+  // (backstop.ts) writes `entity_slug` (a resolved slug, e.g. a
+  // slugify-floor or stub-guard-blocked unprefixed slug like
   // `people-jane-doe`) with `row_num` NULL whenever the slug has no
   // fenceable page. Those rows can never satisfy the migration's exit
   // condition (no page to fence onto, and `apply-migrations` is a
@@ -194,12 +200,17 @@ export async function runExtractFacts(
   // — ~16/day, mislabeled "v0.31 pending backfill." We now require a
   // live backing page, which both genuine pre-v0.32.2 rows (their
   // entity page exists) satisfy and inline-writer unfenceable rows do
-  // not.
+  // not. #2646: soft-expired rows (`expired_at IS NOT NULL`) are also
+  // excluded — `forget_fact`, the officially sanctioned removal path,
+  // soft-expires legacy rows rather than deleting them, so counting
+  // expired rows would leave the guard permanently stuck with no
+  // supported way to drain the backlog.
   const legacy = await engine.executeRaw<{ n: string }>(
     `SELECT COUNT(*) AS n
        FROM facts f
       WHERE f.row_num IS NULL
         AND f.entity_slug IS NOT NULL
+        AND f.expired_at IS NULL
         AND EXISTS (
           SELECT 1 FROM pages p
            WHERE p.source_id = f.source_id

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -93,6 +93,13 @@ function dedupeFactsByContentKey(facts: FenceExtractedFact[]): FenceExtractedFac
  * neither count as "stale" (which would force a wipe every cycle) nor
  * be compared against the fence's row set. Mirrors the
  * excludeSourcePrefixes filter deleteFactsForPage applies on the wipe.
+ *
+ * Also excludes soft-expired legacy rows (#2646: `row_num IS NULL AND
+ * expired_at IS NOT NULL`) — rows that `forget_fact` expired via its
+ * legacy DB-only path. They are not fence-owned (fence rows always
+ * carry a row_num), so they must neither count as "stale" (forcing a
+ * wipe every cycle) nor mask a fence row from insertion. Mirrors the
+ * preserveExpiredLegacy filter deleteFactsForPage applies on the wipe.
  */
 async function listExistingFactsForPage(
   engine: BrainEngine,
@@ -105,6 +112,7 @@ async function listExistingFactsForPage(
       WHERE source_id = $1
         AND source_markdown_slug = $2
         AND COALESCE(source, '') NOT LIKE 'cli:%'
+        AND NOT (row_num IS NULL AND expired_at IS NOT NULL)
       ORDER BY row_num ASC, id ASC`,
     [sourceId, slug],
   );
@@ -345,9 +353,12 @@ export async function runExtractFacts(
         // partial-UNIQUE-index keyspace). #1928: `cli:`-origin facts
         // (conversation facts from extract-conversation-facts) are NOT
         // fence-owned — the page carries no `## Facts` fence to recreate
-        // them — so they MUST survive this reconcile.
+        // them — so they MUST survive this reconcile. #2646: soft-expired
+        // legacy rows (forget_fact's record of the forget) likewise
+        // survive via preserveExpiredLegacy.
         const deleted = await engine.deleteFactsForPage(slug, sourceId, {
           excludeSourcePrefixes: ['cli:'],
+          preserveExpiredLegacy: true,
         });
         result.factsDeleted += deleted.deleted;
       }
@@ -374,10 +385,11 @@ export async function runExtractFacts(
     if (hasStaleExisting || hasDuplicateExisting || hasRowNumDrift) {
       // Fall back to the legacy page-level reconcile when old DB rows must
       // be removed. Same delete scoping as above: legacy
-      // NULL-source_markdown_slug rows and `cli:`-origin conversation
-      // facts (#1928) survive.
+      // NULL-source_markdown_slug rows, `cli:`-origin conversation
+      // facts (#1928), and soft-expired legacy rows (#2646) survive.
       const deleted = await engine.deleteFactsForPage(slug, sourceId, {
         excludeSourcePrefixes: ['cli:'],
+        preserveExpiredLegacy: true,
       });
       result.factsDeleted += deleted.deleted;
       toInsert = extracted;

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -100,6 +100,17 @@ function dedupeFactsByContentKey(facts: FenceExtractedFact[]): FenceExtractedFac
  * carry a row_num), so they must neither count as "stale" (forcing a
  * wipe every cycle) nor mask a fence row from insertion. Mirrors the
  * preserveExpiredLegacy filter deleteFactsForPage applies on the wipe.
+ *
+ * Deliberate consequence: if the fence still carries the same
+ * (claim, source) as an expired legacy row, the reconcile inserts it
+ * as a fresh ACTIVE fence-owned row. That is the fence-is-canonical
+ * contract working as documented — legacy DB-only forgets "DO NOT
+ * survive rebuild" (see forget.ts header); suppressing the insert
+ * would instead create silent fence↔DB divergence, the exact failure
+ * mode the empty-fence guard exists to prevent. To durably forget
+ * such a claim, forget the fence-owned row (forget_fact now takes the
+ * fence path, which strikes the row through in markdown). The expired
+ * legacy row survives alongside as the record of the earlier forget.
  */
 async function listExistingFactsForPage(
   engine: BrainEngine,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1791,11 +1791,19 @@ export interface BrainEngine {
    * never recreate them (the page has no `## Facts` fence). Omitted ⇒ legacy
    * behavior (delete every fact on the page coordinate). NULL/empty `source`
    * rows are always deletable (fence default).
+   *
+   * #2646: `preserveExpiredLegacy` protects soft-expired legacy rows
+   * (`row_num IS NULL AND expired_at IS NOT NULL`) — the record left by
+   * `forget_fact`'s legacy DB-only path. Fence rows always carry a
+   * `row_num`, so these rows are never fence-owned and a wipe would
+   * destroy the forget record (or, with the fence still carrying the
+   * claim, effectively revive it as a fresh active row). Omitted ⇒
+   * legacy behavior.
    */
   deleteFactsForPage(
     slug: string,
     source_id: string,
-    opts?: { excludeSourcePrefixes?: string[] },
+    opts?: { excludeSourcePrefixes?: string[]; preserveExpiredLegacy?: boolean },
   ): Promise<{ deleted: number }>;
 
   /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4250,9 +4250,15 @@ export class PGLiteEngine implements BrainEngine {
   async deleteFactsForPage(
     slug: string,
     source_id: string,
-    opts?: { excludeSourcePrefixes?: string[] },
+    opts?: { excludeSourcePrefixes?: string[]; preserveExpiredLegacy?: boolean },
   ): Promise<{ deleted: number }> {
     const prefixes = opts?.excludeSourcePrefixes;
+    // #2646: keep soft-expired legacy rows (row_num NULL — never
+    // fence-owned) so a fence reconcile can't destroy forget_fact's
+    // legacy DB-only forget record.
+    const expiredLegacyFilter = opts?.preserveExpiredLegacy
+      ? ` AND NOT (row_num IS NULL AND expired_at IS NOT NULL)`
+      : '';
     if (prefixes && prefixes.length > 0) {
       // #1928: keep rows whose `source` matches an excluded prefix (e.g.
       // `cli:` conversation facts). COALESCE so NULL/empty-source fence rows
@@ -4261,13 +4267,13 @@ export class PGLiteEngine implements BrainEngine {
       const result = await this.db.query(
         `DELETE FROM facts
            WHERE source_id = $1 AND source_markdown_slug = $2
-             AND NOT (COALESCE(source, '') LIKE ANY($3::text[]))`,
+             AND NOT (COALESCE(source, '') LIKE ANY($3::text[]))${expiredLegacyFilter}`,
         [source_id, slug, patterns],
       );
       return { deleted: result.affectedRows ?? 0 };
     }
     const result = await this.db.query(
-      `DELETE FROM facts WHERE source_id = $1 AND source_markdown_slug = $2`,
+      `DELETE FROM facts WHERE source_id = $1 AND source_markdown_slug = $2${expiredLegacyFilter}`,
       [source_id, slug],
     );
     return { deleted: result.affectedRows ?? 0 };

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4421,10 +4421,16 @@ export class PostgresEngine implements BrainEngine {
   async deleteFactsForPage(
     slug: string,
     source_id: string,
-    opts?: { excludeSourcePrefixes?: string[] },
+    opts?: { excludeSourcePrefixes?: string[]; preserveExpiredLegacy?: boolean },
   ): Promise<{ deleted: number }> {
     const sql = this.sql;
     const prefixes = opts?.excludeSourcePrefixes;
+    // #2646: keep soft-expired legacy rows (row_num NULL — never
+    // fence-owned) so a fence reconcile can't destroy forget_fact's
+    // legacy DB-only forget record.
+    const expiredLegacyFilter = opts?.preserveExpiredLegacy
+      ? sql`AND NOT (row_num IS NULL AND expired_at IS NOT NULL)`
+      : sql``;
     if (prefixes && prefixes.length > 0) {
       // #1928: keep rows whose `source` matches an excluded prefix (e.g.
       // `cli:` conversation facts). COALESCE so NULL/empty-source fence rows
@@ -4435,11 +4441,12 @@ export class PostgresEngine implements BrainEngine {
         WHERE source_id = ${source_id}
           AND source_markdown_slug = ${slug}
           AND NOT (COALESCE(source, '') LIKE ANY(${patterns}))
+          ${expiredLegacyFilter}
       `;
       return { deleted: result.count ?? 0 };
     }
     const result = await sql`
-      DELETE FROM facts WHERE source_id = ${source_id} AND source_markdown_slug = ${slug}
+      DELETE FROM facts WHERE source_id = ${source_id} AND source_markdown_slug = ${slug} ${expiredLegacyFilter}
     `;
     return { deleted: result.count ?? 0 };
   }

--- a/test/apply-migrations-repair-lane.serial.test.ts
+++ b/test/apply-migrations-repair-lane.serial.test.ts
@@ -159,15 +159,21 @@ describe('apply-migrations drift-repair lane (#2646)', () => {
                now(), 'mcp:put_page', 1.0)`,
     );
 
+    const logged: string[] = [];
+    const realLog = console.log;
+    console.log = (...args: unknown[]) => { logged.push(args.join(' ')); };
     let sentinel: ExitSentinel | null = null;
     try {
       await runApplyMigrations([...ARGS, '--dry-run']);
     } catch (e) {
       if (e instanceof ExitSentinel) sentinel = e;
       else throw e;
+    } finally {
+      console.log = realLog;
     }
     expect(sentinel).not.toBeNull();
     expect(sentinel!.code).toBe(0);
+    expect(logged.some(l => l.includes('Would REPAIR'))).toBe(true);
 
     // No side effects: row unstamped, no page written.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -177,15 +183,22 @@ describe('apply-migrations drift-repair lane (#2646)', () => {
   });
 
   test('no drift → plain up-to-date exit 0, repair lane stays silent', async () => {
+    const logged: string[] = [];
+    const realLog = console.log;
+    console.log = (...args: unknown[]) => { logged.push(args.join(' ')); };
     let sentinel: ExitSentinel | null = null;
     try {
       await runApplyMigrations([...ARGS]);
     } catch (e) {
       if (e instanceof ExitSentinel) sentinel = e;
       else throw e;
+    } finally {
+      console.log = realLog;
     }
     expect(sentinel).not.toBeNull();
     expect(sentinel!.code).toBe(0);
+    // No repair messaging on the silent path.
+    expect(logged.some(l => /repair/i.test(l))).toBe(false);
   });
 });
 

--- a/test/apply-migrations-repair-lane.serial.test.ts
+++ b/test/apply-migrations-repair-lane.serial.test.ts
@@ -1,0 +1,196 @@
+/**
+ * #2646 — apply-migrations drift-repair lane lifecycle test.
+ *
+ * Exercises the runner's detect → repair → recount path in-process:
+ * v0.32.2 is ledger-'complete', active legacy rows exist (inserted
+ * after the backfill by a lingering pre-fence writer), and
+ * `runApplyMigrations --yes --migration 0.32.2` must repair them
+ * WITHOUT touching the completed-migrations ledger, then report
+ * up-to-date (exit 0) on the next run.
+ *
+ * Real PGLite via __setTestEngineOverride; GBRAIN_HOME sandboxes the
+ * config + ledger paths (config.json lives at $GBRAIN_HOME/.gbrain/,
+ * completed.jsonl at $GBRAIN_HOME/migrations/ — the two resolvers
+ * differ, both honored here). process.exit is stubbed to a sentinel
+ * throw so the runner's exit-code branches are assertable.
+ *
+ * Serial: mutates process.env.GBRAIN_HOME + process.exit.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { __setTestEngineOverride } from '../src/commands/migrations/v0_32_2.ts';
+import { runApplyMigrations } from '../src/commands/apply-migrations.ts';
+import { parseFactsFence } from '../src/core/facts-fence.ts';
+
+let engine: PGLiteEngine;
+let home: string;
+let brainDir: string;
+let ledgerPath: string;
+let prevGbrainHome: string | undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let realExit: any;
+
+class ExitSentinel extends Error {
+  code: number | undefined;
+  constructor(code: number | undefined) {
+    super(`process.exit(${code})`);
+    this.code = code;
+  }
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  __setTestEngineOverride(engine);
+
+  home = mkdtempSync(join(tmpdir(), 'repair-lane-test-'));
+  // config.json: config.ts appends '.gbrain' to GBRAIN_HOME.
+  mkdirSync(join(home, '.gbrain'), { recursive: true });
+  writeFileSync(
+    join(home, '.gbrain', 'config.json'),
+    JSON.stringify({
+      engine: 'pglite',
+      database_path: join(home, '.gbrain', 'brain.pglite'),
+      embedding_dimensions: 1536,
+    }) + '\n',
+  );
+  // completed.jsonl: preferences.ts treats GBRAIN_HOME as the dir itself.
+  mkdirSync(join(home, 'migrations'), { recursive: true });
+  ledgerPath = join(home, 'migrations', 'completed.jsonl');
+  writeFileSync(
+    ledgerPath,
+    JSON.stringify({ version: '0.32.2', status: 'complete', ts: '2026-01-01T00:00:00Z' }) + '\n',
+  );
+  prevGbrainHome = process.env.GBRAIN_HOME;
+  process.env.GBRAIN_HOME = home;
+
+  realExit = process.exit;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process as any).exit = (code?: number) => { throw new ExitSentinel(code); };
+});
+
+afterAll(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process as any).exit = realExit;
+  if (prevGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = prevGbrainHome;
+  __setTestEngineOverride(null);
+  await engine.disconnect();
+  try { rmSync(home, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+beforeEach(async () => {
+  brainDir = mkdtempSync(join(tmpdir(), 'repair-lane-brain-'));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (engine as any).db.query('DELETE FROM facts');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (engine as any).db.query(
+    `UPDATE sources SET local_path = $1 WHERE id = 'default'`, [brainDir],
+  );
+});
+
+const ARGS = ['--yes', '--non-interactive', '--migration', '0.32.2'];
+
+describe('apply-migrations drift-repair lane (#2646)', () => {
+  test('detect → repair → recount: active legacy rows fenced, ledger untouched, next run up-to-date', async () => {
+    // Post-migration drift: one active + one soft-expired legacy row.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at)
+       VALUES
+         ('default', 'people/alice', 'post-migration active claim', 'fact', 'private', 'medium',
+          now(), 'mcp:put_page', 1.0, NULL),
+         ('default', 'people/alice', 'post-migration forgotten claim', 'fact', 'private', 'medium',
+          now(), 'mcp:put_page', 1.0, now())`,
+    );
+    const ledgerBefore = readFileSync(ledgerPath, 'utf-8');
+
+    // Run 1: v0.32.2 is 'complete' → normal plan has nothing to run →
+    // the repair lane fires. Successful repair must NOT process.exit.
+    await runApplyMigrations([...ARGS]);
+
+    // The active row is fenced + stamped; the forgotten one untouched.
+    const pagePath = join(brainDir, 'people/alice.md');
+    expect(existsSync(pagePath)).toBe(true);
+    const parsed = parseFactsFence(readFileSync(pagePath, 'utf-8'));
+    expect(parsed.facts.map(f => f.claim)).toEqual(['post-migration active claim']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, row_num, source_markdown_slug, expired_at FROM facts ORDER BY id`,
+    );
+    expect(rows.rows[0]).toMatchObject({
+      fact: 'post-migration active claim', row_num: 1, source_markdown_slug: 'people/alice',
+    });
+    expect(rows.rows[0].expired_at).toBeNull();
+    expect(rows.rows[1].row_num).toBeNull();
+    expect(rows.rows[1].expired_at).not.toBeNull();
+
+    // Ledger invariant: the repair never appends to completed.jsonl.
+    expect(readFileSync(ledgerPath, 'utf-8')).toBe(ledgerBefore);
+
+    // Run 2: drift is drained → the runner reaches the up-to-date
+    // branch, which exits 0.
+    let sentinel: ExitSentinel | null = null;
+    try {
+      await runApplyMigrations([...ARGS]);
+    } catch (e) {
+      if (e instanceof ExitSentinel) sentinel = e;
+      else throw e;
+    }
+    expect(sentinel).not.toBeNull();
+    expect(sentinel!.code).toBe(0);
+    // Ledger still untouched.
+    expect(readFileSync(ledgerPath, 'utf-8')).toBe(ledgerBefore);
+  });
+
+  test('--dry-run surfaces the drift as Would REPAIR and takes no action', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence)
+       VALUES ('default', 'people/bob', 'drifted claim', 'fact', 'private', 'medium',
+               now(), 'mcp:put_page', 1.0)`,
+    );
+
+    let sentinel: ExitSentinel | null = null;
+    try {
+      await runApplyMigrations([...ARGS, '--dry-run']);
+    } catch (e) {
+      if (e instanceof ExitSentinel) sentinel = e;
+      else throw e;
+    }
+    expect(sentinel).not.toBeNull();
+    expect(sentinel!.code).toBe(0);
+
+    // No side effects: row unstamped, no page written.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(`SELECT row_num FROM facts`);
+    expect(rows.rows[0].row_num).toBeNull();
+    expect(existsSync(join(brainDir, 'people/bob.md'))).toBe(false);
+  });
+
+  test('no drift → plain up-to-date exit 0, repair lane stays silent', async () => {
+    let sentinel: ExitSentinel | null = null;
+    try {
+      await runApplyMigrations([...ARGS]);
+    } catch (e) {
+      if (e instanceof ExitSentinel) sentinel = e;
+      else throw e;
+    }
+    expect(sentinel).not.toBeNull();
+    expect(sentinel!.code).toBe(0);
+  });
+});
+
+afterAll(() => {
+  try {
+    if (brainDir) rmSync(brainDir, { recursive: true, force: true });
+  } catch { /* best-effort */ }
+});

--- a/test/apply-migrations.test.ts
+++ b/test/apply-migrations.test.ts
@@ -210,8 +210,11 @@ describe('runApplyMigrations exit codes (v0.36.1.x #1062)', () => {
   test('source contains process.exit(0) on list/dry-run/up-to-date branches', async () => {
     const { readFileSync } = await import('fs');
     const src = readFileSync('src/commands/apply-migrations.ts', 'utf8');
-    expect(src).toMatch(/cli\.list\s*\)\s*\{\s*printList\(plan,\s*installed\);\s*process\.exit\(0\);/);
-    expect(src).toMatch(/cli\.dryRun\s*\)\s*\{\s*printDryRun\(plan,\s*installed\);\s*process\.exit\(0\);/);
+    // #2646: the list/dry-run blocks may print a drift-repair notice
+    // between the plan print and the exit — the invariant is that each
+    // block still terminates with process.exit(0).
+    expect(src).toMatch(/cli\.list\s*\)\s*\{\s*printList\(plan,\s*installed\);[\s\S]{0,800}?process\.exit\(0\);/);
+    expect(src).toMatch(/cli\.dryRun\s*\)\s*\{\s*printDryRun\(plan,\s*installed\);[\s\S]{0,800}?process\.exit\(0\);/);
     expect(src).toMatch(/All migrations up to date[\s\S]{0,80}process\.exit\(0\)/);
   });
 });

--- a/test/apply-migrations.test.ts
+++ b/test/apply-migrations.test.ts
@@ -10,7 +10,10 @@ import { describe, test, expect } from 'bun:test';
 import { __testing } from '../src/commands/apply-migrations.ts';
 import type { CompletedMigrationEntry } from '../src/core/preferences.ts';
 
-const { parseArgs, indexCompleted, buildPlan, statusForVersion } = __testing;
+const {
+  parseArgs, indexCompleted, buildPlan, statusForVersion,
+  evaluateV0_32_2RepairOutcome,
+} = __testing;
 
 describe('parseArgs', () => {
   test('default flags', () => {
@@ -206,6 +209,38 @@ describe('force-retry escape hatch', () => {
 // date" paths must exit 0 so shell scripts gating on the exit code work.
 // Pre-fix, these `return` statements left the CLI dispatcher's implicit
 // non-zero exit code in place when callers checked $?.
+describe('evaluateV0_32_2RepairOutcome (#2646 drift-repair lane)', () => {
+  test('complete + remaining 0 → success', () => {
+    const v = evaluateV0_32_2RepairOutcome('complete', 0);
+    expect(v.failed).toBe(false);
+    expect(v.message).toContain('Drift repair complete');
+  });
+
+  test('complete + remaining > 0 → success with loud pending warning (legitimate skips must not perma-fail postinstall)', () => {
+    const v = evaluateV0_32_2RepairOutcome('complete', 3);
+    expect(v.failed).toBe(false);
+    expect(v.message).toContain('3 active legacy row(s) still pending');
+  });
+
+  test('complete + unverifiable remainder → failure', () => {
+    const v = evaluateV0_32_2RepairOutcome('complete', null);
+    expect(v.failed).toBe(true);
+    expect(v.message).toContain('could not be verified');
+  });
+
+  test('partial → failure (exit 1) with resume guidance', () => {
+    const v = evaluateV0_32_2RepairOutcome('partial', null);
+    expect(v.failed).toBe(true);
+    expect(v.message).toContain('PARTIAL');
+  });
+
+  test('failed → failure', () => {
+    const v = evaluateV0_32_2RepairOutcome('failed', null);
+    expect(v.failed).toBe(true);
+    expect(v.message).toContain('status=failed');
+  });
+});
+
 describe('runApplyMigrations exit codes (v0.36.1.x #1062)', () => {
   test('source contains process.exit(0) on list/dry-run/up-to-date branches', async () => {
     const { readFileSync } = await import('fs');

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -367,6 +367,82 @@ describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {
     expect(rows.rows[0].fact).toBe('forgotten legacy claim');
   });
 
+  test('expired legacy row WITH source_markdown_slug set survives reconcile untouched (#2646 codex P2)', async () => {
+    // Hybrid shape: row_num NULL (legacy — never fence-owned) but
+    // source_markdown_slug matching a live page. Without the
+    // preserveExpiredLegacy filter, the reconcile pass would count it
+    // as "stale", trigger a wipe, hard-delete the forget record, and
+    // reinsert the fence's rows fresh — reviving a forgotten claim as
+    // an active fact.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at, source_markdown_slug)
+       VALUES ('default', 'people/alice', 'forgotten hybrid claim', 'fact', 'private', 'medium',
+               now(), 'mcp:put_page', 1.0, now(), 'people/alice')`,
+    );
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | fence fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r1 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    const r2 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r1.guardTriggered).toBe(false);
+    // The expired hybrid row is invisible to the reconcile: the fence
+    // fact inserts normally, nothing is wiped, and re-running stays
+    // idempotent (the hybrid row must not read as perpetually stale).
+    expect(r1.factsInserted).toBe(1);
+    expect(r1.factsDeleted).toBe(0);
+    expect(r2.factsInserted).toBe(0);
+    expect(r2.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, expired_at FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY id`,
+    );
+    expect(rows.rows).toHaveLength(2);
+    expect(rows.rows[0].fact).toBe('forgotten hybrid claim');
+    expect(rows.rows[0].expired_at).not.toBeNull();
+    expect(rows.rows[1].fact).toBe('fence fact');
+    expect(rows.rows[1].expired_at).toBeNull();
+  });
+
+  test('expired legacy hybrid row survives even a stale-row wipe on the same page (#2646 codex P2)', async () => {
+    // Force the wipe path: seed a fence, reconcile, then change the
+    // fence so the old DB row goes stale. The wipe must delete the
+    // stale fence-owned row but preserve the expired legacy hybrid.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at, source_markdown_slug)
+       VALUES ('default', 'people/alice', 'forgotten hybrid claim', 'fact', 'private', 'medium',
+               now(), 'mcp:put_page', 1.0, now(), 'people/alice')`,
+    );
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | old fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // Replace the fence content — 'old fact' is now stale in the DB.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | replacement fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1); // only the stale fence-owned row
+    expect(r.factsInserted).toBe(1);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY id`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact))
+      .toEqual(['forgotten hybrid claim', 'replacement fact']);
+  });
+
   test('mixed active + expired legacy rows: guard counts only the active ones (#2646)', async () => {
     // One active legacy row + one soft-expired legacy row. The guard
     // must still trigger (an active row is pending backfill) but the

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -334,6 +334,67 @@ describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {
     expect(r.factsInserted).toBe(1);
   });
 
+  test('soft-expired legacy rows do NOT trigger the guard (#2646 — forget_fact drains the backlog)', async () => {
+    // A legacy row that forget_fact already soft-expired. Before #2646
+    // the guard counted it forever: apply-migrations no-ops (migration
+    // marked applied) and forget_fact only sets expired_at, so the
+    // phase was permanently blocked with no sanctioned way out.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at)
+       VALUES ('default', 'people/alice', 'forgotten legacy claim', 'fact', 'private', 'medium',
+               now(), 'mcp:put_page', 1.0, now())`,
+    );
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | new fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.guardTriggered).toBe(false);
+    expect(r.legacyRowsPending).toBe(0);
+    expect(r.factsInserted).toBe(1);
+
+    // The expired legacy row itself is untouched (soft-expire is the
+    // record of the forget; the phase must not hard-delete it).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE row_num IS NULL AND expired_at IS NOT NULL`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].fact).toBe('forgotten legacy claim');
+  });
+
+  test('mixed active + expired legacy rows: guard counts only the active ones (#2646)', async () => {
+    // One active legacy row + one soft-expired legacy row. The guard
+    // must still trigger (an active row is pending backfill) but the
+    // pending count must exclude the expired row — so each forget_fact
+    // visibly drains the counter toward release.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at)
+       VALUES
+         ('default', 'people/alice', 'active legacy claim', 'fact', 'private', 'medium',
+          now(), 'mcp:put_page', 1.0, NULL),
+         ('default', 'people/alice', 'expired legacy claim', 'fact', 'private', 'medium',
+          now(), 'mcp:put_page', 1.0, now())`,
+    );
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | new fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.guardTriggered).toBe(true);
+    expect(r.legacyRowsPending).toBe(1);
+    expect(r.factsInserted).toBe(0);
+    expect(r.factsDeleted).toBe(0);
+  });
+
   test('NULL entity_slug legacy rows do NOT trigger the guard (they are structurally unfenceable)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (engine as any).db.query(

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -443,6 +443,49 @@ describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {
       .toEqual(['forgotten hybrid claim', 'replacement fact']);
   });
 
+  test('fence claim matching an expired legacy row is inserted active — fence is canonical (#2646)', async () => {
+    // Deliberate semantics, pinned: legacy DB-only forgets are
+    // documented NOT to survive rebuild (forget.ts header — the
+    // explicit DB-only exception). When the fence still carries the
+    // same (claim, source), the reconcile inserts a fresh active
+    // fence-owned row; the expired legacy row survives alongside as
+    // the record of the earlier forget. Suppressing the insert would
+    // create silent fence↔DB divergence ("0 facts" while the fence
+    // says otherwise) — the exact failure mode the guard prevents.
+    // To durably forget, forget the fence-owned row (fence path).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, expired_at, source_markdown_slug)
+       VALUES ('default', 'people/alice', 'shared claim', 'fact', 'private', 'medium',
+               now(), 's', 1.0, now(), 'people/alice')`,
+    );
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | shared claim | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r1 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    const r2 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r1.factsInserted).toBe(1);
+    expect(r1.factsDeleted).toBe(0);
+    // Idempotent thereafter — the coexisting pair is stable state.
+    expect(r2.factsInserted).toBe(0);
+    expect(r2.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, row_num, expired_at FROM facts
+        WHERE source_markdown_slug = 'people/alice' ORDER BY id`,
+    );
+    expect(rows.rows).toHaveLength(2);
+    expect(rows.rows[0]).toMatchObject({ fact: 'shared claim', row_num: null });
+    expect(rows.rows[0].expired_at).not.toBeNull();   // forget record preserved
+    expect(rows.rows[1]).toMatchObject({ fact: 'shared claim', row_num: 1 });
+    expect(rows.rows[1].expired_at).toBeNull();       // fence-canonical active row
+  });
+
   test('mixed active + expired legacy rows: guard counts only the active ones (#2646)', async () => {
     // One active legacy row + one soft-expired legacy row. The guard
     // must still trigger (an active row is pending backfill) but the

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -17,7 +17,10 @@ import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
-import { v0_32_2, __setTestEngineOverride, __testing } from '../src/commands/migrations/v0_32_2.ts';
+import {
+  v0_32_2, __setTestEngineOverride, __testing,
+  countActiveLegacyRows, detectV0_32_2Drift,
+} from '../src/commands/migrations/v0_32_2.ts';
 import { parseFactsFence } from '../src/core/facts-fence.ts';
 
 let engine: PGLiteEngine;
@@ -55,12 +58,16 @@ async function seedLegacyFact(input: {
   source_id?: string;
   visibility?: 'private' | 'world';
   notability?: 'high' | 'medium' | 'low';
+  /** #2646: seed as soft-expired (what forget_fact leaves behind). */
+  expired?: boolean;
+  /** #2646: override the `source` column (dedup key half). */
+  source?: string;
 }): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const r = await (engine as any).db.query(
     `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
-                        valid_from, source, confidence)
-     VALUES ($1, $2, $3, 'fact', $4, $5, now(), 'mcp:put_page', 1.0)
+                        valid_from, source, confidence, expired_at)
+     VALUES ($1, $2, $3, 'fact', $4, $5, now(), $6, 1.0, $7)
      RETURNING id`,
     [
       input.source_id ?? 'default',
@@ -68,6 +75,8 @@ async function seedLegacyFact(input: {
       input.fact,
       input.visibility ?? 'private',
       input.notability ?? 'medium',
+      input.source ?? 'mcp:put_page',
+      input.expired ? new Date() : null,
     ],
   );
   return r.rows[0].id;
@@ -285,6 +294,170 @@ describe('phaseBFenceFacts — dirty-tree refusal scoping (#927)', () => {
   });
 });
 
+describe('phaseBFenceFacts — active-only predicate (#2646)', () => {
+  test('soft-expired legacy rows are NOT fenced (forget_fact removals stay removed)', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Active claim' });
+    const expiredId = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Forgotten claim', expired: true });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('scanned=1');
+    expect(r.detail).toContain('fenced=1');
+
+    const body = readFileSync(join(brainDir, 'people/alice.md'), 'utf-8');
+    expect(body).toContain('Active claim');
+    expect(body).not.toContain('Forgotten claim');
+
+    // The expired row stays in the legacy keyspace, untouched.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = await (engine as any).db.query(
+      `SELECT row_num, source_markdown_slug, expired_at FROM facts WHERE id = $1`, [expiredId],
+    );
+    expect(row.rows[0].row_num).toBeNull();
+    expect(row.rows[0].source_markdown_slug).toBeNull();
+    expect(row.rows[0].expired_at).not.toBeNull();
+  });
+
+  test('dry-run counts exclude expired rows (predicate parity with the fetch)', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Active' });
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Expired', expired: true });
+    await seedLegacyFact({ entity_slug: null, fact: 'Unparented expired', expired: true });
+
+    const r = await __testing.phaseBFenceFacts(engine, DRY_OPTS);
+    expect(r.detail).toContain('would fence 1 rows');
+    expect(r.detail).toContain('0 unfenceable');
+  });
+});
+
+describe('phaseBFenceFacts — duplicate legacy rows (#2646)', () => {
+  test('duplicate (claim, source) rows: one stamped, extras soft-expired, no UNIQUE violation', async () => {
+    const id1 = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim' });
+    const id2 = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim' });
+    const id3 = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('fenced=1');
+    expect(r.detail).toContain('expired_duplicates=2');
+
+    // Fence carries the claim once.
+    const parsed = parseFactsFence(readFileSync(join(brainDir, 'people/alice.md'), 'utf-8'));
+    expect(parsed.facts).toHaveLength(1);
+
+    // First row stamped; the duplicates soft-expired (never hard-deleted).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT id, row_num, expired_at FROM facts ORDER BY id`,
+    );
+    expect(rows.rows).toHaveLength(3);
+    expect(rows.rows[0]).toMatchObject({ id: id1, row_num: 1 });
+    expect(rows.rows[0].expired_at).toBeNull();
+    for (const dup of [rows.rows[1], rows.rows[2]]) {
+      expect([id2, id3]).toContain(dup.id);
+      expect(dup.row_num).toBeNull();
+      expect(dup.expired_at).not.toBeNull();
+    }
+
+    // The guard's backlog is fully drained.
+    expect(await countActiveLegacyRows(engine)).toBe(0);
+
+    // Idempotent: a re-run finds nothing to do.
+    const r2 = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r2.status).toBe('complete');
+    expect(r2.detail).toContain('scanned=0');
+  });
+
+  test('same claim under different sources is NOT a duplicate (two fence rows)', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim', source: 'src-a' });
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim', source: 'src-b' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.detail).toContain('fenced=2');
+    expect(r.detail).not.toContain('expired_duplicates');
+
+    const parsed = parseFactsFence(readFileSync(join(brainDir, 'people/alice.md'), 'utf-8'));
+    expect(parsed.facts).toHaveLength(2);
+  });
+});
+
+describe('phaseBFenceFacts — interrupted-run resume (#2646)', () => {
+  test('resume after rename succeeded but DB stamps never ran (fence row_nums consumed as a queue)', async () => {
+    // The exact interruption the verdict flags: the atomic rename
+    // committed the fence, then the process died before ANY UPDATE.
+    // Simulate by running phase B fully, then clearing every stamp.
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'First' });
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Second' });
+    await __testing.phaseBFenceFacts(engine, OPTS);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `UPDATE facts SET row_num = NULL, source_markdown_slug = NULL`,
+    );
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('fenced=2');
+
+    // No duplicate fence rows appended; each DB row re-claimed its
+    // fence row_num exactly once.
+    const parsed = parseFactsFence(readFileSync(join(brainDir, 'people/alice.md'), 'utf-8'));
+    expect(parsed.facts).toHaveLength(2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT row_num FROM facts ORDER BY row_num`,
+    );
+    expect(rows.rows.map((r: { row_num: number }) => r.row_num)).toEqual([1, 2]);
+    expect(await countActiveLegacyRows(engine)).toBe(0);
+  });
+
+  test('resume mid-stamp with duplicate claims: remaining rows drain without UNIQUE violation', async () => {
+    // Duplicate-claim group interrupted after the rename + the FIRST
+    // stamp: one row owns fence row_num 1, its duplicate is still
+    // active-legacy. The re-run must soft-expire the leftover (the
+    // fence row is already backed) instead of re-assigning row_num 1
+    // and violating the partial UNIQUE index.
+    const id1 = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim' });
+    const id2 = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Same claim' });
+    await __testing.phaseBFenceFacts(engine, OPTS);
+    // Undo the duplicate's soft-expire to reconstruct the mid-stamp state:
+    // id1 stamped, id2 active-legacy, fence already carries the claim.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `UPDATE facts SET expired_at = NULL WHERE id = $1`, [id2],
+    );
+    expect(await countActiveLegacyRows(engine)).toBe(1);
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('expired_duplicates=1');
+    expect(await countActiveLegacyRows(engine)).toBe(0);
+
+    // id1's stamp is untouched; the fence still carries the claim once.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row1 = await (engine as any).db.query(
+      `SELECT row_num, expired_at FROM facts WHERE id = $1`, [id1],
+    );
+    expect(row1.rows[0].row_num).toBe(1);
+    expect(row1.rows[0].expired_at).toBeNull();
+    const parsed = parseFactsFence(readFileSync(join(brainDir, 'people/alice.md'), 'utf-8'));
+    expect(parsed.facts).toHaveLength(1);
+  });
+});
+
+describe('drift detection (#2646 repair lane)', () => {
+  test('detectV0_32_2Drift counts only active legacy rows with an entity', async () => {
+    expect(await detectV0_32_2Drift()).toBe(0);
+
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Active drift' });
+    await seedLegacyFact({ entity_slug: 'people/bob', fact: 'Forgotten', expired: true });
+    await seedLegacyFact({ entity_slug: null, fact: 'Unparented' });
+    expect(await detectV0_32_2Drift()).toBe(1);
+
+    // Running the backfill drains the drift to zero.
+    await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(await detectV0_32_2Drift()).toBe(0);
+  });
+});
+
 describe('phaseCVerify', () => {
   test('returns complete when fence + DB row counts match', async () => {
     await seedLegacyFact({ entity_slug: 'people/alice', fact: 'F1' });
@@ -313,6 +486,40 @@ describe('phaseCVerify', () => {
     expect(r.status).toBe('failed');
     expect(r.detail).toContain('drifted');
     expect(r.detail).toContain('people/alice');
+  });
+
+  test('touched-pages scoping (#2646): pre-existing drift on an untouched page does not fail the run', async () => {
+    // A page with fence↔DB drift that THIS run never touched.
+    mkdirSync(join(brainDir, 'people'), { recursive: true });
+    writeFileSync(
+      join(brainDir, 'people/stale.md'),
+      `---\ntype: person\ntitle: Stale\nslug: people/stale\n---\n\n# Stale\n\n## Facts\n\n<!--- gbrain:facts:begin -->\n| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |\n|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|\n| 1 | drifted row | fact | 1.0 | world | medium | 2026-01-01 |  | manual |  |\n| 2 | second drifted row | fact | 1.0 | world | medium | 2026-01-01 |  | manual |  |\n<!--- gbrain:facts:end -->\n`,
+      'utf-8',
+    );
+    // DB knows only ONE fenced row for people/stale → count mismatch.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', 'people/stale', 'drifted row', 'fact', 'private', 'medium',
+               now(), 'manual', 1.0, 1, 'people/stale')`,
+    );
+
+    // This run touches only people/alice.
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Fresh claim' });
+    const b = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(b.status).toBe('complete');
+
+    // Scoped verify: complete despite the stale page's drift.
+    const scoped = await __testing.phaseCVerify(engine, OPTS, b.touchedPages);
+    expect(scoped.status).toBe('complete');
+    expect(scoped.detail).toContain('pages_checked=1');
+    expect(scoped.detail).toContain('active_legacy_remaining=0');
+
+    // Unscoped verify (legacy behavior) still sees it.
+    const full = await __testing.phaseCVerify(engine, OPTS);
+    expect(full.status).toBe('failed');
+    expect(full.detail).toContain('people/stale');
   });
 });
 

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -443,6 +443,59 @@ describe('phaseBFenceFacts — interrupted-run resume (#2646)', () => {
   });
 });
 
+describe('phaseBFenceFacts — raced forget between fetch and stamp (#2646 codex P1)', () => {
+  test('unbacked fence row is removed again; the forget is preserved', async () => {
+    const id = await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Claim being forgotten' });
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Untouched claim' });
+
+    // Simulate forget_fact winning the race: the moment phase B issues
+    // its first stamp UPDATE, expire the target row out from under it.
+    let raced = false;
+    const racedEngine = new Proxy(engine, {
+      get(target, prop) {
+        if (prop === 'executeRaw') {
+          return async (sql: string, params?: unknown[]) => {
+            if (!raced && /UPDATE facts SET row_num/.test(sql) && params?.[2] === id) {
+              raced = true;
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              await (engine as any).db.query(
+                `UPDATE facts SET expired_at = now() WHERE id = $1`, [id],
+              );
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (target as any).executeRaw(sql, params);
+          };
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const v = Reflect.get(target, prop) as any;
+        return typeof v === 'function' ? v.bind(target) : v;
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await __testing.phaseBFenceFacts(racedEngine as any, OPTS);
+    expect(raced).toBe(true);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('raced_forgets=1');
+    expect(r.detail).toContain('fenced=1'); // only the untouched claim
+
+    // The fence must NOT carry the forgotten claim — leaving it would
+    // let the next extract_facts cycle resurrect it as an active fact.
+    const parsed = parseFactsFence(readFileSync(join(brainDir, 'people/alice.md'), 'utf-8'));
+    expect(parsed.facts.map(f => f.claim)).toEqual(['Untouched claim']);
+
+    // The DB row stays expired-legacy (forget record intact) and the
+    // guard backlog is fully drained.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = await (engine as any).db.query(
+      `SELECT row_num, expired_at FROM facts WHERE id = $1`, [id],
+    );
+    expect(row.rows[0].row_num).toBeNull();
+    expect(row.rows[0].expired_at).not.toBeNull();
+    expect(await countActiveLegacyRows(engine)).toBe(0);
+  });
+});
+
 describe('drift detection (#2646 repair lane)', () => {
   test('detectV0_32_2Drift counts only active legacy rows with an entity', async () => {
     expect(await detectV0_32_2Drift()).toBe(0);


### PR DESCRIPTION
## Summary

Addresses the report in #2646 — and full credit to @herove for a precise diagnosis: the `extract_facts` legacy-row guard counted every `row_num IS NULL AND entity_slug IS NOT NULL` row regardless of `expired_at`, so a brain whose legacy rows postdate the v0_32_2 backfill (written by a lingering pre-fence writer) was permanently blocked. `apply-migrations` no-ops (migration already marked applied) and `forget_fact` — the officially sanctioned removal path — only soft-expires, so the guard count could never drain. The issue's SQL-level analysis was exactly right.

We hit the same state on our own production brain (78 legacy rows, all active): `extract_facts skipped: 78 legacy v0.31 facts pending fence backfill` on every nightly dream, with no supported way out.

This PR implements **both** suggested fixes from the issue — they are two halves of one consistency repair: (1) alone cannot drain an active backlog without hand-running `forget_fact` per row, and (2) alone would have re-fenced forgotten (soft-expired) facts, resurrecting them in markdown.

## Part 1 — guard counts only active rows (suggested fix 1)

- The guard COUNT in `src/core/cycle/extract-facts.ts` now carries `AND expired_at IS NULL`, so `forget_fact` visibly drains the pending count toward release.
- **Reconcile preserves soft-expired legacy rows** (codex round-1 P2): with the guard now releasing while expired legacy rows exist, an expired legacy row whose `source_markdown_slug` matches a live page would have entered the reconcile comparison, read as perpetually stale, and been hard-deleted by the wipe (destroying the forget record). Both sides now exclude the `row_num IS NULL AND expired_at IS NOT NULL` shape: `listExistingFactsForPage` filters it, and the wipe passes a new `preserveExpiredLegacy` option to `deleteFactsForPage` (implemented in both engines per the parity rule).
- **Pinned semantics for claim overlap** (codex round-2): if the fence still carries the same `(claim, source)` as an expired legacy row, the reconcile inserts it as a fresh active fence-owned row. Deliberate, documented in code + pinned by a test: legacy DB-only forgets are documented NOT to survive rebuild (`forget.ts` header), and suppressing the insert would create silent fence↔DB divergence — the exact failure mode the guard exists to prevent. Codex ACCEPTed this disposition in round 3.

## Part 2 — active-only backfill + targeted drift-repair lane (suggested fix 2)

The completed-migration ledger marker is **never touched or reset**: "the migration ran" (ledger) and "the DB currently satisfies the post-condition" (drift) are treated as different statements.

- **Repair lane in `apply-migrations`**: when v0.32.2 is ledger-`complete` AND active legacy rows exist, the v0_32_2 orchestrator re-runs as a repair after the normal chain. `--list` / `--dry-run` surface the drift (`Would REPAIR`); a repair that leaves rows behind reports the remainder and resumes on the next run from the drift check.
- **One backfill-target predicate everywhere** (`row_num IS NULL AND entity_slug IS NOT NULL AND expired_at IS NULL`): dry-run counts, the phase B fetch, drift detection, and the phase C remainder report cannot disagree. Soft-expired legacy rows are never fenced back into markdown.
- **Race-safe stamps**: DB stamps carry `row_num IS NULL AND expired_at IS NULL` + `RETURNING id`; a `forget_fact` winning the race between fetch and stamp leaves the row expired-legacy, and the just-committed unbacked fence row is removed again (second atomic rewrite, counted as `raced_forgets`) so the forgotten claim cannot be resurrected by the next cycle (codex P1, tested via an engine proxy injecting the race).
- **Duplicate legacy rows**: fence row_nums are consumed as a once-only queue — the previous `find()`-based lookup assigned the same row_num to every DB row sharing a `(claim, source)` key, violating the partial UNIQUE index on the second stamp and leaving the group permanently half-migrated. True duplicates are soft-expired (never hard-deleted), reported via `expired_duplicates`. Fence row_nums already claimed by a stamped DB row are excluded from the queue (mid-stamp interruption resume).
- **Touched-pages verification**: phase C verifies the pages phase B rewrote this run (+ reports the remaining active-legacy count); pre-existing drift on unrelated pages belongs to doctor and no longer turns legitimate runs partial.
- **Strict, unit-tested repair verdict**: failed/partial status or an unverifiable remainder exit 1 (ledger untouched, progress preserved). `complete` + remaining > 0 stays exit 0 with a loud warning — deliberate deviation from a codex suggestion, because rows can legitimately remain (`skipped_no_local_path` on thin-client sources) and exiting 1 would perma-fail every postinstall `apply-migrations` for those users.
- **PGLite lock-release handoffs awaited**: both `detectV0_32_2Drift` and the orchestrator's `finalizeResult` now await their engine disconnect before the runner opens the next engine (recount), closing a false-"could not be verified" race.

## Testing

- `test/extract-facts-phase.test.ts`: 5 new guard/reconcile regression tests (guard drain, mixed active+expired counting, hybrid-shape preservation incl. under a stale-row wipe, fence-canonical overlap pinning).
- `test/migrations-v0_32_2.test.ts`: active-only predicate (expired rows never fenced; dry-run parity), duplicate handling (one stamped / extras soft-expired / no UNIQUE violation; different-source same-claim not deduped), interrupted-run resume (rename-committed-no-stamps; mid-stamp with duplicate claims), raced-forget cleanup via engine-proxy race injection, drift detection, touched-pages verify scoping.
- `test/apply-migrations-repair-lane.serial.test.ts`: in-process runner lifecycle — detect → repair → recount with the ledger byte-identical throughout, next-run up-to-date exit 0, `--dry-run` prints `Would REPAIR` with zero side effects, no-drift path emits no repair messaging (process.exit stubbed to a sentinel, GBRAIN_HOME sandboxed).
- `test/apply-migrations.test.ts`: pure repair-verdict helper unit tests; the #1062 exit-code source-pattern test updated for the new block shape (invariant unchanged: exit 0).
- **Revert-check performed**: with the `src/` changes reverted, the new tests fail (guard tests, preserve tests, mid-stamp queue test red; migration tests fail at import against the pre-change module); with the fix restored, all pass.
- Affected suites: 87 pass / 0 fail (`extract-facts-phase`, `insert-facts-batch`, `facts-reconcile-protect-cli`, `migrations-v0_32_2`, `apply-migrations`, `apply-migrations-repair-lane.serial`), plus the wider facts/fence suites green. `bun run typecheck` clean.
- Known test limitation (codex round-3 P3, accepted): the lifecycle test runs on the shared test-engine override, which intentionally skips orchestrator-owned disconnects — so the awaited-disconnect fix itself is not regression-guarded by it (a config-backed dual-engine harness would be needed; noted rather than built to keep the PR bounded).

## Multi-model review

Codex (gpt-5.6-sol, high reasoning), 3 rounds on each half: guard half — round-1 P2 fixed, round-2 P2 resolved as pinned deliberate semantics, round 3 ACCEPT with no findings. Repair half — round-1 P1 (raced forget) + P2s fixed, round-2 ACCEPTs + new P2 (disconnect handoff) fixed, round-3 P2 ACCEPT; remaining P3s addressed (console-output assertions) or documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
