### PR TITLE
fix(ai): declare max_batch_tokens on google embedding recipe

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -12,6 +12,14 @@ export const google: Recipe = {
   touchpoints: {
     embedding: {
       models: ['gemini-embedding-001'],
+      // Without max_batch_tokens the gateway's recursive-halving safety net
+      // never engages (see warnRecipesMissingBatchTokens), so oversized
+      // batches hit the provider raw and fail. Conservative declaration in
+      // the dashscope pattern: pre-split before whatever server-side limit
+      // applies. chars_per_token=3 overestimates tokens for mixed content,
+      // leaving headroom.
+      max_batch_tokens: 8192,
+      chars_per_token: 3,
       default_dims: 768,
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -445,17 +445,18 @@ describe('startup warning for recipes missing max_batch_tokens', () => {
       console.warn = original;
     }
 
-    // The warning text should match the documented contract.
+    // Every fixed-cap remote recipe now declares max_batch_tokens, so the
+    // startup sweep should be silent for this configuration.
     const contractMatch = warnings.filter(w =>
       w.includes('[ai.gateway]') && w.includes('declares an embedding touchpoint'),
     );
-    expect(contractMatch.length).toBe(1);
+    expect(contractMatch.length).toBe(0);
 
-    // Voyage declares max_batch_tokens → suppressed. OpenAI is the
-    // canonical fast-path recipe → also suppressed by id. Both must be
+    // Voyage and google declare max_batch_tokens → suppressed. OpenAI is
+    // the canonical fast-path recipe → suppressed by id. All must be
     // absent from the warnings.
     expect(warnings.find(w => w.includes('"voyage"'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"openai"'))).toBeUndefined();
-    expect(warnings.find(w => w.includes('"google"'))).toBeDefined();
+    expect(warnings.find(w => w.includes('"google"'))).toBeUndefined();
   });
 });

--- a/test/ai/no-batch-cap-suppression.serial.test.ts
+++ b/test/ai/no-batch-cap-suppression.serial.test.ts
@@ -82,8 +82,8 @@ describe('v0.32 #779: no_batch_cap suppresses the missing-max_batch_tokens warni
     messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
     expect(
       messages.some(m => m.includes('"google"') && m.includes('without max_batch_tokens')),
-      'google should warn when configured because it has fixed-cap models',
-    ).toBe(true);
+      'google declares max_batch_tokens and must not warn even when configured',
+    ).toBe(false);
   });
 
   test('every recipe with empty models[] declares user_provided_models OR has openai-fast-path', () => {


### PR DESCRIPTION
## What

Adds `max_batch_tokens: 8192` and `chars_per_token: 3` to the google recipe's embedding touchpoint, following the conservative-declaration pattern dashscope already uses.

## Why

The gateway's recursive-halving batch splitter only engages when a recipe declares `max_batch_tokens` (the doc comment on `warnRecipesMissingBatchTokens` calls this out). Since google shipped without it, oversized embedding batches went to gemini-embedding-001 raw and failed with no safety net.

Hit this in production: a screenpipe backfill against `google:gemini-embedding-001` died with 274 consecutive put failures, all surfacing the `[ai.gateway] recipe "google" declares an embedding touchpoint without max_batch_tokens` warning. After declaring the cap locally, the same 384-page backfill completed with zero errors, and a 65KB single-page body embedded cleanly as 25 chunks.

## Tests

Two tests used google as the canonical missing-cap recipe; both are updated to assert the new contract (google is now suppressed like voyage, and the startup sweep is silent for the openai+google configuration). `bun test test/ai/`: 405 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)