### PR TITLE
chore(gitignore): ignore CLAUDE.local.md / AGENTS.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ export/
 # .context/test-shards/. Workspace-local by design — never committed.
 .context/
 
+# Local agent instruction overrides (CLAUDE.local.md / AGENTS.local.md) — personal,
+# per-clone, loaded after the committed CLAUDE.md/AGENTS.md. Never committed.
+CLAUDE.local.md
+AGENTS.local.md
+
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar
 test/fixtures/pglite-snapshot.version


### PR DESCRIPTION
## What

Adds `CLAUDE.local.md` and `AGENTS.local.md` to `.gitignore`.

## Why

gbrain commits both `CLAUDE.md` and `AGENTS.md`. Agent tools (Claude Code, Codex, and others) support a `*.local.md` counterpart to those files for **personal, per-clone instruction overrides** — they load *after* the committed instructions and are meant to stay uncommitted (the same role `settings.local.json` plays for config).

This mirrors a convention the repo already follows for workspace-local agent artifacts: `.context/` is ignored as *"workspace-local by design — never committed,"* and `.claude/` (which already covers `.claude/settings.local.json`) is ignored too. The two root-level `*.local.md` files are the remaining gap.

Ignoring them repo-side lets contributors — and anyone working in a fork — keep local agent instructions without a `.git/info/exclude` workaround or a personal global gitignore, and prevents accidentally committing them into a PR.

## Notes

- Explicit filenames rather than a broad `*.local.md` glob, to match the existing commented, specific style and avoid ignoring a file someone deliberately named `x.local.md`.
- `.claude/settings.local.json` is already covered by the existing `.claude/` rule — untouched here.
