### PR TITLE
reland: fix: Bun+Windows write-through EEXIST, non-Anthropic --max-cost pricing, dream-page exclusion in enrich (#2407)

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -32,6 +32,7 @@ import { mkdirSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { gbrainPath } from '../config.ts';
 import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
+import { canonicalLookup } from '../model-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
@@ -213,6 +214,12 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
+  // Fall back to the full canonical pricing table so non-Anthropic chat
+  // models with a known price (openai:*, google:*, deepseek:*) resolve under
+  // --max-cost instead of TX2 no_pricing hard-failing at $0. ANTHROPIC_PRICING
+  // above is only the bare-keyed Claude view.
+  const canon = canonicalLookup(modelId);
+  if (canon) return canon;
   return null;
 }
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -6007,6 +6007,9 @@ export class PGLiteEngine implements BrainEngine {
       );
     }
 
+    // Exclude dream/synthesize-generated pages (parity with postgres-engine).
+    where.push(`(p.frontmatter ->> 'dream_generated') IS DISTINCT FROM 'true'`);
+
     const orderKey = ENRICH_ORDER_SQL[opts.order] ? opts.order : 'inbound-links';
     const orderBy = ENRICH_ORDER_SQL[orderKey];
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -6293,6 +6293,12 @@ export class PostgresEngine implements BrainEngine {
           )`
       : sql``;
 
+    // Exclude dream/synthesize-generated pages (reflections, originals, cycle
+    // logs carrying frontmatter dream_generated:true). enrich develops ENTITY
+    // stubs; running it on a generated essay/log creates circular self-citation
+    // and drops the H1. IS DISTINCT FROM 'true' keeps NULL/'false' rows.
+    const dreamCondition = sql`AND (p.frontmatter ->> 'dream_generated') IS DISTINCT FROM 'true'`;
+
     // Whitelisted ORDER BY (no injection — enum maps to a literal fragment).
     const orderKey = ENRICH_ORDER_SQL[opts.order] ? opts.order : 'inbound-links';
     const orderBy = sql.unsafe(ENRICH_ORDER_SQL[orderKey]);
@@ -6316,6 +6322,7 @@ export class PostgresEngine implements BrainEngine {
         AND (char_length(p.compiled_truth) + char_length(COALESCE(p.timeline, ''))) < ${threshold}
         ${sourceCondition}
         ${recencyCondition}
+        ${dreamCondition}
       ORDER BY ${orderBy}
       LIMIT ${limit}
     `;

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -174,7 +174,11 @@ export async function writePageThrough(
       }
     }
 
-    mkdirSync(dirname(filePath), { recursive: true });
+    // On Bun + Windows, mkdirSync(dir, { recursive: true }) can still throw
+    // EEXIST when the directory already exists (POSIX no-ops it). That aborts
+    // the put_page / enrich / capture write-through whenever the prefix dir
+    // already exists, silently leaving the DB and the .md file plane out of sync.
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
     // Atomic write: unique temp sibling + rename. Unique name (pid + random)
     // so two concurrent saves to the same target can't clobber each other's


### PR DESCRIPTION
## Why a reland

PR #2407 was squash-merged as 2941e177, but its merge batch went red on master CI and the whole batch was auto-reverted (439bbaac). This cherry-picks the original squash commit back onto current master to determine innocence — and the change gates green locally, so #2407 was not the batch culprit.

## Conflict resolution

One textual conflict in `src/core/write-through.ts` against the later #3119 case-insensitive-collision guard: kept the #3119 guard and applied #2407's Bun+Windows EEXIST guard to the same `mkdirSync` call (reusing the existing `dir` local). Everything else applied clean.

## Local gates (all green)

- `bun run typecheck` — exit 0
- `bun test` on every file covering the touched modules — exit 0:
  - `test/write-through.test.ts`, `test/write-through-commit.serial.test.ts`
  - `test/budget-tracker.test.ts`, `test/core/budget/budget-tracker.test.ts`, `test/core/budget/gateway-budget-composition.test.ts`
  - `test/model-pricing.test.ts`, `test/anthropic-pricing.test.ts`
  - `test/enrich/thin.test.ts`, `test/enrich/idempotency.test.ts`, `test/e2e/enrich-pglite.test.ts`
  - `test/enrichment.test.ts`, `test/enrichment-service.test.ts`, `test/self-fix.test.ts`

(One beforeEach hook-timeout flake in `test/enrichment.test.ts` under a parallel 4-file run; passes deterministically on rerun both alone and in the same batch.)

## Invariants checked

Dream-page exclusion lands in BOTH engines (engine parity); no JSONB stringify-into-cast; no source-scoping or trust-boundary changes; no docs edits.

Original author: @nguyenchiviet — authorship preserved via cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)