### PR TITLE
v0.42.65.0 fix(backfill): stamp raw-trace exemption on pre-existing dream-cycle index pages (#1978)

### DIFF
--- a/src/commands/backfill.ts
+++ b/src/commands/backfill.ts
@@ -79,11 +79,17 @@ Usage:
   gbrain backfill <kind> [flags]      Run a registered backfill.
   gbrain backfill list                 Show registered backfills + checkpoints.
 
-Backfills (v0.30.1):
+Backfills (\`gbrain backfill list\` is the authoritative registry):
   effective_date     Compute effective_date for pages imported pre-v0.29.1.
   emotional_weight   Recompute emotional_weight for pages with stale stamp.
   embedding_voyage   Declared-only in v0.30.1 (multi-column embedding lands
                      in v0.30.2 alongside the schema migration).
+  modality           Tag image-asset chunks whose modality was missed by
+                     pre-v0.27.1 ingest.
+  dream_cycle_index_provenance
+                     Stamp raw_trace_exempt on dream-cycle index pages that
+                     predate synthesize.ts stamping it (clears the doctor
+                     raw_provenance warn for those pages, #1978).
 
 Flags:
   --batch-size N     Initial batch size before adaptive halving (default 1000).

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -22,6 +22,7 @@ import { loadCompletedMigrations } from '../core/preferences.ts';
 import { compareVersions } from './migrations/index.ts';
 import { createProgress, startHeartbeat, type ProgressReporter } from '../core/progress.ts';
 import { categorizeCheck, type CheckCategory } from '../core/doctor-categories.ts';
+import { untracedSynthesizedPagesPredicate } from '../core/raw-provenance.ts';
 import { rankIssues, type RankedIssue } from '../core/doctor-cause-rank.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import type { DbUrlSource } from '../core/config.ts';
@@ -548,12 +549,10 @@ export async function childTableOrphansCheck(engine: BrainEngine): Promise<Check
  * childTableOrphansCheck so tests can target it directly.
  */
 export async function rawProvenanceCheck(engine: BrainEngine): Promise<Check> {
-  const where = `
-        p.deleted_at IS NULL
-    AND (COALESCE(p.frontmatter->>'dream_generated', '') = 'true' OR p.type = 'synthesis')
-    AND NOT (COALESCE(p.frontmatter, '{}'::jsonb) ?| ARRAY['raw_trace', 'raw_source', 'source_uri', 'raw_trace_exempt'])
-    AND NOT EXISTS (SELECT 1 FROM raw_data rd WHERE rd.page_id = p.id)
-    AND NOT EXISTS (SELECT 1 FROM synthesis_evidence se WHERE se.synthesis_page_id = p.id)`;
+  // Predicate lives in core/raw-provenance.ts so the
+  // `dream_cycle_index_provenance` backfill (which exists to clear exactly
+  // these rows) cannot drift from the check it satisfies.
+  const where = untracedSynthesizedPagesPredicate('p');
   try {
     const rows = await engine.executeRaw<{ n: string | number }>(
       `SELECT COUNT(*)::int AS n FROM pages p WHERE ${where}`,
@@ -576,7 +575,8 @@ export async function rawProvenanceCheck(engine: BrainEngine): Promise<Check> {
       message:
         `${n} synthesized page(s) lack a raw trace (no raw_trace/raw_source/source_uri frontmatter, ` +
         `raw_data row, or synthesis evidence) and carry no raw_trace_exempt marker. e.g. ${slugs}. ` +
-        `Fix: stamp raw_source (path/URI of the source material) or raw_trace_exempt: true + ` +
+        `Fix: for pre-existing dream-cycle index pages run \`gbrain backfill dream_cycle_index_provenance\`; ` +
+        `otherwise stamp raw_source (path/URI of the source material) or raw_trace_exempt: true + ` +
         `raw_trace_exempt_reason in frontmatter. Warn-only (#1978).`,
     };
   } catch {

--- a/src/core/backfill-base.ts
+++ b/src/core/backfill-base.ts
@@ -50,6 +50,40 @@ export interface BackfillSpec<TRow = Record<string, unknown>> {
    */
   compute: (rows: TRow[], engine: BrainEngine) => Promise<Array<{ id: number; updates: Record<string, unknown> }>>;
   /**
+   * Optional per-column right-hand-side SQL. The runner's default write is
+   * `col = $N` (whole-value replace). A backfill that needs a cast or a
+   * read-modify-write done IN SQL supplies a builder here; it receives the
+   * bound placeholder (`"$2"`) and returns the RHS expression, e.g.
+   *
+   *   { frontmatter: v => `COALESCE(frontmatter, '{}'::jsonb) || ${v}::jsonb` }
+   *
+   * Two reasons this exists rather than merging in JS:
+   *   - JSONB binding: a JS object only round-trips at an explicit
+   *     `$N::jsonb` position (see executeRawJsonb's contract in sql-query.ts).
+   *     Never pre-stringify into that position — that is the #2339
+   *     double-encode bug, guarded by scripts/check-jsonb-params.mjs.
+   *   - Concurrency: `||` merges against the CURRENT row, so a concurrent
+   *     writer's keys survive. A JS-side merge would write back a snapshot
+   *     read one statement earlier and clobber them.
+   *
+   * Developer-authored SQL only, exactly like `needsBackfill` — never
+   * interpolate user input here.
+   */
+  columnUpdateSql?: Record<string, (valuePlaceholder: string) => string>;
+  /**
+   * Whether progress is checkpointed to `backfill.<name>.last_id`.
+   * Default true (the historical behavior).
+   *
+   * Set false for a backfill whose predicate is SELF-CLEARING — i.e. the
+   * write it performs is itself excluded by `needsBackfill`, so a re-run
+   * naturally finds only rows that still need work. For those, a checkpoint
+   * buys nothing and costs correctness: if a row regresses (e.g. a later
+   * import overwrites the column the backfill stamped), a checkpointed
+   * re-run skips it because its id is below the watermark, and only
+   * `--fresh` would repair it.
+   */
+  resumable?: boolean;
+  /**
    * Optional partial-index requirement (P2 / X4). Runner verifies/creates
    * the index CONCURRENTLY on first run. Skipped on PGLite (no CONCURRENTLY).
    */
@@ -181,8 +215,9 @@ export async function runBackfill<TRow = Record<string, unknown>>(
     await ensureBackfillIndex(engine, spec);
   }
 
+  const resumable = spec.resumable !== false;
   let batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
-  let lastId = await getCheckpoint(engine, spec.name, opts.fresh === true);
+  let lastId = resumable ? await getCheckpoint(engine, spec.name, opts.fresh === true) : 0;
   let examined = 0;
   let updated = 0;
   let errors = 0;
@@ -269,7 +304,9 @@ export async function runBackfill<TRow = Record<string, unknown>>(
               const params: unknown[] = [id];
               let paramIdx = 2;
               for (const [col, val] of Object.entries(updates)) {
-                setClauses.push(`${col} = $${paramIdx}`);
+                const placeholder = `$${paramIdx}`;
+                const rhs = spec.columnUpdateSql?.[col]?.(placeholder) ?? placeholder;
+                setClauses.push(`${col} = ${rhs}`);
                 params.push(val);
                 paramIdx++;
               }
@@ -306,7 +343,7 @@ export async function runBackfill<TRow = Record<string, unknown>>(
     const idAccessor = idCol;
     const lastBatchId = (rows[rows.length - 1] as Record<string, unknown>)[idAccessor];
     if (typeof lastBatchId === 'number') lastId = lastBatchId;
-    if (!opts.dryRun) await setCheckpoint(engine, spec.name, lastId);
+    if (!opts.dryRun && resumable) await setCheckpoint(engine, spec.name, lastId);
 
     opts.onBatch?.({
       batch: batchNum,

--- a/src/core/backfill-registry.ts
+++ b/src/core/backfill-registry.ts
@@ -16,6 +16,11 @@ import type { BrainEngine } from './engine.ts';
 import type { BackfillSpec } from './backfill-base.ts';
 import { computeEffectiveDate } from './effective-date.ts';
 import { computeEmotionalWeight } from './cycle/emotional-weight.ts';
+import {
+  DREAM_CYCLE_INDEX_SLUG_SQL_PATTERN,
+  DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
+  untracedSynthesizedPagesPredicate,
+} from './raw-provenance.ts';
 
 export interface RegisteredBackfill {
   spec: BackfillSpec<Record<string, unknown>>;
@@ -234,11 +239,90 @@ function modalityBackfill(): RegisteredBackfill {
   };
 }
 
+interface DreamCycleIndexRow {
+  id: number;
+  slug: string;
+}
+
+/**
+ * #1978 follow-up: stamp the raw-trace exemption on dream-cycle index pages
+ * written BEFORE synthesize.ts started stamping it prospectively.
+ *
+ * `writeSummaryPage` in core/cycle/synthesize.ts now stamps every new
+ * `dream-cycle-summaries/<date>` page with `raw_trace_exempt: true` plus a
+ * reason — the index is deterministic, it has no source document of its own,
+ * and the raw traces live on the pages it lists. Index pages written before
+ * that code landed carry no stamp, so `doctor`'s `raw_provenance` check warns
+ * about them forever with no way to clear it. This backfill applies the
+ * writer's own stamp to those rows.
+ *
+ * Scope is deliberately just the index pages. Other pre-existing synthesized
+ * pages (wiki/*, extracts/*) want a `raw_source` pointing at the transcript
+ * they were derived from, and that mapping cannot be reconstructed after the
+ * fact — blanket-exempting them would silence the check rather than satisfy
+ * it, so they are left alone.
+ *
+ * Predicate = doctor's own `raw_provenance` predicate (shared, so the two
+ * cannot drift) AND the dream-cycle index slug shape AND the writer's
+ * `dream_generated` marker. Idempotent: the stamp adds `raw_trace_exempt`,
+ * which the shared predicate excludes, so a second run matches no rows.
+ *
+ * Content is untouched — only `frontmatter` moves, so `content_hash` /
+ * `compiled_truth` are unchanged and nothing re-chunks or re-embeds.
+ *
+ * Known limitation: this repairs the DB row, not the historical markdown
+ * file the dream cycle dual-wrote. If such a file is later edited and
+ * re-imported, the import replaces frontmatter wholesale and the exemption
+ * is lost again. `resumable: false` below is what makes that recoverable —
+ * re-running the backfill re-stamps the row instead of skipping it because
+ * a checkpoint says the id was already visited.
+ */
+function dreamCycleIndexProvenanceBackfill(): RegisteredBackfill {
+  return {
+    description: 'Stamp raw_trace_exempt on dream-cycle index pages written before synthesize.ts stamped it (#1978)',
+    v030_1_status: 'implemented',
+    spec: {
+      name: 'dream_cycle_index_provenance',
+      table: 'pages',
+      idColumn: 'id',
+      selectColumns: ['slug'],
+      // The predicate is self-clearing (the stamp it writes is one of the
+      // keys the shared predicate excludes), so a checkpoint buys nothing
+      // and actively harms the re-import repair path described above.
+      resumable: false,
+      needsBackfill: `
+        ${untracedSynthesizedPagesPredicate('pages')}
+    AND pages.slug ~ '${DREAM_CYCLE_INDEX_SLUG_SQL_PATTERN}'
+    AND COALESCE(pages.frontmatter->>'dream_generated', '') = 'true'
+    AND pages.frontmatter->>'dream_cycle_date' = right(pages.slug, 10)`,
+      // Merge in SQL against the CURRENT row (not a JS-side snapshot) and
+      // bind the delta as a raw object at an explicit ::jsonb position —
+      // mirrors stampDreamProvenance's write in core/cycle/synthesize.ts.
+      columnUpdateSql: {
+        frontmatter: v => `COALESCE(frontmatter, '{}'::jsonb) || ${v}::jsonb`,
+      },
+      compute: async (rows) => {
+        return (rows as unknown as DreamCycleIndexRow[]).map(r => ({
+          id: r.id,
+          updates: {
+            frontmatter: {
+              raw_trace_exempt: true,
+              raw_trace_exempt_reason: DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
+            },
+          },
+        }));
+      },
+      estimateRowsPerSecond: 5000, // metadata-only merge
+    },
+  };
+}
+
 function registerCoreBackfills(): void {
   registerBackfill(effectiveDateBackfill());
   registerBackfill(emotionalWeightBackfill());
   registerBackfill(embeddingVoyageBackfill());
   registerBackfill(modalityBackfill());
+  registerBackfill(dreamCycleIndexProvenanceBackfill());
 }
 
 // Auto-register on first import.

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -46,6 +46,10 @@ import type { Page, PageType } from '../types.ts';
 import { validateSourceId } from '../utils.ts';
 import { safeSplitIndex } from '../text-safe.ts';
 import { PAGE_SLUG_SEG } from '../cjk.ts';
+import {
+  DREAM_CYCLE_SUMMARY_SLUG_PREFIX,
+  DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
+} from '../raw-provenance.ts';
 
 // Slug grammar from validatePageSlug — shared via PAGE_SLUG_SEG (#738).
 // Used for the orchestrator-written summary index slug.
@@ -700,7 +704,7 @@ export async function runPhaseSynthesize(
 
     // Summary index page (deterministic; orchestrator-written via direct
     // engine.putPage so no allow-list path needed).
-    const summarySlug = `dream-cycle-summaries/${summaryDate}`;
+    const summarySlug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}${summaryDate}`;
     // Back-compat: writeSummaryPage takes string[] for display; map refs back to slugs.
     const writtenSlugs = writtenRefs.map(r => r.slug);
     if (SUMMARY_SLUG_RE.test(summarySlug)) {
@@ -1447,9 +1451,13 @@ async function writeSummaryPage(
       dream_cycle_date: summaryDate,
       // #1978: deterministic index page — no source document of its own;
       // raw traces live on the listed pages. Explicit exemption keeps the
-      // doctor raw_provenance check quiet.
+      // doctor raw_provenance check quiet. Literals shared with the
+      // `dream_cycle_index_provenance` backfill (core/raw-provenance.ts)
+      // so the stamp
+      // this writes prospectively and the stamp the backfill applies to
+      // pre-existing index pages stay byte-identical.
       raw_trace_exempt: true,
-      raw_trace_exempt_reason: 'deterministic dream-cycle index; raw traces live on listed pages',
+      raw_trace_exempt_reason: DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
     } as Record<string, unknown>,
     body,
     '',

--- a/src/core/raw-provenance.ts
+++ b/src/core/raw-provenance.ts
@@ -1,0 +1,79 @@
+/**
+ * Raw-provenance shared vocabulary (#1978).
+ *
+ * Three consumers have to agree on the SAME literals or the invariant is
+ * unenforceable:
+ *
+ *   1. the WRITER — `src/core/cycle/synthesize.ts` stamps the dream-cycle
+ *      index page with `raw_trace_exempt` + `raw_trace_exempt_reason`
+ *      prospectively, at write time;
+ *   2. the CHECK — `rawProvenanceCheck` in `src/commands/doctor.ts` flags
+ *      synthesized pages that carry no trace and no exemption;
+ *   3. the BACKFILL — the `dream_cycle_index_provenance` entry in
+ *      `src/core/backfill-registry.ts` applies (1)'s stamp to index pages
+ *      that predate the writer's stamping code.
+ *
+ * Keeping the predicate and the exemption literals here means the backfill
+ * can never drift from the check it is meant to satisfy, and the stamp it
+ * writes can never drift from the stamp the writer produces.
+ */
+
+/**
+ * Slug namespace the dream cycle writes its per-cycle index page into.
+ * `synthesize.ts` composes `${prefix}${YYYY-MM-DD}`.
+ */
+export const DREAM_CYCLE_SUMMARY_SLUG_PREFIX = 'dream-cycle-summaries/';
+
+/**
+ * SQL (POSIX ARE) pattern matching exactly the slugs the dream-cycle index
+ * writer produces — namespace prefix plus an ISO date, nothing else. Narrow
+ * on purpose: a hand-authored page that happens to live under the namespace
+ * must NOT be auto-exempted by the backfill.
+ *
+ * Safe to interpolate the prefix: it is a fixed literal with no ARE
+ * metacharacters (asserted by
+ * test/backfill-dream-cycle-index-provenance.test.ts).
+ */
+export const DREAM_CYCLE_INDEX_SLUG_SQL_PATTERN =
+  `^${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}[0-9]{4}-[0-9]{2}-[0-9]{2}$`;
+
+/**
+ * Exemption reason stamped on the dream-cycle index page. The index is
+ * deterministic — it has no source document of its own; the raw traces live
+ * on the pages it lists.
+ */
+export const DREAM_INDEX_RAW_TRACE_EXEMPT_REASON =
+  'deterministic dream-cycle index; raw traces live on listed pages';
+
+/**
+ * Frontmatter keys that satisfy the raw-provenance invariant. Kept as one
+ * list so the doctor predicate and any future consumer share it.
+ */
+export const RAW_TRACE_FRONTMATTER_KEYS = [
+  'raw_trace',
+  'raw_source',
+  'source_uri',
+  'raw_trace_exempt',
+] as const;
+
+/**
+ * SQL predicate naming synthesized/derived pages that carry NO raw trace and
+ * NO explicit exemption — i.e. the rows `doctor`'s `raw_provenance` check
+ * warns about.
+ *
+ * `alias` is the table alias (or table name) the caller qualifies `pages`
+ * columns with. It is developer-supplied, never user input, and is validated
+ * as a bare SQL identifier before interpolation.
+ */
+export function untracedSynthesizedPagesPredicate(alias: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
+    throw new Error(`untracedSynthesizedPagesPredicate: invalid SQL alias ${JSON.stringify(alias)}`);
+  }
+  const traceKeys = RAW_TRACE_FRONTMATTER_KEYS.map(k => `'${k}'`).join(', ');
+  return `
+        ${alias}.deleted_at IS NULL
+    AND (COALESCE(${alias}.frontmatter->>'dream_generated', '') = 'true' OR ${alias}.type = 'synthesis')
+    AND NOT (COALESCE(${alias}.frontmatter, '{}'::jsonb) ?| ARRAY[${traceKeys}])
+    AND NOT EXISTS (SELECT 1 FROM raw_data rd WHERE rd.page_id = ${alias}.id)
+    AND NOT EXISTS (SELECT 1 FROM synthesis_evidence se WHERE se.synthesis_page_id = ${alias}.id)`;
+}

--- a/test/backfill-base.test.ts
+++ b/test/backfill-base.test.ts
@@ -127,6 +127,53 @@ describe('runBackfill — happy path', () => {
   });
 });
 
+describe('runBackfill — columnUpdateSql + resumable', () => {
+  test('default write is `col = $N`; columnUpdateSql rewrites the RHS and keeps param order', async () => {
+    const engine = new FakeEngine();
+    engine.rows = [{ id: 7, needs_backfill: true }];
+    const seen: Array<{ sql: string; params: unknown[] }> = [];
+    const raw = engine.executeRaw.bind(engine);
+    engine.executeRaw = (async (sql: string, params?: unknown[]) => {
+      if (sql.startsWith('UPDATE')) seen.push({ sql, params: params ?? [] });
+      return raw(sql, params);
+    }) as typeof engine.executeRaw;
+
+    const spec: BackfillSpec<FakeRow> = {
+      ...makeSpec(),
+      compute: async (rows) => rows.map(r => ({
+        id: r.id,
+        updates: { frontmatter: { a: 1 }, needs_backfill: false },
+      })),
+      columnUpdateSql: {
+        frontmatter: v => `COALESCE(frontmatter, '{}'::jsonb) || ${v}::jsonb`,
+      },
+    };
+    await runBackfill(engine as never, spec, { batchSize: 10 });
+
+    expect(seen).toHaveLength(1);
+    // frontmatter takes the custom RHS at $2; needs_backfill keeps the
+    // default `col = $N` at $3. Params stay [id, ...values] in key order,
+    // and the jsonb value is bound as a raw OBJECT (never JSON.stringify —
+    // that is the #2339 double-encode shape).
+    expect(seen[0].sql).toBe(
+      `UPDATE pages SET frontmatter = COALESCE(frontmatter, '{}'::jsonb) || $2::jsonb, needs_backfill = $3 WHERE id = $1`,
+    );
+    expect(seen[0].params).toEqual([7, { a: 1 }, false]);
+  });
+
+  test('resumable:false ignores and does not write a checkpoint', async () => {
+    const engine = new FakeEngine();
+    engine.config.set('backfill.test_backfill.last_id', '999');
+    engine.rows = [{ id: 5, needs_backfill: true }];
+
+    const result = await runBackfill(engine as never, { ...makeSpec(), resumable: false }, { batchSize: 10 });
+    // A checkpoint of 999 would have skipped id=5 entirely.
+    expect(result.examined).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(engine.config.get('backfill.test_backfill.last_id')).toBe('999');
+  });
+});
+
 describe('runBackfill — error handling', () => {
   test('non-retryable error during SELECT throws', async () => {
     const engine = new FakeEngine();

--- a/test/backfill-dream-cycle-index-provenance.test.ts
+++ b/test/backfill-dream-cycle-index-provenance.test.ts
@@ -1,0 +1,244 @@
+/**
+ * #1978 follow-up — `gbrain backfill dream_cycle_index_provenance`.
+ *
+ * Dream-cycle index pages written BEFORE synthesize.ts started stamping
+ * `raw_trace_exempt` prospectively warn forever in `doctor`'s raw_provenance
+ * check. This backfill applies the writer's own stamp to those rows and
+ * nothing else.
+ *
+ * Runs against real PGLite so the predicate SQL (`?|`, `~`, NOT EXISTS) and
+ * the `frontmatter || $N::jsonb` merge are pinned on an actual engine.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { getBackfill } from '../src/core/backfill-registry.ts';
+import { runBackfill } from '../src/core/backfill-base.ts';
+import { rawProvenanceCheck } from '../src/commands/doctor.ts';
+import {
+  DREAM_CYCLE_SUMMARY_SLUG_PREFIX,
+  DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
+  untracedSynthesizedPagesPredicate,
+} from '../src/core/raw-provenance.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let engine: PGLiteEngine;
+
+const UNSTAMPED_INDEX = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-05-24`;
+const STAMPED_INDEX = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-06-01`;
+const HAND_AUTHORED_IN_NAMESPACE = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}notes-about-dreams`;
+const WIKI_SYNTHESIS = 'wiki/derived/cross-org-pattern';
+const EXTRACT_SYNTHESIS = 'extracts/some-transcript';
+
+function spec() {
+  const reg = getBackfill('dream_cycle_index_provenance');
+  if (!reg) throw new Error('dream_cycle_index_provenance backfill not registered');
+  return reg.spec;
+}
+
+async function frontmatterOf(slug: string): Promise<Record<string, unknown>> {
+  const rows = await engine.executeRaw<{ frontmatter: unknown }>(
+    `SELECT frontmatter FROM pages WHERE slug = $1`,
+    [slug],
+  );
+  const raw = rows[0]?.frontmatter;
+  if (typeof raw === 'string') return JSON.parse(raw) as Record<string, unknown>;
+  return (raw ?? {}) as Record<string, unknown>;
+}
+
+async function contentFingerprintOf(slug: string): Promise<{ compiled_truth: string; content_hash: string | null }> {
+  const rows = await engine.executeRaw<{ compiled_truth: string; content_hash: string | null }>(
+    `SELECT compiled_truth, content_hash FROM pages WHERE slug = $1`,
+    [slug],
+  );
+  return rows[0];
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // 1. The target: a dream-cycle index page from before the writer stamped
+  //    the exemption. Carries the writer's dream_generated + dream_cycle_date.
+  await engine.putPage(UNSTAMPED_INDEX, {
+    type: 'note', title: 'Dream cycle 2026-05-24', compiled_truth: '# Dream cycle 2026-05-24', timeline: '',
+    frontmatter: { dream_generated: true, dream_cycle_date: '2026-05-24' },
+  });
+  // 2. Already stamped by the current writer — must not be rewritten.
+  await engine.putPage(STAMPED_INDEX, {
+    type: 'note', title: 'Dream cycle 2026-06-01', compiled_truth: '# Dream cycle 2026-06-01', timeline: '',
+    frontmatter: {
+      dream_generated: true,
+      dream_cycle_date: '2026-06-01',
+      raw_trace_exempt: true,
+      raw_trace_exempt_reason: DREAM_INDEX_RAW_TRACE_EXEMPT_REASON,
+    },
+  });
+  // 3. Hand-authored page that merely lives under the namespace — the slug
+  //    tail is not an ISO date, so it is out of scope even though it is
+  //    dream_generated.
+  await engine.putPage(HAND_AUTHORED_IN_NAMESPACE, {
+    type: 'note', title: 'Notes about dreams', compiled_truth: 'body', timeline: '',
+    frontmatter: { dream_generated: true },
+  });
+  // 4/5. Synthesis pages whose accurate provenance is a raw_source that
+  //      cannot be reconstructed — deliberately out of scope.
+  await engine.putPage(WIKI_SYNTHESIS, {
+    type: 'note', title: 'Cross-org pattern', compiled_truth: 'body', timeline: '',
+    frontmatter: { dream_generated: true, dream_cycle_date: '2026-07-03' },
+  });
+  await engine.putPage(EXTRACT_SYNTHESIS, {
+    type: 'synthesis', title: 'Extract', compiled_truth: 'body', timeline: '',
+    frontmatter: {},
+  });
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('dream_cycle_index_provenance backfill (#1978 follow-up)', () => {
+  test('the slug prefix is a literal with no regex metacharacters', () => {
+    // DREAM_CYCLE_INDEX_SLUG_SQL_PATTERN interpolates the prefix into a
+    // POSIX ARE; that is only safe while the prefix stays metachar-free.
+    expect(DREAM_CYCLE_SUMMARY_SLUG_PREFIX).toMatch(/^[a-z0-9-]+\/$/);
+  });
+
+  test('predicate helper rejects a non-identifier alias', () => {
+    expect(() => untracedSynthesizedPagesPredicate('p; DROP TABLE pages --')).toThrow();
+  });
+
+  test('stamps only the unstamped dream-cycle index page', async () => {
+    const before = await contentFingerprintOf(UNSTAMPED_INDEX);
+
+    const result = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(result.updated).toBe(1);
+    expect(result.errors).toBe(0);
+
+    const fm = await frontmatterOf(UNSTAMPED_INDEX);
+    expect(fm.raw_trace_exempt).toBe(true);
+    expect(fm.raw_trace_exempt_reason).toBe(DREAM_INDEX_RAW_TRACE_EXEMPT_REASON);
+    // Merge, not replace — the writer's existing markers survive.
+    expect(fm.dream_generated).toBe(true);
+    expect(fm.dream_cycle_date).toBe('2026-05-24');
+
+    // Content untouched: nothing re-chunks or re-embeds off this write.
+    const after = await contentFingerprintOf(UNSTAMPED_INDEX);
+    expect(after.compiled_truth).toBe(before.compiled_truth);
+    expect(after.content_hash).toBe(before.content_hash);
+  });
+
+  test('leaves the already-stamped index page, the hand-authored namespace page, and wiki/extracts synthesis pages untouched', async () => {
+    const stamped = await frontmatterOf(STAMPED_INDEX);
+    expect(stamped.raw_trace_exempt).toBe(true);
+    expect(stamped.dream_cycle_date).toBe('2026-06-01');
+
+    for (const slug of [HAND_AUTHORED_IN_NAMESPACE, WIKI_SYNTHESIS, EXTRACT_SYNTHESIS]) {
+      const fm = await frontmatterOf(slug);
+      expect(fm.raw_trace_exempt).toBeUndefined();
+      expect(fm.raw_trace_exempt_reason).toBeUndefined();
+    }
+  });
+
+  test('re-running is a no-op — and needs no --fresh, because the backfill is not checkpointed', async () => {
+    expect(spec().resumable).toBe(false);
+    const rerun = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(rerun.examined).toBe(0);
+    expect(rerun.updated).toBe(0);
+    expect(rerun.errors).toBe(0);
+  });
+
+  test('doctor no longer names the index page, and still warns about the out-of-scope pages', async () => {
+    const check = await rawProvenanceCheck(engine as unknown as BrainEngine);
+    expect(check.status).toBe('warn');
+    expect(check.message).not.toContain(UNSTAMPED_INDEX);
+    expect(check.message).toContain(WIKI_SYNTHESIS);
+    expect(check.message).toContain('gbrain backfill dream_cycle_index_provenance');
+  });
+
+  test('soft-deleted index pages are not stamped', async () => {
+    const deletedSlug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-04-01`;
+    await engine.putPage(deletedSlug, {
+      type: 'note', title: 'Dream cycle 2026-04-01', compiled_truth: 'body', timeline: '',
+      frontmatter: { dream_generated: true, dream_cycle_date: '2026-04-01' },
+    });
+    await engine.executeRaw(`UPDATE pages SET deleted_at = now() WHERE slug = $1`, [deletedSlug]);
+
+    const result = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(result.updated).toBe(0);
+    expect((await frontmatterOf(deletedSlug)).raw_trace_exempt).toBeUndefined();
+  });
+
+  test('an index page with an existing raw trace is skipped (predicate parity with doctor)', async () => {
+    const tracedSlug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-03-01`;
+    await engine.putPage(tracedSlug, {
+      type: 'note', title: 'Dream cycle 2026-03-01', compiled_truth: 'body', timeline: '',
+      // dream_cycle_date matches the slug tail on purpose, so this fixture
+      // is stopped by the raw-trace guard rather than the date guard.
+      frontmatter: {
+        dream_generated: true,
+        dream_cycle_date: '2026-03-01',
+        raw_source: '/transcripts/2026-03-01.md',
+      },
+    });
+
+    const result = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(result.updated).toBe(0);
+    expect((await frontmatterOf(tracedSlug)).raw_trace_exempt).toBeUndefined();
+  });
+
+  test('a date-shaped slug whose dream_cycle_date disagrees with the slug tail is skipped', async () => {
+    // The writer always composes the slug FROM dream_cycle_date, so a
+    // mismatch means this page was not produced by writeSummaryPage.
+    const impostorSlug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-02-01`;
+    await engine.putPage(impostorSlug, {
+      type: 'note', title: 'Impostor', compiled_truth: 'body', timeline: '',
+      frontmatter: { dream_generated: true, dream_cycle_date: '2025-12-31' },
+    });
+
+    const result = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(result.updated).toBe(0);
+    expect((await frontmatterOf(impostorSlug)).raw_trace_exempt).toBeUndefined();
+  });
+
+  test('an index page with an attached raw_data row is skipped', async () => {
+    const slug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-02-02`;
+    const page = await engine.putPage(slug, {
+      type: 'note', title: 'Has raw_data', compiled_truth: 'body', timeline: '',
+      frontmatter: { dream_generated: true, dream_cycle_date: '2026-02-02' },
+    });
+    await engine.executeRaw(
+      `INSERT INTO raw_data (page_id, source, data) VALUES ($1, 'test', '{}'::jsonb)`,
+      [page.id],
+    );
+
+    const result = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(result.updated).toBe(0);
+    expect((await frontmatterOf(slug)).raw_trace_exempt).toBeUndefined();
+  });
+
+  // The synthesis_evidence arm of the predicate is not re-tested here: it is
+  // the SAME string as doctor's (untracedSynthesizedPagesPredicate), already
+  // pinned against a real engine by test/doctor-raw-provenance.test.ts, and
+  // seeding a row requires a full takes(page_id, row_num) FK parent. The
+  // raw_data case above proves the NOT EXISTS arms execute on this engine.
+
+  test('dry-run reports the row without writing it', async () => {
+    const slug = `${DREAM_CYCLE_SUMMARY_SLUG_PREFIX}2026-01-05`;
+    await engine.putPage(slug, {
+      type: 'note', title: 'Dry run target', compiled_truth: 'body', timeline: '',
+      frontmatter: { dream_generated: true, dream_cycle_date: '2026-01-05' },
+    });
+
+    const dry = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100, dryRun: true });
+    expect(dry.examined).toBe(1);
+    expect(dry.updated).toBe(0);
+    expect((await frontmatterOf(slug)).raw_trace_exempt).toBeUndefined();
+
+    // And the real run then stamps it.
+    const real = await runBackfill(engine as unknown as BrainEngine, spec(), { batchSize: 100 });
+    expect(real.updated).toBe(1);
+    expect((await frontmatterOf(slug)).raw_trace_exempt).toBe(true);
+  });
+});

--- a/test/e2e/postgres-jsonb.test.ts
+++ b/test/e2e/postgres-jsonb.test.ts
@@ -26,6 +26,9 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import {
   hasDatabase, setupDB, teardownDB, getEngine, getConn,
 } from './helpers.ts';
+import { getBackfill } from '../../src/core/backfill-registry.ts';
+import { runBackfill } from '../../src/core/backfill-base.ts';
+import { DREAM_INDEX_RAW_TRACE_EXEMPT_REASON } from '../../src/core/raw-provenance.ts';
 
 const skip = !hasDatabase();
 const describeE2E = skip ? describe.skip : describe;
@@ -170,5 +173,44 @@ describeE2E('Postgres JSONB round-trip — frontmatter / data / pages_updated / 
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0].jt).toBe('object');
     expect(rows[0].mood).toBe('happy');
+  });
+  test('backfill columnUpdateSql — jsonb merge binds an object, not a string literal (#1978)', async () => {
+    const engine = getEngine();
+    const conn = getConn();
+
+    // A dream-cycle index page written before synthesize.ts stamped the
+    // raw-trace exemption. PGLite cannot surface the double-encode class
+    // (#2339), so the runner's `$N::jsonb` write path is pinned HERE.
+    await engine.putPage('dream-cycle-summaries/2026-05-24', {
+      type: 'note',
+      title: 'Dream cycle 2026-05-24',
+      compiled_truth: '# Dream cycle 2026-05-24',
+      frontmatter: { dream_generated: true, dream_cycle_date: '2026-05-24' },
+    });
+
+    const reg = getBackfill('dream_cycle_index_provenance');
+    expect(reg).toBeDefined();
+    const result = await runBackfill(engine, reg!.spec, { batchSize: 100 });
+    expect(result.updated).toBe(1);
+
+    const rows = await conn.unsafe(`
+      SELECT
+        jsonb_typeof(frontmatter)              AS jt,
+        frontmatter->>'raw_trace_exempt'       AS exempt,
+        frontmatter->>'raw_trace_exempt_reason' AS reason,
+        frontmatter->>'dream_cycle_date'       AS cycle_date,
+        frontmatter->>'dream_generated'        AS generated
+      FROM pages
+      WHERE slug = 'dream-cycle-summaries/2026-05-24'
+    `);
+
+    expect(rows).toHaveLength(1);
+    // 'object', not 'string' — a double-encoded write would report 'string'.
+    expect(rows[0].jt).toBe('object');
+    expect(rows[0].exempt).toBe('true');
+    expect(rows[0].reason).toBe(DREAM_INDEX_RAW_TRACE_EXEMPT_REASON);
+    // Merge, not replace: the pre-existing keys survive.
+    expect(rows[0].cycle_date).toBe('2026-05-24');
+    expect(rows[0].generated).toBe('true');
   });
 });

--- a/test/e2e/v030_1-integration-pglite.test.ts
+++ b/test/e2e/v030_1-integration-pglite.test.ts
@@ -83,11 +83,16 @@ describe('Lane C — backfill registry on empty brain', () => {
   test('listBackfills returns the canonical registry entries', () => {
     // v0.30.1 shipped 3 entries (effective_date, embedding_voyage,
     // emotional_weight). v0.36 cross-modal wave adds `modality` for
-    // historical image-asset chunks. Extend this assertion as new
-    // backfills land.
+    // historical image-asset chunks. #1978 adds
+    // `dream_cycle_index_provenance` for dream-cycle index pages written
+    // before synthesize.ts stamped their raw-trace exemption. Extend this
+    // assertion as new backfills land.
     const list = listBackfills();
     const names = list.map(e => e.spec.name).sort();
-    expect(names).toEqual(['effective_date', 'embedding_voyage', 'emotional_weight', 'modality']);
+    expect(names).toEqual([
+      'dream_cycle_index_provenance', 'effective_date', 'embedding_voyage',
+      'emotional_weight', 'modality',
+    ]);
   });
 
   test('embedding_voyage is declared-only in v0.30.1', () => {


### PR DESCRIPTION
Follow-up to #1978. Complements #3300.

## The gap

#3300 added the warn-only `raw_provenance` check in `doctor`: a synthesized page must carry a raw trace (`raw_trace` / `raw_source` / `source_uri` frontmatter, a `raw_data` row, or `synthesis_evidence` rows) or an explicit `raw_trace_exempt` marker.

In the same wave `writeSummaryPage` in `src/core/cycle/synthesize.ts` began stamping the per-cycle index page `dream-cycle-summaries/<date>` with `raw_trace_exempt: true` + `raw_trace_exempt_reason` — the index is deterministic, it has no source document of its own, and the raw traces live on the pages it lists.

**That stamping is prospective only. There is no backfill.** Index pages written before that code landed carry no stamp, so on any brain that has them the check warns permanently with no supported way to clear it.

This PR adds `gbrain backfill dream_cycle_index_provenance`, which applies the writer's own stamp to exactly those rows. It is not a new design decision — it applies semantics this repo already shipped to rows that predate the code.

## What dogfooding showed

This started as a live warn on a real 1609-page brain (v0.42.65.0, schema v125, PGLite). Measured directly in Postgres with the `raw_provenance` predicate:

| probe | value |
|---|---|
| pages matching the `raw_provenance` predicate | **183** |
| ... `dream-cycle-summaries/<ISO date>` | **49**, created 2026-05-24 .. 2026-07-23 |
| ... `wiki/*` | 79, created 2026-07-03 .. 2026-07-23 |
| ... `extracts/*` | 55, created 2026-05-29 .. 2026-07-23 |
| rows in `synthesis_evidence` | **0** |
| of the 49 index pages, `dream_cycle_date` == slug tail | 49 |

Being precise about the state you would see if you probed that brain right now: **it reports OK, because I remediated it out-of-band a few hours before opening this PR** — I stamped the frontmatter directly in the DB (content untouched, so no re-chunk or re-embed), keeping a backup of all 183 rows first. So the 183 is a real measurement with a retained artifact, not a number I can re-derive from that brain on demand. I would rather state that plainly than either present an unreproducible live count or drop the evidence entirely.

Two observations from that data that cut in different directions:

- **`synthesis_evidence` is empty on a brain that has been running dream cycles for two months.** That branch of the check is theoretical in practice, so for these pages the exemption stamp is the only thing that can satisfy it.
- **My out-of-band fix for the other 134 pages is deliberately *not* what this PR proposes.** For `wiki/*` and `extracts/*` I stamped a blanket exemption to quiet my own brain, which silences the check rather than satisfying it. That is a defensible local stopgap and a bad upstream default, which is exactly why this PR scopes itself to the index pages and leaves those two namespaces to you (see below).

The `dream_cycle_date == slug tail` row above is load-bearing for the predicate: it confirms the extra guard excludes no real index page.

## Why the backfill registry and not a schema migration

A migration auto-applies on upgrade and would reach every brain without operator action, which is genuinely attractive here. I went the other way because of what this repo already does with each vehicle:

- `MIGRATIONS` in `src/core/migrate.ts` carries schema/DDL and trigger work. The only `UPDATE pages` in the whole array is a no-op `SET id = id` touch to re-fire a trigger.
- Historical **row-data** repairs go through the backfill lane — `effective_date`, `emotional_weight`, `modality` — which brings keyset pagination, adaptive batch halving, a reserved-connection write path and `--dry-run`.
- `modality` is the exact precedent for this shape: `doctor` warns and the message says ``Fix: `gbrain backfill modality` ``. This PR mirrors that, and updates the `raw_provenance` message to point at the new lane the same way.

Happy to convert it to a migration if you would rather it auto-apply — it is a small change either way.

## Deliberately out of scope: `wiki/*` and `extracts/*`

Other pre-existing synthesized pages want a `raw_source` naming the transcript they were derived from. That mapping (child job -> source path) is gone once the cycle has run, so it cannot be reconstructed retroactively. Blanket-stamping an exemption on them would silence the check rather than satisfy it, and would destroy the signal for the pages that genuinely lack provenance. **I am leaving that call to you** — the options are roughly: accept a permanent warn for pre-existing content pages, add a distinct lower-confidence marker, or scope the check to pages created after the stamping code landed.

## Implementation notes

- **No drift by construction.** The predicate and the exemption literals move into `src/core/raw-provenance.ts`; the check, the writer and the backfill all import from there.
- **Predicate.** The shared untraced-page predicate, plus the index slug shape (`^dream-cycle-summaries/[0-9]{4}-[0-9]{2}-[0-9]{2}$`), plus `dream_generated = 'true'`, plus `dream_cycle_date = right(slug, 10)` — the writer always composes the slug from that date, so a mismatch means the page did not come from `writeSummaryPage`.
- **Idempotent.** The stamp it writes is one of the keys the shared predicate excludes, so a second run matches nothing.
- **Content untouched.** Only `frontmatter` moves — `compiled_truth` and `content_hash` are unchanged, so nothing re-chunks or re-embeds. The existing generation/cache-invalidation triggers fire, as they would for any frontmatter write.
- Two optional, backward-compatible knobs on `BackfillSpec`:
  - `columnUpdateSql` — per-column RHS builder. Used as `frontmatter = COALESCE(frontmatter,'{}'::jsonb) || $N::jsonb`, which both binds a raw object at an explicit `::jsonb` position (never `JSON.stringify` there — the #2339 shape) and merges against the *current* row instead of a JS-side snapshot.
  - `resumable` — defaults to true, so existing backfills are unaffected. This one sets it false: its predicate is self-clearing, so a checkpoint buys nothing and costs correctness (see the known limitation below).

**Known limitation.** The backfill repairs the DB row, not the historical markdown file the dream cycle dual-wrote. If such a file is later edited and re-imported, the import replaces frontmatter wholesale and the exemption is lost again. `resumable: false` is what makes that recoverable: a plain re-run re-stamps the row rather than skipping it below a watermark. Persisting the stamp into the canonical markdown is a larger change and I left it out.

## Testing

- New `test/backfill-dream-cycle-index-provenance.test.ts` against real PGLite: stamps the unstamped index page; leaves alone an already-stamped page, a hand-authored page in the namespace, a date-shaped impostor whose `dream_cycle_date` disagrees with its slug, a page with a `raw_data` row, a soft-deleted page, and `wiki/*` / `extracts/*` synthesis pages; asserts the merge preserves existing keys and leaves `compiled_truth` / `content_hash` untouched; asserts re-running is a no-op and `--dry-run` writes nothing.
- `test/backfill-base.test.ts`: pins the exact generated `UPDATE` SQL and parameter order for `columnUpdateSql`, and that `resumable: false` neither reads nor writes a checkpoint.
- `test/e2e/postgres-jsonb.test.ts`: `DATABASE_URL`-gated case asserting `jsonb_typeof(frontmatter) = 'object'` after the merge, since PGLite cannot surface the double-encode class.
- `bun run verify` 31/31 green; `bun run typecheck` clean; affected suites green. I could not run the `DATABASE_URL`-gated e2e case locally (no Postgres available in this environment) — CI covers it.

