### PR TITLE
docs(skills): require browser fallback for dynamic research

### DIFF
--- a/skills/data-research/SKILL.md
+++ b/skills/data-research/SKILL.md
@@ -118,6 +118,8 @@ Three example recipes ship with GBrain (see `~/.gbrain/recipes/`):
 - Creating tracker entries without raw source links
 - Running without deduplication (leads to double-counted entries)
 - Hardcoding source-specific patterns in the pipeline code (use recipes)
+- Giving up on dynamic websites after direct HTTP/API access fails. Use browser/manual click-through for user-relevant fields visible in the rendered site, then structure the data.
+- Leading with technical scrape limitations instead of delivering the researched data. Mention limitations only where they affect confidence in a specific field.
 
 ## Output Format
 


### PR DESCRIPTION
## Why
Dynamic-site research sometimes stops after direct HTTP or API access fails even though the requested fields remain visible in a rendered browser.

## Change
Add two data-research failure modes: use browser/manual click-through before conceding, and report technical limitations only where they affect field confidence.

## Validation
Documentation-only two-line skill guidance change; diff reviewed against current upstream skill.