### PR TITLE
fix(sync): surface a failed updateSlug in the rename path instead of silently swallowing it (#3056)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -199,6 +199,16 @@ export interface SyncResult {
   pagesAffected: string[];
   failedFiles?: number; // count of parse failures (Bug 9)
   /**
+   * #3056: renames whose cheap path (updateSlug) did not move a row — either
+   * the UPDATE matched nothing (old slug absent in the scoped source) or it
+   * threw (destination slug occupied, invalid slug). Each one fell back to
+   * add semantics, same as before this counter existed; the difference is
+   * it's now surfaced (counted here + a per-file warn naming both slugs)
+   * instead of silently swallowed. 0 / absent = every rename took the cheap
+   * page_id-preserving path.
+   */
+  renameFallbacks?: number;
+  /**
    * v0.41.13.0 partial-sync fields (only set when status === 'partial').
    *
    * D-V3-1 (honest scope): --timeout aborts ONLY in pre-bookmark phases
@@ -1794,6 +1804,8 @@ function buildPartialResult(opts: {
   renamed: number;
   reason: 'timeout' | 'pull_timeout' | 'pull_failed' | 'stall_timeout' | 'checkpoint_unavailable';
   bankedFiles?: number;
+  /** #3056: renames that fell back to add semantics before this abort. */
+  renameFallbacks?: number;
 }): SyncResult {
   return {
     status: 'partial',
@@ -1809,6 +1821,7 @@ function buildPartialResult(opts: {
     filesImported: opts.filesImported,
     reason: opts.reason,
     bankedFiles: opts.bankedFiles,
+    ...(opts.renameFallbacks ? { renameFallbacks: opts.renameFallbacks } : {}),
   };
 }
 
@@ -2605,6 +2618,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // on success (consecutive-failure semantics for the auto-skip valve).
   const succeededPaths: string[] = [];
   let chunksCreated = 0;
+  // #3056: renames that fell off the cheap updateSlug path (zero-row match or
+  // throw). Hoisted above partial() (below) so an abort mid-run still
+  // reports whatever fallbacks were counted before the abort, instead of a
+  // TDZ error or a silently dropped count.
+  let renameFallbacks = 0;
   // v0.41.13.0 (T2): tracks add+modify files actually persisted so far.
   // Only bumped from inside importOnePath's success path. partial() reports
   // this as `filesImported` so cron operators can see how much work the
@@ -2642,6 +2660,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       renamed: filtered.renamed.length,
       reason: checkpointDead ? 'checkpoint_unavailable' : reason,
       bankedFiles,
+      renameFallbacks,
     });
   };
 
@@ -2874,11 +2893,30 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         : await resolveSlugByPathOrSourcePath(engine, from, undefined);
       // The new path doesn't yet have a row, so resolve from path only.
       const newSlug = resolveSlugForPath(to);
+      // #3056: the cheap rename is OBSERVED, not assumed. A zero-row UPDATE
+      // doesn't throw, and a thrown collision used to be swallowed by an
+      // empty catch — both fell through to importFile, which created/updated
+      // the row at the new path while the old row stayed behind live
+      // (invisible to every existing signal). Both shapes are now warned
+      // with enough context to self-diagnose and counted in renameFallbacks;
+      // behavior otherwise stays "treat as add" (unchanged).
+      let renameApplied = false;
       try {
-        await engine.updateSlug(oldSlug, newSlug, renameOpts);
-      } catch {
-        // Slug doesn't exist or collision, treat as add
+        renameApplied = (await engine.updateSlug(oldSlug, newSlug, renameOpts)) > 0;
+        if (!renameApplied) {
+          serr(
+            `  [sync] rename fallback: updateSlug matched no row for ` +
+            `${oldSlug} -> ${newSlug} (${from} -> ${to}); treating as add.`,
+          );
+        }
+      } catch (err) {
+        serr(
+          `  [sync] rename fallback: updateSlug failed for ${oldSlug} -> ${newSlug} ` +
+          `(${from} -> ${to}): ${err instanceof Error ? err.message : String(err)}; ` +
+          `treating as add.`,
+        );
       }
+      if (!renameApplied) renameFallbacks++;
       // Reimport at new path (picks up content changes). Wrapped to match the
       // deletes/adds loops: a malformed renamed file is recorded to failedFiles
       // and skipped, NOT thrown uncaught. importFile still throws on content
@@ -3404,6 +3442,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       pagesAffected,
       failedFiles: failedFiles.length,
       bankedFiles,
+      ...(renameFallbacks > 0 ? { renameFallbacks } : {}),
     };
   }
 
@@ -3566,6 +3605,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     chunksCreated,
     embedded,
     pagesAffected,
+    ...(renameFallbacks > 0 ? { renameFallbacks } : {}),
   };
 }
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1940,8 +1940,14 @@ export interface BrainEngine {
    * preserved via stable page_id). `opts.sourceId` scopes the UPDATE — without
    * it, the bare `WHERE slug = old` matches every row across every source and
    * would either rename them all OR violate the (source_id, slug) UNIQUE.
+   *
+   * Returns the number of rows moved. 0 means the old slug had no row in the
+   * scoped source — an UPDATE that matches nothing does NOT throw, so callers
+   * that need to know whether the rename actually happened (e.g. the sync
+   * rename path, #3056) must check the return value rather than rely on the
+   * catch block.
    */
-  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void>;
+  updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number>;
   rewriteLinks(oldSlug: string, newSlug: string): Promise<void>;
 
   /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5445,15 +5445,18 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (mirrors postgres-engine.ts).
-    await this.db.query(
+    const result = await this.db.query(
       `UPDATE pages SET slug = $1, updated_at = now() WHERE slug = $2 AND source_id = $3`,
       [newSlug, oldSlug, sourceId]
     );
+    // #3056: report rows moved so callers can distinguish a real rename from
+    // a zero-row no-op (old slug absent), which UPDATE does not throw on.
+    return result.affectedRows ?? 0;
   }
 
   async rewriteLinks(_oldSlug: string, _newSlug: string): Promise<void> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5533,14 +5533,17 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Sync
-  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<void> {
+  async updateSlug(oldSlug: string, newSlug: string, opts?: { sourceId?: string }): Promise<number> {
     newSlug = validateSlug(newSlug);
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify so a rename in source A doesn't sweep up same-slug rows
     // in sources B/C/D (which would either rename them all OR fail the
     // (source_id, slug) UNIQUE if the new slug already exists in another source).
-    await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
+    const result = await sql`UPDATE pages SET slug = ${newSlug}, updated_at = now() WHERE slug = ${oldSlug} AND source_id = ${sourceId}`;
+    // #3056: report rows moved so callers can distinguish a real rename from
+    // a zero-row no-op (old slug absent), which UPDATE does not throw on.
+    return result.count ?? 0;
   }
 
   async rewriteLinks(_oldSlug: string, _newSlug: string): Promise<void> {

--- a/test/sync-rename-fallback.serial.test.ts
+++ b/test/sync-rename-fallback.serial.test.ts
@@ -1,0 +1,286 @@
+/**
+ * #3056 — sync rename path: a failed `updateSlug` must be surfaced, not
+ * silently swallowed.
+ *
+ * Before the fix, the rename loop in src/commands/sync.ts swallowed
+ * `updateSlug` failures with an empty catch ("treat as add") and could not
+ * see a zero-row UPDATE at all (updateSlug returned void). The run then
+ * fell through to importFile, which created/updated the row at the new
+ * path — while the old row stayed behind, live, with its slug occupied.
+ * Nothing was logged and no counter moved, so the failed rename was
+ * indistinguishable from a successful one.
+ *
+ * This is the surfacing-only cut: it observes and reports the fallback
+ * (SyncResult.renameFallbacks + a per-file stderr warn naming both slugs).
+ * It intentionally does NOT reconcile (delete) the stale old row — that's
+ * out of scope for this PR; cleanup stays with the existing `integrity` /
+ * `orphans` tooling.
+ *
+ * Coverage:
+ *   - engine contract: updateSlug returns the number of rows moved
+ *     (0 = old slug not present, i.e. the silent no-op case).
+ *   - collision fallback: destination slug already occupied → updateSlug
+ *     throws UNIQUE → surfaced (warn + counter), old row left in place.
+ *   - zero-row fallback: stored slug diverged from the path-derived one →
+ *     UPDATE matches nothing → surfaced (warn + counter), old row left in
+ *     place.
+ *   - happy path: a clean git mv reports renameFallbacks 0 and keeps the
+ *     page_id (no regression to the cheap rename).
+ *   - partial-result survival: renameFallbacks counted before a mid-run
+ *     abort must reach the returned partial SyncResult, not be dropped
+ *     (buildPartialResult didn't carry this field originally).
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+const repos: string[] = [];
+// Serial-file requirement: blocked runs write real rows to the sync-failure
+// ledger under $HOME/.gbrain — isolate HOME per test so the operator's actual
+// ledger is never touched (same pattern as sync-failure-ledger.serial.test.ts).
+let tmpHome: string;
+const originalGbrainHome = process.env.GBRAIN_HOME;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-3056-home-'));
+  // configDir() resolves under GBRAIN_HOME when set (see
+  // gbrain-home-isolation.test.ts) — os.homedir() itself isn't
+  // overridable from process.env.HOME on Bun, so GBRAIN_HOME is the real
+  // isolation lever for the operator's ~/.gbrain sync-failure ledger.
+  process.env.GBRAIN_HOME = tmpHome;
+  await resetPgliteState(engine);
+});
+
+afterEach(() => {
+  if (originalGbrainHome !== undefined) process.env.GBRAIN_HOME = originalGbrainHome;
+  else delete process.env.GBRAIN_HOME;
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  while (repos.length) {
+    const d = repos.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function personMd(title: string, body: string): string {
+  return ['---', 'type: person', `title: ${title}`, '---', '', body].join('\n');
+}
+
+/** Create a temp git repo seeded with the given files + an initial commit. */
+function mkRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-3056-'));
+  repos.push(dir);
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+  for (const [rel, content] of Object.entries(files)) {
+    mkdirSync(join(dir, rel, '..'), { recursive: true });
+    writeFileSync(join(dir, rel), content);
+  }
+  execSync('git add -A && git commit -m "initial"', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+const SYNC_OPTS = { noPull: true, noEmbed: true, noExtract: true, sourceId: 'default' } as const;
+
+/** Capture stderr warnings (serr falls through to console.error in tests). */
+async function captureErr<T>(fn: () => Promise<T>): Promise<{ result: T; err: string }> {
+  const lines: string[] = [];
+  const origErr = console.error;
+  console.error = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+  try {
+    const result = await fn();
+    return { result, err: lines.join('\n') };
+  } finally {
+    console.error = origErr;
+  }
+}
+
+async function countPages(): Promise<number> {
+  const rows = await engine.executeRaw<{ n: number | string }>(
+    `SELECT count(*)::int AS n FROM pages WHERE source_id = 'default'`,
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+describe('updateSlug engine contract (#3056)', () => {
+  test('returns 1 when the old slug row is moved', async () => {
+    await engine.putPage('people/old', {
+      type: 'person', title: 'Old', compiled_truth: 'body',
+    }, { sourceId: 'default' });
+    const moved = await engine.updateSlug('people/old', 'people/new', { sourceId: 'default' });
+    expect(moved).toBe(1);
+    expect(await engine.getPage('people/new')).not.toBeNull();
+  });
+
+  test('returns 0 when the old slug has no row (the silent no-op case)', async () => {
+    const moved = await engine.updateSlug('people/ghost', 'people/new', { sourceId: 'default' });
+    expect(moved).toBe(0);
+  });
+});
+
+describe('#3056: surfacing a failed updateSlug in the sync rename path', () => {
+  test('collision: destination slug occupied → surfaced, old row left in place (add semantics)', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(await engine.getPage('people/carol')).not.toBeNull();
+
+    // A pre-existing row already occupies the rename destination, so
+    // updateSlug throws (source_id, slug) UNIQUE and the loop falls back.
+    await engine.putPage('people/dana', {
+      type: 'person', title: 'Dana (stale)', compiled_truth: 'occupies the destination slug',
+    }, { sourceId: 'default' });
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result, err } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+
+    // The failure is surfaced: counted in the run result + warned on stderr.
+    expect(result.renameFallbacks).toBe(1);
+    expect(err).toContain('people/carol');
+    expect(err).toContain('people/dana');
+
+    // Add semantics: updateSlug threw (never touched the row), so importFile
+    // upserts the pre-existing "dana" row in place with the renamed file's
+    // content — the ORIGINAL "Dana (stale)" content is overwritten. This is
+    // the pre-existing add-semantics behavior; this PR's job is only to
+    // surface that a fallback happened (asserted above), not to prevent the
+    // overwrite — that would need the reconcile machinery, out of scope here.
+    const dana = await engine.getPage('people/dana');
+    expect(dana).not.toBeNull();
+    expect(dana!.compiled_truth).toContain('Carol is a person.');
+
+    // ...and the OLD (now-orphaned) row is left in place, still live under
+    // its original slug (no reconcile in this surfacing-only cut — cleanup
+    // stays with `integrity` / `orphans` tooling, per maintainer guidance).
+    expect(await engine.getPage('people/carol')).not.toBeNull();
+    expect(await countPages()).toBe(2); // carol (orphaned) + dana (overwritten with carol's content)
+  });
+
+  test('zero-row fallback: divergent stored slug → surfaced, not silent', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+
+    // Corrupt the row the way the field report describes: the stored slug no
+    // longer matches the path-derived one, and there is no source_path to
+    // find it by. resolveSlugsByPaths misses → the loop falls back to the
+    // path-derived slug → the UPDATE matches zero rows.
+    await engine.executeRaw(
+      `UPDATE pages SET slug = 'people/carol-divergent', source_path = NULL
+       WHERE source_id = 'default' AND slug = 'people/carol'`,
+    );
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const { result, err } = await captureErr(() => performSync(engine, { repoPath: repo, ...SYNC_OPTS }));
+    expect(result.status).toBe('synced');
+
+    // The zero-row UPDATE is no longer invisible: counted + warned with both
+    // slugs so an operator can self-diagnose (the exact diagnostic the
+    // reporter asked for).
+    expect(result.renameFallbacks).toBe(1);
+    expect(err).toContain('people/carol');
+    expect(err).toContain('people/dana');
+
+    // The new path imported; the divergent row is left as-is.
+    expect(await engine.getPage('people/dana')).not.toBeNull();
+    expect(await engine.getPage('people/carol-divergent')).not.toBeNull();
+  });
+
+  test('happy path: clean git mv rename keeps page_id and reports zero fallbacks', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({ 'people/carol.md': personMd('Carol', 'Carol is a person.') });
+    await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    const before = await engine.getPage('people/carol');
+    expect(before).not.toBeNull();
+
+    execSync('git mv people/carol.md people/dana.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m "rename carol to dana"', { cwd: repo, stdio: 'pipe' });
+
+    const result = await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(result.status).toBe('synced');
+    expect(result.renameFallbacks ?? 0).toBe(0);
+
+    const after = await engine.getPage('people/dana');
+    expect(after).not.toBeNull();
+    expect(after!.id).toBe(before!.id); // cheap-path rename preserved the row
+    expect(await engine.getPage('people/carol')).toBeNull();
+    expect(await countPages()).toBe(1);
+  });
+
+  test('renameFallbacks counted before a mid-run abort reaches the partial SyncResult', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    // Deterministic abort, not a timing race: wrap updateSlug so the FIRST
+    // call (rename #1, which will fall back) fires ac.abort() synchronously
+    // right after it resolves. Iteration #1 still finishes normally
+    // (import etc.); the abort check at the top of iteration #2 is what
+    // actually short-circuits the loop — guaranteed order, no poll/sleep.
+    const origUpdateSlug = engine.updateSlug.bind(engine);
+    const ac = new AbortController();
+    let calls = 0;
+    engine.updateSlug = async (...args: Parameters<typeof origUpdateSlug>) => {
+      calls += 1;
+      const thisCall = calls;
+      // try/finally: the collision scenario this test drives makes
+      // origUpdateSlug THROW (UNIQUE violation) — abort() must still fire
+      // on that path, not just the resolve path.
+      try {
+        return await origUpdateSlug(...args);
+      } finally {
+        if (thisCall === 1) ac.abort();
+      }
+    };
+    try {
+      const repo = mkRepo({
+        'people/carol.md': personMd('Carol', 'Carol is a person.'),
+        'people/erin.md': personMd('Erin', 'Erin is a person.'),
+      });
+      await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+
+      // Both destinations pre-occupied so EVERY rename in this run falls
+      // back (updateSlug throws) — the first call still increments
+      // renameFallbacks before the wrapper's abort() fires.
+      await engine.putPage('people/bob', {
+        type: 'person', title: 'Bob (stale)', compiled_truth: 'occupies the destination slug',
+      }, { sourceId: 'default' });
+      await engine.putPage('people/frank', {
+        type: 'person', title: 'Frank (stale)', compiled_truth: 'occupies the destination slug',
+      }, { sourceId: 'default' });
+      execSync('git mv people/carol.md people/bob.md', { cwd: repo, stdio: 'pipe' });
+      execSync('git mv people/erin.md people/frank.md', { cwd: repo, stdio: 'pipe' });
+      execSync('git commit -m "rename both to occupied destinations"', { cwd: repo, stdio: 'pipe' });
+
+      const result = await performSync(engine, { repoPath: repo, ...SYNC_OPTS, signal: ac.signal });
+
+      // This is the actual regression: buildPartialResult originally had no
+      // renameFallbacks field at all, so a mid-run abort silently dropped
+      // the count. The wrapper guarantees exactly 1 rename processed (and
+      // counted) before the abort short-circuits the 2nd.
+      expect(result.status).toBe('partial');
+      expect(result.renameFallbacks).toBe(1);
+      expect(calls).toBe(1); // proves the abort landed BEFORE the 2nd rename's updateSlug call
+    } finally {
+      engine.updateSlug = origUpdateSlug;
+    }
+  });
+});


### PR DESCRIPTION
Surfacing-only re-send of #3252, scoped to exactly what you flagged as reviewable: "returning the moved-row count from both engines, warning with `oldSlug -> newSlug` and both paths, and counting it in `SyncResult`." The reconcile half (locating and deleting the stale old row via a new `deletePage` call + three-outcome branching in the sync rename loop) is intentionally **not** included — that's the highest-blast-radius path in the system, per your review, and stays out of scope here.

**What changed.** `updateSlug` returns the number of rows moved (0 = no-op) in both `pglite-engine.ts` and `postgres-engine.ts`. The sync rename loop observes that return value — plus the throw case (destination collision) — to warn with both slugs and both paths, and counts it in `SyncResult.renameFallbacks`. Behavior is otherwise **unchanged**: a fallback still resolves as "treat as add," nothing is deleted or reconciled.

**Being upfront about what this does and doesn't fix.** In the collision case (destination slug pre-occupied), `updateSlug` throws, so `importFile` at the new path upserts the pre-existing destination row in place — silently overwriting whatever content was there before, while the orphaned old-slug row is left behind untouched. That data-loss shape is pre-existing (not introduced by this diff) and this PR does not change it — it only makes the fact that a fallback happened *visible*, via the warn + counter, instead of silent. Fixing the overwrite itself is exactly the reconcile work you scoped out of #3252.

**Testing.** `test/sync-rename-fallback.serial.test.ts`: engine contract (`updateSlug` returns 1 / 0), collision fallback (surfaced, old row left in place), zero-row fallback (divergent stored slug, surfaced), happy path (clean rename, `renameFallbacks` 0, page_id preserved), and a partial-result test proving `renameFallbacks` survives a mid-run abort into the returned partial `SyncResult` (deterministic — wraps `updateSlug` to abort after the first call rather than racing a checkpoint poll).

That last test exists because my first pass had a real bug here: `buildPartialResult` didn't carry the field at all, so a timeout/checkpoint-abort mid-rename-loop would silently drop the count — caught by an independent Codex review pass, along with a test-isolation bug (my test changed `process.env.HOME`, which doesn't actually redirect Bun's `os.homedir()` — needed `GBRAIN_HOME`) and two lines that overshot your stated scope (an aggregate warning + an ingest-summary suffix), both removed.

`bun run typecheck` clean. Full new test file green (6/6, repeated 5x with no flakes). Ran the broader `sync` / `pglite-engine` / `source-id-tx-regression` / `gbrain-home-isolation` / `sync-resumable-import` suites (225 tests) with no regressions. Postgres-engine parity for the new return-value contract is untested — no Docker on this machine — the implementation mirrors the established `result.count` pattern already used elsewhere in that file, but flagging the gap rather than claiming coverage I don't have.
