### PR TITLE
fix(cycle): extract_facts skip-wipe-on-warnings — malformed fence parse is non-authoritative (TODOS P2)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -21,13 +21,6 @@ source scope).
   under that harness. The real regression guard lives in `test/bootstrap.test.ts` (which
   does drop → re-bootstrap → assert). Add the DROP statements to the strip block so the
   coverage test genuinely exercises its own entry.
-- [ ] **P2 — extract-facts reconcile still wipes-then-reinserts when the parse emitted MALFORMED warnings.**
-  `runExtractFacts` (`src/core/cycle/extract-facts.ts`) deletes a page's facts and
-  reinserts from the parsed fence even when `parseFactsFence` surfaced
-  `FACTS_TABLE_MALFORMED` warnings — any future parse defect becomes a deletion vector
-  (rows the parser failed to read get wiped with nothing to reinsert). Consider
-  skip-wipe-on-warnings: treat a warning-bearing parse as non-authoritative for that page
-  (skip the wipe, surface a warn), mirroring the empty-fence legacy-row guard's posture.
 - [ ] **P3 — bare-name resolution quarantines even on an exact unique match when prefix siblings exist.**
   With pages `companies/acme` + `companies/acme-labs`, a bare `"Acme"` yields two
   `findPrefixCandidates` rows, so `tryUnambiguousPrefixExpansion` declines — even though

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1161,17 +1161,25 @@ async function runPhaseExtractFacts(
         `destructive full walk may have wiped non-fence facts (#1928).`,
       );
     }
+    // TODOS P2 (skip-wipe-on-warnings): pages with a warning-bearing
+    // fence parse are skipped wholesale — surface the count in the
+    // summary line so the daily report shows the un-reconciled backlog
+    // instead of it hiding inside the warning list.
+    const skippedSummary = result.pagesSkippedMalformed > 0
+      ? `, ${result.pagesSkippedMalformed} page(s) skipped (malformed fence)`
+      : '';
     return {
       phase: 'extract_facts',
       status: result.warnings.length > 0 ? 'warn' : 'ok',
       duration_ms: 0,
-      summary: `${result.factsInserted} fact(s) reconciled across ${result.pagesScanned} page(s)${phantomSummary}` +
+      summary: `${result.factsInserted} fact(s) reconciled across ${result.pagesScanned} page(s)${phantomSummary}${skippedSummary}` +
         (result.warnings.length > 0 ? ` (${result.warnings.length} warning(s))` : ''),
       details: {
         pagesScanned: result.pagesScanned,
         pagesWithFacts: result.pagesWithFacts,
         factsInserted: result.factsInserted,
         factsDeleted: result.factsDeleted,
+        pagesSkippedMalformed: result.pagesSkippedMalformed,
         warnings: result.warnings.slice(0, 5),
         // v0.35.5: phantom counters surfaced so extractTotals() can lift
         // them to CycleReport.totals and the daily report makes the

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -9,7 +9,10 @@
  * Source-of-truth contract: the fence is canonical. For each page in
  * the affected slug set, this phase:
  *   1. Reads the markdown body (DB-side fetch via engine.getPage).
- *   2. Parses the `## Facts` fence with parseFactsFence.
+ *   2. Parses the `## Facts` fence with parseFactsFence. A
+ *      warning-bearing parse (FACTS_TABLE_MALFORMED etc.) is
+ *      non-authoritative: the page is skipped entirely — no wipe, no
+ *      insert — so a parse defect never becomes a deletion vector.
  *   3. Maps ParsedFact → FenceExtractedFact via extractFactsFromFenceText.
  *   4. De-dupes rows by canonical (claim, source) content key.
  *   5. Reconciles the page-scoped DB index: no-op when already in sync,
@@ -137,6 +140,12 @@ export interface ExtractFactsResult {
   factsDeleted: number;
   legacyRowsPending: number;
   guardTriggered: boolean;
+  /**
+   * TODOS P2 — pages whose fence parse emitted warnings and were
+   * therefore skipped entirely (non-authoritative parse: no wipe, no
+   * insert). The per-page warning in `warnings` names each one.
+   */
+  pagesSkippedMalformed: number;
   warnings: string[];
   /** v0.35.5: phantom-redirect pre-pass counts. */
   phantomsScanned: number;
@@ -164,6 +173,7 @@ export async function runExtractFacts(
     factsDeleted: 0,
     legacyRowsPending: 0,
     guardTriggered: false,
+    pagesSkippedMalformed: 0,
     warnings: [],
     phantomsScanned: 0,
     phantomsRedirected: 0,
@@ -303,6 +313,23 @@ export async function runExtractFacts(
       result.warnings.push(
         ...parsed.warnings.map(w => `${slug}: ${w}`),
       );
+      // TODOS P2 — skip-wipe-on-warnings: a warning-bearing parse is
+      // non-authoritative for this page. The parser demonstrably failed
+      // to read at least part of the fence, so the parsed row set can't
+      // be trusted as the complete truth: wiping against it would turn
+      // any future parse defect into a deletion vector (rows the parser
+      // couldn't read get wiped with nothing to reinsert), and inserting
+      // from it risks row_num collisions with the unread rows. Mirror
+      // the empty-fence legacy-row guard's posture: touch nothing,
+      // surface a warn, resume once the fence is fixed. Fence-less
+      // pages are unaffected (parseFactsFence returns zero warnings
+      // for a body with no fence markers).
+      result.pagesSkippedMalformed += 1;
+      result.warnings.push(
+        `${slug}: fence parse emitted warnings — page skipped, DB facts left untouched ` +
+        `(non-authoritative parse; fix the fence rows above to resume reconciliation)`,
+      );
+      continue;
     }
 
     if (parsed.facts.length > 0) result.pagesWithFacts += 1;

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -449,7 +449,10 @@ export async function runExtractFacts(
         cost_usd: 0,
         summary:
           `Reconciled ${result.factsInserted} facts (and deleted ${result.factsDeleted}) ` +
-          `across ${result.pagesScanned} scanned pages.`,
+          `across ${result.pagesScanned} scanned pages.` +
+          (result.pagesSkippedMalformed > 0
+            ? ` ${result.pagesSkippedMalformed} page(s) skipped on malformed fence parse.`
+            : ''),
       });
     } catch (err) {
       console.error(`[extract_facts] receipt write failed: ${(err as Error).message}`);

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -536,6 +536,41 @@ describe('runExtractFacts — skip-wipe-on-warnings (TODOS P2)', () => {
     expect(rows.rows).toHaveLength(1);
   });
 
+  test('dry-run counter semantics: malformed page counts as scanned + skipped, not pagesWithFacts', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Broken | UNPARSEABLE-KIND | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'], dryRun: true });
+    expect(r.pagesScanned).toBe(1);
+    expect(r.pagesWithFacts).toBe(0);
+    expect(r.pagesSkippedMalformed).toBe(1);
+    expect(r.factsInserted).toBe(0);
+    expect(r.factsDeleted).toBe(0);
+  });
+
+  test('mixed batch: valid pages reconcile, malformed pages skip, counters split correctly', async () => {
+    await putPage('people/valid', FACT_FENCE(
+      `| 1 | Good fact | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await putPage('people/broken', FACT_FENCE(
+      `| 1 | Bad fact | UNPARSEABLE-KIND | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r = await runExtractFacts(engine, { slugs: ['people/valid', 'people/broken'] });
+    expect(r.pagesScanned).toBe(2);
+    expect(r.pagesWithFacts).toBe(1);
+    expect(r.pagesSkippedMalformed).toBe(1);
+    expect(r.factsInserted).toBe(1);
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, source_markdown_slug FROM facts ORDER BY id`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0]).toMatchObject({ fact: 'Good fact', source_markdown_slug: 'people/valid' });
+  });
+
   test('fence-less pages are NOT skipped — the empty-fence wipe still works', async () => {
     // Regression guard for the skip itself: a page with no fence at all
     // produces zero parse warnings, so removing a fence entirely must

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -453,6 +453,106 @@ describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {
   });
 });
 
+describe('runExtractFacts — skip-wipe-on-warnings (TODOS P2)', () => {
+  test('malformed fence row → page skipped entirely, existing DB facts survive', async () => {
+    // Seed a clean fence and reconcile it into the DB.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | B | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // Corrupt the fence: row 2's kind becomes unparseable — the exact
+    // shape where the old wipe-then-reinsert would delete both rows
+    // and reinsert only row 1 (a parse defect as a deletion vector).
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | B | UNPARSEABLE-KIND | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.pagesSkippedMalformed).toBe(1);
+    expect(r.factsInserted).toBe(0);
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_TABLE_MALFORMED'))).toBe(true);
+    expect(r.warnings.some(w => w.includes('page skipped'))).toBe(true);
+
+    // Both previously-reconciled DB rows survive untouched.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['A', 'B']);
+  });
+
+  test('fixing the fence resumes reconciliation on the next run', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | B | UNPARSEABLE-KIND | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    const r1 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    expect(r1.pagesSkippedMalformed).toBe(1);
+    expect(r1.factsInserted).toBe(0);
+
+    // Fix the broken row.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | B | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    const r2 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    expect(r2.pagesSkippedMalformed).toBe(0);
+    expect(r2.factsInserted).toBe(2);
+    expect(r2.pagesWithFacts).toBe(1);
+  });
+
+  test('unbalanced fence markers also skip the page (no empty-fence wipe from a broken fence)', async () => {
+    // Reconcile a clean fence first.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // Break the fence: drop the end marker. parseFactsFence returns
+    // zero facts + FACTS_FENCE_UNBALANCED — without the skip, the
+    // empty-fence branch would wipe the page's DB facts.
+    await putPage('people/alice', `# Page
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+`);
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.pagesSkippedMalformed).toBe(1);
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  test('fence-less pages are NOT skipped — the empty-fence wipe still works', async () => {
+    // Regression guard for the skip itself: a page with no fence at all
+    // produces zero parse warnings, so removing a fence entirely must
+    // still reconcile to an empty index (pre-existing contract).
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPage('people/alice', '# Just a page\n\nNo fence.\n');
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.pagesSkippedMalformed).toBe(0);
+    expect(r.factsDeleted).toBe(1);
+  });
+});
+
 describe('runExtractFacts — multi-source isolation', () => {
   test('deleteFactsForPage scoping does not affect other sources', async () => {
     // Seed sources work + home.


### PR DESCRIPTION
> **Stacked on #3234** (extract_facts legacy-row guard + v0_32_2 drift-repair lane) — that PR should merge first; this branch is cut from its HEAD because both touch `src/core/cycle/extract-facts.ts`. Only the last two commits are new here.

## Summary

Implements the TODOS.md P2 entry: *"extract-facts reconcile still wipes-then-reinserts when the parse emitted MALFORMED warnings"* — and removes the entry in the same PR.

`runExtractFacts` deleted a page's facts and reinserted from the parsed fence even when `parseFactsFence` surfaced `FACTS_TABLE_MALFORMED` / `FACTS_FENCE_UNBALANCED` warnings. Any future parse defect thereby became a deletion vector: rows the parser failed to read got wiped with nothing to reinsert.

## Changes

- **Skip-wipe-on-warnings** (`src/core/cycle/extract-facts.ts`): a warning-bearing parse is non-authoritative for that page. The page is skipped entirely — no wipe AND no insert (inserting from a partial parse also risks `row_num` collisions with the unread rows, which would abort the atomic insert transaction) — a per-page warning names it, and a new `pagesSkippedMalformed` counter reports the backlog. Mirrors the empty-fence legacy-row guard's posture: touch nothing, warn, resume once the fence is fixed.
- **Fence-less pages are unaffected**: `parseFactsFence` returns zero warnings for a body with no fence markers, so the empty-fence "reconcile to empty index" contract is preserved — pinned by a regression test.
- **Reporting** (codex round-1 P2): the cycle phase summary line appends `N page(s) skipped (malformed fence)`, the counter joins the phase details, and the receipt summary names the skips. The extract rollup deliberately still counts a skip-bearing run as a completed round — unlike the legacy-row guard (which halts the whole phase), these skips are page-scoped warnings and the round did run; codex accepted this in round 2.
- **TODOS.md**: the completed P2 entry is removed; no other lines touched.

## Testing

- 6 new tests in `test/extract-facts-phase.test.ts`: malformed-row skip preserves existing DB facts; fixing the fence resumes reconciliation; unbalanced fence markers don't trigger the empty-fence wipe; fence-less pages still wipe (regression guard for the skip itself); dry-run counter semantics; mixed valid/malformed multi-page batch.
- **Revert-check performed**: with the `src/` change stashed, the 4 core skip tests fail (the malformed page gets wiped / counters missing); restored, all pass.
- Touched-area suites green (extract-facts-phase 28 pass, plus insert-facts-batch / facts-reconcile-protect-cli / facts-fence / cycle-extract-source), `bun run typecheck` clean.

## Multi-model review

Codex (gpt-5.6-sol, high reasoning), 2 rounds: round-1 P2 (reporting surfacing) + P3 (test coverage) fixed; round 2: both ACCEPTed, no new P1/P2/P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
