### PR TITLE
fix(test): restore extended local E2E reliability

### DIFF
--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -262,12 +262,14 @@ printf '%s\\n' 1 2 3 4 | xargs -P4 -I{} sh -c '
   echo \"[shard \${shard}] e2e phase (SHARD=\${shard}/4, DATABASE_URL=postgres-\${shard})\" >> \$log
   if [ -s /tmp/e2e-selected.txt ]; then
     SHARD=\${shard}/4 \\
+    GBRAIN_TEST_DB=1 \\
     DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
     GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \\
     GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \\
     xargs -a /tmp/e2e-selected.txt bash scripts/run-e2e.sh >> \$log 2>&1
   else
     SHARD=\${shard}/4 \\
+    GBRAIN_TEST_DB=1 \\
     DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
     GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \\
     GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \\

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -80,6 +80,9 @@ mkdir -p "$E2E_TMP_HOME/.gbrain"
 for _e2e_var in $(env | grep -oE '^(CONDUCTOR_|MCP_|OPENCLAW_|GBRAIN_)[A-Za-z0-9_]*' | sort -u); do
   case "$_e2e_var" in
     GBRAIN_HOME) ;;  # required for HOME isolation (set above) — keep
+    # Narrow test-only safety opt-in. Schema drift still requires a test-shaped
+    # database name before it will reset a non-local Docker service host.
+    GBRAIN_TEST_DB) ;;
     *) unset "$_e2e_var" || true ;;
   esac
 done

--- a/src/core/cross-modal-eval/aggregate.ts
+++ b/src/core/cross-modal-eval/aggregate.ts
@@ -107,8 +107,11 @@ export function aggregate(input: AggregateInput): AggregateResult {
     const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
     const min = Math.min(...scores);
     const roll: DimensionRoll = { mean: round1(mean), min, scores };
-    if (roll.mean < PASS_MEAN_THRESHOLD) roll.failReason = 'mean_below_7';
-    else if (roll.min < PASS_FLOOR_THRESHOLD) roll.failReason = 'min_below_5';
+    // The floor is the stronger failure: when a score breaches both rules,
+    // report the individual-model collapse rather than hiding it behind the
+    // aggregate mean.
+    if (roll.min < PASS_FLOOR_THRESHOLD) roll.failReason = 'min_below_5';
+    else if (roll.mean < PASS_MEAN_THRESHOLD) roll.failReason = 'mean_below_7';
     dimensions[dim] = roll;
   }
 

--- a/src/core/cross-modal-eval/runner.ts
+++ b/src/core/cross-modal-eval/runner.ts
@@ -79,6 +79,8 @@ export interface RunEvalOpts {
   abortSignal?: AbortSignal;
   /** Stderr progress callback (cycle 1/3, slot A done, etc.). */
   onProgress?: (event: ProgressEvent) => void;
+  /** Test seam: alternative chat function; production defaults to the gateway. */
+  _chat?: typeof gwChat;
 }
 
 export type ProgressEvent =
@@ -142,6 +144,7 @@ export async function runEval(opts: RunEvalOpts): Promise<RunEvalResult> {
       abortSignal: opts.abortSignal,
       cycle,
       onProgress: opts.onProgress,
+      chat: opts._chat ?? gwChat,
     });
 
     const agg = aggregate({ slots: slotResults });
@@ -199,6 +202,7 @@ interface OneCycleOpts {
   abortSignal?: AbortSignal;
   cycle: number;
   onProgress?: (event: ProgressEvent) => void;
+  chat: typeof gwChat;
 }
 
 async function runOneCycle(opts: OneCycleOpts): Promise<SlotResult[]> {
@@ -226,7 +230,7 @@ async function callSlot(
     const messages: ChatMessage[] = [
       { role: 'user', content: prompt },
     ];
-    const result = await gwChat({
+    const result = await opts.chat({
       model: slot.model,
       system: SYSTEM_PROMPT,
       messages,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3310,7 +3310,8 @@ export class PGLiteEngine implements BrainEngine {
              array_agg(DISTINCT n.last_link_type)
                FILTER (WHERE n.last_link_type IS NOT NULL) AS via_link_types,
              (array_agg(array_to_string(n.path, chr(9))
-               ORDER BY n.depth ASC, array_length(n.path, 1) ASC))[1] AS path_str,
+               ORDER BY n.depth ASC, array_length(n.path, 1) ASC,
+                        array_to_string(n.path, chr(9)) ASC))[1] AS path_str,
              (SELECT cc.id FROM content_chunks cc
                WHERE cc.page_id = n.id ORDER BY cc.chunk_index ASC LIMIT 1) AS canonical_chunk_id
       FROM walk n

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3459,7 +3459,8 @@ export class PostgresEngine implements BrainEngine {
              array_agg(DISTINCT n.last_link_type)
                FILTER (WHERE n.last_link_type IS NOT NULL) AS via_link_types,
              (array_agg(array_to_string(n.path, chr(9))
-               ORDER BY n.depth ASC, array_length(n.path, 1) ASC))[1] AS path_str,
+               ORDER BY n.depth ASC, array_length(n.path, 1) ASC,
+                        array_to_string(n.path, chr(9)) ASC))[1] AS path_str,
              (SELECT cc.id FROM content_chunks cc
                WHERE cc.page_id = n.id ORDER BY cc.chunk_index ASC LIMIT 1) AS canonical_chunk_id
       FROM walk n

--- a/test/e2e/cross-modal-eval.test.ts
+++ b/test/e2e/cross-modal-eval.test.ts
@@ -45,7 +45,7 @@ afterEach(() => {
 
 function makeChatStub(scoresBySlot: Record<string, number[]>) {
   let callIdx = 0;
-  const order = ['openai:gpt-4o', 'anthropic:claude-opus-4-7', 'google:gemini-1.5-pro'];
+  const order = ['openai:gpt-5.2', 'anthropic:claude-opus-4-7', 'google:gemini-1.5-pro'];
   return mock(async (opts: { model?: string }) => {
     const model = opts.model ?? '';
     callIdx++;
@@ -74,16 +74,10 @@ function makeChatStub(scoresBySlot: Record<string, number[]>) {
 describe('gbrain eval cross-modal — runner verdict contract', () => {
   test('PASS: 3 happy responses, all dims >=7', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 8],
+      'openai:gpt-5.2': [9, 8],
       'anthropic:claude-opus-4-7': [8, 7],
       'google:gemini-1.5-pro': [8, 8],
     });
-    mock.module('../../src/core/ai/gateway.ts', () => ({
-      chat: chatStub,
-      configureGateway,
-      isAvailable: () => true,
-    }));
-
     const { runEval } = await import('../../src/core/cross-modal-eval/runner.ts');
     const result = await runEval({
       task: 'sample task',
@@ -91,6 +85,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
       slug: 'demo',
       receiptDir: tempDir,
       cycles: 1,
+      _chat: chatStub as typeof import('../../src/core/ai/gateway.ts').chat,
     });
 
     expect(result.finalAggregate.verdict).toBe('pass');
@@ -105,16 +100,10 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('FAIL: one dim mean below 7', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 6],
+      'openai:gpt-5.2': [9, 6],
       'anthropic:claude-opus-4-7': [8, 6],
       'google:gemini-1.5-pro': [8, 6],
     });
-    mock.module('../../src/core/ai/gateway.ts', () => ({
-      chat: chatStub,
-      configureGateway,
-      isAvailable: () => true,
-    }));
-
     const { runEval } = await import('../../src/core/cross-modal-eval/runner.ts');
     const result = await runEval({
       task: 'sample task',
@@ -122,6 +111,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
       slug: 'demo',
       receiptDir: tempDir,
       cycles: 1,
+      _chat: chatStub as typeof import('../../src/core/ai/gateway.ts').chat,
     });
 
     expect(result.finalAggregate.verdict).toBe('fail');
@@ -130,16 +120,10 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('FAIL: min-score floor caught when one model scores <5 (Q2)', async () => {
     const chatStub = makeChatStub({
-      'openai:gpt-4o': [9, 8],
+      'openai:gpt-5.2': [9, 8],
       'anthropic:claude-opus-4-7': [8, 8],
       'google:gemini-1.5-pro': [4, 8], // goal=4 trips the floor
     });
-    mock.module('../../src/core/ai/gateway.ts', () => ({
-      chat: chatStub,
-      configureGateway,
-      isAvailable: () => true,
-    }));
-
     const { runEval } = await import('../../src/core/cross-modal-eval/runner.ts');
     const result = await runEval({
       task: 'sample task',
@@ -147,6 +131,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
       slug: 'demo',
       receiptDir: tempDir,
       cycles: 1,
+      _chat: chatStub as typeof import('../../src/core/ai/gateway.ts').chat,
     });
 
     expect(result.finalAggregate.verdict).toBe('fail');
@@ -155,7 +140,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
 
   test('INCONCLUSIVE: 2 of 3 mock 5xx -> exit 2 contract (Q3)', async () => {
     const chatStub = mock(async (opts: { model?: string }) => {
-      if (opts.model === 'openai:gpt-4o') {
+      if (opts.model === 'openai:gpt-5.2') {
         return {
           text: JSON.stringify({
             scores: { goal: { score: 8 } },
@@ -170,12 +155,6 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
       }
       throw new Error(`mock: forced 5xx for ${opts.model}`);
     });
-    mock.module('../../src/core/ai/gateway.ts', () => ({
-      chat: chatStub,
-      configureGateway,
-      isAvailable: () => true,
-    }));
-
     const { runEval } = await import('../../src/core/cross-modal-eval/runner.ts');
     const result = await runEval({
       task: 'sample task',
@@ -183,6 +162,7 @@ describe('gbrain eval cross-modal — runner verdict contract', () => {
       slug: 'demo',
       receiptDir: tempDir,
       cycles: 1,
+      _chat: chatStub as typeof import('../../src/core/ai/gateway.ts').chat,
     });
 
     expect(result.finalAggregate.verdict).toBe('inconclusive');

--- a/test/e2e/dream-cycle-phase-order-pglite.test.ts
+++ b/test/e2e/dream-cycle-phase-order-pglite.test.ts
@@ -40,14 +40,20 @@ mock.module('../../src/core/embedding.ts', () => ({
   embedQuery: async () => new Float32Array(1536),
   embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(1536)),
   embedMultimodal: async () => [],
+  embedMultimodalSafe: async () => ({ embeddings: [], failures: [] }),
+  embedQueryMultimodal: async () => new Float32Array(1024),
+  embedQueryMultimodalImage: async () => new Float32Array(1024),
   getEmbeddingModelName: () => 'text-embedding-3-large',
   getEmbeddingDimensions: () => 1536,
   EMBEDDING_MODEL: 'text-embedding-3-large',
   EMBEDDING_DIMENSIONS: 1536,
   EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
+  currentEmbeddingPricePerMTok: () => 0.13,
   estimateEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
   // v0.41.31: embed phase reads the current signature to stamp provenance.
   currentEmbeddingSignature: () => 'text-embedding-3-large:1536',
+  willEmbedSynchronously: () => 'deferred',
+  shouldBlockSync: () => false,
 }));
 
 const { runCycle, ALL_PHASES } = await import('../../src/core/cycle.ts');

--- a/test/e2e/extract-atoms-discovery-sql.test.ts
+++ b/test/e2e/extract-atoms-discovery-sql.test.ts
@@ -38,7 +38,7 @@ afterAll(async () => {
 beforeEach(async () => {
   if (skip) return;
   // Clean test-source rows + atoms + meeting pages between tests
-  await engine.executeRaw(`DELETE FROM pages WHERE source_id IN ('default', 'dept-x') AND (type = 'atom' OR type IN ('meeting', 'source', 'article', 'video', 'book', 'original'))`);
+  await engine.executeRaw(`DELETE FROM pages WHERE source_id IN ('default', 'dept-x') AND (type = 'atom' OR type IN ('meeting', 'source', 'article', 'video', 'book', 'original', 'note'))`);
   await engine.executeRaw(`DELETE FROM sources WHERE id = 'dept-x'`);
 });
 
@@ -80,22 +80,22 @@ describeIfDB('v0.41.2.1 D10 — discoverExtractablePages on real Postgres', () =
     const slugs = discovered.map((d) => d.slug).sort();
     expect(slugs).toContain('meeting/a');
     expect(slugs).toContain('source/b');
-    expect(slugs).not.toContain('notes/skip');
+    expect(slugs).toContain('notes/skip');
   });
 
   test('ANY($::text[]) bind works through postgres.unsafe (PGLite parity proof)', async () => {
-    // Seed all 6 extractable types + one non-extractable. The SQL uses
+    // Seed the legacy 6 types plus pack-extractable note. The SQL uses
     // type = ANY($2::text[]) — if the binding shape differs between
     // PGLite and postgres.js's unsafe(), this catches it.
     for (const type of ['meeting', 'source', 'article', 'video', 'book', 'original']) {
       await seedPage({ slug: `${type}/x`, type, content_hash: `hash-${type}-1234567890ab` });
     }
-    await seedPage({ slug: 'note/skip', type: 'note', content_hash: 'hash-note-1234567890' });
+    await seedPage({ slug: 'note/x', type: 'note', content_hash: 'hash-note-1234567890' });
 
     const discovered = await discoverExtractablePages(engine, 'default');
     const slugs = discovered.map((d) => d.slug).sort();
     expect(slugs).toEqual([
-      'article/x', 'book/x', 'meeting/x', 'original/x', 'source/x', 'video/x',
+      'article/x', 'book/x', 'meeting/x', 'note/x', 'original/x', 'source/x', 'video/x',
     ]);
   });
 

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -53,6 +53,9 @@ const ALL_TABLES = [
   // join), but stale rows poison stats/count assertions across runs.
   'context_volunteer_events',
   'pages',       // last because of foreign keys
+  // Source rows are mutable E2E data too. Leaving a non-default source behind
+  // makes later sync tests auto-route imports away from `default`.
+  'sources',
   'config',
   'minion_attachments',
   'minion_inbox',
@@ -132,8 +135,12 @@ export async function setupDB(): Promise<PostgresEngine> {
 
   // Re-seed config (initSchema inserts default config rows)
   await conn.unsafe(`
+    INSERT INTO sources (id, name, config)
+    VALUES ('default', 'default', '{"federated": true}'::jsonb)
+    ON CONFLICT (id) DO NOTHING;
+
     INSERT INTO config (key, value) VALUES ('schema_version', '1')
-    ON CONFLICT (key) DO NOTHING
+    ON CONFLICT (key) DO NOTHING;
   `);
 
   engine = new PostgresEngine();

--- a/test/e2e/phantom-redirect.test.ts
+++ b/test/e2e/phantom-redirect.test.ts
@@ -247,15 +247,14 @@ describeMaybe('phantom-redirect E2E (Postgres)', () => {
       // intentionally re-derives from fence and embedding is regenerated
       // by the embed phase.
       //
-      // The pinning assertion: at NO point is the embedding column
-      // populated with a STRING (postgres-js's text shape leak — that
-      // bug class would produce a non-null text-shaped value here, not
-      // a clean NULL).
+      // The pinning assertion: at NO point is the embedding column populated
+      // with a non-vector type. Modern pgvector uses halfvec for this column;
+      // older installations retain vector.
       const stringShaped = await engine.executeRaw<{ ct: string }>(
         `SELECT COUNT(*)::text AS ct FROM facts
          WHERE source_id='default'
            AND embedding IS NOT NULL
-           AND pg_typeof(embedding)::text != 'vector'`,
+           AND pg_typeof(embedding)::text NOT IN ('vector', 'halfvec')`,
       );
       expect(parseInt(stringShaped[0].ct, 10)).toBe(0);
       expect(rows.length).toBeGreaterThan(0);

--- a/test/e2e/serve-http-oauth.test.ts
+++ b/test/e2e/serve-http-oauth.test.ts
@@ -575,7 +575,7 @@ describeE2E('serve-http OAuth 2.1 E2E (v0.26.1 + v0.26.2 + v0.26.3)', () => {
     try {
       await sql`
         INSERT INTO oauth_tokens (token_hash, token_type, client_id, scopes, expires_at)
-        VALUES (${tokenHash}, ${'access'}, ${publicClientId!}, ${sql.array(['read'])}, ${Math.floor(Date.now() / 1000) + 3600})
+        VALUES (${tokenHash}, ${'access'}, ${publicClientId!}, ${'{read}'}, ${Math.floor(Date.now() / 1000) + 3600})
       `;
     } finally {
       await sql.end();


### PR DESCRIPTION
## Summary
- repair seven extended E2E contracts exposed by the complete local gate
- reset shared source state between database-backed E2E files
- make Postgres/PGLite representative-path selection deterministic
- preserve the guarded test-database reset opt-in inside Docker E2E runs

## Evidence
- targeted seven-file set: 77 passed, 0 failed
- contamination sequence: 32 passed, 0 failed
- engine parity: 26 passed, 148 assertions, 0 failed
- complete default one-worker Docker gate: 164 files, 1,113 tests, 0 failed
- current upstream verification: 32/32 checks passed

Follow-up to closed #3467, split as requested. This PR contains no private brain page slugs, local evidence notes, node_modules cleanup, or unrelated artifact-sync changes.