### PR TITLE
test(pglite): CLI-level regression coverage for pre-v121 schema bootstrap (#2775)

### DIFF
--- a/test/migration-in-process.serial.test.ts
+++ b/test/migration-in-process.serial.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from
 import { join } from 'path';
 import { withEnv } from './helpers/with-env.ts';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { LATEST_VERSION } from '../src/core/migrate.ts';
 import {
   runMigrateOnlyCore,
   runGbrainSubprocess,
@@ -45,6 +46,76 @@ describe('#1605 runMigrateOnlyCore (in-process schema)', () => {
         "SELECT to_regclass('public.pages')::text AS t",
       );
       expect(rows[0]?.t).toBe('pages');
+    } finally {
+      await verify.disconnect();
+    }
+  });
+
+  // Regression coverage for #2775: `gbrain init --migrate-only` (this
+  // function, in-process) failed with `column "event_page_id" does not
+  // exist` on any PGLite brain whose schema predates migration v121, because
+  // `PGLiteEngine#initSchema` replayed the embedded schema blob — which
+  // indexes `timeline_entries.event_page_id` — BEFORE `runMigrations()` had
+  // a chance to add that column. The fix (forward-reference bootstrap probe
+  // for `timeline_entries.event_page_id`) already shipped in #2735 (closing
+  // #2724, the Postgres-side report of the same ordering bug) ahead of this
+  // test. `test/bootstrap.test.ts` and `test/schema-bootstrap-coverage.test.ts`
+  // already cover the bootstrap contract at the engine-method level; this
+  // test closes the remaining gap by exercising the exact CLI-facing entry
+  // point (`runMigrateOnlyCore`, i.e. `gbrain init --migrate-only`) so a
+  // future regression in the wiring between the CLI and `initSchema()` would
+  // still be caught even if the lower-level bootstrap contract stayed intact.
+  test('brings a pre-v121 PGLite brain (missing timeline_entries.event_page_id) to head without spawning (#2775)', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'mip-pre121-'));
+    const dataDir = join(home, 'data');
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'pglite', database_path: dataDir }),
+    );
+
+    await withEnv(
+      { GBRAIN_HOME: home, DATABASE_URL: undefined, GBRAIN_DATABASE_URL: undefined },
+      async () => {
+        // Bring the brain to LATEST first (fresh install), then simulate a
+        // pre-v121 brain by stripping the forward-referenced column/indexes
+        // migration v121 added and rolling `config.version` back to a
+        // pre-v121 value — the same down-mutation pattern used by
+        // test/bootstrap.test.ts's "pre-v121 timeline shape" case.
+        await runMigrateOnlyCore();
+
+        const rollback = new PGLiteEngine();
+        await rollback.connect({ database_path: dataDir });
+        try {
+          await (rollback as any).db.exec(`
+            DROP INDEX IF EXISTS idx_timeline_event_page;
+            DROP INDEX IF EXISTS idx_timeline_event_dedup;
+            ALTER TABLE timeline_entries DROP CONSTRAINT IF EXISTS timeline_entries_event_page_id_fkey;
+            ALTER TABLE timeline_entries DROP COLUMN IF EXISTS event_page_id;
+          `);
+          await rollback.setConfig('version', '97');
+        } finally {
+          await rollback.disconnect();
+        }
+
+        // The literal repro from #2775: re-running the `gbrain init
+        // --migrate-only` code path against the downgraded brain must NOT
+        // throw `column "event_page_id" does not exist` — it must bring the
+        // schema back to LATEST_VERSION.
+        const result = await runMigrateOnlyCore();
+        expect(result.engine).toBe('pglite');
+      },
+    );
+
+    const verify = new PGLiteEngine();
+    await verify.connect({ database_path: dataDir });
+    try {
+      const versionStr = await verify.getConfig('version');
+      expect(parseInt(versionStr || '0', 10)).toBe(LATEST_VERSION);
+      const rows = await verify.executeRaw<{ t: string | null }>(
+        "SELECT to_regclass('public.idx_timeline_event_page')::text AS t",
+      );
+      expect(rows[0]?.t).toBe('idx_timeline_event_page');
     } finally {
       await verify.disconnect();
     }


### PR DESCRIPTION
## Summary

Investigated #2775 (`gbrain init --migrate-only` fails on pre-v121 PGLite brains with `column "event_page_id" does not exist`) before implementing anything, per the diagnosis-first workflow. Finding: **the root cause was already fixed on `master`, before this PR, by #2735 (the PR that resolved the Postgres-side report of the identical ordering bug, #2724).**

- #2735 added a `timeline_entries.event_page_id` forward-reference bootstrap probe to *both* `src/core/pglite-engine.ts` and `src/core/postgres-engine.ts` (`needsTimelineEventPageId`), so `PGLiteEngine#initSchema()` no longer replays the embedded schema blob's `idx_timeline_event_page` index before the column exists on old brains.
- #2735 also added regression coverage: `test/bootstrap.test.ts` ("pre-v121 timeline shape reaches LATEST through full initSchema") and an entry in `test/schema-bootstrap-coverage.test.ts`'s `REQUIRED_BOOTSTRAP_COVERAGE`.
- I independently reproduced #2775's exact repro against current `master` (manually downgraded a fresh PGLite brain's `timeline_entries` to a pre-v121 shape + `config.version=97`, then ran `gbrain init --migrate-only`): it now succeeds and brings the schema to head. Pre-fix (verified by locally neutralizing the `needsTimelineEventPageId` probe), the same repro throws exactly `column "event_page_id" does not exist` (Postgres error `42703`).
- The A2 structural guard in `test/schema-bootstrap-coverage.test.ts` (which statically parses every `CREATE INDEX` in the schema blob and asserts bootstrap coverage) also currently reports zero uncovered forward references, so there's no sibling column with the same hazard class left uncovered.

Since there was no remaining code bug to fix, this PR does **not** touch `src/core/pglite-engine.ts` / `src/core/postgres-engine.ts` (re-adding the already-present fix would be redundant and risks drifting from the existing, well-tested implementation).

## What this PR adds

A CLI-facing regression test in `test/migration-in-process.serial.test.ts`, alongside the existing `runMigrateOnlyCore` coverage. The existing tests (`test/bootstrap.test.ts`, `test/schema-bootstrap-coverage.test.ts`) exercise `applyForwardReferenceBootstrap()` directly at the engine-method level; none of them exercise the actual command users run (`gbrain init --migrate-only` → `runMigrateOnlyCore()`). The new test closes that gap: it builds a fresh PGLite brain, downgrades it to a pre-v121 shape (same down-mutation technique `test/bootstrap.test.ts` already uses), then calls `runMigrateOnlyCore()` again and asserts it reaches `LATEST_VERSION` without throwing — i.e. the literal `gbrain init --migrate-only` repro from #2775.

I verified this test is a real regression guard, not a tautology: temporarily setting `needsTimelineEventPageId = false` in `pglite-engine.ts` (simulating pre-#2735 behavior) makes the new test fail with the exact reported error; reverting makes it pass. (That temporary edit was not committed — `git diff` on `src/core/pglite-engine.ts` is empty in this PR.)

## Note: a second, separate, still-open issue

#2775 also reported that `gbrain apply-migrations --yes` prints `All migrations up to date.` and does nothing, even while `gbrain doctor` reports the schema is behind. I reproduced this too, and it is real — but it has a **separate root cause** from the `event_page_id` ordering bug, so I did not fix it here (kept this PR scoped to #2775's diagnosed root cause):

- `runApplyMigrations()` (`src/commands/apply-migrations.ts`) only applies the *orchestrator* migration registry (`src/commands/migrations/index.ts`, currently topping out at `v0.32.2`), not the numbered schema `MIGRATIONS` array in `src/core/migrate.ts`. Once a brain's orchestrator migrations are all marked complete (true for essentially every brain that has been through a few upgrade cycles), `apply-migrations --yes` has nothing left to do and reports "up to date" regardless of schema drift.
- The one place that *would* warn about schema drift (the pre-flight check around `apply-migrations.ts:365-386`) is explicitly skipped for PGLite (`skipPreflight = cfg.engine === 'pglite'`), a deliberate v0.36.x #1100 fix to avoid a PGLite single-writer lock race with a legacy subprocess-spawn path — unrelated to the #2735/#2724 ordering bug.
- Practically, this is non-fatal on current `master`: any other `gbrain` command (e.g. `gbrain doctor`) goes through `connectEngine()` in `src/cli.ts`, which calls `tryRunPendingMigrations()` and silently brings the schema to head anyway. But `doctor`'s own remediation text ("Fix: `gbrain apply-migrations --yes`") is misleading for PGLite users in this specific state, since that command does not actually apply the pending schema migrations.

This is worth its own issue/PR — happy to file it, but wanted to flag it here rather than silently drop it or scope-creep it into this PR.

## Test plan

```
bun test test/migration-in-process.serial.test.ts test/bootstrap.test.ts test/schema-bootstrap-coverage.test.ts
# 25 pass, 0 fail

bun run typecheck
# clean
```

Related to #2775.
