### PR TITLE
fix(extract): inferTypeByDir no longer asserts works_at without evidence (#3466)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -343,13 +343,36 @@ export function resolveSlugAll(
  * v0.13: aligned type names with link-extraction.ts (was: 'mention' →
  * 'mentions', 'attendee' → 'attended'). Diverged historically; the v0_13_0
  * migration normalizes any legacy rows on existing brains.
+ *
+ * v0.42.70: fix #3466 — the people→companies adjacency no longer
+ * asserts `works_at` without evidence. Previously every link from a
+ * people/ page to a companies/ page defaulted to `works_at`, producing
+ * 19k+ false employment claims on non-startup brains. The function now
+ * only returns `works_at` when the frontmatter carries explicit signals
+ * (role / title / position / company / employer / employee fields),
+ * defaulting to `mentions` otherwise — matching the evidence-based
+ * policy of `inferLinkType` in link-extraction.ts, which never
+ * asserts a typed edge without a regex match.
  */
-function inferTypeByDir(fromDir: string, toDir: string, frontmatter?: Record<string, unknown>): string {
+export function inferTypeByDir(fromDir: string, toDir: string, frontmatter?: Record<string, unknown>): string {
   const from = fromDir.split('/')[0];
   const to = toDir.split('/')[0];
   if (from === 'people' && to === 'companies') {
     if (Array.isArray(frontmatter?.founded)) return 'founded';
-    return 'works_at';
+    // issue #3466: only infer `works_at` when frontmatter carries
+    // explicit employment signals (role, title, position, company,
+    // employer, employee). Otherwise default to `mentions`.
+    if (frontmatter) {
+      const hasEmploymentSignal =
+        frontmatter.role !== undefined
+        || frontmatter.title !== undefined
+        || frontmatter.position !== undefined
+        || frontmatter.company !== undefined
+        || frontmatter.employer !== undefined
+        || frontmatter.employee !== undefined;
+      if (hasEmploymentSignal) return 'works_at';
+    }
+    return 'mentions';
   }
   if (from === 'people' && to === 'deals') return 'involved_in';
   if (from === 'deals' && to === 'companies') return 'deal_for';

--- a/test/infer-type-by-dir.test.ts
+++ b/test/infer-type-by-dir.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for inferTypeByDir — directory-based link-type inference for the
+ * fs-source path.
+ *
+ * Fixes issue #3466: the people→companies adjacency no longer asserts
+ * `works_at` without evidence. Default is now `mentions` when no
+ * frontmatter signals an employment relationship.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { inferTypeByDir } from '../src/commands/extract.ts';
+
+describe('inferTypeByDir', () => {
+  describe('people → companies', () => {
+    test('defaults to mentions when no frontmatter', () => {
+      // issue #3466 regression: previously returned 'works_at' without evidence
+      expect(inferTypeByDir('people/alice', 'companies/acme')).toBe('mentions');
+    });
+
+    test('defaults to mentions when frontmatter is empty', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {})).toBe('mentions');
+    });
+
+    test('defaults to mentions when frontmatter has unrelated fields', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        bio: 'Alice is a hacker',
+        location: 'NYC',
+      })).toBe('mentions');
+    });
+
+    test('returns founded when frontmatter has founded array', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        founded: ['acme'],
+      })).toBe('founded');
+    });
+
+    test('returns works_at when frontmatter has role', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        role: 'Engineer',
+      })).toBe('works_at');
+    });
+
+    test('returns works_at when frontmatter has title', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        title: 'CTO',
+      })).toBe('works_at');
+    });
+
+    test('returns works_at when frontmatter has position', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        position: 'Senior Engineer',
+      })).toBe('works_at');
+    });
+
+    test('returns works_at when frontmatter has company', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        company: 'Acme Corp',
+      })).toBe('works_at');
+    });
+
+    test('returns works_at when frontmatter has employer', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        employer: 'Acme Corp',
+      })).toBe('works_at');
+    });
+
+    test('returns works_at when frontmatter has employee flag', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        employee: true,
+      })).toBe('works_at');
+    });
+
+    test('founded takes precedence over employment signals', () => {
+      expect(inferTypeByDir('people/alice', 'companies/acme', {
+        founded: ['acme'],
+        role: 'CTO',
+      })).toBe('founded');
+    });
+  });
+
+  describe('other adjacencies', () => {
+    test('people → deals returns involved_in', () => {
+      expect(inferTypeByDir('people/alice', 'deals/series-a')).toBe('involved_in');
+    });
+
+    test('deals → companies returns deal_for', () => {
+      expect(inferTypeByDir('deals/series-a', 'companies/acme')).toBe('deal_for');
+    });
+
+    test('meetings → people returns attended', () => {
+      expect(inferTypeByDir('meetings/standup', 'people/alice')).toBe('attended');
+    });
+
+    test('unrecognized adjacency returns mentions', () => {
+      expect(inferTypeByDir('concepts/rag', 'concepts/embeddings')).toBe('mentions');
+    });
+
+    test('people → companies with subdir paths still works', () => {
+      expect(inferTypeByDir('people/team/alice', 'companies/tech/acme')).toBe('mentions');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #3466: the directory-based link-type inference function `inferTypeByDir` defaulted to `works_at` for every people→companies adjacency, producing **19k+ false employment claims** on non-startup brains where people pages simply linked to companies without any employment relationship.

## Root Cause

`inferTypeByDir` (in `src/commands/extract.ts`) had no evidence threshold — it asserted `works_at` purely from the directory path pattern (people/ → companies/), unlike the canonical `inferLinkType` in `link-extraction.ts` which only emits a typed edge after a regex match on explicit context text.



## Changes

1. **Default people→companies links to `mentions`** instead of `works_at` — matching the evidence-based policy of `inferLinkType`
2. **Only infer `works_at`** when frontmatter carries explicit employment signals: `role`, `title`, `position`, `company`, `employer`, `employee` fields
3. **Keep `founded` inference** (via `frontmatter.founded` array) as before
4. **Export `inferTypeByDir`** for unit testability
5. **Add comprehensive test suite** (`test/infer-type-by-dir.test.ts`) with 14 test cases covering:
   - Default behavior (mentions without evidence)
   - Founded inference (with founded array)
   - Works_at inference (with employment signals)
   - Signal precedence (founded > employment signals)
   - All other adjacency types (deals, meetings, unrecognized)

## Impact

Prevents mass knowledge graph corruption on non-startup brains where people pages reference companies in non-employment contexts (e.g., investment, advisory, competition). The fix aligns fs-source inference with the evidence-based policy already used by db-source `inferLinkType`.

## Testing

- [x] Added 14 unit tests for `inferTypeByDir` covering all adjacency types and signal combinations
- [x] Regression test for the specific issue #3466 scenario (people→companies without evidence → mentions)
- [x] Code diagnostics clean (no type/lint errors)
- [x] All existing adjacency types preserved (deals, meetings, unrecognized)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] The fix addresses the root cause described in the issue
- [x] Backward compatible — only changes default behavior, no API breakage