### PR TITLE
reland: fix(health): count 'entity' pages in graph health metrics (#2639)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5261,7 +5261,7 @@ export class PGLiteEngine implements BrainEngine {
     // dashboard, v0.10.3 metrics give entity-page-level granularity.
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -5289,7 +5289,7 @@ export class PGLiteEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company')
       ORDER BY link_count DESC
       LIMIT 5
     `);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5364,7 +5364,7 @@ export class PostgresEngine implements BrainEngine {
     // dashboard health.
     const [h] = await sql`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -5389,7 +5389,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company')
       ORDER BY link_count DESC
       LIMIT 5
     `;

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1434,6 +1434,7 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     await engine.putPage('people/alice', { ...testPage, type: 'person', title: 'Alice' });
     await engine.putPage('people/bob', { ...testPage, type: 'person', title: 'Bob' });
     await engine.putPage('companies/acme', { ...testPage, type: 'company', title: 'Acme' });
+    await engine.putPage('entities/project-x', { ...testPage, type: 'entity', title: 'Project X' });
   });
 
   test('link_coverage = 0 when no links exist', async () => {
@@ -1442,17 +1443,17 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
   });
 
   test('link_coverage = % of entity pages with >= 1 inbound link', async () => {
-    // Acme gets 1 inbound link (from Alice), Alice/Bob get 0 inbound.
-    // 1 of 3 entity pages has inbound links -> 33%.
+    // Acme gets 1 inbound link (from Alice); Alice/Bob/Project X get 0 inbound.
+    // 1 of 4 entity pages has inbound links -> 25%.
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     const h = await engine.getHealth();
-    expect(h.link_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.link_coverage).toBeCloseTo(1 / 4, 2);
   });
 
   test('timeline_coverage = % with >= 1 timeline entry', async () => {
     await engine.addTimelineEntry('people/alice', { date: '2026-01-15', summary: 'Joined' });
     const h = await engine.getHealth();
-    expect(h.timeline_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.timeline_coverage).toBeCloseTo(1 / 4, 2);
   });
 
   test('most_connected lists top entities by link count', async () => {
@@ -1465,7 +1466,9 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
   });
 
   test('orphan_pages: pages with neither inbound nor outbound links', async () => {
-    // All 3 pages start with no links. Expect 3 orphans.
+    // All 4 pages start with no links, but entities/project-x is excluded
+    // from orphan reporting by the shared orphan policy ('entities' is a
+    // first-segment exclusion in orphan-policy.ts). Expect 3 orphans.
     const h = await engine.getHealth();
     expect(h.orphan_pages).toBe(3);
 


### PR DESCRIPTION
## Summary

Reland of #2639, which was squash-merged (8fc93c8f) and then auto-reverted (68e4cebd) when its batch went red on master CI.

#2639 was a genuine culprit in that batch: its test change added an entity-typed page at slug `entities/project-x` and expected it in `orphan_pages`, but #3023 (shared orphan-reporting policy, landed 2026-07-21 — before #2639 merged) excludes the `entities` first segment from orphan reporting. The PR's own `orphan_pages` test therefore failed against master.

## What changed vs the original

- The SQL fix is unchanged: `getHealth`'s entity_pages CTE and the top-linked-pages query now include `'entity'` alongside `'person'`/`'company'`, in both PGLite and Postgres engines (engine parity).
- The `orphan_pages` test expectations are corrected for the orphan-policy exclusion: the `entities/project-x` page is (correctly) not in the orphan denominator, so orphan counts stay 3 → 1. Link/timeline coverage expectations (1/4, type-based SQL) are unchanged from the original PR and pass.

## Local gates (on origin/master + this cherry-pick)

- `bun run typecheck` — exit 0
- `bun test test/pglite-engine.test.ts` — 109 pass / 0 fail (includes the 5 getHealth graph-metrics tests)
- Related coverage: advisor-op-gate, advisor-core, orphans-pure-fn, brain-score-breakdown, doctor-timeline-metric-labels-2298, advisor-ranking-eval, features, doctor-brain-checks-score, doctor-orphan-ratio, orphans-source-scope — 103 pass / 0 fail
- `bun test test/embed.serial.test.ts` — 31 pass / 0 fail

Original author: @tyler-robinson (authorship preserved on the cherry-picked commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)