### PR TITLE
fix(extract): make receipt shortRunId canonical under slugifySegment (#3443)

### DIFF
--- a/src/core/extract/receipt-writer.ts
+++ b/src/core/extract/receipt-writer.ts
@@ -85,11 +85,21 @@ const RUN_ID_SHORT_LEN = 8;
 /**
  * Truncate a run id to the standard 8-char short form used in slug
  * paths. Idempotent — passing an already-short id returns it unchanged.
- * Non-hex / non-alphanumeric chars survive (op-checkpoint ids may
- * include dashes or other separators).
+ * Non-hex / non-alphanumeric chars survive INSIDE the short form
+ * (op-checkpoint ids may include dashes or other separators), but
+ * boundary hyphens are trimmed (#3443): `slugifySegment()` strips
+ * leading/trailing hyphens during repo sync, so a short form like
+ * 'propose-' (from propose-<timestamp> run ids) made the DB receipt
+ * slug and its Git-backed slug disagree — writing the receipt through
+ * to the repo created a normalized sibling instead of materializing
+ * the existing page. Invariant: slugifySegment(shortRunId(x)) ===
+ * shortRunId(x) for slug-safe run ids.
  */
 export function shortRunId(runId: string): string {
-  return runId.slice(0, RUN_ID_SHORT_LEN);
+  // ponytail: truncation-based discrimination is only as good as the run id's
+  // first 8 chars; families that need per-run uniqueness must front-load it.
+  const short = runId.slice(0, RUN_ID_SHORT_LEN).replace(/^-+|-+$/g, '');
+  return short || (runId ? 'run' : '');
 }
 
 /**

--- a/test/extract/receipt-writer.test.ts
+++ b/test/extract/receipt-writer.test.ts
@@ -20,6 +20,7 @@ import {
   writeReceipt,
   type ExtractReceiptInput,
 } from '../../src/core/extract/receipt-writer.ts';
+import { slugifySegment } from '../../src/core/sync.ts';
 
 const BASE_INPUT: ExtractReceiptInput = {
   kind: 'facts.conversation',
@@ -79,6 +80,31 @@ describe('shortRunId / dateFromIso — pure helpers', () => {
   test('shortRunId preserves dashes / underscores within the 8 chars', () => {
     expect(shortRunId('run-1234-rest')).toBe('run-1234');
     expect(shortRunId('op_check_abc')).toBe('op_check');
+  });
+
+  // #3443 — a short form ending in '-' (e.g. propose-<timestamp> run ids)
+  // desynced the DB receipt slug from its Git-backed slug: slugifySegment()
+  // strips boundary hyphens during repo sync, so the write-through created a
+  // normalized sibling instead of materializing the existing page.
+  test('shortRunId is canonical under slugifySegment for every receipt-producing run-id family (#3443)', () => {
+    const familyRunIds = [
+      'propose-20260724103000-ab12cd34',           // cycle/propose-takes.ts
+      `atoms-${Date.now().toString(36)}-pers`,     // cycle/extract-atoms.ts
+      `efacts-${Date.now().toString(36)}-pers`,    // cycle/extract-facts.ts
+      `concepts-${Date.now().toString(36)}`,       // cycle/synthesize-concepts.ts
+      `ecf-${Date.now().toString(36)}-pers`,       // extract-conversation-facts.ts
+    ];
+    for (const runId of familyRunIds) {
+      const short = shortRunId(runId);
+      expect(slugifySegment(short)).toBe(short);
+      expect(short.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('shortRunId trims boundary hyphens introduced by truncation', () => {
+    expect(shortRunId('propose-20260724103000-ab12cd34')).toBe('propose');
+    // Pathological all-separator prefix still yields a non-empty segment.
+    expect(shortRunId('--------tail')).toBe('run');
   });
 
   test('dateFromIso extracts YYYY-MM-DD prefix', () => {


### PR DESCRIPTION
Fixes #3443.

## Bug

`shortRunId()` (`src/core/extract/receipt-writer.ts:91`) is `runId.slice(0, 8)`. `propose_takes` run ids are `propose-<YYYYMMDDHHMMSS>-<uuid8>` (`src/core/cycle/propose-takes.ts:441`), so the short form is `'propose-'` — and `slugifySegment()` (`src/core/sync.ts:418`) strips boundary hyphens during repo sync, yielding `'propose'`. The DB receipt slug and its Git-backed markdown slug disagree; write-through creates a normalized sibling/collision instead of materializing the existing page.

## Fix

Trim boundary hyphens after truncation, in the one shared helper. Invariant (as requested in the issue): `slugifySegment(shortRunId(runId)) === shortRunId(runId)`. Non-empty `'run'` fallback for pathological all-separator prefixes. Every other run-id family (`atoms-`, `efacts-`, `concepts-`, `ecf-`) produces an unchanged short form, so existing receipt slugs stay stable.

Note on discrimination: today's `'propose-'` short form was already constant across every propose run, so trimming to `'propose'` does not change collision behavior — it only makes the DB and Git slugs agree. Front-loading per-run uniqueness into the run id itself is a separate (out-of-scope) improvement; flagged with a comment on the helper.

## Discrimination proof

New round-trip test on unmodified master:

```
Expected: "propose-"
Received: "propose"
✗ shortRunId is canonical under slugifySegment for every receipt-producing run-id family (#3443)
```

With the fix: 14/14 pass in test/extract/receipt-writer.test.ts. Sibling consumers green (test/skillpack-migrate-fence.test.ts, test/post-install-advisory.test.ts — 28/28).

`bun run typecheck` clean; `bun run verify` 32/32 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)