### PR TITLE
reland: fix(minions): default timeout for contextual reindex (#2611)

### DIFF
--- a/src/core/minions/handler-timeouts.ts
+++ b/src/core/minions/handler-timeouts.ts
@@ -24,6 +24,7 @@
  */
 
 const THIRTY_MIN_MS = 30 * 60 * 1000;
+const SIXTY_MIN_MS = 60 * 60 * 1000;
 const TEN_MIN_MS = 10 * 60 * 1000;
 
 /**
@@ -42,6 +43,10 @@ export const HANDLER_DEFAULT_TIMEOUT_MS: Readonly<Record<string, number>> = {
   // few writes. Generous 10-min budget (vs the tight null-default) covers a
   // slow gateway without the 30-min loop budget.
   chronicle_extract: TEN_MIN_MS,
+  // Per-page contextual reindex jobs process chunks sequentially with one
+  // rate-leased LLM synopsis call per chunk; large transcript pages need more
+  // than the standard 30-min long-job budget.
+  contextual_reindex_per_chunk: SIXTY_MIN_MS,
 };
 
 /**

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -354,6 +354,13 @@ describe('MinionQueue: #1737 per-handler default timeout', () => {
     expect(sub.timeout_ms).toBe(30 * 60 * 1000);
   });
 
+  test('contextual per-chunk reindex gets the 60-min default', async () => {
+    const job = await queue.add('contextual_reindex_per_chunk', { page_slug: 'large-transcript' }, undefined, {
+      allowProtectedSubmit: true,
+    });
+    expect(job.timeout_ms).toBe(60 * 60 * 1000);
+  });
+
   test('explicit timeout_ms always wins over the default', async () => {
     const job = await queue.add('embed-backfill', { sourceId: 'x' }, { timeout_ms: 5000 });
     expect(job.timeout_ms).toBe(5000);


### PR DESCRIPTION
## Reland of #2611

PR #2611 (squash commit fc1f88cd) was auto-reverted in f02919c0 because its merge BATCH went red on master CI — the whole batch was reverted wholesale, not because this change was implicated.

## Why it's innocent

The change is purely additive: one new constant (`SIXTY_MIN_MS`) and one new entry in `HANDLER_DEFAULT_TIMEOUT_MS` (`contextual_reindex_per_chunk: SIXTY_MIN_MS`) in `src/core/minions/handler-timeouts.ts`, plus one unit test. It touches no shared behavior — existing handlers keep their defaults, and explicit `timeout_ms` still wins.

## Local gates (cherry-pick of fc1f88cd onto current origin/master, ca47c054)

- Cherry-pick applied clean, no conflicts.
- `bun run typecheck` — exit 0.
- `bun test test/minions.test.ts` — 181 pass / 0 fail (includes the new 60-min default test).
- `bun test test/queue-child-done.test.ts test/queue-getstats-wedge.test.ts test/queue-lock-retry.test.ts test/minions-shell.test.ts test/embed-backfill-submit.test.ts test/minions-lease-full-retry.test.ts` — 80 pass / 0 fail.

Original author: @spiky02plateau

🤖 Generated with [Claude Code](https://claude.com/claude-code)