### PR TITLE
reland: fix(queue): dead/cancelled jobs no longer block idempotency re-submission (#2253)

### DIFF
--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -133,12 +133,27 @@ export class MinionQueue {
       // 1. Idempotency fast path — if a row already exists for this key, return it
       //    without doing any other work. The unique partial index guarantees
       //    no second row can be inserted with the same non-null key.
+      //
+      //    Dead/cancelled jobs represent permanently-failed work whose
+      //    idempotency slot must be freed so a fresh attempt can be inserted.
+      //    We NULL the key (preserving the row for audit) and fall through
+      //    to the INSERT path below.
       if (opts?.idempotency_key) {
         const existing = await tx.executeRaw<Record<string, unknown>>(
           `SELECT * FROM minion_jobs WHERE idempotency_key = $1`,
           [opts.idempotency_key]
         );
-        if (existing.length > 0) return rowToMinionJob(existing[0]);
+        if (existing.length > 0) {
+          const existingJob = rowToMinionJob(existing[0]);
+          if (existingJob.status === 'dead' || existingJob.status === 'cancelled') {
+            await tx.executeRaw(
+              `UPDATE minion_jobs SET idempotency_key = NULL WHERE id = $1`,
+              [existingJob.id]
+            );
+          } else {
+            return existingJob;
+          }
+        }
       }
 
       // 1b. Submission-time backpressure for high-frequency named jobs.

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -1582,6 +1582,73 @@ describe('MinionQueue: Idempotency', () => {
     expect(j2.id).toBe(j1.id);
     expect(j2.data).toEqual({ v: 1 }); // first wins
   });
+
+  test('dead job with idempotency_key allows re-submission', async () => {
+    const j1 = await queue.add('test-synth', { prompt: 'synthesize' }, {
+      idempotency_key: 'dream:synth:test:abc123',
+      max_attempts: 1,
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET status = 'dead', finished_at = now() WHERE id = $1`,
+      [j1.id]
+    );
+    const j2 = await queue.add('test-synth', { prompt: 'synthesize' }, {
+      idempotency_key: 'dream:synth:test:abc123',
+      max_attempts: 8,
+    });
+    expect(j2.id).not.toBe(j1.id);
+    expect(j2.status).toBe('waiting');
+    const oldRow = await engine.executeRaw<{ idempotency_key: string | null }>(
+      `SELECT idempotency_key FROM minion_jobs WHERE id = $1`,
+      [j1.id]
+    );
+    expect(oldRow[0].idempotency_key).toBeNull();
+  });
+
+  test('cancelled job with idempotency_key allows re-submission', async () => {
+    const j1 = await queue.add('test-synth', {}, {
+      idempotency_key: 'dream:synth:test:cancel',
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET status = 'cancelled', finished_at = now() WHERE id = $1`,
+      [j1.id]
+    );
+    const j2 = await queue.add('test-synth', {}, {
+      idempotency_key: 'dream:synth:test:cancel',
+    });
+    expect(j2.id).not.toBe(j1.id);
+    expect(j2.status).toBe('waiting');
+  });
+
+  test('completed job with idempotency_key still blocks re-submission', async () => {
+    const j1 = await queue.add('sync', {}, {
+      idempotency_key: 'dream:synth:test:completed',
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET status = 'completed', finished_at = now() WHERE id = $1`,
+      [j1.id]
+    );
+    const j2 = await queue.add('sync', {}, {
+      idempotency_key: 'dream:synth:test:completed',
+    });
+    expect(j2.id).toBe(j1.id);
+    expect(j2.status).toBe('completed');
+  });
+
+  test('active job with idempotency_key still blocks re-submission', async () => {
+    const j1 = await queue.add('sync', {}, {
+      idempotency_key: 'dream:synth:test:active',
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET status = 'active' WHERE id = $1`,
+      [j1.id]
+    );
+    const j2 = await queue.add('sync', {}, {
+      idempotency_key: 'dream:synth:test:active',
+    });
+    expect(j2.id).toBe(j1.id);
+    expect(j2.status).toBe('active');
+  });
 });
 
 // --- v7 child_done auto-post ---


### PR DESCRIPTION
## Reland of #2253

#2253 was squash-merged as c0cb6c53 but its merge batch went red on master CI, and the whole batch was auto-reverted (3225bdf7). This PR re-lands the original commit unchanged (clean cherry-pick of c0cb6c53 onto current master) after verifying #2253 itself is innocent.

## Local gates (green)

- `bun run typecheck` — exit 0
- `bun test` on every test file touching the changed module and its idempotency-key consumers — 413 pass / 0 fail across 14 files:
  - `test/minions.test.ts` (includes the 4 new dead/cancelled/completed/active idempotency tests), `test/queue-child-done.test.ts`, `test/queue-lock-retry.test.ts`, `test/queue-getstats-wedge.test.ts`, `test/minions-lease-full-retry.test.ts`, `test/embed-backfill-submit.test.ts`, `test/minions-shell.test.ts`, `test/minions-quiet-hours.test.ts`
  - `test/remediation-step.test.ts`, `test/autopilot-fanout.test.ts`, `test/extract-by-mention.test.ts`, `test/propose-takes.test.ts`, `test/brain-score-recommendations.test.ts`, `test/autopilot-global-maintenance.test.ts`

## Original change (unchanged)

`queue.add()` with an `idempotency_key` returned any existing row regardless of status, so dead/cancelled jobs permanently blocked re-submission of the same work. Fix NULLs the key on the dead/cancelled row (preserving it for audit) and falls through to the INSERT path. Positional params only — no JSONB writes, engine-agnostic via `executeRaw`.

Credit: @rafaelreis-r (original author, preserved on the cherry-picked commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)