### PR TITLE
fix(search): exact alias match should promote, not nudge — align with the inject branch

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -704,7 +704,28 @@ export async function applyAliasHop(
   for (const ref of ordered) {
     const idx = out.findIndex(r => r.slug === ref.slug && (r.source_id ?? 'default') === ref.source_id);
     if (idx >= 0) {
-      if (Number.isFinite(out[idx].score)) out[idx].score *= ALIAS_HOP_PRESENT_BOOST;
+      // PINGU LOCAL PATCH (S390) — an exact alias match PROMOTES, it doesn't nudge.
+      //
+      // Upstream multiplied by ALIAS_HOP_PRESENT_BOOST (1.10). That cannot rescue a
+      // page RRF has already buried: measured S390, the query "how is my brain set up"
+      // put its target at VECTOR rank 1 (0.8007) AND matched a registered alias, yet
+      // landed at hybrid rank 13 — because BM25 scored it 0.0000 (the conversational
+      // phrasing appears nowhere in the body) and RRF averaged a rank-1 vote with a
+      // rank-50 vote. A 10% bump on 0.6354 doesn't move that.
+      //
+      // It also removes a real inconsistency: the ABSENT branch below injects the
+      // canonical at top-of-organic, so a page could rank WORSE for having been found
+      // organically than for being missing entirely. Both branches now agree.
+      //
+      // Rationale: an alias is an EXACT, HUMAN-AUTHORED mapping from a phrase to a
+      // page — someone wrote it down precisely so that phrasing would land there. On
+      // this brain that is a stronger signal than either lexical or semantic
+      // similarity. Bounded by MAX_ALIAS_INJECT (3) and by requiring a FULL normalized
+      // query match, so it cannot fire on partial or incidental overlap.
+      if (Number.isFinite(out[idx].score)) {
+        injectScore += 1e-6;
+        out[idx].score = Math.max(out[idx].score * ALIAS_HOP_PRESENT_BOOST, injectScore);
+      }
       out[idx].alias_hit = true;
       continue;
     }


### PR DESCRIPTION
## The bug

`applyAliasHop` treats a canonical page differently depending on whether it is already in the organic results:

- **absent** → injected at top-of-organic (`injectScore += 1e-6`)
- **present** → `score *= ALIAS_HOP_PRESENT_BOOST` (1.10)

So a page can rank **worse for having been found organically** than for being missing entirely. That asymmetry is the bug.

## Why 1.10 isn't enough

A bounded 10% bump cannot rescue a page RRF has already buried.

Measured on a real brain (~14.8k pages): the query `"how is my brain set up"` put its target at **vector rank 1 (0.8007)** *and* matched a registered alias — yet it landed at **hybrid rank 13**. BM25 scored it **0.0000**, because that conversational phrasing appears nowhere in the body, and RRF averaged a rank-1 vote against a rank-50 vote. 10% on 0.6354 moved nothing.

`gbrain search diagnose` before:

```
keyword: rank=50 score=0.0000
vector:  rank=1  score=0.8007
alias:   query IS a registered alias of the target
hybrid:  rank=13 score=0.6354  evidence=alias_hit
```

after: `hybrid: rank=1`.

This shows up specifically on **natural-language aliases**, where zero lexical overlap is expected rather than evidence of irrelevance. An alias is an exact, human-authored mapping from a phrase to a page — someone wrote it down precisely so that phrasing would land there. Treating it as a tie-breaker under-uses the strongest intent signal in the index.

## The change

Both branches now agree: a present canonical is lifted to the same top-of-organic position the absent branch already used.

Still bounded — `MAX_ALIAS_INJECT` (3) caps how many pages can be promoted, and it still requires a **full normalized-query** alias match, so it cannot fire on partial or incidental overlap. `Math.max` keeps it monotonic: a page already scoring above the injection point is never demoted.

## Measurements

80-question NamedThingBench-style fixture, 7 families, real brain:

| family | before | after |
|---|---|---|
| title-substring Hit@1 | 67% | **89%** |
| title-substring MRR | 0.833 | **0.944** |
| generic-to-named Hit@3 | 63% | **67%** |
| generic-to-named MRR | 0.575 | **0.606** |
| hard-negative | 100% | **100%** (held) |

The hard-negative family is the important guard here: alias promotion does **not** surface forbidden/superseded pages.

- `bun run typecheck` — clean
- `bun test test/search-alias-resolved-boost.test.ts test/engine-resolve-slug-with-alias.test.ts` — **11 pass / 0 fail**

Happy to adjust the approach if you'd prefer the promotion gated behind a mode-bundle knob rather than applied unconditionally.