### PR TITLE
v0.42.59.0 fix(jobs): honor prune safety flags (#2712)

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -22,6 +22,21 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+/** Parse `--max-waiting N` from CLI args. Returns undefined if absent.
+ *  Throws on malformed input (caller should surface the error and exit).
+ *  Clamps to [1, 100] to match the queue-layer clamp in MinionQueue.add.
+ *  Exported for unit tests; the CLI handler at `jobs submit` wraps this
+ *  with process.exit(1) on throw so operators see 'must be positive integer'. */
+export function parseMaxWaitingFlag(args: string[]): number | undefined {
+  const raw = parseFlag(args, '--max-waiting');
+  if (raw === undefined) return undefined;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error('--max-waiting must be a positive integer (will be clamped to [1, 100])');
+  }
+  return Math.max(1, Math.min(100, parsed));
+}
+
 export interface JobsPruneArgs {
   help: boolean;
   dryRun: boolean;
@@ -81,21 +96,6 @@ FLAGS
   --dry-run          Report how many rows would be deleted; do not delete.
   --help, -h         Show this help.
 `);
-}
-
-/** Parse `--max-waiting N` from CLI args. Returns undefined if absent.
- *  Throws on malformed input (caller should surface the error and exit).
- *  Clamps to [1, 100] to match the queue-layer clamp in MinionQueue.add.
- *  Exported for unit tests; the CLI handler at `jobs submit` wraps this
- *  with process.exit(1) on throw so operators see 'must be positive integer'. */
-export function parseMaxWaitingFlag(args: string[]): number | undefined {
-  const raw = parseFlag(args, '--max-waiting');
-  if (raw === undefined) return undefined;
-  const parsed = parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    throw new Error('--max-waiting must be a positive integer (will be clamped to [1, 100])');
-  }
-  return Math.max(1, Math.min(100, parsed));
 }
 
 /** Parse `--max-rss N` (MB). Returns:

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -22,6 +22,67 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+export interface JobsPruneArgs {
+  help: boolean;
+  dryRun: boolean;
+  olderThanDays: number;
+}
+
+function parseOlderThanDays(raw: string): number {
+  const m = raw.trim().match(/^(\d+)(d?)$/);
+  if (!m) {
+    throw new Error(`--older-than must be a positive number of days (e.g. 30d), got: ${JSON.stringify(raw)}`);
+  }
+  const days = parseInt(m[1], 10);
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error(`--older-than must be a positive number of days (e.g. 30d), got: ${JSON.stringify(raw)}`);
+  }
+  return days;
+}
+
+export function parseJobsPruneArgs(args: string[]): JobsPruneArgs {
+  const out: JobsPruneArgs = { help: false, dryRun: false, olderThanDays: 30 };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      out.dryRun = true;
+      continue;
+    }
+    if (arg === '--older-than') {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error('Error: --older-than requires a value (e.g. 30d).');
+      }
+      out.olderThanDays = parseOlderThanDays(value);
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--older-than=')) {
+      out.olderThanDays = parseOlderThanDays(arg.slice('--older-than='.length));
+      continue;
+    }
+    throw new Error(`Error: unknown jobs prune flag ${JSON.stringify(arg)}.`);
+  }
+  return out;
+}
+
+function printJobsPruneHelp(): void {
+  console.log(`gbrain jobs prune — delete old terminal jobs
+
+USAGE
+  gbrain jobs prune [--older-than 30d] [--dry-run]
+
+FLAGS
+  --older-than DAYS  Delete terminal jobs older than this many days (default: 30d).
+  --dry-run          Report how many rows would be deleted; do not delete.
+  --help, -h         Show this help.
+`);
+}
+
 /** Parse `--max-waiting N` from CLI args. Returns undefined if absent.
  *  Throws on malformed input (caller should surface the error and exit).
  *  Clamps to [1, 100] to match the queue-layer clamp in MinionQueue.add.
@@ -539,18 +600,30 @@ HANDLER TYPES (built in)
     }
 
     case 'prune': {
-      const olderThanStr = parseFlag(args, '--older-than') ?? '30d';
-      const days = parseInt(olderThanStr, 10);
-      if (isNaN(days) || days <= 0) {
-        console.error('Error: --older-than must be a positive number (days). Example: --older-than 30d');
+      let pruneArgs: JobsPruneArgs;
+      try {
+        pruneArgs = parseJobsPruneArgs(args.slice(1));
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
         process.exit(1);
+      }
+      if (pruneArgs.help) {
+        printJobsPruneHelp();
+        break;
       }
 
       try { await queue.ensureSchema(); }
       catch (e) { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); }
 
-      const count = await queue.prune({ olderThan: new Date(Date.now() - days * 86400000) });
-      console.log(`Pruned ${count} jobs older than ${days} days.`);
+      const olderThan = new Date(Date.now() - pruneArgs.olderThanDays * 86400000);
+      if (pruneArgs.dryRun) {
+        const count = await queue.countPrunable({ olderThan });
+        console.log(`[dry-run] would prune ${count} jobs older than ${pruneArgs.olderThanDays} days.`);
+        break;
+      }
+
+      const count = await queue.prune({ olderThan });
+      console.log(`Pruned ${count} jobs older than ${pruneArgs.olderThanDays} days.`);
       break;
     }
 

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -501,6 +501,20 @@ export class MinionQueue {
     return parseInt(rows[0]?.count ?? '0', 10);
   }
 
+  /** Count jobs that would be pruned without deleting them. */
+  async countPrunable(opts?: { olderThan?: Date; status?: MinionJobStatus[] }): Promise<number> {
+    const statuses = opts?.status ?? ['completed', 'dead', 'cancelled'];
+    const olderThan = opts?.olderThan ?? new Date(Date.now() - 30 * 86400000);
+
+    const rows = await this.engine.executeRaw<{ count: string }>(
+      `SELECT count(*)::text as count
+       FROM minion_jobs
+       WHERE status = ANY($1) AND updated_at < $2`,
+      [statuses, olderThan.toISOString()]
+    );
+    return parseInt(rows[0]?.count ?? '0', 10);
+  }
+
   /** Get job statistics. */
   async getStats(opts?: { since?: Date; queue?: string }): Promise<{
     by_status: Record<string, number>;

--- a/test/jobs-prune-cli.test.ts
+++ b/test/jobs-prune-cli.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import { parseJobsPruneArgs, runJobs } from '../src/commands/jobs.ts';
+
+let engine: PGLiteEngine;
+let queue: MinionQueue;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+  queue = new MinionQueue(engine);
+}, 30000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM minion_jobs');
+});
+
+async function addOldCancelledJob(daysAgo = 60): Promise<number> {
+  const job = await queue.add('sync', {});
+  await queue.cancelJob(job.id);
+  await engine.executeRaw(
+    'UPDATE minion_jobs SET updated_at = $1 WHERE id = $2',
+    [new Date(Date.now() - daysAgo * 86400000).toISOString(), job.id],
+  );
+  return job.id;
+}
+
+async function withCapturedStdout<T>(fn: () => Promise<T>): Promise<{ value: T; output: string }> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    const value = await fn();
+    return { value, output: lines.join('\n') };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+describe('gbrain jobs prune CLI safety flags', () => {
+  test('--dry-run reports count without deleting terminal jobs', async () => {
+    const id = await addOldCancelledJob();
+
+    const { output } = await withCapturedStdout(() =>
+      runJobs(engine, ['prune', '--older-than', '30d', '--dry-run']),
+    );
+
+    expect(output).toContain('[dry-run] would prune 1 jobs');
+    expect(await queue.getJob(id)).not.toBeNull();
+  });
+
+  test('--help is side-effect-free', async () => {
+    const id = await addOldCancelledJob();
+
+    const { output } = await withCapturedStdout(() => runJobs(engine, ['prune', '--help']));
+
+    expect(output).toContain('gbrain jobs prune');
+    expect(await queue.getJob(id)).not.toBeNull();
+  });
+
+  test('unknown flags fail before the prune path can run', () => {
+    expect(() => parseJobsPruneArgs(['--dryrun'])).toThrow('unknown jobs prune flag');
+    expect(() => parseJobsPruneArgs(['--older-than', '30d', '--bogus'])).toThrow('unknown jobs prune flag');
+  });
+});


### PR DESCRIPTION
Fixes #2712.

## Summary

- Make `gbrain jobs prune` parse its own supported flags strictly before touching queue state.
- Add side-effect-free handling for `--help` and `--dry-run`; dry-run now counts rows with the same terminal-status/age predicate without deleting them.
- Fail fast on unknown prune flags so mistyped safety flags cannot silently fall through to the destructive path.
- Add focused regression coverage for dry-run, help, and unknown-flag behavior.

## Tests

- `bun test test/jobs-prune-cli.test.ts` (3 pass)
- `bun test test/minions.test.ts` (176 pass)
- Local gate: GREEN; verify passed with the known platform-only operations-filter guard tolerated, focused units passed (179 pass), and diff-selected E2E resolved to the fail-closed all-set so it was skipped locally per gate policy.
