### PR TITLE
fix(admin): deduplicate concurrent login submissions

### DIFF
--- a/admin/src/lib/login-submit-once.ts
+++ b/admin/src/lib/login-submit-once.ts
@@ -1,0 +1,24 @@
+type AsyncOperation<Args extends unknown[], Result> = (...args: Args) => Promise<Result>;
+
+export function createLoginSubmitOnce<Args extends unknown[], Result>(
+  operation: AsyncOperation<Args, Result>,
+): AsyncOperation<Args, Result> {
+  let inFlight: Promise<Result> | undefined;
+
+  return (...args: Args) => {
+    if (inFlight) return inFlight;
+
+    let request: Promise<Result>;
+    try {
+      request = Promise.resolve(operation(...args));
+    } catch (error) {
+      request = Promise.reject(error);
+    }
+
+    const tracked = request.finally(() => {
+      if (inFlight === tracked) inFlight = undefined;
+    });
+    inFlight = tracked;
+    return tracked;
+  };
+}

--- a/admin/src/pages/Login.tsx
+++ b/admin/src/pages/Login.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { api } from '../api';
+import { createLoginSubmitOnce } from '../lib/login-submit-once';
 
 // v0.26.3 trust model (D11 + D12):
 // - The bootstrap token is NEVER stored in browser JS state. No
@@ -17,13 +18,17 @@ export function LoginPage({ onLogin }: { onLogin: () => void }) {
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const submitLogin = useMemo(
+    () => createLoginSubmitOnce((submittedToken: string) => api.login(submittedToken)),
+    [],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     setLoading(true);
     try {
-      await api.login(token);
+      await submitLogin(token);
       // Don't persist the token. The HttpOnly cookie is the only
       // session credential after this point.
       setToken('');

--- a/test/admin-login-submit-once.test.ts
+++ b/test/admin-login-submit-once.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test';
+import { createLoginSubmitOnce } from '../admin/src/lib/login-submit-once';
+
+test('coalesces concurrent login submissions and permits retry after a successful settle', async () => {
+  let resolveLogin!: () => void;
+  let loginCalls = 0;
+  const login = () => {
+    loginCalls += 1;
+    return new Promise<void>(resolve => {
+      resolveLogin = resolve;
+    });
+  };
+  const submitLogin = createLoginSubmitOnce(login);
+
+  const first = submitLogin();
+  const second = submitLogin();
+
+  expect(loginCalls).toBe(1);
+  expect(second).toBe(first);
+
+  resolveLogin();
+  await first;
+
+  const third = submitLogin();
+
+  expect(loginCalls).toBe(2);
+  expect(third).not.toBe(first);
+});
+
+test('permits retry after a failed settle', async () => {
+  let rejectLogin!: (error: Error) => void;
+  let loginCalls = 0;
+  const login = () => {
+    loginCalls += 1;
+    return new Promise<void>((_resolve, reject) => {
+      rejectLogin = reject;
+    });
+  };
+  const submitLogin = createLoginSubmitOnce(login);
+
+  const first = submitLogin();
+  rejectLogin(new Error('invalid token'));
+  await expect(first).rejects.toThrow('invalid token');
+
+  submitLogin();
+
+  expect(loginCalls).toBe(2);
+});


### PR DESCRIPTION
## Summary

- Add a single-flight guard to the Admin `LoginPage` submission path.
- Concurrent submissions trigger only one `/admin/login` request.
- A new login submission is allowed after the prior request succeeds or fails.

## Validation

- `bun test test/admin-login-submit-once.test.ts`
- `bun run typecheck`
- `git diff --check`

This pull request is intentionally opened as a draft.