### PR TITLE
fix(ai): Azure Entra keyless mode requires explicit opt-in (master red after #2354)

### DIFF
--- a/src/core/ai/recipes/azure-openai.ts
+++ b/src/core/ai/recipes/azure-openai.ts
@@ -45,9 +45,14 @@ export function __setEntraTokenForTests(token: string | null): void {
   _entraToken = token === null ? null : { token, fetchedAt: Date.now() };
 }
 
-/** Entra/keyless mode: explicit opt-in, or no api-key present (disableLocalAuth). */
+/** Entra/keyless mode: EXPLICIT opt-in only (AZURE_OPENAI_USE_ENTRA=1 /
+ * config azure_openai_use_entra). A missing api-key must NOT silently shell
+ * out to `az` — that surprises CI boxes and every non-Azure-CLI environment,
+ * and it broke the cross-recipe auth iron-rule test. Keyless subscriptions
+ * (disableLocalAuth) set the flag; missing key without the flag keeps the
+ * original loud AIConfigError. */
 function isEntraMode(env: Record<string, string | undefined>): boolean {
-  return env.AZURE_OPENAI_USE_ENTRA === '1' || !env.AZURE_OPENAI_API_KEY;
+  return env.AZURE_OPENAI_USE_ENTRA === '1';
 }
 
 /**

--- a/test/ai/recipe-azure-openai.test.ts
+++ b/test/ai/recipe-azure-openai.test.ts
@@ -74,7 +74,7 @@ describe('recipe: azure-openai', () => {
     expect(auth.headerName).toBe('api-key');
   });
 
-  test('resolveAuth Entra mode (no key) returns Authorization Bearer from the token cache', async () => {
+  test('resolveAuth Entra mode (explicit opt-in, no key) returns Authorization Bearer from the token cache', async () => {
     const { __setEntraTokenForTests } = await import('../../src/core/ai/recipes/azure-openai.ts');
     __setEntraTokenForTests('fake-aad-token');
     try {
@@ -82,6 +82,7 @@ describe('recipe: azure-openai', () => {
       const auth = r.resolveAuth!({
         AZURE_OPENAI_ENDPOINT: FULL_ENV.AZURE_OPENAI_ENDPOINT,
         AZURE_OPENAI_DEPLOYMENT: FULL_ENV.AZURE_OPENAI_DEPLOYMENT,
+        AZURE_OPENAI_USE_ENTRA: '1',
       });
       expect(auth.headerName).toBe('Authorization');
       expect(auth.token).toBe('Bearer fake-aad-token');
@@ -110,7 +111,8 @@ describe('recipe: azure-openai', () => {
     const cfg = r.resolveOpenAICompatConfig!({
       AZURE_OPENAI_ENDPOINT: FULL_ENV.AZURE_OPENAI_ENDPOINT,
       AZURE_OPENAI_DEPLOYMENT: FULL_ENV.AZURE_OPENAI_DEPLOYMENT,
-    }); // no key → Entra mode
+      AZURE_OPENAI_USE_ENTRA: '1',
+    }); // explicit Entra opt-in (no key)
     const capturedAuth: (string | null)[] = [];
     const realFetch = globalThis.fetch;
     globalThis.fetch = ((_input: any, init?: any) => {


### PR DESCRIPTION
Master's test shard is red at b30f0aa7: #2354's isEntraMode treated a missing AZURE_OPENAI_API_KEY as implicit Entra mode, so the cross-recipe auth iron-rule test (test/ai/recipes-existing-regression.test.ts:131) shells out to `az` on every CI box — 6s timeout, then mismatched auth. Keyless mode now requires the explicit AZURE_OPENAI_USE_ENTRA=1 / azure_openai_use_entra opt-in that #2354 itself introduced; a missing key without the flag restores the original loud AIConfigError. Keyless (disableLocalAuth) users set one flag, documented in the recipe.

Verified: recipe-azure-openai 17/17 (tests updated to pin the explicit contract), recipes-existing-regression 17/17 (was the red one), typecheck 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)