### PR TITLE
reland: fix(init): point soul-audit hint at the conversational skill, not a nonexistent CLI verb (#2486)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1491,7 +1491,7 @@ export function reportModStatus(): void {
     console.log('  cd ~/.claude/skills/gstack && ./setup');
   }
   console.log('Resolver: skills/RESOLVER.md');
-  console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
+  console.log('Soul audit: ask your agent to "run a soul audit" to customize its identity (see skills/soul-audit)');
   // Retrieval Reflex (#1981): the deterministic pointer layer is ON by default
   // (no action needed). The policy skill is installed into the HOST repo on
   // request — we PRINT the command rather than silently mutating the host repo.


### PR DESCRIPTION
Relands #2486, which was squash-merged as f8dbfca2 and then auto-reverted in a6aafddd because its merge BATCH went red on master CI — not because of this change.

The change is a one-line `console.log` string fix in `src/commands/init.ts` (`reportModStatus`): the post-init hint pointed at a nonexistent `gbrain soul-audit` CLI verb; it now points at the conversational `skills/soul-audit` skill. No logic, schema, or engine surface is touched.

Verified innocent by cherry-picking f8dbfca2 onto current `origin/master`:
- `bun run typecheck` — exit 0
- `bun test` on all 6 init-covering test files (init-embed-check, init-env-detection, init-mcp-only, init-migrate-only, init-mode-picker, init-provider-picker) — 85 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)