### PR TITLE
feat(exports): expose runThink synthesis via gbrain/think subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./backoff": "./src/core/backoff.ts",
     "./search/hybrid": "./src/core/search/hybrid.ts",
     "./search/expansion": "./src/core/search/expansion.ts",
+    "./think": "./src/core/think/index.ts",
     "./ai/gateway": "./src/core/ai/gateway.ts",
     "./extract": "./src/commands/extract.ts",
     "./ingestion": "./src/core/ingestion/index.ts",

--- a/scripts/check-exports-count.sh
+++ b/scripts/check-exports-count.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=20
+EXPECTED_COUNT=21
 
 # Count top-level keys in the exports object. `node -e` parses JSON
 # reliably without needing jq (which isn't in every CI environment).

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -49,6 +49,7 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/backoff', canary: [] },
   { subpath: 'gbrain/search/hybrid', canary: ['hybridSearch', 'rrfFusion'] },
   { subpath: 'gbrain/search/expansion', canary: ['expandQuery'] },
+  { subpath: 'gbrain/think', canary: ['runThink', 'stripGapsSection'] },
   { subpath: 'gbrain/ai/gateway', canary: ['configureGateway', 'embed'] },
   { subpath: 'gbrain/extract', canary: [] },
   { subpath: 'gbrain/ingestion', canary: ['INGESTION_SOURCE_API_VERSION', 'validateIngestionEvent', 'computeContentHash'] },
@@ -68,7 +69,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(20);
+    expect(count).toBe(21);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## What

Adds `./think` to gbrain's public `exports` map, pointing at the existing `src/core/think/index.ts`.

## Why

The think synthesis pipeline — `runThink`, `stripGapsSection`, `persistSynthesis`, `maxOutputTokensFor`, and the `ThinkResult` / `ParsedCitation` types — already lives in `src/core/think/index.ts`, but it is not reachable through the package `exports` map. A downstream consumer that does:

```ts
import { runThink, type ParsedCitation } from "gbrain/think";
```

fails with `Cannot find module 'gbrain/think'`, and no other exported entrypoint (`.`, `./engine`, `./operations`, …) re-exports `runThink`. So there is currently no supported way to drive gbrain's synthesis layer as a library — only the CLI/MCP `think` operation.

This is the last missing piece for using gbrain purely as a library alongside `./engine`, `./search/hybrid`, and `./ingestion` (which we already consume to build a cross-client MCP memory server on top of gbrain).

## Changes

- `package.json` — add `"./think": "./src/core/think/index.ts"` (placed next to the other retrieval/synthesis subpaths).
- `test/public-exports.test.ts` — bump the locked export count `20 → 21` and add an `EXPECTED_EXPORTS` row with runtime canaries `runThink`, `stripGapsSection`, per the contract-test convention documented in that file.

## Verification

```
bun test test/public-exports.test.ts
38 pass / 0 fail
```

The new subpath resolves through the exports map and both canary symbols exist at runtime.

## Notes

- No new code — this only widens the public surface to a module that already exists.
- I deliberately did **not** touch `VERSION`, the `package.json` version, `CHANGELOG.md`, or the `llms` bundles, to avoid colliding with your `/ship` version-queue allocator. Happy to fold those in if you'd prefer the PR carry the bump.