### PR TITLE
feat(ai): configurable output-language policy for curation phases (#3357)

### DIFF
--- a/src/core/ai/curation-language.ts
+++ b/src/core/ai/curation-language.ts
@@ -1,0 +1,73 @@
+/**
+ * Configurable output-language policy for dream curation phases (issue #3357).
+ *
+ * gbrain's phase prompts (EXTRACTOR_SYSTEM, propose_takes, synthesize, …) carry
+ * no output-language rule beyond "capture verbatim where possible", so on
+ * non-English captures the model tends to emit English claim text — losing the
+ * source-language framing of a bilingual brain.
+ *
+ * This appends a short directive to the phase system prompt, driven by the
+ * `dream.curation.output_language` config (DB plane, like `models.tier.*`):
+ *   - unset / "source" (default): match the detected dominant language of the input.
+ *   - "off" / "none":             no directive (prior native behavior).
+ *   - a language code ("ko","en","ja","zh",…): force that language.
+ *
+ * Prompts stay hardcoded; only the policy is config-driven — no fork of the
+ * prompt text, and default behavior is unchanged for English users.
+ */
+
+const LANG_NAMES: Record<string, string> = {
+  ko: 'Korean',
+  en: 'English',
+  ja: 'Japanese',
+  zh: 'Chinese',
+};
+
+/**
+ * Cheap, dependency-free dominant-language detection by script. Hangul-heavy
+ * text → 'ko', otherwise 'en'. Intentionally conservative (a small amount of
+ * Korean in mostly-Latin text still reads as 'ko', matching how a bilingual
+ * user writes: Korean prose with Latin brand/entity names).
+ */
+export function detectDominantLanguage(text: string): string {
+  let hangul = 0;
+  let latin = 0;
+  for (const ch of text) {
+    const c = ch.codePointAt(0) ?? 0;
+    if ((c >= 0xac00 && c <= 0xd7a3) || (c >= 0x3130 && c <= 0x318f)) hangul++;
+    else if ((c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a)) latin++;
+  }
+  // Ratio-based so it works for short and long inputs alike (a small absolute
+  // floor avoids classifying mostly-Latin text with a stray Hangul char as ko).
+  return hangul >= 2 && hangul >= 0.15 * (hangul + latin) ? 'ko' : 'en';
+}
+
+type ConfigReader = { getConfig(key: string): Promise<string | null> } | null;
+
+/**
+ * Build the output-language directive to append to a curation phase's system
+ * prompt. Returns '' when the policy is disabled or the engine is unavailable
+ * (fail-open: never breaks a phase). `sampleText` is the phase input used for
+ * "source" detection (e.g. the turn/page content).
+ */
+export async function curationLanguageDirective(
+  engine: ConfigReader,
+  sampleText: string,
+): Promise<string> {
+  let policy = 'source';
+  try {
+    const v = engine ? await engine.getConfig('dream.curation.output_language') : null;
+    if (v && v.trim()) policy = v.trim().toLowerCase();
+  } catch {
+    /* config unavailable → keep default */
+  }
+  if (policy === 'off' || policy === 'none') return '';
+  const lang = policy === 'source' ? detectDominantLanguage(sampleText) : policy;
+  const name = LANG_NAMES[lang] ?? lang;
+  return (
+    `\n\nOUTPUT LANGUAGE: Write ALL generated text (fact claims, take claim_text, ` +
+    `page prose, concept summaries) in ${name}, matching the source. Preserve proper ` +
+    `nouns, brand names, numbers, and the user's exact wording verbatim; do NOT translate ` +
+    `the user's content into another language.`
+  );
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -990,6 +990,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'dream.synthesize.output_root',
   'dream.synthesize.subagent_timeout_ms',
   'dream.synthesize.subagent_wait_timeout_ms',
+  // #3357: output-language policy for curation phases — "source" (default) | "<lang>" | "off".
+  'dream.curation.output_language',
   'dream.patterns.lookback_days',
   'dream.patterns.min_evidence',
   // #2782-family: patterns-phase subagent timeouts (mirror of the

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -40,6 +40,7 @@
 import { randomUUID, createHash } from 'node:crypto';
 import { BaseCyclePhase, type ScopedReadOpts, type BasePhaseOpts } from './base-phase.ts';
 import { chat as gatewayChat, getChatModel, probeChatModel } from '../ai/gateway.ts';
+import { curationLanguageDirective } from '../ai/curation-language.ts'; // #3357
 import { normalizeModelId } from '../model-id.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
@@ -272,9 +273,14 @@ const EXTRACTOR_CALL_TIMEOUT_MS = 90_000;
 export async function defaultExtractor(
   input: Parameters<ProposeTakesExtractor>[0],
 ): Promise<ProposedTake[]> {
+  // #3357: honor the output-language policy (default "source" = match the page's language).
+  const langDirective = await curationLanguageDirective(
+    (input as { engine?: BrainEngine }).engine ?? null,
+    input.pageBody,
+  );
   const prompt = EXTRACT_TAKES_PROMPT
     .replace('{EXISTING_TAKES_JSON}', JSON.stringify(input.existingTakes, null, 2))
-    .replace('{PAGE_BODY}', input.pageBody);
+    .replace('{PAGE_BODY}', input.pageBody) + langDirective;
 
   // Bound each call so one stalled provider socket can't pin the phase for the
   // full gateway default (GBRAIN_AI_CHAT_TIMEOUT_MS, 300s) x pageLimit. The

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -24,6 +24,7 @@ import type { ProgressReporter } from '../progress.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { chat as gatewayChat, isAvailable } from '../ai/gateway.ts';
+import { curationLanguageDirective } from '../ai/curation-language.ts'; // #3357
 // #2163: concept pages route through importFromContent (the same
 // parse→chunk→embed pipeline put_page uses) instead of a bare engine.putPage,
 // so they land in the retrieval surface (content_chunks + embeddings) where
@@ -183,8 +184,13 @@ export async function runPhaseSynthesizeConcepts(
         narrative = deterministicNarrative(group);
       } else {
         try {
+          // #3357: match the concept's source language (default "source").
+          const langDirective = await curationLanguageDirective(
+            engine,
+            `${group.atomTitles.join('\n')}\n${group.atomBodies.join('\n')}`.slice(0, 2000),
+          );
           const result = await chat({
-            system: SYNTH_PROMPT,
+            system: SYNTH_PROMPT + langDirective,
             messages: [
               {
                 role: 'user',

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -23,6 +23,7 @@
 
 import { chat, embedOne, isAvailable } from '../ai/gateway.ts';
 import type { ChatResult } from '../ai/gateway.ts';
+import { curationLanguageDirective } from '../ai/curation-language.ts'; // #3357
 import { INJECTION_PATTERNS } from '../think/sanitize.ts';
 import { resolveModel } from '../model-config.ts';
 import { normalizeModelId } from '../model-id.ts';
@@ -240,11 +241,14 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
       ? ` Known entity slugs the user already mentioned: ${input.entityHints.slice(0, 5).join(', ')}.`
       : ''
   }`;
+  // #3357: append the configured output-language directive (default "source" =
+  // match the turn's dominant language) so non-English captures don't drift to English.
+  const outLangDirective = await curationLanguageDirective(input.engine, cleaned);
   let result: ChatResult;
   try {
     result = await chat({
       model,
-      system: EXTRACTOR_SYSTEM,
+      system: EXTRACTOR_SYSTEM + outLangDirective,
       messages: [{ role: 'user', content: userContent }],
       maxTokens,
       abortSignal: input.abortSignal,
@@ -260,7 +264,7 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
       );
       result = await chat({
         model,
-        system: EXTRACTOR_SYSTEM,
+        system: EXTRACTOR_SYSTEM + outLangDirective,
         messages: [{ role: 'user', content: userContent }],
         maxTokens: maxTokens * 2,
         abortSignal: input.abortSignal,

--- a/test/curation-language.test.ts
+++ b/test/curation-language.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for src/core/ai/curation-language.ts (#3357 configurable curation
+ * output-language policy).
+ */
+import { describe, test, expect } from 'bun:test';
+import { detectDominantLanguage, curationLanguageDirective } from '../src/core/ai/curation-language.ts';
+
+describe('detectDominantLanguage', () => {
+  test('Hangul-dominant text → ko', () => {
+    expect(detectDominantLanguage('디사일로 시리즈B 라운드에서 부분 엑싯 목표')).toBe('ko');
+  });
+  test('Latin-dominant text → en', () => {
+    expect(detectDominantLanguage('targeting a partial exit in the Series B round')).toBe('en');
+  });
+  test('mostly-Latin with a stray Hangul char → en (ratio guard)', () => {
+    expect(detectDominantLanguage('mostly english text with one 디 char here and there')).toBe('en');
+  });
+  test('empty string → en', () => {
+    expect(detectDominantLanguage('')).toBe('en');
+  });
+});
+
+describe('curationLanguageDirective', () => {
+  const cfg = (v: string | null) => ({ getConfig: async () => v });
+
+  test('default "source" (unset config) matches the input language', async () => {
+    const ko = await curationLanguageDirective(cfg(null), '디사일로 이승명 세후 30억 부분 엑싯');
+    expect(ko).toContain('in Korean');
+    const en = await curationLanguageDirective(cfg(null), 'plain english only text here');
+    expect(en).toContain('in English');
+  });
+
+  test('null engine falls open to "source"', async () => {
+    expect(await curationLanguageDirective(null, '디사일로 시리즈B 라운드')).toContain('in Korean');
+  });
+
+  test('"off" / "none" → empty (prior native behavior)', async () => {
+    expect(await curationLanguageDirective(cfg('off'), '디사일로')).toBe('');
+    expect(await curationLanguageDirective(cfg('none'), '디사일로')).toBe('');
+  });
+
+  test('explicit language code forces that language regardless of input', async () => {
+    expect(await curationLanguageDirective(cfg('ja'), 'anything at all')).toContain('in Japanese');
+    expect(await curationLanguageDirective(cfg('ko'), 'plain english input')).toContain('in Korean');
+  });
+
+  test('a getConfig that throws falls open to "source" (never breaks a phase)', async () => {
+    const throwing = { getConfig: async () => { throw new Error('db down'); } };
+    expect(await curationLanguageDirective(throwing, '디사일로 라운드 엑싯')).toContain('in Korean');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the configurable output-language policy requested in #3357.

Curation phases (`extract_facts`, `propose_takes`, `synthesize_concepts`) carried no output-language rule beyond *"capture verbatim where possible"*, so on non-English captures the model drifts to English — losing the source-language framing of a bilingual brain.

## Change

New DB-plane config `dream.curation.output_language`:
- `"source"` (default) — match the input's detected dominant language
- `"<lang>"` — force a language (e.g. `ko`, `en`, `ja`)
- `"off"` / `"none"` — prior behavior (no directive)

`src/core/ai/curation-language.ts` (new) holds the config read + a dependency-free ratio-based dominant-language detector + the directive builder. Each phase appends the directive to its system prompt — prompts stay hardcoded, only the policy is config-driven. Registered in `KNOWN_CONFIG_KEYS`.

**Backward-compatible:** default `"source"` leaves English captures unchanged; only non-English output changes (the fix). Fail-open — a missing/unavailable config never breaks a phase.

## Validation

`test/curation-language.test.ts` — 9 cases (detection ko/en/stray/empty; directive source/off/forced/null-engine/throwing-engine). Empirically, a Korean-language capture that previously produced English fact claims now produces Korean, with proper nouns preserved verbatim.

## Notes

- Left `VERSION`/`CHANGELOG` to your `/ship` flow to avoid conflicts.
- `synthesize`'s subagent-prose path is a follow-up (gated by default via `session_corpus_dir`); happy to extend it in this PR if you'd prefer.

Closes #3357.
