### PR TITLE
fix(sync): make path containment separator-safe (win32 sync imports nothing)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, statSync, realpathSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
+import { isAbsolute, join, relative, sep } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
 import { DELETE_BATCH_SIZE } from '../core/engine-constants.ts';
 import { importFile } from '../core/import-file.ts';
@@ -1153,15 +1153,27 @@ function createSyncBaselineCommit(repoPath: string): void {
 }
 
 /**
+ * True when `childReal` is `rootReal` itself or lives inside it. Both arguments
+ * must already be realpath-resolved. Containment is decided by `relative()`
+ * rather than a string prefix, so it holds on Windows too: `realpathSync`
+ * returns backslash paths there, and a literal `rootReal + '/'` prefix can
+ * never match one. A sibling (`root-evil`) is rejected because `relative`
+ * yields `../root-evil`, and a cross-drive path because it yields an absolute.
+ */
+export function isWithinRoot(childReal: string, rootReal: string): boolean {
+  if (childReal === rootReal) return true;
+  const rel = relative(rootReal, childReal);
+  return rel !== '' && rel !== '..' && !rel.startsWith('..' + sep) && !isAbsolute(rel);
+}
+
+/**
  * #774 NAV-1 TOCTOU: true only if filePath realpath-resolves inside gitRoot.
  * Guards symlink escape at the per-file level (a committed symlink whose
  * target lives outside the repo), not just at scope entry.
  */
 function isPathSafe(filePath: string, gitRoot: string): boolean {
   try {
-    const real = realpathSync(filePath);
-    const rootReal = realpathSync(gitRoot);
-    return real === rootReal || real.startsWith(rootReal + '/');
+    return isWithinRoot(realpathSync(filePath), realpathSync(gitRoot));
   } catch {
     return false;
   }
@@ -1932,7 +1944,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // NAV-1/NAV-2 scope-entry guard: the realpath-resolved scope must live
   // inside the realpath-resolved git root. Catches `--src-subpath ../escape`
   // AND a symlinked subdir pointing outside the repo, before any git op runs.
-  if (syncScopeRoot !== gitContextRoot && !syncScopeRoot.startsWith(gitContextRoot + '/')) {
+  if (!isWithinRoot(syncScopeRoot, gitContextRoot)) {
     throw new Error(
       `Sync scope ${syncScopeRoot} resolves outside git repo ${gitContextRoot}. ` +
       `Refusing to sync: possible path traversal via --src-subpath.`,

--- a/test/sync-path-containment.test.ts
+++ b/test/sync-path-containment.test.ts
@@ -1,0 +1,61 @@
+/**
+ * #774 NAV-1/NAV-2 path-containment guard (`isWithinRoot` in sync.ts).
+ *
+ * The guard decides whether a realpath-resolved file lives inside the
+ * realpath-resolved git root. It backs BOTH the `--src-subpath` scope-entry
+ * check and the per-file TOCTOU re-check in the incremental import drain.
+ *
+ * It used to be a string prefix test (`real.startsWith(rootReal + '/')`). That
+ * hardcoded separator makes the guard fail CLOSED for every path on Windows,
+ * where `realpathSync` returns `C:\repo\file.md` and the `C:\repo/` prefix can
+ * never match: every file in the drain is recorded as a symlink escape and the
+ * sync imports nothing. These cases pin the containment semantics against the
+ * platform's own separator, so a future prefix-based rewrite is caught.
+ *
+ * The Windows regression itself is only OBSERVABLE on win32 — on POSIX the old
+ * prefix form and the current `relative()` form agree on every case here.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { join, sep, parse } from 'path';
+import { isWithinRoot } from '../src/commands/sync.ts';
+
+describe('isWithinRoot path containment (#774 NAV-1/NAV-2)', () => {
+  const root = join(parse(process.cwd()).root, 'repo');
+
+  test('accepts the root itself', () => {
+    expect(isWithinRoot(root, root)).toBe(true);
+  });
+
+  test('accepts a direct child', () => {
+    expect(isWithinRoot(join(root, 'page.md'), root)).toBe(true);
+  });
+
+  test('accepts a nested descendant (the case a hardcoded "/" broke on win32)', () => {
+    expect(isWithinRoot(join(root, 'wiki', 'notes', 'page.md'), root)).toBe(true);
+  });
+
+  test('rejects the parent directory', () => {
+    expect(isWithinRoot(parse(root).dir, root)).toBe(false);
+  });
+
+  test('rejects a path escaping upward', () => {
+    expect(isWithinRoot(join(root, '..', 'outside', 'page.md'), root)).toBe(false);
+  });
+
+  test('rejects a sibling sharing the root as a string prefix', () => {
+    expect(isWithinRoot(root + '-evil', root)).toBe(false);
+    expect(isWithinRoot(join(root + '-evil', 'page.md'), root)).toBe(false);
+  });
+
+  test('rejects a sibling whose name extends the last segment', () => {
+    expect(isWithinRoot(join(parse(root).dir, 'repository', 'page.md'), root)).toBe(false);
+  });
+
+  test('containment does not depend on a hardcoded forward slash', () => {
+    // On win32 `sep` is '\\'; the child below is genuinely inside `root` and a
+    // `root + '/'` prefix test would have rejected it.
+    const child = `${root}${sep}sub${sep}page.md`;
+    expect(isWithinRoot(child, root)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The `#774` NAV-1/NAV-2 path-containment guard added by #2942 decides containment
with a hardcoded forward slash:

```ts
return real === rootReal || real.startsWith(rootReal + '/');
```

`realpathSync` returns native separators, so on Windows the root resolves to
`C:\repo` and the prefix `C:\repo/` can never match `C:\repo\wiki\page.md`. The
guard therefore fails **closed for every path**, and because it is fail-closed by
design the failure is silent-but-total rather than a crash:

- `sync.ts` per-file TOCTOU re-check in the import drain: every file is recorded
  as `path resolves outside git repo (symlink escape)`, so an incremental
  `gbrain sync` imports **zero** files and the bookmark never advances.
- the rename branch (`isPathSafe` before re-import) silently skips the re-import.
- the `--src-subpath` scope-entry guard rejects any legitimate subdir.

Reproduced on Windows 11 / bun 1.3.14 against current `master`:

```
rootReal = "C:\Work\gbrain"
fileReal = "C:\Work\gbrain\src\commands\sync.ts"
current  -> false      # legitimate in-repo file rejected
fixed    -> true
```

## Fix

Extract the containment test into `isWithinRoot(childReal, rootReal)` and decide
it with `path.relative` instead of a string prefix:

```ts
const rel = relative(rootReal, childReal);
return rel !== '' && rel !== '..' && !rel.startsWith('..' + sep) && !isAbsolute(rel);
```

Both call sites (the per-file `isPathSafe` and the scope-entry check) now share
it. This keeps every security property the prefix form had and adds two the
prefix form only got right by accident of the trailing slash:

- sibling sharing a string prefix (`repo-evil`) -> `relative` yields
  `../repo-evil` -> rejected.
- cross-drive / different-root path -> `relative` yields an absolute -> rejected.
- parent or upward escape -> `..` or `../...` -> rejected.

`relative()` is purely lexical here, which is safe because both arguments are
already realpath-resolved by the callers.

## Tests

New `test/sync-path-containment.test.ts` pins the containment semantics against
the platform's own separator (8 cases: root itself, direct child, nested
descendant, parent, upward escape, two string-prefix siblings, and an explicit
`sep`-built child).

Note on observability: this regression is **only reachable on win32**. On POSIX
the old prefix form and the new `relative` form agree on every case in the file,
so the new test passes on Linux CI either way - it is there as a guard against a
future prefix-based rewrite. Verified pre-fix on Windows: 3 of the 8 cases fail
against `master`'s implementation.

Verified on this branch (rebased onto `master` @ 3fafb69b):

- `bun run typecheck` - clean
- `bun test test/sync-path-containment.test.ts` - 8 pass
- `bun test test/sync-monorepo.test.ts test/sync-git-autoinit.test.ts` - 26 pass,
  1 fail (`symlink subdir pointing outside repo`), which fails identically
  without this change: `symlinkSync` needs Developer Mode/elevation on Windows
  and returns `EPERM` in the test's own setup. Unrelated to this diff.
