### PR TITLE
fix(test): progress signal-handler singleton guard asserts the delta, not global process state (#3235)

### DIFF
--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -216,17 +216,28 @@ describe('progress reporter', () => {
   });
 
   test('only one process-level signal handler installed across many reporters', () => {
-    // Baseline: one handler already installed by prior tests in this file.
-    const installedBefore = __signalHandlerInstalledForTest();
+    // #3235: this guard used to assert an absolute process-level count, which
+    // is order-dependent — `signalHandlerInstalled` and `liveReporters` are
+    // module-level (process-wide) singletons, so whatever ran earlier in this
+    // worker (other tests in this file, or other test files sharing the same
+    // CI shard) can leave non-zero baseline state. Assert THIS test's own
+    // delta instead of a global absolute.
+    const liveBefore = __liveReporterCountForTest();
     const { stream } = sink(false);
     for (let i = 0; i < 50; i++) {
       const p = createProgress({ mode: 'json', stream, minIntervalMs: 0, minItems: 1 });
       p.start(`phase_${i}`, 1);
       p.finish();
     }
-    // After 50 reporter lifecycles, still exactly one handler and zero leaked live entries.
-    expect(__signalHandlerInstalledForTest()).toBe(installedBefore || true);
-    expect(__liveReporterCountForTest()).toBe(0);
+    // The signal-handler singleton is a monotonic latch (false -> true, never
+    // back), and this test's own loop starts 50 reporters — so it must be
+    // installed by now regardless of whatever ran before this test.
+    expect(__signalHandlerInstalledForTest()).toBe(true);
+    // Each of the 50 start/finish lifecycles above must register and then
+    // deregister itself, so this test's own net contribution to the shared
+    // live-reporter set is zero — independent of whatever baseline (0 or
+    // otherwise) prior tests/files left behind.
+    expect(__liveReporterCountForTest()).toBe(liveBefore);
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {


### PR DESCRIPTION
## Summary

`test/progress.test.ts` — `only one process-level signal handler installed
across many reporters` — asserted an **absolute process-level count**
(`__signalHandlerInstalledForTest()` and `__liveReporterCountForTest()` compared
against a hardcoded baseline / `0`). Both are module-level (process-wide)
singletons in `src/core/progress.ts`, so whatever ran earlier in the same
worker/shard (other tests in this file, or unrelated test files sharing the
same CI shard that start-but-don't-finish a reporter) can leave non-zero
baseline state. That makes the assertion order/shard-composition dependent
rather than deterministic.

Addresses the report in #3235: PR #3233 (diff touched only
`src/core/embedding-pricing.ts` / `src/core/budget/budget-tracker.ts` and a
budget-tracker test — nothing near `src/core/progress.ts`) saw `test (5)` fail
twice in a row on this exact assertion (run 29955576210), while the identical
commit run locally in isolation (`bun test test/progress.test.ts`) was
17 pass / 0 fail.

## Fix (direction 1 from #3235)

Capture the live-reporter baseline (`liveBefore`) **before** the test's own
50 start/finish lifecycles run, then assert this test's own net contribution
(delta) is zero, instead of asserting the shared set is empty in absolute
terms. The signal-handler-installed check is simplified to assert `true`
directly — it's a monotonic latch (`false -> true`, never back), and the
test's own loop always exercises the install path (`createProgress()` calls
`installSignalHandler()` for any non-quiet mode), so it's correct regardless
of what ran before this test.

I looked at direction 2 (module-level test introspection) as well, but the
module already exposes exactly the introspection direction 1 needs
(`__liveReporterCountForTest()` / `__signalHandlerInstalledForTest()`); no new
export was necessary, so direction 1 is the smaller, more surgical change and
matches the existing test-only-hook style already used in this file. Direction
3 (spawn a fresh process for full isolation) was explicitly called out in the
issue as heavier than needed and wasn't pursued.

Production behavior of `src/core/progress.ts` (the handler-singleton
mechanism itself) is unchanged — this is a test-assertion fix only.

## Verification

- `bun test test/progress.test.ts` (targeted): 17 pass / 0 fail, before and
  after the change.
- `tsc --noEmit`: clean.
- **Order-dependence repro**: wrote a standalone scratch test that (1) starts
  a reporter and deliberately never calls `.finish()` on it (simulating a
  leaked live entry left behind by an unrelated test/file in the same
  shard), then (2) runs the old assertion style (`toBe(0)`) against that
  contaminated baseline — confirmed it throws/fails — and (3) runs the new
  delta-based assertion against the same contaminated baseline — confirmed it
  passes. This reproduces the shard-composition-dependent failure mode
  described in #3235 and confirms the fix resolves it without weakening the
  original lifecycle guarantee (50 start/finish cycles still must net to
  zero).
- **Revert-check**: the old absolute-count assertion, run against the same
  contamination scenario above, fails — confirming the new assertion is
  what actually fixes the order dependence (not incidental to some other
  change).

## Review

Reviewed with `codex exec` (bounded, diff-only, single-shot, model
`gpt-5.6-sol`, reasoning effort `high`) against the diff in
`test/progress.test.ts`. Result: no Critical/Warning/Suggestion findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
