### PR TITLE
fix(test): correct the deadline inversion in the durability-hook serial tests (#2943)

### DIFF
--- a/test/brain-durability-hook.serial.test.ts
+++ b/test/brain-durability-hook.serial.test.ts
@@ -11,21 +11,58 @@ import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
 import { hardenBrainRepo } from '../src/core/brain-repo-durability.ts';
 
+// #2943 root cause: `env: process.env` is REQUIRED here. Bun snapshots
+// process.env at startup, so without it the spawned git — and any post-commit
+// hook it fires — is blind to beforeEach's HOME/GBRAIN_HOME mutations (the
+// same Bun quirk as #2747, see resolveGbrainCliPath in brain-repo-durability).
+// Pre-fix, the hook under test resolved ${GBRAIN_HOME:-$HOME/.gbrain} to the
+// OPERATOR'S REAL ~/.gbrain: it wrote its log lines there (polluting the real
+// brain-push.log on every run), the LOCAL-ONLY test never saw them in the
+// temp log it polls, and the assertion only passed when the scaffolding push
+// from beforeEach (spawned by hardenBrainRepo WITH explicit env) happened to
+// still be in flight, lose the ref race, and retry AFTER the test had pointed
+// origin at the dead path — an accidental, load-dependent signal. That race
+// is the CI flake.
 function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', ['-C', cwd, '-c', 'protocol.file.allow=always', ...args], {
-    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8', env: process.env,
   }).trim();
 }
 function originHead(bare: string): string {
   return git(bare, 'rev-parse', 'refs/heads/main');
 }
-async function waitForOrigin(bare: string, expectSha: string, ms = 8000): Promise<boolean> {
+// #2943: 30s poll deadlines (was 8s) for headroom under loaded CI shards —
+// the unreachable-origin path runs ~6 sequential process spawns after the
+// hook detaches. Every hook test also passes an explicit 60_000 third-arg
+// timeout: bun 1.3.14 IGNORES bunfig.toml's `timeout` key, so a bare
+// `bun test` enforces its 5000ms default and killed these tests before the
+// internal deadline could even elapse (the runner scripts pass --timeout
+// explicitly, which is why the inversion only bit direct local runs).
+async function waitForOrigin(bare: string, expectSha: string, ms = 30_000): Promise<boolean> {
   const deadline = Date.now() + ms;
   while (Date.now() < deadline) {
     try { if (originHead(bare) === expectSha) return true; } catch { /* */ }
     await new Promise(r => setTimeout(r, 150));
   }
   return false;
+}
+
+/** #2943 (index.lock form): hardenBrainRepo installs the post-commit hook
+ * BEFORE committing the scaffolding, so that commit fires the hook and
+ * detaches a background brain_push. If that push loses the ref race against
+ * hardenBrainRepo's own synchronous push, it falls back to `git pull
+ * --rebase`, which takes .git/index.lock — racing the test body's first git
+ * calls ("Unable to create '.../.git/index.lock': File exists"). Wait for the
+ * detached push's terminal log line before handing the repo to the test. */
+async function waitForHookPushSettled(ms = 30_000): Promise<void> {
+  const log = join(process.env.GBRAIN_HOME!, 'brain-push.log');
+  const terminal = /\[push\] (ok|lock-timeout|LOCAL-ONLY)/;
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (existsSync(log) && terminal.test(readFileSync(log, 'utf-8'))) return;
+    await new Promise(r => setTimeout(r, 150));
+  }
+  throw new Error(`detached hook push did not settle within ${ms}ms (${log})`);
 }
 
 let root: string, work: string, bare: string;
@@ -38,14 +75,15 @@ beforeEach(async () => {
   process.env.GBRAIN_HOME = join(process.env.HOME, '.gbrain');
   process.env.GBRAIN_GIT_ALLOW_FILE_TRANSPORT = '1';
   bare = mkdtempSync(join(root, 'origin-')) + '.git';
-  execFileSync('git', ['init', '-q', '--bare', '-b', 'main', bare], { stdio: 'ignore' });
+  execFileSync('git', ['init', '-q', '--bare', '-b', 'main', bare], { stdio: 'ignore', env: process.env });
   work = mkdtempSync(join(root, 'work-'));
-  execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, work], { stdio: 'ignore' });
+  execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, work], { stdio: 'ignore', env: process.env });
   git(work, 'config', 'user.email', 't@t.t'); git(work, 'config', 'user.name', 'tester');
   writeFileSync(join(work, 'README.md'), 'init\n');
   git(work, 'add', 'README.md'); git(work, 'commit', '-qm', 'init'); git(work, 'push', '-q', 'origin', 'main');
   git(work, 'remote', 'set-head', 'origin', 'main');
   await hardenBrainRepo({ repoPath: work, sourceId: 'wiki', pat: 'ghp_x', installCron: false });
+  await waitForHookPushSettled();
 });
 afterEach(() => {
   if (oldHome === undefined) delete process.env.HOME; else process.env.HOME = oldHome;
@@ -65,7 +103,7 @@ describe('brain-commit-push.sh (D13 guarantee)', () => {
     expect(originHead(bare)).toBe(git(work, 'rev-parse', 'HEAD'));
     // origin actually has the file
     const verify = mkdtempSync(join(root, 'verify-'));
-    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, verify], { stdio: 'ignore' });
+    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, verify], { stdio: 'ignore', env: process.env });
     expect(existsSync(join(verify, 'people', 'alice.md'))).toBe(true);
   });
 
@@ -102,7 +140,7 @@ describe('brain-commit-push.sh (D13 guarantee)', () => {
     rmSync(join(work, '.git', 'hooks', 'post-commit'));
     // Advance the remote from a second clone so a pull is genuinely needed.
     const other = mkdtempSync(join(root, 'other-'));
-    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, other], { stdio: 'ignore' });
+    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, other], { stdio: 'ignore', env: process.env });
     git(other, 'config', 'user.email', 'o@o.o'); git(other, 'config', 'user.name', 'other');
     writeFileSync(join(other, 'remote.md'), 'from other\n');
     git(other, 'add', 'remote.md'); git(other, 'commit', '-qm', 'remote change'); git(other, 'push', '-q', 'origin', 'main');
@@ -128,26 +166,26 @@ describe('post-commit hook (D9 local, D7 self-contained)', () => {
     git(work, 'add', 'note.md'); git(work, 'commit', '-qm', 'note'); // fires .git/hooks/post-commit
     const head = git(work, 'rev-parse', 'HEAD');
     expect(await waitForOrigin(bare, head)).toBe(true);
-  });
+  }, 60_000);
 
   test('the hook works even with the committed helper deleted (self-contained)', async () => {
     rmSync(join(work, 'scripts', 'brain-commit-push.sh'));
     git(work, 'add', '-A'); git(work, 'commit', '-qm', 'remove helper');
     const head = git(work, 'rev-parse', 'HEAD');
     expect(await waitForOrigin(bare, head)).toBe(true);
-  });
+  }, 60_000);
 
   test('logs a clear LOCAL-ONLY line when origin is unreachable', async () => {
     git(work, 'remote', 'set-url', 'origin', join(root, 'gone2.git'));
     writeFileSync(join(work, 'orphan.md'), 'o\n');
     git(work, 'add', 'orphan.md'); git(work, 'commit', '-qm', 'orphan');
     const log = join(process.env.GBRAIN_HOME!, 'brain-push.log');
-    const deadline = Date.now() + 8000;
+    const deadline = Date.now() + 30_000;
     let found = false;
     while (Date.now() < deadline) {
       if (existsSync(log) && readFileSync(log, 'utf-8').includes('NEEDS ATTENTION')) { found = true; break; }
       await new Promise(r => setTimeout(r, 150));
     }
     expect(found).toBe(true);
-  });
+  }, 60_000);
 });

--- a/test/e2e/jsonb-roundtrip.test.ts
+++ b/test/e2e/jsonb-roundtrip.test.ts
@@ -69,7 +69,7 @@ describeE2E('E2E: JSONB roundtrip — v0.12.1 reliability wave', () => {
     `;
     expect(row.t).toBe('object');
     expect(row.marker).toBe('rawdata-value');
-  });
+  }, 30_000);
 
   test('logIngest writes pages_updated as array, not double-encoded string', async () => {
     const engine = getEngine();
@@ -91,7 +91,7 @@ describeE2E('E2E: JSONB roundtrip — v0.12.1 reliability wave', () => {
     expect(row.t).toBe('array');
     expect(Number(row.n)).toBe(3);
     expect(row.first).toBe('test/a');
-  });
+  }, 30_000);
 
   // files.ts:254 (uploadRaw's cloud-upload branch) was changed from
   // `${JSON.stringify({...})}::jsonb` to `${sql.json({...})}` in v0.12.1.
@@ -114,7 +114,7 @@ describeE2E('E2E: JSONB roundtrip — v0.12.1 reliability wave', () => {
     expect(row.t).toBe('object');
     expect(row.type).toBe('pdf');
     expect(row.method).toBe('TUS resumable');
-  });
+  }, 30_000);
 
   // Source-level tripwire: if anyone re-introduces the old `${JSON.stringify(x)}::jsonb`
   // pattern for the fixed sites, fail loudly. Greps actual source files per the
@@ -129,5 +129,5 @@ describeE2E('E2E: JSONB roundtrip — v0.12.1 reliability wave', () => {
       const source = await Bun.file(new URL(rel, import.meta.url)).text();
       expect(source.match(bad)?.[0] ?? null).toBeNull();
     }
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Fixes #2943 — the durability-hook serial test flake that has burned CI 6+ times.

## What was actually wrong (three layers, one deeper than diagnosed)

**1. Deadline inversion (bare local runs).** The tests' internal poll deadlines were 8s, but no third-arg timeout was passed, so bun's default 5000ms killed the test first — the 8s budget was unreachable dead code. Confirmed the crux: **bun 1.3.14 ignores `bunfig.toml`'s `timeout = 60_000` key** (`bunfig.toml:9`). Every baseline failure below is `this test timed out after 5000ms` despite the bunfig setting. This is why every runner script passes `--timeout` explicitly and why the inversion only bit direct `bun test` runs.

**2. The 8s internal budget was too short for loaded CI shards** — the unreachable-origin path runs ~6 sequential process spawns after the hook detaches.

**3. The real root cause, found while verifying the fix: the test's `git()` helper did not pass `env: process.env`.** Bun snapshots `process.env` at startup (the same quirk as #2747, documented at `src/core/brain-repo-durability.ts:103`), so the `beforeEach` HOME/GBRAIN_HOME mutations were invisible to the spawned git — and to the post-commit hook it fires. The hook under test resolved `${GBRAIN_HOME:-$HOME/.gbrain}` to the **operator's real `~/.gbrain`**: it wrote its `NEEDS ATTENTION` line there (polluting the real `brain-push.log` on every historical run of this test), and the temp log the test polls never received it. The LOCAL-ONLY assertion only ever passed by accident: the scaffolding commit inside `hardenBrainRepo` (which DOES pass explicit env) fires the freshly installed hook; when that detached push was still in flight, lost the ref race against `hardenBrainRepo`'s own synchronous push, and retried AFTER the test had already pointed origin at the dead path, it wrote `NEEDS ATTENTION` into the temp log. Whether that race lined up is load-dependent — that is the CI flake. Raising the deadline alone would NOT have fixed it (verified: with only the timeout changes, the test fails deterministically at 30s once the accidental race source is removed).

## The fix

- `test/brain-durability-hook.serial.test.ts`:
  - `git()` helper (and the three bare `execFileSync('git', ...)` calls) now pass `env: process.env`, so the hook under test sees the test's temp HOME/GBRAIN_HOME. The intended signal (the orphan commit's own hook) now lands in the polled log within ~1s, deterministically. Also stops the test writing into the operator's real `~/.gbrain` on every run.
  - Internal poll deadlines `8000` → `30_000` (`waitForOrigin` default + the LOCAL-ONLY loop) for loaded-shard headroom.
  - Explicit `}, 60_000)` third arg on the three hook tests, so bare `bun test` stops inverting the budget.
  - New `waitForHookPushSettled()` in `beforeEach` — see index.lock below.
  - Poll loops untouched; they were always correct poll-with-deadline loops (the `150` is the poll interval).
- `test/e2e/jsonb-roundtrip.test.ts`: the four tests without an explicit timeout now pass `}, 30_000)`, matching the first test — same deadline-inversion class flagged on the issue.

## The index.lock race — addressed

The third observed CI form (`fatal: Unable to create '.../.git/index.lock': File exists` at the test's first `git add`/`commit`) is the scaffolding commit's detached hook push racing the test body: `hardenBrainRepo` installs the hook *before* committing the scaffolding, so that commit detaches a background `brain_push`; when it loses the ref race against `hardenBrainRepo`'s own synchronous push (observed in this investigation: `cannot lock ref 'refs/heads/main'`), it falls back to `git pull --rebase`, which takes `.git/index.lock` while the test body runs its own git calls. Fixed by waiting, not sleeping: `beforeEach` now polls the push log for the detached push's terminal line (`ok` / `lock-timeout` / `LOCAL-ONLY`) before handing the repo to the test.

## Why 30s and not an arbitrary bigger number

The unreachable-origin path is ~6 sequential process spawns completing in <1s idle; the observed worst case under load was ~6s. 30s is ~5x that worst case while staying well under the 60s harness cap (`scripts/run-serial-tests.sh` passes `--timeout=60000`), so a genuine product hang still fails inside the test's own budget with a clear assertion instead of a harness kill. And this is not a timeout masking a product bug: post-fix the signal arrives in ~1s from the intended source (full file passes in ~7s bare); the widened deadline is pure headroom, not a crutch — the env fix is what makes the test pass.

## Verification (10 bare runs each, output captured to files, exit codes read directly)

Unmodified master (`6920744d`):

```
run 1 EXIT=1   run 2 EXIT=0   run 3 EXIT=0   run 4 EXIT=1   run 5 EXIT=0
run 6 EXIT=1   run 7 EXIT=0   run 8 EXIT=0   run 9 EXIT=0   run 10 EXIT=0
```

**7 pass / 3 fail** — every failure: `✗ post-commit hook … logs a clear LOCAL-ONLY line when origin is unreachable` + `this test timed out after 5000ms` (at 5.6–6.3s test duration, i.e. bun's default killing the 8s internal budget).

This branch:

```
run 1 EXIT=0   run 2 EXIT=0   run 3 EXIT=0   run 4 EXIT=0   run 5 EXIT=0
run 6 EXIT=0   run 7 EXIT=0   run 8 EXIT=0   run 9 EXIT=0   run 10 EXIT=0
```

**10 pass / 0 fail** (7/7 tests each run, full file in ~7s bare — the LOCAL-ONLY signal now arrives in ~1s from the intended source). A separate check confirmed the fixed runs append nothing to the operator's real `~/.gbrain/brain-push.log`.

Also green: `bun run typecheck`, `bun run verify`. `test/e2e/jsonb-roundtrip.test.ts` parses and skips cleanly without `DATABASE_URL` (timeout-arg-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
