### PR TITLE
feat(sync): exclude CLAUDE.md and AGENTS.md from ingest

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -340,7 +340,10 @@ export type SyncableReason =
  * It was the lone structural sibling missing from this list, so it leaked
  * into the index as a content page (slug `resolver`).
  */
-export const SYNC_SKIP_FILES = ['schema.md', 'index.md', 'log.md', 'README.md', 'RESOLVER.md'] as const;
+// Also skip CLAUDE.md / AGENTS.md alongside RESOLVER.md: these self-documenting
+// authoring files (agent guides, routing decision tree) belong on disk as
+// git-versioned agent context, but should NOT be ingested as brain pages.
+export const SYNC_SKIP_FILES = ['schema.md', 'index.md', 'log.md', 'README.md', 'RESOLVER.md', 'CLAUDE.md', 'AGENTS.md'] as const;
 
 /**
  * Internal classifier. Returns null when the path IS syncable, or a tagged

--- a/test/sync-isSyncable-shape.test.ts
+++ b/test/sync-isSyncable-shape.test.ts
@@ -27,6 +27,8 @@ describe('#1433 — isSyncable / unsyncableReason are duals of one classifier', 
     { path: 'docs/README.md', expected: 'metafile', note: 'nested README' },
     { path: 'RESOLVER.md', expected: 'metafile', note: 'top-level master routing config (closes #345)' },
     { path: 'brain/RESOLVER.md', expected: 'metafile', note: 'RESOLVER.md anywhere is metafile (closes #345)' },
+    { path: 'CLAUDE.md', expected: 'metafile', note: 'agent guide, authoring file not a brain page' },
+    { path: 'brain/AGENTS.md', expected: 'metafile', note: 'AGENTS.md anywhere is metafile, authoring file not a brain page' },
     { path: 'people/alice.txt', expected: 'strategy', note: '.txt rejected by markdown strategy' },
     { path: 'ops/scratch/note.md', expected: null, note: 'ops/ is ordinary content, not pruned (#2404)' },
     { path: 'vendor/pkg/note.md', expected: 'pruned-dir', note: 'vendor/ is pruned' },
@@ -54,7 +56,7 @@ describe('#1433 — isSyncable / unsyncableReason are duals of one classifier', 
   });
 
   test('SYNC_SKIP_FILES export contains the canonical structural metafiles', () => {
-    expect([...SYNC_SKIP_FILES]).toEqual(['schema.md', 'index.md', 'log.md', 'README.md', 'RESOLVER.md']);
+    expect([...SYNC_SKIP_FILES]).toEqual(['schema.md', 'index.md', 'log.md', 'README.md', 'RESOLVER.md', 'CLAUDE.md', 'AGENTS.md']);
   });
 
   test('isSyncable(p) === (unsyncableReason(p) === null) — duality holds for all canonical cases', () => {


### PR DESCRIPTION
## Summary

`RESOLVER.md` is already excluded from ingest via `SYNC_SKIP_FILES` (#345) as a
self-documenting authoring file. `CLAUDE.md` and `AGENTS.md` are the same class:
agent guides and routing docs that belong on disk as git-versioned context, not
as brain pages. Without this, a brain that keeps a root `CLAUDE.md`/`AGENTS.md`
(common for agent-operated vaults) has them ingested as content.

Add both to `SYNC_SKIP_FILES` so they are classified as metafiles and excluded,
anywhere in the tree, matching the existing `RESOLVER.md` behaviour.

## Linked issue

Fixes #3361

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

1. `bun test test/sync-isSyncable-shape.test.ts` (20 pass; adds `CLAUDE.md` and `brain/AGENTS.md` metafile cases and updates the `SYNC_SKIP_FILES` export assertion).
2. Manually: put a root `CLAUDE.md`, run `gbrain sync`, confirm it is no longer ingested as a page.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end. `bun run verify` (31/31 green) and the isSyncable suite (20 pass). Did not run e2e (needs DATABASE_URL); the change is a static classification covered by unit tests.

## Model used

Claude Opus 4.8 (1M context) via Claude Code, used to sanitise the comment, extend the test, and write the PR/issue. The one-line skip-list change is the author's patch.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
