### PR TITLE
fix(cli): make backfill command reachable — add to CLI_ONLY (#3224)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ export function bigintToStringReplacer(_key: string, value: unknown): unknown {
 }
 
 // CLI-only commands that bypass the operation layer
-export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'maintain', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'reconcile-links', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'retrieval-upgrade', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector']);
+export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'maintain', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'reconcile-links', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'retrieval-upgrade', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector', 'backfill']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -2448,6 +2448,7 @@ TOOLS
   publish <page.md> [--password]     Shareable HTML (strips private data, optional AES-256)
   check-backlinks <check|fix> [dir]  Find/fix missing back-links across brain
   lint <dir|file> [--fix]            Catch LLM artifacts, placeholder dates, bad frontmatter
+  backfill <kind|list>               v0.30.1: run a registered backfill (effective-date, ...)
   orphans [--json] [--count]         Find pages with no inbound wikilinks
   salience [--days N] [--kind P]     v0.29: pages ranked by emotional + activity salience
   anomalies [--since D] [--sigma N]  v0.29: cohort-based statistical anomalies (tag, type)

--- a/test/reconcile-links-cli-reachability.test.ts
+++ b/test/reconcile-links-cli-reachability.test.ts
@@ -19,3 +19,23 @@ describe('CLI_ONLY command reachability (#2900)', () => {
     expect(CLI_ONLY.has('reconcile-links')).toBe(true);
   });
 });
+
+// #3224 — same drift class: `backfill` has a full `case 'backfill'` handler
+// (cli.ts, dispatching to commands/backfill.ts) but was missing from CLI_ONLY,
+// so every invocation hit the generic "Unknown command" branch.
+describe('CLI_ONLY command reachability (#3224)', () => {
+  test('`backfill` is in CLI_ONLY so dispatch reaches its handler', () => {
+    expect(CLI_ONLY.has('backfill')).toBe(true);
+  });
+
+  test('`gbrain backfill --help` is dispatched, not rejected as unknown', () => {
+    const { spawnSync } = require('node:child_process') as typeof import('node:child_process');
+    const result = spawnSync('bun', ['run', 'src/cli.ts', 'backfill', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: { ...process.env, GBRAIN_HOME: '/tmp/gbrain-test-backfill-nonexistent' },
+    });
+    expect(result.stderr ?? '').not.toContain('Unknown command');
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #3224.

## Bug

`gbrain backfill` is fully implemented (`case 'backfill'` in `src/cli.ts` → `src/commands/backfill.ts`, handling `kind | list | --help`) but was absent from the `CLI_ONLY` set at `src/cli.ts:58`, so dispatch rejected it before the case was ever reached:

```
$ gbrain backfill --help
Unknown command: backfill
```

Same drift class as #2900 (`reconcile-links`) and #2035 (`calibration`).

## Fix

One word: add `'backfill'` to `CLI_ONLY`. Also lists it in the main `--help` TOOLS section (it was undocumented there too).

## Discrimination proof

New behavioral test spawns the real dispatcher (`bun run src/cli.ts backfill --help`). On unmodified master:

```
Expected to not contain: "Unknown command"
Received: "Unknown command: backfill\nRun gbrain --help for available commands."
✗ CLI_ONLY command reachability (#3224) > `gbrain backfill --help` is dispatched, not rejected as unknown
```

With the fix: 3 pass / 0 fail.

`bun run typecheck` clean; `bun run verify` 32/32 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)