### PR TITLE
fix(sync): surface and reconcile failed updateSlug in the rename path instead of leaving a duplicate row (#3056)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2887,7 +2887,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // NAV-1 TOCTOU: refuse a destination that realpath-resolves outside the
       // repo (committed symlink pointing out).
       const filePath = join(gitContextRoot, to);
-      let importOk = false;
+      // #3056: "destination materialized" = the new path's row demonstrably
+      // exists with the file's content. A bare errorless `skipped` is NOT
+      // enough — identity dedup can skip against the OLD row (result.slug ===
+      // oldSlug), in which case nothing landed at newSlug and reconciling
+      // would delete the only copy.
+      let destMaterialized = false;
       if (existsSync(filePath) && isPathSafe(filePath, gitContextRoot)) {
         try {
           const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
@@ -2895,33 +2900,54 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           else if (result.status === 'skipped' && (result as { error?: string }).error) {
             failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
           }
-          importOk = result.status === 'imported' ||
-            (result.status === 'skipped' && !(result as { error?: string }).error);
+          destMaterialized = result.status === 'imported' ||
+            (result.status === 'skipped' && !result.error && result.slug === newSlug);
         } catch (e: unknown) {
           failedFiles.push({ path: to, error: e instanceof Error ? e.message : String(e) });
         }
       }
-      // #3056 reconcile: the rename fell back to add semantics, so any row
-      // still sitting at oldSlug is the stale half of the rename (git reported
-      // the old path gone; a plain delete of that path would remove this row
-      // — same delete-and-add posture the F-C rename-to-unsyncable path
-      // already takes). Only after a successful import, so a failed import
-      // never widens into losing the old row too; deletePage is a scoped
-      // single-row primitive and a no-op when the row cannot be found (the
-      // divergent-stored-slug case, which the warn above already surfaced).
-      if (!renameApplied && importOk && oldSlug !== newSlug) {
+      // #3056 reconcile: the rename fell back to add semantics, so the row
+      // that still represents the OLD path is the stale half of the rename
+      // (git reported the old path gone; a plain delete of that path would
+      // remove this row — same delete-and-add posture the F-C
+      // rename-to-unsyncable path already takes). The stale row is located
+      // POSITIVELY by `source_path = from`, never by the oldSlug guess: after
+      // a destination collision, a path-derived fallback slug could name an
+      // unrelated (e.g. manually curated) row. No source_path match → nothing
+      // is deleted and the warn above stands as the only trace. Runs only
+      // after the destination demonstrably materialized, so a failed import
+      // never widens into losing the old row too.
+      let reconcileFailed = false;
+      if (!renameApplied && destMaterialized) {
         try {
-          await engine.deletePage(oldSlug, renameOpts);
+          const staleMap = await engine.resolveSlugsByPaths([from], {
+            sourceId: opts.sourceId ?? DEFAULT_SOURCE_ID,
+          });
+          const staleSlug = staleMap.get(from);
+          if (staleSlug !== undefined && staleSlug !== newSlug) {
+            await engine.deletePage(staleSlug, renameOpts);
+            serr(`  [sync] rename fallback: reconciled stale row ${staleSlug} (source_path ${from}).`);
+          } else if (staleSlug === undefined) {
+            serr(
+              `  [sync] rename fallback: no row has source_path ${from}; ` +
+              `a stale row (if any) could not be located for reconcile.`,
+            );
+          }
         } catch (e: unknown) {
-          serr(
-            `  [sync] rename fallback: could not reconcile stale row ${oldSlug}: ` +
-            `${e instanceof Error ? e.message : String(e)}`,
-          );
+          // Surface through failedFiles so the failure gate blocks the
+          // bookmark and the next run retries the rename — a warn alone
+          // would checkpoint past the duplicate permanently.
+          reconcileFailed = true;
+          failedFiles.push({
+            path: to,
+            error: `rename reconcile failed (stale row for ${from} not removed): ` +
+              `${e instanceof Error ? e.message : String(e)}`,
+          });
         }
       }
       pagesAffected.push(newSlug);
       deletedSlugs.delete(newSlug); // #1284: rename landed on a previously-deleted slug → embeddable again
-      await markCompleted(to);
+      if (!reconcileFailed) await markCompleted(to);
       progress.tick(1, newSlug);
     }
     progress.finish();

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2899,10 +2899,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       let destMaterialized = false;
       let importAttempted = false;
       let importFailureRecorded = false;
+      let importResult: Awaited<ReturnType<typeof importFile>> | undefined;
       if (existsSync(filePath) && isPathSafe(filePath, gitContextRoot)) {
         importAttempted = true;
         try {
           const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
+          importResult = result;
           if (result.status === 'imported') chunksCreated += result.chunks;
           else if (result.status === 'skipped' && (result as { error?: string }).error) {
             failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
@@ -2915,64 +2917,117 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           importFailureRecorded = true;
         }
       }
-      // #3056 round-2 review: on the fallback path, an import that did not
-      // land at newSlug (e.g. identity dedup skipped against the OLD row) is
-      // a failed rename, not a success — record it so the failure gate blocks
-      // the bookmark instead of silently advancing past a rename that never
-      // happened.
-      const renameUnresolved = !renameApplied && importAttempted && !destMaterialized;
-      if (renameUnresolved && !importFailureRecorded) {
-        failedFiles.push({
-          path: to,
-          error: `rename fallback: destination row ${newSlug} did not materialize ` +
-            `(import skipped against a different row); old row left in place`,
-        });
-      }
-      // #3056 reconcile: the rename fell back to add semantics, so the row
-      // that still represents the OLD path is the stale half of the rename
-      // (git reported the old path gone; a plain delete of that path would
-      // remove this row — same delete-and-add posture the F-C
-      // rename-to-unsyncable path already takes). The stale row is located
-      // POSITIVELY by `source_path = from`, never by the oldSlug guess: after
-      // a destination collision, a path-derived fallback slug could name an
-      // unrelated (e.g. manually curated) row. No source_path match → nothing
-      // is deleted and the warn above stands as the only trace. Runs only
-      // after the destination demonstrably materialized, so a failed import
-      // never widens into losing the old row too.
+      // #3056 fallback resolution. Three outcomes:
+      //   1. destination materialized → reconcile the stale old row (below);
+      //   2. import skipped against the very row that represents the old file
+      //      (source_path = from) and the destination slug is FREE → the row
+      //      keeps its identity-derived slug (a supported divergence — e.g.
+      //      frontmatter-pinned or exotic-filename slugs whose path-derived
+      //      form is degenerate) and only its source_path moves to `to`;
+      //   3. anything else (identity dedup against the old row while a
+      //      foreign row occupies the destination, or an unrelated skip) is a
+      //      rename that never happened → record it so the failure gate
+      //      blocks the bookmark instead of silently advancing (round-2/3
+      //      review).
       let reconcileFailed = false;
-      if (!renameApplied && destMaterialized) {
-        try {
-          const staleMap = await engine.resolveSlugsByPaths([from], {
-            sourceId: opts.sourceId ?? DEFAULT_SOURCE_ID,
-          });
-          const staleSlug = staleMap.get(from);
-          if (staleSlug !== undefined && staleSlug !== newSlug) {
-            await engine.deletePage(staleSlug, renameOpts);
-            serr(`  [sync] rename fallback: reconciled stale row ${staleSlug} (source_path ${from}).`);
-          } else if (staleSlug === undefined) {
-            serr(
-              `  [sync] rename fallback: no row has source_path ${from}; ` +
-              `a stale row (if any) could not be located for reconcile.`,
-            );
+      let renameUnresolved = false;
+      if (!renameApplied && importAttempted) {
+        const scopeOpts = { sourceId: opts.sourceId ?? DEFAULT_SOURCE_ID };
+        if (destMaterialized) {
+          // Reconcile: the rename fell back to add semantics, so the row that
+          // still represents the OLD path is the stale half of the rename
+          // (git reported the old path gone; a plain delete of that path
+          // would remove this row — same delete-and-add posture the F-C
+          // rename-to-unsyncable path already takes). The stale row is
+          // located POSITIVELY by `source_path = from`, never by the oldSlug
+          // guess: after a destination collision, a path-derived fallback
+          // slug could name an unrelated (e.g. manually curated) row. No
+          // source_path match → nothing is deleted and the warn above stands
+          // as the only trace. Runs only after the destination demonstrably
+          // materialized, so a failed import never widens into losing the
+          // old row too.
+          try {
+            const staleMap = await engine.resolveSlugsByPaths([from], scopeOpts);
+            const staleSlug = staleMap.get(from);
+            if (staleSlug !== undefined && staleSlug !== newSlug) {
+              await engine.deletePage(staleSlug, renameOpts);
+              serr(`  [sync] rename fallback: reconciled stale row ${staleSlug} (source_path ${from}).`);
+            } else if (staleSlug === undefined) {
+              serr(
+                `  [sync] rename fallback: no row has source_path ${from}; ` +
+                `a stale row (if any) could not be located for reconcile.`,
+              );
+            }
+          } catch (e: unknown) {
+            // Surface through failedFiles so the failure gate blocks the
+            // bookmark and the next run retries the rename — a warn alone
+            // would checkpoint past the duplicate permanently.
+            reconcileFailed = true;
+            failedFiles.push({
+              path: to,
+              error: `rename reconcile failed (stale row for ${from} not removed): ` +
+                `${e instanceof Error ? e.message : String(e)}`,
+            });
           }
-        } catch (e: unknown) {
-          // Surface through failedFiles so the failure gate blocks the
-          // bookmark and the next run retries the rename — a warn alone
-          // would checkpoint past the duplicate permanently.
-          reconcileFailed = true;
-          failedFiles.push({
-            path: to,
-            error: `rename reconcile failed (stale row for ${from} not removed): ` +
-              `${e instanceof Error ? e.message : String(e)}`,
-          });
+        } else {
+          const skippedAt = importResult && importResult.status === 'skipped' && !importResult.error
+            ? importResult.slug
+            : undefined;
+          if (skippedAt !== undefined) {
+            try {
+              const staleMap = await engine.resolveSlugsByPaths([from], scopeOpts);
+              let destOccupied = false;
+              if (staleMap.get(from) === skippedAt) {
+                try {
+                  destOccupied = (await engine.getPage(newSlug, scopeOpts)) !== null;
+                } catch {
+                  // Degenerate path-derived slug (e.g. exotic filename) —
+                  // nothing can occupy it.
+                  destOccupied = false;
+                }
+              }
+              if (staleMap.get(from) === skippedAt && !destOccupied) {
+                // Outcome 2: same row, destination free — keep the identity
+                // slug, move only source_path (slug=slug is a no-op rename).
+                await engine.updateSlug(skippedAt, skippedAt, { ...scopeOpts, sourcePath: to });
+                serr(
+                  `  [sync] rename fallback resolved: row ${skippedAt} keeps its slug; ` +
+                  `source_path now tracks ${to}.`,
+                );
+              } else {
+                renameUnresolved = true;
+              }
+            } catch (e: unknown) {
+              reconcileFailed = true;
+              failedFiles.push({
+                path: to,
+                error: `rename fallback resolution failed for ${from} -> ${to}: ` +
+                  `${e instanceof Error ? e.message : String(e)}`,
+              });
+            }
+          } else {
+            renameUnresolved = true;
+          }
+          if (renameUnresolved && !importFailureRecorded) {
+            failedFiles.push({
+              path: to,
+              error: `rename fallback: destination row ${newSlug} did not materialize ` +
+                `(import skipped against a different row); old row left in place`,
+            });
+          }
         }
       }
       pagesAffected.push(newSlug);
       deletedSlugs.delete(newSlug); // #1284: rename landed on a previously-deleted slug → embeddable again
       // An unresolved fallback or a failed reconcile must NOT checkpoint —
       // the failure gate keeps last_commit in place and the next run retries
-      // this rename from the same diff.
-      if (!reconcileFailed && !renameUnresolved) await markCompleted(to);
+      // this rename from the same diff. A resolved rename records `to` as
+      // succeeded so any prior open failure-ledger row for the destination
+      // clears (round-3 review).
+      if (!reconcileFailed && !renameUnresolved) {
+        succeededPaths.push(to);
+        await markCompleted(to);
+      }
       progress.tick(1, newSlug);
     }
     progress.finish();

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2861,7 +2861,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // reconcile below removes it after a successful import.
       let renameApplied = false;
       try {
-        renameApplied = (await engine.updateSlug(oldSlug, newSlug, renameOpts)) > 0;
+        // sourcePath: this rename tracks a FILE move, so refresh source_path
+        // in the same UPDATE — an unchanged-file rename skips reimport and
+        // would otherwise keep the OLD path, breaking every later
+        // source_path-based resolution for this row (#3056 round-2 review).
+        renameApplied = (await engine.updateSlug(oldSlug, newSlug, { ...renameOpts, sourcePath: to })) > 0;
         if (!renameApplied) {
           serr(
             `  [sync] rename fallback: updateSlug matched no row for ` +
@@ -2893,18 +2897,36 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // oldSlug), in which case nothing landed at newSlug and reconciling
       // would delete the only copy.
       let destMaterialized = false;
+      let importAttempted = false;
+      let importFailureRecorded = false;
       if (existsSync(filePath) && isPathSafe(filePath, gitContextRoot)) {
+        importAttempted = true;
         try {
           const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
           if (result.status === 'imported') chunksCreated += result.chunks;
           else if (result.status === 'skipped' && (result as { error?: string }).error) {
             failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
+            importFailureRecorded = true;
           }
           destMaterialized = result.status === 'imported' ||
             (result.status === 'skipped' && !result.error && result.slug === newSlug);
         } catch (e: unknown) {
           failedFiles.push({ path: to, error: e instanceof Error ? e.message : String(e) });
+          importFailureRecorded = true;
         }
+      }
+      // #3056 round-2 review: on the fallback path, an import that did not
+      // land at newSlug (e.g. identity dedup skipped against the OLD row) is
+      // a failed rename, not a success — record it so the failure gate blocks
+      // the bookmark instead of silently advancing past a rename that never
+      // happened.
+      const renameUnresolved = !renameApplied && importAttempted && !destMaterialized;
+      if (renameUnresolved && !importFailureRecorded) {
+        failedFiles.push({
+          path: to,
+          error: `rename fallback: destination row ${newSlug} did not materialize ` +
+            `(import skipped against a different row); old row left in place`,
+        });
       }
       // #3056 reconcile: the rename fell back to add semantics, so the row
       // that still represents the OLD path is the stale half of the rename
@@ -2947,7 +2969,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       }
       pagesAffected.push(newSlug);
       deletedSlugs.delete(newSlug); // #1284: rename landed on a previously-deleted slug → embeddable again
-      if (!reconcileFailed) await markCompleted(to);
+      // An unresolved fallback or a failed reconcile must NOT checkpoint —
+      // the failure gate keeps last_commit in place and the next run retries
+      // this rename from the same diff.
+      if (!reconcileFailed && !renameUnresolved) await markCompleted(to);
       progress.tick(1, newSlug);
     }
     progress.finish();

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -199,6 +199,15 @@ export interface SyncResult {
   pagesAffected: string[];
   failedFiles?: number; // count of parse failures (Bug 9)
   /**
+   * #3056: renames whose cheap path (updateSlug) did not move a row — either
+   * the UPDATE matched nothing (old slug absent in the scoped source) or it
+   * threw (destination slug occupied, invalid slug). Each one fell back to
+   * add semantics; where the stale old row could be located it was reconciled
+   * (deleted after a successful import), otherwise a warn names both slugs.
+   * 0 / absent = every rename took the cheap page_id-preserving path.
+   */
+  renameFallbacks?: number;
+  /**
    * v0.41.13.0 partial-sync fields (only set when status === 'partial').
    *
    * D-V3-1 (honest scope): --timeout aborts ONLY in pre-bookmark phases
@@ -2785,10 +2794,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // v0.41.19.0 (T4): pre-batched slug resolution per Phase 3 of the plan.
   // Renames' per-file cost is dominated by importFile() (file IO + chunking
   // + embedding), so the per-iteration updateSlug + importFile loop stays;
-  // only the upfront slug-resolve N+1 gets batched. The try/catch around
-  // updateSlug for slug-doesn't-exist preserves verbatim.
+  // only the upfront slug-resolve N+1 gets batched. #3056: a failed/no-op
+  // updateSlug is no longer silently swallowed — see the fallback handling
+  // inside the loop.
   // v0.42.x (#1794): resume-filter renames on the destination path.
   const renamesToDo = filtered.renamed.filter(r => !completed.has(r.to));
+  // #3056: renames that fell off the cheap updateSlug path (zero-row match or
+  // throw). Surfaced in SyncResult.renameFallbacks + a per-file warn so a
+  // rename that didn't actually rename is visible without reading the DB.
+  let renameFallbacks = 0;
   if (renamesToDo.length > 0) {
     progress.start('sync.renames', renamesToDo.length);
     // v0.18.0+ multi-source: scope updateSlug so the rename only touches the
@@ -2836,11 +2850,32 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         : await resolveSlugByPathOrSourcePath(engine, from, undefined);
       // The new path doesn't yet have a row, so resolve from path only.
       const newSlug = resolveSlugForPath(to);
+      // #3056: the cheap rename is OBSERVED, not assumed. A zero-row UPDATE
+      // doesn't throw, and a thrown collision used to be swallowed by an
+      // empty catch — both fell through to importFile, which created/updated
+      // the row at the new path while the old row stayed behind live
+      // (0 chunks after the next embed pass, slug occupied, page count
+      // unchanged: invisible to every existing signal). Now both shapes are
+      // warned with enough context to self-diagnose, counted in
+      // renameFallbacks, and — where the stale row can be located — the
+      // reconcile below removes it after a successful import.
+      let renameApplied = false;
       try {
-        await engine.updateSlug(oldSlug, newSlug, renameOpts);
-      } catch {
-        // Slug doesn't exist or collision, treat as add
+        renameApplied = (await engine.updateSlug(oldSlug, newSlug, renameOpts)) > 0;
+        if (!renameApplied) {
+          serr(
+            `  [sync] rename fallback: updateSlug matched no row for ` +
+            `${oldSlug} -> ${newSlug} (${from} -> ${to}); treating as add.`,
+          );
+        }
+      } catch (err) {
+        serr(
+          `  [sync] rename fallback: updateSlug failed for ${oldSlug} -> ${newSlug} ` +
+          `(${from} -> ${to}): ${err instanceof Error ? err.message : String(err)}; ` +
+          `treating as add.`,
+        );
       }
+      if (!renameApplied) renameFallbacks++;
       // Reimport at new path (picks up content changes). Wrapped to match the
       // deletes/adds loops: a malformed renamed file is recorded to failedFiles
       // and skipped, NOT thrown uncaught. importFile still throws on content
@@ -2852,6 +2887,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // NAV-1 TOCTOU: refuse a destination that realpath-resolves outside the
       // repo (committed symlink pointing out).
       const filePath = join(gitContextRoot, to);
+      let importOk = false;
       if (existsSync(filePath) && isPathSafe(filePath, gitContextRoot)) {
         try {
           const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
@@ -2859,8 +2895,28 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           else if (result.status === 'skipped' && (result as { error?: string }).error) {
             failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
           }
+          importOk = result.status === 'imported' ||
+            (result.status === 'skipped' && !(result as { error?: string }).error);
         } catch (e: unknown) {
           failedFiles.push({ path: to, error: e instanceof Error ? e.message : String(e) });
+        }
+      }
+      // #3056 reconcile: the rename fell back to add semantics, so any row
+      // still sitting at oldSlug is the stale half of the rename (git reported
+      // the old path gone; a plain delete of that path would remove this row
+      // — same delete-and-add posture the F-C rename-to-unsyncable path
+      // already takes). Only after a successful import, so a failed import
+      // never widens into losing the old row too; deletePage is a scoped
+      // single-row primitive and a no-op when the row cannot be found (the
+      // divergent-stored-slug case, which the warn above already surfaced).
+      if (!renameApplied && importOk && oldSlug !== newSlug) {
+        try {
+          await engine.deletePage(oldSlug, renameOpts);
+        } catch (e: unknown) {
+          serr(
+            `  [sync] rename fallback: could not reconcile stale row ${oldSlug}: ` +
+            `${e instanceof Error ? e.message : String(e)}`,
+          );
         }
       }
       pagesAffected.push(newSlug);
@@ -2869,6 +2925,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       progress.tick(1, newSlug);
     }
     progress.finish();
+    if (renameFallbacks > 0) {
+      serr(
+        `  [sync] ${renameFallbacks} rename(s) fell back to add semantics ` +
+        `(updateSlug did not move a row; see warnings above).`,
+      );
+    }
   }
 
   // Process adds and modifies.
@@ -3366,6 +3428,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       pagesAffected,
       failedFiles: failedFiles.length,
       bankedFiles,
+      ...(renameFallbacks > 0 ? { renameFallbacks } : {}),
     };
   }
 
@@ -3391,7 +3454,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     source_type: 'git_sync',
     source_ref: `${repoPath} @ ${headCommit.slice(0, 8)}`,
     pages_updated: pagesAffected,
-    summary: `Sync: +${filtered.added.length} ~${filtered.modified.length} -${filtered.deleted.length} R${filtered.renamed.length}, ${chunksCreated} chunks, ${elapsed}ms`,
+    summary: `Sync: +${filtered.added.length} ~${filtered.modified.length} -${filtered.deleted.length} R${filtered.renamed.length}, ${chunksCreated} chunks, ${elapsed}ms` +
+      (renameFallbacks > 0 ? `, ${renameFallbacks} rename fallback(s)` : ''),
   });
 
   // Auto-extract links + timeline (cheap CPU, but skip-inline for LARGE syncs).
@@ -3528,6 +3592,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     chunksCreated,
     embedded,
     pagesAffected,
+    ...(renameFallbacks > 0 ? { renameFallbacks } : {}),
   };
 }
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1916,8 +1916,14 @@ export interface BrainEngine {
    * preserved via stable page_id). `opts.sourceId` scopes the UPDATE — without
    * it, the bare `WHERE slug = old` matches every row across every source and
    * would either rename them all OR violate the (source_id, slug) UNIQUE.
+   *
+   * Returns the number of rows moved. 0 means the old slug had no row in the
+   * scoped source — an UPDATE that matches nothing does NOT throw, so callers
+   * that need to know whether the rename actually happened (e.g. the sync
+   * rename path, #3056) must check the return value rather than rely on the
+   * catch block.
    */
-  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void>;
+  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number>;
   rewriteLinks(oldSlug: string, newSlug: string): Promise<void>;
 
   /**

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1922,8 +1922,14 @@ export interface BrainEngine {
    * that need to know whether the rename actually happened (e.g. the sync
    * rename path, #3056) must check the return value rather than rely on the
    * catch block.
+   *
+   * `opts.sourcePath`: when the rename tracks a FILE move (sync), also
+   * refresh `source_path` in the same UPDATE. Without it, an unchanged-file
+   * rename skips reimport and the row keeps the OLD path — breaking every
+   * later source_path-based resolution for that row. Omit for pure slug
+   * migrations (the file path did not change).
    */
-  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number>;
+  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string; sourcePath?: string }): Promise<number>;
   rewriteLinks(oldSlug: string, newSlug: string): Promise<void>;
 
   /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5414,15 +5414,18 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (mirrors postgres-engine.ts).
-    await this.db.query(
+    const result = await this.db.query(
       `UPDATE pages SET slug = $1, updated_at = now() WHERE slug = $2 AND source_id = $3`,
       [newSlug, oldSlug, sourceId]
     );
+    // #3056: report rows moved so callers can distinguish a real rename from
+    // a zero-row no-op (old slug absent), which UPDATE does not throw on.
+    return result.affectedRows ?? 0;
   }
 
   async rewriteLinks(_oldSlug: string, _newSlug: string): Promise<void> {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5414,15 +5414,22 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string; sourcePath?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (mirrors postgres-engine.ts).
-    const result = await this.db.query(
-      `UPDATE pages SET slug = $1, updated_at = now() WHERE slug = $2 AND source_id = $3`,
-      [newSlug, oldSlug, sourceId]
-    );
+    // #3056: opts.sourcePath refreshes source_path in the same UPDATE (file
+    // moves); omitted for pure slug migrations.
+    const result = opts?.sourcePath !== undefined
+      ? await this.db.query(
+          `UPDATE pages SET slug = $1, source_path = $4, updated_at = now() WHERE slug = $2 AND source_id = $3`,
+          [newSlug, oldSlug, sourceId, opts.sourcePath]
+        )
+      : await this.db.query(
+          `UPDATE pages SET slug = $1, updated_at = now() WHERE slug = $2 AND source_id = $3`,
+          [newSlug, oldSlug, sourceId]
+        );
     // #3056: report rows moved so callers can distinguish a real rename from
     // a zero-row no-op (old slug absent), which UPDATE does not throw on.
     return result.affectedRows ?? 0;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5516,14 +5516,18 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string; sourcePath?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (which would either rename them all OR fail the
     // (source_id, slug) UNIQUE if the new slug already exists in another source).
-    const result = await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
+    // #3056: opts.sourcePath refreshes source_path in the same UPDATE (file
+    // moves); omitted for pure slug migrations.
+    const result = opts?.sourcePath !== undefined
+      ? await sql`UPDATE pages SET slug = ${newSlug}, source_path = ${opts.sourcePath}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`
+      : await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
     // #3056: report rows moved so callers can distinguish a real rename from
     // a zero-row no-op (old slug absent), which UPDATE does not throw on.
     return result.count ?? 0;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5516,14 +5516,17 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (which would either rename them all OR fail the
     // (source_id, slug) UNIQUE if the new slug already exists in another source).
-    await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
+    const result = await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
+    // #3056: report rows moved so callers can distinguish a real rename from
+    // a zero-row no-op (old slug absent), which UPDATE does not throw on.
+    return result.count ?? 0;
   }
 
   async rewriteLinks(_oldSlug: string, _newSlug: string): Promise<void> {

--- a/test/sync-rename-fallback.serial.test.ts
+++ b/test/sync-rename-fallback.serial.test.ts
@@ -35,6 +35,12 @@ import { resetPgliteState } from './helpers/reset-pglite.ts';
 
 let engine: PGLiteEngine;
 const repos: string[] = [];
+// Serial-file requirement: blocked runs write real rows to the sync-failure
+// ledger under $HOME/.gbrain — isolate HOME per test so the operator's actual
+// ledger is never touched (round-3 review; same pattern as
+// sync-failure-ledger.serial.test.ts).
+let tmpHome: string;
+const originalHome = process.env.HOME;
 
 beforeAll(async () => {
   engine = new PGLiteEngine();
@@ -47,10 +53,14 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-3056-home-'));
+  process.env.HOME = tmpHome;
   await resetPgliteState(engine);
 });
 
 afterEach(() => {
+  if (originalHome) process.env.HOME = originalHome; else delete process.env.HOME;
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
   while (repos.length) {
     const d = repos.pop();
     if (d) rmSync(d, { recursive: true, force: true });
@@ -320,5 +330,42 @@ describe('#3056: failed updateSlug in the sync rename path', () => {
     expect(dana).not.toBeNull();
     expect(dana!.compiled_truth).toContain('Carol is a person.');
     expect(await countPages()).toBe(1);
+
+    // Round-3 review: the successful retry must also close the failure-ledger
+    // row recorded against the destination path — otherwise doctor keeps
+    // warning about a rename that has since converged.
+    const { loadSyncFailures } = await import('../src/core/sync-failure-ledger.ts');
+    const openRows = loadSyncFailures().filter(f => f.path === 'people/dana.md' && f.state === 'open');
+    expect(openRows).toHaveLength(0);
+  });
+
+  test('exotic filename rename (degenerate path-derived slug) converges without blocking', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    // A top-level emoji filename derives an EMPTY path slug, so the row's
+    // slug comes from the pinned frontmatter `slug:` and every rename of the
+    // file takes the fallback path (updateSlug rejects the empty new slug).
+    // Round-3 review: this must converge (identity slug kept, source_path
+    // follows the file) instead of blocking the bookmark forever.
+    const md = ['---', 'type: person', 'title: Star Page', 'slug: star-page', '---', '', 'Star is a page.'].join('\n');
+    const repo = mkRepo({ '🌟.md': md });
+    const first = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(first.result.status).toBe('first_sync');
+    const before = await engine.executeRaw<{ slug: string; source_path: string | null }>(
+      `SELECT slug, source_path FROM pages WHERE source_id = 'default'`,
+    );
+    expect(before).toHaveLength(1);
+
+    execSync('git mv "🌟.md" "⭐.md"', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename star emoji"', { cwd: repo, stdio: 'pipe' });
+
+    const { result } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+
+    const after = await engine.executeRaw<{ slug: string; source_path: string | null }>(
+      `SELECT slug, source_path FROM pages WHERE source_id = 'default'`,
+    );
+    expect(after).toHaveLength(1);          // no duplicate row
+    expect(after[0].slug).toBe(before[0].slug); // identity slug preserved
+    expect(after[0].source_path).toBe('⭐.md'); // path tracking follows the file
   });
 });

--- a/test/sync-rename-fallback.test.ts
+++ b/test/sync-rename-fallback.test.ts
@@ -181,6 +181,76 @@ describe('#3056: failed updateSlug in the sync rename path', () => {
     expect(await engine.getPage('people/carol-divergent')).not.toBeNull();
   });
 
+  test('dedup-skip against the old row must NOT reconcile (codex P1): the only copy survives', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    // frontmatter.id gives identity dedup a handle: the import at the new
+    // path can skip as "identical to <old row>" — in which case NOTHING
+    // landed at the destination and deleting the old row would destroy the
+    // only copy of the content.
+    const md = ['---', 'type: person', 'title: Carol', 'id: ext-3056', '---', '', 'Carol is a person.'].join('\n');
+    const repo = mkRepo({ 'people/carol.md': md });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(await engine.getPage('people/carol')).not.toBeNull();
+
+    // Destination occupied → updateSlug throws → fallback path.
+    await engine.putPage('people/dana', {
+      type: 'person', title: 'Dana (stale)', compiled_truth: 'occupies the destination slug',
+    }, { sourceId: 'default' });
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+    expect(result.renameFallbacks).toBe(1);
+
+    // The import skipped against the OLD row (identity dedup), so the
+    // destination never materialized — the reconcile must not have deleted
+    // the old row, which still holds the only copy of the content.
+    const carol = await engine.getPage('people/carol');
+    expect(carol).not.toBeNull();
+    expect(carol!.compiled_truth).toContain('Carol is a person.');
+  });
+
+  test('reconcile never deletes by slug guess (codex P1): unrelated manual row survives', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+
+    // The file's real row drifts to a divergent slug with no source_path
+    // (unlocatable), and an UNRELATED manually-curated page happens to sit at
+    // the path-derived slug the fallback resolution will guess.
+    await engine.executeRaw(
+      `UPDATE pages SET slug = 'people/carol-divergent', source_path = NULL
+       WHERE source_id = 'default' AND slug = 'people/carol'`,
+    );
+    await engine.putPage('people/carol', {
+      type: 'person', title: 'Manual Carol', compiled_truth: 'hand-authored, not from the file',
+    }, { sourceId: 'default' });
+    // Destination occupied → updateSlug throws UNIQUE instead of moving the
+    // manual row → fallback path.
+    await engine.putPage('people/dana', {
+      type: 'person', title: 'Dana (stale)', compiled_truth: 'occupies the destination slug',
+    }, { sourceId: 'default' });
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+    expect(result.renameFallbacks).toBe(1);
+
+    // The destination materialized with the file's content...
+    const dana = await engine.getPage('people/dana');
+    expect(dana).not.toBeNull();
+    expect(dana!.compiled_truth).toContain('Carol is a person.');
+    // ...but no row had source_path = from, so the reconcile deleted NOTHING:
+    // the unrelated manual row at the guessed slug survives.
+    const manual = await engine.getPage('people/carol');
+    expect(manual).not.toBeNull();
+    expect(manual!.compiled_truth).toContain('hand-authored');
+  });
+
   test('happy path: clean git mv rename keeps page_id and reports zero fallbacks', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });

--- a/test/sync-rename-fallback.test.ts
+++ b/test/sync-rename-fallback.test.ts
@@ -1,0 +1,204 @@
+/**
+ * #3056 — sync rename path: a failed `updateSlug` must be surfaced and
+ * reconciled instead of silently leaving a duplicate row.
+ *
+ * Before the fix, the rename loop in src/commands/sync.ts swallowed
+ * `updateSlug` failures with an empty catch ("treat as add") and could not
+ * see a zero-row UPDATE at all (updateSlug returned void). The run then
+ * fell through to importFile, which created/updated the row at the new
+ * path — while the old row stayed behind, live, with its slug occupied.
+ * Nothing was logged and no counter moved, so the failed rename was
+ * indistinguishable from a successful one.
+ *
+ * Coverage:
+ *   - engine contract: updateSlug returns the number of rows moved
+ *     (0 = old slug not present, i.e. the silent no-op case).
+ *   - collision fallback: destination slug already occupied → updateSlug
+ *     throws UNIQUE → run reconciles the stale old row after a successful
+ *     import (delete-and-add semantics, same posture as the F-C
+ *     rename-to-unsyncable path) and reports it in renameFallbacks.
+ *   - unlocatable old row: stored slug diverged from the path-derived one
+ *     AND no source_path to find it by → the duplicate cannot be safely
+ *     removed, but the fallback is surfaced (warn + counter) instead of
+ *     silent.
+ *   - happy path: a clean git mv reports renameFallbacks 0 and keeps the
+ *     page_id (no regression to the cheap rename).
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+const repos: string[] = [];
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+afterEach(() => {
+  while (repos.length) {
+    const d = repos.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function personMd(title: string, body: string): string {
+  return ['---', 'type: person', `title: ${title}`, '---', '', body].join('\n');
+}
+
+/** Create a temp git repo seeded with the given files + an initial commit. */
+function mkRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-3056-'));
+  repos.push(dir);
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+  for (const [rel, content] of Object.entries(files)) {
+    mkdirSync(join(dir, rel, '..'), { recursive: true });
+    writeFileSync(join(dir, rel), content);
+  }
+  execSync('git add -A && git commit -m "initial"', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+const SYNC_OPTS = { noPull: true, noEmbed: true, noExtract: true, sourceId: 'default' } as const;
+
+/** Capture stderr warnings (serr falls through to console.error in tests). */
+async function captureErr<T>(fn: () => Promise<T>): Promise<{ result: T; err: string }> {
+  const lines: string[] = [];
+  const origErr = console.error;
+  console.error = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    const result = await fn();
+    return { result, err: lines.join('\n') };
+  } finally {
+    console.error = origErr;
+  }
+}
+
+async function countPages(): Promise<number> {
+  const rows = await engine.executeRaw<{ n: number | string }>(
+    `SELECT count(*)::int AS n FROM pages WHERE source_id = 'default'`,
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+describe('updateSlug engine contract (#3056)', () => {
+  test('returns 1 when the old slug row is moved', async () => {
+    await engine.putPage('people/old', {
+      type: 'person', title: 'Old', compiled_truth: 'body',
+    }, { sourceId: 'default' });
+    const moved = await engine.updateSlug('people/old', 'people/new', { sourceId: 'default' });
+    expect(moved).toBe(1);
+    expect(await engine.getPage('people/new')).not.toBeNull();
+  });
+
+  test('returns 0 when the old slug has no row (the silent no-op case)', async () => {
+    const moved = await engine.updateSlug('people/ghost', 'people/new', { sourceId: 'default' });
+    expect(moved).toBe(0);
+  });
+});
+
+describe('#3056: failed updateSlug in the sync rename path', () => {
+  test('collision: destination slug occupied → old row reconciled, fallback counted', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(await engine.getPage('people/carol')).not.toBeNull();
+
+    // A pre-existing row already occupies the rename destination, so
+    // updateSlug throws (source_id, slug) UNIQUE and the loop falls back.
+    await engine.putPage('people/dana', {
+      type: 'person', title: 'Dana (stale)', compiled_truth: 'occupies the destination slug',
+    }, { sourceId: 'default' });
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result, err } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+
+    // The failure is surfaced: counted in the run result + warned on stderr.
+    expect(result.renameFallbacks).toBe(1);
+    expect(err).toContain('people/carol');
+    expect(err).toContain('people/dana');
+
+    // The new path is live with the renamed file's content...
+    const dana = await engine.getPage('people/dana');
+    expect(dana).not.toBeNull();
+    expect(dana!.compiled_truth).toContain('Carol is a person.');
+
+    // ...and the old row did NOT stay behind as a live duplicate.
+    expect(await engine.getPage('people/carol')).toBeNull();
+    expect(await countPages()).toBe(1);
+  });
+
+  test('unlocatable old row: divergent stored slug with no source_path → surfaced, not silent', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+
+    // Corrupt the row the way the field report describes: the stored slug no
+    // longer matches the path-derived one, and there is no source_path to
+    // find it by. resolveSlugsByPaths misses → the loop falls back to the
+    // path-derived slug → the UPDATE matches zero rows.
+    await engine.executeRaw(
+      `UPDATE pages SET slug = 'people/carol-divergent', source_path = NULL
+       WHERE source_id = 'default' AND slug = 'people/carol'`,
+    );
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result, err } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+
+    // The zero-row UPDATE is no longer invisible: counted + warned with both
+    // slugs so an operator can self-diagnose (the exact diagnostic the
+    // reporter asked for).
+    expect(result.renameFallbacks).toBe(1);
+    expect(err).toContain('people/carol');
+    expect(err).toContain('people/dana');
+
+    // The new path imported; the divergent row cannot be safely located, so
+    // it remains — but the run said so instead of looking successful.
+    expect(await engine.getPage('people/dana')).not.toBeNull();
+    expect(await engine.getPage('people/carol-divergent')).not.toBeNull();
+  });
+
+  test('happy path: clean git mv rename keeps page_id and reports zero fallbacks', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    const before = await engine.getPage('people/carol');
+    expect(before).not.toBeNull();
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const result = await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(result.status).toBe('synced');
+    expect(result.renameFallbacks ?? 0).toBe(0);
+
+    const after = await engine.getPage('people/dana');
+    expect(after).not.toBeNull();
+    expect(after!.id).toBe(before!.id); // cheap-path rename preserved the row
+    expect(await engine.getPage('people/carol')).toBeNull();
+    expect(await countPages()).toBe(1);
+  });
+});

--- a/test/sync-rename-fallback.test.ts
+++ b/test/sync-rename-fallback.test.ts
@@ -201,12 +201,17 @@ describe('#3056: failed updateSlug in the sync rename path', () => {
     execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
 
     const { result } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
-    expect(result.status).toBe('synced');
-    expect(result.renameFallbacks).toBe(1);
 
     // The import skipped against the OLD row (identity dedup), so the
-    // destination never materialized — the reconcile must not have deleted
-    // the old row, which still holds the only copy of the content.
+    // destination never materialized. That is a rename that never happened:
+    // the run must NOT advance the bookmark as if it had (round-2 review) —
+    // it lands in failedFiles and blocks, like any other unresolved file.
+    expect(result.status).toBe('blocked_by_failures');
+    expect(result.renameFallbacks).toBe(1);
+    expect(result.failedFiles).toBe(1);
+
+    // ...and the reconcile must not have deleted the old row, which still
+    // holds the only copy of the content.
     const carol = await engine.getPage('people/carol');
     expect(carol).not.toBeNull();
     expect(carol!.compiled_truth).toContain('Carol is a person.');
@@ -269,6 +274,51 @@ describe('#3056: failed updateSlug in the sync rename path', () => {
     expect(after).not.toBeNull();
     expect(after!.id).toBe(before!.id); // cheap-path rename preserved the row
     expect(await engine.getPage('people/carol')).toBeNull();
+    expect(await countPages()).toBe(1);
+
+    // Round-2 review: the unchanged-file rename skips reimport, so the
+    // UPDATE itself must refresh source_path — otherwise every later
+    // source_path-based resolution for this row points at the old path.
+    const rows = await engine.executeRaw<{ source_path: string | null }>(
+      `SELECT source_path FROM pages WHERE source_id = 'default' AND slug = 'people/dana'`,
+    );
+    expect(rows[0]?.source_path).toBe('people/dana.md');
+  });
+
+  test('reconcile failure blocks the bookmark and the next run retries to convergence', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    await engine.putPage('people/dana', {
+      type: 'person', title: 'Dana (stale)', compiled_truth: 'occupies the destination slug',
+    }, { sourceId: 'default' });
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    // Inject a transient failure into the reconcile delete.
+    const origDelete = engine.deletePage.bind(engine);
+    engine.deletePage = async () => { throw new Error('injected transient delete failure'); };
+    let blocked;
+    try {
+      blocked = (await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }))).result;
+    } finally {
+      engine.deletePage = origDelete;
+    }
+
+    // The failed reconcile is not checkpointed past: the run blocks, the
+    // bookmark stays, and the stale duplicate is still visible.
+    expect(blocked.status).toBe('blocked_by_failures');
+    expect(blocked.failedFiles).toBe(1);
+    expect(await engine.getPage('people/carol')).not.toBeNull();
+
+    // Next run (failure gone) retries the same rename diff and converges.
+    const { result } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+    expect(await engine.getPage('people/carol')).toBeNull();
+    const dana = await engine.getPage('people/dana');
+    expect(dana).not.toBeNull();
+    expect(dana!.compiled_truth).toContain('Carol is a person.');
     expect(await countPages()).toBe(1);
   });
 });


### PR DESCRIPTION
Addresses the report in #3056. Thanks to @johannesmanske for the precise field report and the code archaeology — the observation that the two neighbouring loops were hardened while this one call site produced no record at all is what shaped this patch.

## The problem

In the sync rename loop, `updateSlug` failure was invisible twice over:

1. A **thrown** failure (destination slug occupied, invalid new slug) was swallowed by an empty `catch`.
2. A **zero-row UPDATE** (old slug has no row in the scoped source) never threw at all — `updateSlug` returned `void`, so there was nothing to observe.

Both shapes fell through to `importFile`, which created/updated the row at the new path while the old row stayed behind live: 0 chunks after the next embed pass, slug occupied, page count unchanged — exactly the duplicate described in the report, invisible to every existing signal.

## What this PR does

Following the report's "suggested changes, in order of value":

**1. Surface (log + count).** `updateSlug` now returns the number of rows moved (both engines: `result.count` on postgres.js, `affectedRows` on PGLite — both established patterns in each engine). The rename loop warns on either failure shape with `oldSlug -> newSlug`, the `from -> to` paths, and the error message — the self-diagnosing line the reporter asked for. Fallbacks are counted in a new optional `SyncResult.renameFallbacks` field, a run-end stderr summary line, and the ingest-log summary. Existing `updateSlug` callers (`migrate.ts`) ignore the return value unchanged.

**2. Reconcile the stale row.** When the rename fell back and the destination row demonstrably materialized, the row that still represents the OLD path is located **positively via `source_path = from`** (never by the resolved-slug guess, which can name an unrelated row after a collision) and deleted, scoped to the source. This is the same delete-and-add posture the existing rename-to-unsyncable path (F-C in `test/sync.test.ts`) already takes for a rename whose cheap path can't apply — a rename is semantically old-path-gone + new-path-present, and git has already reported the old path gone. Ordering is loss-safe: the reconcile runs only **after** a successful import, so a failed import never widens into losing the old row too. If no row carries `source_path = from` (the report's unexplained divergent case), nothing is deleted and the warn is the record.

**3. Identity-slug renames resolve instead of blocking.** When the import skips against the very row that represents the old file (`source_path = from`) and the destination slug is free — e.g. a frontmatter-pinned `slug:` whose path-derived form is degenerate, the exact divergence class the report names — the row keeps its identity slug and only its `source_path` moves to the new path (`updateSlug` gained an optional `sourcePath` refresh for file-move renames; pure slug migrations omit it).

**4. A rename that never happened no longer looks like one that did.** If the fallback import did not land at the destination (identity dedup against the old row while a foreign row occupies the destination slug), or the reconcile delete itself fails, the path is recorded in `failedFiles` and skips the checkpoint — the existing failure gate holds `last_commit` and the next run retries the same rename diff. This reuses the sync's established failure posture (ledger, `--skip-failed`, bounded auto-skip) rather than inventing a new one.

Cleaning up duplicates from past incidents is intentionally out of scope, per the issue.

## Safety posture of the reconcile (why deleting is OK here)

- The delete target is identified by `source_path = from` only — a positive claim that the row represents the renamed-away file. No source_path match → no delete.
- It fires only after the destination row provably exists with the file's content (`imported`, or an errorless skip that names the destination slug).
- `deletePage` is the same scoped single-row primitive the sync delete loop already uses for removed files; a rename is git telling us the old path was removed.
- Failure of the delete blocks the bookmark (recorded failure) instead of being checkpointed past.

## Tests (`test/sync-rename-fallback.serial.test.ts`, +2 engine-contract cases)

All written red-first against the pre-fix code and revert-checked (4 fail on the original code):

- engine contract: `updateSlug` returns 1 on a real move, 0 on the silent no-op.
- collision: destination occupied → fallback surfaced (`renameFallbacks`, stderr) + stale old row reconciled; 1 live row after.
- divergent stored slug with no `source_path`: surfaced (warn names both slugs), nothing deleted — honest about what can't be safely located.
- dedup-skip against the old row: the only copy of the content survives and the run **blocks** rather than advancing past a rename that never happened.
- unrelated manual row at the guessed slug: survives (reconcile never deletes by slug guess).
- injected reconcile-delete failure: run blocks, bookmark holds, next run retries to convergence **and closes the failure-ledger row**.
- pinned-slug emoji filename rename: converges (identity slug kept, `source_path` follows the file) instead of blocking.
- happy path: clean `git mv` keeps `page_id`, reports zero fallbacks, and now also refreshes `source_path` (an unchanged-file rename skips reimport, so previously the row kept the old path).

The test file runs under a per-test temp `HOME` (serial-quarantined per `scripts/check-test-isolation.sh`) so blocked runs never touch the operator's real `~/.gbrain/sync-failures.jsonl`.

## Verification

- `bun run typecheck` clean.
- Targeted suites green (313 tests across the touched area: the new file + `sync-rename-batch`, `sync`, `source-id-tx-regression`, `sync-delete-batch`, `sync-reconcile-mass-delete`, `migrate`, `sync-failure-ledger`).
- `scripts/check-test-isolation.sh` green.
- Full suite deferred to CI (per contributor guidance to keep local runs targeted).
- Three rounds of external model review (Codex, high effort); all P1/P2 findings fixed and re-verified — including two data-loss hazards in the first reconcile cut that the final design closes (dedup-skip deleting the only copy; deleting by slug guess).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
