### PR TITLE
fix(heavy-tests): use supported init flag

### DIFF
--- a/tests/heavy/frontmatter_scan_wallclock.sh
+++ b/tests/heavy/frontmatter_scan_wallclock.sh
@@ -83,7 +83,7 @@ echo "[fm_wallclock] fixture seeded in ${SEED_ELAPSED}s" | tee -a "$LOG"
 # This script measures doctor's frontmatter-scan wallclock — it never embeds —
 # so the CI runner doesn't need OPENAI_API_KEY / ZEROENTROPY_API_KEY / VOYAGE_API_KEY.
 echo "[fm_wallclock] init brain..." | tee -a "$LOG"
-timeout 120s bun run src/cli.ts init --pglite --yes --no-embedding >> "$LOG" 2>&1 || {
+timeout 120s bun run src/cli.ts init --pglite --non-interactive --no-embedding >> "$LOG" 2>&1 || {
   echo "[fm_wallclock] FAIL: gbrain init exited non-zero" >&2
   echo "Log tail:" >&2
   tail -30 "$LOG" >&2


### PR DESCRIPTION
## Summary

- Replace the removed `gbrain init --yes` flag in the frontmatter wall-clock heavy test with the supported `--non-interactive` equivalent.
- Restore the scheduled Heavy Tests entry point so the remaining heavy scripts can run.

## Rationale

Fixes #3410.

Strict init-flag validation now rejects the stale `--yes` argument before the heavy test can initialize its isolated PGLite brain. `--non-interactive` is the supported equivalent and preserves the test's existing non-interactive behavior.

## Test plan

- [x] `bash -n tests/heavy/frontmatter_scan_wallclock.sh`
- [x] `REAL_PAGES=100 NODE_MODULES_PAGES=500 WALLCLOCK_BUDGET_S=60 bash tests/heavy/frontmatter_scan_wallclock.sh`
- [x] `bun run verify`
- [x] `git diff --check`
- [x] Fork CI completed successfully

## Risk

Low. This changes one CLI argument in one heavy-test script; production behavior is unchanged.
