### PR TITLE
feat(search): pin versioned retrieval contracts

### DIFF
--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -8,6 +8,8 @@ lives in `CHANGELOG.md` + `git log` / `git blame`, NOT here. Do not append
 per-release `**vX.Y.Z:**` narration — CI enforces this
 (`scripts/check-key-files-current-state.sh`).
 
+- `docs/architecture/SEARCH_CONTRACT.md` + `src/core/search/search-contract.ts` — versioned retrieval compatibility pin. `gbrain search contract pin|check` records provider/model, dimensions, pgvector column/representation, query/document semantics, cosine metric, contextual-retrieval profile, reranker policy, and autocut. Ordinary runtime startup fails closed on pinned drift; doctor/config/migration recovery remain reachable. The contract fingerprint participates in query-cache identity.
+
 - `docs/operations/conversation-parser-llm-fallback.md` — operator and maintainer contract for the default-off LLM parse fallback: exact config key, deterministic-first dispatch boundary, sampled data surface, untrusted-content prompt handling, page-date/cache-key coupling, timestamp validation, cache/checkpoint behavior, observability, limitations, and focused test commands.
 
 - `src/commands/serve-http.ts` confidential revoke extension — a pre-router `/revoke` handler validates the RFC 7009 body, verifies hash-only secrets for both `client_secret_post` and `client_secret_basic`, rejects mixed authentication, preserves the SDK path for public clients, and separates opaque client-auth failures from retryable/backend failures. OAuth metadata advertises both confidential methods. Pinned by `test/e2e/serve-http-oauth.test.ts`.

--- a/docs/architecture/SEARCH_CONTRACT.md
+++ b/docs/architecture/SEARCH_CONTRACT.md
@@ -1,0 +1,73 @@
+# Search Contract v1
+
+GBrain Search Contract v1 is an opt-in compatibility pin for the embedding
+space and retrieval profile that produce persisted vectors and cached results.
+It does not select a new model and it does not move inference into PostgreSQL.
+
+## Ownership boundary
+
+- GBrain's AI gateway creates document and query embeddings.
+- PostgreSQL + pgvector store vectors and execute cosine-distance retrieval.
+- GBrain fuses lexical, vector, graph, recency, and relational candidates.
+- GBrain's search layer calls the reranker and fails open to hybrid/RRF order.
+
+## Contract fields
+
+A v1 snapshot records:
+
+- embedding provider/model;
+- dimensions;
+- active pgvector column and `vector`/`halfvec` representation;
+- cosine metric;
+- symmetric, query/document, or query/passage input semantics;
+- search mode and contextual-retrieval policy;
+- reranker enablement, model, candidate count, timeout, and fail-open policy;
+- autocut enablement and threshold.
+
+The canonical JSON is stored in the DB config plane at
+`search.contract.v1`. Its SHA-256 prefix is folded into query-cache identity.
+
+## Commands
+
+```bash
+# Inspect current behavior and the pin
+gbrain search contract check
+
+# Pin current resolved behavior (idempotent)
+gbrain search contract pin
+
+# Replace a prior pin only after a deliberate migration
+gbrain search contract pin --force
+```
+
+Ordinary CLI, daemon, MCP, sync, search, and embed startup fails closed when a
+pin exists and the resolved runtime contract differs. Doctor, config recovery,
+contract inspection, and `gbrain migrate embeddings` remain reachable.
+
+`gbrain doctor` also checks page embedding signatures. Missing or stale
+provenance warns with the supported repair command:
+
+```bash
+gbrain embed --stale --include-null-signature
+```
+
+A pending/null embedding remains valid during that controlled repair. Contract
+pinning never requires clearing the model metadata column to null.
+
+## Deliberate model migration
+
+Never edit `embedding_model` over an existing vector space. Use:
+
+```bash
+gbrain migrate embeddings --to <provider:model> --dry-run
+gbrain migrate embeddings --to <provider:model> --yes
+```
+
+The migration command probes the target, transitions schema when dimensions
+change, invalidates stale vectors including legacy null-signature pages, purges
+the query cache, and resumes the re-embed safely. After validation, replace the
+pin explicitly with `gbrain search contract pin --force`.
+
+Changing only the reranker does not require re-embedding, but it still changes
+the contract and cache fingerprint. Benchmark retrieval quality before
+re-pinning.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -267,16 +267,22 @@ async function main() {
   // NOT a free-text search for the literal word "modes". Free-text
   // `gbrain search "<query>"` falls through to the cheap-hybrid `search` op
   // below (T4). Preserves the v0.41.6.0 read-only connect+dispatch timeout.
-  if (command === 'search' && ['modes', 'stats', 'tune', 'diagnose'].includes(subArgs[0] ?? '')) {
+  if (command === 'search' && ['modes', 'stats', 'tune', 'diagnose', 'contract'].includes(subArgs[0] ?? '')) {
     const { withTimeout, OperationTimeoutError } = await import('./core/timeout.ts');
     const isDiagnose = subArgs[0] === 'diagnose';
+    const isContract = subArgs[0] === 'contract';
     const label = 'gbrain search';
-    // diagnose runs real retrieval (keyword + vector + hybrid) so it gets a
-    // longer deadline than the read-only dashboard.
-    const timeoutMs = isDiagnose ? 60_000 : 10_000;
+    // Diagnose runs real retrieval; contract resolves both config planes and
+    // may hit a cold remote Postgres endpoint. Both need the operational
+    // budget rather than the lightweight dashboard ceiling.
+    const timeoutMs = isDiagnose || isContract ? 60_000 : 10_000;
     let engine: BrainEngine;
     try {
-      engine = await withTimeout(connectEngine(), timeoutMs, `${label}: connect`);
+      engine = await withTimeout(
+        connectEngine({ skipSearchContractCheck: subArgs[0] === 'contract' }),
+        timeoutMs,
+        `${label}: connect`,
+      );
     } catch (e) {
       if (e instanceof OperationTimeoutError) { console.error(`${e.label} timed out.`); process.exit(124); }
       throw e;
@@ -1358,13 +1364,13 @@ async function handleCliOnly(command: string, args: string[]) {
     // (cheap path D7), NOT the full doctor walk.
     if (args.includes('--remediation-plan')) {
       const { runRemediationPlan } = await import('./commands/doctor.ts');
-      const eng = await connectEngine();
+      const eng = await connectEngine({ skipSearchContractCheck: true });
       try { await runRemediationPlan(eng, args); } finally { await finishCliTeardown({ engine: eng }); }
       return;
     }
     if (args.includes('--remediate')) {
       const { runRemediate } = await import('./commands/doctor.ts');
-      const eng = await connectEngine();
+      const eng = await connectEngine({ skipSearchContractCheck: true });
       try { await runRemediate(eng, args); } finally { await finishCliTeardown({ engine: eng }); }
       return;
     }
@@ -1386,7 +1392,7 @@ async function handleCliOnly(command: string, args: string[]) {
       // teardown are a pre-existing class, tracked as a TODOS.md follow-up.
       let eng: BrainEngine | null = null;
       try {
-        eng = await connectEngine();
+        eng = await connectEngine({ skipSearchContractCheck: true });
         await runDoctor(eng, args);
       } catch {
         // DB unavailable — still run filesystem checks
@@ -1707,8 +1713,14 @@ async function handleCliOnly(command: string, args: string[]) {
     }
   }
 
-  // All remaining CLI-only commands need a DB connection
-  const engine = await connectEngine();
+  // All remaining CLI-only commands need a DB connection. Contract/config
+  // recovery and an explicit embedding migration must remain reachable when
+  // the current runtime has drifted from the pin.
+  const engine = await connectEngine({
+    skipSearchContractCheck:
+      command === 'config' ||
+      (command === 'migrate' && args[0] === 'embeddings'),
+  });
   try {
     switch (command) {
       case 'import': {
@@ -2248,7 +2260,10 @@ async function dispatchReadOnlyCommand(engine: BrainEngine, command: string, arg
 import { buildGatewayConfig } from './core/ai/build-gateway-config.ts';
 export { buildGatewayConfig };
 
-async function connectEngine(opts?: { probeOnly?: boolean }): Promise<BrainEngine> {
+async function connectEngine(opts?: {
+  probeOnly?: boolean;
+  skipSearchContractCheck?: boolean;
+}): Promise<BrainEngine> {
   const config = loadConfig();
   if (!config) {
     console.error('No brain configured. Run: gbrain init');
@@ -2343,6 +2358,15 @@ async function connectEngine(opts?: { probeOnly?: boolean }): Promise<BrainEngin
     await reconfigureGatewayWithEngine(engine);
   } catch {
     // Non-fatal. Pre-v39 brains may not have a usable config table yet.
+  }
+
+  // Search Contract v1 is opt-in. Once pinned, ordinary runtime entrypoints
+  // fail closed on model/config drift before reading or writing against a
+  // different embedding space. Recovery and migration commands bypass this
+  // assertion explicitly so the operator can inspect and repair the pin.
+  if (!opts?.skipSearchContractCheck) {
+    const { assertSearchContractV1 } = await import('./core/search/search-contract.ts');
+    await assertSearchContractV1(engine);
   }
 
   return engine;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -922,6 +922,7 @@ export async function doctorReportRemote(engine: BrainEngine): Promise<DoctorRep
   // search.reranker.enabled FIRST so absence-of-failures means different
   // things when reranker is on vs off.
   checks.push(await checkRerankerHealth(engine));
+  checks.push(await checkSearchContractV1Health(engine));
 
   // 9a. v0.40.4 graph_signals_coverage: when graph_signals is enabled
   // (via mode bundle default or explicit config override), surface
@@ -1660,6 +1661,69 @@ export async function checkRerankerHealth(engine: BrainEngine): Promise<Check> {
       name: 'reranker_health',
       status: 'warn',
       message: `Could not check reranker audit: ${msg}`,
+    };
+  }
+}
+
+/** Search Contract v1 pin, drift, and stored-vector provenance health. */
+export async function checkSearchContractV1Health(engine: BrainEngine): Promise<Check> {
+  try {
+    const { checkSearchContractV1 } = await import('../core/search/search-contract.ts');
+    const report = await checkSearchContractV1(engine);
+    if (report.status === 'unpinned') {
+      return {
+        name: 'search_contract_v1',
+        status: 'ok',
+        message: 'Search Contract v1 is not pinned (optional). Pin current behavior with `gbrain search contract pin`.',
+      };
+    }
+    if (report.status === 'invalid') {
+      return {
+        name: 'search_contract_v1',
+        status: 'fail',
+        message: `Pinned Search Contract v1 is invalid: ${report.error}. Inspect with \`gbrain search contract check\`.`,
+      };
+    }
+    if (report.status === 'drift') {
+      return {
+        name: 'search_contract_v1',
+        status: 'fail',
+        message: `Search Contract v1 drift: ${report.differences.join('; ')}. Runtime is fail-closed. Inspect with \`gbrain search contract check\`.`,
+      };
+    }
+
+    // Re-embedding workflows need a reachable pending/null state, so stale
+    // provenance is a doctor warning rather than a startup blocker. Query the
+    // invariant directly so this check works across engine versions that
+    // predate countStaleChunks({ includeNullSignature }).
+    const signature = `${report.current.embedding.model}:${report.current.embedding.dimensions}`;
+    const rows = await engine.executeRaw<{ count: number | string }>(
+      `SELECT count(*)::int AS count
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+        WHERE NOT (COALESCE(p.frontmatter, '{}'::jsonb) ? 'embed_skip')
+          AND (cc.embedding IS NULL OR p.embedding_signature IS DISTINCT FROM $1)`,
+      [signature],
+    );
+    const stale = Number(rows[0]?.count ?? 0);
+    if (stale > 0) {
+      return {
+        name: 'search_contract_v1',
+        status: 'warn',
+        message: `${stale} chunk(s) are stale or lack embedding-space provenance for ${signature}. ` +
+          'Repair with `gbrain embed --stale --include-null-signature`, then re-run doctor.',
+      };
+    }
+    return {
+      name: 'search_contract_v1',
+      status: 'ok',
+      message: `Pinned contract matches runtime (${report.current_fingerprint}); all chunks have current embedding provenance.`,
+    };
+  } catch (error) {
+    return {
+      name: 'search_contract_v1',
+      status: 'fail',
+      message: `Could not validate Search Contract v1: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }
@@ -2901,9 +2965,13 @@ export async function checkSearchMode(engine: BrainEngine): Promise<Check> {
   try {
     const mode = await engine.getConfig('search.mode');
     const overrides = await engine.listConfigKeys('search.');
-    // Exclude search.mode itself + the upgrade-notice state key from the
-    // override roster — they aren't knobs.
-    const overrideKeys = overrides.filter(k => k !== 'search.mode' && k !== 'search.mode_upgrade_notice_shown');
+    // Exclude search.mode itself, internal state, and the immutable contract
+    // pin from the override roster — none are tunable mode knobs.
+    const overrideKeys = overrides.filter(k =>
+      k !== 'search.mode' &&
+      k !== 'search.mode_upgrade_notice_shown' &&
+      k !== 'search.contract.v1'
+    );
 
     if (!mode) {
       return {
@@ -7638,6 +7706,8 @@ export async function buildChecks(
     // v0.35.0.0+ reranker_health — read JSONL audit; warn on auth or volume.
     progress.heartbeat('reranker_health');
     checks.push(await checkRerankerHealth(engine));
+    progress.heartbeat('search_contract_v1');
+    checks.push(await checkSearchContractV1Health(engine));
     // v0.41.18.0 batch_retry_health — Supavisor circuit-breaker incident
     // surfacing via the batch-retry audit JSONL. Codex H-9 thresholds.
     progress.heartbeat('batch_retry_health');

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -39,6 +39,12 @@ import {
   type ModeBundle,
 } from '../core/search/mode.ts';
 import { readSearchStats } from '../core/search/telemetry.ts';
+import { setCliExitVerdict } from '../core/cli-force-exit.ts';
+import {
+  SEARCH_CONTRACT_V1_KEY,
+  checkSearchContractV1,
+  serializeSearchContractV1,
+} from '../core/search/search-contract.ts';
 
 const KNOB_DESCRIPTIONS: Record<keyof ModeBundle, string> = {
   cache_enabled: 'Semantic query cache on/off',
@@ -172,7 +178,11 @@ async function runModesSubcommand(engine: BrainEngine, args: string[]): Promise<
       process.exit(1);
     }
     const overrides = await engine.listConfigKeys('search.');
-    const toRemove = overrides.filter((k) => k !== SEARCH_MODE_KEY && k !== 'search.mode_upgrade_notice_shown');
+    const toRemove = overrides.filter((k) =>
+      k !== SEARCH_MODE_KEY &&
+      k !== 'search.mode_upgrade_notice_shown' &&
+      k !== SEARCH_CONTRACT_V1_KEY
+    );
     if (toRemove.length === 0) {
       console.log('No search.* overrides set. Mode bundle is the only voice.');
       return;
@@ -520,7 +530,55 @@ function buildRevertCommand(r: TuneRecommendation): string {
   return r.apply_command;
 }
 
-const USAGE = `Usage: gbrain search <modes|stats|tune> [flags]
+async function runContractSubcommand(engine: BrainEngine, args: string[]): Promise<void> {
+  const action = args[0] ?? 'check';
+  const json = args.includes('--json');
+  const force = args.includes('--force');
+
+  if (!['check', 'show', 'pin'].includes(action)) {
+    console.error(`Unknown contract action: ${action}`);
+    console.error('Usage: gbrain search contract <check|show|pin> [--json] [--force]');
+    setCliExitVerdict(1);
+    return;
+  }
+
+  let report = await checkSearchContractV1(engine);
+  if (action === 'pin') {
+    if ((report.status === 'drift' || report.status === 'invalid') && !force) {
+      console.error('A different Search Contract v1 is already pinned. Refusing to overwrite it.');
+      console.error('Inspect with `gbrain search contract check`; after a deliberate migration, re-run `pin --force`.');
+      setCliExitVerdict(1);
+      return;
+    }
+    await engine.setConfig(SEARCH_CONTRACT_V1_KEY, serializeSearchContractV1(report.current));
+    report = await checkSearchContractV1(engine);
+  }
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(`GBrain Search Contract v1: ${report.status}`);
+    console.log(`  current fingerprint: ${report.current_fingerprint}`);
+    console.log(`  pinned fingerprint:  ${report.pinned_fingerprint ?? '(none)'}`);
+    console.log(`  embedding: ${report.current.embedding.model} / ${report.current.embedding.dimensions}d / ${report.current.embedding.representation}(${report.current.embedding.dimensions})`);
+    console.log(`  input semantics: ${report.current.embedding.input_semantics}; metric: ${report.current.embedding.metric}`);
+    console.log(`  retrieval: ${report.current.retrieval.mode}; contextual=${report.current.retrieval.contextual_retrieval}`);
+    console.log(`  reranker: ${report.current.reranker.enabled ? report.current.reranker.model : 'disabled'}; top_n=${report.current.reranker.top_n_in}; timeout=${report.current.reranker.timeout_ms}ms`);
+    if (report.differences.length > 0) {
+      console.log('  drift:');
+      for (const difference of report.differences) console.log(`    - ${difference}`);
+    }
+    if (report.error) console.log(`  error: ${report.error}`);
+    if (action === 'pin' && report.status === 'match') console.log('  pinned successfully');
+    if (report.status === 'unpinned') console.log('  pin with: gbrain search contract pin');
+  }
+
+  if (action !== 'pin' && (report.status === 'drift' || report.status === 'invalid')) {
+    setCliExitVerdict(1);
+  }
+}
+
+const USAGE = `Usage: gbrain search <modes|stats|tune|contract> [flags]
 
 Subcommands:
   modes [--json]              Show active mode, bundles, and per-knob source.
@@ -528,6 +586,8 @@ Subcommands:
   modes --source <mode>       Dry-run: list what --reset would change.
   stats [--days N] [--json]   Cache hit rate, intent mix, budget pressure.
   tune [--apply] [--json]     Print recommendations; --apply mutates config.
+  contract check [--json]     Compare resolved behavior with the v1 pin.
+  contract pin [--force]      Pin current behavior; refuse replacement by default.
 
 Examples:
   gbrain search modes
@@ -555,6 +615,9 @@ export async function runSearch(engine: BrainEngine, args: string[]): Promise<vo
       return;
     case 'tune':
       await runTuneSubcommand(engine, rest);
+      return;
+    case 'contract':
+      await runContractSubcommand(engine, rest);
       return;
     default:
       console.error(`Unknown subcommand: ${sub}`);

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -103,6 +103,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'flagged_pages',
   'salience_health',
   'scraper_junk_pages',
+  'search_contract_v1',
   'source_config_shape',
   'source_routing_health',
   'stub_guard_24h',

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -15,6 +15,7 @@ import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
 import { embed, embedQuery } from '../embedding.ts';
 import { registerBackgroundWorkDrainer } from '../background-work.ts';
 import { resolveEmbeddingColumn, isCacheSafe } from './embedding-column.ts';
+import { buildSearchContractV1, searchContractFingerprint } from './search-contract.ts';
 import { resolveHardExcludes } from './source-boost.ts';
 import {
   resolveAdaptiveReturn,
@@ -1771,6 +1772,9 @@ export async function hybridSearchCached(
   const cacheKnobsHash = knobsHash(resolvedForCache, {
     embeddingColumn: resolvedColCached.name,
     embeddingModel: resolvedColCached.embeddingModel,
+    searchContractFingerprint: searchContractFingerprint(
+      buildSearchContractV1(resolvedColCached, resolvedForCache),
+    ),
     // #2825 — fold the resolved hard-exclude prefix list (defaults ∪
     // GBRAIN_SEARCH_EXCLUDE ∪ per-call exclude_slug_prefixes, minus
     // include_slug_prefixes — exactly what the engines' query-build path

--- a/src/core/search/mode.ts
+++ b/src/core/search/mode.ts
@@ -766,7 +766,11 @@ export function attributeKnob<K extends keyof ModeBundle>(
 // written between the #3391 stale-fix (which changes which chunks count as
 // current) and the operator's migration run. Same one-time global cold-miss
 // pattern as the bumps above.
-export const KNOBS_HASH_VERSION = 13;
+// bump 13→14: Search Contract v1 fingerprint. Provider:model alone is not a
+// complete embedding-space identity: dimensions, vector representation,
+// query/document semantics, contextual wrapping, and reranker policy also
+// matter. `sc=` folds the canonical contract snapshot into cache identity.
+export const KNOBS_HASH_VERSION = 14;
 
 /**
  * v0.36 (D8 / CDX-2) — second-arg context for the cache key. The
@@ -805,6 +809,8 @@ export interface KnobsHashContext {
    * 'none' for legacy callers that don't thread excludes.
    */
   hardExcludes?: string[];
+  /** Canonical Search Contract v1 fingerprint. */
+  searchContractFingerprint?: string;
 }
 
 export function knobsHash(
@@ -898,6 +904,9 @@ export function knobsHash(
     // across processes. Sorted copy so ['a/','b/'] and ['b/','a/'] hash
     // identically; undefined falls back to 'none' for legacy callers.
     `hx=${ctx?.hardExcludes ? [...ctx.hardExcludes].sort().join(',') : 'none'}`,
+    // v=14 addition (append-only): full embedding/retrieval compatibility
+    // fingerprint. Legacy callers use `none`; production hybrid supplies it.
+    `sc=${ctx?.searchContractFingerprint ?? 'none'}`,
   ];
   const h = createHash('sha256');
   h.update(parts.join('|'));

--- a/src/core/search/search-contract.ts
+++ b/src/core/search/search-contract.ts
@@ -1,0 +1,272 @@
+/**
+ * Versioned search-contract pinning.
+ *
+ * A search contract names the embedding space and the retrieval behavior that
+ * make persisted vectors and cached results compatible. The pin is opt-in and
+ * lives in the DB config plane at `search.contract.v1`. Once pinned, ordinary
+ * runtime entrypoints fail closed when their resolved contract drifts. Recovery
+ * and deliberate migrations bypass the startup assertion and use the helpers
+ * in this module to report or replace the pin explicitly.
+ */
+
+import { createHash } from 'node:crypto';
+import type { BrainEngine } from '../engine.ts';
+import type { ResolvedColumn } from '../types.ts';
+import { loadConfig, loadConfigWithEngine } from '../config.ts';
+import { getEmbeddingModel, getEmbeddingDimensions } from '../ai/gateway.ts';
+import { resolveEmbeddingColumn } from './embedding-column.ts';
+import {
+  loadSearchModeConfig,
+  resolveSearchMode,
+  type ResolvedSearchKnobs,
+} from './mode.ts';
+
+export const SEARCH_CONTRACT_V1_KEY = 'search.contract.v1';
+export const SEARCH_CONTRACT_VERSION = 1 as const;
+
+export type EmbeddingInputSemantics =
+  | 'symmetric'
+  | 'query_document'
+  | 'query_passage';
+
+export interface SearchContractV1 {
+  version: 1;
+  embedding: {
+    model: string;
+    dimensions: number;
+    column: string;
+    representation: 'vector' | 'halfvec';
+    metric: 'cosine';
+    input_semantics: EmbeddingInputSemantics;
+  };
+  retrieval: {
+    mode: string;
+    contextual_retrieval: string;
+    contextual_retrieval_disabled: boolean;
+  };
+  reranker: {
+    enabled: boolean;
+    model: string;
+    top_n_in: number;
+    top_n_out: number | null;
+    timeout_ms: number;
+    failure_policy: 'fail_open';
+    autocut: boolean;
+    autocut_jump: number;
+  };
+}
+
+export interface SearchContractCheck {
+  status: 'unpinned' | 'match' | 'drift' | 'invalid';
+  current: SearchContractV1;
+  pinned: SearchContractV1 | null;
+  current_fingerprint: string;
+  pinned_fingerprint: string | null;
+  differences: string[];
+  error?: string;
+}
+
+/**
+ * The provider/model side of the retrieval space. This mirrors the input-type
+ * routing implemented in ai/dims.ts and gateway compatibility shims.
+ */
+export function embeddingInputSemantics(model: string): EmbeddingInputSemantics {
+  const normalized = model.toLowerCase();
+  if (normalized.startsWith('zeroentropyai:zembed-1')) return 'query_document';
+  if (normalized.startsWith('voyage:')) return 'query_document';
+  if (normalized.startsWith('minimax:embo-01')) return 'query_document';
+  if (normalized.startsWith('nvidia:')) return 'query_passage';
+  return 'symmetric';
+}
+
+export function buildSearchContractV1(
+  column: ResolvedColumn,
+  knobs: ResolvedSearchKnobs,
+  embeddingModel = column.embeddingModel,
+  embeddingDimensions = column.dimensions,
+): SearchContractV1 {
+  return {
+    version: SEARCH_CONTRACT_VERSION,
+    embedding: {
+      model: embeddingModel,
+      dimensions: embeddingDimensions,
+      column: column.name,
+      representation: column.type,
+      metric: 'cosine',
+      input_semantics: embeddingInputSemantics(embeddingModel),
+    },
+    retrieval: {
+      mode: knobs.resolved_mode,
+      contextual_retrieval: knobs.contextual_retrieval,
+      contextual_retrieval_disabled: knobs.contextual_retrieval_disabled,
+    },
+    reranker: {
+      enabled: knobs.reranker_enabled,
+      model: knobs.reranker_model,
+      top_n_in: knobs.reranker_top_n_in,
+      top_n_out: knobs.reranker_top_n_out,
+      timeout_ms: knobs.reranker_timeout_ms,
+      failure_policy: 'fail_open',
+      autocut: knobs.autocut,
+      autocut_jump: knobs.autocut_jump,
+    },
+  };
+}
+
+export function serializeSearchContractV1(contract: SearchContractV1): string {
+  // The builder and parser both produce this fixed field order. Avoid a generic
+  // recursive sorter: the schema itself owns canonicalization.
+  return JSON.stringify(contract);
+}
+
+export function searchContractFingerprint(contract: SearchContractV1): string {
+  return createHash('sha256')
+    .update(serializeSearchContractV1(contract))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function requireObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseSearchContractV1(raw: string): SearchContractV1 {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const root = requireObject(parsed, 'contract');
+  const embedding = requireObject(root.embedding, 'embedding');
+  const retrieval = requireObject(root.retrieval, 'retrieval');
+  const reranker = requireObject(root.reranker, 'reranker');
+
+  if (root.version !== SEARCH_CONTRACT_VERSION) {
+    throw new Error(`unsupported version ${String(root.version)} (expected 1)`);
+  }
+  if (typeof embedding.model !== 'string' || !embedding.model.includes(':')) {
+    throw new Error('embedding.model must be a provider:model string');
+  }
+  if (!Number.isInteger(embedding.dimensions) || (embedding.dimensions as number) <= 0) {
+    throw new Error('embedding.dimensions must be a positive integer');
+  }
+  if (typeof embedding.column !== 'string' || !/^[a-z_][a-z0-9_]*$/.test(embedding.column)) {
+    throw new Error('embedding.column must be a lowercase SQL identifier');
+  }
+  if (embedding.representation !== 'vector' && embedding.representation !== 'halfvec') {
+    throw new Error('embedding.representation must be vector or halfvec');
+  }
+  if (embedding.metric !== 'cosine') throw new Error('embedding.metric must be cosine');
+  if (!['symmetric', 'query_document', 'query_passage'].includes(String(embedding.input_semantics))) {
+    throw new Error('embedding.input_semantics is invalid');
+  }
+  if (typeof retrieval.mode !== 'string' || typeof retrieval.contextual_retrieval !== 'string' ||
+      typeof retrieval.contextual_retrieval_disabled !== 'boolean') {
+    throw new Error('retrieval fields are invalid');
+  }
+  if (typeof reranker.enabled !== 'boolean' || typeof reranker.model !== 'string' ||
+      !Number.isInteger(reranker.top_n_in) || (reranker.top_n_in as number) <= 0 ||
+      !(reranker.top_n_out === null ||
+        (Number.isInteger(reranker.top_n_out) && (reranker.top_n_out as number) > 0)) ||
+      !Number.isInteger(reranker.timeout_ms) || (reranker.timeout_ms as number) <= 0 ||
+      reranker.failure_policy !== 'fail_open' ||
+      typeof reranker.autocut !== 'boolean' || typeof reranker.autocut_jump !== 'number' ||
+      !Number.isFinite(reranker.autocut_jump) || reranker.autocut_jump < 0 || reranker.autocut_jump > 1) {
+    throw new Error('reranker fields are invalid');
+  }
+
+  return parsed as SearchContractV1;
+}
+
+export function diffSearchContracts(
+  pinned: SearchContractV1,
+  current: SearchContractV1,
+): string[] {
+  const differences: string[] = [];
+  const walk = (a: unknown, b: unknown, path: string): void => {
+    if (a && b && typeof a === 'object' && typeof b === 'object' && !Array.isArray(a) && !Array.isArray(b)) {
+      const keys = new Set([...Object.keys(a as object), ...Object.keys(b as object)]);
+      for (const key of [...keys].sort()) {
+        walk((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key], path ? `${path}.${key}` : key);
+      }
+      return;
+    }
+    if (!Object.is(a, b)) differences.push(`${path}: pinned=${JSON.stringify(a)} current=${JSON.stringify(b)}`);
+  };
+  walk(pinned, current, '');
+  return differences;
+}
+
+export async function resolveSearchContractV1(engine: BrainEngine): Promise<SearchContractV1> {
+  const merged = await loadConfigWithEngine(engine, loadConfig());
+  const cfg = merged ?? ({ engine: engine.kind } as const);
+  const column = resolveEmbeddingColumn(undefined, cfg);
+  const knobs = resolveSearchMode(await loadSearchModeConfig(engine));
+
+  // Gateway resolution is the write/query truth for the builtin embedding
+  // column. A named alternate column carries its own provider + dimensions.
+  const model = column.name === 'embedding' ? getEmbeddingModel() : column.embeddingModel;
+  const dimensions = column.name === 'embedding' ? getEmbeddingDimensions() : column.dimensions;
+  return buildSearchContractV1(column, knobs, model, dimensions);
+}
+
+export async function checkSearchContractV1(engine: BrainEngine): Promise<SearchContractCheck> {
+  const current = await resolveSearchContractV1(engine);
+  const currentFingerprint = searchContractFingerprint(current);
+  const raw = await engine.getConfig(SEARCH_CONTRACT_V1_KEY);
+  if (!raw) {
+    return {
+      status: 'unpinned', current, pinned: null,
+      current_fingerprint: currentFingerprint, pinned_fingerprint: null,
+      differences: [],
+    };
+  }
+  let pinned: SearchContractV1;
+  try {
+    pinned = parseSearchContractV1(raw);
+  } catch (error) {
+    return {
+      status: 'invalid', current, pinned: null,
+      current_fingerprint: currentFingerprint, pinned_fingerprint: null,
+      differences: [], error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  const differences = diffSearchContracts(pinned, current);
+  return {
+    status: differences.length === 0 ? 'match' : 'drift',
+    current,
+    pinned,
+    current_fingerprint: currentFingerprint,
+    pinned_fingerprint: searchContractFingerprint(pinned),
+    differences,
+  };
+}
+
+export class SearchContractDriftError extends Error {
+  readonly code = 'search_contract_drift';
+  readonly check: SearchContractCheck;
+
+  constructor(check: SearchContractCheck) {
+    const detail = check.status === 'invalid'
+      ? `Pinned contract is invalid: ${check.error}`
+      : `Resolved search behavior differs from the pinned contract:\n  ${check.differences.join('\n  ')}`;
+    super(
+      `GBrain Search Contract v1 drift detected. ${detail}\n` +
+      'Refusing to mix embedding/search spaces. Inspect with `gbrain search contract check`.\n' +
+      'For a deliberate model migration, use `gbrain migrate embeddings`; then re-pin explicitly.',
+    );
+    this.name = 'SearchContractDriftError';
+    this.check = check;
+  }
+}
+
+export async function assertSearchContractV1(engine: BrainEngine): Promise<void> {
+  const check = await checkSearchContractV1(engine);
+  if (check.status === 'drift' || check.status === 'invalid') {
+    throw new SearchContractDriftError(check);
+  }
+}

--- a/test/cli-search-dispatch.test.ts
+++ b/test/cli-search-dispatch.test.ts
@@ -57,4 +57,14 @@ describe('T5 — gbrain search dispatch', () => {
       expect(stdout).toMatch(/total_calls|cache_hit_rate|window_days/);
     });
   });
+
+  test('`search contract pin` routes to the contract command and verifies its write', () => {
+    withHome((home) => {
+      const pinned = run(['search', 'contract', 'pin', '--json'], home);
+      expect(pinned.status).toBe(0);
+      const report = JSON.parse(pinned.stdout);
+      expect(report.status).toBe('match');
+      expect(report.pinned_fingerprint).toBe(report.current_fingerprint);
+    });
+  });
 });

--- a/test/commands-search.test.ts
+++ b/test/commands-search.test.ts
@@ -8,6 +8,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runSearch } from '../src/commands/search.ts';
+import { checkSearchContractV1 } from '../src/core/search/search-contract.ts';
 import { recordSearchTelemetry, _resetTelemetryWriterForTest, getTelemetryWriter } from '../src/core/search/telemetry.ts';
 import type { HybridSearchMeta } from '../src/core/types.ts';
 
@@ -131,6 +132,29 @@ describe('gbrain search modes --reset', () => {
     // Notice key preserved (it's not an "override"); tokenBudget gone.
     expect(await engine.getConfig('search.mode_upgrade_notice_shown')).toBe('true');
     expect(await engine.getConfig('search.tokenBudget')).toBeNull();
+  });
+
+  test('--reset preserves the Search Contract v1 pin', async () => {
+    await engine.setConfig('search.contract.v1', '{"version":1}');
+    await engine.setConfig('search.tokenBudget', '4000');
+    await captureRun(() => runSearch(engine, ['modes', '--reset']));
+    expect(await engine.getConfig('search.contract.v1')).toBe('{"version":1}');
+    expect(await engine.getConfig('search.tokenBudget')).toBeNull();
+  });
+});
+
+describe('gbrain search contract', () => {
+  test('pin captures current behavior and later mode drift is explicit', async () => {
+    await engine.setConfig('search.mode', 'balanced');
+    await captureRun(() => runSearch(engine, ['contract', 'pin', '--json']));
+
+    const pinned = await checkSearchContractV1(engine);
+    expect(pinned.status).toBe('match');
+
+    await engine.setConfig('search.mode', 'tokenmax');
+    const drifted = await checkSearchContractV1(engine);
+    expect(drifted.status).toBe('drift');
+    expect(drifted.differences.some((d) => d.includes('retrieval.mode'))).toBe(true);
   });
 });
 

--- a/test/doctor-search-mode.test.ts
+++ b/test/doctor-search-mode.test.ts
@@ -60,6 +60,13 @@ describe('checkSearchMode [CDX-20]', () => {
     expect(c.message).toContain('no per-key overrides');
   });
 
+  test('Search Contract v1 pin is excluded from override count', async () => {
+    await engine.setConfig('search.mode', 'balanced');
+    await engine.setConfig('search.contract.v1', '{"version":1}');
+    const c = await checkSearchMode(engine);
+    expect(c.message).toContain('no per-key overrides');
+  });
+
   test('tokenmax mode is recognized without any override warning', async () => {
     await engine.setConfig('search.mode', 'tokenmax');
     const c = await checkSearchMode(engine);

--- a/test/search-contract.test.ts
+++ b/test/search-contract.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveSearchMode, knobsHash } from '../src/core/search/mode.ts';
+import {
+  buildSearchContractV1,
+  diffSearchContracts,
+  embeddingInputSemantics,
+  parseSearchContractV1,
+  searchContractFingerprint,
+  serializeSearchContractV1,
+} from '../src/core/search/search-contract.ts';
+
+const column = {
+  name: 'embedding',
+  type: 'vector' as const,
+  dimensions: 2560,
+  embeddingModel: 'zeroentropyai:zembed-1',
+};
+const balanced = resolveSearchMode({ mode: 'balanced' });
+
+function contract() {
+  return buildSearchContractV1(column, balanced);
+}
+
+describe('Search Contract v1', () => {
+  test('captures zembed-1 2560d asymmetric retrieval and zerank-2', () => {
+    const value = contract();
+    expect(value).toMatchObject({
+      version: 1,
+      embedding: {
+        model: 'zeroentropyai:zembed-1',
+        dimensions: 2560,
+        column: 'embedding',
+        representation: 'vector',
+        metric: 'cosine',
+        input_semantics: 'query_document',
+      },
+      retrieval: { mode: 'balanced' },
+      reranker: {
+        enabled: true,
+        model: 'zeroentropyai:zerank-2',
+        top_n_in: 25,
+        timeout_ms: 5000,
+        failure_policy: 'fail_open',
+      },
+    });
+  });
+
+  test('round-trips canonical JSON and produces a stable fingerprint', () => {
+    const value = contract();
+    const raw = serializeSearchContractV1(value);
+    expect(parseSearchContractV1(raw)).toEqual(value);
+    expect(searchContractFingerprint(parseSearchContractV1(raw))).toBe(
+      searchContractFingerprint(value),
+    );
+  });
+
+  test('detects model, dimensions, representation, and reranker drift', () => {
+    const pinned = contract();
+    const current = structuredClone(pinned);
+    current.embedding.model = 'openai:text-embedding-3-large';
+    current.embedding.dimensions = 3072;
+    current.embedding.representation = 'halfvec';
+    current.reranker.model = 'zeroentropyai:zerank-1';
+    const differences = diffSearchContracts(pinned, current);
+    expect(differences.some((d) => d.startsWith('embedding.model:'))).toBe(true);
+    expect(differences.some((d) => d.startsWith('embedding.dimensions:'))).toBe(true);
+    expect(differences.some((d) => d.startsWith('embedding.representation:'))).toBe(true);
+    expect(differences.some((d) => d.startsWith('reranker.model:'))).toBe(true);
+  });
+
+  test('classifies provider input semantics explicitly', () => {
+    expect(embeddingInputSemantics('zeroentropyai:zembed-1')).toBe('query_document');
+    expect(embeddingInputSemantics('voyage:voyage-3-large')).toBe('query_document');
+    expect(embeddingInputSemantics('nvidia:nvidia/nv-embed-v1')).toBe('query_passage');
+    expect(embeddingInputSemantics('openai:text-embedding-3-large')).toBe('symmetric');
+  });
+
+  test('rejects malformed or unsupported pins', () => {
+    expect(() => parseSearchContractV1('{bad')).toThrow('invalid JSON');
+    const value = contract() as unknown as Record<string, unknown>;
+    value.version = 2;
+    expect(() => parseSearchContractV1(JSON.stringify(value))).toThrow('unsupported version');
+  });
+
+  test('contract fingerprint participates in query-cache identity', () => {
+    const first = contract();
+    const changed = structuredClone(first);
+    changed.embedding.dimensions = 1280;
+    const firstHash = knobsHash(balanced, {
+      embeddingColumn: 'embedding',
+      embeddingModel: first.embedding.model,
+      searchContractFingerprint: searchContractFingerprint(first),
+    });
+    const changedHash = knobsHash(balanced, {
+      embeddingColumn: 'embedding',
+      embeddingModel: changed.embedding.model,
+      searchContractFingerprint: searchContractFingerprint(changed),
+    });
+    expect(changedHash).not.toBe(firstHash);
+  });
+});

--- a/test/search-mode.test.ts
+++ b/test/search-mode.test.ts
@@ -410,10 +410,10 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // #2825: bumped 11→12 to fold the resolved hard-exclude prefix list
     // (hx=) — cached rows leaked GBRAIN_SEARCH_EXCLUDE'd slugs across
     // processes.
-    // #3390/#3391: bumped 12→13 for the embedding-provider migration wave —
-    // legacy callers hash prov=default before AND after a provider swap, so
-    // pre-migration cache rows must become unreachable on upgrade.
-    expect(KNOBS_HASH_VERSION).toBe(13);
+    // Search Contract v1: bumped 13→14 so dimensions, representation,
+    // input semantics, and the full retrieval profile participate in cache
+    // identity rather than relying on provider:model alone.
+    expect(KNOBS_HASH_VERSION).toBe(14);
   });
 
   test('T1 (codex): floor_ratio set vs unset produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -578,8 +578,8 @@ describe('v0.40.4 — graph_signals knob', () => {
 });
 
 describe('v0.42.3.0 — autocut knobs', () => {
-  test('KNOBS_HASH_VERSION is 13 (12→13 embedding-migration wave, #3390/#3391)', () => {
-    expect(KNOBS_HASH_VERSION).toBe(13);
+  test('KNOBS_HASH_VERSION is 14 (Search Contract v1 cache identity)', () => {
+    expect(KNOBS_HASH_VERSION).toBe(14);
   });
 
   test('bundle defaults: conservative off, balanced/tokenmax on @0.20', () => {


### PR DESCRIPTION
## Summary

Persisted vectors can currently be searched under a different runtime retrieval configuration without an explicit compatibility boundary. Matching dimensions are not enough: provider/model identity, query-vs-document encoding, storage representation, distance metric, fusion behavior, reranking, contextual text policy, and post-processing all affect retrieval semantics.

This introduces an opt-in, versioned Search Contract that can be pinned to a brain. Once pinned, ordinary runtime entrypoints fail closed when the active configuration is incompatible, while doctor, config, contract inspection, and explicit embedding-migration commands remain available for recovery.

The contract fingerprint is also part of semantic query-cache identity, so retrieval-defining changes invalidate stale cache entries. Doctor reports contract, schema, and embedding-provenance drift without making explicit repair workflows unreachable.

Existing installations remain unchanged until an operator runs `gbrain search contract pin`. The pin survives search-mode reset and can be inspected with `gbrain search contract show` or validated with `gbrain search contract check`. Future embedding-space changes are documented as reviewed migrations rather than dimension-only configuration edits.

## Validation

- `bun test test/search-contract.test.ts test/search-mode.test.ts test/doctor-search-mode.test.ts test/commands-search.test.ts test/cli-search-dispatch.test.ts test/doctor-categories.test.ts test/doctor.test.ts test/search.test.ts test/hybrid-search-lite.serial.test.ts` — 270 passed, 0 failed
- `bun run typecheck` — passed
- `bun run verify` — 32/32 checks passed
- `gbrain eval export --since 7d` — zero captured rows, so retrieval replay was not available

## New concepts

**Retrieval-space contract**

A retrieval-space contract is a serialized compatibility boundary for persisted vectors and the behavior that consumes them. It treats semantic identity as more than vector width: two 2,560-dimensional vectors may still be incompatible when they come from different models or use different query/document encoding semantics.

The contract is pinned separately from tunable search settings. Operators can tune within the compatible space, but changing a field that redefines that space produces an explicit drift failure and a cache-fingerprint change instead of silently mixing results.

This pattern is useful when embeddings outlive individual process configurations or deployments. It is unnecessary for stateless retrieval systems that never persist vectors or semantic caches.
