### PR TITLE
fix: circuit-break Gemini embedding billing failures

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -19,6 +19,7 @@ import {
 } from '../core/pace-mode.ts';
 import { tryAcquireDbLock, type DbLockHandle } from '../core/db-lock.ts';
 import { embedBackfillLockId } from '../core/embed-backfill-lock.ts';
+import { AIConfigError } from '../core/ai/errors.ts';
 
 export interface EmbedOpts {
   /** Embed ALL pages (every chunk). */
@@ -960,6 +961,10 @@ async function embedAllStale(
   // with stale chunks still remaining (un-embeddable for a non-transient reason)
   // surfaces that loudly instead of looking like a clean run.
   let embedFailures = 0;
+  // Provider-wide configuration/billing failures cannot be repaired by
+  // retrying another page. Probe one page before opening the worker pool and
+  // stop the whole pass when that probe trips this breaker.
+  let providerUnavailable = false;
 
   // E-3 (paced-backfill): bounded end-of-run re-entry. A longer paced run gives
   // a live writer (sync / put_page) more time to insert NEW stale rows BEHIND
@@ -1084,6 +1089,7 @@ async function embedAllStale(
           // spam per-page "Error embedding" lines when we're shutting down.
           if (effectiveSignal.aborted) return;
           embedFailures++;
+          if (e instanceof AIConfigError) providerUnavailable = true;
           serr(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
         }
         totalProcessedPages++;
@@ -1109,11 +1115,16 @@ async function embedAllStale(
       // `!budgetSignal.aborted` gate) AND threads abort into in-flight
       // onItem via the local-abort composition for D13. embedOneKey
       // already handles its own per-key errors via try/catch + stderr.
+      // Serial first-call probe prevents a permanent account/spend-cap error
+      // from fanning out to every worker before the first response arrives.
+      const [probeKey, ...remainingKeys] = keys;
+      if (probeKey !== undefined) await embedOneKey(probeKey);
+      if (providerUnavailable) break;
       await runSlidingPool({
-        items: keys,
+        items: remainingKeys,
         workers: CONCURRENCY,
         signal: effectiveSignal,
-        onItem: (key) => embedOneKey(key),
+        onItem: (key) => providerUnavailable ? Promise.resolve() : embedOneKey(key),
         failureLabel: (key) => key,
       });
 
@@ -1260,6 +1271,10 @@ export async function embedBatchWithBackoff(
     } catch (e: unknown) {
       // If the budget fired we may have been aborted mid-fetch; bubble out.
       if (signal?.aborted) throw e;
+      // Billing caps, bad credentials, and invalid model configuration are
+      // provider-wide. Retrying a 429-shaped AIConfigError wastes minutes and
+      // amplifies one permanent failure across the worker pool.
+      if (e instanceof AIConfigError) throw e;
       const msg = e instanceof Error ? e.message : String(e);
       // D4: structured detection first (handles gateway-wrapped errors via
       // cause chain); message-match as fallback for providers whose wrappers

--- a/src/core/embed-stale.ts
+++ b/src/core/embed-stale.ts
@@ -22,6 +22,7 @@ import type { ChunkInput } from './types.ts';
 import { embedBatchWithBackoff } from '../commands/embed.ts';
 import { type DbPacer, createNoopPacer, observed } from './db-pacer.ts';
 import { AbortError } from './abort-check.ts';
+import { AIConfigError } from './ai/errors.ts';
 
 /** Last visited (page_id, chunk_index) for keyset-resume across runs. */
 export interface StaleCursor {
@@ -132,6 +133,7 @@ export async function embedStaleForSource(
     aborted: false,
   };
   const signature = opts.embeddingSignature;
+  let providerUnavailable = false;
 
   // v0.41.31: invalidate embeddings stamped under a prior model signature so
   // the NULL cursor below re-embeds them. GRANDFATHER: NULL signature
@@ -238,6 +240,7 @@ export async function embedStaleForSource(
       } catch (e: unknown) {
         // Aborted mid-fetch is expected; treat as graceful exit.
         if (signal?.aborted) return;
+        if (e instanceof AIConfigError) providerUnavailable = true;
         // Otherwise log and skip — the chunk stays NULL and next call retries.
         process.stderr.write(
           `\n  [embed-stale] error on ${keySourceId}/${slug}: ${
@@ -263,7 +266,13 @@ export async function embedStaleForSource(
       }
     }
 
-    const numWorkers = Math.min(concurrency, keys.length);
+    // Probe a single page before starting the pool. Provider-wide billing or
+    // configuration failures often arrive as HTTP 429; without the probe,
+    // every worker would issue the same doomed request concurrently.
+    const probeKey = keys[nextIdx++];
+    if (probeKey !== undefined) await embedOneKey(probeKey);
+    if (providerUnavailable) return result;
+    const numWorkers = Math.min(concurrency, keys.length - nextIdx);
     await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
     if (opts.onProgress) {

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -5,7 +5,7 @@
  * cost-estimate prompt so users with large brains see a dollar figure
  * before the chunker-version sweep re-embeds.
  *
- * Prices in USD per 1M tokens. Numbers as of 2026-05-11. Verify alongside
+ * Prices in USD per 1M tokens. Numbers as of 2026-07-24. Verify alongside
  * the Anthropic-pricing refresh cycle; drift here produces estimates
  * that mislead operators.
  *
@@ -31,6 +31,9 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   'openai:text-embedding-3-small': { pricePerMTok: 0.02 },
   // Legacy OpenAI ada (still common in older brains)
   'openai:text-embedding-ada-002': { pricePerMTok: 0.10 },
+  // Google Gemini API standard paid tier
+  // (https://ai.google.dev/gemini-api/docs/pricing, verified 2026-07-24)
+  'google:gemini-embedding-001':    { pricePerMTok: 0.15 },
   // Voyage (https://www.voyageai.com/pricing)
   'voyage:voyage-3-large':         { pricePerMTok: 0.18 },
   'voyage:voyage-3':               { pricePerMTok: 0.06 },

--- a/test/core/budget/budget-tracker.test.ts
+++ b/test/core/budget/budget-tracker.test.ts
@@ -319,6 +319,21 @@ describe('BudgetTracker.reserve', () => {
     expect(caught).toBeInstanceOf(BudgetExhausted);
     expect((caught as BudgetExhausted).reason).toBe('cost');
   });
+
+  test('Google Gemini embed is priced under --max-cost', () => {
+    const t = new BudgetTracker({ maxCostUsd: 1.0, label: 'test', auditPath });
+    expect(() =>
+      t.reserve({
+        modelId: 'google:gemini-embedding-001',
+        estimatedInputTokens: 1000,
+        maxOutputTokens: 0,
+        kind: 'embed',
+      }),
+    ).not.toThrow();
+    const audit = readAudit();
+    expect(audit[0].event).toBe('reserve');
+    expect(audit[0].projected_cost_usd).toBeCloseTo(0.00015, 8);
+  });
 });
 
 describe('BudgetTracker.record', () => {

--- a/test/embed-stale.serial.test.ts
+++ b/test/embed-stale.serial.test.ts
@@ -16,6 +16,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { embedStaleForSource } from '../src/core/embed-stale.ts';
 import type { ChunkInput } from '../src/core/types.ts';
+import { AIConfigError } from '../src/core/ai/errors.ts';
 
 let engine: PGLiteEngine;
 
@@ -194,6 +195,30 @@ describe('embedStaleForSource', () => {
     expect(result.embedded).toBe(2);
     const stale = await engine.countStaleChunks({ sourceId: 'default' });
     expect(stale).toBe(2);
+  });
+
+  test('provider config failure probes once and stops before pool fan-out', async () => {
+    await seedPageWithStaleChunks('a', 2);
+    await seedPageWithStaleChunks('b', 2);
+    await seedPageWithStaleChunks('c', 2);
+    let calls = 0;
+
+    const result = await embedStaleForSource(engine, 'default', {
+      concurrency: 20,
+      embedFn: async () => {
+        calls++;
+        throw new AIConfigError(
+          'Your project has exceeded its monthly spending cap.',
+          'Increase the provider spending cap.',
+          { status: 429 },
+        );
+      },
+    });
+
+    expect(calls).toBe(1);
+    expect(result.done).toBe(false);
+    expect(result.embedded).toBe(0);
+    expect(await engine.countStaleChunks({ sourceId: 'default' })).toBe(6);
   });
 
   test('source-scoped: does not touch other sources', async () => {

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -663,6 +663,22 @@ describe('embedBatchWithBackoff (D2/D4/D4a/D8)', () => {
     expect(lastEmbedBatchOpts).toBeDefined();
     expect((lastEmbedBatchOpts as { maxRetries?: number }).maxRetries).toBe(0);
   });
+
+  test('provider billing-cap 429 is not retried', async () => {
+    const { embedBatchWithBackoff } = await import('../src/commands/embed.ts');
+    const { AIConfigError } = await import('../src/core/ai/errors.ts');
+    let calls = 0;
+    embedBatchBehavior = async () => {
+      calls++;
+      throw new AIConfigError(
+        'Your project has exceeded its monthly spending cap.',
+        'Increase the provider spending cap.',
+        { status: 429 },
+      );
+    };
+    await expect(embedBatchWithBackoff(['x'])).rejects.toThrow('monthly spending cap');
+    expect(calls).toBe(1);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────

--- a/test/embedding-pricing.test.ts
+++ b/test/embedding-pricing.test.ts
@@ -20,6 +20,12 @@ describe('lookupEmbeddingPrice — first-class providers', () => {
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.13);
   });
 
+  test('Google gemini-embedding-001 at $0.15/MTok', () => {
+    const r = lookupEmbeddingPrice('google:gemini-embedding-001');
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.15);
+  });
+
   test('Voyage voyage-3-large at $0.18/MTok', () => {
     const r = lookupEmbeddingPrice('voyage:voyage-3-large');
     expect(r.kind).toBe('known');


### PR DESCRIPTION
## Summary
- add official paid-tier pricing for google:gemini-embedding-001 so capped backfill jobs can enforce budgets
- classify AIConfigError 429s as provider-wide and skip rate-limit retries
- probe one page before worker fan-out so billing/config failures issue one request instead of one per worker

## Why
Google AI Studio monthly spending-cap responses use HTTP 429. The generic rate-limit path retried each concurrent page five times, turning a permanent billing failure into minutes of request amplification. The budget tracker also rejected Gemini backfills before calling the provider because the embedding pricing table lacked the configured model.

## Verification
- 72 targeted pricing/budget/embed tests pass
- 9 embed-stale integration tests pass
- TypeScript typecheck passes
- production proof: capped-provider backfill exits after one request in 14s, with no retries or worker fan-out