### PR TITLE
fix(onboard): gate extract-ner / timeline recs on whether the action can actually help (takeover of #2362)

### DIFF
--- a/src/core/extract-ner.ts
+++ b/src/core/extract-ner.ts
@@ -19,7 +19,7 @@ import type { BrainEngine } from './engine.ts';
 import type { LinkBatchInput } from './engine.ts';
 import { buildGazetteer, findMentionedEntities, type Gazetteer } from './by-mention.ts';
 import { inferLinkTypeFromPack } from './schema-pack/link-inference.ts';
-import { loadActivePackBestEffort } from './schema-pack/best-effort.ts';
+import { loadActivePackBestEffort, packSupportsNerInference } from './schema-pack/best-effort.ts';
 
 export interface ExtractNerOpts {
   /** When true: enumerate but don't write. */
@@ -103,17 +103,14 @@ export async function extractNerLinks(
 ): Promise<ExtractNerResult> {
   const dryRun = opts.dryRun ?? false;
 
-  // Pack best-effort: no pack → no inference → nothing to do.
+  // Pack best-effort: no pack, or no link_type with an inference.regex → NER
+  // has no patterns to match and we'd waste a full walk. `!pack` first so TS
+  // narrows pack to non-null for the rest of the function; packSupportsNerInference
+  // (shared with the onboard recommender) covers the no-link-types / no-regex cases.
   const pack = await loadActivePackBestEffort({ engine } as never);
-  if (!pack || !pack.manifest?.link_types || pack.manifest.link_types.length === 0) {
+  if (!pack || !packSupportsNerInference(pack)) {
     return { pages: 0, created: 0, pack_unavailable: true };
   }
-  // Require at least one link_type with an inference.regex; otherwise NER
-  // has no patterns to match and we'd waste a full walk.
-  const hasRegex = pack.manifest.link_types.some(
-    (lt) => lt.inference && typeof lt.inference === 'object' && 'regex' in lt.inference,
-  );
-  if (!hasRegex) return { pages: 0, created: 0, pack_unavailable: true };
 
   const gazetteer = opts.gazetteer ?? await buildGazetteer(engine);
   if (gazetteer.size === 0) {

--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -18,6 +18,7 @@
 import type { BrainEngine } from '../engine.ts';
 import type { RemediationStep } from '../remediation-step.ts';
 import { makeRemediationStep } from '../remediation-step.ts';
+import { loadActivePackBestEffort, packSupportsNerInference } from '../schema-pack/best-effort.ts';
 
 /** Shared shape returned by all four checks. */
 export interface OnboardCheckResult {
@@ -170,32 +171,29 @@ export async function checkEntityLinkCoverage(
   // surfaces the same fix via the onboard plan either way.
   if (coverage >= 0.7) {
     message = `Coverage ${pct}% ± ${ciPct}%${sampleNote}`;
-  } else if (coverage >= 0.4) {
-    status = 'warn';
-    message = `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_ner_links',
-      job: 'extract-ner',
-      params: {},
-      severity: 'medium',
-      est_seconds: 300,
-      est_usd_cost: 0,
-      rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
-      status: 'remediable',
-    }));
   } else {
     status = 'warn';
     message = `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_ner_links',
-      job: 'extract-ner',
-      params: {},
-      severity: 'high',
-      est_seconds: 600,
-      est_usd_cost: 0,
-      rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
-      status: 'remediable',
-    }));
+    // Only recommend NER extraction if the active pack actually declares
+    // inference.regex rules — otherwise `extract-ner` is a structural no-op
+    // (pack_unavailable, 0 links) and the recommendation could never clear.
+    // Gate on the SAME predicate the handler uses so the two can't drift.
+    const pack = await loadActivePackBestEffort({ engine } as never);
+    if (packSupportsNerInference(pack)) {
+      remediations.push(makeRemediationStep({
+        id: 'onboard.extract_ner_links',
+        job: 'extract-ner',
+        params: {},
+        severity: coverage >= 0.4 ? 'medium' : 'high',
+        est_seconds: coverage >= 0.4 ? 300 : 600,
+        est_usd_cost: 0,
+        rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
+        status: 'remediable',
+      }));
+    } else {
+      message += ' — no auto-fix: the active schema pack declares no NER inference rules'
+        + ' (add link_types[].inference.regex, or upgrade the pack)';
+    }
   }
   return {
     check: { name: 'entity_link_coverage', status, message },
@@ -259,32 +257,31 @@ export async function checkTimelineCoverage(
   // code doesn't flip on a fresh brain.
   if (coverage >= 0.9) {
     message = `Coverage ${pct}% ± ${ciPct}%${sampleNote}`;
-  } else if (coverage >= 0.7) {
-    status = 'warn';
-    message = `Coverage ${pct}% ± ${ciPct}% (target 90%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_timeline_from_meetings',
-      job: 'extract-timeline-from-meetings',
-      params: {},
-      severity: 'medium',
-      est_seconds: 240,
-      est_usd_cost: 0,
-      rationale: `Timeline coverage at ${pct}%; meeting-derived entries lift it`,
-      status: 'remediable',
-    }));
   } else {
     status = 'warn';
     message = `Coverage ${pct}% ± ${ciPct}% (target 90%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_timeline_from_meetings',
-      job: 'extract-timeline-from-meetings',
-      params: {},
-      severity: 'high',
-      est_seconds: 480,
-      est_usd_cost: 0,
-      rationale: `Timeline coverage at ${pct}%; meeting-derived entries lift it`,
-      status: 'remediable',
-    }));
+    // Only recommend meeting-derived timeline extraction if there are dated
+    // meeting pages to extract FROM — otherwise the job creates 0 entries
+    // (it skips meetings without effective_date) and the rec never clears.
+    const datableMeetings = await safeCount(
+      engine,
+      `SELECT COUNT(*) AS count FROM pages
+         WHERE type = 'meeting' AND effective_date IS NOT NULL AND deleted_at IS NULL`,
+    );
+    if (datableMeetings > 0) {
+      remediations.push(makeRemediationStep({
+        id: 'onboard.extract_timeline_from_meetings',
+        job: 'extract-timeline-from-meetings',
+        params: {},
+        severity: coverage >= 0.7 ? 'medium' : 'high',
+        est_seconds: coverage >= 0.7 ? 240 : 480,
+        est_usd_cost: 0,
+        rationale: `Timeline coverage at ${pct}%; meeting-derived entries lift it`,
+        status: 'remediable',
+      }));
+    } else {
+      message += ' — no auto-fix: no dated meeting pages to extract timeline entries from';
+    }
   }
   return {
     check: { name: 'timeline_coverage', status, message },

--- a/src/core/schema-pack/best-effort.ts
+++ b/src/core/schema-pack/best-effort.ts
@@ -57,3 +57,22 @@ export async function loadActivePackBestEffort(
     return null;
   }
 }
+
+/**
+ * Does the active pack declare at least one `link_types[].inference.regex`
+ * rule? This is the EXACT capability `extractNerLinks` requires — without it,
+ * NER extraction is a structural no-op (returns `pack_unavailable`, 0 links).
+ *
+ * Shared so the onboard recommender (`checks.ts`, which suggests `extract-ner`)
+ * and the handler (`extract-ner.ts`) gate on ONE definition. Recommending a
+ * fix the handler will silently skip is the phantom-recommendation bug this
+ * closes; co-locating the predicate with the loader keeps the two from drifting
+ * (same anti-drift rationale as `loadActivePackBestEffort` above).
+ */
+export function packSupportsNerInference(pack: ResolvedPack | null | undefined): boolean {
+  const linkTypes = pack?.manifest?.link_types;
+  if (!linkTypes || linkTypes.length === 0) return false;
+  return linkTypes.some(
+    (lt) => lt.inference && typeof lt.inference === 'object' && 'regex' in lt.inference,
+  );
+}

--- a/test/onboard-phantom-rec-gates.test.ts
+++ b/test/onboard-phantom-rec-gates.test.ts
@@ -1,0 +1,123 @@
+// test/onboard-phantom-rec-gates.test.ts
+//
+// Regression test for phantom onboard recommendations — recs that fire on a
+// coverage metric but recommend an action that structurally cannot move it,
+// so they persist forever (the `onboard --check` nag that confused a
+// maintenance agent: it ran the direct equivalents, they no-op'd, the recs
+// stayed). See reports/onboard-auto-loop-2026-06-22 (companion to the loop fix).
+//
+// Two gates:
+//   - extract-ner is only recommended when the active pack actually declares
+//     NER inference rules (packSupportsNerInference) — the SAME predicate the
+//     handler gates on, so recommender and handler can't drift.
+//   - extract-timeline-from-meetings is only recommended when there is at least
+//     one dated meeting page to extract FROM.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { checkEntityLinkCoverage, checkTimelineCoverage } from '../src/core/onboard/checks.ts';
+import { packSupportsNerInference } from '../src/core/schema-pack/best-effort.ts';
+import type { ResolvedPack } from '../src/core/schema-pack/registry.ts';
+import { _resetPackCacheForTests } from '../src/core/schema-pack/registry.ts';
+import { _resetPackLocatorForTests } from '../src/core/schema-pack/load-active.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  _resetPackCacheForTests();
+  _resetPackLocatorForTests();
+});
+
+async function seedEntities(n: number) {
+  for (let i = 0; i < n; i++) {
+    await engine.putPage(`person-${i}`, {
+      title: `Person ${i}`,
+      type: 'person' as never,
+      compiled_truth: 'body that is long enough to pass any minimum-length guards in the codebase',
+      timeline: '', frontmatter: {}, source_path: `people/person-${i}.md`,
+    });
+  }
+}
+
+// Minimal pack-shaped object for the pure predicate (only manifest.link_types read).
+function fakePack(linkTypes: unknown[]): ResolvedPack {
+  return { manifest: { link_types: linkTypes } } as unknown as ResolvedPack;
+}
+
+describe('packSupportsNerInference (shared recommender/handler gate)', () => {
+  it('false for null/undefined', () => {
+    expect(packSupportsNerInference(null)).toBe(false);
+    expect(packSupportsNerInference(undefined)).toBe(false);
+  });
+
+  it('false when the pack declares no link_types', () => {
+    expect(packSupportsNerInference(fakePack([]))).toBe(false);
+  });
+
+  it('false when no link_type has an inference.regex (the real gbrain-base case)', () => {
+    expect(packSupportsNerInference(fakePack([
+      { verb: 'mentions' },
+      { verb: 'works_at', inference: { gazetteer: true } }, // inference, but no regex
+    ]))).toBe(false);
+  });
+
+  it('true when at least one link_type carries an inference.regex', () => {
+    expect(packSupportsNerInference(fakePack([
+      { verb: 'mentions' },
+      { verb: 'cites', inference: { regex: '\\bRFC\\s?\\d+\\b' } },
+    ]))).toBe(true);
+  });
+});
+
+describe('checkEntityLinkCoverage — NER capability gate', () => {
+  it('low coverage + pack without NER rules → WARN but NO extract-ner rec, with a reason', async () => {
+    // Fresh brain's active pack (gbrain-base) has no inference.regex link_types,
+    // so packSupportsNerInference is false → the rec must be withheld.
+    await seedEntities(3); // entity pages, zero inbound links → coverage 0%
+    const { check, remediations } = await checkEntityLinkCoverage(engine);
+    expect(check.status).toBe('warn');
+    expect(remediations).toHaveLength(0);
+    expect(check.message).toContain('no auto-fix');
+    expect(check.message).toContain('NER inference rules');
+  });
+});
+
+describe('checkTimelineCoverage — datable-meetings gate', () => {
+  it('low coverage + zero dated meetings → WARN but NO rec, with a reason', async () => {
+    await seedEntities(3); // entity pages with no timeline entries → coverage 0%
+    const { check, remediations } = await checkTimelineCoverage(engine);
+    expect(check.status).toBe('warn');
+    expect(remediations).toHaveLength(0);
+    expect(check.message).toContain('no auto-fix');
+    expect(check.message).toContain('dated meeting');
+  });
+
+  it('low coverage + a dated meeting present → recommends extract-timeline-from-meetings', async () => {
+    await seedEntities(3);
+    await engine.putPage('m0', {
+      title: 'Standup', type: 'meeting' as never,
+      compiled_truth: 'body that is long enough to pass any minimum-length guards in the codebase',
+      timeline: '', frontmatter: {}, source_path: 'meetings/m0.md',
+    });
+    await engine.executeRaw(
+      `UPDATE pages SET effective_date = '2026-01-01' WHERE slug = $1`,
+      ['m0'],
+    );
+    const { check, remediations } = await checkTimelineCoverage(engine);
+    expect(check.status).toBe('warn');
+    expect(remediations).toHaveLength(1);
+    expect(remediations[0]?.job).toBe('extract-timeline-from-meetings');
+  });
+});


### PR DESCRIPTION
Supersedes #2362 (fork branch went stale against fast-moving master; diff re-applied 3-way onto current master, applies cleanly). Full credit to @DarkNightForge — Co-authored-by preserved on the commit.

## Problem

`gbrain onboard --check --explain` surfaces remediations that can never clear, because they're emitted purely on a coverage threshold with no check that the recommended job is capable of moving the metric:

- **`extract-ner`** is recommended whenever `entity_link_coverage` is low — even when the active schema pack declares no `link_types[].inference.regex` rules. `extractNerLinks` then early-returns `pack_unavailable`, creates 0 links, and the rec re-fires forever.
- **`extract-timeline-from-meetings`** is recommended whenever `timeline_coverage` is low — even with no dated meeting pages. The handler skips meetings without `effective_date`, so it creates 0 entries and the rec persists.

## Fix

- **`packSupportsNerInference(pack)`** extracted into `src/core/schema-pack/best-effort.ts` — the exact capability `extractNerLinks` already checks. The handler and the onboard recommender now gate on one definition and can't drift.
- **Timeline gate** — `checkTimelineCoverage` only emits the rec when a dated meeting page exists, matching the handler's own precondition.
- When a gate withholds the rec, the check stays WARN (coverage really is low) and the message explains why there's no auto-fix. Merged coverage branches preserve the original severity/est_seconds tiers via ternaries.

`checks.ts` is intentionally brain-wide (`sourcescope:file-brain-wide` header) — the new COUNT query follows the file's existing pattern.

## Testing

- `test/onboard-phantom-rec-gates.test.ts` (new): pins `packSupportsNerInference` (null / no link_types / inference-without-regex / regex present) plus PGLite engine tests for both gates — withheld-with-reason when capability/content is absent, emitted when a dated meeting exists.
- `bun run typecheck` exit 0.
- `bun test test/onboard-phantom-rec-gates.test.ts test/schema-pack-best-effort.test.ts test/onboard-pack-upgrade-checks.test.ts` — 19 pass / 0 fail.

Versioning/CHANGELOG left to the maintainer's ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)