### PR TITLE
feat(gateway): resolveNativeBaseUrl falls back to the config plane

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/ubuntu/gbrain-fork/node_modules

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -445,7 +445,16 @@ export function resolveNativeBaseUrl(
   cfg: AIGatewayConfig,
 ): string | undefined {
   const envKey = provider === 'anthropic' ? 'ANTHROPIC_BASE_URL' : 'OPENAI_BASE_URL';
-  const raw = cfg.env[envKey];
+  // Fall back to the config plane (provider_base_urls.<provider>, routed into
+  // cfg.base_urls by buildGatewayConfig) when the *_BASE_URL env var is absent or
+  // empty, so a native provider can target an OpenAI/Anthropic-compatible endpoint
+  // from config.json alone, with no dependence on an exported env var. This is the
+  // same fallback rationale buildGatewayConfig already applies to API keys: env
+  // wins when it carries a real value, but daemon/launchd/MCP contexts that never
+  // sourced the shell (or that inject an empty ANTHROPIC_BASE_URL) still resolve
+  // from config.json.
+  const envRaw = cfg.env[envKey];
+  const raw = envRaw && envRaw.trim() ? envRaw : cfg.base_urls?.[provider];
   if (!raw || !raw.trim()) return undefined;
   const trimmed = raw.trim().replace(/\/+$/, '');
   return /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;

--- a/test/ai/resolve-native-base-url.test.ts
+++ b/test/ai/resolve-native-base-url.test.ts
@@ -7,7 +7,7 @@
  * makes the SDK POST <base>/messages → 404. resolveNativeBaseUrl normalizes a configured
  * base URL to carry /v1, and returns undefined when unset so the SDK default is preserved.
  *
- * Pure function over cfg.env — no process.env mutation, so no withEnv() needed.
+ * Pure function over cfg (env + base_urls), no process.env mutation, so no withEnv() needed.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -59,5 +59,52 @@ describe('resolveNativeBaseUrl (#1250)', () => {
   test('each provider only reads its own env var', () => {
     expect(resolveNativeBaseUrl('openai', cfgWith({ ANTHROPIC_BASE_URL: 'https://x' }))).toBeUndefined();
     expect(resolveNativeBaseUrl('anthropic', cfgWith({ OPENAI_BASE_URL: 'https://x' }))).toBeUndefined();
+  });
+
+  // Config-plane fallback: provider_base_urls is routed into cfg.base_urls by
+  // buildGatewayConfig, keyed by provider name. When the env var is absent (or
+  // empty), resolve from there instead, so config.json alone works in env-less
+  // (daemon/launchd/MCP) contexts.
+  function cfgWithBase(
+    env: Record<string, string | undefined>,
+    base_urls: Record<string, string>,
+  ): AIGatewayConfig {
+    return { env, base_urls } as unknown as AIGatewayConfig;
+  }
+
+  test('anthropic: falls back to cfg.base_urls when the env var is unset', () => {
+    expect(
+      resolveNativeBaseUrl('anthropic', cfgWithBase({}, { anthropic: 'https://compat.example/v1' })),
+    ).toBe('https://compat.example/v1');
+  });
+
+  test('anthropic: config-plane fallback still gets /v1 normalization', () => {
+    expect(
+      resolveNativeBaseUrl('anthropic', cfgWithBase({}, { anthropic: 'https://compat.example' })),
+    ).toBe('https://compat.example/v1');
+  });
+
+  test('anthropic: a real env value wins over the config-plane fallback', () => {
+    expect(
+      resolveNativeBaseUrl(
+        'anthropic',
+        cfgWithBase({ ANTHROPIC_BASE_URL: 'https://env.example' }, { anthropic: 'https://config.example' }),
+      ),
+    ).toBe('https://env.example/v1');
+  });
+
+  test('anthropic: an empty env var falls through to the config plane', () => {
+    expect(
+      resolveNativeBaseUrl(
+        'anthropic',
+        cfgWithBase({ ANTHROPIC_BASE_URL: '' }, { anthropic: 'https://config.example' }),
+      ),
+    ).toBe('https://config.example/v1');
+  });
+
+  test('openai: falls back to cfg.base_urls[openai] when the env var is unset', () => {
+    expect(
+      resolveNativeBaseUrl('openai', cfgWithBase({}, { openai: 'https://oai-compat.example/v1' })),
+    ).toBe('https://oai-compat.example/v1');
   });
 });


### PR DESCRIPTION
## Summary

`resolveNativeBaseUrl` only read the `*_BASE_URL` env var, so a native
`anthropic:` / `openai:` provider could not pick up a base URL set only in
`config.json` (`provider_base_urls.<provider>`). Env-less contexts (a `gbrain
serve` systemd unit, launchd, an MCP server that never sourced the shell) could
not reach a configured compatible endpoint even though config.json looked
complete.

This falls back to `cfg.base_urls[provider]` when the env var is absent, keeping
the existing `/v1` normalisation for both sources. Env still wins when present,
mirroring the config-as-fallback rationale `buildGatewayConfig` already applies
to API keys. It completes the config-plane path #919 described (that issue was
closed by wiring the env var, not `provider_base_urls`).

## Linked issue

Fixes #3350

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

1. `bun test test/ai/resolve-native-base-url.test.ts` (11 pass). The suite now includes the config-plane fallback cases the fix adds: falls back to `cfg.base_urls[provider]` when the env var is unset, a real env value wins over config, an empty env var falls through to config, and the openai path, all with `/v1` normalisation. The pre-existing env-only cases are unchanged.
2. Manually: set `provider_base_urls.anthropic` in config.json with no `ANTHROPIC_BASE_URL` exported, use `chat_model: "anthropic:<model>"`, and confirm the request targets the configured endpoint.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end. `bun run verify` (31/31 checks green), the unit test (11 pass), and `check-privacy.sh`. Did not run the DB e2e suite (needs DATABASE_URL); this is a pure config-resolution function covered by unit tests.

## Model used

Claude Opus 4.8 (1M context) via Claude Code, used to sanitise the comment, write the PR/issue, and run the test. The one-line logic change is the author's own patch.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
