### PR TITLE
fix(test): swap downstream-fork real name for the agent-fork placeholder — unbreaks check:test-names on master

### DIFF
--- a/test/autopilot-install.test.ts
+++ b/test/autopilot-install.test.ts
@@ -108,7 +108,7 @@ describe('autopilot wrapper script — env source order (v0.36.1.x #966)', () =>
 // operators put in ~/.bashrc never reach this subprocess. Without the
 // explicit export the wrapper silently dies with `env: bun: No such file
 // or directory`, leaves a stale lockfile, and blocks every subsequent tick
-// for the 10-min stale-lock window. Regression: see Hermes `cron doctor`
+// for the 10-min stale-lock window. Regression: see agent-fork `cron doctor`
 // reports — this caused a 1-week nightly-cycle outage on at least one
 // operator machine before being diagnosed.
 describe('autopilot wrapper script — bun PATH export (v0.42.x regression)', () => {


### PR DESCRIPTION
## Summary

`verify` has been failing on master since #2013 merged: its comment in `test/autopilot-install.test.ts` names the downstream agent fork, which `scripts/check-test-real-names.sh` bans in `test/` fixtures:

```
check-test-real-names: banned real-name references found in test/ fixtures.
test/autopilot-install.test.ts:111:// … Regression: see Hermes `cron doctor`
```

Every open PR inherits the red `verify` through the merge ref, so this blocks the whole queue, not just master pushes.

## Change

One word in one comment: the banned name → the checker's canonical `agent-fork` placeholder. The fork's identity isn't load-bearing for the comment (it documents a cron PATH regression), so this follows the checker's stated preference for placeholders over a fourth ALLOWLIST entry.

## Verification

- `bun run check:test-names` on master: exit 1 → exit 0 with this change.
- Comment-only; no executable code touched.