### PR TITLE
fix(takes): query the active row before superseding

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -291,7 +291,7 @@ async function cmdSupersede(engine: BrainEngine, args: string[], sourceId?: stri
     const pageId = await getPageId(engine, slug, sourceId);
 
     // Read existing row to inherit kind/holder unless overridden
-    const existing = await engine.listTakes({ page_id: pageId, active: false, limit: 500 });
+    const existing = await engine.listTakes({ page_id: pageId, active: true, limit: 500 });
     const target = existing.find(t => t.row_num === rowNum);
     if (!target) {
       console.error(`Row #${rowNum} not found on ${slug}.`);

--- a/test/takes-command-source-scope.test.ts
+++ b/test/takes-command-source-scope.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runTakes } from '../src/commands/takes.ts';
-import type { BrainEngine, TakeBatchInput } from '../src/core/engine.ts';
+import type { BrainEngine, TakeBatchInput, TakesListOpts } from '../src/core/engine.ts';
 import { withEnv } from './helpers/with-env.ts';
 
 const tmpRoots: string[] = [];
@@ -149,5 +149,49 @@ describe('gbrain takes CLI source scoping', () => {
     expect(pageLookups).toHaveLength(0);
     expect(added).toHaveLength(0);
     expect(existsSync(join(brainDir, 'shared/page.md'))).toBe(false);
+  });
+
+  test('supersede looks up the active row it is replacing (#2663)', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-takes-supersede-'));
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-takes-home-'));
+    tmpRoots.push(brainDir, home);
+    const listCalls: TakesListOpts[] = [];
+    const engine = {
+      getConfig: async () => null,
+      executeRaw: async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('FROM sources WHERE id = $1')) return [{ id: params[0] as string }];
+        if (sql.includes('FROM sources WHERE local_path IS NOT NULL')) return [];
+        if (sql.includes('FROM pages WHERE slug = $1 AND source_id = $2')) return [{ id: 11 }];
+        return [];
+      },
+      listTakes: async (opts: TakesListOpts) => {
+        listCalls.push(opts);
+        return [{
+          page_id: 11,
+          row_num: 3,
+          claim: 'Current claim',
+          kind: 'take',
+          holder: 'self',
+          weight: 0.8,
+          active: true,
+        }];
+      },
+      supersedeTake: async () => ({ oldRow: 3, newRow: 4 }),
+    } as unknown as BrainEngine;
+
+    await withEnv({ GBRAIN_SOURCE: undefined, GBRAIN_HOME: home }, async () => {
+      await runTakes(engine, [
+        'supersede',
+        'shared/page',
+        '--row',
+        '3',
+        '--claim',
+        'Replacement claim',
+        '--dir',
+        brainDir,
+      ]);
+    });
+
+    expect(listCalls).toEqual([{ page_id: 11, active: true, limit: 500 }]);
   });
 });


### PR DESCRIPTION
## Summary

- query the active take before inheriting its kind, holder, and weight
- keep the existing source-scoped page lookup and supersede path unchanged
- add a CLI regression test that pins `active: true`

## Root cause

`takes supersede` called `listTakes` with `active: false`. Normal supersede targets are still active, so the command could not find the requested row and exited before calling `supersedeTake`.

## Verification

- focused test reproduced the bug before the fix (`active: false` received instead of `active: true`)
- `bun run typecheck`
- 108 focused takes tests pass across 5 suites
- `bun run verify` currently stops on the pre-existing `test/hybrid-recency-config.test.ts` isolation violation already present on `master`; no unrelated baseline files changed

Fixes #2663.