### PR TITLE
fix(onboard): stop counting policy-skipped embed_skip chunks as a critical embed backlog (#2539)

### DIFF
--- a/src/core/brain-score-recommendations.ts
+++ b/src/core/brain-score-recommendations.ts
@@ -226,13 +226,27 @@ export function computeRecommendations(
 
   // ---------------------------------------------------------------------
   // embed.stale — missing embeddings. Critical: invisible to vector search
+  //
+  // #2539: chunks on `embed_skip` pages are excluded from the critical
+  // count — their NULL embedding is the intentional privacy mechanism
+  // (embed-skip.ts), not a backlog. Pre-fix this fired [critical] forever
+  // on any install using embed_skip, training users to ignore onboard
+  // output. `gbrain embed --stale` (the job this recommendation queues)
+  // already excludes embed_skip pages via the same key-existence test
+  // (countStaleChunks/listStaleChunks), so subtracting them here just
+  // makes the count match what the job will actually do.
   // ---------------------------------------------------------------------
-  if (health.missing_embeddings > 0 && ctx.embeddingProviderConfigured !== false) {
+  const skippedByPolicy = Math.min(
+    health.embed_skip_missing_embeddings ?? 0,
+    health.missing_embeddings,
+  );
+  const genuineMissingEmbeddings = health.missing_embeddings - skippedByPolicy;
+  if (genuineMissingEmbeddings > 0 && ctx.embeddingProviderConfigured !== false) {
     const params = { stale: true, sourceId: ctx.sourceId };
     const embedModel = ctx.embeddingModel ?? 'openai:text-embedding-3-large';
     const embedDims = ctx.embeddingDimensions ?? 3072;
     // Rough char estimate per chunk ~ 1.5k chars (chunker target).
-    const estChars = health.missing_embeddings * 1500;
+    const estChars = genuineMissingEmbeddings * 1500;
     let est_usd_cost = 0;
     try {
       const priceLookup = lookupEmbeddingPrice(embedModel);
@@ -242,17 +256,21 @@ export function computeRecommendations(
     } catch {
       /* unknown model — leave at 0, surface as warning elsewhere */
     }
+    const rationale = `${genuineMissingEmbeddings} chunk${genuineMissingEmbeddings === 1 ? '' : 's'} invisible to vector search` +
+      (skippedByPolicy > 0
+        ? ` (${skippedByPolicy} more skipped by embed_skip policy, not counted)`
+        : '');
     out.push({
       id: 'embed.stale',
       job: 'embed',
       params,
       idempotency_key: idemKey(source, 'embed', { ...params, embedModel, embedDims }),
       severity: 'critical',
-      est_seconds: Math.min(3600, 5 + health.missing_embeddings * 0.05),
+      est_seconds: Math.min(3600, 5 + genuineMissingEmbeddings * 0.05),
       est_usd_cost,
       // sync should run first so embed sees fresh pages.
       depends_on: ctx.repoPath && health.stale_pages > 0 ? ['sync.repo'] : [],
-      rationale: `${health.missing_embeddings} chunk${health.missing_embeddings === 1 ? '' : 's'} invisible to vector search`,
+      rationale,
       status: 'remediable',
     });
   }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5287,6 +5287,15 @@ export class PGLiteEngine implements BrainEngine {
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
+        -- #2539: same embed_skip key-existence test the embed path
+        -- (countStaleChunks/listStaleChunks) already applies, so onboard's
+        -- critical count can subtract exactly the chunks the embed job
+        -- would never touch.
+        (SELECT count(*) FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE cc.embedded_at IS NULL
+           AND COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip'
+        ) as embed_skip_missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
@@ -5366,6 +5375,7 @@ export class PGLiteEngine implements BrainEngine {
       stale_pages: stalePages,
       orphan_pages: orphanPages,
       missing_embeddings: Number(r.missing_embeddings),
+      embed_skip_missing_embeddings: Number(r.embed_skip_missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,
       link_coverage: Number(r.link_coverage),

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5393,6 +5393,15 @@ export class PostgresEngine implements BrainEngine {
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
+        -- #2539: same embed_skip key-existence test the embed path
+        -- (countStaleChunks/listStaleChunks) already applies, so onboard's
+        -- critical count can subtract exactly the chunks the embed job
+        -- would never touch.
+        (SELECT count(*) FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE cc.embedded_at IS NULL
+           AND COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip'
+        ) as embed_skip_missing_embeddings,
         (SELECT count(*) FROM links) as link_count,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
@@ -5469,6 +5478,7 @@ export class PostgresEngine implements BrainEngine {
       stale_pages: stalePages,
       orphan_pages: orphanPages,
       missing_embeddings: Number(h.missing_embeddings),
+      embed_skip_missing_embeddings: Number(h.embed_skip_missing_embeddings),
       brain_score: brainScore,
       dead_links: deadLinks,
       link_coverage: Number(h.link_coverage),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1451,6 +1451,19 @@ export interface BrainHealth {
   orphan_pages: number;
   missing_embeddings: number;
   /**
+   * Subset of `missing_embeddings` whose page carries the `embed_skip`
+   * frontmatter marker (src/core/embed-skip.ts) — the NULL embedding is
+   * the intentional privacy mechanism, not a backlog. Same JSONB
+   * key-existence test (`frontmatter ? 'embed_skip'`) the embed path
+   * (`countStaleChunks` / `listStaleChunks`) already applies, so this
+   * count can never promise work `gbrain embed --stale` won't actually
+   * do. Optional (engines populate it; older callers/mocks may omit it,
+   * treat as 0). Consumed by brain-score-recommendations.ts to keep the
+   * onboard/doctor "invisible to vector search" critical check from
+   * firing forever on installs that use embed_skip (#2539).
+   */
+  embed_skip_missing_embeddings?: number;
+  /**
    * Composite quality score, 0-100. Weighted sum of five components: embed
    * coverage, link density, timeline coverage, orphan avoidance, dead-link
    * avoidance. See the per-component *_score fields below for breakdown.

--- a/test/brain-score-recommendations.test.ts
+++ b/test/brain-score-recommendations.test.ts
@@ -129,6 +129,7 @@ function makeHealth(overrides: Partial<BrainHealth> = {}): BrainHealth {
     stale_pages: 0,
     orphan_pages: 0,
     missing_embeddings: 0,
+    embed_skip_missing_embeddings: 0,
     brain_score: 100,
     dead_links: 0,
     link_coverage: 1.0,
@@ -159,6 +160,62 @@ describe('computeRecommendations', () => {
     expect(embedRec.severity).toBe('critical');
     expect(embedRec.job).toBe('embed');
     expect(embedRec.params.stale).toBe(true);
+  });
+
+  // #2539: chunks on embed_skip pages are an intentional privacy
+  // mechanism, not a backlog — they must never make onboard/doctor cry
+  // [critical] forever.
+  test('#2539: chunks entirely on embed_skip pages are NOT counted as critical', () => {
+    const health = makeHealth({
+      missing_embeddings: 40,
+      embed_skip_missing_embeddings: 40,
+      brain_score: 65,
+    });
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    expect(recs.find((r) => r.id === 'embed.stale')).toBeUndefined();
+  });
+
+  // #2539: a genuine backlog on non-skipped pages must still be critical
+  // — the fix must not silently swallow real embed backlogs.
+  test('#2539: genuine missing embeddings on normal pages still fire critical', () => {
+    const health = makeHealth({ missing_embeddings: 25, embed_skip_missing_embeddings: 0, brain_score: 65 });
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const embedRec = recs.find((r) => r.id === 'embed.stale');
+    expect(embedRec).toBeDefined();
+    expect(embedRec!.severity).toBe('critical');
+    expect(embedRec!.rationale).toBe('25 chunks invisible to vector search');
+  });
+
+  // #2539: mixed case — genuine backlog still critical, but the count and
+  // est_seconds/est_usd_cost reflect ONLY the genuine subset, and the
+  // skipped subset is surfaced informationally in the rationale text
+  // (fits the existing onboard "why:" line without a new output surface).
+  test('#2539: mixed genuine + policy-skipped — count excludes skipped, rationale notes them', () => {
+    const health = makeHealth({
+      missing_embeddings: 110,
+      embed_skip_missing_embeddings: 100,
+      brain_score: 65,
+    });
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const embedRec = recs.find((r) => r.id === 'embed.stale');
+    expect(embedRec).toBeDefined();
+    expect(embedRec!.severity).toBe('critical');
+    expect(embedRec!.rationale).toBe(
+      '10 chunks invisible to vector search (100 more skipped by embed_skip policy, not counted)',
+    );
+    // Cost/time estimates must scale off the genuine count, not the raw total.
+    expect(embedRec!.est_seconds).toBeCloseTo(5 + 10 * 0.05, 5);
+  });
+
+  // #2539: BrainHealth.embed_skip_missing_embeddings is optional (older
+  // callers/mocks may omit it) — must default to 0, not throw/NaN.
+  test('#2539: embed_skip_missing_embeddings omitted defaults to 0 (no behavior change)', () => {
+    const health = makeHealth({ missing_embeddings: 30, brain_score: 65 });
+    delete (health as { embed_skip_missing_embeddings?: number }).embed_skip_missing_embeddings;
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const embedRec = recs.find((r) => r.id === 'embed.stale');
+    expect(embedRec).toBeDefined();
+    expect(embedRec!.rationale).toBe('30 chunks invisible to vector search');
   });
 
   test('missing embeddings + API key absent: NOT emitted (blocked surfaces separately)', () => {

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1141,6 +1141,31 @@ describe('PGLiteEngine: Stats & Health', () => {
     expect(health.missing_embeddings).toBe(1); // chunk has no embedding
     expect(health.embed_coverage).toBe(0);
   });
+
+  // #2539: a NULL-embedding chunk on an embed_skip page must be counted
+  // in `embed_skip_missing_embeddings` (same key-existence test the embed
+  // path uses), not just lumped into the raw `missing_embeddings` total —
+  // otherwise onboard/doctor can't tell a policy-skip from a real backlog.
+  test('#2539: embed_skip_missing_embeddings tracks NULL-embedding chunks on embed_skip pages', async () => {
+    const before = await engine.getHealth();
+    await engine.putPage('test/embed-skip-health', {
+      ...testPage,
+      title: 'Embed-skip page',
+      frontmatter: { embed_skip: { reason: 'oversized', bytes: 999999, assessed_at: new Date().toISOString() } },
+    });
+    await engine.upsertChunks('test/embed-skip-health', [
+      { chunk_index: 0, chunk_text: 'skipped chunk', chunk_source: 'compiled_truth' },
+    ]);
+    try {
+      const health = await engine.getHealth();
+      // Total NULL-embedding count grows by exactly the one new chunk...
+      expect(health.missing_embeddings).toBe(before.missing_embeddings + 1);
+      // ...and that growth is entirely attributed to the policy-skip bucket.
+      expect(health.embed_skip_missing_embeddings).toBe((before.embed_skip_missing_embeddings ?? 0) + 1);
+    } finally {
+      await engine.deletePage('test/embed-skip-health');
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Defect

`gbrain onboard --check` reports chunks with NULL embeddings as
`[critical] N chunks invisible to vector search` and queues an `(auto)`
`gbrain embed --stale` remediation — but `N` included chunks belonging to
pages stamped `embed_skip: true`, whose NULL embedding is the *intentional*
privacy mechanism (`src/core/embed-skip.ts`). On an install using
`embed_skip` for sensitive subtrees, the check cried critical forever and
the number never reached zero, training users to ignore onboard output.

(#2539)

## Root cause

`BrainHealth.missing_embeddings` (`getHealth()` in both
`postgres-engine.ts` and `pglite-engine.ts`) is a raw
`content_chunks WHERE embedded_at IS NULL` count with no join to
`pages`/frontmatter — it has no way to tell a policy-skip apart from a
real backlog.

The actual embed job (`gbrain embed --stale`, dispatched via
`countStaleChunks()` / `listStaleChunks()`) already excludes `embed_skip`
pages via the JSONB key-existence test
`COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip'`
(`src/core/postgres-engine.ts:2586`, `:2687`, `:2697`; same predicate in
`pglite-engine.ts`). So the count onboard showed and the work the queued
job would actually do had silently diverged.

## Fix

- Added `BrainHealth.embed_skip_missing_embeddings` (optional, both
  engines populate it), computed with the **exact same** key-existence
  predicate the embed path already uses — same string, same semantics, no
  second test to drift out of sync.
- `computeRecommendations()` (`src/core/brain-score-recommendations.ts`)
  now subtracts `embed_skip_missing_embeddings` from `missing_embeddings`
  before deciding whether to emit the `embed.stale` recommendation and
  what count/cost/time estimate to show:
  - All-skipped brain → **no critical entry at all** (nothing the embed
    job could act on).
  - Genuine backlog on non-skipped pages → still `[critical]`, unchanged
    severity, count reflects only the genuine subset.
  - Mixed case → critical entry for the genuine subset, with the skipped
    count folded into the rationale as an informational aside, e.g.
    `"10 chunks invisible to vector search (100 more skipped by embed_skip
    policy, not counted)"` — this reuses the existing "why:" rationale
    line onboard already renders, rather than adding a new output surface.

## Auto-remediation / egress safety (the sharper half of the issue)

Verified the `(auto)` remediation **cannot** embed `embed_skip` content,
today, unmodified by this PR:

- The `embed.stale` recommendation queues job `embed` with
  `params: { stale: true, sourceId }`.
- That job is registered in `src/commands/jobs.ts:1485` and calls
  `runEmbedCore(engine, { stale: true, ... })` (`src/commands/embed.ts`).
- The stale path resolves work via `engine.countStaleChunks()` /
  `engine.listStaleChunks()`, both of which already filter out
  `embed_skip` pages with the same JSONB key-existence predicate
  (`postgres-engine.ts:2577-2610`, `:2658-2699`; `pglite-engine.ts` has
  the equivalent `NOT (... ? 'embed_skip')` guard in every branch of
  `listStaleChunks`).

So no redundant guard was added — the egress protection already existed
independently of the (buggy) count; this PR only fixes the count/severity
that onboard *displays*, matching it to what the job actually does.

## What I verified

```
bun test test/brain-score-recommendations.test.ts test/pglite-engine.test.ts \
  test/embed-skip.test.ts test/sum-stale-chunk-chars.test.ts \
  test/advisor-core.test.ts test/advisor-ranking-eval.test.ts \
  test/features.test.ts test/doctor-timeline-metric-labels-2298.test.ts \
  test/onboard-pack-upgrade-checks.test.ts test/e2e/onboard-full-flow.test.ts \
  test/doctor-brain-checks-score.test.ts test/brain-score-breakdown.test.ts
# 246 pass, 0 fail, 511 expect() calls, 12 files

bun run typecheck   # tsc --noEmit — clean
bun run verify       # 31 parallel checks — all green (incl. check:jsonb)
```

New/extended tests (fail before the fix, pass after):
- `test/brain-score-recommendations.test.ts` — 4 new cases: all-skipped
  chunks produce no critical entry; genuine backlog on normal pages still
  fires critical with the plain rationale; mixed case excludes the
  skipped count from severity/cost/time and folds it into the rationale;
  omitted `embed_skip_missing_embeddings` defaults to 0 (back-compat for
  older callers/mocks).
- `test/pglite-engine.test.ts` — real-engine integration test: seeds an
  `embed_skip` page with a NULL-embedding chunk and asserts
  `getHealth().embed_skip_missing_embeddings` grows by exactly that
  chunk while `missing_embeddings` also grows by 1 (both counted, only
  one flagged as policy).

## Multi-model review (Codex, `model_reasoning_effort=high`)

No Critical findings. Two Warnings, both about code paths **not touched
by this diff** (confirmed by grepping the diff — neither `embed_coverage`,
`classifyChecks`, nor `maxReachableScore` appear in it) — documenting them
here rather than expanding this fix's surface:

1. **`embed_coverage` / `embed_coverage_score` / `maxReachableScore` still
   count policy-skipped chunks against the brain-health score**, and
   `classifyChecks()` still labels the `missing_embeddings` check
   `remediable` even when everything remaining is policy-skipped — so
   `--target-score` can claim an unreachable ceiling is reachable. This
   is pre-existing: `embed_coverage` was already computed over all chunks
   with no `embed_skip` awareness before this PR, and
   `classifyChecks`/`maxReachableScore` never received per-check health
   detail to begin with. This PR only fixes the onboard critical
   count/rationale (the literal scope of #2539); fixing the score
   denominator has a much larger blast radius (`embed_coverage` also
   feeds `gbrain doctor`'s separate warn-level check, `features.ts`'s
   pitch copy, `migrate-engine.ts`, and the advisor's
   `collect-usage-shape.ts`) and deserves its own issue/PR.
2. **Whole-brain counts driving a source-scoped job**: `getHealth()`
   takes no arguments and has always been whole-brain for every field
   (`stale_pages`, `dead_links`, the original `missing_embeddings`, and
   now `embed_skip_missing_embeddings`) — `computeRecommendations()` has
   never scoped health data to `ctx.sourceId` even though it stamps
   `sourceId` onto the emitted job. Pre-existing architectural gap,
   identical in kind for every `BrainHealth` field; not introduced or
   worsened by this PR. Threading `sourceId` through `getHealth()` across
   both engines is a separate, materially larger change.

## Out of scope (deliberately)

- The two Codex warnings above (separate follow-up).
- `gbrain doctor`'s own `warn`-level "embeddings" check
  (`src/commands/doctor.ts:5767-5769`) and `features.ts`'s pitch copy
  still use the raw (non-skip-aware) `missing_embeddings` — they're
  `warn`, not a permanent `[critical]`, and outside the issue's stated
  repro (`gbrain onboard --check`).
