### PR TITLE
reland: fix(storage): Supabase signed URLs — prepend /storage/v1 (#2565)

### DIFF
--- a/src/core/storage/supabase.ts
+++ b/src/core/storage/supabase.ts
@@ -195,7 +195,14 @@ export class SupabaseStorage implements StorageBackend {
       throw new Error(`Supabase signed URL failed: ${res.status} ${body}`);
     }
     const result = await res.json() as { signedURL: string };
-    return `${this.projectUrl}${result.signedURL}`;
+    // Supabase returns `signedURL` relative to the Storage API root, e.g.
+    // "/object/sign/<bucket>/<path>?token=...". Prepend projectUrl + "/storage/v1"
+    // (not just projectUrl) or the link 404s. Tolerate an already-absolute URL or a
+    // value that already carries the /storage/v1 prefix.
+    const signed = result.signedURL;
+    if (/^https?:\/\//.test(signed)) return signed;
+    if (signed.startsWith('/storage/v1')) return `${this.projectUrl}${signed}`;
+    return `${this.projectUrl}/storage/v1${signed.startsWith('/') ? '' : '/'}${signed}`;
   }
 
   async getUrl(path: string): Promise<string> {


### PR DESCRIPTION
## Reland of #2565

#2565 was squash-merged (5a295bc2) but its merge batch went red on master CI and the whole batch was auto-reverted (10b57460). This PR cherry-picks the original squash commit back onto current master — the change itself is innocent.

### Original change
`SupabaseStorage.getSignedUrl` built the download URL as `${projectUrl}${signedURL}`, but Supabase's sign API returns `signedURL` relative to the Storage API root (`/object/sign/<bucket>/<path>?token=...`), so the generated link dropped `/storage/v1` and 404'd. Now prepends `${projectUrl}/storage/v1`, tolerating an already-absolute URL or a value that already carries the prefix.

### Verification (local, on this branch)
- Clean cherry-pick of 5a295bc2 onto master (no conflicts)
- `bun run typecheck` — exit 0
- `bun test` on all storage suites (storage, storage-backfill, storage-config, storage-export, storage-pglite, storage-status, storage-sync): 77 pass / 1 fail on first run — the single failure was a beforeEach migration-setup timeout in `test/storage-pglite.test.ts` (unrelated to this diff, which only touches Supabase signed-URL string building); it passes cleanly standalone (6 pass / 0 fail)

Credit: original fix by @FloridaStyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)