### PR TITLE
fix(chunker): CJK-dense content gets token-aware char cap (issue #3037)

### DIFF
--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -14,10 +14,17 @@
  * guarantees no chunk overflows OpenAI's 8192-token embedding limit even
  * on pathological CJK / whitespace-less text.
  *
+ * v0.42.70 (issue #3037): CJK-dense content gets a token-aware cap.
+ * The embedder limits by TOKENS not characters; for CJK text 1 char ≈ 1
+ * token, so a 6000-char CJK chunk can be ~6000 tokens and get silently
+ * rejected (exit 0, never embedded). The chunker now detects CJK density
+ * and applies a tighter char budget (3000 chars for CJK-dominant text)
+ * so chunks stay under the typical 8192-token limit.
+ *
  * Lossless invariant: non-overlapping portions reassemble to original.
  */
 
-import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } from '../cjk.ts';
+import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS, CJK_DENSITY_THRESHOLD, hasCJK } from '../cjk.ts';
 
 /**
  * Markdown chunker version. Folded into the per-page chunker_version column
@@ -34,7 +41,7 @@ import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } fr
  * post-upgrade reembed sweep. See
  * `src/core/contextual-retrieval-service.ts`.
  */
-export const MARKDOWN_CHUNKER_VERSION = 3;
+export const MARKDOWN_CHUNKER_VERSION = 4;
 
 const DELIMITERS: string[][] = [
   ['\n\n'],                          // L0: paragraphs
@@ -87,10 +94,17 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const stripped = stripFactsFence(stripTakesFence(text), { keepVisibility: ['world'] });
   if (!stripped || stripped.trim().length === 0) return [];
 
+  // v0.42.70 (issue #3037): detect CJK density upfront so we can apply
+  // a token-aware cap. CJK text has ~1 char/token ratio vs ~3.5 chars/
+  // token for English; the same char cap produces very different token
+  // counts. We compute an effective char cap that accounts for CJK
+  // density, ensuring chunks stay under the embedder's token limit.
+  const effectiveMaxChars = computeEffectiveMaxChars(stripped, maxChars);
+
   const wordCount = countWords(stripped);
   if (wordCount <= chunkSize) {
-    // Single-chunk path: still apply the maxChars cap.
-    const capped = capByChars(stripped.trim(), maxChars);
+    // Single-chunk path: still apply the CJK-aware maxChars cap.
+    const capped = capByChars(stripped.trim(), effectiveMaxChars);
     return capped.map((t, i) => ({ text: t, index: i }));
   }
 
@@ -101,11 +115,50 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   // v0.32.7: hard char cap. Catches pathological CJK + whitespace-less text
   // that the word-level pipeline can't bound (a single Chinese paragraph can
   // exceed 8192 OpenAI embedding tokens at any word count).
+  //
+  // v0.42.70 (issue #3037): use the CJK-aware effective cap. CJK-dense
+  // chunks need a tighter char budget because 1 CJK char ≈ 1 token (vs
+  // 3.5 chars/token for English). Without this, a 6000-char CJK chunk
+  // would be ~6000 tokens, dangerously close to the 8192-token limit.
   const capped: string[] = [];
   for (const chunk of withOverlap) {
-    capped.push(...capByChars(chunk.trim(), maxChars));
+    capped.push(...capByChars(chunk.trim(), effectiveMaxChars));
   }
   return capped.map((t, i) => ({ text: t, index: i }));
+}
+
+/**
+ * Compute an effective char cap that accounts for CJK token density
+ * (issue #3037).
+ *
+ * The embedder limits by TOKENS, not characters. For English text,
+ * ~3.5 chars = 1 token; for CJK text, ~1 char = 1 token. The default
+ * maxChars (6000) is safe for English (≈1714 tokens) but dangerous for
+ * CJK (≈6000 tokens, close to the 8192-token limit).
+ *
+ * This function detects CJK density and scales the cap proportionally:
+ * - CJK density < 0.30: keep original maxChars (Latin-dominant)
+ * - CJK density ≥ 0.30: scale cap by density / CJK_DENSITY_THRESHOLD
+ *   so that at full CJK density (1.0), the cap is maxChars * 0.30
+ *   ≈ 1800 chars, keeping chunks well under the 8192-token limit.
+ *
+ * The formula: effectiveMaxChars = maxChars * (CJK_DENSITY_THRESHOLD / density)
+ * clamped to [500, maxChars].
+ */
+function computeEffectiveMaxChars(text: string, maxChars: number): number {
+  const cjkMatches = text.match(new RegExp(`[${'一-鿿぀-ゟ゠-ヿ가-힯'}]`, 'g'));
+  const cjkCount = cjkMatches ? cjkMatches.length : 0;
+  const nonWhitespace = text.replace(/\s/g, '').length;
+  if (nonWhitespace === 0) return maxChars;
+  const density = cjkCount / nonWhitespace;
+  if (density < CJK_DENSITY_THRESHOLD) return maxChars;
+  // CJK-dominant: scale down the char cap. At density=1.0 (pure CJK),
+  // effective = maxChars * (0.30 / 1.0) = maxChars * 0.30 ≈ 1800 chars.
+  // This keeps chunks well under the 8192-token embedder limit.
+  const scaleFactor = CJK_DENSITY_THRESHOLD / density;
+  const scaled = Math.floor(maxChars * scaleFactor);
+  // Never exceed the original cap; never go below a minimum useful size.
+  return Math.max(500, Math.min(maxChars, scaled));
 }
 
 /**

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -135,13 +135,13 @@ describe('Recursive Text Chunker', () => {
 });
 
 describe('CJK chunking (v0.32.7)', () => {
-  test('MARKDOWN_CHUNKER_VERSION is 3', async () => {
-    // v0.40.3.0: bumped 2→3 to signal the post-upgrade reembed sweep that
-    // contextual retrieval wrapping is now applied at embed time. Chunk
-    // boundaries themselves are unchanged; the bump forces re-embed for
-    // pages where chunker_version < 3.
+  test('MARKDOWN_CHUNKER_VERSION is 4', async () => {
+    // v0.42.70 (issue #3037): bumped 3→4 to signal the CJK token-aware cap
+    // change. Post-upgrade sweep must re-chunk existing pages so CJK-dense
+    // content gets the tighter char budget that keeps chunks under the
+    // embedder's token limit.
     const mod = await import('../../src/core/chunkers/recursive.ts');
-    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(3);
+    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(4);
   });
 
   test('long pure-Chinese paragraph splits into multiple chunks', () => {
@@ -214,5 +214,41 @@ describe('CJK chunking (v0.32.7)', () => {
     expect(chunks.length).toBeGreaterThan(0);
     // Should have been chunked by word boundaries (English-dominant doc).
     expect(chunks.every(c => /^[\x20-\x7e\s]+$/.test(c.text))).toBe(true);
+  });
+
+  test('CJK token-aware cap reduces maxChars for CJK-dense text (issue #3037)', () => {
+    // Pure Chinese text has density ≈ 1.0, so the effective cap should be
+    // maxChars * (0.30 / 1.0) = 6000 * 0.30 ≈ 1800 chars. This prevents
+    // chunks from silently exceeding the embedder's token limit.
+    const text = '测试'.repeat(10000); // 20K CJK chars, no whitespace
+    const chunks = chunkText(text, { chunkSize: 100000, chunkOverlap: 0, maxChars: 6000 });
+    expect(chunks.length).toBeGreaterThan(1);
+    // For pure CJK (density=1.0), effectiveMaxChars ≈ 1800
+    // So chunks should be ≤ 1800 chars, not 6000
+    for (const c of chunks) {
+      // Allow some tolerance due to overlap
+      expect(c.text.length).toBeLessThanOrEqual(2000); // ~1800 + overlap
+    }
+  });
+
+  test('CJK token-aware cap fires earlier for very-high-density CJK', () => {
+    const text = '你好世界测试人工智能语义搜索'.repeat(500); // 7500 CJK chars
+    const chunks = chunkText(text, { chunkSize: 100000, chunkOverlap: 0, maxChars: 6000 });
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    // Each chunk should be around 1800 chars (6000 * 0.30)
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(2000);
+    }
+  });
+
+  test('English text keeps original maxChars cap', () => {
+    // Pure English text has CJK density ≈ 0, so effectiveMaxChars = maxChars
+    const text = 'A'.repeat(8000); // 8000 ASCII chars
+    const chunks = chunkText(text, { chunkSize: 100000, chunkOverlap: 0, maxChars: 6000 });
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    // English text should respect the original 6000 char cap
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(6000);
+    }
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes issue #3037: the markdown chunker capped chunks by **characters** (default 6000) while the embedder limited by **tokens**. For English text (~3.5 chars/token) this was safe (~1714 tokens), but for CJK text (~1 char/token) a 6000-char chunk was ~6000 tokens — dangerously close to the 8192-token embedder limit. CJK-dense content was **silently rejected** (exit 0, never embedded), causing permanent retrieval gaps.

## Root Cause

The `capByChars()` function in `src/core/chunkers/recursive.ts` used a fixed `maxChars` with no awareness of the different char-per-token ratios between languages. The chunker's word-counting was already CJK-aware (via `countCJKAwareWords`), but the safety-belt character cap was not.

## Changes

1. **Added `computeEffectiveMaxChars()`** function that detects CJK density and scales the char cap proportionally:
   - CJK density < 0.30: keep original `maxChars` (Latin-dominant, no behavior change)
   - CJK density ≥ 0.30: scale by `CJK_DENSITY_THRESHOLD / density`
   - At pure CJK density (1.0): 6000 × 0.30 ≈ **1800 chars** ≈ 1800 tokens, well under the 8192-token limit

2. **Applied the effective cap** to BOTH code paths in `chunkText()`:
   - Single-chunk fast path (word count ≤ chunkSize)
   - Multi-chunk sliding window path

3. **Bumped `MARKDOWN_CHUNKER_VERSION`** 3→4 to force post-upgrade re-chunk of existing pages with CJK-dense content

4. **Added 3 new test cases**:
   - Pure CJK text: chunks capped at ~1800 chars (vs old 6000)
   - High-density CJK: properly produces multiple chunks
   - English text: keeps original 6000-char cap unchanged

## Testing

- [x] Updated `MARKDOWN_CHUNKER_VERSION` test to expect version 4
- [x] Added 3 new test cases for CJK token-aware cap behavior
- [x] Code diagnostics clean (no type/lint errors)
- [x] Existing English chunking behavior is unchanged (verified by regression test)

## Impact

**Prevents silent embedding failures** for CJK-dense content. The fix:
- Ensures CJK chunks stay well under the embedder's token limit
- Maintains backward compatibility for English-dominant text
- Requires re-chunking of CJK-heavy pages after upgrade (signaled by chunker_version bump)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] The fix addresses the root cause described in the issue
- [x] Backward compatible — English text behavior unchanged