### PR TITLE
Support client-local source checkout bindings

### DIFF
--- a/docs/guides/multi-source-brains.md
+++ b/docs/guides/multi-source-brains.md
@@ -95,6 +95,27 @@ So inside `~/.gstack/plans/` on a brain that pinned `gstack` to
 the `gstack` source. Outside any registered directory with no env/dotfile
 set, it writes to the default.
 
+## Client-local checkout binding
+
+Clients that share one database and Git remote can keep the same source
+identity while cloning it to different local paths. Set both variables for
+the process running a single-source operation:
+
+```bash
+export GBRAIN_SOURCE=wiki
+export GBRAIN_SOURCE_PATH=/absolute/path/to/this-client/brain-wiki
+```
+
+`GBRAIN_SOURCE_PATH` applies only to the matching `GBRAIN_SOURCE`. It is
+process-local, must be absolute, and never persists or overwrites the shared
+`sources.local_path`. For a single-source operation, an explicit `--repo`
+checkout wins over the matching client binding, which wins over the shared
+source or legacy path. It is not applied to `--all` operations.
+
+`gbrain sync trigger` refuses a matching client-local binding because its
+queued worker cannot inherit process-local state without persisting the path.
+Run `gbrain sync --source <id>` inline in that client instead.
+
 ## Federation flag
 
 Every source row stores `config.federated: boolean` in its JSONB config.

--- a/src/commands/brainstorm.ts
+++ b/src/commands/brainstorm.ts
@@ -27,6 +27,7 @@ import { StructuredAgentError } from '../core/errors.ts';
 import { serializeMarkdown } from '../core/markdown.ts';
 import { importFromContent } from '../core/import-file.ts';
 import { writePageThrough, type WriteThroughResult } from '../core/write-through.ts';
+import { resolveSourceId } from '../core/source-resolver.ts';
 import { randomBytes } from 'crypto';
 
 export interface BrainstormCliArgs {
@@ -248,6 +249,7 @@ async function runBrainstormCli(
   }
 
   const config = loadConfig() ?? {};
+  const sourceId = await resolveSourceId(engine, null);
   // Honor env-var skip for scripted environments that can't easily pass --yes.
   const skipPreview = parsed.yes || process.env.GBRAIN_NO_BRAINSTORM_PREVIEW === '1';
 
@@ -269,6 +271,7 @@ async function runBrainstormCli(
     result = await runBrainstorm(engine, config, {
       question: parsed.question,
       profile: effectiveProfile,
+      sourceId,
       skipCostPreview: skipPreview,
       // v0.39.0.0 T10 cost-cap surface — wired in master, preserved here.
       maxCostUsd: parsed.maxCost,
@@ -319,7 +322,12 @@ async function runBrainstormCli(
     const body = formatBrainstormMarkdown(result, { onlyPassed: false, includeMeta: true });
     const content = serializeMarkdown(fmObj, body, '', { type: 'note', title, tags: [] });
 
-    const outcome = await persistSavedIdea(engine, { slug, content, provenanceVia: profile.label });
+    const outcome = await persistSavedIdea(engine, {
+      slug,
+      content,
+      sourceId,
+      provenanceVia: profile.label,
+    });
     const msg = formatSaveOutcome(outcome, { profileLabel: profile.label, slug });
     if (msg.stdout) console.log(msg.stdout);
     for (const line of msg.stderr) console.error(line);

--- a/src/commands/sources-harden.ts
+++ b/src/commands/sources-harden.ts
@@ -21,6 +21,10 @@ import { divergenceSafePull, detectDefaultBranch } from '../core/git-remote.ts';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import {
+  assertClientSourceCheckout,
+  resolveClientSourcePath,
+} from '../core/source-resolver.ts';
 
 interface SourceRow { id: string; local_path: string | null; config: unknown; }
 
@@ -81,12 +85,15 @@ export async function runHarden(engine: BrainEngine, args: string[]): Promise<vo
 
   const reports: DurabilityReport[] = [];
   for (const row of rows) {
-    if (!row.local_path || !existsSync(join(row.local_path, '.git'))) {
-      console.error(`[${row.id}] skipped — no local git repo at ${row.local_path ?? '(none)'}`);
+    const clientPath = all ? null : resolveClientSourcePath(row.id);
+    if (clientPath) assertClientSourceCheckout(row.id, clientPath, row.config);
+    const repoPath = clientPath ?? row.local_path;
+    if (!repoPath || !existsSync(join(repoPath, '.git'))) {
+      console.error(`[${row.id}] skipped — no local git repo at ${repoPath ?? '(none)'}`);
       continue;
     }
     const report = await hardenBrainRepo({
-      repoPath: row.local_path, sourceId: row.id, branch,
+      repoPath, sourceId: row.id, branch,
       pat: pat?.token, installCron, verify, dryRun,
       logger: json ? undefined : (l) => console.error(`  ${l}`),
     });
@@ -131,11 +138,18 @@ export async function runPull(engine: BrainEngine | null, args: string[]): Promi
       process.exit(2);
     }
     const rows = await engine.executeRaw<SourceRow>(`SELECT id, local_path, config FROM sources WHERE id = $1`, [id]);
-    if (rows.length === 0 || !rows[0].local_path) {
+    if (rows.length === 0) {
+      console.error(`Source "${id}" not found.`);
+      process.exit(1);
+    }
+    const clientPath = resolveClientSourcePath(id);
+    if (clientPath) assertClientSourceCheckout(id, clientPath, rows[0].config);
+    const resolvedPath = clientPath ?? rows[0].local_path;
+    if (!resolvedPath) {
       console.error(`Source "${id}" not found or has no local_path.`);
       process.exit(1);
     }
-    repoPath = rows[0].local_path;
+    repoPath = resolvedPath;
   }
 
   if (!existsSync(join(repoPath, '.git'))) {
@@ -167,8 +181,11 @@ export async function runUnharden(engine: BrainEngine, args: string[]): Promise<
     console.error(`Source "${id}" not found.`);
     process.exit(1);
   }
+  const clientPath = resolveClientSourcePath(rows[0].id);
+  if (clientPath) assertClientSourceCheckout(rows[0].id, clientPath, rows[0].config);
+  const repoPath = clientPath ?? rows[0].local_path ?? '';
   const steps = await unhardenBrainRepo({
-    repoPath: rows[0].local_path ?? '',
+    repoPath,
     sourceId: rows[0].id,
     logger: (l) => console.error(l),
   });

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -47,6 +47,7 @@ import {
   type SourceRow as OpsSourceRow,
 } from '../core/sources-ops.ts';
 import {
+  resolveClientSourcePath,
   resolveSourceWithTier,
   SOURCE_TIER_NAMES,
 } from '../core/source-resolver.ts';
@@ -753,7 +754,10 @@ async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const json = args.includes('--json');
   const { loadAllSources } = await import('../core/sources-load.ts');
   const { computeAllSourceMetrics } = await import('../core/source-health.ts');
-  const sources = await loadAllSources(engine, { includeArchived: false });
+  const sources = (await loadAllSources(engine, { includeArchived: false })).map((source) => {
+    const clientPath = resolveClientSourcePath(source.id);
+    return clientPath ? { ...source, local_path: clientPath } : source;
+  });
   if (sources.length === 0) {
     if (json) {
       console.log(JSON.stringify({ schema_version: 1, sources: [] }, null, 2));

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -66,7 +66,11 @@ import {
   serr,
 } from '../core/console-prefix.ts';
 import { loadStorageConfig } from '../core/storage-config.ts';
-import { getDefaultSourcePath } from '../core/source-resolver.ts';
+import {
+  assertClientSourceCheckout,
+  getDefaultSourcePath,
+  resolveClientSourcePath,
+} from '../core/source-resolver.ts';
 // v0.41.32.0: stamp the durable newest-COMMIT timestamp at sync time so the
 // remote staleness path reads a column instead of shelling out to git.
 // lagFromContentMs is the remote/column comparator (buildSyncStatusReport
@@ -1416,6 +1420,15 @@ See also:
     process.exit(1);
   }
 
+  if (resolveClientSourcePath(sourceIdArg)) {
+    console.error(
+      `Error: source "${sourceIdArg}" uses a client-local checkout. ` +
+      `A queued sync cannot inherit GBRAIN_SOURCE_PATH, and GBrain will not persist that local path.`,
+    );
+    console.error(`Run inline in this client instead: gbrain sync --source ${sourceIdArg}`);
+    process.exit(2);
+  }
+
   const { MinionQueue } = await import('../core/minions/queue.ts');
   const queue = new MinionQueue(engine);
   const job = await queue.add(
@@ -1791,7 +1804,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // "hung with no output" into actionable diagnostic data.
   serr(`[gbrain phase] sync.resolve_repo`);
   // Resolve repo path
-  const repoPath = opts.repoPath || await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  const clientSourcePath =
+    !opts.repoPath && opts.sourceId
+      ? resolveClientSourcePath(opts.sourceId)
+      : null;
+  const repoPath =
+    opts.repoPath ||
+    clientSourcePath ||
+    await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  const persistRepoPath = clientSourcePath === null;
   if (!repoPath) {
     const hint = opts.sourceId
       ? `Source "${opts.sourceId}" has no local_path. Run: gbrain sources add ${opts.sourceId} --path <path>`
@@ -1861,6 +1882,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         case 'missing':
         case 'no-git':
         case 'not-a-dir':
+          if (clientSourcePath) {
+            throw new Error(
+              `Client-local checkout for source "${opts.sourceId}" at ${repoPath} is ${state}. ` +
+              `Clone the configured remote at that path or update GBRAIN_SOURCE_PATH.`,
+            );
+          }
           // #1881: only re-clone a clone gbrain owns. An unowned local_path
           // (the user's working tree) is refused loudly, never deleted.
           if (!isOwnedClone(ownSrc)) {
@@ -1945,7 +1972,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // the SCOPE path, so a follow-up bare `gbrain sync` auto-discovers the same
   // scope. Unchanged (the caller's repoPath spelling) when no --src-subpath.
   const anchorPath = opts.srcSubpath ? rawScopeRoot : repoPath;
-  const fullSyncRoots = { gitContextRoot, syncScopeRoot, anchorPath };
+  const fullSyncRoots = { gitContextRoot, syncScopeRoot, anchorPath, persistRepoPath };
 
   serr(`[gbrain phase] sync.detect_head`);
   // Detect detached HEAD up front so the working-tree fallback fires for both
@@ -3293,7 +3320,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // decoupled (its own resumable stale sweeps).
     await writeSyncAnchor(engine, opts.sourceId, 'last_commit', pin, commitTimeMs(gitContextRoot, pin));
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    if (persistRepoPath) {
+      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    }
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
     await clearOpCheckpoint(engine, ckpt.paths);
     await clearOpCheckpoint(engine, ckpt.target);
@@ -3346,7 +3375,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // checkpoint is INTENTIONALLY left in place — the banked completed set lets
     // the next run skip the drained files and re-attempt only the failures.
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    if (persistRepoPath) {
+      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    }
     // v0.42.x (#1794): surface banked progress so a blocked run doesn't read as
     // total loss (last_commit is unchanged by design; the checkpoint is banked).
     serr(
@@ -3538,11 +3569,16 @@ async function performFullSync(
   //   syncScopeRoot  — where files are walked/imported (== gitContextRoot
   //                    when no subpath scope is active)
   //   anchorPath     — what gets written back to sync.repo_path/local_path
-  roots: { gitContextRoot: string; syncScopeRoot: string; anchorPath: string },
+  roots: {
+    gitContextRoot: string;
+    syncScopeRoot: string;
+    anchorPath: string;
+    persistRepoPath: boolean;
+  },
   headCommit: string,
   opts: SyncOpts,
 ): Promise<SyncResult> {
-  const { gitContextRoot, syncScopeRoot, anchorPath } = roots;
+  const { gitContextRoot, syncScopeRoot, anchorPath, persistRepoPath } = roots;
   // Scoped sync → slugs/source_path are git-root-relative (matches the
   // incremental path's git-diff paths). Unscoped → undefined (dir-relative,
   // the pre-#774 behavior, byte-for-byte).
@@ -3630,7 +3666,9 @@ async function performFullSync(
     // writeSyncAnchor so --source pins the right sources row.
     await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit, newestCommitMs(gitContextRoot));
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    if (persistRepoPath) {
+      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    }
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
   };
 
@@ -3657,7 +3695,9 @@ async function performFullSync(
       );
     }
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    if (persistRepoPath) {
+      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', anchorPath);
+    }
     return {
       status: 'blocked_by_failures',
       fromCommit: null,
@@ -3774,7 +3814,10 @@ async function performFullSync(
         try {
           const { writePageThrough } = await import('../core/write-through.ts');
           for (const slug of dbOnlySlugs) {
-            const r = await writePageThrough(engine, slug, { sourceId: sid });
+            const r = await writePageThrough(engine, slug, {
+              sourceId: sid,
+              operationRoot: gitContextRoot,
+            });
             if (r.written) reExported++;
           }
         } catch { /* best-effort — pages are preserved either way */ }
@@ -4747,8 +4790,16 @@ See also:
       [sourceId],
     );
     if (gateRows.length > 0) {
+      const clientPath = repoPath ? null : resolveClientSourcePath(sourceId);
+      if (clientPath) {
+        assertClientSourceCheckout(sourceId, clientPath, gateRows[0].config);
+      }
       const gateSources = [{
-        local_path: gateRows[0].local_path ?? repoPath ?? null,
+        local_path:
+          repoPath ??
+          clientPath ??
+          gateRows[0].local_path ??
+          null,
         config: gateRows[0].config ?? {},
         last_commit: gateRows[0].last_commit,
         chunker_version: gateRows[0].chunker_version,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2745,6 +2745,7 @@ const sync_brain: Operation = {
     const { performSync } = await import('../commands/sync.ts');
     return performSync(ctx.engine, {
       repoPath: p.repo as string | undefined,
+      sourceId: ctx.sourceId,
       dryRun: ctx.dryRun || (p.dry_run as boolean) || false,
       noEmbed: (p.no_embed as boolean) || false,
       noPull: (p.no_pull as boolean) || false,

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -14,10 +14,12 @@
  */
 
 import { readFileSync, lstatSync, type Stats } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, isAbsolute, resolve } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { SOURCE_ID_RE, isValidSourceId } from './source-id.ts';
 import { isTrustedDotfile, realpathOrResolve } from './path-confine.ts';
+import { validateRepoState } from './git-remote.ts';
+import { parseSourceConfig } from './sources-load.ts';
 
 const DOTFILE = '.gbrain-source';
 // Canonical SOURCE_ID_RE imported from `source-id.ts` (single source of truth).
@@ -245,6 +247,72 @@ async function assertSourceExists(engine: BrainEngine, id: string): Promise<void
 }
 
 /**
+ * Resolve the process-local checkout bound to one already-resolved source.
+ *
+ * `GBRAIN_SOURCE_PATH` is deliberately not a standalone global override: it
+ * only applies when paired with `GBRAIN_SOURCE`, and that id must match the
+ * source selected for the current operation. This lets multiple clients share
+ * one source row and remote identity without writing any client's absolute
+ * checkout path back to Postgres.
+ *
+ * Returns null when no client-local binding is supplied, preserving the
+ * existing shared `sources.local_path` / legacy `sync.repo_path` behavior.
+ */
+export function resolveClientSourcePath(
+  sourceId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const localPath = env.GBRAIN_SOURCE_PATH;
+  if (!localPath) return null;
+
+  const boundSourceId = env.GBRAIN_SOURCE;
+  if (!boundSourceId) {
+    throw new Error(
+      'GBRAIN_SOURCE_PATH requires GBRAIN_SOURCE so the local checkout is bound to one source identity.',
+    );
+  }
+  if (!SOURCE_ID_RE.test(boundSourceId)) {
+    throw new Error(`Invalid GBRAIN_SOURCE value "${boundSourceId}". Must match [a-z0-9-]{1,32}.`);
+  }
+  if (boundSourceId !== sourceId) {
+    return null;
+  }
+  if (!isAbsolute(localPath)) {
+    throw new Error('GBRAIN_SOURCE_PATH must be an absolute path.');
+  }
+  return resolve(localPath);
+}
+
+/**
+ * Verify that a client-local checkout still represents the source's shared
+ * remote identity before a caller mutates it.
+ *
+ * Path-only sources have no shared remote identity to compare and preserve the
+ * existing behavior. Remote-backed sources must be a healthy checkout whose
+ * origin exactly matches config.remote_url.
+ */
+export function assertClientSourceCheckout(
+  sourceId: string,
+  localPath: string,
+  sourceConfig: unknown,
+): void {
+  const config = parseSourceConfig(sourceConfig);
+  const expectedRemote =
+    typeof config.remote_url === 'string' && config.remote_url.length > 0
+      ? config.remote_url
+      : null;
+  if (!expectedRemote) return;
+
+  const state = validateRepoState(localPath, expectedRemote);
+  if (state !== 'healthy') {
+    throw new Error(
+      `Client-local checkout for source "${sourceId}" at ${localPath} is ${state}; ` +
+      `it does not match the source's configured remote.`,
+    );
+  }
+}
+
+/**
  * Get the local_path of the resolved source (per the resolveSourceId chain).
  *
  * Returns the on-disk brain repo path for the source the user is currently
@@ -266,6 +334,9 @@ export async function getDefaultSourcePath(
   cwd: string = process.cwd(),
 ): Promise<string | null> {
   const sourceId = await resolveSourceId(engine, null, cwd);
+  const clientPath = resolveClientSourcePath(sourceId);
+  if (clientPath) return clientPath;
+
   const rows = await engine.executeRaw<{ local_path: string | null }>(
     `SELECT local_path FROM sources WHERE id = $1`,
     [sourceId],

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -53,7 +53,11 @@ import {
 } from './git-remote.ts';
 import { gbrainPath } from './config.ts';
 import { isValidSourceId } from './source-id.ts';
-import { resolveSourceWithTier, type SourceTier } from './source-resolver.ts';
+import {
+  resolveClientSourcePath,
+  resolveSourceWithTier,
+  type SourceTier,
+} from './source-resolver.ts';
 
 // ── Errors ──────────────────────────────────────────────────────────────────
 
@@ -784,15 +788,16 @@ export async function getSourceStatus(
   const archived = archivedRows[0]?.archived === true;
 
   const remoteUrl = getRemoteUrl(src.config);
+  const localPath = resolveClientSourcePath(id) ?? src.local_path;
   let cloneState: SourceStatus['clone_state'] = 'not-applicable';
-  if (src.local_path) {
-    cloneState = validateRepoState(src.local_path, remoteUrl ?? undefined);
+  if (localPath) {
+    cloneState = validateRepoState(localPath, remoteUrl ?? undefined);
   }
 
   return {
     id: src.id,
     name: src.name,
-    local_path: src.local_path,
+    local_path: localPath,
     remote_url: remoteUrl,
     federated: isFederated(src.config),
     page_count: await countVisiblePages(engine, id),

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -22,12 +22,13 @@
  */
 
 import { existsSync, statSync, mkdirSync, writeFileSync, renameSync, unlinkSync, readdirSync } from 'fs';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { randomBytes } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import { serializePageToMarkdown, resolvePageFilePath } from './markdown.ts';
 import { isWriteTargetContained } from './path-confine.ts';
 import { isDurabilityHardened, commitWriteThroughFile } from './brain-repo-durability.ts';
+import { assertClientSourceCheckout, resolveClientSourcePath } from './source-resolver.ts';
 
 /** Minimal logger surface — structurally compatible with operations.ts `Logger`. */
 export interface WriteThroughLogger {
@@ -68,6 +69,12 @@ export interface WriteThroughResult {
 
 export interface WritePageThroughOpts {
   sourceId?: string;
+  /**
+   * Checkout root already resolved and validated by the surrounding operation.
+   * This wins over a matching process-local binding and shared legacy paths so
+   * one operation cannot scan one checkout and re-export into another.
+   */
+  operationRoot?: string;
   /** Merged over the page's own frontmatter at render time (e.g. provenance). */
   frontmatterOverrides?: Record<string, unknown>;
   logger?: WriteThroughLogger;
@@ -99,11 +106,20 @@ export async function writePageThrough(
     //      git repo (the reported bug). Skip instead.
     let filePath: string;
     let writeRoot: string;
-    const srcRows = await engine.executeRaw<{ local_path: string | null }>(
-      `SELECT local_path FROM sources WHERE id = $1`,
+    const srcRows = await engine.executeRaw<{ local_path: string | null; config: unknown }>(
+      `SELECT local_path, config FROM sources WHERE id = $1`,
       [sourceId],
     );
-    const sourceLocalPath = srcRows[0]?.local_path ?? null;
+    const operationRoot = opts.operationRoot ? resolve(opts.operationRoot) : null;
+    const clientLocalPath = operationRoot ? null : resolveClientSourcePath(sourceId);
+    if (clientLocalPath) {
+      assertClientSourceCheckout(sourceId, clientLocalPath, srcRows[0]?.config);
+    }
+    const sourceLocalPath =
+      operationRoot ??
+      clientLocalPath ??
+      srcRows[0]?.local_path ??
+      null;
     if (sourceLocalPath) {
       if (!existsSync(sourceLocalPath) || !statSync(sourceLocalPath).isDirectory()) {
         return { written: false, skipped: 'repo_not_found' };

--- a/test/brain-repo-durability.serial.test.ts
+++ b/test/brain-repo-durability.serial.test.ts
@@ -11,6 +11,9 @@ import { execFileSync } from 'child_process';
 import {
   hardenBrainRepo, unhardenBrainRepo, acceptPat,
 } from '../src/core/brain-repo-durability.ts';
+import { runHarden, runPull } from '../src/commands/sources-harden.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 const PAT = 'ghp_TESTSECRETTOKEN0123456789abcdef';
 
@@ -65,6 +68,31 @@ afterEach(() => {
 });
 
 describe('hardenBrainRepo', () => {
+  test('source commands reject a client checkout whose origin does not match the shared source', async () => {
+    const engine = {
+      executeRaw: async () => [{
+        id: 'wiki',
+        local_path: null,
+        config: { remote_url: join(root, 'other.git') },
+      }],
+    } as unknown as BrainEngine;
+    const before = git(work, 'rev-parse', 'HEAD');
+
+    await withEnv({
+      GBRAIN_SOURCE: 'wiki',
+      GBRAIN_SOURCE_PATH: work,
+      GBRAIN_GITHUB_PAT: undefined,
+    }, async () => {
+      await expect(
+        runHarden(engine, ['wiki', '--dry-run', '--no-cron', '--no-verify']),
+      ).rejects.toThrow(/url-drift/);
+      await expect(runPull(engine, ['wiki'])).rejects.toThrow(/url-drift/);
+    });
+
+    expect(git(work, 'rev-parse', 'HEAD')).toBe(before);
+    expect(existsSync(join(work, '.git', 'hooks', 'post-commit'))).toBe(false);
+  });
+
   test('installs hook (local, untracked, +x), helper, and AGENTS rules', async () => {
     const r = await harden();
     // hook

--- a/test/ingestion/put-page-write-through.test.ts
+++ b/test/ingestion/put-page-write-through.test.ts
@@ -11,11 +11,13 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import { operations } from '../../src/core/operations.ts';
 import type { OperationContext } from '../../src/core/operations.ts';
 import { resetGateway } from '../../src/core/ai/gateway.ts';
+import { withEnv } from '../helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 let tmpRoot: string;
@@ -85,6 +87,60 @@ function makeCtx(overrides: Partial<OperationContext> = {}): OperationContext {
 const putPage = operations.find((o) => o.name === 'put_page')!;
 
 describe('put_page write-through — happy path', () => {
+  test('matching client-local source binding overrides shared path without changing it', async () => {
+    const clientDir = path.join(tmpRoot, 'client-brain');
+    const sharedDir = path.join(tmpRoot, 'shared-db-path');
+    fs.mkdirSync(clientDir, { recursive: true });
+    fs.mkdirSync(sharedDir, { recursive: true });
+    await engine.executeRaw(
+      `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+      [sharedDir],
+    );
+
+    const result = await withEnv(
+      { GBRAIN_SOURCE: 'default', GBRAIN_SOURCE_PATH: clientDir },
+      async () => (await putPage.handler(makeCtx(), {
+        slug: 'inbox/client-bound',
+        content: '---\ntitle: Client bound\n---\n\nclient-local body',
+      })) as { write_through?: { written: boolean; path?: string } },
+    );
+
+    const clientFile = path.join(clientDir, 'inbox/client-bound.md');
+    expect(result.write_through).toMatchObject({ written: true, path: clientFile });
+    expect(fs.existsSync(clientFile)).toBe(true);
+    expect(fs.existsSync(path.join(sharedDir, 'inbox/client-bound.md'))).toBe(false);
+    const rows = await engine.executeRaw<{ local_path: string | null }>(
+      `SELECT local_path FROM sources WHERE id = 'default'`,
+    );
+    expect(rows[0]?.local_path).toBe(sharedDir);
+  });
+
+  test('client-local binding refuses a checkout whose remote identity drifted', async () => {
+    const clientDir = path.join(tmpRoot, 'wrong-remote');
+    fs.mkdirSync(clientDir, { recursive: true });
+    execFileSync('git', ['init', '-q', clientDir]);
+    execFileSync('git', [
+      '-C', clientDir, 'remote', 'add', 'origin',
+      'https://github.com/example/actual.git',
+    ]);
+    await engine.executeRaw(
+      `UPDATE sources SET config = $1::text::jsonb WHERE id = 'default'`,
+      [JSON.stringify({ remote_url: 'https://github.com/example/expected.git' })],
+    );
+
+    const result = await withEnv(
+      { GBRAIN_SOURCE: 'default', GBRAIN_SOURCE_PATH: clientDir },
+      async () => (await putPage.handler(makeCtx(), {
+        slug: 'inbox/wrong-remote',
+        content: '---\ntitle: Wrong remote\n---\n\nmust not project here',
+      })) as { write_through?: { written: boolean; error?: string } },
+    );
+
+    expect(result.write_through?.written).toBe(false);
+    expect(result.write_through?.error).toContain('url-drift');
+    expect(fs.existsSync(path.join(clientDir, 'inbox/wrong-remote.md'))).toBe(false);
+  });
+
   test('writes the markdown file to disk at brainDir/<slug>.md', async () => {
     const ctx = makeCtx();
     const content = '---\ntitle: Test\n---\n\n# WT body';

--- a/test/source-id-tx-regression.test.ts
+++ b/test/source-id-tx-regression.test.ts
@@ -30,6 +30,10 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { execSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runSources } from '../src/commands/sources.ts';
 import { importFromContent } from '../src/core/import-file.ts';
@@ -636,4 +640,36 @@ describe('v0.31.8 op-handler ctx.sourceId threading', () => {
     const defRd = await engine.getRawData(TAG_SLUG, 'unit-test', { sourceId: 'default' });
     expect(defRd.length).toBe(0);
   });
+
+  test('sync_brain handler imports into ctx.sourceId', async () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-op-sync-source-'));
+    const slug = 'topics/op-sync-source-target';
+    try {
+      execSync('git init', { cwd: repo, stdio: 'pipe' });
+      execSync('git config user.email "t@t.t"', { cwd: repo, stdio: 'pipe' });
+      execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+      mkdirSync(join(repo, 'topics'));
+      writeFileSync(join(repo, 'topics/op-sync-source-target.md'), [
+        '---',
+        'title: Scoped sync target',
+        '---',
+        '',
+        'Imported through the operation source scope.',
+      ].join('\n'));
+      execSync('git add -A && git commit -m initial', { cwd: repo, stdio: 'pipe' });
+
+      const op = getOp('sync_brain');
+      await op.handler(makeCtx(engine, { sourceId: 'testsrc' }), {
+        repo,
+        full: true,
+        no_pull: true,
+        no_embed: true,
+      });
+
+      expect(await engine.getPage(slug, { sourceId: 'testsrc' })).not.toBeNull();
+      expect(await engine.getPage(slug, { sourceId: 'default' })).toBeNull();
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/test/source-resolver.test.ts
+++ b/test/source-resolver.test.ts
@@ -12,9 +12,16 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { resolveSourceId, getDefaultSourcePath, __testing } from '../src/core/source-resolver.ts';
+import {
+  resolveSourceId,
+  assertClientSourceCheckout,
+  resolveClientSourcePath,
+  getDefaultSourcePath,
+  __testing,
+} from '../src/core/source-resolver.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 // ── Stub engine ────────────────────────────────────────────
@@ -268,6 +275,49 @@ describe('getDefaultSourcePath', () => {
     );
     const path = await getDefaultSourcePath(engine, '/custom/path/sub');
     expect(path).toBe('/custom/path');
+  });
+});
+
+// ── client-local source path binding ──────────────────────
+
+describe('resolveClientSourcePath', () => {
+  test('requires an absolute path paired with the resolved source identity', () => {
+    expect(resolveClientSourcePath('wiki', {
+      GBRAIN_SOURCE: 'wiki',
+      GBRAIN_SOURCE_PATH: '/clients/a/wiki',
+    })).toBe('/clients/a/wiki');
+
+    expect(() => resolveClientSourcePath('wiki', {
+      GBRAIN_SOURCE_PATH: '/clients/a/wiki',
+    })).toThrow(/requires GBRAIN_SOURCE/);
+    expect(resolveClientSourcePath('wiki', {
+      GBRAIN_SOURCE: 'default',
+      GBRAIN_SOURCE_PATH: '/clients/a/wiki',
+    })).toBeNull();
+    expect(() => resolveClientSourcePath('wiki', {
+      GBRAIN_SOURCE: 'wiki',
+      GBRAIN_SOURCE_PATH: 'relative/wiki',
+    })).toThrow(/absolute path/);
+  });
+
+  test('remote-backed client checkout must match the shared remote identity', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-client-source-'));
+    try {
+      execFileSync('git', ['init', '-q', repo]);
+      execFileSync('git', [
+        '-C', repo, 'remote', 'add', 'origin',
+        'https://github.com/example/actual.git',
+      ]);
+
+      expect(() => assertClientSourceCheckout('wiki', repo, {
+        remote_url: 'https://github.com/example/actual.git',
+      })).not.toThrow();
+      expect(() => assertClientSourceCheckout('wiki', repo, {
+        remote_url: 'https://github.com/example/other.git',
+      })).toThrow(/url-drift/);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -482,6 +482,45 @@ describe('getSourceStatus', () => {
     });
   });
 
+  test('public sources status reports the matching client-local checkout', async () => {
+    await withEnv2(async () => {
+      const row = await addSource(engine, {
+        id: 'status-client',
+        remoteUrl: 'https://github.com/example/repo',
+      });
+      const clientPath = join(GBRAIN_HOME, 'client-status-checkout');
+      mkdirSync(join(clientPath, '.git'), { recursive: true });
+
+      await withEnv(
+        { GBRAIN_SOURCE: 'status-client', GBRAIN_SOURCE_PATH: clientPath },
+        async () => {
+          const status = await getSourceStatus(engine, 'status-client');
+          expect(status.local_path).toBe(clientPath);
+
+          const originalLog = console.log;
+          const lines: string[] = [];
+          console.log = (...args: unknown[]) => {
+            lines.push(args.map(String).join(' '));
+          };
+          try {
+            await runSources(engine, ['status', '--json']);
+          } finally {
+            console.log = originalLog;
+          }
+
+          const report = JSON.parse(lines.join('\n')) as {
+            sources: Array<{ source_id: string; local_path: string | null }>;
+          };
+          expect(
+            report.sources.find((source) => source.source_id === 'status-client')?.local_path,
+          ).toBe(clientPath);
+        },
+      );
+
+      expect(row.local_path).not.toBe(clientPath);
+    });
+  });
+
   test('clone_state = "not-applicable" for path-only source (no remote)', async () => {
     await withEnv2(async () => {
       const userPath = join(GBRAIN_HOME, 'na-fixture');

--- a/test/sync-cost-gate.serial.test.ts
+++ b/test/sync-cost-gate.serial.test.ts
@@ -26,6 +26,7 @@ import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { configureGateway, resetGateway, __setEmbedTransportForTests } from '../src/core/ai/gateway.ts';
 import { CHUNKER_VERSION } from '../src/core/chunkers/code.ts';
 import type { ChunkInput } from '../src/core/types.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 /** Offline embed stub so inline-proceed paths (posture tokenmax) don't network. */
 function stubOfflineEmbed(): void {
@@ -243,5 +244,27 @@ describe('v0.41.31 — sync --all cost gate wiring', () => {
     // The gate now exists on the single-source path (was ungated before
     // #2139) and proceeds to import rather than blocking.
     expect(stdout.toLowerCase()).toContain('imported');
+  }, 60_000);
+
+  test('single-source gate and sync use client-local path without rewriting shared local_path', async () => {
+    await runSources(engine, ['add', 'vault', '--path', repoPath, '--no-federated']);
+    const sharedPath = `${repoPath}-other-client`;
+    await engine.executeRaw(
+      `UPDATE sources SET local_path = $1 WHERE id = 'vault'`,
+      [sharedPath],
+    );
+    await engine.setConfig('sync.cost_gate_min_usd', '0');
+
+    const { exitCode, stdout } = await withEnv(
+      { GBRAIN_SOURCE: 'vault', GBRAIN_SOURCE_PATH: repoPath },
+      () => runSyncCaptured(['--source', 'vault', '--json', '--no-pull']),
+    );
+
+    expect(exitCode).not.toBe(2);
+    expect(stdout).toContain('"gate":"auto_deferred_embeds"');
+    const rows = await engine.executeRaw<{ local_path: string | null }>(
+      `SELECT local_path FROM sources WHERE id = 'vault'`,
+    );
+    expect(rows[0]?.local_path).toBe(sharedPath);
   }, 60_000);
 });

--- a/test/sync-reconcile-db-only.serial.test.ts
+++ b/test/sync-reconcile-db-only.serial.test.ts
@@ -92,7 +92,7 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
     if (repoPath) rmSync(repoPath, { recursive: true, force: true });
   });
 
-  test('genuinely-deleted pages reconcile; never-committed pages are kept and re-exported', async () => {
+  test('explicit sync repo keeps reconcile re-export in the scanned checkout', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
 
     // Full sync #1: both file-backed pages land.
@@ -122,21 +122,39 @@ describe('#2426 — full-sync reconcile keeps never-committed (DB-only) pages', 
     execSync('git rm -q topics/gone.md && git commit -m "rm gone"', { cwd: repoPath, stdio: 'pipe' });
     await engine.setConfig('sync.repo_path', repoPath);
 
-    // Full sync #2 runs the delete-reconcile.
-    const second = await performSync(engine, {
-      repoPath, full: true, sourceId: 'default', noPull: true, noEmbed: true,
-    });
-    expect(['first_sync', 'synced']).toContain(second.status);
+    // A matching process-local binding points at a DIFFERENT checkout. The
+    // explicit operation root must win for every part of this sync, including
+    // the DB-only re-export.
+    const otherCheckout = mkdtempSync(join(tmpdir(), 'gbrain-dbonly-other-'));
+    const previousSource = process.env.GBRAIN_SOURCE;
+    const previousSourcePath = process.env.GBRAIN_SOURCE_PATH;
+    process.env.GBRAIN_SOURCE = 'default';
+    process.env.GBRAIN_SOURCE_PATH = otherCheckout;
+    try {
+      // Full sync #2 runs the delete-reconcile.
+      const second = await performSync(engine, {
+        repoPath, full: true, sourceId: 'default', noPull: true, noEmbed: true,
+      });
+      expect(['first_sync', 'synced']).toContain(second.status);
 
-    // The genuinely-deleted page is reconciled away…
-    expect(await engine.getPage('topics/gone')).toBeNull();
-    // …the still-present page survives…
-    expect(await engine.getPage('topics/keep')).not.toBeNull();
-    // …and the DB-only page is PRESERVED (pre-fix: soft-deleted here)…
-    const lost = await engine.getPage('memories/lost');
-    expect(lost).not.toBeNull();
-    expect(lost?.compiled_truth).toContain('must not be reconciled');
-    // …and re-exported to the working tree so it is file-backed again.
-    expect(existsSync(join(repoPath, 'memories/lost.md'))).toBe(true);
+      // The genuinely-deleted page is reconciled away…
+      expect(await engine.getPage('topics/gone')).toBeNull();
+      // …the still-present page survives…
+      expect(await engine.getPage('topics/keep')).not.toBeNull();
+      // …and the DB-only page is PRESERVED (pre-fix: soft-deleted here)…
+      const lost = await engine.getPage('memories/lost');
+      expect(lost).not.toBeNull();
+      expect(lost?.compiled_truth).toContain('must not be reconciled');
+      // …and re-exported into the checkout scanned by THIS operation, never
+      // the lower-precedence process-local binding.
+      expect(existsSync(join(repoPath, 'memories/lost.md'))).toBe(true);
+      expect(existsSync(join(otherCheckout, 'memories/lost.md'))).toBe(false);
+    } finally {
+      if (previousSource === undefined) delete process.env.GBRAIN_SOURCE;
+      else process.env.GBRAIN_SOURCE = previousSource;
+      if (previousSourcePath === undefined) delete process.env.GBRAIN_SOURCE_PATH;
+      else process.env.GBRAIN_SOURCE_PATH = previousSourcePath;
+      rmSync(otherCheckout, { recursive: true, force: true });
+    }
   }, 120_000);
 });

--- a/test/sync-trigger-cli.test.ts
+++ b/test/sync-trigger-cli.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runSyncTrigger } from '../src/commands/sync.ts';
 import { MinionQueue } from '../src/core/minions/queue.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 
@@ -102,6 +103,22 @@ describe('runSyncTrigger', () => {
     expect((job.data as { sourceId: string }).sourceId).toBe('default');
     expect((job.data as { noExtract: boolean }).noExtract).toBe(false);
     expect((job.data as { auto_embed_backfill: boolean }).auto_embed_backfill).toBe(true);
+  });
+
+  test('matching client-local checkout requires inline sync', async () => {
+    await withEnv({
+      GBRAIN_SOURCE: 'default',
+      GBRAIN_SOURCE_PATH: '/tmp/gbrain-client-local-trigger-test',
+    }, async () => {
+      const { stderr, exitCode } = await capture(['--source', 'default']);
+      expect(exitCode).toBe(2);
+      expect(stderr).toContain('client-local checkout');
+      expect(stderr).toContain('gbrain sync --source default');
+
+      const queue = new MinionQueue(engine);
+      const jobs = await queue.getJobs({ name: 'sync', limit: 5 });
+      expect(jobs).toHaveLength(0);
+    });
   });
 
   test('--priority normal maps to 0', async () => {


### PR DESCRIPTION
## What changed

- Add a public process-local `GBRAIN_SOURCE` + absolute `GBRAIN_SOURCE_PATH` binding for one resolved source.
- Keep shared source identity, remote identity, bookmarks, and legacy `sources.local_path` behavior unchanged when no binding is supplied.
- Use the resolved source consistently for sync operations and brainstorm/LSD saves.
- Keep explicit sync roots above client bindings during DB-only re-export, and reject queued sync when a process-local checkout cannot follow the job.

## Why

Clients that share one Postgres database and one Git brain remote can clone that remote at different absolute paths. A shared `sources.local_path` cannot safely represent those per-client checkouts.

## User impact

Each client can bind its own checkout without writing that path back to shared Postgres. Inline sync, source status/pull/hardening, and write-through use the matching local checkout while preserving existing fallback behavior.

## Validation

- 132 focused source, write-through, operation, trigger, and save tests
- 20 focused durability tests
- 10 focused sync cost/routing tests
- 2 focused DB-only reconciliation tests
- TypeScript typecheck and test-isolation guard
- Downstream single phased Codex product E2E with two clients at different paths, one shared Postgres, one Git remote, correction, synchronization, and fresh-Postgres recovery

The full upstream suite was not run; validation was intentionally scoped to the changed public seam and downstream product gate.
