### PR TITLE
fix(mcp): GBRAIN_MCP_TAKES_HOLDERS stdio takes-holder allow-list override (#2657)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,6 +15,21 @@ import {
 } from '../core/context/resolve-ipc.ts';
 import { resolveEntitiesToPointers, logDeliveredReflexPointers } from '../core/context/retrieval-reflex.ts';
 
+/**
+ * #2657: stdio takes-holder allow-list. Fail-closed default ['world'] (the
+ * v0.28 contract — agent-facing callers never see private hunches unless the
+ * operator opts in). GBRAIN_MCP_TAKES_HOLDERS is the env escape hatch (same
+ * pattern as GBRAIN_SOURCE): comma-separated holder list, e.g.
+ * `GBRAIN_MCP_TAKES_HOLDERS=world,brain,people/alice-example`.
+ * Empty / whitespace-only values fall back to the default (never widen).
+ */
+export function resolveStdioTakesHolders(
+  raw: string | undefined = process.env.GBRAIN_MCP_TAKES_HOLDERS,
+): string[] {
+  const parsed = (raw ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  return parsed.length > 0 ? parsed : ['world'];
+}
+
 export async function startMcpServer(engine: BrainEngine) {
   const server = new Server(
     { name: 'gbrain', version: VERSION },
@@ -52,15 +67,15 @@ export async function startMcpServer(engine: BrainEngine) {
     // v0.28: stdio MCP has no per-token auth (local pipe). Default the
     // takes-holder allow-list to ['world'] so agent-facing callers don't
     // see private hunches via takes_list / takes_search / query. Operators
-    // who want stdio to see everything should call ops directly via
-    // `gbrain call <op>` (sets remote=false in src/cli.ts).
+    // widen it with GBRAIN_MCP_TAKES_HOLDERS (comma-separated, #2657) or
+    // call ops directly via `gbrain call <op>` (sets remote=false in cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
       // #1061: mark the transport so whoami can report {transport: 'stdio'}
       // instead of throwing unknown_transport. Trust posture unchanged —
       // stdio stays remote/untrusted.
       transport: 'stdio',
-      takesHoldersAllowList: ['world'],
+      takesHoldersAllowList: resolveStdioTakesHolders(),
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set
       // GBRAIN_SOURCE in the env or use --source via `gbrain call`.

--- a/test/mcp-stdio-takes-holders.test.ts
+++ b/test/mcp-stdio-takes-holders.test.ts
@@ -1,0 +1,43 @@
+/**
+ * #2657 — stdio MCP takes-holder allow-list operator override.
+ *
+ * The stdio transport hardcoded takesHoldersAllowList to ['world'] with no
+ * escape hatch, making non-world takes unreachable for stdio MCP agents.
+ * GBRAIN_MCP_TAKES_HOLDERS (comma-separated) is the opt-in widening; the
+ * fail-closed ['world'] default is preserved when unset/empty/garbage.
+ */
+import { describe, test, expect } from 'bun:test';
+import { resolveStdioTakesHolders } from '../src/mcp/server.ts';
+
+describe('resolveStdioTakesHolders (#2657)', () => {
+  test('unset → fail-closed default ["world"]', () => {
+    // `undefined` activates the parameter default, which reads
+    // process.env.GBRAIN_MCP_TAKES_HOLDERS — isolate from whatever the
+    // ambient shell happens to have set so this test is deterministic.
+    const saved = process.env.GBRAIN_MCP_TAKES_HOLDERS;
+    delete process.env.GBRAIN_MCP_TAKES_HOLDERS;
+    try {
+      expect(resolveStdioTakesHolders(undefined)).toEqual(['world']);
+    } finally {
+      if (saved !== undefined) process.env.GBRAIN_MCP_TAKES_HOLDERS = saved;
+    }
+  });
+
+  test('empty / whitespace-only → default, never an empty allow-list', () => {
+    expect(resolveStdioTakesHolders('')).toEqual(['world']);
+    expect(resolveStdioTakesHolders('  ')).toEqual(['world']);
+    expect(resolveStdioTakesHolders(', ,')).toEqual(['world']);
+  });
+
+  test('comma-split with trimming', () => {
+    expect(resolveStdioTakesHolders('world, brain , people/alice-example')).toEqual([
+      'world',
+      'brain',
+      'people/alice-example',
+    ]);
+  });
+
+  test('single non-world holder is honored (the unreachable-takes case)', () => {
+    expect(resolveStdioTakesHolders('brain')).toEqual(['brain']);
+  });
+});


### PR DESCRIPTION
Narrower re-send of the `GBRAIN_MCP_TAKES_HOLDERS` piece from #3126, which you closed as superseded but flagged as "the one piece with standalone merit" — the rest of that PR (take-proposal review CLI, calendar lookahead docs, pricing-drift guard) is intentionally left out here.

**Problem (#2657).** The stdio MCP transport hardcodes `takesHoldersAllowList: ['world']` with no escape hatch. Non-`world` takes are structurally unreachable via `takes_list` / `takes_search` / `query` for stdio MCP agents, even though `doctor` and the CLI can see them fine — confirmed independently on my own fork ([Masashi-Ono0611/gbrain](https://github.com/Masashi-Ono0611/gbrain)) when ~1176 extracted takes under the default `system`/`brain` holder were invisible via the primary MCP interface.

**Fix.** `resolveStdioTakesHolders()` reads `GBRAIN_MCP_TAKES_HOLDERS` (comma-separated, same escape-hatch pattern as `GBRAIN_SOURCE`) as an opt-in widening. Unset / empty / whitespace-only values keep the fail-closed `['world']` default — it can only widen, never silently shrink or flip open.

Tests cover: unset → default, empty/whitespace/garbage → default (never an empty allow-list), comma-split with trimming, and a single non-`world` holder being honored.

`bun run typecheck` clean; full test file green under both a clean env and an ambient `GBRAIN_MCP_TAKES_HOLDERS` (the one test that reads the parameter default is env-isolated so it can't pick up whatever the running shell happens to have set).
