### PR TITLE
reland: fix(chunkers/code): tolerate tiktoken special tokens in estimateTokens (#2453)

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -1235,7 +1235,25 @@ export function estimateTokens(text: string): number {
     tiktokenInitialized = true;
   }
   if (tiktokenEncoder) {
-    return tiktokenEncoder.encode(text).length;
+    try {
+      return tiktokenEncoder.encode(text).length;
+    } catch {
+      // Code legitimately contains tiktoken special-token strings (e.g. CLIP/GPT
+      // tokenizers embed the literal "<|endoftext|>"). The default encode() uses
+      // disallowed_special='all' and THROWS on those, crashing reindex-code on
+      // valid source files. For a token COUNT we don't need special-token
+      // semantics: re-encode treating them as ordinary text (never throws),
+      // heuristic only if even that fails.
+      try {
+        return (
+          tiktokenEncoder as unknown as {
+            encode: (s: string, allowed: string[], disallowed: string[]) => Uint32Array;
+          }
+        ).encode(text, [], []).length;
+      } catch {
+        return Math.max(1, Math.ceil(text.length / 4));
+      }
+    }
   }
   return Math.max(1, Math.ceil(text.length / 4));
 }


### PR DESCRIPTION
Relands #2453 (squash commit b7f70970), which was auto-reverted in 94535fc0 when its merge batch went red on master CI.

The change is innocent: local gates on a clean cherry-pick onto current master are green:
- `bun run typecheck` — exit 0
- `bun test` on all 16 test files that import/cover `src/core/chunkers/code.ts` and `estimateTokens` consumers (chunkers/code, edge-extractor, sync-classifier-widening, sync-strategy, parent-scope, sync-cost-gate.serial, language-manifest, chunker-timeout, sync-cost-preview, doctor, sync-cost-estimate, chunker-version-gate, token-budget, diarize payload-fitter x2, reindex-code) — 263 pass / 0 fail

Original change (unchanged, cherry-picked): code legitimately contains tiktoken special-token strings (e.g. the literal `<|endoftext|>`); the default `encode()` throws on those, crashing reindex-code on valid source files. Re-encode treating them as ordinary text, heuristic fallback if even that fails.

Cherry-picked cleanly with original authorship preserved (Jim Tang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)