### PR TITLE
docs(security): document the security-CI trio posture — audit follow-up to #2917 (#2182 #2142 #2272)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,14 @@ host port with `GBRAIN_CI_PG_PORT=5435 bun run ci:local` if 5434 collides.
 Fail-closed selector: an unmapped `src/` change runs all 29 E2E files. Hand-tune
 narrower mappings via `scripts/e2e-test-map.ts`.
 
+### PR-side security checks
+
+Besides the test gate, PRs may trigger three security workflows: Semgrep CE
+SAST (every PR — **advisory/non-blocking** while the baseline is tuned, so a
+Semgrep finding won't fail your PR), OSV-Scanner (only when `package.json` or
+`bun.lock` change), and actionlint (only when `.github/workflows/**` change).
+See `SECURITY.md` → "Automated security scanning" for details.
+
 ## Building
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,30 @@ on GitHub.
 
 Do not open a public issue for security vulnerabilities.
 
+## Automated security scanning
+
+CI runs three automated security checks alongside secret scanning (Gitleaks):
+
+- **Dependency vulnerabilities** — OSV-Scanner
+  (`.github/workflows/osv-scanner.yml`) runs weekly and on any PR that touches
+  `package.json` or `bun.lock`.
+- **Static analysis (SAST)** — Semgrep CE (`.github/workflows/semgrep.yml`)
+  runs on every PR and weekly. It is currently **advisory (non-blocking)**
+  while the finding baseline is tuned; the graduation path to a blocking check
+  is documented in the workflow file.
+- **Release binary provenance** — release builds
+  (`.github/workflows/release.yml`) attest each compiled binary with
+  [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations).
+  Verify a downloaded release binary with:
+
+  ```bash
+  gh attestation verify ./gbrain-darwin-arm64 -R garrytan/gbrain
+  gh attestation verify ./gbrain-linux-x64 -R garrytan/gbrain
+  ```
+
+All security workflows use SHA-pinned actions and least-privilege permissions,
+enforced structurally by actionlint on every workflow change.
+
 ## Remote MCP Security
 
 ### ⚠️ Do NOT use open OAuth client registration for remote MCP


### PR DESCRIPTION
Closes #2182, closes #2142, closes #2272 (all three were already closed by #2917; referenced here so this follow-up threads to them).

## Audit: what was already on master (via #2917, merged 2026-07-17)

The full maintainer-approved trio landed and is green — this PR deliberately does **not** duplicate it:

1. **OSV-Scanner** (`.github/workflows/osv-scanner.yml`): weekly schedule + PR trigger on `package.json`/`bun.lock`, SHA-pinned reusable workflow (v2.3.8), least-privilege. The reusable-workflow caller-permission trap is already handled: the caller grants `security-events: write` even with `upload-sarif: false`, because GitHub validates the superset at startup (the prior startup_failure lesson) — recent runs all succeed.
2. **Artifact attestations** (`.github/workflows/release.yml`): build job has `id-token: write` + `attestations: write`, SHA-pinned `actions/attest-build-provenance` (v4.1.1) on both compiled binaries. **Note for maintainers:** this workflow has never fired — the repo has no `v*` tags and no GitHub Releases; releases in practice are VERSION bumps on master. The attestation wiring is correct and dormant; it will attest the moment a `v*` tag is pushed. No other CI path builds binaries, so there is nowhere else to attach it.
3. **Semgrep CE** (`.github/workflows/semgrep.yml`): PR + weekly, `p/default` + `p/typescript`, SHA-pinned container digest + pinned checkout, **non-blocking** (`continue-on-error: true`). Tuning plan (already commented in the workflow): triage the baseline findings (fix or `# nosemgrep`), then remove `continue-on-error` so new findings block PRs.

## What this PR adds (the only real gap)

#2917 shipped zero docs. This adds the functional posture notes the issues explicitly asked for:

- `SECURITY.md`: new "Automated security scanning" section — what runs and when, plus the `gh attestation verify` commands for release binaries (#2142 suggested fix, item 4). Functional description only, per the repo's responsible-disclosure rule.
- `CONTRIBUTING.md`: PR-side note that Semgrep is advisory/non-blocking while the baseline is tuned (#2272 suggested fix, item 5), and when OSV-Scanner/actionlint fire on a PR.

No workflow files changed, so actionlint has nothing new to lint (the repo's `actionlint.yml` gates any future workflow edits).

Credit: all three issues were filed by @maxpetrusenkoagent (Co-authored-by on the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)