### PR TITLE
fix(ai): Ollama compatibility fixes for local-first usage (takeover of #1854)

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -33,6 +33,20 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
+    expansion: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
   },
   setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
 };

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -361,6 +361,11 @@ function isAxisScoreInRange(n: unknown): n is number {
 function validateIdeaShape(raw: unknown): { id: string; scores: JudgeAxisScores; note: string } | null {
   if (typeof raw !== 'object' || raw === null) return null;
   const r = raw as Record<string, unknown>;
+  // Some models (e.g. Kimi K2) return numeric ids instead of string ids like "Idea 01".
+  // Coerce to string for compatibility.
+  if (typeof r.id === 'number') {
+    r.id = 'Idea ' + String(r.id).padStart(2, '0');
+  }
   if (typeof r.id !== 'string') return null;
   const note = typeof r.note === 'string' ? r.note : '';
   const s = r.scores;

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -156,6 +156,20 @@ const FREE_LOCAL_EMBED_PROVIDERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Provider id prefixes whose chat models run on local inference (electricity,
+ * not API tokens) and so price at $0. Without this, a `--max-cost`-bounded
+ * brainstorm/lsd configured for a local chat provider TX2 hard-fails because
+ * lookupPricing has no entry for them. Matched against the provider half
+ * of the `provider:model` string.
+ *
+ * Sibling to FREE_LOCAL_EMBED_PROVIDERS and FREE_LOCAL_RERANK_PROVIDERS.
+ */
+const FREE_LOCAL_CHAT_PROVIDERS: ReadonlySet<string> = new Set([
+  'ollama',
+  'llama-server',
+]);
+
+/**
  * Look up `modelId` in the chat or embedding pricing maps. Returns a
  * per-1M-token price tuple, or null when unknown.
  *
@@ -199,6 +213,9 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   // under `--max-cost`. Only the rerank kind — chat/embed already have
   // their own provider-specific pricing surfaces.
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
+    return { input: 0, output: 0 };
+  }
+  if (kind === 'chat' && providerId && FREE_LOCAL_CHAT_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
   return null;

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -815,7 +815,7 @@ function buildGracefulMessage(modelStr: string): {
     type: 'message',
     role: 'assistant',
     model: modelStr,
-    content: [{ type: 'text', text: '(no LLM available — set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env)' }],
+    content: [{ type: 'text', text: '(no LLM available — set chat_model, expansion_model, or anthropic_api_key via gbrain config)' }],
     usage: { input_tokens: 0, output_tokens: 0 },
     stop_reason: 'end_turn',
   };


### PR DESCRIPTION
Supersedes #1854 (fork branch stalled against fast-moving master). Credit to @starm2010 — authorship preserved via Co-authored-by.

## What landed (4 of the original 5 fixes)

1. **`--max-cost` no longer hard-fails on local chat providers**: new `FREE_LOCAL_CHAT_PROVIDERS` set (`ollama`, `llama-server`) in `src/core/budget/budget-tracker.ts` returns zero pricing, sibling to the existing `FREE_LOCAL_EMBED_PROVIDERS` / `FREE_LOCAL_RERANK_PROVIDERS`.
2. **Numeric idea IDs no longer crash brainstorm judges**: `validateIdeaShape` coerces numeric `id` (`5` → `"Idea 05"`) before the string type check (some models, e.g. Kimi K2 via Ollama, emit numeric ids).
3. **Clearer "no LLM available" message**: `buildGracefulMessage` in `src/core/think/index.ts` now mentions `chat_model`, `expansion_model`, or `anthropic_api_key` — that sentinel can fire for any provider, not just Anthropic.
4. **Ollama recipe gains chat + expansion touchpoints** (`llama3.3`, `qwen3`, `deepseek-r1`; `supports_tools: true`, zero cost) so the recipe system can route reasoning calls to Ollama.

## What was dropped as already superseded

The original fix #3 (scope the `NO_ANTHROPIC_API_KEY` warning to `providerId === 'anthropic'`) is obsolete on current master: the #1698 probe work in `runThink` already distinguishes `MODEL_NOT_USABLE` from `NO_ANTHROPIC_API_KEY`, and `probeChatModel` only returns `'unavailable'` for anthropic-without-key — so a non-Anthropic provider can no longer produce a false `NO_ANTHROPIC_API_KEY`.

## Testing

- `bun run typecheck` exit 0
- 217 tests pass across the 16 test files touching the changed areas (budget-tracker, brainstorm, think gateway adapter, recipes regression, model-pricing drift guard, providers)

Related: #1307, #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)