### PR TITLE
reland: fix(extract): recognize reference wikilinks (#2071)

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -82,11 +82,11 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
 /**
  * Directory prefix whitelist. These are the top-level slug dirs the extractor
  * recognizes as entity references. Upstream canonical + our extensions:
- *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects
+ *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects, reference
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|reference)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -141,6 +141,17 @@ describe('extractEntityRefs', () => {
     expect(wikiRefs[0].needsResolution).toBe(true);
   });
 
+  test('recognizes reference-page wikilinks as concrete targets', () => {
+    const refs = extractEntityRefs('See [[reference/mcminnville-market-data]] for source context.');
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toMatchObject({
+      name: 'reference/mcminnville-market-data',
+      slug: 'reference/mcminnville-market-data',
+      dir: 'reference',
+    });
+    expect(refs[0].needsResolution).toBeUndefined();
+  });
+
   test('skips qualified-syntax tokens (those belong to 2a)', () => {
     // [[wiki:topics/ai]] looks like 2a's qualified shape — even though
     // it wouldn't satisfy DIR_PATTERN, 2c must not claim it either


### PR DESCRIPTION
## Reland of #2071

#2071 (squash commit 49cf5202) was merged in a batch that went red on master CI, and the whole batch was auto-reverted (revert commit a1dadebd). This PR cherry-picks the original squash commit back onto post-revert master.

## Innocence evidence

The change adds `reference` to the extractor's `DIR_PATTERN` directory whitelist in `src/core/link-extraction.ts` plus one test. Local gates on the cherry-picked worktree:

- `bun run typecheck` — exit 0
- `bun test` on every test file touching `link-extraction` (test/link-extraction.test.ts, test/public-exports.test.ts, test/extract-stale.test.ts, test/link-extraction-code-refs.test.ts, test/sync-inline-extract-stamps.serial.test.ts, test/link-inference-pack.test.ts, test/search/title-retrieval-arm.test.ts) — 231 pass, 0 fail

Cherry-pick applied with no conflicts. The change is regex-whitelist-only, no schema/engine/JSONB surface.

Do not squash the revert back in — this PR is the reland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)