### PR TITLE
fix(autopilot): restore full-cycle timeout floor after #2852 revert (takeover of #3298)

### DIFF
--- a/src/commands/autopilot-timeout.ts
+++ b/src/commands/autopilot-timeout.ts
@@ -1,0 +1,9 @@
+export function resolveAutopilotDispatchTimeoutMs(
+  baseIntervalSeconds: number,
+  fullCycle: boolean,
+): number {
+  const intervalDerivedTimeoutMs = Math.max(baseIntervalSeconds * 2 * 1000, 300_000);
+  return fullCycle
+    ? Math.max(intervalDerivedTimeoutMs, 1_800_000)
+    : intervalDerivedTimeoutMs;
+}

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -39,6 +39,7 @@ import { detectInstallMethod } from './upgrade.ts';
 import { evaluateQuietHours } from '../core/minions/quiet-hours.ts';
 import { inspectLock } from '../core/db-lock.ts';
 import { registerCleanup } from '../core/process-cleanup.ts';
+import { resolveAutopilotDispatchTimeoutMs } from './autopilot-timeout.ts';
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -728,7 +729,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const queue = new MinionQueue(engine);
         const slotMs = Math.floor(Date.now() / (baseInterval * 1000)) * baseInterval * 1000;
         const slot = new Date(slotMs).toISOString();
-        const timeoutMs = Math.max(baseInterval * 2 * 1000, 300_000);
+        const timeoutMs = resolveAutopilotDispatchTimeoutMs(baseInterval, false);
 
         // ── v0.40 D17: per-source freshness check ────────────────────
         // Runs first; independent of score gate. Submits a 'sync' job per
@@ -983,7 +984,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           const result = await dispatchPerSource(engine, queue, {
             repoPath,
             slot,
-            timeoutMs,
+            // A full consolidation cycle can outlive the polling cadence.
+            // Lighter targeted dispatches retain the interval-derived bound.
+            timeoutMs: resolveAutopilotDispatchTimeoutMs(baseInterval, true),
             fanoutMax,
             jsonMode,
           });

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { resolveAutopilotDispatchTimeoutMs } from '../src/commands/autopilot-timeout.ts';
 
 const AUTOPILOT_SRC = readFileSync(
   join(import.meta.dir, '..', 'src', 'commands', 'autopilot.ts'),
@@ -22,6 +23,19 @@ const AUTOPILOT_SRC = readFileSync(
 );
 
 describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
+  test('applies the 30-minute floor only to full-cycle dispatch', () => {
+    const baseIntervalSeconds = 60;
+    const intervalDerived = Math.max(baseIntervalSeconds * 2 * 1000, 300_000);
+
+    expect(resolveAutopilotDispatchTimeoutMs(baseIntervalSeconds, true)).toBe(30 * 60_000);
+    expect(resolveAutopilotDispatchTimeoutMs(baseIntervalSeconds, false)).toBe(intervalDerived);
+    expect(AUTOPILOT_SRC).toContain(
+      'const timeoutMs = resolveAutopilotDispatchTimeoutMs(baseInterval, false);',
+    );
+    expect(AUTOPILOT_SRC).toMatch(
+      /dispatchPerSource\(engine, queue, \{[\s\S]{0,300}timeoutMs: resolveAutopilotDispatchTimeoutMs\(baseInterval, true\)/,
+    );
+  });
   test('imports dispatchPerSource from the fan-out helper', () => {
     expect(AUTOPILOT_SRC).toMatch(
       /(import\s+.*dispatchPerSource.*from\s+['"]\.\/autopilot-fanout\.ts['"]|await import\(['"]\.\/autopilot-fanout\.ts['"]\))/,


### PR DESCRIPTION
Supersedes #3298 (fork branch went CONFLICTING vs master; taken over onto a fresh origin/master base with the one import conflict resolved). Fixes #3295.

Re-lands the behavior from merged PR #2852, which was removed in the July 23 batch revert (9a709451) without a replacement — same re-land pattern as #3340/#3337/#3343.

## Fix

- Light sync / targeted / global-maintenance jobs keep the existing interval-derived timeout (`max(baseInterval * 2s, 5min)`).
- Only per-source full consolidation cycles get a 30-minute minimum.
- Calculation centralized in a pure helper (`src/commands/autopilot-timeout.ts`) and pinned at both production call sites by `test/autopilot-fanout-wiring.test.ts`.

No installer, cadence, queue, phase, retry, or provider behavior changes.

## Production evidence (from #3298)

On a healthy 1,713-page Postgres brain at score 92 / 100% embeddings: default 5-minute cadence derives a 10-minute job deadline; full cycle job dead-lettered after 628.3s; the next healthy full cycle completed in ~17 minutes. The scheduler deadline, not database/model failure, killed valid work.

## Verification

- `bun run typecheck` exit 0 on origin/master base
- 84 autopilot fan-out / global-maintenance / wiring tests pass, including the new test proving the 30-minute floor applies only to full cycles

Credit: original fix by @rp-agent-bot (David Guidry), carried as Co-authored-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)