### PR TITLE
reland: fix(webhook): extract links for incremental push syncs (#2850)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2217,8 +2217,10 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   //     Other event types (ping, pull_request, etc.) return 202 'ignored'
   //     so GitHub doesn't retry.
   // D15.5: HMAC compare uses the shared safeHexEqual helper.
-  // D18: submits 'sync' job with auto_embed_backfill=true and priority -10
-  //     (above autopilot's 0).
+  // D18: submits 'sync' job with extraction + auto_embed_backfill enabled and
+  //     priority -10 (above autopilot's 0). This opts normal incremental pushes
+  //     into sync's inline extraction while pagesAffected still identifies the
+  //     changed pages. The sync core can still defer large (>100) changes.
   // ---------------------------------------------------------------------------
   const githubWebhookLimiter = rateLimit({
     windowMs: 60_000,
@@ -2338,6 +2340,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
           'sync',
           {
             sourceId: source.id,
+            noExtract: false,
             auto_embed_backfill: true,
             embed_reason: 'webhook',
           },

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1423,6 +1423,7 @@ See also:
     {
       sourceId: sourceIdArg,
       repoPath: source.local_path,
+      noExtract: false,
       auto_embed_backfill: true,
       embed_reason: 'sync_trigger',
     },

--- a/test/sources-webhook.test.ts
+++ b/test/sources-webhook.test.ts
@@ -16,6 +16,7 @@
  */
 import { describe, test, expect } from 'bun:test';
 import { createHmac } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { safeHexEqual } from '../src/core/timing-safe.ts';
 
 const GITHUB_SECRET = 'super-secret-webhook-key';
@@ -121,5 +122,27 @@ describe('Branch ref construction (D5)', () => {
     const trackedBranch: string = 'main';
     const pushedRef: string = 'refs/heads/feature/new-stuff';
     expect(pushedRef === `refs/heads/${trackedBranch}`).toBe(false);
+  });
+});
+
+describe('Webhook sync job extraction contract', () => {
+  test('opts into extraction before the pushed commit is consumed', () => {
+    const serveSource = readFileSync(
+      new URL('../src/commands/serve-http.ts', import.meta.url),
+      'utf8',
+    );
+    const routeStart = serveSource.indexOf("'/webhooks/github'");
+    const queueStart = serveSource.indexOf('const job = await queue.add(', routeStart);
+    const responseStart = serveSource.indexOf('res.status(202)', queueStart);
+    expect(routeStart).toBeGreaterThanOrEqual(0);
+    expect(queueStart).toBeGreaterThan(routeStart);
+    expect(responseStart).toBeGreaterThan(queueStart);
+
+    const routeSource = serveSource.slice(queueStart, responseStart);
+    const payload = routeSource.match(
+      /queue\.add\(\s*'sync',\s*\{([\s\S]*?)\}\s*,\s*\{/,
+    );
+    expect(payload).not.toBeNull();
+    expect(payload?.[1]).toMatch(/\bnoExtract:\s*false\b/);
   });
 });

--- a/test/sync-trigger-cli.test.ts
+++ b/test/sync-trigger-cli.test.ts
@@ -100,6 +100,7 @@ describe('runSyncTrigger', () => {
     const job = jobs[0];
     expect(job.priority).toBe(-10);
     expect((job.data as { sourceId: string }).sourceId).toBe('default');
+    expect((job.data as { noExtract: boolean }).noExtract).toBe(false);
     expect((job.data as { auto_embed_backfill: boolean }).auto_embed_backfill).toBe(true);
   });
 


### PR DESCRIPTION
## Why

PR #2850 was squash-merged as 11659743, but the batch it landed in went red on master CI and the entire batch was auto-reverted (45f85df8). This PR re-lands the original change unmodified — the commit cherry-picks cleanly onto current master and passes all local gates, indicating #2850 was innocent of the batch failure.

## What (unchanged from #2850)

- Webhook `sync` job submission (`src/commands/serve-http.ts`) and `runSyncTrigger` (`src/commands/sync.ts`) now pass `noExtract: false`, opting incremental push syncs into inline extraction (sync core still defers large >100-page changes).
- Tests pin the contract in `test/sources-webhook.test.ts` and `test/sync-trigger-cli.test.ts`.

## Local gates (on cherry-pick over current master ca47c054)

- `bun run typecheck` — exit 0
- `bun test test/sources-webhook.test.ts test/sync-trigger-cli.test.ts` — 19 pass / 0 fail
- 12 additional serve-http/sync coverage files — 99 pass / 0 fail
- 5 sync serial/mcp coverage files — 48 pass / 0 fail

Original author: @patentsong (Song).

🤖 Generated with [Claude Code](https://claude.com/claude-code)