### PR TITLE
fix(sync): separator-agnostic path containment — unblock sync on Windows

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, statSync, realpathSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
+import { isPathContained, isResolvedContained } from '../core/path-confine.ts';
 import type { BrainEngine } from '../core/engine.ts';
 import { DELETE_BATCH_SIZE } from '../core/engine-constants.ts';
 import { importFile } from '../core/import-file.ts';
@@ -1112,15 +1113,14 @@ function createSyncBaselineCommit(repoPath: string): void {
  * #774 NAV-1 TOCTOU: true only if filePath realpath-resolves inside gitRoot.
  * Guards symlink escape at the per-file level (a committed symlink whose
  * target lives outside the repo), not just at scope entry.
+ *
+ * #3057: delegates to the shared separator-agnostic helper — the previous
+ * inline `startsWith(rootReal + '/')` was always false on Windows
+ * (realpathSync returns backslashes), recording every in-repo file as
+ * SYMLINK_NOT_ALLOWED and freezing the sync bookmark.
  */
 function isPathSafe(filePath: string, gitRoot: string): boolean {
-  try {
-    const real = realpathSync(filePath);
-    const rootReal = realpathSync(gitRoot);
-    return real === rootReal || real.startsWith(rootReal + '/');
-  } catch {
-    return false;
-  }
+  return isPathContained(filePath, gitRoot);
 }
 
 function hasOriginRemote(repoPath: string): boolean {
@@ -1887,7 +1887,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // NAV-1/NAV-2 scope-entry guard: the realpath-resolved scope must live
   // inside the realpath-resolved git root. Catches `--src-subpath ../escape`
   // AND a symlinked subdir pointing outside the repo, before any git op runs.
-  if (syncScopeRoot !== gitContextRoot && !syncScopeRoot.startsWith(gitContextRoot + '/')) {
+  // #3057: separator-agnostic (both sides already realpath'd above).
+  if (!isResolvedContained(syncScopeRoot, gitContextRoot)) {
     throw new Error(
       `Sync scope ${syncScopeRoot} resolves outside git repo ${gitContextRoot}. ` +
       `Refusing to sync: possible path traversal via --src-subpath.`,

--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -20,11 +20,34 @@
  */
 
 import { realpathSync, existsSync, type Stats } from 'fs';
+import * as nodePath from 'path';
 import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join } from 'path';
 
 /**
+ * Pure containment predicate over ALREADY-resolved paths: true iff `child`
+ * IS `parent` or lives under it. Separator-agnostic via `path.relative`.
+ *
+ * #3057: the previous `startsWith(parent + '/')` form is false for EVERY
+ * path on Windows — `realpathSync` returns backslash separators there — so
+ * every containment check built on it failed closed and blocked sync
+ * entirely (same separator class as #2828/#2836). `pathMod` is injectable
+ * so POSIX CI can pin the win32 semantics with `path.win32`.
+ */
+export function isResolvedContained(
+  child: string,
+  parent: string,
+  pathMod: Pick<typeof nodePath, 'relative' | 'isAbsolute' | 'sep'> = nodePath,
+): boolean {
+  const rel = pathMod.relative(parent, child);
+  // '' = same path; '..' or '../…' = escapes upward; absolute = different
+  // root entirely (e.g. another drive on Windows, where relative() returns
+  // the child verbatim).
+  return rel === '' || (rel !== '..' && !rel.startsWith('..' + pathMod.sep) && !pathMod.isAbsolute(rel));
+}
+
+/**
  * Symlink-safe path confinement: realpath BOTH sides, then a separator-aware
- * prefix check. A plain `startsWith()` on un-resolved paths would let a
+ * containment check. A plain `startsWith()` on un-resolved paths would let a
  * `parent/skills` symlink → `/etc` (or `$GBRAIN_HOME/clones/<id>` → `/etc`)
  * bypass the boundary; resolving first defeats that.
  *
@@ -41,9 +64,7 @@ export function isPathContained(child: string, parent: string): boolean {
   } catch {
     return false; // missing / unresolvable path → not contained
   }
-  // Append a separator so /foo doesn't match /foobar.
-  const parentWithSep = resolvedParent.endsWith('/') ? resolvedParent : resolvedParent + '/';
-  return resolvedChild === resolvedParent || resolvedChild.startsWith(parentWithSep);
+  return isResolvedContained(resolvedChild, resolvedParent);
 }
 
 /**

--- a/test/path-confine.test.ts
+++ b/test/path-confine.test.ts
@@ -15,10 +15,10 @@ import {
   mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, chmodSync,
   lstatSync, type Stats,
 } from 'fs';
-import { join } from 'path';
+import { join, win32, posix } from 'path';
 import { tmpdir } from 'os';
 import {
-  isTrustedDotfile, isPathContained, realpathOrResolve, isWriteTargetContained,
+  isTrustedDotfile, isPathContained, isResolvedContained, realpathOrResolve, isWriteTargetContained,
 } from '../src/core/path-confine.ts';
 import { validateSlug } from '../src/core/utils.ts';
 import { resolveSourceId } from '../src/core/source-resolver.ts';
@@ -146,6 +146,37 @@ describe('isPathContained', () => {
     const foo = join(base, 'foo'); const foobar = join(base, 'foobar');
     mkdirSync(foo); mkdirSync(foobar);
     expect(isPathContained(foobar, foo)).toBe(false);
+  });
+});
+
+// #3057: the containment predicate must be separator-agnostic. On Windows,
+// realpathSync returns backslash separators, and the old
+// `startsWith(parent + '/')` form was false for EVERY in-repo file — sync's
+// isPathSafe recorded every file SYMLINK_NOT_ALLOWED and froze the bookmark.
+// win32 semantics are pinned here via the injectable path module so this
+// regression is caught on POSIX CI.
+describe('isResolvedContained — win32 separators (#3057)', () => {
+  test('in-repo file with backslash separators IS contained', () => {
+    expect(isResolvedContained('C:\\repo\\notes\\a.md', 'C:\\repo', win32)).toBe(true);
+  });
+  test('root itself is contained', () => {
+    expect(isResolvedContained('C:\\repo', 'C:\\repo', win32)).toBe(true);
+  });
+  test('upward escape is NOT contained', () => {
+    expect(isResolvedContained('C:\\other\\x.md', 'C:\\repo', win32)).toBe(false);
+    expect(isResolvedContained('C:\\', 'C:\\repo', win32)).toBe(false);
+  });
+  test('sibling prefix does not match (C:\\repo vs C:\\repofoo)', () => {
+    expect(isResolvedContained('C:\\repofoo\\x.md', 'C:\\repo', win32)).toBe(false);
+  });
+  test('different drive is NOT contained', () => {
+    expect(isResolvedContained('D:\\repo\\x.md', 'C:\\repo', win32)).toBe(false);
+  });
+  test('posix semantics unchanged', () => {
+    expect(isResolvedContained('/repo/notes/a.md', '/repo', posix)).toBe(true);
+    expect(isResolvedContained('/repofoo/x.md', '/repo', posix)).toBe(false);
+    expect(isResolvedContained('/repo', '/repo', posix)).toBe(true);
+    expect(isResolvedContained('/', '/repo', posix)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Backlog fix wave nwf9.

## Fixes #3057 — Windows sync fully blocked by hardcoded '/' in isPathSafe

`isPathSafe` in `src/commands/sync.ts` did `real.startsWith(rootReal + '/')`; `realpathSync` returns backslash separators on Windows, so the predicate was false for every in-repo file — each one recorded `SYMLINK_NOT_ALLOWED`, freezing the sync bookmark. Same separator class as #2828/#2836.

Root cause is the shared idiom: `isPathContained` in `src/core/path-confine.ts` carried the same hardcoded `'/'`. Fix lands there once:

- New pure `isResolvedContained(child, parent, pathMod)` using the `path.relative` idiom (matching `isWriteTargetContained`), separator-agnostic and cross-drive-safe; `pathMod` is injectable so POSIX CI pins the win32 semantics with `path.win32`.
- `isPathContained` delegates to it (all existing callers — sources-ops clone confinement, repo-root skills-dir detection — get the fix for free).
- `sync.ts`'s `isPathSafe` and the NAV-1/NAV-2 scope-entry guard (same bug: every `--src-subpath` sync threw on Windows) both delegate to the shared helper.

Tests: new `isResolvedContained` win32 + posix cases in `test/path-confine.test.ts`; all existing containment/symlink-escape tests unchanged and green.

## References #3056 — verified, fix already open as PR #3252 (not duplicated here)

Adversarial verification of the in-flight community fix: applied #3252 onto current master locally — typecheck clean, its 9-test suite passes, `updateSlug` signature change lands in BOTH engines in lockstep, failures are recorded (stderr warn + `failedFiles` + `renameFallbacks`, checkpoint blocked on unresolved fallbacks) rather than re-swallowed, and the legitimate "old row genuinely absent → add" path is preserved. Recommend merging #3252 as-is; nothing for it is included in this PR.

## Skipped #3055 — already fixed on master

`list_pages` now honors explicit limits for trusted local callers (`ctx.remote === false` → effectively uncapped), warns on remote clamp, and the param description documents the remote 100 cap — landed in commit 70ffe4a2 (#2591). Issue #3055 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)