### PR TITLE
fix(skillpack): export manifest-declared shared bundle files in scaffold

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -75,7 +75,11 @@
     "skills/_AGENT_README.md",
     "skills/_brain-filing-rules.md",
     "skills/_brain-filing-rules.json",
-    "skills/_output-rules.md"
+    "skills/_output-rules.md",
+    "skills/RESOLVER.md",
+    "skills/manifest.json",
+    "skills/_friction-protocol.md",
+    "skills/migrations"
   ],
   "excluded_from_install": [
     "skills/setup",

--- a/test/scaffold-shared-bundle-files.test.ts
+++ b/test/scaffold-shared-bundle-files.test.ts
@@ -1,0 +1,33 @@
+/**
+ * #2759: skillpack scaffold exports only the files listed in
+ * openclaw.plugin.json#shared_deps. skills/manifest.json declares a resolver
+ * (RESOLVER.md), and several skills reference sibling bundle files
+ * (manifest.json, migrations/, _friction-protocol.md), but none of those were
+ * in shared_deps, so a scaffolded consumer received a bundle whose own manifest
+ * and skills pointed at files that were never installed.
+ *
+ * These assertions read the REAL bundle config (not a fixture) so the shared_deps
+ * list cannot silently drop a manifest-declared or skill-referenced file again.
+ */
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const plugin = JSON.parse(readFileSync(join(root, 'openclaw.plugin.json'), 'utf-8'));
+const manifest = JSON.parse(readFileSync(join(root, 'skills', 'manifest.json'), 'utf-8'));
+const shared = new Set<string>(plugin.shared_deps as string[]);
+
+describe('bundle exports manifest-declared and skill-referenced shared files (#2759)', () => {
+  test('the resolver declared in skills/manifest.json is exported via shared_deps', () => {
+    expect(manifest.resolver).toBeTruthy();
+    expect(shared.has(`skills/${manifest.resolver}`)).toBe(true);
+  });
+
+  test('shared_deps exports the manifest registry, migrations, and friction protocol', () => {
+    for (const f of ['skills/manifest.json', 'skills/migrations', 'skills/_friction-protocol.md']) {
+      expect(shared.has(f)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`skillpack scaffold` exports only the files in `openclaw.plugin.json#shared_deps`.
That list omitted several files the bundle's own manifest and skills reference,
so a scaffolded consumer received a bundle pointing at files that were never
installed:

- `RESOLVER.md`, declared as the resolver in `skills/manifest.json` but never exported (#2759)
- `manifest.json` itself (skill-creator's MECE check reads it)
- `migrations/` (maintain and skillpack-check reference `skills/migrations/*`)
- `_friction-protocol.md` (referenced by several skills)

This adds all four to `shared_deps` so `enumerateScaffoldEntries` carries them
into a scaffolded workspace.

## Linked issue

Fixes #2759

(Sibling #2758, which is about the `skills` bundle list omitting resolver-routed
skills like `frontmatter-guard`/`smoke-test`, is a separate field and out of
scope here.)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

1. `bun test test/scaffold-shared-bundle-files.test.ts` (2 pass; reads the real `openclaw.plugin.json` + `skills/manifest.json` and asserts the declared resolver and the referenced shared files are all in `shared_deps`).
2. Manually: `gbrain skillpack scaffold --all --workspace <empty> --trust`, then confirm `<empty>/skills/RESOLVER.md`, `manifest.json`, `migrations/`, and `_friction-protocol.md` are present. Before this change `RESOLVER.md` (and the others) were absent.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end. `bun run verify` (31/31 green), the new unit test (2 pass), and a real `scaffold --all` into a scratch workspace (all four files now export). Did not run e2e (needs DATABASE_URL).

## Model used

Claude Opus 4.8 (1M context) via Claude Code, used to extend the shared_deps list to also cover RESOLVER.md (#2759), add the test, and write the PR. The original shared_deps fix is the author's patch.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
