### PR TITLE
fix(sources): honor unfederate for unqualified reads (#2928)

### DIFF
--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -200,32 +200,27 @@ export function resolveSourceIdEngineFree(
  * doesn't auto-resolve. Shared by `resolveSourceId` and `resolveSourceWithTier`
  * so the heuristic can't drift between the two entry points.
  *
- * #2928: also refuses to auto-pick a source EXPLICITLY marked isolated
- * (`gbrain sources unfederate <id>` / `--no-federated` → config.federated =
- * false). Auto-routing there made an unqualified `query`/`search`/`think`
- * surface the isolated source's pages — the exact thing unfederate promises
- * to prevent ("only searched when explicitly named"). UNSET federated stays
- * eligible: a fresh `sources add` writes no federated key, and the #1434
- * sole-source convenience must keep working for it. Narrowing-only by
- * design — an isolated sole source falls through to 'default'; the tier
- * never widens to some OTHER source it wouldn't have picked before.
+ * NOTE (#2928): this tier deliberately does NOT consult config.federated —
+ * `--no-federated` governs READ mixing, not write routing, and unqualified
+ * `sync`/`import` on a single-vault brain must keep landing in the vault
+ * (#1434, pinned by test/sync-sole-non-default-routing.test.ts). The
+ * unfederate read fix lives in `localFederatedSourceIds` below.
  */
 async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | null> {
   // archived column was added in v34 (v0.26.5). Older brains may not have
   // it — fall back to the un-archived query in that case via try/catch.
-  let rows: Array<{ id: string; config: unknown }>;
+  let rows: Array<{ id: string }>;
   try {
-    rows = await engine.executeRaw<{ id: string; config: unknown }>(
-      `SELECT id, config FROM sources WHERE local_path IS NOT NULL AND id != 'default' AND archived = false`,
+    rows = await engine.executeRaw<{ id: string }>(
+      `SELECT id FROM sources WHERE local_path IS NOT NULL AND id != 'default' AND archived = false`,
     );
   } catch {
-    rows = await engine.executeRaw<{ id: string; config: unknown }>(
-      `SELECT id, config FROM sources WHERE local_path IS NOT NULL AND id != 'default'`,
+    rows = await engine.executeRaw<{ id: string }>(
+      `SELECT id FROM sources WHERE local_path IS NOT NULL AND id != 'default'`,
     );
   }
-  if (rows.length !== 1) return null;
-  if (parseSourceConfig(rows[0].config).federated === false) return null;
-  return rows[0].id;
+  if (rows.length === 1) return rows[0].id;
+  return null;
 }
 
 /**
@@ -404,7 +399,10 @@ export async function resolveSourceWithTier(
  *
  *   - explicit tiers (`flag` / `env` / `dotfile`): the user named a source;
  *     scalar scope stands (that IS the qualified case);
- *   - no other federated source exists: keep the scalar fast path unchanged.
+ *   - no other federated source exists: keep the scalar fast path unchanged;
+ *   - #2928: the resolved source is explicitly isolated (config.federated =
+ *     false): it must not be mixed into a cross-source read in EITHER
+ *     direction, so the scalar scope stands.
  *
  * Archived sources are excluded (same rationale as pickSoleNonDefaultSource);
  * the archived column is v34+, so fall back to the un-archived query on older
@@ -426,6 +424,16 @@ export async function localFederatedSourceIds(
     rows = await engine.executeRaw<{ id: string; config: unknown }>(
       `SELECT id, config FROM sources ORDER BY id`,
     );
+  }
+  // #2928: an EXPLICITLY isolated anchor (`sources unfederate` /
+  // `--no-federated` → config.federated = false) opted out of cross-source
+  // read mixing — never widen it into the federated set (which would drag
+  // other sources' pages into its unqualified reads and vice versa). Scalar
+  // scope stands. UNSET federated keeps the pre-#2928 widening behavior;
+  // write routing (tier 5.5 above) is deliberately untouched.
+  const resolvedRow = rows.find((row) => row.id === sourceId);
+  if (resolvedRow && parseSourceConfig(resolvedRow.config).federated === false) {
+    return undefined;
   }
   const ids = [
     sourceId,

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -16,7 +16,7 @@
 import { readFileSync, lstatSync, type Stats } from 'fs';
 import { join, dirname, resolve } from 'path';
 import type { BrainEngine } from './engine.ts';
-import { isSourceFederated } from './sources-load.ts';
+import { isSourceFederated, parseSourceConfig } from './sources-load.ts';
 import { SOURCE_ID_RE, isValidSourceId } from './source-id.ts';
 import { isTrustedDotfile, realpathOrResolve } from './path-confine.ts';
 
@@ -199,22 +199,33 @@ export function resolveSourceIdEngineFree(
  * Excludes archived sources (`archived = false`) so a soft-deleted source
  * doesn't auto-resolve. Shared by `resolveSourceId` and `resolveSourceWithTier`
  * so the heuristic can't drift between the two entry points.
+ *
+ * #2928: also refuses to auto-pick a source EXPLICITLY marked isolated
+ * (`gbrain sources unfederate <id>` / `--no-federated` → config.federated =
+ * false). Auto-routing there made an unqualified `query`/`search`/`think`
+ * surface the isolated source's pages — the exact thing unfederate promises
+ * to prevent ("only searched when explicitly named"). UNSET federated stays
+ * eligible: a fresh `sources add` writes no federated key, and the #1434
+ * sole-source convenience must keep working for it. Narrowing-only by
+ * design — an isolated sole source falls through to 'default'; the tier
+ * never widens to some OTHER source it wouldn't have picked before.
  */
 async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | null> {
   // archived column was added in v34 (v0.26.5). Older brains may not have
   // it — fall back to the un-archived query in that case via try/catch.
-  let rows: Array<{ id: string }>;
+  let rows: Array<{ id: string; config: unknown }>;
   try {
-    rows = await engine.executeRaw<{ id: string }>(
-      `SELECT id FROM sources WHERE local_path IS NOT NULL AND id != 'default' AND archived = false`,
+    rows = await engine.executeRaw<{ id: string; config: unknown }>(
+      `SELECT id, config FROM sources WHERE local_path IS NOT NULL AND id != 'default' AND archived = false`,
     );
   } catch {
-    rows = await engine.executeRaw<{ id: string }>(
-      `SELECT id FROM sources WHERE local_path IS NOT NULL AND id != 'default'`,
+    rows = await engine.executeRaw<{ id: string; config: unknown }>(
+      `SELECT id, config FROM sources WHERE local_path IS NOT NULL AND id != 'default'`,
     );
   }
-  if (rows.length === 1) return rows[0].id;
-  return null;
+  if (rows.length !== 1) return null;
+  if (parseSourceConfig(rows[0].config).federated === false) return null;
+  return rows[0].id;
 }
 
 /**

--- a/test/unfederate-read-scope-2928.test.ts
+++ b/test/unfederate-read-scope-2928.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #2928 — `gbrain sources unfederate <id>` (config.federated = false) must
+ * keep the isolated source out of UNQUALIFIED reads.
+ *
+ * Root cause is NOT the functions the issue points at (`sourceScopeOpts` /
+ * the dead `federatedOnly` loader flag): the read-widening path
+ * (`localFederatedSourceIds` → `federatedSearchScope`) already excludes
+ * non-federated sources. The intent is lost one step earlier, in source
+ * RESOLUTION: `pickSoleNonDefaultSource` (tier 5.5, #1434) auto-picks the
+ * single non-default source as the anchor of an unqualified call without
+ * consulting config.federated — so an explicitly isolated source becomes the
+ * scalar read scope and its pages surface in unqualified query/search/think.
+ *
+ * All imports here exist on master, so this file runs against an unmodified
+ * master checkout and fails BEHAVIORALLY there (resolution returns the
+ * isolated source).
+ *
+ * Also pins the unscoped-local invariant that sank #3470/#3497: an empty
+ * scope must stay UNSCOPED ({}), never collapse to 'default'.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import {
+  resolveSourceWithTier,
+  localFederatedSourceIds,
+} from '../src/core/source-resolver.ts';
+import {
+  sourceScopeOpts,
+  federatedSearchScope,
+  type OperationContext,
+} from '../src/core/operations.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+let engine: PGLiteEngine;
+/** A cwd guaranteed to be outside every registered source local_path. */
+let outsideCwd: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+/** Resolve with the env tier neutralized (host shell may set GBRAIN_SOURCE). */
+function resolveClean(explicit: string | null, cwd: string) {
+  return withEnv({ GBRAIN_SOURCE: undefined }, () => resolveSourceWithTier(engine, explicit, cwd));
+}
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  outsideCwd = mkdtempSync(join(tmpdir(), 'gbrain-2928-cwd-'));
+});
+
+async function addSource(id: string, config: Record<string, unknown>): Promise<void> {
+  const localPath = mkdtempSync(join(tmpdir(), `gbrain-2928-${id}-`));
+  // $N::text::jsonb (never bare ::jsonb on a stringified param) per the
+  // JSONB invariant in CLAUDE.md.
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ($1, $1, $2, $3::text::jsonb)`,
+    [id, localPath, JSON.stringify(config)],
+  );
+}
+
+function ctxOf(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine: engine as any,
+    config: {} as any,
+    logger: console as any,
+    dryRun: false,
+    remote: false,
+    ...overrides,
+  } as OperationContext;
+}
+
+describe('#2928 — unfederated source and the sole_non_default tier', () => {
+  test('explicitly isolated sole source no longer anchors unqualified resolution', async () => {
+    await addSource('isolated-src', { federated: false });
+    const resolved = await resolveClean(null, outsideCwd);
+    // Master auto-picks the isolated source (tier sole_non_default), which
+    // makes an unqualified query/search return its pages — the exact thing
+    // `sources unfederate` promises to prevent.
+    expect(resolved.source_id).toBe('default');
+    expect(resolved.tier).toBe('seed_default');
+  });
+
+  test('full unqualified read chain excludes the isolated source from the scope', async () => {
+    await addSource('isolated-src', { federated: false });
+    const resolved = await resolveClean(null, outsideCwd);
+    const localFed = await localFederatedSourceIds(engine, resolved.source_id, resolved.tier);
+    const ctx = ctxOf({
+      sourceId: resolved.source_id,
+      ...(localFed ? { localFederatedSourceIds: localFed } : {}),
+    });
+    const scope = federatedSearchScope(ctx);
+    expect(scope.sourceId).not.toBe('isolated-src');
+    expect(scope.sourceIds ?? []).not.toContain('isolated-src');
+    expect(scope).toEqual({ sourceId: 'default' });
+  });
+
+  test('UNSET federated keeps the #1434 sole-source convenience (no over-narrowing)', async () => {
+    await addSource('vault', {});
+    const resolved = await resolveClean(null, outsideCwd);
+    expect(resolved.source_id).toBe('vault');
+    expect(resolved.tier).toBe('sole_non_default');
+  });
+
+  test('federated: true sole source still auto-resolves', async () => {
+    await addSource('wiki', { federated: true });
+    const resolved = await resolveClean(null, outsideCwd);
+    expect(resolved.source_id).toBe('wiki');
+    expect(resolved.tier).toBe('sole_non_default');
+  });
+
+  test('explicit --source still reaches an isolated source (only unqualified routing changes)', async () => {
+    await addSource('isolated-src', { federated: false });
+    const resolved = await resolveClean('isolated-src', outsideCwd);
+    expect(resolved.source_id).toBe('isolated-src');
+    expect(resolved.tier).toBe('flag');
+  });
+
+  test('multi-source brain: widening set already excludes the isolated source (pin)', async () => {
+    await addSource('isolated-src', { federated: false });
+    await addSource('wiki', { federated: true });
+    // Two non-default sources → tier 5.5 stays out; resolution lands on 'default'.
+    const resolved = await resolveClean(null, outsideCwd);
+    expect(resolved.source_id).toBe('default');
+    const localFed = await localFederatedSourceIds(engine, resolved.source_id, resolved.tier);
+    expect(localFed).toEqual(['default', 'wiki']);
+    const scope = federatedSearchScope(ctxOf({ sourceId: 'default', localFederatedSourceIds: localFed }));
+    expect(scope).toEqual({ sourceIds: ['default', 'wiki'] });
+  });
+});
+
+describe('unscoped local path stays UNSCOPED (the #3470/#3497 regression class)', () => {
+  test('sourceScopeOpts with no sourceId and no grant returns {} — never "default"', () => {
+    expect(sourceScopeOpts(ctxOf())).toEqual({});
+  });
+
+  test('federatedSearchScope with an empty local context returns {} (brain-wide read)', () => {
+    expect(federatedSearchScope(ctxOf())).toEqual({});
+  });
+
+  test('empty allowedSources [] does not widen; scalar sourceId wins', () => {
+    const ctx = ctxOf({ sourceId: 'a', auth: { allowedSources: [] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({ sourceId: 'a' });
+  });
+
+  test('federated grant outranks scalar (precedence ladder pin)', () => {
+    const ctx = ctxOf({ sourceId: 'a', auth: { allowedSources: ['a', 'b'] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({ sourceIds: ['a', 'b'] });
+  });
+});

--- a/test/unfederate-read-scope-2928.test.ts
+++ b/test/unfederate-read-scope-2928.test.ts
@@ -2,21 +2,24 @@
  * #2928 — `gbrain sources unfederate <id>` (config.federated = false) must
  * keep the isolated source out of UNQUALIFIED reads.
  *
- * Root cause is NOT the functions the issue points at (`sourceScopeOpts` /
- * the dead `federatedOnly` loader flag): the read-widening path
- * (`localFederatedSourceIds` → `federatedSearchScope`) already excludes
- * non-federated sources. The intent is lost one step earlier, in source
- * RESOLUTION: `pickSoleNonDefaultSource` (tier 5.5, #1434) auto-picks the
- * single non-default source as the anchor of an unqualified call without
- * consulting config.federated — so an explicitly isolated source becomes the
- * scalar read scope and its pages surface in unqualified query/search/think.
+ * The leak: tier 5.5 (#1434) anchors an unqualified call on the sole
+ * non-default source — correct for writes and for the anchor itself — but
+ * `localFederatedSourceIds` then widened that anchor into the federated set
+ * (`[isolated-src, default]`), mixing the isolated source's pages with
+ * federated sources' pages in unqualified query/search/think, both
+ * directions. The fix is READ-ONLY: an explicitly isolated anchor
+ * (config.federated === false) is never widened; scalar scope stands.
+ *
+ * Deliberately unchanged (pinned below):
+ *   - tier 5.5 write routing — `--no-federated` governs read mixing, not
+ *     where unqualified sync/import land (#1434,
+ *     test/sync-sole-non-default-routing.test.ts);
+ *   - the unscoped-local invariant that sank #3470/#3497: an empty scope
+ *     must stay UNSCOPED ({}), never collapse to 'default'.
  *
  * All imports here exist on master, so this file runs against an unmodified
- * master checkout and fails BEHAVIORALLY there (resolution returns the
- * isolated source).
- *
- * Also pins the unscoped-local invariant that sank #3470/#3497: an empty
- * scope must stay UNSCOPED ({}), never collapse to 'default'.
+ * master checkout and fails BEHAVIORALLY there (the widened scope contains
+ * both sources).
  */
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
@@ -80,29 +83,36 @@ function ctxOf(overrides: Partial<OperationContext> = {}): OperationContext {
   } as OperationContext;
 }
 
-describe('#2928 — unfederated source and the sole_non_default tier', () => {
-  test('explicitly isolated sole source no longer anchors unqualified resolution', async () => {
+describe('#2928 — isolated anchor is never widened into a cross-source read', () => {
+  test('explicitly isolated resolved source gets NO federated widening set', async () => {
     await addSource('isolated-src', { federated: false });
-    const resolved = await resolveClean(null, outsideCwd);
-    // Master auto-picks the isolated source (tier sole_non_default), which
-    // makes an unqualified query/search return its pages — the exact thing
-    // `sources unfederate` promises to prevent.
-    expect(resolved.source_id).toBe('default');
-    expect(resolved.tier).toBe('seed_default');
+    // Master returns ['isolated-src', 'default'] here (the seeded default is
+    // federated), which mixes the isolated source's pages with default's in
+    // every unqualified query/search/think — the #2928 report.
+    const localFed = await localFederatedSourceIds(engine, 'isolated-src', 'sole_non_default');
+    expect(localFed).toBeUndefined();
   });
 
-  test('full unqualified read chain excludes the isolated source from the scope', async () => {
+  test('full unqualified read chain stays scalar: no default pages mixed in', async () => {
     await addSource('isolated-src', { federated: false });
     const resolved = await resolveClean(null, outsideCwd);
+    // Write/anchor routing is UNCHANGED: the sole vault still resolves (#1434).
+    expect(resolved.source_id).toBe('isolated-src');
+    expect(resolved.tier).toBe('sole_non_default');
     const localFed = await localFederatedSourceIds(engine, resolved.source_id, resolved.tier);
     const ctx = ctxOf({
       sourceId: resolved.source_id,
       ...(localFed ? { localFederatedSourceIds: localFed } : {}),
     });
-    const scope = federatedSearchScope(ctx);
-    expect(scope.sourceId).not.toBe('isolated-src');
-    expect(scope.sourceIds ?? []).not.toContain('isolated-src');
-    expect(scope).toEqual({ sourceId: 'default' });
+    // Scalar scope: the isolated source is not mixed with 'default' (and
+    // vice versa). Master produces { sourceIds: ['isolated-src','default'] }.
+    expect(federatedSearchScope(ctx)).toEqual({ sourceId: 'isolated-src' });
+  });
+
+  test('isolated brain_default anchor is not widened either (same seam)', async () => {
+    await addSource('isolated-src', { federated: false });
+    const localFed = await localFederatedSourceIds(engine, 'isolated-src', 'brain_default');
+    expect(localFed).toBeUndefined();
   });
 
   test('UNSET federated keeps the #1434 sole-source convenience (no over-narrowing)', async () => {
@@ -110,6 +120,10 @@ describe('#2928 — unfederated source and the sole_non_default tier', () => {
     const resolved = await resolveClean(null, outsideCwd);
     expect(resolved.source_id).toBe('vault');
     expect(resolved.tier).toBe('sole_non_default');
+    // Only an EXPLICIT federated:false suppresses widening; unset keeps the
+    // pre-#2928 behavior (the seeded 'default' is federated).
+    const localFed = await localFederatedSourceIds(engine, 'vault', 'sole_non_default');
+    expect(localFed).toEqual(['vault', 'default']);
   });
 
   test('federated: true sole source still auto-resolves', async () => {


### PR DESCRIPTION
Fixes #2928.

## Root cause — confirmed, but NOT where the issue points

The issue names `sourceScopeOpts` / `resolveRequestedScope` and the dead `federatedOnly` loader flag. Independent trace disagrees, and I verified that disagreement: those functions never see `config.federated` because the flag is consumed upstream. The leak is the interaction of two upstream pieces:

1. `pickSoleNonDefaultSource` (tier 5.5, the #1434 sole-source convenience) anchors an unqualified call on the single non-default source — regardless of `config.federated`.
2. `localFederatedSourceIds` (`src/core/source-resolver.ts`) then widens that anchor into `[resolvedSource, ...federated others]` — the resolved source is always included, and the seeded `default` is federated. So in the issue's exact repro (brain = `default` + one explicitly-unfederated source, unqualified `gbrain query` from an unrelated cwd), the read scope becomes `["isolated-src", "default"]`: the isolated source's pages mixed into a cross-source result set — precisely the reporter's observation.

Migration v62's `oauth_clients.federated_read` backfill is not implicated — that governs the remote OAuth channel (`ctx.auth.allowedSources`); this leak is on the trusted local unqualified path.

## Fix — READ path only

`--no-federated` / `sources unfederate` means "don't mix me into cross-source READS", not "don't route my writes here". So the fix lives entirely in `localFederatedSourceIds`, which feeds `federatedSearchScope` exclusively (search/query/get_page/list_pages/resolve_slugs — reads): when the **resolved** source is explicitly `config.federated === false`, the widening set is suppressed and the scalar scope stands. The isolated source's unqualified reads stay in-source; its pages are never mixed with `default`'s and vice versa. Same seam serves CLI, stdio MCP, and HTTP MCP transports.

Deliberately NOT changed:

- **Tier 5.5 write routing is untouched.** Unqualified `sync`/`import` on a single-vault brain still lands in the vault even when it is `--no-federated` (#1434; `test/sync-sole-non-default-routing.test.ts` passes unmodified). An earlier revision of this branch excluded isolated sources from tier 5.5 itself; CI correctly rejected that — it silently redirected writes to `default`. Reverted in the second commit.
- **UNSET `federated` keeps pre-existing widening.** Only an explicit opt-out changes behavior; a fresh `sources add` (no `federated` key) behaves exactly as before.
- **Empty local scope stays UNSCOPED.** `sourceScopeOpts`/`federatedSearchScope` return `{}` for a local caller with no source in scope — never collapsed to `'default'` (the over-narrowing class that closed #3470/#3497; pinned by dedicated tests).
- **Explicit tiers still reach an isolated source** (`--source`, env, dotfile) — naming it IS the qualified case, per the flag's own contract.

Semantics note for the maintainer: with a sole isolated vault, an unqualified read is scoped to that vault alone (the read analog of #1434) rather than the vault being invisible. Isolation = "never mixed into cross-source results", not "invisible to the brain's own unqualified reads". If the intended contract is full invisibility, reads and writes would have to resolve different anchors from the same unqualified context (a `gbrain import` immediately invisible to `gbrain query`) — flagging that as a design decision rather than landing it silently.

## Discrimination proof (behavioral, on unmodified master)

`test/unfederate-read-scope-2928.test.ts` imports only master-existing exports. With `src/core/source-resolver.ts` checked out from `origin/master` (`git checkout origin/master -- src/core/source-resolver.ts`), 3 tests fail behaviorally and the rest pass:

```
✗ explicitly isolated resolved source gets NO federated widening set
    expect(localFed).toBeUndefined()   Received: ["isolated-src", "default"]
✗ full unqualified read chain stays scalar: no default pages mixed in
    expected { sourceId: "isolated-src" }   Received: { sourceIds: ["isolated-src", "default"] }
✗ isolated brain_default anchor is not widened either (same seam)
    Received: ["isolated-src", "default"]
```

With the fix: 11/11 pass, and `test/sync-sole-non-default-routing.test.ts` passes **unmodified** alongside.

Coverage highlights:
- isolated anchor is never widened (sole_non_default AND brain_default tiers)
- full read chain (`resolveSourceWithTier` → `localFederatedSourceIds` → `federatedSearchScope`) yields scalar scope
- tier 5.5 still anchors the isolated sole vault (write-routing pin)
- UNSET-federated sole source keeps auto-routing AND keeps widening (#1434 + #3242 guards)
- explicit `--source` still reaches an isolated source
- multi-source widening set already excludes isolated non-anchors (pin)
- **unscoped local path**: `sourceScopeOpts`/`federatedSearchScope` with no sourceId and no grant return `{}` — never `'default'` (#3470/#3497 regression class)
- empty `allowedSources: []` does not widen; federated grant > scalar precedence pin

## Verification

- `bun test test/unfederate-read-scope-2928.test.ts test/sync-sole-non-default-routing.test.ts test/source-resolver*.test.ts test/source-scope-resolver.test.ts` → 88 pass / 0 fail
- `bun test test/local-federated-search-scope.test.ts` (pre-existing #3242 widening suite) → 19 pass / 0 fail
- `bun run typecheck` → clean
- `bun run verify` → 32 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
