### PR TITLE
fix: preserve source scope and recover deferred embeddings

### DIFF
--- a/scripts/check-wasm-embedded.sh
+++ b/scripts/check-wasm-embedded.sh
@@ -27,6 +27,15 @@ trap 'rm -f "$OUT_BIN"' EXIT
 # chunker + WASM path resolution, not unrelated CLI wiring.
 bun build --compile --outfile "$OUT_BIN" scripts/chunker-smoketest.ts >/dev/null 2>&1
 
+# Some hardened macOS hosts kill Bun 1.3.12 compiled binaries because that
+# release emits a corrupt LC_CODE_SIGNATURE. Remove the malformed signature
+# before applying an ad-hoc one so this guard tests the embedded WASM path
+# instead of failing at AppleSystemPolicy. Other platforms are unchanged.
+if [ "$(uname -s)" = "Darwin" ] && command -v codesign >/dev/null 2>&1; then
+  codesign --remove-signature "$OUT_BIN" >/dev/null 2>&1
+  codesign --force --sign - "$OUT_BIN" >/dev/null 2>&1
+fi
+
 # Run it and capture JSON output.
 OUTPUT="$("$OUT_BIN" 2>&1)"
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -196,6 +196,8 @@ export interface SyncResult {
   chunksCreated: number;
   /** Pages re-embedded during this sync's auto-embed step. 0 if --no-embed or skipped. */
   embedded: number;
+  /** True when sync itself auto-deferred embedding because the incremental delta exceeded the inline limit. */
+  embeddingDeferred?: boolean;
   pagesAffected: string[];
   failedFiles?: number; // count of parse failures (Bug 9)
   /**
@@ -2467,7 +2469,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     };
   }
 
-  const noEmbed = opts.noEmbed || totalChanges > 100;
+  const embeddingDeferred = !opts.noEmbed && totalChanges > 100;
+  const noEmbed = opts.noEmbed || embeddingDeferred;
   if (totalChanges > 100) {
     slog(`Large sync (${totalChanges} files). Importing text, deferring embeddings.`);
   }
@@ -3527,6 +3530,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     renamed: filtered.renamed.length,
     chunksCreated,
     embedded,
+    embeddingDeferred,
     pagesAffected,
   };
 }

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -307,6 +307,11 @@ export async function importFromContent(
   // silently fabricated a duplicate at (default, slug) — causing later
   // bare-slug subqueries (getTags, deleteChunks, etc.) to crash with 21000.
   const sourceId = opts.sourceId;
+  // Write paths need one concrete source for both the read-before-write and
+  // the transaction. An undefined getPage scope federates across sources and
+  // can mistake a foreign same-slug row for the row this import will update.
+  const effectiveSourceId = sourceId ?? 'default';
+  const sourceOpts = { sourceId: effectiveSourceId };
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
   // so the network path behaves identically to the file path.
@@ -347,7 +352,7 @@ export async function importFromContent(
     content,
     metadata: {
       slug,
-      source_id: sourceId ?? 'default',
+      source_id: effectiveSourceId,
       source_path: opts.sourcePath ?? null,
       source_kind: opts.source_kind ?? null,
       source_uri: opts.source_uri ?? null,
@@ -546,7 +551,7 @@ export async function importFromContent(
   // #1035: fetch the existing page BEFORE the hash compute so (a) the type
   // preservation below participates in the hash (a no-op re-put stays a
   // hash-match skip) and (b) the hash short-circuit below reuses this row.
-  const existing = await engine.getPage(slug, sourceId ? { sourceId } : undefined);
+  const existing = await engine.getPage(slug, sourceOpts);
 
   // #1035: absence of an explicit frontmatter `type:` on an EXISTING page
   // means "preserve the stored type", not "re-infer". Pre-fix, a round-trip
@@ -620,7 +625,7 @@ export async function importFromContent(
   if (!opts.forceRechunk && engine.findDuplicatePage) {
     let dup: { slug: string; id: number } | null = null;
     try {
-      dup = await engine.findDuplicatePage(sourceId ?? 'default', {
+      dup = await engine.findDuplicatePage(effectiveSourceId, {
         hash,
         frontmatterId: fmIdStr,
       });
@@ -632,7 +637,7 @@ export async function importFromContent(
     }
     if (dup && dup.slug !== slug) {
       // Look up the duplicate page so we can compare frontmatter.id.
-      const dupPage = await engine.getPage(dup.slug, sourceId ? { sourceId } : undefined);
+      const dupPage = await engine.getPage(dup.slug, sourceOpts);
       const dupFmId = (dupPage?.frontmatter as Record<string, unknown> | undefined)?.id;
       const dupFmIdStr = typeof dupFmId === 'string' && dupFmId.length > 0 ? dupFmId : null;
       const sameExternalId = fmIdStr !== null && dupFmIdStr === fmIdStr;
@@ -640,7 +645,7 @@ export async function importFromContent(
         // True duplicate (same external ID). Skip + log to stderr.
         process.stderr.write(
           `[import] skipping ${opts.sourcePath ?? slug}: identical to ${dup.slug} ` +
-          `(frontmatter.id=${fmIdStr}) in source ${sourceId ?? 'default'}. ` +
+          `(frontmatter.id=${fmIdStr}) in source ${effectiveSourceId}. ` +
           `Pass --force-rechunk to override.\n`
         );
         return { slug: dup.slug, status: 'skipped', chunks: 0, parsedPage };
@@ -711,7 +716,7 @@ export async function importFromContent(
     const resolution = resolveContextualRetrievalMode({
       pageFrontmatter: parsed.frontmatter,
       source: {
-        id: sourceId ?? 'default',
+        id: effectiveSourceId,
         contextual_retrieval_mode: null,
         trust_frontmatter_overrides: false,
       },
@@ -760,10 +765,8 @@ export async function importFromContent(
         });
 
   // Transaction wraps all DB writes. Every per-page tx call carries the
-  // caller's sourceId so writes target (sourceId, slug) rather than the
-  // schema DEFAULT — required for multi-source brains; harmless ('default')
-  // for single-source callers.
-  const txOpts = sourceId ? { sourceId } : undefined;
+  // same concrete source used by the read-before-write above.
+  const txOpts = sourceOpts;
   await engine.transaction(async (tx) => {
     if (existing) await tx.createVersion(slug, txOpts);
 
@@ -818,7 +821,7 @@ export async function importFromContent(
     if (!opts.noEmbed) {
       await tx.updatePageContextualRetrievalState(
         slug,
-        sourceId ?? 'default',
+        effectiveSourceId,
         effectiveCRMode,
         corpusGeneration,
       );

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2733,6 +2733,7 @@ const sync_brain: Operation = {
   description: 'Sync git repo to brain (incremental)',
   params: {
     repo: { type: 'string', description: 'Path to git repo (optional if configured)' },
+    source_id: { type: 'string', description: 'Named source to sync (defaults to the operation context source)' },
     dry_run: { type: 'boolean', description: 'Preview changes without applying' },
     full: { type: 'boolean', description: 'Full re-sync (ignore checkpoint)' },
     no_pull: { type: 'boolean', description: 'Skip git pull' },
@@ -2749,6 +2750,7 @@ const sync_brain: Operation = {
       noEmbed: (p.no_embed as boolean) || false,
       noPull: (p.no_pull as boolean) || false,
       full: (p.full as boolean) || false,
+      sourceId: (p.source_id as string | undefined) ?? ctx.sourceId,
     });
   },
   cliHints: { name: 'sync', hidden: true },

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2744,14 +2744,46 @@ const sync_brain: Operation = {
   localOnly: true,
   handler: async (ctx, p) => {
     const { performSync } = await import('../commands/sync.ts');
-    return performSync(ctx.engine, {
+    const sourceId = (p.source_id as string | undefined) ?? ctx.sourceId;
+    const resolvedSourceId = sourceId ?? 'default';
+    const noEmbed = (p.no_embed as boolean) || false;
+    const result = await performSync(ctx.engine, {
       repoPath: p.repo as string | undefined,
       dryRun: ctx.dryRun || (p.dry_run as boolean) || false,
-      noEmbed: (p.no_embed as boolean) || false,
+      noEmbed,
       noPull: (p.no_pull as boolean) || false,
       full: (p.full as boolean) || false,
-      sourceId: (p.source_id as string | undefined) ?? ctx.sourceId,
+      sourceId,
     });
+
+    let embedBackfillReason: string | null = result.embeddingDeferred
+      ? 'sync_operation_deferred'
+      : null;
+    if (!embedBackfillReason && result.status === 'up_to_date' && !noEmbed) {
+      const { quoteIdentifier, resolveEmbeddingColumn } = await import('./search/embedding-column.ts');
+      const embeddingColumn = quoteIdentifier(resolveEmbeddingColumn(undefined, ctx.config).name);
+      const rows = await ctx.engine.executeRaw<{ missing: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1
+             FROM content_chunks cc
+             JOIN pages p ON p.id = cc.page_id
+            WHERE p.source_id = $1
+              AND p.deleted_at IS NULL
+              AND cc.${embeddingColumn} IS NULL
+         ) AS missing`,
+        [resolvedSourceId],
+      );
+      if (rows[0]?.missing) embedBackfillReason = 'sync_operation_backlog';
+    }
+
+    if (embedBackfillReason) {
+      const { submitEmbedBackfill } = await import('./embed-backfill-submit.ts');
+      const embedBackfill = await submitEmbedBackfill(ctx.engine, resolvedSourceId, {
+        reason: embedBackfillReason,
+      });
+      return { ...result, embed_backfill: embedBackfill };
+    }
+    return result;
   },
   cliHints: { name: 'sync', hidden: true },
 };

--- a/test/source-id-routing.test.ts
+++ b/test/source-id-routing.test.ts
@@ -83,6 +83,34 @@ describe('source-id routing (v0.36.x #891 + #978 regression)', () => {
     expect(rows[0].source_id).toBe('default');
   });
 
+  test('default import does not version a same-slug page from another source', async () => {
+    const slug = 'systems/vercel/deployments/dpl-cross-source';
+    await importFromContent(
+      engine,
+      slug,
+      '---\ntype: note\ntitle: Work deployment\n---\nWork-source body.',
+      { noEmbed: true, sourceId: 'work' },
+    );
+
+    await expect(
+      importFromContent(
+        engine,
+        slug,
+        '---\ntype: note\ntitle: Default deployment\n---\nDefault-source body.',
+        { noEmbed: true },
+      ),
+    ).resolves.toBeTruthy();
+
+    const rows = await engine.executeRaw<{ source_id: string; title: string }>(
+      `SELECT source_id, title FROM pages WHERE slug = $1 ORDER BY source_id`,
+      [slug],
+    );
+    expect(rows).toEqual([
+      { source_id: 'default', title: 'Default deployment' },
+      { source_id: 'work', title: 'Work deployment' },
+    ]);
+  });
+
   test('chunks land under the requested source, not default', async () => {
     await importFromContent(engine, 'people/carol', '---\ntype: person\ntitle: Carol\n---\n\nNotes about Carol.', {
       noEmbed: true,

--- a/test/sync-operation-source.serial.test.ts
+++ b/test/sync-operation-source.serial.test.ts
@@ -1,21 +1,42 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { OperationContext } from '../src/core/operations.ts';
-import type { SyncOpts } from '../src/commands/sync.ts';
+import type { SyncOpts, SyncResult } from '../src/commands/sync.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 
 const calls: SyncOpts[] = [];
+const upToDateResult = (): SyncResult => ({
+  status: 'up_to_date' as const,
+  fromCommit: 'head',
+  toCommit: 'head',
+  added: 0,
+  modified: 0,
+  deleted: 0,
+  renamed: 0,
+  chunksCreated: 0,
+  embedded: 0,
+  pagesAffected: [] as string[],
+});
+let nextResult = upToDateResult();
 
 mock.module('../src/commands/sync.ts', () => ({
   performSync: async (_engine: unknown, opts: SyncOpts) => {
     calls.push(opts);
-    return { mode: 'incremental', added: 0, modified: 0, deleted: 0 };
+    return nextResult;
   },
 }));
 
 const { operations } = await import('../src/core/operations.ts');
 
-function context(sourceId: string): OperationContext {
+const noBacklogEngine = {
+  executeRaw: async () => [{ missing: false }],
+} as unknown as OperationContext['engine'];
+
+function context(
+  sourceId: string,
+  engine: OperationContext['engine'] = noBacklogEngine,
+): OperationContext {
   return {
-    engine: {} as OperationContext['engine'],
+    engine,
     config: {} as OperationContext['config'],
     logger: console as OperationContext['logger'],
     dryRun: false,
@@ -27,6 +48,7 @@ function context(sourceId: string): OperationContext {
 describe('sync_brain source routing', () => {
   beforeEach(() => {
     calls.length = 0;
+    nextResult = upToDateResult();
   });
 
   test('explicit source_id overrides the ambient MCP source', async () => {
@@ -56,4 +78,89 @@ describe('sync_brain source routing', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].sourceId).toBe('devdocs-ops');
   });
+
+  test('automatic large-sync deferral queues one source-scoped durable embed backfill', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    try {
+      nextResult = {
+        status: 'synced',
+        fromCommit: 'before',
+        toCommit: 'after',
+        added: 101,
+        modified: 0,
+        deleted: 0,
+        renamed: 0,
+        chunksCreated: 101,
+        embedded: 0,
+        pagesAffected: ['systems/example'],
+        embeddingDeferred: true,
+      };
+
+      const op = operations.find((candidate) => candidate.name === 'sync_brain');
+      expect(op).toBeDefined();
+      await op!.handler(context('default', engine), {
+        repo: '/tmp/devdocs-brain',
+        source_id: 'devdocs-ops',
+        no_pull: true,
+      });
+
+      const jobs = await engine.executeRaw<{ name: string; source_id: string; reason: string }>(
+        `SELECT name, data->>'sourceId' AS source_id, data->>'reason' AS reason
+           FROM minion_jobs
+          ORDER BY id`,
+      );
+      expect(jobs).toEqual([{
+        name: 'embed-backfill',
+        source_id: 'devdocs-ops',
+        reason: 'sync_operation_deferred',
+      }]);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
+
+  test('up-to-date sync with missing embeddings queues one source-scoped durable embed backfill', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    try {
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name) VALUES ('devdocs-ops', 'DevDocs Operations')
+         ON CONFLICT (id) DO NOTHING`,
+      );
+      const pages = await engine.executeRaw<{ id: number }>(
+        `INSERT INTO pages (source_id, slug, type, title, compiled_truth, timeline, frontmatter)
+         VALUES ('devdocs-ops', 'systems/example', 'note', 'Example', 'body', '', '{}'::jsonb)
+         RETURNING id`,
+      );
+      await engine.executeRaw(
+        `INSERT INTO content_chunks (page_id, chunk_index, chunk_text, chunk_source)
+         VALUES ($1, 0, 'unembedded body', 'compiled_truth')`,
+        [pages[0]!.id],
+      );
+
+      const op = operations.find((candidate) => candidate.name === 'sync_brain');
+      expect(op).toBeDefined();
+      await op!.handler(context('default', engine), {
+        repo: '/tmp/devdocs-brain',
+        source_id: 'devdocs-ops',
+        no_pull: true,
+      });
+
+      const jobs = await engine.executeRaw<{ name: string; source_id: string; reason: string }>(
+        `SELECT name, data->>'sourceId' AS source_id, data->>'reason' AS reason
+           FROM minion_jobs
+          ORDER BY id`,
+      );
+      expect(jobs).toEqual([{
+        name: 'embed-backfill',
+        source_id: 'devdocs-ops',
+        reason: 'sync_operation_backlog',
+      }]);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
 });

--- a/test/sync-operation-source.serial.test.ts
+++ b/test/sync-operation-source.serial.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { OperationContext } from '../src/core/operations.ts';
+import type { SyncOpts } from '../src/commands/sync.ts';
+
+const calls: SyncOpts[] = [];
+
+mock.module('../src/commands/sync.ts', () => ({
+  performSync: async (_engine: unknown, opts: SyncOpts) => {
+    calls.push(opts);
+    return { mode: 'incremental', added: 0, modified: 0, deleted: 0 };
+  },
+}));
+
+const { operations } = await import('../src/core/operations.ts');
+
+function context(sourceId: string): OperationContext {
+  return {
+    engine: {} as OperationContext['engine'],
+    config: {} as OperationContext['config'],
+    logger: console as OperationContext['logger'],
+    dryRun: false,
+    remote: false,
+    sourceId,
+  };
+}
+
+describe('sync_brain source routing', () => {
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  test('explicit source_id overrides the ambient MCP source', async () => {
+    const op = operations.find((candidate) => candidate.name === 'sync_brain');
+    expect(op).toBeDefined();
+    expect(op!.params.source_id).toBeDefined();
+
+    await op!.handler(context('default'), {
+      repo: '/tmp/devdocs-brain',
+      source_id: 'devdocs-ops',
+      no_pull: true,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sourceId).toBe('devdocs-ops');
+  });
+
+  test('ambient MCP source is threaded when source_id is omitted', async () => {
+    const op = operations.find((candidate) => candidate.name === 'sync_brain');
+    expect(op).toBeDefined();
+
+    await op!.handler(context('devdocs-ops'), {
+      repo: '/tmp/devdocs-brain',
+      no_pull: true,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sourceId).toBe('devdocs-ops');
+  });
+});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -464,6 +464,41 @@ describe('performSync dry-run never writes', () => {
     expect(typeof result.embedded).toBe('number');
   });
 
+  test('large incremental sync reports automatic embedding deferral', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const seeded = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(seeded.status).toBe('first_sync');
+
+    for (let i = 0; i < 101; i++) {
+      const suffix = String(i).padStart(3, '0');
+      writeFileSync(join(repoPath, `people/large-${suffix}.md`), [
+        '---',
+        'type: person',
+        `title: Large ${suffix}`,
+        '---',
+        '',
+        `Large-sync fixture ${suffix}.`,
+      ].join('\n'));
+    }
+    execSync('git add -A && git commit -m "large incremental batch"', { cwd: repoPath, stdio: 'pipe' });
+
+    const result = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noExtract: true,
+    });
+
+    expect(result.status).toBe('synced');
+    expect(result.added).toBe(101);
+    expect(result.embedded).toBe(0);
+    expect(result.embeddingDeferred).toBe(true);
+  });
+
   test('detached HEAD skips git pull and ingests local working-tree files', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const seeded = await performSync(engine, {


### PR DESCRIPTION
## Summary

- preserve explicit/ambient `source_id` through `sync_brain` and source-scoped imports
- prevent cross-source same-slug reads from versioning the wrong page
- report when large incremental syncs defer inline embeddings
- enqueue one durable, source-scoped embed backfill after automatic deferral
- enqueue a backfill when an otherwise up-to-date source still has missing embeddings

## Why

A federated `sync_brain` could ingest into `default` or read a same-slug page from another source. Large syncs could also defer embeddings without leaving durable recovery work, making newly indexed pages invisible to vector retrieval.

## Verification

- `bun test test/sync-operation-source.serial.test.ts test/sync.test.ts test/source-id-routing.test.ts` — 80 passed
- `bun run verify` — 31/31 checks passed
- `git diff --check` — passed
- live source-scoped `sync_brain` advanced `devdocs-ops` and retrieval returned the new provider records from that source

## Safety

- backfill jobs are source-scoped and deduplicated by the existing submit helper
- explicit `--no-embed` remains respected and does not enqueue automatic work
- `.codex/` local configuration is excluded
