### PR TITLE
fix(think): unwrap markdown-fenced JSON before parsing synthesis output (#2364)

### DIFF
--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -174,19 +174,58 @@ function inferIntent(question: string, anchor?: string): string {
   return 'general';
 }
 
+/**
+ * Parse the synthesis model's response into the `{answer, citations, gaps}`
+ * shape, tolerating a Markdown code fence around (or a lead-in sentence
+ * before) the JSON — models routinely add one despite the system prompt
+ * asking for "no prose outside JSON" (#2364).
+ *
+ * Three candidate substrings are tried, in this fixed order, and — this is
+ * the important part — EVERY candidate that parses as an object is
+ * considered before returning: a candidate whose parsed shape actually has
+ * a string `answer` field always wins over one that doesn't, regardless of
+ * which candidate was tried first. Short-circuiting on the first candidate
+ * that merely parses (rather than the first one that looks like a real
+ * response) is what caused earlier regressions here — e.g. a fenced code
+ * snippet embedded INSIDE a valid `answer` value can itself look like a
+ * wrapping fence, or even parse to a valid-but-wrong object like `{}`.
+ *   1. The full trimmed text (handles the common no-fence case, and any
+ *      fence-looking sequence that's actually just part of a string value).
+ *   2. The Markdown-fenced region, if a fence is present: from the first
+ *      opening fence marker to the LAST closing one (not anchored to the
+ *      very start/end, so a lead-in sentence before the fence doesn't
+ *      defeat it; not non-greedy, so a nested fence inside the JSON's own
+ *      `answer` markdown doesn't truncate it early).
+ *   3. The first `{...}` block found anywhere in the full text — the
+ *      original fallback, for prose-wrapped JSON with no fence at all.
+ */
 function tryParseJSON(text: string): unknown {
-  // The model may wrap JSON in code fences. Strip if present.
-  const stripped = text.trim().replace(/^```(?:json)?\s*\n?/, '').replace(/```\s*$/, '');
-  try {
-    return JSON.parse(stripped);
-  } catch {
-    // Fallback: extract the first {...} block. Useful when the model emits prose alongside JSON.
-    const m = stripped.match(/\{[\s\S]*\}/);
-    if (m) {
-      try { return JSON.parse(m[0]); } catch { /* ignore */ }
-    }
-    return null;
+  const trimmed = text.trim();
+  const candidates: string[] = [trimmed];
+
+  const fenceOpen = trimmed.match(/```[ \t]*(?:json)?[ \t]*\n?/i);
+  if (fenceOpen && fenceOpen.index !== undefined) {
+    const contentStart = fenceOpen.index + fenceOpen[0].length;
+    const closeIdx = trimmed.lastIndexOf('```');
+    candidates.push((closeIdx > contentStart ? trimmed.slice(contentStart, closeIdx) : trimmed.slice(contentStart)).trim());
   }
+
+  const braceMatch = trimmed.match(/\{[\s\S]*\}/);
+  if (braceMatch) candidates.push(braceMatch[0]);
+
+  let weakMatch: unknown = null;
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    if (typeof (parsed as Record<string, unknown>).answer === 'string') return parsed;
+    if (weakMatch === null) weakMatch = parsed;
+  }
+  return weakMatch;
 }
 
 /**

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -265,6 +265,190 @@ describe('runThink (with stub client)', () => {
     expect(result.citations.length).toBeGreaterThanOrEqual(2);
   });
 
+  // #2364: models routinely wrap the JSON response in a Markdown code fence
+  // despite the system prompt asking for "no prose outside JSON". Before the
+  // fix, the parser only stripped an ANCHORED fence (one wrapping the whole
+  // response) and otherwise fell through to a naive `{...}` brace-scan of
+  // the raw text — so a fenced response was previously misreported as
+  // synthesisOk=false with the raw fenced blob leaking into `answer`.
+  test('unwraps a markdown-fenced JSON response → synthesisOk true, clean answer', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_stub_fenced',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          text: '```json\n' + JSON.stringify({
+            answer: 'Alice [people/alice-example#1] is the CEO of Acme.',
+            citations: [
+              { page_slug: 'people/alice-example', row_num: 1, citation_index: 1 },
+            ],
+            gaps: [],
+          }) + '\n```',
+        }],
+      }),
+    };
+
+    const result = await runThink(engine, {
+      question: 'fenced json test',
+      client: stubClient,
+    });
+
+    expect(result.warnings).not.toContain('LLM_OUTPUT_NOT_JSON');
+    expect(result.warnings).not.toContain('CITATIONS_REGEX_FALLBACK');
+    expect(result.synthesisOk).toBe(true);
+    expect(result.answer).toBe('Alice [people/alice-example#1] is the CEO of Acme.');
+    expect(result.answer).not.toContain('```');
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0].page_slug).toBe('people/alice-example');
+  });
+
+  // Regression case for the actual defect: a lead-in sentence before the
+  // fence (common with reasoning-style models) that itself contains a brace
+  // used to poison the naive whole-text `{...}` brace-scan fallback, since
+  // the anchored fence-strip only handles a fence wrapping the ENTIRE text.
+  test('unwraps a fenced JSON response with a brace in the lead-in prose', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_stub_fenced_preamble',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          text: 'Based on the context above (e.g. {some background}), here is the synthesis:\n```json\n'
+            + JSON.stringify({ answer: 'Clean synthesis text.', citations: [], gaps: [] })
+            + '\n```',
+        }],
+      }),
+    };
+
+    const result = await runThink(engine, {
+      question: 'fenced json with preamble test',
+      client: stubClient,
+    });
+
+    expect(result.warnings).not.toContain('LLM_OUTPUT_NOT_JSON');
+    expect(result.synthesisOk).toBe(true);
+    expect(result.answer).toBe('Clean synthesis text.');
+  });
+
+  // Codex review regression guard: a valid, UNFENCED top-level JSON response
+  // whose own `answer` value happens to contain a markdown code fence (e.g.
+  // a code snippet) must parse as-is, not get truncated by the fence
+  // heuristic above.
+  test('parses valid unfenced JSON whose answer field contains an embedded code fence', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_stub_embedded_fence',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          // No outer fence — this is already valid top-level JSON. The
+          // `answer` value itself embeds a markdown code fence.
+          text: JSON.stringify({
+            answer: 'Example: ```ts const x = {}; ```',
+            citations: [],
+            gaps: [],
+          }),
+        }],
+      }),
+    };
+
+    const result = await runThink(engine, {
+      question: 'embedded fence test',
+      client: stubClient,
+    });
+
+    expect(result.warnings).not.toContain('LLM_OUTPUT_NOT_JSON');
+    expect(result.synthesisOk).toBe(true);
+    expect(result.answer).toBe('Example: ```ts const x = {}; ```');
+  });
+
+  // Codex review regression guard (round 2): same embedded-fence case as
+  // above, PLUS trailing prose after the JSON object. The trailing prose
+  // means a full-text JSON.parse fails, forcing the fence heuristic to run;
+  // it must not mistake the embedded fence for a real wrapper and hand the
+  // brace-match fallback an over-narrow (and wrong) slice of text.
+  test('recovers full JSON via whole-text fallback when an embedded fence + trailing prose both confuse the fence heuristic', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_stub_embedded_fence_postamble',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            answer: 'Example: ```ts const x = {}; ```',
+            citations: [],
+            gaps: [],
+          }) + '\nHope this helps.',
+        }],
+      }),
+    };
+
+    const result = await runThink(engine, {
+      question: 'embedded fence plus postamble test',
+      client: stubClient,
+    });
+
+    expect(result.answer).toBe('Example: ```ts const x = {}; ```');
+  });
+
+  // Codex review regression guard (round 3): the embedded fence's own
+  // content happens to be valid JSON on its own ("{}"), so the fence-scoped
+  // candidate parses successfully — but it isn't the REAL response (it has
+  // no `answer` field). The whole-text candidate (found via the final
+  // brace-match fallback, since trailing postamble breaks a direct parse)
+  // has to win because it's the one that actually looks like a
+  // ThinkResponse, even though the mis-scoped candidate parsed "first".
+  test('prefers the answer-shaped candidate over a coincidentally-valid embedded-fence fragment', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_stub_embedded_fence_valid_json',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            answer: 'Example: ```{}```',
+            citations: [],
+            gaps: [],
+          }) + '\nHope this helps.',
+        }],
+      }),
+    };
+
+    const result = await runThink(engine, {
+      question: 'embedded fence with coincidentally valid json test',
+      client: stubClient,
+    });
+
+    expect(result.answer).toBe('Example: ```{}```');
+    expect(result.synthesisOk).toBe(true);
+  });
+
   test('degrades gracefully without ANTHROPIC_API_KEY', async () => {
     // Hermetic: neutralize BOTH the env var AND ~/.gbrain config key, else a
     // developer/CI machine with a configured key fires a real LLM call and this


### PR DESCRIPTION
## Defect

`think` reports `synthesisOk: false` with warnings `LLM_OUTPUT_NOT_JSON` + `CITATIONS_REGEX_FALLBACK` on perfectly good answers, and the top-level `answer` field ships the raw Markdown-fenced JSON blob instead of clean prose. Reported in (#2364).

## Root cause

The synthesis model routinely wraps its structured JSON response in a Markdown code fence (```` ```json … ``` ````) despite the system prompt's "no prose outside JSON" instruction. `tryParseJSON()` in `src/core/think/index.ts` only stripped a fence that **anchored the entire response** (`^```...```$`). Any lead-in sentence before the fence (common with reasoning-style models) defeated that anchored strip, and the whole-text brace-scan fallback would then latch onto a stray `{`/`}` inside that preamble instead of the real JSON — producing exactly the reported symptom even though the JSON was present and well-formed inside its fence.

## Fix

`tryParseJSON()` now builds up to three candidate substrings and prefers whichever one actually looks like the expected `{answer, citations, gaps}` shape:

1. The full trimmed text (handles the common no-fence case).
2. The fenced region, located by **first opening marker → last closing marker** (not anchored to the very start/end, so a lead-in sentence doesn't defeat it; not non-greedy, so a nested fence inside the JSON's own `answer` markdown doesn't truncate it early).
3. The first `{...}` block found anywhere in the full text (the original fallback, for prose-wrapped JSON with no fence at all).

Every candidate that parses as an object is considered before returning — a candidate with a string `answer` field always wins over one that doesn't, rather than short-circuiting on whichever candidate happened to parse first. This ordering came out of three rounds of bounded Codex review against the draft diff, each of which surfaced a real edge case (see Verification below). The fence-tag match was also widened to be case-insensitive with an optional space (```` ```JSON ````, ```` ``` json ````).

The regex citation fallback (`CITATIONS_REGEX_FALLBACK` path in `cite-render.ts`) is untouched — it's a real fallback for genuinely non-JSON output and still fires correctly when there's no JSON to recover.

## Verified

- `bun test test/think-pipeline.serial.test.ts` — 35 pass, 0 fail, 92 `expect()` calls. Includes a new test that reproduces the original bug (a preamble sentence with a stray brace before a real fence) and was confirmed to fail against the pre-fix implementation before the fix was applied, plus tests for the anchored-fence case, and three regression-guard tests added in response to Codex review findings (embedded fence inside `answer`, embedded fence + trailing prose, and an embedded fence whose content is itself coincidentally valid JSON).
- `bun run typecheck` — clean (`tsc --noEmit`, no errors).
- `bun run verify` — 31/31 checks green.
- `git diff --stat upstream/master` — 2 files changed (`src/core/think/index.ts`, `test/think-pipeline.serial.test.ts`), no unintended files, no secrets.
- Bounded `codex exec` review (4 rounds, `model_reasoning_effort=high`, diff-scoped) — each round's Critical/Warning findings were addressed in the diff before the next round; the final round's remaining two findings are noted below as deliberate scope boundaries.

## Deliberately out of scope

Two findings from the final Codex review round were not chased further, to stay within "robust but not speculative":

- The whole-text brace-scan fallback still can't disambiguate multiple independent brace regions in already-noisy text (e.g. valid JSON followed by unrelated prose that itself happens to contain a balanced `{...}`). This is a pre-existing limitation of the brace-scan fallback (it existed in the original code too, since the anchored strip never touched this case either) — not introduced by this change.
- The candidate-preference logic doesn't try to detect an earlier illustrative "example" JSON object the model might include unprompted before the real response. Disambiguating that would need a materially different extraction strategy, and is an increasingly unrealistic scenario given the system prompt's explicit "no prose outside JSON" instruction — there's no evidence models exhibit this pattern for this schema.

Both would need a more general "extract the right one of several plausible JSON objects from noisy text" solution, which felt disproportionate to the reported bug.
