### PR TITLE
fix(ai): migrate DeepSeek recipe to v4 model names (#1255)

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -134,7 +134,7 @@ EXAMPLES
   gbrain providers list
   gbrain providers test --model openai:text-embedding-3-large
   gbrain providers test --touchpoint chat --model anthropic:claude-haiku-4-5
-  gbrain providers test --touchpoint chat --model deepseek:deepseek-chat
+  gbrain providers test --touchpoint chat --model deepseek:deepseek-v4-flash
   gbrain providers env ollama
   gbrain providers explain --json
 `);

--- a/src/core/ai/recipes/deepseek.ts
+++ b/src/core/ai/recipes/deepseek.ts
@@ -1,9 +1,10 @@
 import type { Recipe } from '../types.ts';
 
 /**
- * `deepseek-reasoner` returns its answer in a separate `reasoning_content`
- * field and leaves `content` empty/whitespace when the whole response was
- * reasoning. The AI SDK's openai-compatible adapter reads only `content`, so
+ * DeepSeek's thinking mode (default on `deepseek-v4-flash`/`deepseek-v4-pro`;
+ * formerly the `deepseek-reasoner` model, retired 2026-07-24) returns its
+ * answer in a separate `reasoning_content` field and leaves `content`
+ * empty/whitespace when the whole response was reasoning. The AI SDK's openai-compatible adapter reads only `content`, so
  * the model appears to answer with nothing. This transport shim promotes
  * `reasoning_content` into `content` when `content` is empty, before the
  * adapter parses the body. Fail-open: any error returns the original response.
@@ -80,20 +81,25 @@ export const deepseek: Recipe = {
     // gateway's expansion path is a plain languageModel call). Without this
     // declaration an explicit `expansion_model: deepseek:...` silently
     // yields no expansion (#1135).
+    // `deepseek-chat` / `deepseek-reasoner` were retired by DeepSeek on
+    // 2026-07-24 (#1255); both map to `deepseek-v4-flash` (non-thinking /
+    // thinking mode). Do not re-add the old names — the API 404s them.
+    // openai-compat tier means user-configured legacy names still pass
+    // validation locally; the provider rejects them at call time.
     expansion: {
-      models: ['deepseek-chat'],
+      models: ['deepseek-v4-flash'],
       cost_per_1m_tokens_usd: 0.14,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-07-27',
     },
     chat: {
-      models: ['deepseek-chat', 'deepseek-reasoner'],
+      models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,
-      max_context_tokens: 128000,
-      cost_per_1m_input_usd: 0.14, // deepseek-chat off-peak baseline
+      max_context_tokens: 1_000_000,
+      cost_per_1m_input_usd: 0.14, // deepseek-v4-flash cache-miss baseline
       cost_per_1m_output_usd: 0.28,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-07-27',
     },
   },
   setup_hint: 'Get an API key at https://platform.deepseek.com/api_keys, then `export DEEPSEEK_API_KEY=...`',

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -93,7 +93,12 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
 
   // ── Together / DeepSeek (cross-modal-eval panel) ───────────────────────
   'together:meta-llama/Llama-3.3-70B-Instruct-Turbo': { input: 0.88, output: 0.88 },
+  // `deepseek-chat` was retired by DeepSeek 2026-07-24 (#1255); kept so
+  // historical usage/audit rows still price. New calls use the v4 names.
   'deepseek:deepseek-chat':               { input:  0.14, output:  0.28 },
+  // DeepSeek v4 (verified 2026-07-27 at api-docs.deepseek.com): cache-miss rates.
+  'deepseek:deepseek-v4-flash':           { input:  0.14, output:  0.28 },
+  'deepseek:deepseek-v4-pro':             { input:  0.435, output: 0.87 },
 };
 
 /**

--- a/test/ai/deepseek-reasoning-content.test.ts
+++ b/test/ai/deepseek-reasoning-content.test.ts
@@ -121,4 +121,9 @@ describe('applyOpenAICompatConfig — compat.fetch wiring (gateway seam)', () =>
   test('recipe wires the shim via compat.fetch', () => {
     expect(deepseek.compat?.fetch).toBe(deepseekReasoningContentCompatFetch);
   });
+
+  test('recipe lists only v4 model names — deepseek-chat/deepseek-reasoner retired 2026-07-24 (#1255)', () => {
+    expect(deepseek.touchpoints.chat?.models).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro']);
+    expect(deepseek.touchpoints.expansion?.models).toEqual(['deepseek-v4-flash']);
+  });
 });

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -110,6 +110,9 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
     expect(() => assertTouchpoint(getRecipe('anthropic')!, 'chat', 'claude-opus-4-7')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('openai')!, 'chat', 'gpt-5.2')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.0-flash')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-v4-flash')).not.toThrow();
+    // Legacy id retired by DeepSeek 2026-07-24 (#1255): still passes local
+    // validation (openai-compat tier), rejection surfaces at the provider.
     expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-chat')).not.toThrow();
   });
 


### PR DESCRIPTION
Fixes #1255. Thanks @W4RW1CK for the report.

## Why (deprecation evidence)

DeepSeek retired the model names `deepseek-chat` and `deepseek-reasoner` on **2026-07-24** in favor of the v4 family. Per https://api-docs.deepseek.com/ (verified 2026-07-27):

- Current model IDs: `deepseek-v4-flash`, `deepseek-v4-pro`
- `deepseek-chat` → non-thinking mode of `deepseek-v4-flash`
- `deepseek-reasoner` → thinking mode of `deepseek-v4-flash`
- Pricing (cache-miss, per https://api-docs.deepseek.com/quick_start/pricing): v4-flash $0.14 in / $0.28 out per 1M (unchanged from deepseek-chat), v4-pro $0.435 / $0.87. Both 1M context.

Every DeepSeek-configured brain 404s on the old names as of the retirement date.

## What changed

- `src/core/ai/recipes/deepseek.ts` — chat models `['deepseek-v4-flash', 'deepseek-v4-pro']`, expansion `['deepseek-v4-flash']`, `max_context_tokens` 128K → 1M, `price_last_verified: 2026-07-27`. Shim doc updated: `reasoning_content` promotion applies unchanged to v4 thinking mode.
- `src/core/model-pricing.ts` — canonical entries added for `deepseek:deepseek-v4-flash` and `deepseek:deepseek-v4-pro`; legacy `deepseek:deepseek-chat` row kept so historical usage/audit rows still price.
- `src/commands/providers.ts` — help example now uses `deepseek:deepseek-v4-flash`.
- Tests: new recipe-list pin in `test/ai/deepseek-reasoning-content.test.ts`; `test/ai/gateway-chat.test.ts` updated (v4 id accepted; legacy id still passes local validation on the openai-compat tier — provider rejection surfaces at call time, so stale user configs fail with a clear provider error, not a local throw).

Out of scope: OpenRouter's `deepseek/deepseek-chat` slug (OpenRouter's own catalog namespace, still routed by OR).

## Verification

- `bun run typecheck` — exit 0
- `bun test` on touched + adjacent files (`deepseek-reasoning-content`, `gateway-chat`, `model-pricing`, `think-max-output-tokens`, `gateway`, `gateway-probe-chat-model`) — 105 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)