### PR TITLE
fix(extract): recognize operations and system entity refs

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -84,9 +84,10 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
  * recognizes as entity references. Upstream canonical + our extensions:
  *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects, reference
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
+ *   - Operational knowledge prefixes: operations, system
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|reference)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|operations|system|entities|reference)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -111,6 +111,25 @@ describe('extractEntityRefs', () => {
     expect(refs[0].dir).toBe('meetings');
   });
 
+  test('extracts operations and system refs across supported link shapes', () => {
+    const wikilinks = extractEntityRefs(
+      'See [[operations/gbrain-hermes-integration]] and [[system/hermes-gbrain-gemini-validation]].',
+    );
+    expect(wikilinks.map(r => r.slug)).toEqual([
+      'operations/gbrain-hermes-integration',
+      'system/hermes-gbrain-gemini-validation',
+    ]);
+    expect(wikilinks.map(r => r.dir)).toEqual(['operations', 'system']);
+
+    const markdown = extractEntityRefs(
+      'See [Integration](operations/gbrain-hermes-integration) and [Canary](system/hermes-gbrain-gemini-validation).',
+    );
+    expect(markdown.map(r => r.slug)).toEqual([
+      'operations/gbrain-hermes-integration',
+      'system/hermes-gbrain-gemini-validation',
+    ]);
+  });
+
   // ─── issue #972: generic `[[bare-name]]` wikilinks (pass 2c) ─────────────
 
   test('tags bare wikilinks with needsResolution flag', () => {


### PR DESCRIPTION
## Summary
- recognize `operations/` and `system/` as concrete entity-reference prefixes
- preserve the existing `reference/` prefix
- cover both wikilink and Markdown-link extraction shapes

## Validation
- `bun test test/link-extraction.test.ts` — 163 passed
- `bun run typecheck`
- `git diff --check origin/master...HEAD`
- `scripts/check-privacy.sh`

The change is intentionally narrow; upstream-equivalent doctor/orphan changes from the original local patch were dropped during rebase.