### PR TITLE
fix(remediation): terminate onboard --auto loop on a terminally-failed step (takeover of #2361)

### DIFF
--- a/src/core/brain-score-recommendations.ts
+++ b/src/core/brain-score-recommendations.ts
@@ -400,8 +400,12 @@ function pickMax(current: number, max: number, status: RemediationStatus | undef
 
 // ---------------------------------------------------------------------
 // Idempotency key construction (D9 — content-hash, no time-slot).
-// Same params produce the same key across runs. Failed-row replay
-// appends `:r<N>` (caller responsibility — handled by --remediate loop).
+// Same params produce the same key across runs (exactly-once dedup via the
+// queue's unique partial index). The --remediate loop attempts each step at
+// most once per run and excludes terminally-failed ids from later rechecks
+// (selectActiveRecs in remediation-step.ts); it does NOT mutate this key. The
+// `:r<N>` failed-row replay suffix was designed but never implemented and is
+// unnecessary given queue-level max_attempts.
 // ---------------------------------------------------------------------
 
 function idemKey(source: string, job: string, params: Record<string, unknown>): string {

--- a/src/core/remediation-step.ts
+++ b/src/core/remediation-step.ts
@@ -39,9 +39,14 @@ export type RemediationStatus = 'remediable' | 'human_only' | 'blocked';
  *                     References other steps via depends_on.
  *   job             — Minion handler name. Must match a registered handler.
  *   params          — passed verbatim to the handler.
- *   idempotency_key — content-hash dedup key. Same (job, params) →
- *                     same key. Across retries (--remediate re-runs)
- *                     pre-existing failed jobs append `:r<N>` suffix.
+ *   idempotency_key — content-hash dedup key. Same (job, params) → same
+ *                     key (exactly-once: the queue's unique partial index
+ *                     means a re-submit returns the existing row, terminal
+ *                     or not). The --remediate loop therefore attempts a
+ *                     step at most once per run and excludes terminally-
+ *                     failed ids from later rechecks (see selectActiveRecs);
+ *                     it does NOT mutate this key. The next scheduled run
+ *                     retries with a fresh abort set.
  *   severity        — drives ordering.
  *   est_seconds     — upper-bound runtime estimate for budgeting.
  *   est_usd_cost    — USD cost estimate when applicable.
@@ -149,4 +154,31 @@ export function makeRemediationStep(opts: {
     protected: opts.protected,
     status: opts.status ?? 'remediable',
   };
+}
+
+/**
+ * Select the steps that are still actionable on the current --remediate
+ * pass. The loop recomputes recommendations from fresh health after every
+ * step (D7); this filters that recomputed set to:
+ *   - status === 'remediable' (the only kind that executes), and
+ *   - ids NOT already in `abortedIds`.
+ *
+ * The second clause is the loop-termination guarantee. A step that reached a
+ * terminal NON-completed state this run (failed / dead / cancelled) is in
+ * `abortedIds`. Because idempotency keys are content-stable and queue.add
+ * already exhausted `max_attempts`, re-dispatching such a step returns the
+ * SAME terminal row forever — so if its underlying metric never improves the
+ * recommendation re-fires every recheck and the loop spins (the failure a
+ * cancelled job triggers under `onboard --auto`). Excluding aborted ids makes
+ * progress monotonic: each step is attempted at most once per run, then
+ * abandoned until the next scheduled run (which starts with an empty set).
+ *
+ * Pure + side-effect-free so the loop-progress invariant is unit-testable
+ * without the (deferred) Minion-worker stub harness.
+ */
+export function selectActiveRecs(
+  recs: RemediationStep[],
+  abortedIds: ReadonlySet<string>,
+): RemediationStep[] {
+  return recs.filter((r) => r.status === 'remediable' && !abortedIds.has(r.id));
 }

--- a/src/core/remediation/run.ts
+++ b/src/core/remediation/run.ts
@@ -15,7 +15,7 @@ import type { BrainEngine } from '../engine.ts';
 import {
   computeRecommendations,
 } from '../brain-score-recommendations.ts';
-import type { RemediationStep } from '../remediation-step.ts';
+import { selectActiveRecs, type RemediationStep } from '../remediation-step.ts';
 import { loadRecommendationContext } from './context.ts';
 import { computeRemediationPlan } from './plan.ts';
 import type {
@@ -246,6 +246,23 @@ export async function runRemediation(
         continue;
       }
 
+      // Forward-progress guard (loop-termination fix). A step in abortedIds
+      // already reached a terminal NON-completed state earlier this run.
+      // Idempotency keys are content-stable (same job+params → same key) and
+      // queue.add already retried via max_attempts, so re-dispatching returns
+      // the SAME terminal row forever — an infinite loop when the step's metric
+      // never improves (the failure a cancelled job triggers under
+      // onboard --auto). selectActiveRecs below normally keeps aborted ids out
+      // of recs; this is the explicit, locally-checkable backstop. Skip without
+      // re-adding to abortedIds (already present → aborted_count unaffected).
+      if (abortedIds.has(step.id)) {
+        const result: StepResult = { step: stepCount, id: step.id, job_id: null, status: 'skipped_already_aborted' };
+        submitted.push(result);
+        hooks.onStepEnd?.(result);
+        recs.shift();
+        continue;
+      }
+
       hooks.onStepStart?.(stepCount, totalSteps, step);
       try {
         const isProtected = !!step.protected;
@@ -300,12 +317,17 @@ export async function runRemediation(
       }
 
       recs.shift();
-      // D7: scoped recheck — re-compute plan from fresh health snapshot.
-      // The next plan may drop completed steps and re-introduce failed
-      // steps with bumped retry suffix (D1).
+      // D7: scoped recheck — re-compute the plan from a fresh health snapshot.
+      // selectActiveRecs drops completed steps (the metric improved, so the
+      // recommendation no longer fires) AND excludes ids already in abortedIds,
+      // so a terminally-failed/cancelled step is attempted at most once per run
+      // instead of being re-introduced every recheck. The `:r<N>` retry-suffix
+      // replay referenced by older comments was never implemented and is
+      // unnecessary: queue.add already retries via max_attempts, and the next
+      // scheduled run starts fresh (empty abortedIds).
       if (recs.length === 0 || stepCount >= maxJobs) break;
       const freshHealth = await engine.getHealth();
-      recs = computeRecommendations(freshHealth, ctx).filter((r) => r.status === 'remediable');
+      recs = selectActiveRecs(computeRecommendations(freshHealth, ctx), abortedIds);
     }
   };
 
@@ -323,7 +345,7 @@ export async function runRemediation(
 
   // Clear checkpoint on a clean run (no budget abort). Failed steps in the
   // submitted set don't disqualify the cleanup — they re-surface on the
-  // next plan with bumped suffixes.
+  // next scheduled run, which starts with a fresh abortedIds set.
   if (!budgetAbort) {
     clearRemediationCheckpoint(planHash);
   }

--- a/src/core/remediation/types.ts
+++ b/src/core/remediation/types.ts
@@ -67,7 +67,8 @@ export interface RemediationOpts {
 
 /**
  * Result of one step. status mirrors Minion job terminal states + a few
- * synthetic ones ('skipped_dep_aborted', 'skipped_completed_in_checkpoint').
+ * synthetic ones ('skipped_dep_aborted', 'skipped_already_aborted',
+ * 'skipped_completed_in_checkpoint', 'dry_run').
  */
 export interface StepResult {
   step: number;

--- a/test/remediation-loop-termination.test.ts
+++ b/test/remediation-loop-termination.test.ts
@@ -1,0 +1,90 @@
+// test/remediation-loop-termination.test.ts
+//
+// Regression test for the `onboard --auto` infinite loop (fix in
+// src/core/remediation/run.ts). A step whose job reaches a terminal
+// NON-completed state (failed / dead / cancelled) is recorded in the loop's
+// `abortedIds`. Before the fix, the per-step recheck (D7) recomputed the plan
+// from fresh health and re-introduced that step verbatim; because idempotency
+// keys are content-stable (same job+params → same key) and the job already
+// exhausted `max_attempts`, queue.add returned the SAME terminal row every
+// iteration and the loop spun until `maxJobs` (default Infinity). A cancelled
+// extract job under `onboard --auto` reproduced exactly this.
+//
+// `selectActiveRecs` is the extracted, pure progress-decision: it excludes
+// aborted ids from the recomputed set so loop progress is monotonic. Full
+// orchestrator e2e (real Minion handlers firing) stays deferred upstream until
+// the per-handler stub seam lands (see test/e2e/onboard-full-flow.test.ts) —
+// this pins the termination invariant at the decision boundary.
+
+import { describe, expect, test } from 'bun:test';
+import {
+  makeRemediationStep,
+  selectActiveRecs,
+  type RemediationStatus,
+} from '../src/core/remediation-step.ts';
+
+function step(id: string, status: RemediationStatus = 'remediable') {
+  return makeRemediationStep({
+    id,
+    job: id,
+    params: {},
+    severity: 'medium',
+    est_seconds: 10,
+    rationale: `step ${id}`,
+    status,
+  });
+}
+
+describe('selectActiveRecs — remediation loop termination', () => {
+  test('empty abortedIds: returns all remediable steps unchanged', () => {
+    const recs = [step('extract.all'), step('embed.stale')];
+    const out = selectActiveRecs(recs, new Set());
+    expect(out.map((r) => r.id)).toEqual(['extract.all', 'embed.stale']);
+  });
+
+  test('drops non-remediable steps (human_only / blocked)', () => {
+    const recs = [step('extract.all'), step('manual.only', 'human_only'), step('blk', 'blocked')];
+    const out = selectActiveRecs(recs, new Set());
+    expect(out.map((r) => r.id)).toEqual(['extract.all']);
+  });
+
+  test('excludes ids already in abortedIds (the core fix)', () => {
+    const recs = [step('extract.all'), step('embed.stale')];
+    const out = selectActiveRecs(recs, new Set(['extract.all']));
+    expect(out.map((r) => r.id)).toEqual(['embed.stale']);
+  });
+
+  test('infinite-loop scenario: a re-emitted aborted step is filtered out so recs drains', () => {
+    // Models the D7 recompute cycle. The recommendation keeps re-firing because
+    // its metric never improved (the job was cancelled), but once the step is in
+    // abortedIds it is excluded — so the active set strictly shrinks and the
+    // loop's `recs.length === 0` break fires instead of spinning forever.
+    const aborted = new Set<string>();
+    let recs = [step('extract.all')];
+
+    // iteration 1: step is dispatched, its job is cancelled → recorded aborted.
+    expect(selectActiveRecs(recs, aborted).map((r) => r.id)).toEqual(['extract.all']);
+    aborted.add('extract.all');
+
+    // recompute re-emits the SAME recommendation (health unchanged)…
+    recs = [step('extract.all')];
+    // …but selectActiveRecs now excludes it → empty → the loop terminates.
+    expect(selectActiveRecs(recs, aborted)).toEqual([]);
+  });
+
+  test('monotonic: once aborted, the id stays excluded across repeated rechecks', () => {
+    const aborted = new Set(['a']);
+    for (let i = 0; i < 5; i++) {
+      const out = selectActiveRecs([step('a'), step('b')], aborted);
+      expect(out.map((r) => r.id)).toEqual(['b']);
+    }
+  });
+
+  test('a NON-aborted sibling still runs while the aborted step is skipped', () => {
+    // Cascade sanity: aborting one step must not starve unrelated remediable
+    // steps — only the failed id is excluded.
+    const recs = [step('extract.all'), step('embed.stale'), step('backlinks.fix')];
+    const out = selectActiveRecs(recs, new Set(['embed.stale']));
+    expect(out.map((r) => r.id)).toEqual(['extract.all', 'backlinks.fix']);
+  });
+});


### PR DESCRIPTION
Supersedes #2361 (fork branch by @DarkNightForge, stalled behind fast-moving master). Diff re-applied 3-way onto current origin/master; author credited via Co-authored-by.

## Problem

`gbrain onboard --auto` / `doctor --remediate` can spin forever when a remediation step's job reaches a terminal non-completed state (failed/dead/cancelled) and its underlying health metric never improves.

## Root cause

The `runRemediation` D7 recheck (`src/core/remediation/run.ts`) recomputed recommendations from a fresh health snapshot without excluding ids already in `abortedIds`. Idempotency keys are content-stable and `queue.add` already carries `max_attempts`, so re-dispatching an aborted step hits the queue's exactly-once path and returns the same terminal row every iteration — with `maxJobs` defaulting to `Infinity`, the loop never terminates.

## Fix (caller-side; queue contract untouched)

- `selectActiveRecs(recs, abortedIds)` — new pure helper in `remediation-step.ts`; drops non-remediable steps AND ids already aborted, used at the D7 recompute. Each step is attempted at most once per run, then abandoned until the next scheduled run (fresh abort set).
- Top-of-loop `skipped_already_aborted` backstop.
- Queue idempotency in `minions/queue.ts` intentionally unchanged (shared exactly-once contract). Stale `:r<N>` replay-suffix comments (never implemented) updated to match reality.

## Testing

- `test/remediation-loop-termination.test.ts` (new) pins the termination invariant at the decision boundary.
- `bun run typecheck` exit 0.
- `bun test` on remediation-loop-termination, remediation-step, brain-score-recommendations, doctor (137 pass / 0 fail) + `test/e2e/onboard-full-flow.test.ts` (13 pass / 0 fail).

Versioning / CHANGELOG left to the maintainer's ship flow.

Co-authored-by: Nightforge (@DarkNightForge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)