### PR TITLE
fix: reserve autopilot worker capacity

### DIFF
--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -92,6 +92,15 @@ export interface FanoutResult {
  * PGLite produces no parallelism, only queue pressure. The override is
  * still allowed (operator opt-in) but documented as ineffective on PGLite.
  */
+/** Worker capacity = every possible waiting parent plus one child slot. */
+export function resolveManagedWorkerConcurrency(fanoutMax: number): number {
+  return fanoutMax + 2; // per-source parents + global-maintenance parent + child
+}
+
+export function clampFanoutToManagedWorker(fanoutMax: number, workerConcurrency: number): number {
+  return Math.max(0, Math.min(fanoutMax, workerConcurrency - 2));
+}
+
 export async function resolveFanoutMax(engine: BrainEngine): Promise<number> {
   const override = await engine.getConfig('autopilot.fanout_max_per_tick');
   if (override) {
@@ -132,8 +141,8 @@ export async function readSupervisorConcurrency(queue = 'default'): Promise<numb
  * Resolve fanoutMax CLAMPED to the worker's effective concurrency (#2194 fix #1).
  *
  * Fanning out more cycles than the worker can run guarantees waiters that then
- * race the stalled-sweeper. Clamp to `max(1, concurrency - 1)` — reserving ≥1
- * slot for targeted sync/embed jobs that share the `default` queue.
+ * race the stalled-sweeper. Reserve one global-maintenance parent and one child
+ * slot; low-concurrency workers may therefore run zero per-source parents.
  *
  * codex #9 / D5: the clamp is BEHAVIOR-changing, so it trusts only a
  * proven-alive supervisor (live DB-lock holder, `ttl_expires_at`-gated). With
@@ -152,7 +161,7 @@ export async function resolveEffectiveFanoutMax(engine: BrainEngine, queue = 'de
     if (!snap || !isLockHolderLive(snap, SUPERVISOR_LOCK_TTL_MIN)) return base; // no live holder → unknown → no clamp
     const concurrency = await readSupervisorConcurrency(queue);
     if (concurrency === null) return base;
-    return Math.max(1, Math.min(base, concurrency - 1));
+    return clampFanoutToManagedWorker(base, concurrency);
   } catch {
     return base;
   }

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -434,6 +434,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
 
   let stopping = false;
   let childSupervisor: ChildWorkerSupervisor | null = null;
+  let autopilotWorkerConcurrency: number | null = null;
 
   // #1872: graceful engine shutdown. On PGLite the cycle steps run INLINE in
   // this process, so a hard `process.exit` mid-write (systemctl stop →
@@ -474,10 +475,12 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     // RAM) to [4096,16384]. Bare `gbrain jobs work` resolves the same default;
     // we pass it explicitly so the spawn log + child agree.
     const { resolveDefaultMaxRssMb } = await import('../core/minions/rss-default.ts');
+    const { resolveFanoutMax, resolveManagedWorkerConcurrency } = await import('./autopilot-fanout.ts');
     const autopilotMaxRssMb = resolveDefaultMaxRssMb();
+    autopilotWorkerConcurrency = resolveManagedWorkerConcurrency(await resolveFanoutMax(engine));
     childSupervisor = new ChildWorkerSupervisor({
       cliPath,
-      args: ['jobs', 'work', '--max-rss', String(autopilotMaxRssMb)],
+      args: ['jobs', 'work', '--concurrency', String(autopilotWorkerConcurrency), '--max-rss', String(autopilotMaxRssMb)],
       // process.env clone; autopilot doesn't gate shell jobs the way the
       // standalone supervisor does (autopilot is the operator-trust path).
       env: { ...process.env },
@@ -493,7 +496,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         // existing logs see the same lines.
         if (event.kind === 'worker_spawned') {
           console.log(
-            `[autopilot] Minions worker spawned (pid: ${event.pid}, watchdog: ${autopilotMaxRssMb}MB${event.tini ? ', tini: active' : ''})`,
+            `[autopilot] Minions worker spawned (pid: ${event.pid}, concurrency: ${autopilotWorkerConcurrency}, watchdog: ${autopilotMaxRssMb}MB${event.tini ? ', tini: active' : ''})`,
           );
         } else if (event.kind === 'worker_spawn_failed') {
           console.error(
@@ -975,12 +978,15 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           // codex P1-3). Fresh-install brains with no sources rows fall
           // back to the legacy single autopilot-cycle so existing
           // behavior is preserved.
-          const { dispatchPerSource, dispatchGlobalMaintenance, resolveEffectiveFanoutMax } = await import('./autopilot-fanout.ts');
+          const { dispatchPerSource, dispatchGlobalMaintenance, resolveEffectiveFanoutMax, clampFanoutToManagedWorker } = await import('./autopilot-fanout.ts');
           // #2194 fix #1: clamp fan-out to the worker's effective concurrency
           // (reserve ≥1 slot), gated on a LIVE supervisor so a stale audit row
           // can't shrink throughput (codex #9/D5). autopilot-cycle jobs run on
           // the 'default' queue, so that's the concurrency we compare against.
-          const fanoutMax = await resolveEffectiveFanoutMax(engine, 'default');
+          const requestedFanoutMax = await resolveEffectiveFanoutMax(engine, 'default');
+          const fanoutMax = autopilotWorkerConcurrency === null
+            ? requestedFanoutMax
+            : clampFanoutToManagedWorker(requestedFanoutMax, autopilotWorkerConcurrency);
           const result = await dispatchPerSource(engine, queue, {
             repoPath,
             slot,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1941,7 +1941,7 @@ export async function computeAutopilotFanoutConcurrencyCheck(engine: BrainEngine
       return { name: 'autopilot_fanout_concurrency', status: 'ok', message: 'No supervisor observed — skipping fan-out/concurrency check' };
     }
     const fanoutMax = await resolveFanoutMax(engine);
-    const effectiveSlots = Math.max(1, concurrency - 1);
+    const effectiveSlots = Math.max(0, concurrency - 2);
     if (fanoutMax > effectiveSlots) {
       return {
         name: 'autopilot_fanout_concurrency',
@@ -1950,7 +1950,7 @@ export async function computeAutopilotFanoutConcurrencyCheck(engine: BrainEngine
           `autopilot fan-out (${fanoutMax}/tick) exceeds worker concurrency (${concurrency}). ` +
           `Surplus cycles queue behind the worker and race the stalled-sweeper. ` +
           `Lower fan-out: \`gbrain config set autopilot.fanout_max_per_tick ${effectiveSlots}\`, ` +
-          `or raise the supervisor's \`--concurrency\` to ${fanoutMax + 1}. ` +
+          `or raise the supervisor's \`--concurrency\` to ${fanoutMax + 2}. ` +
           `(The clamp in autopilot does this automatically unless disabled.)`,
         details: { fanout_max: fanoutMax, concurrency, effective_slots: effectiveSlots },
       };

--- a/test/autopilot-fanout-clamp.serial.test.ts
+++ b/test/autopilot-fanout-clamp.serial.test.ts
@@ -1,7 +1,8 @@
 /**
  * #2194 fix #1 (codex #9 / D5): resolveEffectiveFanoutMax clamps the per-tick
- * fan-out to the worker's effective concurrency (max(1, concurrency-1),
- * reserving ≥1 slot) — but ONLY when a LIVE supervisor holds the queue lock.
+ * fan-out to the worker's safe capacity (max(0, concurrency-2), reserving a
+ * global-maintenance parent and a child slot) — but ONLY when a LIVE supervisor
+ * holds the queue lock.
  * A stale `started` audit row must not shrink throughput for a supervisor that
  * isn't running that config, so with no live holder the clamp is skipped and
  * the unclamped base is used.
@@ -62,13 +63,13 @@ describe('resolveEffectiveFanoutMax — clamp gated on live supervisor (#2194/co
     expect(n).toBe(8); // unclamped base
   });
 
-  test('live holder + concurrency 3 → clamp to max(1, 3-1) = 2', async () => {
+  test('live holder + concurrency 3 → reserve global + child slots, fanout = 1', async () => {
     writeStarted(3);
     const holder = await tryAcquireDbLock(engine, supervisorLockId('default'), SUPERVISOR_LOCK_TTL_MIN);
     expect(holder).not.toBeNull();
     try {
       const n = await resolveEffectiveFanoutMax(engine, 'default');
-      expect(n).toBe(2);
+      expect(n).toBe(1);
     } finally {
       await holder!.release();
     }
@@ -86,12 +87,12 @@ describe('resolveEffectiveFanoutMax — clamp gated on live supervisor (#2194/co
     }
   });
 
-  test('live holder + concurrency 1 → floor at 1 (never below 1)', async () => {
+  test('live holder + concurrency 1 → no per-source fanout', async () => {
     writeStarted(1);
     const holder = await tryAcquireDbLock(engine, supervisorLockId('default'), SUPERVISOR_LOCK_TTL_MIN);
     try {
       const n = await resolveEffectiveFanoutMax(engine, 'default');
-      expect(n).toBe(1);
+      expect(n).toBe(0);
     } finally {
       await holder!.release();
     }

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -16,6 +16,8 @@ import {
   isSourceStale,
   selectSourcesForDispatch,
   resolveFanoutMax,
+  resolveManagedWorkerConcurrency,
+  clampFanoutToManagedWorker,
   dispatchPerSource,
 } from '../src/commands/autopilot-fanout.ts';
 import type { SourceRow, BrainEngine } from '../src/core/engine.ts';
@@ -71,6 +73,17 @@ describe('isSourceStale', () => {
     const past = new Date(NOW - 6 * 60_000).toISOString();
     expect(isSourceStale(src('a', past), NOW, 5)).toBe(true);
     expect(isSourceStale(src('a', past), NOW, 60)).toBe(false);
+  });
+});
+
+describe('managed worker capacity', () => {
+  test('reserves one child slot and caps runtime fanout to startup capacity', () => {
+    for (const fanoutMax of [1, 4, 10]) {
+      const concurrency = resolveManagedWorkerConcurrency(fanoutMax);
+      expect(concurrency - (fanoutMax + 1)).toBe(1);
+      expect(clampFanoutToManagedWorker(fanoutMax + 10, concurrency)).toBe(fanoutMax);
+      expect(clampFanoutToManagedWorker(1, concurrency)).toBe(1);
+    }
   });
 });
 

--- a/test/autopilot-supervisor-wiring.test.ts
+++ b/test/autopilot-supervisor-wiring.test.ts
@@ -50,14 +50,10 @@ describe('autopilot.ts ↔ ChildWorkerSupervisor wiring', () => {
     expect(AUTOPILOT_SRC).not.toContain('STABLE_RUN_RESET_MS');
   });
 
-  it("spawns the worker with an auto-sized --max-rss (issue #1678)", () => {
-    // Post-v0.41.39.0 the flat 2048 default is gone: autopilot resolves
-    // resolveDefaultMaxRssMb() (cgroup-aware) and passes it as the cap. The
-    // argv must still carry the --max-rss flag token + the resolved value.
+  it("spawns the worker with safe concurrency and an auto-sized --max-rss", () => {
+    expect(AUTOPILOT_SRC).toContain("'jobs', 'work', '--concurrency', String(autopilotWorkerConcurrency)");
     expect(AUTOPILOT_SRC).toContain("resolveDefaultMaxRssMb");
     expect(AUTOPILOT_SRC).toContain("'--max-rss', String(autopilotMaxRssMb)");
-    expect(AUTOPILOT_SRC).toContain("'jobs', 'work'");
-    // The footgun literal must NOT come back.
     expect(AUTOPILOT_SRC).not.toContain("'--max-rss', '2048'");
   });
 

--- a/test/doctor-autopilot-fanout-concurrency.serial.test.ts
+++ b/test/doctor-autopilot-fanout-concurrency.serial.test.ts
@@ -1,8 +1,8 @@
 /**
  * #2194 fix #5: `gbrain doctor` warns when autopilot's per-tick fan-out exceeds
- * the worker's effective concurrency. Fanning out more cycles than there are
- * worker slots guarantees waiters that race the stalled-sweeper — a silent
- * misconfig the operator never saw before this check.
+ * effective safe capacity. Fanning out more cycles than there are worker slots
+ * after reserving global-maintenance + child capacity guarantees waiters that
+ * race the stalled-sweeper — a silent misconfig the operator never saw before.
  *
  * Drives computeAutopilotFanoutConcurrencyCheck directly with a fake engine so
  * the fan-out (config) and concurrency (audit) inputs are controllable without
@@ -53,12 +53,12 @@ function writeStarted(concurrency: number): void {
 }
 
 describe('computeAutopilotFanoutConcurrencyCheck (#2194 fix #5)', () => {
-  test('warns when fan-out (4) exceeds effective slots (concurrency 2 → 1)', async () => {
+  test('warns when fan-out (4) exceeds safe slots (concurrency 2 → 0)', async () => {
     writeStarted(2);
     const check = await computeAutopilotFanoutConcurrencyCheck(fakeEngine());
     expect(check.status).toBe('warn');
     expect(check.message).toContain('exceeds worker concurrency');
-    expect(check.details).toMatchObject({ fanout_max: 4, concurrency: 2, effective_slots: 1 });
+    expect(check.details).toMatchObject({ fanout_max: 4, concurrency: 2, effective_slots: 0 });
   });
 
   test('ok when fan-out fits (override 1, concurrency 4)', async () => {


### PR DESCRIPTION
Closes #2050.

## Summary
- size the managed worker for every per-source parent, global maintenance, and one child
- clamp per-tick fanout if config rises after startup
- apply the same safe capacity to externally managed workers and doctor guidance

## Verification
- `bun test test/autopilot-fanout.test.ts test/autopilot-supervisor-wiring.test.ts test/autopilot-fanout-clamp.serial.test.ts test/doctor-autopilot-fanout-concurrency.serial.test.ts` (44 pass)
- `bun run verify` (31/31)
- independent Codex blocker review: PASS