### PR TITLE
feat(exports): expose runThink synthesis via gbrain/think subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./backoff": "./src/core/backoff.ts",
     "./search/hybrid": "./src/core/search/hybrid.ts",
     "./search/expansion": "./src/core/search/expansion.ts",
+    "./think": "./src/core/think/index.ts",
     "./ai/gateway": "./src/core/ai/gateway.ts",
     "./extract": "./src/commands/extract.ts",
     "./ingestion": "./src/core/ingestion/index.ts",

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -49,6 +49,7 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/backoff', canary: [] },
   { subpath: 'gbrain/search/hybrid', canary: ['hybridSearch', 'rrfFusion'] },
   { subpath: 'gbrain/search/expansion', canary: ['expandQuery'] },
+  { subpath: 'gbrain/think', canary: ['runThink', 'stripGapsSection'] },
   { subpath: 'gbrain/ai/gateway', canary: ['configureGateway', 'embed'] },
   { subpath: 'gbrain/extract', canary: [] },
   { subpath: 'gbrain/ingestion', canary: ['INGESTION_SOURCE_API_VERSION', 'validateIngestionEvent', 'computeContentHash'] },
@@ -68,7 +69,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(20);
+    expect(count).toBe(21);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
The think synthesis pipeline (runThink, stripGapsSection, persistSynthesis, maxOutputTokensFor + the ThinkResult/ParsedCitation types) lives in src/core/think/index.ts but is not reachable through the public exports map. Downstream consumers importing `gbrain/think` fail to resolve it, and no other exported entrypoint re-exports runThink.

Add `./think` to package.json exports and extend the public-exports contract test (count 20 -> 21; new EXPECTED_EXPORTS row with runtime canaries runThink + stripGapsSection). Test passes 38/38.

Left the VERSION / package.json version / CHANGELOG / llms bumps to the maintainer /ship flow to avoid colliding with the version-queue allocator.