### PR TITLE
fix(cli): restore help-line adjacency pinned by #2795 (master red after #3426)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2372,9 +2372,9 @@ IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
+                                     See also: autopilot --install (continuous daemon).
   sync --all --missing-path skip     Classify sources whose local_path is absent
                                      on this machine as skipped, not failed
-                                     See also: autopilot --install (continuous daemon).
   export [--dir ./out/]              Export to markdown
   export --restore-only [--repo <p>] Restore missing supabase-only files
         [--type T] [--slug-prefix S] With optional filters


### PR DESCRIPTION
Master's test (1) shard is red at d2ac2aef: #3426's conflict resolution inserted the two --missing-path help lines between `sync --watch` and its `See also: autopilot --install` line, breaking the adjacency regex in test/cli-help-discoverability.test.ts (#2795 pin). This reorders the lines so the See-also immediately follows sync --watch, keeping #3426's help content. Verified: cli-help-discoverability 10/10, sync-all-missing-path green, typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)