### PR TITLE
feat(config): embedding_max_chunk_tokens — opt-in estimated-token chunk cap for strict embedding backends

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -18,8 +18,9 @@
  * at runtime.
  */
 
-import { chunkText as recursiveChunk } from './recursive.ts';
+import { chunkText as recursiveChunk, capByEstimatedTokens } from './recursive.ts';
 import { buildQualifiedName } from './qualified-names.ts';
+import { estimateEmbeddingTokens } from '../cjk.ts';
 
 // Embed the tree-sitter runtime + per-language grammars as files.
 // `with { type: 'file' }` returns a path (string) at runtime. Bun bundles
@@ -177,6 +178,18 @@ export interface CodeChunkOptions {
    * smallest common embedder context (e.g. nomic-embed-text, 2048).
    */
   maxChunkTokens?: number;
+  /**
+   * Opt-in hard cap on any emitted chunk's ESTIMATED embedding tokens, for
+   * embedding backends with strict per-request token limits. Unlike
+   * `maxChunkTokens` (structural re-split triggered by the generic
+   * estimateTokens, ~3.5 chars/token — an underestimate for CJK and
+   * URL-dense text), this is measured with the conservative CJK-aware
+   * estimateEmbeddingTokens (cjk.ts) and enforced as a final pass, so it
+   * GUARANTEES the bound. UNSET (default): no final cap — behavior is
+   * identical to previous releases. Wired to the
+   * `embedding_max_chunk_tokens` config key by the import path.
+   */
+  maxEmbedTokens?: number;
 }
 
 /**
@@ -718,7 +731,14 @@ export async function chunkCodeTextFull(
     if (chunks.length === 0) {
       return { chunks: capOversizedChunks(fallbackChunks(source, filePath, language, opts), filePath, language, opts), edges: rawEdges };
     }
-    return { chunks: capOversizedChunks(mergeSmallSiblings(chunks, chunkTarget), filePath, language, opts), edges: rawEdges };
+    // Layer both caps when maxEmbedTokens is set. capOversizedChunks (#1675)
+    // splits by the generic estimateTokens (~3.5 chars/token), which
+    // undercounts CJK (~1 char/token) and URL-dense text — a Korean chunk 3x
+    // over the real limit passes its trigger untouched. capCodeChunks
+    // re-checks with the CJK-aware estimateEmbeddingTokens and is a no-op
+    // when every chunk is already under the cap.
+    const astChunks = capOversizedChunks(mergeSmallSiblings(chunks, chunkTarget), filePath, language, opts);
+    return { chunks: opts.maxEmbedTokens ? capCodeChunks(astChunks, opts.maxEmbedTokens) : astChunks, edges: rawEdges };
   } catch {
     return { chunks: fallbackChunks(source, filePath, language, opts), edges: [] };
   } finally {
@@ -799,6 +819,33 @@ function mergeSmallSiblings(chunks: CodeChunk[], chunkTarget: number): CodeChunk
     i = j;
   }
   return merged;
+}
+
+/**
+ * Opt-in final safety pass for AST-path chunks
+ * (CodeChunkOptions.maxEmbedTokens): split any chunk whose ESTIMATED
+ * embedding tokens (conservative per-char-class heuristic, cjk.ts) exceed
+ * the cap. Reaches chunks the AST logic can't subdivide — splitLargeNode
+ * returns [] for nodes with < 2 body children (giant single-statement
+ * functions, huge literals), which ship whole at any size.
+ *
+ * Split pieces inherit the source chunk's metadata verbatim; start/end
+ * lines become approximate for pieces after the first. Acceptable —
+ * these chunks exist for embedding + retrieval, and the alternative is
+ * an embedding request the server rejects (or worse, crashes on).
+ */
+function capCodeChunks(chunks: CodeChunk[], maxEmbedTokens: number): CodeChunk[] {
+  if (chunks.every((c) => estimateEmbeddingTokens(c.text) <= maxEmbedTokens)) {
+    return chunks;
+  }
+  const out: CodeChunk[] = [];
+  for (const c of chunks) {
+    const pieces = capByEstimatedTokens(c.text, maxEmbedTokens);
+    for (const piece of pieces) {
+      out.push({ ...c, text: piece, index: out.length, metadata: { ...c.metadata } });
+    }
+  }
+  return out;
 }
 
 function buildMergedChunk(group: CodeChunk[], index: number): CodeChunk {
@@ -901,7 +948,7 @@ function fallbackChunks(
 ): CodeChunk[] {
   const size = opts.fallbackChunkSizeWords ?? 300;
   const overlap = opts.fallbackOverlapWords ?? 50;
-  return recursiveChunk(source, { chunkSize: size, chunkOverlap: overlap }).map((chunk, index) =>
+  return recursiveChunk(source, { chunkSize: size, chunkOverlap: overlap, maxEmbedTokens: opts.maxEmbedTokens }).map((chunk, index) =>
     buildChunk({
       body: chunk.text, filePath, language,
       symbolName: null, symbolType: 'module',

--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -17,7 +17,13 @@
  * Lossless invariant: non-overlapping portions reassemble to original.
  */
 
-import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } from '../cjk.ts';
+import {
+  countCJKAwareWords,
+  CJK_SENTENCE_DELIMITERS,
+  CJK_CLAUSE_DELIMITERS,
+  charEmbedTokenWeight,
+  estimateEmbeddingTokens,
+} from '../cjk.ts';
 
 /**
  * Markdown chunker version. Folded into the per-page chunker_version column
@@ -48,6 +54,21 @@ export interface ChunkOptions {
   chunkSize?: number;    // target words per chunk (default 300)
   chunkOverlap?: number; // overlap words (default 50)
   maxChars?: number;     // hard cap on any chunk's char length (default 6000)
+  /**
+   * Opt-in hard cap on any chunk's ESTIMATED embedding tokens, for
+   * embedding backends with strict per-request token limits (e.g. a local
+   * llama-server with `-ub 2048` hard-fails past ~2,050 tokens/chunk;
+   * Ollama's runner EOFs similarly). Estimate = conservative per-char-class
+   * weights (see cjk.ts estimateEmbeddingTokens) — deliberately high, so
+   * the real tokenizer count stays below this value. Pick a value that
+   * leaves headroom for the contextual-retrieval prefix (≤ ~630 chars),
+   * e.g. 1500 under a ~2,050-token server limit.
+   *
+   * UNSET (default): no token cap — chunking behavior is byte-identical
+   * to previous releases. Wired to the `embedding_max_chunk_tokens`
+   * config key by the import path.
+   */
+  maxEmbedTokens?: number;
 }
 
 export interface TextChunk {
@@ -73,6 +94,7 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const chunkSize = opts?.chunkSize || 300;
   const chunkOverlap = opts?.chunkOverlap || 50;
   const maxChars = opts?.maxChars || 6000;
+  const maxEmbedTokens = opts?.maxEmbedTokens;
 
   if (!text || text.trim().length === 0) return [];
 
@@ -89,8 +111,11 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
 
   const wordCount = countWords(stripped);
   if (wordCount <= chunkSize) {
-    // Single-chunk path: still apply the maxChars cap.
-    const capped = capByChars(stripped.trim(), maxChars);
+    // Single-chunk path: still apply the maxChars cap (+ opt-in token cap).
+    let capped = capByChars(stripped.trim(), maxChars);
+    if (maxEmbedTokens) {
+      capped = capped.flatMap((t) => capByEstimatedTokens(t, maxEmbedTokens));
+    }
     return capped.map((t, i) => ({ text: t, index: i }));
   }
 
@@ -101,9 +126,15 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   // v0.32.7: hard char cap. Catches pathological CJK + whitespace-less text
   // that the word-level pipeline can't bound (a single Chinese paragraph can
   // exceed 8192 OpenAI embedding tokens at any word count).
+  // Opt-in estimated-token cap on top (maxEmbedTokens) — the char cap alone
+  // passes token-dense content (URL soup at ~1.6 chars/token) that overflows
+  // strict embedding-server limits.
   const capped: string[] = [];
   for (const chunk of withOverlap) {
-    capped.push(...capByChars(chunk.trim(), maxChars));
+    for (const piece of capByChars(chunk.trim(), maxChars)) {
+      if (maxEmbedTokens) capped.push(...capByEstimatedTokens(piece, maxEmbedTokens));
+      else capped.push(piece);
+    }
   }
   return capped.map((t, i) => ({ text: t, index: i }));
 }
@@ -128,6 +159,69 @@ function capByChars(text: string, maxChars: number): string[] {
     const slice = text.slice(i, i + maxChars).trim();
     if (slice.length > 0) out.push(slice);
     if (i + maxChars >= text.length) break;
+  }
+  return out;
+}
+
+/**
+ * How far back (in chars) the token cap looks for a friendly cut point
+ * before falling back to a hard cut. 300 covers typical rollup/list line
+ * lengths so forced splits land at line starts, not mid-URL.
+ */
+const TOKEN_CAP_CUT_LOOKBACK = 300;
+
+/**
+ * Hard-cap a chunk's ESTIMATED embedding tokens (opt-in via
+ * ChunkOptions.maxEmbedTokens). Final safety pass — runs after capByChars
+ * on every chunk, so no upstream miscounting (whitespace-word fallback,
+ * overlap inflation, char-cap survivors) can emit a chunk past the cap.
+ *
+ * Cut placement prefers, within the last TOKEN_CAP_CUT_LOOKBACK chars of
+ * the window: a newline, then any whitespace, then a hard cut. This keeps
+ * forced splits off mid-line/mid-URL positions for list-shaped content
+ * and inside code fences. No overlap is added; pieces reassemble
+ * byte-for-byte (`pieces.join('') === text`) — boundary whitespace is
+ * kept with the leading piece, never dropped.
+ *
+ * @internal exported for the code chunker (code.ts) and tests.
+ */
+export function capByEstimatedTokens(text: string, maxTokens: number): string[] {
+  if (text.length === 0) return [];
+  if (estimateEmbeddingTokens(text) <= maxTokens) return [text];
+
+  const out: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    // Greedily extend the window until the next char would break the cap.
+    // Always take at least one char so the loop makes forward progress.
+    let est = 0;
+    let end = start;
+    while (end < text.length) {
+      const w = charEmbedTokenWeight(text.charCodeAt(end));
+      if (est + w > maxTokens && end > start) break;
+      est += w;
+      end++;
+    }
+
+    if (end < text.length) {
+      const windowStart = Math.max(start + 1, end - TOKEN_CAP_CUT_LOOKBACK);
+      let cut = text.lastIndexOf('\n', end - 1);
+      if (cut < windowStart) {
+        cut = -1;
+        for (let i = end - 1; i >= windowStart; i--) {
+          const code = text.charCodeAt(i);
+          if (code === 0x20 || (code >= 0x09 && code <= 0x0d)) {
+            cut = i;
+            break;
+          }
+        }
+      }
+      if (cut >= windowStart) end = cut + 1;
+    }
+
+    const slice = text.slice(start, end);
+    if (slice.length > 0) out.push(slice);
+    start = end;
   }
   return out;
 }

--- a/src/core/cjk.ts
+++ b/src/core/cjk.ts
@@ -73,3 +73,64 @@ export function countCJKAwareWords(s: string): number {
 export function escapeLikePattern(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
+
+/**
+ * Conservative per-char-class embedding-token weights (markdown chunker v4).
+ *
+ * Why this exists: the chunker's "word" counting drastically UNDER-counts
+ * whitespace-less ASCII runs (a 150-char URL = 1 whitespace word), so
+ * word-based size targets can emit chunks that overflow an embedding
+ * server's per-request token limit. Measured on a local Qwen3-embedding
+ * llama-server stack:
+ *   - URL/phone/email-dense text tokenizes at ~1.6 chars/token
+ *   - base64-ish / minified blobs approach ~1.3 chars/token (worst case)
+ *   - Korean prose tokenizes NO WORSE than 1 char/token in practice
+ *
+ * Weights are deliberately HIGH (tokens are overestimated) so any cap
+ * based on this estimate is safe against real tokenizers:
+ *   - CJK char        → 1.0 token  (real CJK prose is cheaper)
+ *   - other non-space → 0.75 token (≈1.33 chars/token, covers base64)
+ *   - whitespace      → 0.1 token  (mostly folds into neighbor tokens)
+ */
+export const EMBED_TOKEN_WEIGHT_CJK = 1.0;
+export const EMBED_TOKEN_WEIGHT_OTHER = 0.75;
+export const EMBED_TOKEN_WEIGHT_WS = 0.1;
+
+/** BMP CJK check by UTF-16 code unit — same ranges as CJK_SLUG_CHARS. */
+export function isCJKCodeUnit(code: number): boolean {
+  return (
+    (code >= 0x4e00 && code <= 0x9fff) || // Han
+    (code >= 0x3040 && code <= 0x309f) || // Hiragana
+    (code >= 0x30a0 && code <= 0x30ff) || // Katakana
+    (code >= 0xac00 && code <= 0xd7af)    // Hangul Syllables
+  );
+}
+
+/**
+ * Per-code-unit token weight. Unrecognized whitespace (exotic Unicode
+ * spaces) intentionally falls into OTHER — that only overestimates.
+ */
+export function charEmbedTokenWeight(code: number): number {
+  if (isCJKCodeUnit(code)) return EMBED_TOKEN_WEIGHT_CJK;
+  if (
+    code === 0x20 || (code >= 0x09 && code <= 0x0d) ||
+    code === 0xa0 || code === 0x3000
+  ) {
+    return EMBED_TOKEN_WEIGHT_WS;
+  }
+  return EMBED_TOKEN_WEIGHT_OTHER;
+}
+
+/**
+ * Tokenizer-free embedding-token estimate (conservative overestimate).
+ * See weight docs above. Astral chars count as 2 OTHER code units —
+ * another overestimate, which is the safe direction.
+ */
+export function estimateEmbeddingTokens(s: string): number {
+  if (s.length === 0) return 0;
+  let est = 0;
+  for (let i = 0; i < s.length; i++) {
+    est += charEmbedTokenWeight(s.charCodeAt(i));
+  }
+  return Math.ceil(est);
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -73,6 +73,25 @@ export interface GBrainConfig {
   embedding_model?: string;
   embedding_dimensions?: number;
   /**
+   * Opt-in hard cap on any chunk's ESTIMATED embedding tokens, for
+   * embedding backends with strict per-request token limits (e.g. a local
+   * llama-server started with `-ub 2048` hard-fails past ~2,050 tokens per
+   * chunk; Ollama's runner EOFs similarly past its physical batch size).
+   * The estimate is the conservative CJK-aware per-char-class heuristic in
+   * cjk.ts (deliberately an overestimate, so the real tokenizer count stays
+   * below the cap — for Latin prose the ASCII weight overstates real
+   * tokenization ~3×, so tight caps split long English chunks that a real
+   * tokenizer would accept; that conservatism is the guarantee's price).
+   * Pick a value that leaves headroom for the contextual-retrieval prefix,
+   * e.g. 1500 under a ~2,050-token limit.
+   *
+   * UNSET (default): no cap — chunking is byte-identical to previous
+   * releases. Applies to newly (re)ingested content only; run
+   * `gbrain reindex --markdown` after setting it to re-chunk existing
+   * pages (no chunker-version bump is involved).
+   */
+  embedding_max_chunk_tokens?: number;
+  /**
    * v0.37 (D9): user opted into deferred-setup mode at init time via
    * `gbrain init --no-embedding`. When true, embed callsites and `gbrain
    * import` refuse with a `gbrain config set embedding_model <id>` hint
@@ -583,6 +602,7 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.OPENROUTER_API_KEY ? { openrouter_api_key: process.env.OPENROUTER_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
+    ...(process.env.GBRAIN_EMBEDDING_MAX_CHUNK_TOKENS ? { embedding_max_chunk_tokens: parseInt(process.env.GBRAIN_EMBEDDING_MAX_CHUNK_TOKENS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
     ...(process.env.GBRAIN_CHAT_MODEL ? { chat_model: process.env.GBRAIN_CHAT_MODEL } : {}),
     ...(process.env.GBRAIN_CHAT_FALLBACK_CHAIN
@@ -793,6 +813,11 @@ export async function loadConfigWithEngine(
     const n = Number(v);
     return Number.isNaN(n) ? undefined : n;
   }
+  const dbMaxChunkTokens = await dbInt('embedding_max_chunk_tokens');
+  if (merged.embedding_max_chunk_tokens === undefined && dbMaxChunkTokens !== undefined) {
+    merged.embedding_max_chunk_tokens = dbMaxChunkTokens;
+  }
+
   const dbWarnBytes = await dbInt('content_sanity.bytes_warn');
   const dbBlockBytes = await dbInt('content_sanity.bytes_block');
   const dbJunkEnabled = await dbBool('content_sanity.junk_patterns_enabled');
@@ -924,6 +949,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'azure_openai_use_entra',
   'embedding_model',
   'embedding_dimensions',
+  'embedding_max_chunk_tokens',
   'embedding_disabled',
   'expansion_model',
   'chat_model',

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -113,6 +113,7 @@ const MAX_FENCES_PER_PAGE = Number.parseInt(process.env.GBRAIN_MAX_FENCES_PER_PA
 async function extractFencedChunks(
   markdown: string,
   startChunkIndex: number,
+  maxEmbedTokens?: number,
 ): Promise<ChunkInput[]> {
   const out: ChunkInput[] = [];
   // Fast path: most pages (prose, tables, converted docs) contain no code
@@ -155,7 +156,7 @@ async function extractFencedChunks(
     const lang = detectCodeLanguage(pseudoPath);
     if (!lang) continue;
     try {
-      const chunks = await chunkCodeText(text, pseudoPath);
+      const chunks = await chunkCodeText(text, pseudoPath, { maxEmbedTokens });
       for (const c of chunks) {
         out.push({
           chunk_index: startChunkIndex + indexOffset++,
@@ -388,6 +389,10 @@ export async function importFromContent(
   let pageQuarantined = false;
   let pageFlagged = false;
   let pageFlagReason: 'markup_heavy' | 'oversized' | undefined;
+  // Opt-in estimated-token chunk cap (embedding_max_chunk_tokens config
+  // key) — resolved from the same effective config as the sanity gate and
+  // threaded into the chunkers below. undefined (the default) = no cap.
+  let maxEmbedTokens: number | undefined;
   {
     const baseCfg = loadConfig();
     let effectiveCfg = baseCfg;
@@ -401,6 +406,11 @@ export async function importFromContent(
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[gbrain] content-sanity: DB config lift failed (${msg}); falling back to file/env\n`);
     }
+    const rawMaxEmbedTokens = effectiveCfg?.embedding_max_chunk_tokens;
+    maxEmbedTokens =
+      typeof rawMaxEmbedTokens === 'number' && Number.isFinite(rawMaxEmbedTokens) && rawMaxEmbedTokens > 0
+        ? Math.floor(rawMaxEmbedTokens)
+        : undefined;
     const cs = effectiveCfg?.content_sanity ?? {};
     // GBRAIN_NO_SANITY=1 fast-path: loadConfig() returns null when
     // there's no `~/.gbrain/config.json` AND no DATABASE_URL env var
@@ -670,12 +680,12 @@ export async function importFromContent(
   const embedSkipped = isEmbedSkipped(parsed.frontmatter) || isQuarantined(parsed.frontmatter);
   if (!embedSkipped) {
     if (parsed.compiled_truth.trim()) {
-      for (const c of chunkText(parsed.compiled_truth)) {
+      for (const c of chunkText(parsed.compiled_truth, { maxEmbedTokens })) {
         chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
       }
     }
     if (parsed.timeline?.trim()) {
-      for (const c of chunkText(parsed.timeline)) {
+      for (const c of chunkText(parsed.timeline, { maxEmbedTokens })) {
         chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'timeline' });
       }
     }
@@ -683,7 +693,7 @@ export async function importFromContent(
     // v0.20.0 Cathedral II Layer 8 D2 — extract fenced code blocks from
     // compiled_truth as first-class code chunks.
     if (parsed.compiled_truth.trim()) {
-      const fenceChunks = await extractFencedChunks(parsed.compiled_truth, chunks.length);
+      const fenceChunks = await extractFencedChunks(parsed.compiled_truth, chunks.length, maxEmbedTokens);
       chunks.push(...fenceChunks);
     }
   }

--- a/test/chunkers/token-cap.test.ts
+++ b/test/chunkers/token-cap.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Opt-in estimated-token chunk cap — `embedding_max_chunk_tokens` config
+ * key → ChunkOptions.maxEmbedTokens / CodeChunkOptions.maxEmbedTokens.
+ *
+ * Field failure this exists for: a local llama-server embedding backend
+ * (`-ub 2048`) crashes deterministically (trace/BPT trap → EOF at the
+ * client) when a single chunk exceeds ~2,050 real tokens; Ollama's runner
+ * EOFs the same way past its physical batch size. Two content shapes
+ * trigger it:
+ *
+ *   1. Korean docs carrying one long source URL per line.
+ *      The URLs' ASCII mass pushes CJK density below 0.30, flipping
+ *      countCJKAwareWords to whitespace counting, where a 150-char URL
+ *      counts as ONE word → chunks balloon to 3-4K chars ≈ 2,000+
+ *      real tokens (URL soup tokenizes at ~1.6 chars/token).
+ *
+ *   2. Large JSON code blocks (~7K chars) that the word pipeline
+ *      undercounts the same way (few whitespace tokens).
+ *
+ * With the option SET, every emitted chunk satisfies
+ *   estimateEmbeddingTokens(chunk) <= maxEmbedTokens
+ * where the estimate deliberately OVERSTATES real tokenizer counts.
+ * With the option UNSET (the default), chunking is byte-identical to
+ * previous releases — pinned below.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { chunkText, capByEstimatedTokens } from '../../src/core/chunkers/recursive.ts';
+import { chunkCodeText } from '../../src/core/chunkers/code.ts';
+import { estimateEmbeddingTokens } from '../../src/core/cjk.ts';
+
+/** Cap under test — headroom for the contextual-retrieval prefix under a ~2,050-token server limit. */
+const CAP = 1500;
+
+/** Synthesize the failing shape: Korean rollup lines each ending in a long Notion-style URL. */
+function urlDenseKoreanRollup(lines: number): string {
+  const out: string[] = ['# 링크가 줄마다 붙는 한국어 예시 문서', ''];
+  for (let i = 0; i < lines; i++) {
+    const hex32 = (i * 2654435761 >>> 0).toString(16).padStart(8, '0').repeat(4);
+    out.push(
+      `- **항목 ${i}**: 이 줄은 청커 동작 검증을 위한 의미 없는 한국어 예시 문장입니다 · 전화 000-0000-${String(1000 + i)} · ` +
+      `이메일 user${i}@example.com · 링크: https://docs.example.com/pages/${hex32}?v=abcdef0123456789&ref=sample`,
+    );
+  }
+  return out.join('\n');
+}
+
+/** Synthesize a large pretty-printed JSON block with CJK values. */
+function bigJsonBlock(targetChars: number): string {
+  const entries: string[] = [];
+  let i = 0;
+  let len = 0;
+  while (len < targetChars) {
+    const row =
+      `  "item_${i}": { "name": "예시-${i}", "url": "https://example.com/api/v2/items/${i}?token=abc${i}def", "qty": ${i % 100}, "memo": "한국어 값이 섞인 예시 데이터" }`;
+    entries.push(row);
+    len += row.length;
+    i++;
+  }
+  return `{\n${entries.join(',\n')}\n}`;
+}
+
+describe('default behavior (maxEmbedTokens unset) — unchanged', () => {
+  test('URL-dense doc still emits over-cap chunks by default (cap is opt-in, not a silent default)', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md);
+    expect(chunks.length).toBeGreaterThan(0);
+    // This is the failure shape the option exists for: without opting in,
+    // the word pipeline's whitespace undercount still produces chunks past
+    // the estimate — proof the default path took no cap.
+    expect(chunks.some((c) => estimateEmbeddingTokens(c.text) > CAP)).toBe(true);
+  });
+
+  test('unset option and empty options object produce identical chunks', () => {
+    const md = urlDenseKoreanRollup(60);
+    expect(chunkText(md, {})).toEqual(chunkText(md));
+  });
+});
+
+describe('opt-in cap — URL-dense Korean doc (field-failure shape)', () => {
+  test('every chunk stays under the estimated-token cap', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md, { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(CAP);
+    }
+  });
+
+  test('no chunk reaches the measured 3K-char danger zone for URL soup', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md, { maxEmbedTokens: CAP });
+    // 1500 est tokens at the OTHER weight (0.75/char) bounds chunks to
+    // ~2,000 chars for pure ASCII — well under the ~3,300 chars where
+    // URL-dense content crosses ~2,050 real tokens (1.6 chars/token).
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(2600);
+    }
+  });
+
+  test('content is preserved (no lines dropped by the cap)', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md, { maxEmbedTokens: CAP });
+    const joined = chunks.map((c) => c.text).join('\n');
+    // Spot-check first / middle / last rollup lines survive chunking.
+    for (const marker of ['항목 0', '항목 30', '항목 59']) {
+      expect(joined).toContain(marker);
+    }
+  });
+});
+
+describe('opt-in cap — large JSON blocks', () => {
+  test('7K-char pretty JSON through the prose path stays under the cap', () => {
+    const md = `설정 파일 원문 보존:\n\n\`\`\`\n${bigJsonBlock(7000)}\n\`\`\`\n`;
+    const chunks = chunkText(md, { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(CAP);
+    }
+  });
+
+  test('7K-char minified JSON (single whitespace-less token) stays under the cap', () => {
+    const minified = bigJsonBlock(7000).replace(/\n\s*/g, '');
+    const chunks = chunkText(minified, { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(CAP);
+    }
+  });
+
+  test('json fence via the code chunker stays under the cap (+header slack)', async () => {
+    const chunks = await chunkCodeText(bigJsonBlock(7000), 'fence.json', { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      // buildChunk prepends a short "[JSON] fence.json:…" header AFTER the
+      // body-level cap; allow ~60 est tokens of header slack. Real-token
+      // safety margin (2,050 − overestimated 1,500) absorbs this easily.
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(CAP + 60);
+    }
+  });
+});
+
+describe('opt-in cap — normal content is untouched even when enabled', () => {
+  test('Latin prose chunks are identical when the cap clears their estimate', () => {
+    const prose = Array.from({ length: 120 }, (_, i) =>
+      `This is sentence number ${i} and it talks about ordinary things in plain words.`,
+    ).join(' ');
+    // Largest chunk of this fixture estimates ~1,730 (merge-inflated ~450
+    // words at 0.75/char) — a 2,000 cap clears it, so output is untouched.
+    const chunks = chunkText(prose, { maxEmbedTokens: 2000 });
+    expect(chunks.length).toBeGreaterThan(3);
+    expect(chunks).toEqual(chunkText(prose));
+  });
+
+  test('tight caps split long Latin chunks conservatively — bound still guaranteed', () => {
+    // The ASCII weight (0.75/char) overstates real Latin tokenization ~3×
+    // BY DESIGN (the cap must hold against any tokenizer). Consequence,
+    // pinned here so it is a documented trade-off and not a surprise: a
+    // cap of 1500 splits merge-inflated (~450-word) English chunks that a
+    // real tokenizer would count at only ~600 tokens. Users pick the cap
+    // for THEIR backend's limit; strict caps trade chunk size for the
+    // guarantee.
+    const prose = Array.from({ length: 120 }, (_, i) =>
+      `This is sentence number ${i} and it talks about ordinary things in plain words.`,
+    ).join(' ');
+    const chunks = chunkText(prose, { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(chunkText(prose).length);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(CAP);
+    }
+  });
+
+  test('Korean prose (CJK-dense, no URLs) chunks are identical with and without the cap', () => {
+    const prose = Array.from({ length: 80 }, (_, i) =>
+      `이 문장은 순수 한국어 산문의 청킹 동작을 확인하기 위한 ${i}번째 예시 문장입니다.`,
+    ).join(' ');
+    const chunks = chunkText(prose, { maxEmbedTokens: CAP });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks).toEqual(chunkText(prose));
+    for (const c of chunks) {
+      // CJK-dense chunks are char-counted (≈450 max) — nowhere near 1500.
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(700);
+    }
+  });
+});
+
+describe('capByEstimatedTokens unit behavior', () => {
+  test('returns input unchanged when under the cap', () => {
+    expect(capByEstimatedTokens('short text', 1500)).toEqual(['short text']);
+    expect(capByEstimatedTokens('', 1500)).toEqual([]);
+  });
+
+  test('prefers newline cut points within the lookback window', () => {
+    const line = 'x'.repeat(100);
+    const text = Array.from({ length: 40 }, () => line).join('\n');
+    const pieces = capByEstimatedTokens(text, 1000);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join('')).toBe(text);
+    for (const p of pieces) {
+      // Every piece should be whole lines (multiples of the 100-char line);
+      // a cut piece carries its trailing newline, so filter the empty tail.
+      for (const l of p.split('\n').filter((s) => s.length > 0)) {
+        expect(l).toBe(line);
+      }
+    }
+  });
+
+  test('reassembles byte-for-byte — boundary whitespace survives cuts', () => {
+    // Regression (found in production-scale review of the non-config
+    // predecessor PR #2847): trim() on each forced-split piece dropped
+    // cut-boundary whitespace — 15,882 of 157,823 replayed rows failed
+    // byte-for-byte reassembly.
+    const line = '  indented, with trailing spaces  ';
+    const doc = Array.from({ length: 200 }, () => line).join('\n');
+    const pieces = capByEstimatedTokens(doc, 500);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join('')).toBe(doc);
+  });
+
+  test('makes forward progress on whitespace-less input (hard cut)', () => {
+    const blob = 'a'.repeat(10_000);
+    const pieces = capByEstimatedTokens(blob, 1000);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join('')).toBe(blob);
+    for (const p of pieces) {
+      expect(estimateEmbeddingTokens(p)).toBeLessThanOrEqual(1000);
+    }
+  });
+});
+
+describe('estimateEmbeddingTokens — weight sanity', () => {
+  test('overestimates URL-dense ASCII (0.75/char ≥ measured ~0.63/char)', () => {
+    const url = 'https://docs.example.com/pages/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4?v=abc&ref=sample';
+    const est = estimateEmbeddingTokens(url);
+    expect(est).toBeGreaterThanOrEqual(Math.floor(url.length * 0.7));
+  });
+
+  test('counts CJK at 1 token/char', () => {
+    expect(estimateEmbeddingTokens('가나다라마')).toBe(5);
+  });
+
+  test('whitespace is nearly free', () => {
+    expect(estimateEmbeddingTokens('   \n\t  ')).toBeLessThanOrEqual(1);
+  });
+
+  test('empty string is 0', () => {
+    expect(estimateEmbeddingTokens('')).toBe(0);
+  });
+});

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -331,4 +331,33 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       expect(merged?.engine).toBe('pglite');
     });
   });
+  describe('embedding_max_chunk_tokens merge', () => {
+    test('DB value fills in when file/env did not set it', async () => {
+      const base: GBrainConfig = { engine: 'postgres' };
+      const engine = makeEngine({ embedding_max_chunk_tokens: '1500' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.embedding_max_chunk_tokens).toBe(1500);
+    });
+
+    test('file/env value wins over DB value', async () => {
+      const base: GBrainConfig = { engine: 'postgres', embedding_max_chunk_tokens: 1200 };
+      const engine = makeEngine({ embedding_max_chunk_tokens: '1500' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.embedding_max_chunk_tokens).toBe(1200);
+    });
+
+    test('unset everywhere stays undefined (cap is opt-in)', async () => {
+      const base: GBrainConfig = { engine: 'postgres' };
+      const merged = await loadConfigWithEngine(makeEngine({}), base);
+      expect(merged?.embedding_max_chunk_tokens).toBeUndefined();
+    });
+
+    test('non-numeric and non-positive DB values are ignored', async () => {
+      const base: GBrainConfig = { engine: 'postgres' };
+      for (const bad of ['abc', '0', '-100', '']) {
+        const merged = await loadConfigWithEngine(makeEngine({ embedding_max_chunk_tokens: bad }), base);
+        expect(merged?.embedding_max_chunk_tokens).toBeUndefined();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Refs #2826. This is the config-driven reshape of #2847 / #3074, built to the shape named in their closing review: an opt-in token limit that "defaults to today's behavior."

## Why

URL/phone/email-dense CJK markdown and large JSON code blocks produce 3–4K-char chunks that overflow strict per-request embedding-server token limits (measured: a local llama-server with `-ub 2048` EOFs deterministically past ~2,050 tokens per chunk; Ollama's runner fails the same way past its physical batch size — full reproduction in #2826). The word pipeline's whitespace fallback counts a 150-char URL as one word, so the existing `maxChars: 6000` cap never sees the real token mass. Default providers at 8,192 tokens can't hit this; self-hosted backends can, deterministically.

## What changed vs the closed PRs (blast-radius receipt)

| #2847/#3074 objection | this PR |
|---|---|
| Chunker version bumps force a full re-chunk + re-embed of every install | **No version bumps** (markdown stays v3, code stays v4). Nobody re-chunks unless they opt in and run the sweep themselves |
| Global 1500 default shrinks everyone's CJK/dense chunks; ~3× ASCII overestimate shrinks ordinary English chunks | **No default.** The cap exists only when `embedding_max_chunk_tokens` is set. Unset = **byte-identical chunking**, pinned by tests (including a pin that the URL-dense failure shape still emits over-cap chunks by default — proof the default path takes no cap) |
| Global retrieval-behavior change with no eval receipts | Default behavior unchanged ⇒ nothing to eval. Opted-in installs change chunks only for (a) content that today produces un-embeddable chunks on their backend (no vectors at all), and (b) whatever their chosen cap conservatively splits — an explicit, documented trade-off (see below) |

## Changes

- **`src/core/config.ts`** — new key `embedding_max_chunk_tokens` (positive int). All three planes: `config.json`, `GBRAIN_EMBEDDING_MAX_CHUNK_TOKENS` env, DB plane via `gbrain config set` (merged in `loadConfigWithEngine`, env/file wins, invalid/non-positive values ignored). Registered in `KNOWN_CONFIG_KEYS`.
- **`src/core/cjk.ts`** — `estimateEmbeddingTokens()`: tokenizer-free per-char-class estimate (CJK 1.0/char, other non-whitespace 0.75/char, whitespace 0.1/char). Calibrated against measured ratios (URL-dense ~1.6 chars/token, base64-worst ~1.3) and deliberately **overestimates**, so a cap based on it holds against real tokenizers. Additive exports only — `countCJKAwareWords` and `search/expansion.ts` are untouched.
- **`src/core/chunkers/recursive.ts`** — `ChunkOptions.maxEmbedTokens` (opt-in): when set, `capByEstimatedTokens()` runs as a final pass after `capByChars`, guaranteeing `estimateEmbeddingTokens(chunk) ≤ cap` for every emitted chunk. Cut points prefer a newline, then whitespace, within a 300-char lookback, so forced splits land at line boundaries instead of mid-URL. Pieces reassemble **byte-for-byte** (`pieces.join('') === input`). When unset: the option resolves to `undefined` and the added code paths are skipped entirely.
- **`src/core/chunkers/code.ts`** — `CodeChunkOptions.maxEmbedTokens` (opt-in): same final pass on AST-path chunks (the `splitLargeNode`-returns-empty case ships whole at any size). Composes with #1675's `capOversizedChunks`: that cap triggers on the generic `estimateTokens` (~3.5 chars/token), which undercounts CJK ~3.5× and URL-dense text ~2×, so an over-budget Korean chunk passes it untouched; `capCodeChunks` re-checks with the CJK-aware estimate and is a no-op when everything is already under cap. Threaded into the fallback path via `ChunkOptions.maxEmbedTokens`.
- **`src/core/import-file.ts`** — the page-ingest path (`importFromContent`: prose, timeline, and fenced-code chunks) resolves the key from the same effective config as the content-sanity gate (no additional config round-trips beyond the existing lift) and threads it into both chunkers.

**Scope note**: the standalone code-file import path (`importCodeFile`) is not auto-wired — the measured failures are all markdown-page shaped, and wiring it means either per-file DB config reads in bulk code sync or a plane asymmetry. `CodeChunkOptions.maxEmbedTokens` is exposed, so wiring it (resolved once per sync run) is a clean follow-up if wanted.

## Opt-in workflow

```
gbrain config set embedding_max_chunk_tokens 1500   # headroom for the contextual-retrieval prefix under a ~2,050-token limit
gbrain reindex --markdown                            # re-chunk existing pages; new ingests apply immediately
```

## The conservatism trade-off, stated plainly

The 0.75/char ASCII weight overstates real Latin tokenization ~3× **by design** — the cap must hold against any tokenizer without shipping one. Consequence for opted-in installs: a 1500 cap splits merge-inflated (~450-word) English chunks that a real tokenizer would count at ~600 tokens. This is pinned by a dedicated test so it's a documented property, not a surprise, and it's the user's dial: pick the cap for your backend's real limit; don't set it at all on 8K-token providers.

## Measurements (worst chunk, real Qwen3-family tokenizer via llama-server `/tokenize`, re-measured on THIS branch's code)

| input | cap unset (= today) — real tokens | cap 1500 — real tokens (estimate) |
|---|---|---|
| URL-dense Korean rollup (60 lines) | **2,462** (past the ~2,050 server limit) | 1,208 (est 1,481) |
| 7K-char minified JSON | 2,004 | 1,040 (est 1,499) |
| 7K-char pretty JSON | 1,836 | 1,050 (est 1,499) |

The estimator stayed above the real count in every case (1,481–1,499 estimated vs 1,040–1,208 real), so the guarantee holds with margin. A production-scale replay of the cap logic over 157,823 chunk rows (posted on #2847's review by @stigrunar) split 15,972 over-cap rows into 181,165 pieces with zero over-cap survivors — and surfaced a lossless-invariant bug in the original diff (`trim()` on forced-split pieces dropped boundary whitespace on 15,882 rows). That fix is folded in here, with `pieces.join('') === input` pinned in the unit tests.

## Tests

`test/chunkers/token-cap.test.ts` (17 tests):

- **default behavior pins**: URL-dense failure shape still emits over-cap chunks when the option is unset (the cap is opt-in, not a silent default); unset vs `{}` produce identical output,
- opt-in cap invariant for both failure shapes (URL-dense CJK rollup; large JSON pretty/minified through the prose path and `fence.json` through the code-chunker path),
- content preservation + byte-for-byte reassembly (regression for the #2847 trim bug),
- newline-preferring cut placement, forward progress on whitespace-less input,
- normal-content safety: Latin/CJK prose chunks identical with and without a clearing cap; the tight-cap conservative split pinned explicitly,
- `estimateEmbeddingTokens` weight sanity.

`test/loadConfig-merge.test.ts` (+4): DB-plane merge, file/env precedence, unset stays undefined, invalid values ignored.

## Verification

- `bun run verify`: **31/31 green**.
- Unit suite (project shard runner, `bun run test`): run on this branch vs an `upstream/master` (ddd66e1d) baseline on the same machine — **zero failures unique to this branch**. Branch: 10,526 pass across 3 completed shards, 6 failures (1 sink-drain flake + 5 serial), every one of which also fails on the baseline; baseline additionally fails 3 audit-isolation flakes. My environment has no embedding provider configured, which wedges one shard on the branch run and two on the baseline run (pre-existing, load-sensitive — the same class documented on #2847); the changed surface is fully covered by the directly-exercised domain suites (chunkers / cjk / config / import-file, 100% green above).
- `bun run test:slow`: 41/41.
- E2E: skipped locally (no `DATABASE_URL`), per the `test:full` documented skip path. Engine-agnostic change — pure text pipeline + config plumbing; chunk rows flow through both engines' existing `upsertChunks` unchanged, and the config merge is exercised against the engine interface with fake-engine tests.
- Eval replay: not triggered — no CONTRIBUTING-listed retrieval trigger paths touched, and default chunk boundaries are pinned unchanged by the test suite.
