### PR TITLE
skillify: fail-closed Phase 0 gate + upper-bound scope check

### DIFF
--- a/skills/skillify/SKILL.md
+++ b/skills/skillify/SKILL.md
@@ -60,7 +60,7 @@ Before skillifying, check:
 - Is there >20 lines of logic? (Trivial helpers don't need full infrastructure)
 - Does it have a clear trigger phrase a user would actually say?
 
-If no to all three, it's a script, not a skill. Move on.
+If ANY answer is no, it's a script, not a skill — stop here. Do not scaffold, write a SKILL.md, run evals, or write tests for it. Tell the user why and move on.
 
 ## Phase 1: Audit
 

--- a/skills/skillify/SKILL.md
+++ b/skills/skillify/SKILL.md
@@ -62,6 +62,13 @@ Before skillifying, check:
 
 If ANY answer is no, it's a script, not a skill — stop here. Do not scaffold, write a SKILL.md, run evals, or write tests for it. Tell the user why and move on.
 
+Scope check (upper bound): one skill = one capability = one coherent trigger
+family. If the target spans multiple distinct intents users would invoke
+separately ("run the build" / "roll back the deploy" / "notify the team" are
+three intents, not one), do NOT build one skill covering them all. Stop,
+propose splitting into separate skillify targets, and ask the user which one
+to skillify first.
+
 ## Phase 1: Audit
 
 ```


### PR DESCRIPTION
Fixes items 1 and 2 of #3406 — the two behavioral defects in skillify's Phase 0. Scoped to exactly those two changes; the doc-level items in the issue (numbering, `.ts`/`.mjs`, Step 2/3 contradiction, etc.) are left for separate changes since several depend on the gbrain CLI's actual behavior.

## Patch 1 — fail-closed gate

`If no to all three` required every answer to be no before stopping, while each criterion's parenthetical reads as individually disqualifying. A one-line alias used once (No / No / Yes — "pretty print this json" is a sayable trigger) ran the entire pipeline and was certified properly skilled. Any single no now stops the run, with the forbidden follow-on work enumerated (no scaffold, no SKILL.md, no evals, no tests) so an eager executor can't rationalize past it.

## Patch 2 — upper-bound scope check

Phase 0 only guarded the lower bound, so "skillify our entire CI/CD pipeline" (~4 intent families) answered yes to all three checks and became one mega-skill. The cross-modal eval then diagnosed it correctly — every model, every cycle: "split it" — but no phase can act on that advice (decomposition isn't a file edit), so the only sanctioned path was ship-with-KNOWN_GAPS, after which Phase 4 locked the below-bar scope in with tests. Multi-intent targets now stop in Phase 0 with a proposed split and a question about which target to skillify first. The check deliberately asks about the *set* of intents rather than the existence of a trigger phrase, because check 3 is existential ("ship it" makes a whole subsystem answer yes).

## Validation

Both changes were tested with literal-execution review: executors simulate following the skill text exactly as written across five scenarios (happy path, trivial input, eval-skip pressure, oversized input, missing CLI), and independent reviewers score the traces without seeing the skill text. Before: the trivial and oversized inputs both completed the full pipeline and were certified. After: both stop in Phase 0 with zero artifacts and zero eval spend, the trivial input labeled script-not-skill and the oversized input getting a four-way split proposal — while the legitimate single-feature happy path still passes the scope check and completes the pipeline unchanged (no false-positive stops, verified against the pressure and missing-CLI scenarios too).

Version left at 1.1.0 — bump per your release convention if these land.
