### PR TITLE
feat(config): fold llama_server_api_key into gateway env

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -44,6 +44,12 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // multimodal/image embeds despite config.json looking complete. process.env
   // still wins via the later spread.
   if (c.voyage_api_key) envFromConfig.VOYAGE_API_KEY = c.voyage_api_key;
+  // Bearer for an auth-gated llama-server embed proxy (e.g. a reverse proxy
+  // fronting the embed endpoint). The recipe declares LLAMA_SERVER_API_KEY as an
+  // optional auth env; without this fold the only channel was a raw env var, so a
+  // config-plane URL pointed at an auth-gated endpoint 401s. Mirrors the
+  // openai/anthropic/zeroentropy folds above.
+  if (c.llama_server_api_key) envFromConfig.LLAMA_SERVER_API_KEY = c.llama_server_api_key;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -63,6 +63,14 @@ export interface GBrainConfig {
    * config.json file-plane route is wired through today.
    */
   voyage_api_key?: string;
+  /**
+   * llama-server (llama.cpp) API key. Needed once the embed endpoint is
+   * fronted by an auth-gated reverse proxy (e.g. a bearer-gated cloudflared
+   * URL) rather than a local no-auth port. Folds into the gateway env as
+   * LLAMA_SERVER_API_KEY (see buildGatewayConfig), which the llama-server
+   * recipe reads. File-plane only — kept in ~/.gbrain/config.json (600).
+   */
+  llama_server_api_key?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;
@@ -575,6 +583,7 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
     ...(process.env.OPENROUTER_API_KEY ? { openrouter_api_key: process.env.OPENROUTER_API_KEY } : {}),
+    ...(process.env.LLAMA_SERVER_API_KEY ? { llama_server_api_key: process.env.LLAMA_SERVER_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -139,6 +139,27 @@ describe('buildGatewayConfig config-plane API-key folding', () => {
       expect(cfg.env.VOYAGE_API_KEY).toBe('pa-env-plane');
     });
   });
+
+  // llama_server_api_key: same file-plane fold so a config.json-only key reaches
+  // the llama-server recipe's LLAMA_SERVER_API_KEY in env-less (daemon/launchd/MCP)
+  // contexts. Same fold pattern as voyage/zeroentropy above.
+  test('llama_server_api_key folds into gateway env as LLAMA_SERVER_API_KEY', async () => {
+    await withEnv({ LLAMA_SERVER_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        llama_server_api_key: 'la-config-plane',
+      } as unknown as GBrainConfig);
+      expect(cfg.env.LLAMA_SERVER_API_KEY).toBe('la-config-plane');
+    });
+  });
+
+  test('a real LLAMA_SERVER_API_KEY process.env value wins over the config-plane fallback', async () => {
+    await withEnv({ LLAMA_SERVER_API_KEY: 'la-env-plane' }, async () => {
+      const cfg = buildGatewayConfig({
+        llama_server_api_key: 'la-config-plane',
+      } as unknown as GBrainConfig);
+      expect(cfg.env.LLAMA_SERVER_API_KEY).toBe('la-env-plane');
+    });
+  });
 });
 
 describe('buildGatewayConfig env empty-string clobber guard (#1249)', () => {


### PR DESCRIPTION
## Summary

`config.json`'s `llama_server_api_key` was accepted at the file plane but never
folded into the gateway env, so the `llama-server` recipe's optional
`LLAMA_SERVER_API_KEY` was only reachable via a raw process env var. A
config-plane key aimed at an auth-gated llama-server embed proxy then 401s in
env-less contexts (a `gbrain serve` systemd unit, launchd, MCP) despite
config.json looking complete.

This folds it into the gateway env alongside the existing
openai/anthropic/zeroentropy/openrouter/voyage folds. Process env still wins via
the later spread; this is the file-plane fallback. Same class as #2662 (voyage).

## Linked issue

Fixes #3352

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

1. `bun test test/ai/build-gateway-config.test.ts` (17 pass; includes two new tests: llama_server_api_key folds into `LLAMA_SERVER_API_KEY`, and a real env value wins over the config-plane fallback, mirroring the voyage tests).
2. Manually: set `llama_server_api_key` in config.json with no `LLAMA_SERVER_API_KEY` exported and confirm the llama-server recipe receives it.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end. `bun run verify` (31/31 checks green) and the unit tests (17 pass). Did not run e2e (needs DATABASE_URL); the change is a config-env fold covered by unit tests.

## Model used

Claude Opus 4.8 (1M context) via Claude Code, used to sanitise the comment, add the two mirroring tests, and write the PR/issue. The fold itself is the author's patch.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
