### PR TITLE
fix(mcp): let the search tool scope to a single source (+ search --json)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -466,7 +466,7 @@ async function main() {
     // routed path. Date → ISO string; bigint → string (postgres.js shape);
     // Buffer → object. Microsecond-cost; eliminates a whole drift bug class.
     const result = JSON.parse(JSON.stringify(rawResult, bigintToStringReplacer));
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     // v0.42.20.0 (codex D4): on error, set exitCode + return so the `finally`
@@ -549,7 +549,7 @@ async function runThinClientRouted(
       signal: sigintController.signal,
     });
     const result = unpackToolResult(raw);
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     if (e instanceof RemoteMcpError) {
@@ -840,7 +840,7 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
 }
 
 // Exported for tests (same import-safety contract as cliAliases/printOpHelp).
-export function formatResult(opName: string, result: unknown): string {
+export function formatResult(opName: string, result: unknown, params?: Record<string, unknown>): string {
   switch (opName) {
     case 'volunteer_context': {
       const r = result as any;
@@ -879,6 +879,10 @@ export function formatResult(opName: string, result: unknown): string {
     case 'search':
     case 'query': {
       const results = result as any[];
+      // `--json` (search op only, see its param doc): checked before the
+      // "No results." short-circuit below so scripts/agents piping
+      // `gbrain search --json` always get parseable JSON, including `[]`.
+      if (params?.json === true) return JSON.stringify(results, null, 2) + '\n';
       if (results.length === 0) return 'No results.\n';
       // v0.40.4 — --explain switches to per-stage attribution formatter.
       // Reads CliOptions.explain via the module-level singleton.

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1446,13 +1446,41 @@ const search: Operation = {
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     mode: { type: 'string', description: 'Search mode (conservative|balanced|tokenmax). Local callers only.' },
+    // v0.43.x (reported by morzu117/swairm — a multi-source consumer wiring a
+    // 2nd repo into one shared brain): `search` lacked the per-call source
+    // override that `query`, `search_by_image`, and the code-intel ops
+    // (code_callers/code_callees/code_blast/code_flow) already have via
+    // `resolveRequestedScope`. `search` fell back to `sourceScopeOpts(ctx)`
+    // only, so an MCP tool-caller had no way to scope a single tool call to
+    // one source — only the CLI's `--source` flag (which sets ctx.sourceId
+    // for the whole invocation) worked.
+    source_id: {
+      type: 'string',
+      description:
+        "Scope this search to a single source. Defaults to OperationContext.sourceId (set from CLI --source / GBRAIN_SOURCE / .gbrain-source dotfile). Pass '__all__' to span every source for trusted local callers; for remote callers '__all__' spans only your granted sources.",
+    },
+    // CLI-rendering-only, mirrors the `mode` param's "local callers only"
+    // convention above — the handler always returns the full structured
+    // result (MCP responses are JSON already); this only switches the CLI's
+    // text formatter (src/cli.ts formatResult) from the one-line-per-result
+    // view to raw `JSON.stringify(results)` so scripts/agents piping
+    // `gbrain search` don't have to parse the human format.
+    json: {
+      type: 'boolean',
+      description: 'CLI only: print raw JSON results instead of the human-readable one-line-per-result format.',
+    },
   },
   handler: async (ctx, p) => {
     const startedAt = Date.now();
     const queryText = p.query as string;
     const limit = (p.limit as number) || 20;
     const offset = (p.offset as number) || 0;
-    const scope = sourceScopeOpts(ctx);
+    // Explicit per-call source_id wins over ctx.sourceId; resolveRequestedScope
+    // is the single trust+grant resolver shared by every source-scoped read op
+    // (see its docstring) — remote callers get permission_denied for an
+    // out-of-grant source_id instead of a silent cross-source leak.
+    const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
+    const scope = resolveRequestedScope(ctx, sourceIdParam);
 
     // T4/D5 — per-call mode honored ONLY for trusted/local callers so a remote
     // OAuth client can't escalate to the costly tokenmax bundle. Local + unknown

--- a/test/cli-format-search-json.test.ts
+++ b/test/cli-format-search-json.test.ts
@@ -1,0 +1,36 @@
+/**
+ * `search --json` (reported by morzu117/swairm alongside the source_id fix):
+ * scripts/agents piping `gbrain search` shouldn't have to parse the human
+ * one-line-per-result format. formatResult's `params.json` branch returns raw
+ * JSON — checked BEFORE the "No results." short-circuit so an empty result set
+ * is still valid JSON (`[]`), and only when params are threaded (a regression
+ * guard: the flag was inert until both cli.ts call sites passed `params`).
+ */
+import { describe, test, expect } from 'bun:test';
+import { formatResult } from '../src/cli.ts';
+
+const RESULTS = [
+  { slug: 'notes/alpha-doc', source_id: 'alpha', title: 'Alpha Doc', score: 0.9 },
+  { slug: 'notes/beta-doc', source_id: 'beta', title: 'Beta Doc', score: 0.7 },
+];
+
+describe('formatResult — search --json', () => {
+  test('json:true returns parseable JSON of the full result array', () => {
+    const out = formatResult('search', RESULTS, { json: true });
+    const parsed = JSON.parse(out);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].slug).toBe('notes/alpha-doc');
+  });
+
+  test('json:true on an empty result set returns "[]", not the human "No results." line', () => {
+    const out = formatResult('search', [], { json: true });
+    expect(JSON.parse(out)).toEqual([]);
+    expect(out).not.toContain('No results.');
+  });
+
+  test('without params (default CLI path) still renders the human format, not JSON', () => {
+    const out = formatResult('search', RESULTS);
+    expect(() => JSON.parse(out)).toThrow();
+    expect(out).toContain('notes/alpha-doc');
+  });
+});

--- a/test/mcp-search-source-scope.test.ts
+++ b/test/mcp-search-source-scope.test.ts
@@ -1,0 +1,153 @@
+/**
+ * MCP `search` tool — per-call source scoping (reported by morzu117/swairm,
+ * a multi-source consumer wiring a 2nd repo into one shared brain).
+ *
+ * Pre-fix bug: the `search` op's params had no `source_id` field, and its
+ * handler called plain `sourceScopeOpts(ctx)` — it could ONLY see the
+ * source baked into the OperationContext (CLI `--source` / GBRAIN_SOURCE /
+ * per-token grant). An MCP tool-caller had no way to scope a single
+ * `search` tool call to one source; `query`, `search_by_image`, and the
+ * code-intel ops already supported this via `resolveRequestedScope`.
+ *
+ * This test goes through `dispatchToolCall` — the same code path stdio MCP
+ * and HTTP MCP both use — so it proves the fix end-to-end at the transport
+ * boundary, not just at the op-handler unit level (see
+ * test/source-scope-resolver.test.ts for the resolver's own unit matrix).
+ *
+ * Runs against PGLite in-memory. No DATABASE_URL, no API keys — the search
+ * op is forced into its keyword-only path (`search.mcp_keyword_only`) so
+ * the assertions don't depend on an embedding provider being configured.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { dispatchToolCall } from '../src/mcp/dispatch.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('search.mcp_keyword_only', 'true');
+
+  // Two sources, each with a page carrying a distinct, greppable keyword so
+  // a cross-source leak is unambiguous in the assertions below.
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, config) VALUES ('alpha', 'alpha', '{"federated": true}'::jsonb) ON CONFLICT (id) DO NOTHING`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, config) VALUES ('beta', 'beta', '{"federated": true}'::jsonb) ON CONFLICT (id) DO NOTHING`,
+  );
+  await engine.putPage('notes/alpha-doc', {
+    type: 'note',
+    title: 'Alpha Doc',
+    compiled_truth: 'This page mentions zylophant, a keyword unique to the alpha source.',
+  }, { sourceId: 'alpha' });
+  await engine.putPage('notes/beta-doc', {
+    type: 'note',
+    title: 'Beta Doc',
+    compiled_truth: 'This page mentions quixotron, a keyword unique to the beta source.',
+  }, { sourceId: 'beta' });
+
+  // v0.42.x migration 124 dropped compiled_truth from the search vector
+  // (#2704 — it was overflowing tsvector on large pages). searchKeyword
+  // ranks off content_chunks.search_vector, so seed a chunk per page
+  // directly (same pattern as test/pages-soft-delete.test.ts) — the schema
+  // trigger populates search_vector from chunk_text.
+  const alphaPage = await engine.getPage('notes/alpha-doc', { sourceId: 'alpha' });
+  const betaPage = await engine.getPage('notes/beta-doc', { sourceId: 'beta' });
+  await engine.executeRaw(
+    `INSERT INTO content_chunks (page_id, chunk_index, chunk_text, chunk_source) VALUES ($1, 0, 'This page mentions zylophant, a keyword unique to the alpha source.', 'compiled_truth')`,
+    [alphaPage!.id],
+  );
+  await engine.executeRaw(
+    `INSERT INTO content_chunks (page_id, chunk_index, chunk_text, chunk_source) VALUES ($1, 0, 'This page mentions quixotron, a keyword unique to the beta source.', 'compiled_truth')`,
+    [betaPage!.id],
+  );
+});
+
+describe('MCP search tool — source_id per-call scope', () => {
+  test('no source_id + ctx.sourceId=alpha: search "zylophant" hits, "quixotron" misses', async () => {
+    const hit = await dispatchToolCall(engine, 'search', { query: 'zylophant' }, {
+      remote: true,
+      sourceId: 'alpha',
+    });
+    const hitResults = JSON.parse(hit.content[0].text);
+    expect(hit.isError).toBeFalsy();
+    expect(hitResults.length).toBeGreaterThan(0);
+    expect(hitResults.every((r: any) => r.slug === 'notes/alpha-doc')).toBe(true);
+
+    const miss = await dispatchToolCall(engine, 'search', { query: 'quixotron' }, {
+      remote: true,
+      sourceId: 'alpha',
+    });
+    const missResults = JSON.parse(miss.content[0].text);
+    expect(missResults.length).toBe(0);
+  });
+
+  test('explicit source_id="beta" overrides ctx.sourceId="alpha" for a single tool call', async () => {
+    // ctx.sourceId is 'alpha' (as if the token / stdio env defaulted there),
+    // but this ONE tool call asks for beta — the whole point of the fix.
+    const result = await dispatchToolCall(engine, 'search', {
+      query: 'quixotron',
+      source_id: 'beta',
+    }, {
+      remote: true,
+      sourceId: 'alpha',
+    });
+    expect(result.isError).toBeFalsy();
+    const results = JSON.parse(result.content[0].text);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r: any) => r.slug === 'notes/beta-doc')).toBe(true);
+  });
+
+  test('a remote federated grant rejects an out-of-grant source_id (permission_denied)', async () => {
+    const result = await dispatchToolCall(engine, 'search', {
+      query: 'quixotron',
+      source_id: 'beta',
+    }, {
+      remote: true,
+      sourceId: 'alpha',
+      auth: { token: 't', clientId: 'c', scopes: ['read'], allowedSources: ['alpha'] } as any,
+    });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('permission_denied');
+  });
+
+  test('a remote federated grant allows an in-grant source_id', async () => {
+    const result = await dispatchToolCall(engine, 'search', {
+      query: 'quixotron',
+      source_id: 'beta',
+    }, {
+      remote: true,
+      sourceId: 'alpha',
+      auth: { token: 't', clientId: 'c', scopes: ['read'], allowedSources: ['alpha', 'beta'] } as any,
+    });
+    expect(result.isError).toBeFalsy();
+    const results = JSON.parse(result.content[0].text);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r: any) => r.slug === 'notes/beta-doc')).toBe(true);
+  });
+
+  test('source_id="__all__" from a trusted local (remote:false) caller spans both sources', async () => {
+    const result = await dispatchToolCall(engine, 'search', {
+      query: 'zylophant OR quixotron',
+      source_id: '__all__',
+    }, {
+      remote: false,
+      sourceId: 'alpha',
+    });
+    expect(result.isError).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Problem

The MCP `search` tool has no per-call source override. Its params lack a `source_id` field and its handler uses plain `sourceScopeOpts(ctx)`, so it can only see the source baked into the `OperationContext` (CLI `--source` / `GBRAIN_SOURCE` / per-token grant). `query`, `search_by_image`, and the code-intel ops (`code_callers`/`code_callees`/`code_blast`/`code_flow`) already support per-call scoping via `resolveRequestedScope`.

A multi-source consumer wiring a second repo into one shared brain (reported by **morzu117/swairm**) hit this: there was no way to scope a single `search` **tool call** to one source — only the CLI's whole-invocation `--source` flag worked.

## Fix

- **`search` op:** add an optional `source_id` param and resolve it through the shared `resolveRequestedScope(ctx, source_id)` — the same trust+grant resolver the other source-scoped reads use. Remote callers now get `permission_denied` for an out-of-grant source instead of a silent cross-source result; `'__all__'` spans every source for trusted local callers and only granted sources for remote callers. Backward-compatible: omitting `source_id` keeps the exact prior behavior (falls back to `ctx.sourceId`).
- **`search --json`:** CLI-only raw-JSON output (mirrors the existing `mode` "local callers only" convention) so scripts/agents piping `gbrain search` don't have to parse the human one-line-per-result format. `params` is now threaded through both `formatResult` call sites (the flag was otherwise inert).

## Tests

- `test/mcp-search-source-scope.test.ts` drives `dispatchToolCall` — the real stdio + HTTP MCP path — across default ctx scope, explicit `source_id` override, remote grant allow/deny (`permission_denied`), and `'__all__'`. Runs against in-memory PGLite, keyword-only (no embedding provider needed).
- `test/cli-format-search-json.test.ts` covers the `--json` formatter, including the empty-set edge (`[]`, not `No results.`) and confirms the default path still renders the human format.

30/30 green across the touched surface (`bun test` on the two new files + `cli-format-volunteer` + `source-scope-resolver`).

---
Contributed from the [swarph](https://swarph.ai) project, which runs gbrain as its semantic-memory layer. Thanks for gbrain! 🧠
