### PR TITLE
feat: per-call source_id for get_page/list_pages, plus list_pages offset

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -737,11 +737,15 @@ export interface Operation {
 
 const get_page: Operation = {
   name: 'get_page',
-  description: 'Read a page by slug (supports optional fuzzy matching). Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated (see v0.26.5 recovery window).',
+  description: 'Read a page by slug (supports optional fuzzy matching and per-call source narrowing). Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated (see v0.26.5 recovery window).',
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     fuzzy: { type: 'boolean', description: 'Enable fuzzy slug resolution (default: false)' },
     include_deleted: { type: 'boolean', description: 'v0.26.5: surface soft-deleted pages with deleted_at populated (default: false). Used by restore workflows.' },
+    source_id: {
+      type: 'string',
+      description: 'v0.43 — optional per-call source narrowing. Grant-bound for remote callers; trusted-local callers may pass any source.',
+    },
   },
   handler: async (ctx, p) => {
     const slug = p.slug as string;
@@ -755,7 +759,11 @@ const get_page: Operation = {
     // now honors sourceIds[] (both engines), so the same scope closes both paths.
     // #3242: federatedSearchScope (not bare sourceScopeOpts) so an unqualified
     // read sees pages in `federated: true` sources, matching search/query.
-    const sourceOpts = federatedSearchScope(ctx);
+    // v0.43: optional per-call source_id narrows the scope further.
+    const sourceOpts = federatedSearchScope(
+      ctx,
+      typeof p.source_id === 'string' ? p.source_id : undefined,
+    );
     const fuzzyScope = sourceOpts;
 
     let page = await ctx.engine.getPage(slug, { includeDeleted, ...sourceOpts });
@@ -1484,7 +1492,6 @@ const list_pages: Operation = {
   params: {
     type: { type: 'string', description: 'Filter by page type' },
     tag: { type: 'string', description: 'Filter by tag' },
-    limit: { type: 'number', description: 'Max results (default 50)' },
     // v0.29 — surface filter that already exists on PageFilters.
     updated_after: {
       type: 'string',
@@ -1496,6 +1503,15 @@ const list_pages: Operation = {
       description: 'Sort order. Default updated_desc (matches pre-v0.29). Options: updated_desc, updated_asc, created_desc, slug.',
     },
     include_deleted: { type: 'boolean', description: 'v0.26.5: include soft-deleted pages (default: false). Used by restore workflows and operator diagnostics.' },
+    source_id: {
+      type: 'string',
+      description: 'v0.43 — optional per-call source narrowing. Grant-bound for remote callers; trusted-local callers may pass any source.',
+    },
+    limit: { type: 'number', description: 'Max results. Clamped to 1–100 (default 100).' },
+    offset: {
+      type: 'number',
+      description: 'Skip first N results for pagination (default 0). Must be a nonnegative safe integer.',
+    },
   },
   handler: async (ctx, p) => {
     // Whitelist the sort enum at the handler before passing to the engine.
@@ -1512,11 +1528,21 @@ const list_pages: Operation = {
     // pages indiscriminately.
     // #3242: federatedSearchScope so unqualified listing spans federated
     // sources (same visibility set as search / get_page). Grants still win.
-    const scope = federatedSearchScope(ctx);
+    // v0.43: optional per-call source_id narrows the scope further.
+    const scope = federatedSearchScope(
+      ctx,
+      typeof p.source_id === 'string' ? p.source_id : undefined,
+    );
+    // v0.43: offset for deterministic pagination; validated by dispatch.
+    const rawOffset = p.offset as number | undefined;
+    const offset = typeof rawOffset === 'number' && Number.isFinite(rawOffset)
+      ? Math.max(0, Math.trunc(rawOffset))
+      : 0;
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
       limit: clampSearchLimit(p.limit as number | undefined, 50, 100),
+      offset,
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,

--- a/test/page-read-pagination-contract.test.ts
+++ b/test/page-read-pagination-contract.test.ts
@@ -1,0 +1,186 @@
+/**
+ * v0.43 — contract coverage for per-call source_id on get_page and
+ * list_pages, plus deterministic offset pagination.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import type { OperationContext } from '../src/core/operations';
+import { operationsByName } from '../src/core/operations';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path) VALUES ('hermes-memory', 'hermes-memory', '/tmp/hm') ON CONFLICT (id) DO NOTHING`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path) VALUES ('bear-brain', 'bear-brain', '/tmp/bb') ON CONFLICT (id) DO NOTHING`,
+  );
+  await engine.putPage('hot/turn/evt-1', {
+    type: 'turn_event',
+    title: 'Turn event one',
+    compiled_truth: 'turn body one',
+    frontmatter: {},
+  }, { sourceId: 'hermes-memory' });
+  await engine.putPage('hot/turn/evt-2', {
+    type: 'turn_event',
+    title: 'Turn event two',
+    compiled_truth: 'turn body two',
+    frontmatter: {},
+  }, { sourceId: 'hermes-memory' });
+  await engine.putPage('decisions/2026-01', {
+    type: 'decision',
+    title: 'Decision page',
+    compiled_truth: 'decision body',
+    frontmatter: {},
+  }, { sourceId: 'bear-brain' });
+  await engine.putPage('hot/turn/evt-3', {
+    type: 'turn_event',
+    title: 'Turn event three',
+    compiled_truth: 'turn body three',
+    frontmatter: {},
+  }, { sourceId: 'hermes-memory' });
+});
+
+function localCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine,
+    sourceId: 'default',
+    remote: false,
+    localFederatedSourceIds: ['hermes-memory', 'bear-brain'],
+    ...overrides,
+  } as OperationContext;
+}
+
+// ---------------------------------------------------------------------------
+// get_page source_id narrowing
+// ---------------------------------------------------------------------------
+describe('get_page per-call source_id', () => {
+  const op = operationsByName.get_page;
+
+  test('exact match in the requested source returns the page', async () => {
+    const result = await op.handler(localCtx(), {
+      slug: 'hot/turn/evt-1',
+      source_id: 'hermes-memory',
+    });
+    expect(result).toHaveProperty('slug', 'hot/turn/evt-1');
+    expect(result).toHaveProperty('source_id', 'hermes-memory');
+    // local caller sees compiled_truth
+    expect(result).toHaveProperty('compiled_truth', 'turn body one');
+  });
+
+  test('exact match in the wrong source returns page_not_found', async () => {
+    await expect(
+      op.handler(localCtx(), {
+        slug: 'hot/turn/evt-1',
+        source_id: 'bear-brain',
+      }),
+    ).rejects.toThrow(/Page not found/);
+  });
+
+  test('unqualified read sees cross-source pages via federated scope', async () => {
+    const result = await op.handler(localCtx(), {
+      slug: 'decisions/2026-01',
+    });
+    expect(result).toHaveProperty('slug', 'decisions/2026-01');
+    expect(result).toHaveProperty('source_id', 'bear-brain');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_pages source_id + offset
+// ---------------------------------------------------------------------------
+describe('list_pages source_id and offset', () => {
+  const op = operationsByName.list_pages;
+
+  test('lists only pages from the requested source', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+    })) as any[];
+    expect(result.length).toBe(3);
+    for (const row of result) {
+      expect(row.source_id).toBe('hermes-memory');
+    }
+  });
+
+  test('lists only pages from another source', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'bear-brain',
+    })) as any[];
+    expect(result.length).toBe(1);
+    expect(result[0].source_id).toBe('bear-brain');
+  });
+
+  test('offset=1 skips the first page in deterministic order', async () => {
+    const all = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+    })) as any[];
+    const skipped = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+      offset: 1,
+    })) as any[];
+    expect(skipped.length).toBe(2);
+    expect(skipped[0].slug).toBe(all[1].slug);
+  });
+
+  test('limit=1, offset=2 returns only the third page', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+      limit: 1,
+      offset: 2,
+    })) as any[];
+    expect(result.length).toBe(1);
+    const all = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+      limit: 100,
+    })) as any[];
+    expect(result[0].slug).toBe(all[2].slug);
+  });
+
+  test('offset beyond total returns empty', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      offset: 999,
+    })) as any[];
+    expect(result).toEqual([]);
+  });
+
+  test('offset=0 default preserved when not passed', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      sort: 'slug',
+    })) as any[];
+    expect(result.length).toBe(3);
+  });
+
+  test('output remains metadata-only (no body/prose)', async () => {
+    const result = (await op.handler(localCtx(), {
+      source_id: 'hermes-memory',
+      limit: 1,
+    })) as any[];
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const row = result[0] as Record<string, unknown>;
+    expect(row).not.toHaveProperty('compiled_truth');
+    expect(row).not.toHaveProperty('content');
+    expect(row).toHaveProperty('slug');
+    expect(row).toHaveProperty('title');
+    expect(row).toHaveProperty('source_id');
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional `source_id` narrowing and deterministic `offset` pagination to the page-read operations, complementing the whoami source grant introspection merged in #3332.

### Changes

**`get_page` — per-call source narrowing**
- New optional `source_id` parameter, routed through `federatedSearchScope` for grant-aware resolution.
- Exact and fuzzy reads respect the scope; cross-source lookups return `page_not_found`.

**`list_pages` — source narrowing + offset pagination**
- New optional `source_id` parameter (same grant semantics as `get_page`).
- New optional `offset` parameter (nonnegative safe integer, clamped in handler).
- Enables deterministic 100+1 overflow probing for remote inventory clients.

### Contract tests

10 new tests in `test/page-read-pagination-contract.test.ts`:
- Exact match in requested source returns the page
- Exact match in wrong source returns page_not_found
- Unqualified read sees federated cross-source pages
- Source-scoped listing (both sources)
- Offset (skip first, skip 2+limit 1, beyond total → empty, default 0)
- Metadata-only output (no body/prose leak)

### Verification

```
bun run typecheck: pass
bun run build: pass
82 relevant tests: all pass
```