### PR TITLE
fix(deps): clear OSV advisories in bun.lock (fast-uri, body-parser, @hono/node-server)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,8 +51,9 @@
     "@electric-sql/pglite",
   ],
   "overrides": {
-    "@hono/node-server": "^1.19.13",
-    "fast-uri": "^3.1.2",
+    "@hono/node-server": "^2.0.5",
+    "body-parser": "^2.3.0",
+    "fast-uri": "^3.1.4",
     "fast-xml-builder": "^1.1.7",
     "fast-xml-parser": "^5.7.0",
     "form-data": "^4.0.6",
@@ -162,7 +163,7 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.3", "", {}, "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA=="],
 
     "@jsquash/avif": ["@jsquash/avif@2.1.1", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA=="],
 
@@ -326,7 +327,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -400,7 +401,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
 
@@ -613,6 +614,10 @@
     "@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "body-parser/type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "es-set-tostringtag/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -146,8 +146,9 @@
   "license": "MIT",
   "version": "0.42.64.0",
   "overrides": {
-    "@hono/node-server": "^1.19.13",
-    "fast-uri": "^3.1.2",
+    "@hono/node-server": "^2.0.5",
+    "body-parser": "^2.3.0",
+    "fast-uri": "^3.1.4",
     "fast-xml-builder": "^1.1.7",
     "fast-xml-parser": "^5.7.0",
     "form-data": "^4.0.6",


### PR DESCRIPTION
## Summary

`osv-scan` on #3244 (path-gated on `package.json` changes) surfaced 3 known vulnerabilities already present in `bun.lock` — the weekly scheduled `osv-scan` (Mondays 06:30 UTC) would otherwise fail on the whole repo next week regardless of #3244's own contents. This PR clears them via `package.json` `overrides` + a `bun install` lockfile refresh, following the same-major-bump pattern from #2927.

| advisory | severity | package | before | after |
|---|---|---|---|---|
| [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) | High 7.5 | `fast-uri` | 3.1.3 | 3.1.4 |
| [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) | Medium 5.9 | `@hono/node-server` | 1.19.14 | 2.0.11 |
| [GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6) | Low 3.7 | `body-parser` | 2.2.2 | 2.3.0 |

## `@hono/node-server` next-major note (needs a maintainer call)

Unlike the other two, this fix ships **only on the 2.x line** — there is no 1.x patch. This deviates from the same-major-only precedent in #2927, so flagging explicitly:

- Upstream's [v2.0.0 release notes](https://github.com/honojs/node-server/releases/tag/v2.0.0) state the bump is perf-only: *"the public API stays the same"*.
- gbrain's own source never imports `hono` or `@hono/node-server` directly. The only consumer is `@modelcontextprotocol/sdk`'s `streamableHttp.js`, and it only imports `getRequestListener` — a Node↔WebStandard request adapter — **not** `serveStatic`, which is the actual vulnerable code path (the advisory is a Windows-only path-traversal in `serve-static` via an encoded backslash, `%5C`). So the vulnerable surface isn't reachable through gbrain's usage regardless of version.
- The full `serve-http`/`oauth`/`connect` suite (253 tests — the closest local proxy for the MCP HTTP transport this package feeds) stays green after the bump, as does `typecheck`.

If a maintainer would rather hold `@hono/node-server` back and accept the Medium finding as a documented false-positive (given the unreachable code path), say so and I'll drop that hunk — the High and Low fixes stand on their own either way.

## Verification

- `git diff bun.lock` confirmed the lockfile diff is solely the resolution consequence of the three `overrides` changes (resolved versions + the new nested transitive deps that `body-parser@2.3.0` itself requires, e.g. `content-type@2.0.0`, `type-is@2.1.0`) — no unrelated dependency drift.
- `osv-scanner scan --lockfile bun.lock`: **3 vulnerabilities → 0**.
- `bun run typecheck`: clean.
- `test/serve-http-bootstrap-token.test.ts`, `serve-http-trust-proxy.test.ts`, `serve-http-cors.test.ts`, `serve-http-health.test.ts`, `oauth.test.ts`, `oauth-authorize-scope-default.test.ts`, `connect.test.ts`: **253/253 pass**.
- `test/voyage-response-cap.test.ts`, `test/ai/voyage-code-3-recipe.test.ts`: **23/23 pass**.
- Full local `bun run test` (4-shard parallel + serial phase) could not be used for verification this session — my local machine had two duplicate full-suite runs contending for memory at once (unrelated to this diff), which produced PGLite WASM "Out of memory" errors and shard-level timeouts across all 4 shards. After cleaning that up, I re-ran the one specific test that had failed under that load (`migrations-v0_19_0.test.ts`) solo — it passed 12/12, confirming the failures were machine-load artifacts, not a regression from this change. Deferring full-suite confirmation to this repo's CI shard environment.
- Reviewed with `codex exec` (`gpt-5.6-sol`, high reasoning effort) against the full diff — no P1/P2 issues raised; it independently re-derived the `getRequestListener`-only usage via its own search of `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
