### PR TITLE
fix(think): preserve federated source scope

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2055,7 +2055,7 @@ const think: Operation = {
     let savedSlug: string | undefined;
     let evidenceInserted = 0;
     if (safeSave) {
-      const persisted = await persistSynthesis(ctx.engine, result);
+      const persisted = await persistSynthesis(ctx.engine, result, thinkScope);
       savedSlug = persisted.slug;
       evidenceInserted = persisted.evidenceInserted;
       for (const w of persisted.warnings) result.warnings.push(w);

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -114,6 +114,24 @@ export interface RunThinkOpts {
   remote?: boolean;
 }
 
+type ThinkSourceScope = Pick<RunThinkOpts, 'sourceId' | 'allowedSources'>;
+
+function sourceIdsForThink(scope: ThinkSourceScope): string[] {
+  const allowed = scope.allowedSources?.filter(Boolean);
+  if (allowed && allowed.length > 0) return allowed;
+  return [scope.sourceId ?? 'default'];
+}
+
+function engineSourceScope(scope: ThinkSourceScope): {
+  sourceId?: string;
+  sourceIds?: string[];
+} {
+  const sourceIds = sourceIdsForThink(scope);
+  return scope.allowedSources?.length
+    ? { sourceIds }
+    : { sourceId: sourceIds[0] };
+}
+
 /** Structured response from the LLM (matches the schema declared in prompt.ts). */
 export interface ThinkResponse {
   answer: string;
@@ -211,18 +229,25 @@ async function persistCitations(
   engine: BrainEngine,
   synthesisPageId: number,
   citations: ParsedCitation[],
+  scope: ThinkSourceScope,
 ): Promise<{ inserted: number; warnings: string[] }> {
   const warnings: string[] = [];
+  const sourceIds = sourceIdsForThink(scope);
   // Resolve unique slugs to page_ids
   const slugToPageId = new Map<string, number>();
   for (const c of citations) {
     if (c.row_num === null) continue;  // page-level, skip
     if (slugToPageId.has(c.page_slug)) continue;
-    const rows = await engine.executeRaw<{ id: number }>(
-      `SELECT id FROM pages WHERE slug = $1 LIMIT 1`,
-      [c.page_slug],
-    );
-    if (rows[0]) slugToPageId.set(c.page_slug, rows[0].id);
+    for (const sourceId of sourceIds) {
+      const rows = await engine.executeRaw<{ id: number }>(
+        `SELECT id FROM pages WHERE slug = $1 AND source_id = $2 LIMIT 1`,
+        [c.page_slug, sourceId],
+      );
+      if (rows[0]) {
+        slugToPageId.set(c.page_slug, rows[0].id);
+        break;
+      }
+    }
   }
   const evidenceInputs: SynthesisEvidenceInput[] = [];
   for (const c of citations) {
@@ -295,8 +320,7 @@ export async function runThink(
     anchor: opts.anchor,
     questionEmbedding,
     takesHoldersAllowList: opts.takesHoldersAllowList,
-    ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
-    ...(opts.allowedSources !== undefined ? { sourceIds: opts.allowedSources } : {}),
+    ...engineSourceScope(opts),
   });
 
   // Render evidence blocks for the prompt
@@ -361,7 +385,7 @@ export async function runThink(
         if (candidates.length > 0) {
           const { resolveEntitySlugWithSource } = await import('../entities/resolve.ts');
           const { formatTrajectoryBlock } = await import('../trajectory-format.ts');
-          const sourceIdScalar = opts.sourceId ?? 'default';
+          const sourceIds = sourceIdsForThink(opts);
           // Per-candidate trajectory fetch. Concurrency cap = 3; each call
           // has its own 5s timeout via Promise.race. allSettled prevents
           // one error from killing the others (Codex Problem 13: timeout
@@ -374,9 +398,15 @@ export async function runThink(
             const batch = candidateQueue.splice(0, 3);
             const settled = await Promise.allSettled(
               batch.map(async (cand) => {
-                const resolved = await resolveEntitySlugWithSource(engine, sourceIdScalar, cand.raw);
+                let resolved = null;
+                for (const sourceId of sourceIds) {
+                  const candidate = await resolveEntitySlugWithSource(engine, sourceId, cand.raw);
+                  if (candidate && candidate.source !== 'fallback_slugify') {
+                    resolved = candidate;
+                    break;
+                  }
+                }
                 if (!resolved) return null;
-                if (resolved.source === 'fallback_slugify') return null;
                 if (seenSlugs.has(resolved.slug)) return null;
                 seenSlugs.add(resolved.slug);
                 // 5s per-candidate timeout. Promise.race resolves with the
@@ -384,8 +414,7 @@ export async function runThink(
                 const points = await Promise.race([
                   engine.findTrajectory({
                     entitySlug: resolved.slug,
-                    ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
-                    ...(opts.allowedSources !== undefined ? { sourceIds: opts.allowedSources } : {}),
+                    ...engineSourceScope(opts),
                     ...(opts.remote !== undefined ? { remote: opts.remote } : {}),
                     kind: 'all',
                     limit: 100,
@@ -612,6 +641,7 @@ export function stripGapsSection(answer: string): string {
 export async function persistSynthesis(
   engine: BrainEngine,
   result: ThinkResult,
+  scope: ThinkSourceScope = {},
 ): Promise<{ slug: string; evidenceInserted: number; warnings: string[] }> {
   // #1698: never persist an empty synthesis. Returned signal (NOT a throw, F3) so
   // the MCP `think` op can return the gather result + warning instead of a bare error
@@ -653,7 +683,7 @@ export async function persistSynthesis(
     },
   });
 
-  const persisted = await persistCitations(engine, page.id, result.citations);
+  const persisted = await persistCitations(engine, page.id, result.citations, scope);
   return { slug, evidenceInserted: persisted.inserted, warnings: persisted.warnings };
 }
 

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -337,6 +337,60 @@ describe('runThink (with stub client)', () => {
     );
     expect(Number(ev[0]?.count)).toBe(1);
   });
+
+  test('persistSynthesis resolves duplicate citation slugs within the federated source scope', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config)
+       VALUES ('citation-work', 'citation-work', '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const defaultPage = await engine.putPage('people/citation-scope', {
+      title: 'Default Citation',
+      type: 'person',
+      compiled_truth: 'Default source.',
+    });
+    const workPage = await engine.putPage('people/citation-scope', {
+      title: 'Work Citation',
+      type: 'person',
+      compiled_truth: 'Work source.',
+    }, { sourceId: 'citation-work' });
+    await engine.addTakesBatch([
+      { page_id: defaultPage.id, row_num: 1, claim: 'Default evidence', kind: 'fact', holder: 'world', weight: 1 },
+      { page_id: workPage.id, row_num: 1, claim: 'Work evidence', kind: 'fact', holder: 'world', weight: 1 },
+    ]);
+
+    const result = {
+      question: 'federated citation scope',
+      answer: 'Scoped evidence [people/citation-scope#1].',
+      citations: [{ page_slug: 'people/citation-scope', row_num: 1, citation_index: 1 }],
+      gaps: [],
+      pagesGathered: 1,
+      takesGathered: 0,
+      graphHits: 0,
+      modelUsed: 'stub',
+      rounds: 1,
+      warnings: [],
+      synthesisOk: true,
+      diagnostics: { pagesFromHybrid: 1, takesFromKeyword: 0, takesFromVector: 0, graphHits: 0 },
+    };
+
+    const saved = await persistSynthesis(
+      engine,
+      result,
+      { allowedSources: ['citation-work'] },
+    );
+    const evidence = await engine.executeRaw<{ take_page_id: number }>(
+      `SELECT take_page_id
+         FROM synthesis_evidence
+        WHERE synthesis_page_id = (
+          SELECT id FROM pages WHERE slug = $1 AND source_id = 'default'
+        )`,
+      [saved.slug],
+    );
+
+    expect(defaultPage.id).not.toBe(workPage.id);
+    expect(evidence).toEqual([{ take_page_id: workPage.id }]);
+  });
 });
 
 // #1698 — fail loud, never persist empty.

--- a/test/think-trajectory-injection.test.ts
+++ b/test/think-trajectory-injection.test.ts
@@ -106,6 +106,39 @@ describe('runThink — trajectory injection happy path', () => {
     expect(captured[0].user).not.toContain('Known trajectory:');
     expect(captured[0].user).not.toContain('<trajectory');
   });
+
+  test('federated source array resolves trajectory entities outside default', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config)
+       VALUES ('work', 'work', '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    await engine.putPage('people/wren-scope', {
+      title: 'Wren Scope',
+      type: 'person',
+      compiled_truth: 'Wren changed roles.',
+    }, { sourceId: 'work' });
+    await engine.executeRaw(
+      `INSERT INTO facts (
+         source_id, entity_slug, fact, kind, visibility,
+         valid_from, source, source_session, event_type
+       ) VALUES (
+         'work', 'people/wren-scope', 'joined the work source', 'event', 'private',
+         '2026-06-01T00:00:00Z', 'test', 'scope-session', 'role_change'
+       )`,
+    );
+
+    const { client, captured } = captureClient();
+    await runThink(engine, {
+      question: 'When did Wren Scope change roles?',
+      client,
+      allowedSources: ['work'],
+    });
+
+    expect(captured[0].user).toContain('Known trajectory:');
+    expect(captured[0].user).toContain('<trajectory entity="people/wren-scope"');
+    expect(captured[0].user).toContain('joined the work source');
+  });
 });
 
 describe('runThink — kill switches', () => {


### PR DESCRIPTION
## Summary

- apply one source-precedence rule across think gather, trajectory entity resolution, trajectory reads, and citation persistence
- resolve federated trajectory candidates across the granted source array instead of collapsing to `default`
- persist synthesis evidence against the granted duplicate-slug page and pass operation scope into the save path

## Root cause

The federated source array reached gather and `findTrajectory`, but entity resolution used `opts.sourceId ?? 'default'`. Citation persistence accepted no source scope and queried duplicate slugs without `source_id`. These gaps could omit a granted trajectory or attach saved evidence to an arbitrary same-slug page.

## Verification

- failing reproduction before fix: 42 passed, 2 failed
- targeted source-scope suites after fix: 44 passed, 0 failed
- complete verification gate: 32 passed, 0 failed
- `git diff --check`
