### PR TITLE
reland: fix: handle <think> reasoning tags in parseExtractorOutput (#2559)

### DIFF
--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -299,6 +299,8 @@ export async function defaultExtractor(
 export function parseExtractorOutput(raw: string): ProposedTake[] {
   if (!raw || raw.trim().length === 0) return [];
   let text = raw.trim();
+  // Strip <think>...</think> reasoning tags (MiniMax-M3, DeepSeek-R1, etc.).
+  text = text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
   // Strip markdown code fence wrapper.
   const fenced = text.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/);
   if (fenced) text = (fenced[1] ?? '').trim();
@@ -311,7 +313,21 @@ export function parseExtractorOutput(raw: string): ProposedTake[] {
   try {
     parsed = JSON.parse(text.slice(start));
   } catch {
-    return [];
+    // Fallback: truncate at last ] or } to handle trailing noise (e.g. leftover
+    // markdown fences after <think> stripping). Try array-closing first.
+    const sliced = text.slice(start);
+    const lastArr = sliced.lastIndexOf(']');
+    const lastObj = sliced.lastIndexOf('}');
+    const end = Math.max(lastArr, lastObj);
+    if (end > 0) {
+      try {
+        parsed = JSON.parse(sliced.slice(0, end + 1));
+      } catch {
+        return [];
+      }
+    } else {
+      return [];
+    }
   }
   const arr = Array.isArray(parsed) ? parsed : [parsed];
   const out: ProposedTake[] = [];

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -169,6 +169,26 @@ describe('parseExtractorOutput', () => {
     const out = parseExtractorOutput(raw);
     expect(out[0]!.domain).toBe('macro');
   });
+
+  test('strips <think> reasoning tags before parsing (MiniMax-M3, DeepSeek-R1)', () => {
+    const raw = '<think>Analyzing the prose... I see several claims.</think>\n\n```json\n[{"claim_text":"X","kind":"take","holder":"brain","weight":0.5}]\n```';
+    const out = parseExtractorOutput(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.claim_text).toBe('X');
+  });
+
+  test('strips multiple <think> blocks', () => {
+    const raw = '<think>First thought.</think>\n<tool_call>...</tool_call>\n<think>Second thought.</think>\n\n[{"claim_text":"Y","kind":"bet","holder":"brain","weight":0.7}]';
+    const out = parseExtractorOutput(raw);
+    expect(out).toHaveLength(1);
+  });
+
+  test('handles trailing noise after JSON (leftover fences)', () => {
+    const raw = '<think>done</think>\n```json\n[{"claim_text":"Z","kind":"take","holder":"brain","weight":0.6}]\n```\n';
+    const out = parseExtractorOutput(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.claim_text).toBe('Z');
+  });
 });
 
 // ─── contentHash ────────────────────────────────────────────────────


### PR DESCRIPTION
## Reland of #2559

The original squash commit (2724c3b6) landed in a batch that went red on master CI; the whole batch was auto-reverted (55af5fc0). This PR re-lands the original change verbatim (clean cherry-pick onto current master) — the change itself is innocent.

## Evidence

- `bun run typecheck` — exit 0
- `bun test test/propose-takes.test.ts` — 36 pass / 0 fail (includes the 3 new cases for think tags + trailing noise)
- Diff is fully self-contained: `src/core/cycle/propose-takes.ts` (parseExtractorOutput) + its test file. No DB/engine/JSONB/scope surface touched.

## Original change

Reasoning models (MiniMax-M3, DeepSeek-R1, etc.) emit `<think>...</think>` before the JSON output, breaking both the fence regex and the `indexOf`-based JSON start detection in `parseExtractorOutput`. Fix strips think tags before parsing and adds a truncate-at-last-`]`/`}` fallback for trailing noise.

Co-authored-by: qaz8545355 <603191978@qq.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)