### PR TITLE
reland: Reject unknown init flags before migrations (#2201)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -26,6 +26,8 @@ export async function runInit(args: string[]) {
     return;
   }
 
+  validateInitFlags(args);
+
   const isSupabase = args.includes('--supabase');
   const isPGLite = args.includes('--pglite');
   const isMcpOnly = args.includes('--mcp-only');
@@ -149,6 +151,65 @@ export async function runInit(args: string[]) {
   }
 
   return initPostgres({ databaseUrl, jsonOutput, apiKey, aiOpts, schemaPack, skipEmbedCheck });
+}
+
+const INIT_BOOLEAN_FLAGS = new Set([
+  '--pglite',
+  '--supabase',
+  '--mcp-only',
+  '--force',
+  '--non-interactive',
+  '--migrate-only',
+  '--json',
+  '--no-embedding',
+  '--skip-embed-check',
+]);
+
+const INIT_VALUE_FLAGS = new Set([
+  '--url',
+  '--key',
+  '--path',
+  '--schema-pack',
+  '--embedding-model',
+  '--model',
+  '--embedding-dimensions',
+  '--expansion-model',
+  '--chat-model',
+  '--mcp-url',
+  '--issuer-url',
+  '--oauth-client-id',
+  '--oauth-client-secret',
+]);
+
+function validateInitFlags(args: string[]) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('-')) continue;
+
+    if (INIT_BOOLEAN_FLAGS.has(arg)) continue;
+
+    if (INIT_VALUE_FLAGS.has(arg)) {
+      if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+        failInitFlag(`gbrain init: ${arg} requires a value`, args.includes('--json'));
+      }
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      failInitFlag(`gbrain init: unknown flag ${arg}`, args.includes('--json'));
+    }
+  }
+}
+
+function failInitFlag(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) {
+    console.log(JSON.stringify({ status: 'error', reason: 'invalid_flag', message }));
+  } else {
+    console.error(message);
+    console.error('Run `gbrain init --help` for supported flags.');
+  }
+  process.exit(1);
 }
 
 interface ResolveAIOptionsArgs {

--- a/test/init-migrate-only.test.ts
+++ b/test/init-migrate-only.test.ts
@@ -57,6 +57,25 @@ afterEach(() => {
 });
 
 describe('gbrain init --migrate-only — error paths', () => {
+  test('rejects unknown flags before any migrate-only side effects', () => {
+    const result = run(['init', '--migrate-only', '--dry-run']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag --dry-run');
+    // Unknown safety flags must not fall through to the migration path.
+    expect(result.stderr).not.toContain('No brain configured');
+    expect(existsSync(join(tmp, '.gbrain', 'config.json'))).toBe(false);
+  });
+
+  test('unknown flags respect --json output', () => {
+    const result = run(['init', '--migrate-only', '--dry-run', '--json']);
+    expect(result.exitCode).toBe(1);
+    const lines = result.stdout.split('\n').filter((l: string) => l.trim().startsWith('{'));
+    const parsed = JSON.parse(lines[lines.length - 1]);
+    expect(parsed.status).toBe('error');
+    expect(parsed.reason).toBe('invalid_flag');
+    expect(parsed.message).toContain('unknown flag --dry-run');
+  });
+
   test('errors with clear message when no config exists', () => {
     const result = run(['init', '--migrate-only']);
     expect(result.exitCode).toBe(1);


### PR DESCRIPTION
## Reland of #2201

#2201 was squash-merged (d67be8b5) as part of a batch. The batch went red on master CI and the whole batch was auto-reverted (23df0227). This PR relands the original squash commit unchanged.

## Why #2201 is innocent

The change is self-contained CLI flag validation in `src/commands/init.ts` (allowlist of init flags, fail-fast before any migration side effects) plus two tests in `test/init-migrate-only.test.ts`. It touches no engine, schema, jsonb, or source-scoping code.

Verified against current master:
- Cherry-pick applied cleanly (no conflicts).
- The flag allowlist covers every flag current `init.ts` parses (`--help`/`-h` are handled before validation; global `--quiet`/`--progress-*` flags are stripped by `parseGlobalFlags` before dispatch).

## Local gates (on top of current master 8345abce)

- `bun run typecheck` — exit 0
- `bun test` on all init/CLI coverage (`init-migrate-only`, `init-embed-check`, `init-env-detection`, `init-mcp-only`, `init-mode-picker`, `init-provider-picker`, `cli-help-discoverability`, `cli`): **115 pass, 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)