### PR TITLE
fix: harden multi-source maintenance and Chronicle backfill

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,13 +55,14 @@ export function bigintToStringReplacer(_key: string, value: unknown): unknown {
 }
 
 // CLI-only commands that bypass the operation layer
-export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'maintain', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'reconcile-links', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'retrieval-upgrade', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector']);
+export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'maintain', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'backfill', 'code-callers', 'code-callees', 'reconcile-links', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'retrieval-upgrade', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
 const CLI_ONLY_SELF_HELP = new Set([
   'upgrade', 'post-upgrade', 'check-update',
   'embed', 'config',
+  'backfill',
   'skillpack', 'skillpack-check',
   'integrations', 'friction',
   'frontmatter', 'check-resolvable',
@@ -1168,6 +1169,13 @@ async function handleCliOnly(command: string, args: string[]) {
     await runSchema(args);
     return;
   }
+  if (command === 'backfill') {
+    // The handler owns its engine lifecycle. Keep `list` / `--help` DB-free
+    // and avoid opening a second connection for real backfill runs.
+    const { runBackfillCommand } = await import('./commands/backfill.ts');
+    await runBackfillCommand(args);
+    return;
+  }
   if (command === 'init') {
     const { runInit } = await import('./commands/init.ts');
     await runInit(args);
@@ -2164,13 +2172,6 @@ async function handleCliOnly(command: string, args: string[]) {
         const { reindexFrontmatterCli } = await import('./commands/reindex-frontmatter.ts');
         await reindexFrontmatterCli(args);
         return; // reindexFrontmatterCli handles its own engine lifecycle
-      }
-      case 'backfill': {
-        // v0.30.1: first-class generic backfill command. Subcommand dispatch
-        // is inside runBackfillCommand (kind | list | --help).
-        const { runBackfillCommand } = await import('./commands/backfill.ts');
-        await runBackfillCommand(args);
-        return;
       }
       case 'code-callers': {
         // v0.20.0 Cathedral II Layer 10 (C4): "who calls <symbol>?"

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -92,6 +92,20 @@ export interface Check {
 }
 
 /**
+ * Resolve a files.storage_path against the root of the source that owns it.
+ * The global sync.repo_path is only a legacy fallback: on a multi-source brain
+ * it may point at a completely different checkout.
+ */
+export function resolveImageAssetPath(
+  storagePath: string,
+  sourceLocalPath: string | null,
+  fallbackRepoRoot: string,
+): string {
+  if (isAbsolute(storagePath)) return storagePath;
+  return join(sourceLocalPath ?? fallbackRepoRoot, storagePath);
+}
+
+/**
  * Structured doctor report. Stable shape consumed by:
  *   - gbrain doctor --json (CLI)
  *   - run_doctor MCP op (remote callers)
@@ -7510,21 +7524,26 @@ export async function buildChecks(
   if (engine) {
     progress.heartbeat('image_assets');
     try {
-      const rows = await engine.executeRaw<{ storage_path: string }>(
-        `SELECT storage_path FROM files WHERE mime_type LIKE 'image/%' LIMIT 1000`
+      const rows = await engine.executeRaw<{
+        storage_path: string;
+        source_id: string | null;
+        source_local_path: string | null;
+      }>(
+        `SELECT f.storage_path, f.source_id, s.local_path AS source_local_path
+           FROM files f
+           LEFT JOIN sources s ON s.id = COALESCE(f.source_id, 'default')
+          WHERE f.mime_type LIKE 'image/%'
+          LIMIT 1000`
       );
       let vanished = 0;
       const vanishedPaths: string[] = [];
       const fs = await import('node:fs');
-      const nodePath = await import('node:path');
       // storage_path is repo-relative for sync-ingested assets. Resolving
       // against cwd made this check a false-positive WARN whenever doctor
       // ran outside the brain repo.
       const repoRoot = (await engine.getConfig('sync.repo_path')) ?? process.cwd();
       for (const r of rows) {
-        const abs = nodePath.isAbsolute(r.storage_path)
-          ? r.storage_path
-          : nodePath.join(repoRoot, r.storage_path);
+        const abs = resolveImageAssetPath(r.storage_path, r.source_local_path, repoRoot);
         try {
           fs.statSync(abs);
         } catch {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -105,6 +105,48 @@ export function resolveImageAssetPath(
   return join(sourceLocalPath ?? fallbackRepoRoot, storagePath);
 }
 
+export interface DoctorImageAssetRow {
+  storage_path: string;
+  content_hash: string | null;
+  source_id: string | null;
+  source_local_path: string | null;
+}
+
+/**
+ * Count logical image assets, not files-table rows. Historical imports may
+ * leave both a basename-only row and a source-relative row for the same hash;
+ * one valid path is enough to prove that image is present.
+ */
+export function summarizeImageAssetPresence(
+  rows: DoctorImageAssetRow[],
+  fallbackRepoRoot: string,
+  pathExists: (path: string) => boolean = existsSync,
+): { total: number; missing: number; missingPaths: string[] } {
+  const assets = new Map<string, { present: boolean; examplePath: string }>();
+  for (const row of rows) {
+    const key = row.content_hash || `${row.source_id ?? 'default'}\0${row.storage_path}`;
+    const absolutePath = resolveImageAssetPath(
+      row.storage_path,
+      row.source_local_path,
+      fallbackRepoRoot,
+    );
+    const present = pathExists(absolutePath);
+    const current = assets.get(key);
+    if (!current) {
+      assets.set(key, { present, examplePath: row.storage_path });
+    } else if (present) {
+      current.present = true;
+      current.examplePath = row.storage_path;
+    }
+  }
+  const missingPaths = Array.from(assets.values())
+    .filter(asset => !asset.present)
+    .slice(0, 5)
+    .map(asset => asset.examplePath);
+  const missing = Array.from(assets.values()).filter(asset => !asset.present).length;
+  return { total: assets.size, missing, missingPaths };
+}
+
 /**
  * Structured doctor report. Stable shape consumed by:
  *   - gbrain doctor --json (CLI)
@@ -7524,42 +7566,29 @@ export async function buildChecks(
   if (engine) {
     progress.heartbeat('image_assets');
     try {
-      const rows = await engine.executeRaw<{
-        storage_path: string;
-        source_id: string | null;
-        source_local_path: string | null;
-      }>(
-        `SELECT f.storage_path, f.source_id, s.local_path AS source_local_path
+      const rows = await engine.executeRaw<DoctorImageAssetRow>(
+        `SELECT f.storage_path, f.content_hash, f.source_id,
+                s.local_path AS source_local_path
            FROM files f
            LEFT JOIN sources s ON s.id = COALESCE(f.source_id, 'default')
           WHERE f.mime_type LIKE 'image/%'
           LIMIT 1000`
       );
-      let vanished = 0;
-      const vanishedPaths: string[] = [];
-      const fs = await import('node:fs');
       // storage_path is repo-relative for sync-ingested assets. Resolving
       // against cwd made this check a false-positive WARN whenever doctor
-      // ran outside the brain repo.
+      // ran outside the brain repo. On multi-source brains each row must use
+      // its owning source's local_path, not the global sync.repo_path.
       const repoRoot = (await engine.getConfig('sync.repo_path')) ?? process.cwd();
-      for (const r of rows) {
-        const abs = resolveImageAssetPath(r.storage_path, r.source_local_path, repoRoot);
-        try {
-          fs.statSync(abs);
-        } catch {
-          vanished++;
-          if (vanishedPaths.length < 5) vanishedPaths.push(r.storage_path);
-        }
-      }
-      if (rows.length === 0) {
+      const presence = summarizeImageAssetPresence(rows, repoRoot);
+      if (presence.total === 0) {
         checks.push({ name: 'image_assets', status: 'ok', message: 'No image assets indexed yet' });
-      } else if (vanished === 0) {
-        checks.push({ name: 'image_assets', status: 'ok', message: `${rows.length} image(s) all present on disk` });
+      } else if (presence.missing === 0) {
+        checks.push({ name: 'image_assets', status: 'ok', message: `${presence.total} image(s) all present on disk` });
       } else {
         checks.push({
           name: 'image_assets',
           status: 'warn',
-          message: `${vanished} of ${rows.length} image(s) missing from disk (e.g. ${vanishedPaths.join(', ')}). ` +
+          message: `${presence.missing} of ${presence.total} image(s) missing from disk (e.g. ${presence.missingPaths.join(', ')}). ` +
                    `Fix: restore from git, or \`gbrain sync --skip-failed\` to acknowledge.`,
         });
       }

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -63,6 +63,7 @@ import { createHash } from 'crypto';
 import { runSlidingPool } from '../core/worker-pool.ts';
 import { isAborted } from '../core/abort-check.ts';
 import { parseWorkers, resolveWorkersWithClamp } from '../core/sync-concurrency.ts';
+import { isSourceFederated, loadAllSources } from '../core/sources-load.ts';
 
 // Batch size for addLinksBatch / addTimelineEntriesBatch.
 // Postgres bind-parameter limit is 65535. Links use 4 cols/row → 16K hard ceiling;
@@ -106,10 +107,11 @@ export async function stampExtracted(
 /**
  * v0.42.7 (#1696): pure cross-source resolution for one extracted link
  * candidate. Validates both endpoints exist (else the batch JOIN drops the row),
- * then picks from_source_id / to_source_id: prefer the origin page's source,
- * fall back to 'default', else skip (never push a wrong-source edge). Returns
- * null when the candidate should be skipped. Shared by extractLinksFromDB and
- * extractStaleFromDB so the F10 multi-source resolution can't drift.
+ * then picks from_source_id / to_source_id. Federated sources may fall back to
+ * `default`; isolated sources require both endpoints to stay in the page's
+ * source. Returns null when the candidate should be skipped. Shared by
+ * extractLinksFromDB and extractStaleFromDB so the F10 multi-source resolution
+ * and source-isolation policy can't drift.
  */
 export function resolveCandidateSources(
   c: LinkCandidate,
@@ -117,14 +119,21 @@ export function resolveCandidateSources(
   pageSourceId: string,
   allSlugs: Set<string>,
   slugToSources: Map<string, string[]>,
+  allowCrossSource = true,
 ): { fromSlug: string; fromSourceId: string; toSourceId: string } | null {
   const fromSlug = c.fromSlug ?? pageSlug;
   if (!allSlugs.has(c.targetSlug)) return null;
   if (!allSlugs.has(fromSlug)) return null;
   const fromSources = slugToSources.get(fromSlug) ?? [];
+  const targetSources = slugToSources.get(c.targetSlug) ?? [];
+  if (!allowCrossSource) {
+    if (!fromSources.includes(pageSourceId) || !targetSources.includes(pageSourceId)) {
+      return null;
+    }
+    return { fromSlug, fromSourceId: pageSourceId, toSourceId: pageSourceId };
+  }
   const fromSourceId = fromSources.includes(pageSourceId) ? pageSourceId
     : (fromSources.includes('default') ? 'default' : fromSources[0]);
-  const targetSources = slugToSources.get(c.targetSlug) ?? [];
   let toSourceId: string;
   if (targetSources.includes(fromSourceId)) {
     toSourceId = fromSourceId;
@@ -1451,6 +1460,11 @@ async function extractLinksFromDB(
     list.push(ref.source_id);
     slugToSources.set(ref.slug, list);
   }
+  const federatedSourceIds = new Set(
+    (await loadAllSources(engine))
+      .filter(source => isSourceFederated(source.config))
+      .map(source => source.id),
+  );
   let processed = 0, created = 0;
   // v0.42.7 (#1696): pages whose links we extracted this run — stamped after
   // the loop so a manual `gbrain extract links|all --source db` clears the
@@ -1507,7 +1521,10 @@ async function extractLinksFromDB(
       // helper in v0.42.7 (#1696) so extract --stale reuses the exact same
       // endpoint-validation + from/to source-id picking (null = skip: missing
       // endpoint OR target only in a non-origin/non-default source).
-      const resolved = resolveCandidateSources(c, slug, source_id, allSlugs, slugToSources);
+      const resolved = resolveCandidateSources(
+        c, slug, source_id, allSlugs, slugToSources,
+        federatedSourceIds.has(source_id),
+      );
       if (!resolved) continue;
       const { fromSlug, fromSourceId, toSourceId } = resolved;
 
@@ -1754,6 +1771,11 @@ export async function extractStaleFromDB(
     list.push(ref.source_id);
     slugToSources.set(ref.slug, list);
   }
+  const federatedSourceIds = new Set(
+    (await loadAllSources(engine))
+      .filter(source => isSourceFederated(source.config))
+      .map(source => source.id),
+  );
 
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
   progress.start('extract.stale', totalStale);
@@ -1780,7 +1802,10 @@ export async function extractStaleFromDB(
         { skipFrontmatter: !includeFrontmatter, globalBasename },
       );
       for (const c of extracted.candidates) {
-        const r = resolveCandidateSources(c, page.slug, page.source_id, allSlugs, slugToSources);
+        const r = resolveCandidateSources(
+          c, page.slug, page.source_id, allSlugs, slugToSources,
+          federatedSourceIds.has(page.source_id),
+        );
         if (!r) continue;
         linkRows.push({
           from_slug: r.fromSlug, to_slug: c.targetSlug, link_type: c.linkType,

--- a/src/core/chronicle/extract-events.ts
+++ b/src/core/chronicle/extract-events.ts
@@ -190,6 +190,27 @@ Prefer the page's known date for "when" when the text gives no explicit time. Us
  */
 const DEFAULT_JUDGE_MAX_TOKENS = 4000;
 
+/**
+ * Split a bounded judge window near its midpoint, preferring a line boundary
+ * so transcript/message records are not cut in half. The two segments are
+ * disjoint: combining their proposals cannot double-count boundary text.
+ */
+function splitJudgeBody(body: string): [string, string] | null {
+  if (body.length < 2) return null;
+  const midpoint = Math.floor(body.length / 2);
+  const before = body.lastIndexOf('\n', midpoint);
+  const after = body.indexOf('\n', midpoint);
+  const candidates = [before, after].filter((i) => i > 0 && i < body.length - 1);
+  const splitAt = candidates.length > 0
+    ? candidates.reduce((best, i) =>
+      Math.abs(i - midpoint) < Math.abs(best - midpoint) ? i : best)
+    : midpoint;
+  const skip = body[splitAt] === '\n' ? 1 : 0;
+  const left = body.slice(0, splitAt).trim();
+  const right = body.slice(splitAt + skip).trim();
+  return left && right ? [left, right] : null;
+}
+
 function defaultJudge(engine: BrainEngine): ChronicleJudge {
   return async (input) => {
     const { isAvailable, chat } = await import('../ai/gateway.ts');
@@ -202,33 +223,56 @@ function defaultJudge(engine: BrainEngine): ChronicleJudge {
       const n = parseInt(capRaw, 10);
       if (Number.isFinite(n) && n > 0) maxTokens = n;
     }
-    let text: string;
-    try {
+
+    const judgeBody = async (
+      segment: string,
+      requireUsableOutput = false,
+    ): Promise<ChronicleJudgeResult> => {
       const res = await chat({
         system: JUDGE_SYSTEM,
         messages: [{
           role: 'user',
           content:
             `<page slug="${input.slug}" type="${input.type}" date="${input.effectiveDate ?? ''}">\n` +
-            `${input.title}\n\n${body}\n</page>\n\n` +
+            `${input.title}\n\n${segment}\n</page>\n\n` +
             `Known attendees: ${input.attendees.slice(0, 10).join(', ') || '(none)'}.\nExtract the events.`,
         }],
         maxTokens,
       });
-      if (res.stopReason === 'refusal' || res.stopReason === 'content_filter') return { events: [] };
-      // #2606: output hit the token cap — the JSON array is cut mid-stream.
-      // Do NOT feed it to the parser as if complete; surface the truncation.
+      if (res.stopReason === 'refusal' || res.stopReason === 'content_filter') {
+        // A refusal on the one-shot path remains a legitimate empty result.
+        // During split recovery it means one half was not judged, so treating
+        // it as [] would commit a partial Chronicle and suppress future retry.
+        return requireUsableOutput
+          ? { events: [], failure: 'parse_failed' }
+          : { events: [] };
+      }
       if (res.stopReason === 'length') return { events: [], failure: 'truncated' };
-      text = res.text;
+      const parsed = parseJudgeJson(res.text);
+      return parsed === null
+        ? { events: [], failure: 'parse_failed' }
+        : { events: parsed };
+    };
+
+    try {
+      const first = await judgeBody(body);
+      if (first.failure !== 'truncated') return first;
+
+      // A dense 12k transcript can exceed even providers' hard output caps.
+      // Keep the common path at one call; only a proven truncation retries as
+      // two disjoint half-windows. Both halves must succeed before returning
+      // any proposals, preserving the caller's all-or-nothing parse barrier.
+      const halves = splitJudgeBody(body);
+      if (!halves) return first;
+      const left = await judgeBody(halves[0], true);
+      if (left.failure) return left;
+      const right = await judgeBody(halves[1], true);
+      if (right.failure) return right;
+      return { events: [...left.events, ...right.events] };
     } catch (err) {
       if ((err as Error)?.name === 'AbortError') throw err;
       return { events: [] };
     }
-    const parsed = parseJudgeJson(text);
-    // #2606: non-empty model text with no parseable JSON array is a parse
-    // failure, distinct from the model legitimately answering `[]`.
-    if (parsed === null) return { events: [], failure: 'parse_failed' };
-    return { events: parsed };
   };
 }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -5652,19 +5652,35 @@ const chronicle_backfill: Operation = {
       const { MinionQueue } = await import('./minions/queue.ts');
       queue = new MinionQueue(ctx.engine) as unknown as QueueLike;
     }
-    let scanned = 0, eligible = 0, enqueued = 0;
+    // Match the advisor's definition of "already in the timeline." Without
+    // this guard, any broad updated_at rewrite (reindex, CR migration) makes
+    // the backfill re-enqueue every historical meeting even though the worker
+    // already projected it into an event page.
+    const coveredRows = await ctx.engine.executeRaw<{ slug: string; source_id: string }>(
+      `SELECT DISTINCT p.slug, p.source_id
+         FROM pages p
+         JOIN timeline_entries te ON te.page_id = p.id
+        WHERE p.deleted_at IS NULL
+          AND te.event_page_id IS NOT NULL`,
+    );
+    const covered = new Set(coveredRows.map(row => `${row.source_id}\0${row.slug}`));
+    let scanned = 0, eligible = 0, enqueued = 0, alreadyCovered = 0;
     const errors: { slug: string; error: string }[] = [];
     for (const type of TYPES) {
       const pages = await ctx.engine.listPages({ type, updated_after, limit, ...scope });
       for (const page of pages) {
         scanned++;
+        if (covered.has(`${page.source_id}\0${page.slug}`)) {
+          alreadyCovered++;
+          continue;
+        }
         const dreamGenerated = (page.frontmatter as Record<string, unknown> | undefined)?.dream_generated === true;
         const elig = isChronicleEligible({ type: page.type, slug: page.slug, body: page.compiled_truth, dreamGenerated });
         if (!elig.ok) continue;
         eligible++;
         if (dryRun || !queue) continue;
         try {
-          await queue.add('chronicle_extract', { slug: page.slug, sourceId: ctx.sourceId ?? 'default' });
+          await queue.add('chronicle_extract', { slug: page.slug, sourceId: page.source_id });
           enqueued++;
         } catch (e) {
           // Never swallow — surface per-page failures (the #2057 no-swallow pattern).
@@ -5672,7 +5688,7 @@ const chronicle_backfill: Operation = {
         }
       }
     }
-    return { scanned, eligible, enqueued, dry_run: dryRun, errors };
+    return { scanned, eligible, already_covered: alreadyCovered, enqueued, dry_run: dryRun, errors };
   },
   cliHints: { name: 'chronicle-backfill' },
 };

--- a/test/chronicle-backfill.test.ts
+++ b/test/chronicle-backfill.test.ts
@@ -43,4 +43,34 @@ describe('chronicle_backfill op', () => {
     const jobs = await engine.executeRaw<{ n: number }>(`SELECT count(*)::int AS n FROM minion_jobs WHERE name='chronicle_extract'`);
     expect(Number(jobs[0].n)).toBe(2);
   });
+
+  test('skips pages that already project an event into the timeline', async () => {
+    const covered = await engine.putPage(
+      'meetings/already-covered',
+      { type: 'meeting', title: 'covered', compiled_truth: LONG },
+    );
+    const pending = await engine.putPage(
+      'meetings/still-pending',
+      { type: 'meeting', title: 'pending', compiled_truth: LONG },
+    );
+    const event = await engine.putPage(
+      'events/already-covered',
+      { type: 'event', title: 'event', compiled_truth: LONG },
+    );
+    await engine.executeRaw(
+      `INSERT INTO timeline_entries (page_id, event_page_id, date, source, summary, detail)
+       VALUES ($1, $2, '2026-07-28', 'chronicle', 'Already projected', '')`,
+      [covered.id, event.id],
+    );
+
+    const r = await operationsByName.chronicle_backfill.handler(
+      mkCtx(),
+      { dry_run: true },
+    ) as { eligible: number; already_covered: number; enqueued: number };
+
+    expect(r.eligible).toBe(1);
+    expect(r.already_covered).toBe(1);
+    expect(r.enqueued).toBe(0);
+    expect(pending.source_id).toBe('default');
+  });
 });

--- a/test/chronicle-extract.test.ts
+++ b/test/chronicle-extract.test.ts
@@ -10,6 +10,12 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { isChronicleEligible } from '../src/core/chronicle/eligibility.ts';
 import { runChronicleExtract, parseJudgeJson, type ChronicleJudge } from '../src/core/chronicle/extract-events.ts';
 import { runChronicleBackstop } from '../src/core/chronicle/backstop.ts';
+import {
+  configureGateway,
+  resetGateway,
+  __setChatTransportForTests,
+} from '../src/core/ai/gateway.ts';
+import type { ChatOpts, ChatResult } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 const LONG_BODY = 'A'.repeat(120);
@@ -17,6 +23,39 @@ const LONG_BODY = 'A'.repeat(120);
 async function countEvents(): Promise<number> {
   const r = await engine.executeRaw<{ n: number }>(`SELECT count(*)::int AS n FROM pages WHERE type = 'event'`);
   return Number(r[0].n);
+}
+
+function chatResult(text: string, stopReason: ChatResult['stopReason']): ChatResult {
+  return {
+    text,
+    blocks: [{ type: 'text', text }],
+    stopReason,
+    usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'deepseek:deepseek-v4-flash',
+    providerId: 'deepseek',
+  } as ChatResult;
+}
+
+function eventJson(what: string): string {
+  return JSON.stringify([{
+    when: '2026-06-18',
+    who: ['people/sarah-chen'],
+    what,
+    kind: 'meeting',
+  }]);
+}
+
+function configureChronicleTestGateway(): void {
+  resetGateway();
+  __setChatTransportForTests(null);
+  configureGateway({
+    chat_model: 'deepseek:deepseek-v4-flash',
+    env: { DEEPSEEK_API_KEY: 'sk-test' },
+  });
+}
+
+function restoreGateway(): void {
+  resetGateway();
 }
 
 beforeAll(async () => {
@@ -127,6 +166,102 @@ describe('runChronicleExtract', () => {
     const r = await runChronicleExtract(engine, { slug: 'meetings/2026-06-18-sync', judge: parseFailed });
     expect(r.status).toBe('skipped');
     expect(r.reason).toBe('judge_parse_failed');
+  });
+
+  test('default judge splits a truncated 12k window and recovers both halves', async () => {
+    const body = `LEFT_MARKER\n${'L'.repeat(5_900)}\nRIGHT_MARKER\n${'R'.repeat(5_900)}`;
+    await engine.putPage('meetings/2026-06-18-sync', {
+      type: 'meeting', title: 'Dense sync',
+      compiled_truth: body,
+      frontmatter: { attendees: ['people/sarah-chen'] },
+      effective_date: new Date('2026-06-18T15:00:00Z'),
+    });
+    await engine.setConfig('chronicle.judge_max_tokens', '8000');
+    configureChronicleTestGateway();
+    const seen: ChatOpts[] = [];
+    __setChatTransportForTests(async (opts) => {
+      seen.push(opts);
+      if (seen.length === 1) return chatResult('[{"when":"2026-06-18"', 'length');
+      const prompt = String(opts.messages[0]?.content ?? '');
+      if (prompt.includes('LEFT_MARKER')) return chatResult(eventJson('left event'), 'end');
+      if (prompt.includes('RIGHT_MARKER')) return chatResult(eventJson('right event'), 'end');
+      throw new Error('split prompt did not preserve a segment marker');
+    });
+
+    try {
+      const r = await runChronicleExtract(engine, { slug: 'meetings/2026-06-18-sync' });
+      expect(seen).toHaveLength(3);
+      expect(seen.every((opts) => opts.maxTokens === 8000)).toBe(true);
+      const leftPrompt = String(seen[1]!.messages[0]?.content ?? '');
+      const rightPrompt = String(seen[2]!.messages[0]?.content ?? '');
+      expect(leftPrompt.includes('LEFT_MARKER')).toBe(true);
+      expect(leftPrompt.includes('RIGHT_MARKER')).toBe(false);
+      expect(rightPrompt.includes('LEFT_MARKER')).toBe(false);
+      expect(rightPrompt.includes('RIGHT_MARKER')).toBe(true);
+      expect(r.status).toBe('extracted');
+      expect(r.events_written).toBe(2);
+    } finally {
+      await engine.unsetConfig('chronicle.judge_max_tokens');
+      restoreGateway();
+    }
+  });
+
+  test('split retry remains all-or-nothing when one half is still truncated', async () => {
+    const body = `LEFT_MARKER\n${'L'.repeat(5_900)}\nRIGHT_MARKER\n${'R'.repeat(5_900)}`;
+    await engine.putPage('meetings/2026-06-18-sync', {
+      type: 'meeting', title: 'Dense sync',
+      compiled_truth: body,
+      frontmatter: { attendees: ['people/sarah-chen'] },
+      effective_date: new Date('2026-06-18T15:00:00Z'),
+    });
+    await engine.setConfig('chronicle.judge_max_tokens', '8000');
+    configureChronicleTestGateway();
+    let calls = 0;
+    __setChatTransportForTests(async () => {
+      calls++;
+      if (calls === 1) return chatResult('[{"when":"2026-06-18"', 'length');
+      if (calls === 2) return chatResult(eventJson('left event'), 'end');
+      return chatResult('[{"when":"2026-06-18"', 'length');
+    });
+
+    try {
+      const r = await runChronicleExtract(engine, { slug: 'meetings/2026-06-18-sync' });
+      expect(calls).toBe(3);
+      expect(r.status).toBe('skipped');
+      expect(r.reason).toBe('judge_truncated');
+      expect(await countEvents()).toBe(0);
+    } finally {
+      await engine.unsetConfig('chronicle.judge_max_tokens');
+      restoreGateway();
+    }
+  });
+
+  test('split retry writes nothing when one half is filtered', async () => {
+    const body = `LEFT_MARKER\n${'L'.repeat(5_900)}\nRIGHT_MARKER\n${'R'.repeat(5_900)}`;
+    await engine.putPage('meetings/2026-06-18-sync', {
+      type: 'meeting', title: 'Dense sync',
+      compiled_truth: body,
+      frontmatter: { attendees: ['people/sarah-chen'] },
+      effective_date: new Date('2026-06-18T15:00:00Z'),
+    });
+    configureChronicleTestGateway();
+    let calls = 0;
+    __setChatTransportForTests(async () => {
+      calls++;
+      if (calls === 1) return chatResult('[{"when":"2026-06-18"', 'length');
+      if (calls === 2) return chatResult(eventJson('left event'), 'end');
+      return chatResult('', 'content_filter');
+    });
+
+    try {
+      const r = await runChronicleExtract(engine, { slug: 'meetings/2026-06-18-sync' });
+      expect(calls).toBe(3);
+      expect(r.status).toBe('skipped');
+      expect(r.reason).toBe('judge_parse_failed');
+      expect(await countEvents()).toBe(0);
+    } finally {
+      restoreGateway();
+    }
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -46,6 +46,12 @@ describe('CLI structure', () => {
     expect(onlyMatch![1]).toContain(`'reindex'`);
   });
 
+  test('backfill is in CLI_ONLY (does not get "Unknown command")', () => {
+    const onlyMatch = cliSource.match(/const CLI_ONLY = new Set\(\[([\s\S]*?)\]\)/);
+    expect(onlyMatch).not.toBeNull();
+    expect(onlyMatch![1]).toContain(`'backfill'`);
+  });
+
   test('has formatResult function for CLI output', () => {
     expect(cliSource).toContain('function formatResult');
   });
@@ -157,6 +163,26 @@ describe('CLI dispatch integration', () => {
       expect(stdout).not.toContain('Already up to date.');
       expect(stderr).not.toContain('Already up to date.');
       expect(existsSync(join(home, '.gbrain', 'config.json'))).toBe(false);
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('backfill list reaches its self-contained handler without a configured brain', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-backfill-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'backfill', 'list'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(stdout).toContain('modality');
+      expect(stderr).not.toContain('No database URL');
       expect(exitCode).toBe(0);
     } finally {
       rmSync(home, { recursive: true, force: true });

--- a/test/doctor-image-assets.test.ts
+++ b/test/doctor-image-assets.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveImageAssetPath } from '../src/commands/doctor.ts';
+import {
+  resolveImageAssetPath,
+  summarizeImageAssetPresence,
+} from '../src/commands/doctor.ts';
 
 describe('doctor image asset path resolution', () => {
   test('uses the owning source local_path before the global sync fallback', () => {
@@ -24,5 +27,38 @@ describe('doctor image asset path resolution', () => {
       '/brains/default-source',
       '/brains/fallback',
     )).toBe('/var/lib/gbrain/example.jpg');
+  });
+
+  test('deduplicates rows by content hash when one registered path exists', () => {
+    const existing = new Set(['/brains/default/conversations/images/example.jpg']);
+    const result = summarizeImageAssetPresence([
+      {
+        storage_path: 'example.jpg',
+        content_hash: 'same-hash',
+        source_id: 'default',
+        source_local_path: '/brains/default',
+      },
+      {
+        storage_path: 'conversations/images/example.jpg',
+        content_hash: 'same-hash',
+        source_id: 'default',
+        source_local_path: '/brains/default',
+      },
+    ], '/brains/fallback', path => existing.has(path));
+
+    expect(result).toEqual({ total: 1, missing: 0, missingPaths: [] });
+  });
+
+  test('reports a logical image missing only when none of its paths exist', () => {
+    const result = summarizeImageAssetPresence([
+      {
+        storage_path: 'missing.jpg',
+        content_hash: 'missing-hash',
+        source_id: 'default',
+        source_local_path: '/brains/default',
+      },
+    ], '/brains/fallback', () => false);
+
+    expect(result).toEqual({ total: 1, missing: 1, missingPaths: ['missing.jpg'] });
   });
 });

--- a/test/doctor-image-assets.test.ts
+++ b/test/doctor-image-assets.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveImageAssetPath } from '../src/commands/doctor.ts';
+
+describe('doctor image asset path resolution', () => {
+  test('uses the owning source local_path before the global sync fallback', () => {
+    expect(resolveImageAssetPath(
+      'images/example.jpg',
+      '/brains/default-source',
+      '/brains/other-source',
+    )).toBe('/brains/default-source/images/example.jpg');
+  });
+
+  test('falls back to sync.repo_path for legacy rows without a source root', () => {
+    expect(resolveImageAssetPath(
+      'images/example.jpg',
+      null,
+      '/brains/fallback',
+    )).toBe('/brains/fallback/images/example.jpg');
+  });
+
+  test('keeps absolute storage paths unchanged', () => {
+    expect(resolveImageAssetPath(
+      '/var/lib/gbrain/example.jpg',
+      '/brains/default-source',
+      '/brains/fallback',
+    )).toBe('/var/lib/gbrain/example.jpg');
+  });
+});

--- a/test/extract-stale.test.ts
+++ b/test/extract-stale.test.ts
@@ -148,6 +148,54 @@ describe('gbrain extract --stale', () => {
     expect(await engine.countStalePagesForExtraction()).toBe(2);
   });
 
+  test('non-federated source does not create a cross-source fallback link', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config)
+       VALUES ('isolated-kb', 'isolated-kb', '{"federated":false}'::jsonb)
+       ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config`,
+    );
+    try {
+      await engine.putPage('people/alice', personPage('Alice'));
+      await engine.putPage(
+        'companies/private',
+        companyPage('Private', '[Alice](people/alice) advises Private.'),
+        { sourceId: 'isolated-kb' },
+      );
+
+      await runExtract(engine, ['--stale', '--source-id', 'isolated-kb']);
+
+      const links = await engine.getLinks('companies/private', { sourceId: 'isolated-kb' });
+      expect(links.some(l => l.to_slug === 'people/alice')).toBe(false);
+    } finally {
+      await engine.executeRaw(`DELETE FROM sources WHERE id = 'isolated-kb'`);
+    }
+  });
+
+  test('federated source preserves cross-source fallback links', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config)
+       VALUES ('shared-kb', 'shared-kb', '{"federated":true}'::jsonb)
+       ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config`,
+    );
+    try {
+      await engine.putPage('people/alice', personPage('Alice'));
+      await engine.putPage(
+        'companies/shared',
+        companyPage('Shared', '[Alice](people/alice) advises Shared.'),
+        { sourceId: 'shared-kb' },
+      );
+
+      await runExtract(engine, ['--stale', '--source-id', 'shared-kb']);
+
+      const links = await engine.getLinks('companies/shared', { sourceId: 'shared-kb' });
+      // The target exists only in default, so a created edge proves the
+      // federated fallback stayed enabled.
+      expect(links.some(l => l.to_slug === 'people/alice')).toBe(true);
+    } finally {
+      await engine.executeRaw(`DELETE FROM sources WHERE id = 'shared-kb'`);
+    }
+  });
+
   test('CRITICAL (CDX-1): page edited after stamp is re-extracted', async () => {
     await engine.putPage('people/alice', personPage('Alice'));
     await engine.putPage('companies/acme', companyPage('Acme', 'No links yet.'));


### PR DESCRIPTION
## Summary

- restore the self-contained `backfill` CLI dispatch and keep `retrieval-upgrade`
- prevent non-federated link extraction from falling back across sources
- resolve doctor image assets against each source root and deduplicate logical assets by content hash
- skip pages already projected into Chronicle during bulk backfill
- retry a confirmed truncated Chronicle judge as two disjoint segments, preserving the all-or-nothing write barrier

## Why

These issues surfaced during a real multi-source maintenance pass:

- `gbrain backfill modality` was implemented but unreachable from the CLI dispatcher
- link extraction could recreate cross-source edges for an isolated source
- image doctor checks used the global sync root and double-counted duplicate asset rows
- Chronicle backfill repeatedly enqueued pages that already had event projections
- one dense conversation still hit the provider output cap after raising the configured judge cap

The Chronicle retry keeps the normal one-call path. It splits only after `stopReason=length`, requires both halves to return usable output, and writes nothing if either half truncates, fails to parse, is refused, or is filtered.

## Validation

- `70 pass, 0 fail` across:
  - `test/cli.test.ts`
  - `test/extract-stale.test.ts`
  - `test/doctor-image-assets.test.ts`
  - `test/chronicle-backfill.test.ts`
  - `test/chronicle-extract.test.ts`
- `bun run verify`: `32/32` checks green with an isolated `GBRAIN_HOME`
- production-like validation: a previously `judge_truncated` dense page completed through the segmented retry, with the existing write barrier and idempotent event path intact

Draft while the full local test suite and upstream CI finish.
