### PR TITLE
feat(by-mention): Unicode-aware word tokenizer — Vietnamese/diacritic name extraction

### DIFF
--- a/src/core/by-mention.ts
+++ b/src/core/by-mention.ts
@@ -107,7 +107,9 @@ export interface FindMentionsOpts {
 /**
  * Token-only tokenizer. Returns `[token, offset]` pairs.
  *
- * ASCII: each `[a-zA-Z0-9]+` run is a single token, lowercased.
+ * Word runs: each contiguous run of Unicode letters/marks/numbers (excluding
+ *   CJK) is a single token, lowercased. Covers ASCII and diacritic Latin
+ *   scripts like Vietnamese ("Nguyễn" → one token, not ["nguy","n"]).
  * CJK: each CJK character (Chinese/Japanese/Korean) is an individual
  *   token, lowercased. This allows the normal maximal-munch scan path
  *   to reach CJK gazetteer entries without a separate substring pass.
@@ -116,7 +118,14 @@ export interface FindMentionsOpts {
  * run) — single-word "Acme" lookup succeeds at offset 0; the trailing 's'
  * is harmless noise.
  */
-const TOKEN_RE = /[a-zA-Z0-9]+/g;
+// Word-run tokenizer. Matches contiguous Unicode letters/marks/numbers but
+// EXCLUDES CJK (Han, Hiragana, Katakana, Hangul), which keep going through the
+// per-character path in the walkers below (the excluded ranges mirror isCJK()
+// / cjkCharCount()). The `v` flag enables set subtraction. Latin-script
+// languages with diacritics (Vietnamese, etc.) now tokenize as whole words
+// instead of fragmenting on every accented character — e.g. "Nguyễn" is one
+// token, not ["nguy", "n"], and "Đà Nẵng" is ["đà", "nẵng"], not ["n", "ng"].
+const TOKEN_RE = /[[\p{L}\p{M}\p{N}]--[㐀-䶿一-鿿぀-ゟ゠-ヿ가-힯]]+/gv;
 
 interface ScannedToken {
   text: string;       // lowercase
@@ -198,8 +207,9 @@ function cjkCharCount(s: string): number {
 /**
  * Tokenize a page title for gazetteer insertion.
  *
- * ASCII titles: standard `[a-zA-Z0-9]+` tokenization, lowercased.
- * CJK titles (no ASCII content): split into individual characters —
+ * Word-run titles: Unicode letters/marks/numbers (excluding CJK) tokenization,
+ *   lowercased — ASCII plus diacritic Latin scripts (Vietnamese, etc.).
+ * CJK titles (no word-run content): split into individual characters —
  *   e.g. "纳瓦尔" → ["纳","瓦","尔"]. This allows normal multi-token
  *   maximal-munch matching to work with character-level CJK tokens
  *   produced by `tokenizeForScan`.

--- a/src/core/by-mention.ts
+++ b/src/core/by-mention.ts
@@ -109,21 +109,27 @@ export interface FindMentionsOpts {
  * The CJK character set this module treats as char-level, declared ONCE.
  *
  * `CJK_SLUG_CHARS` (src/core/cjk.ts) is the repo-wide single source of truth
- * — Han U+4E00–9FFF, Hiragana, Katakana, Hangul syllables. This module has
- * additionally always treated Han Extension A (U+3400–4DBF) as CJK in its
- * walkers, while cjk.ts scopes Ext-A out deliberately (see its header), so
- * Ext-A is named and appended here rather than widening the shared constant.
+ * — Han U+4E00–9FFF, Hiragana, Katakana, Hangul syllables — and this module
+ * now uses it verbatim.
+ *
+ * Note the deliberate behaviour change: the walkers here used to carry their
+ * own copy of the ranges that also covered Han Extension A (U+3400–4DBF),
+ * which cjk.ts scopes out repo-wide (see its header). Aligning on the shared
+ * constant means Ext-A characters are no longer treated as CJK by
+ * by-mention: they tokenize as word runs and, being a single sub-4-character
+ * token, an Ext-A-only entity title now falls below MIN_NAME_LENGTH instead
+ * of qualifying under MIN_CJK_NAME_LENGTH. Search, chunking and slug grammar
+ * already ignore Ext-A, so this makes by-mention consistent with them rather
+ * than being the one subsystem that disagrees.
  *
  * Everything below — TOKEN_RE, hasCJK(), cjkCharCount() and the two
- * per-character walkers — derives from this one declaration. There are no
- * other copies of the ranges in this file.
+ * per-character walkers — derives from this one import. There are no copies
+ * of the ranges in this file.
  */
-const HAN_EXT_A_CHARS = '㐀-䶿';
-const CJK_CHARS = `${CJK_SLUG_CHARS}${HAN_EXT_A_CHARS}`;
-const CJK_CHAR_RE = new RegExp(`^[${CJK_CHARS}]$`, 'u');
+const CJK_CHAR_RE = new RegExp(`^[${CJK_SLUG_CHARS}]$`, 'u');
 
 /**
- * Conservative code-point bounds for CJK_CHARS, derived from the range
+ * Conservative code-point bounds for CJK_SLUG_CHARS, derived from the range
  * string itself (strip the `-` separators and the remaining characters are
  * exactly the range endpoints) so they can never drift from it. Used only
  * as a cheap pre-filter — Latin/Vietnamese text short-circuits before the
@@ -132,7 +138,7 @@ const CJK_CHAR_RE = new RegExp(`^[${CJK_CHARS}]$`, 'u');
 const CJK_BOUNDS = ((): { min: number; max: number } => {
   let min = 0x10ffff;
   let max = 0;
-  for (const ch of CJK_CHARS.replace(/-/g, '')) {
+  for (const ch of CJK_SLUG_CHARS.replace(/-/g, '')) {
     const cp = ch.codePointAt(0)!;
     if (cp < min) min = cp;
     if (cp > max) max = cp;
@@ -172,12 +178,12 @@ function isCJKChar(ch: string): boolean {
  *    ADJACENT in the body — so a superscript between the words of
  *    "Acme Corp" would silently break a match that used to work.
  *  - Plain `u` flag, not `v`: the CJK exclusion is a negative lookahead
- *    over CJK_CHARS, the same construction src/core/think/gather.ts
+ *    over CJK_SLUG_CHARS, the same construction src/core/think/gather.ts
  *    already uses. No es2024 target requirement, no set-subtraction syntax.
  */
 const TOKEN_RE = new RegExp(
-  `(?![${CJK_CHARS}])[\\p{L}0-9]` +
-  `(?:(?![${CJK_CHARS}])[\\p{L}\\p{M}0-9])*`,
+  `(?![${CJK_SLUG_CHARS}])[\\p{L}0-9]` +
+  `(?:(?![${CJK_SLUG_CHARS}])[\\p{L}\\p{M}0-9])*`,
   'gu',
 );
 

--- a/src/core/by-mention.ts
+++ b/src/core/by-mention.ts
@@ -27,6 +27,7 @@
  */
 
 import type { BrainEngine } from './engine.ts';
+import { CJK_SLUG_CHARS } from './cjk.ts';
 import { stripCodeBlocks } from './link-extraction.ts';
 
 /** D2: hardcoded entity types for v1. Pack-aware extension is TODO-1. */
@@ -105,27 +106,95 @@ export interface FindMentionsOpts {
 // ============================================================
 
 /**
- * Token-only tokenizer. Returns `[token, offset]` pairs.
+ * The CJK character set this module treats as char-level, declared ONCE.
  *
- * Word runs: each contiguous run of Unicode letters/marks/numbers (excluding
- *   CJK) is a single token, lowercased. Covers ASCII and diacritic Latin
- *   scripts like Vietnamese ("Nguyễn" → one token, not ["nguy","n"]).
- * CJK: each CJK character (Chinese/Japanese/Korean) is an individual
- *   token, lowercased. This allows the normal maximal-munch scan path
- *   to reach CJK gazetteer entries without a separate substring pass.
+ * `CJK_SLUG_CHARS` (src/core/cjk.ts) is the repo-wide single source of truth
+ * — Han U+4E00–9FFF, Hiragana, Katakana, Hangul syllables. This module has
+ * additionally always treated Han Extension A (U+3400–4DBF) as CJK in its
+ * walkers, while cjk.ts scopes Ext-A out deliberately (see its header), so
+ * Ext-A is named and appended here rather than widening the shared constant.
  *
- * Possessive "Acme's" tokenizes as ['acme', 's'] (single-quote breaks the
- * run) — single-word "Acme" lookup succeeds at offset 0; the trailing 's'
- * is harmless noise.
+ * Everything below — TOKEN_RE, hasCJK(), cjkCharCount() and the two
+ * per-character walkers — derives from this one declaration. There are no
+ * other copies of the ranges in this file.
  */
-// Word-run tokenizer. Matches contiguous Unicode letters/marks/numbers but
-// EXCLUDES CJK (Han, Hiragana, Katakana, Hangul), which keep going through the
-// per-character path in the walkers below (the excluded ranges mirror isCJK()
-// / cjkCharCount()). The `v` flag enables set subtraction. Latin-script
-// languages with diacritics (Vietnamese, etc.) now tokenize as whole words
-// instead of fragmenting on every accented character — e.g. "Nguyễn" is one
-// token, not ["nguy", "n"], and "Đà Nẵng" is ["đà", "nẵng"], not ["n", "ng"].
-const TOKEN_RE = /[[\p{L}\p{M}\p{N}]--[㐀-䶿一-鿿぀-ゟ゠-ヿ가-힯]]+/gv;
+const HAN_EXT_A_CHARS = '㐀-䶿';
+const CJK_CHARS = `${CJK_SLUG_CHARS}${HAN_EXT_A_CHARS}`;
+const CJK_CHAR_RE = new RegExp(`^[${CJK_CHARS}]$`, 'u');
+
+/**
+ * Conservative code-point bounds for CJK_CHARS, derived from the range
+ * string itself (strip the `-` separators and the remaining characters are
+ * exactly the range endpoints) so they can never drift from it. Used only
+ * as a cheap pre-filter — Latin/Vietnamese text short-circuits before the
+ * regex in the per-character walkers, which run over every body byte.
+ */
+const CJK_BOUNDS = ((): { min: number; max: number } => {
+  let min = 0x10ffff;
+  let max = 0;
+  for (const ch of CJK_CHARS.replace(/-/g, '')) {
+    const cp = ch.codePointAt(0)!;
+    if (cp < min) min = cp;
+    if (cp > max) max = cp;
+  }
+  return { min, max };
+})();
+
+function isCJKChar(ch: string): boolean {
+  const cp = ch.codePointAt(0) ?? 0;
+  if (cp < CJK_BOUNDS.min || cp > CJK_BOUNDS.max) return false;
+  return CJK_CHAR_RE.test(ch);
+}
+
+/**
+ * Word-run tokenizer: a letter or ASCII digit, followed by any run of
+ * letters, ASCII digits and combining marks — CJK excluded throughout, so
+ * CJK keeps flowing through the per-character path in the walkers below.
+ *
+ * Latin scripts with diacritics tokenize as whole words instead of
+ * fragmenting on every accented character — "Nguyễn" is one token, not
+ * ["nguy","n"], and "Đà Nẵng" is ["đà","nẵng"], not ["n","ng"].
+ *
+ * Four deliberate boundaries, each of which was a real regression:
+ *
+ *  - The LEAD must be a letter or digit, so a token can never consist of
+ *    combining marks alone. U+FE0F (VARIATION SELECTOR-16, category Mn)
+ *    rides on most emoji, so a mark-only token would hijack the gazetteer
+ *    key of every emoji-prefixed entity title ("❤️ Health Notes" keying on
+ *    U+FE0F instead of "health") and collapse all of them into one shared,
+ *    mutually-confusable bucket.
+ *  - Combining marks ARE allowed after the lead. NFD Vietnamese is base
+ *    letter + mark, so excluding \p{M} would re-fragment the exact names
+ *    this tokenizer exists to keep whole.
+ *  - Digits are ASCII-only, exactly as the previous /[a-zA-Z0-9]+/ was.
+ *    \p{N} would additionally mint tokens for ¹ ½ １ (Nl/No/non-ASCII Nd),
+ *    and findMentionedEntities requires gazetteer tokens to be STRICTLY
+ *    ADJACENT in the body — so a superscript between the words of
+ *    "Acme Corp" would silently break a match that used to work.
+ *  - Plain `u` flag, not `v`: the CJK exclusion is a negative lookahead
+ *    over CJK_CHARS, the same construction src/core/think/gather.ts
+ *    already uses. No es2024 target requirement, no set-subtraction syntax.
+ */
+const TOKEN_RE = new RegExp(
+  `(?![${CJK_CHARS}])[\\p{L}0-9]` +
+  `(?:(?![${CJK_CHARS}])[\\p{L}\\p{M}0-9])*`,
+  'gu',
+);
+
+/**
+ * Canonical form for a single token. NFC only — canonical composition, no
+ * compatibility folding — so an NFD body and an NFC gazetteer title produce
+ * the same token, while diacritics stay significant ("Hồng" still must not
+ * match "Hong").
+ *
+ * Applied PER TOKEN, never to the whole text: `Mention.offset` is contracted
+ * to index into the ORIGINAL body (extract-ner.ts slices a context window
+ * from it to infer the link verb), and normalizing the text up front would
+ * silently shift every offset.
+ */
+function normalizeToken(s: string): string {
+  return s.normalize('NFC').toLowerCase();
+}
 
 interface ScannedToken {
   text: string;       // lowercase
@@ -133,48 +202,64 @@ interface ScannedToken {
   length: number;     // original length (for span tracking)
 }
 
-function tokenizeForScan(text: string): ScannedToken[] {
+/**
+ * Body-text tokenizer. Returns `[token, offset]` pairs.
+ *
+ * Word runs: each TOKEN_RE match is one token, NFC-normalized and
+ *   lowercased. Covers ASCII and diacritic Latin scripts like Vietnamese
+ *   ("Nguyễn" → one token, not ["nguy","n"]).
+ * CJK: each CJK character (Chinese/Japanese/Korean) is an individual
+ *   token. This allows the normal maximal-munch scan path to reach CJK
+ *   gazetteer entries without a separate substring pass.
+ *
+ * `offset` and `length` index into the ORIGINAL string — callers slice
+ * context windows out of the untouched body with them.
+ *
+ * Possessive "Acme's" tokenizes as ['acme', 's'] (single-quote breaks the
+ * run) — single-word "Acme" lookup succeeds at offset 0; the trailing 's'
+ * is harmless noise.
+ *
+ * Exported so tests can assert on TOKENIZATION rather than only on the
+ * resolved mention (see tokenizeTitle).
+ */
+export function tokenizeForScan(text: string): ScannedToken[] {
   const out: ScannedToken[] = [];
   TOKEN_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
 
-  // Collect ASCII token spans first.
-  const asciiSpans: Array<{ start: number; end: number }> = [];
+  // Collect word-run token spans first.
+  const wordSpans: Array<{ start: number; end: number }> = [];
   while ((m = TOKEN_RE.exec(text)) !== null) {
-    asciiSpans.push({ start: m.index, end: m.index + m[0].length });
+    wordSpans.push({ start: m.index, end: m.index + m[0].length });
   }
 
-  // Walk character-by-character: emit ASCII tokens at their start positions,
-  // then emit individual CJK characters for non-ASCII positions that fall
-  // outside ASCII token spans.
-  let asciiIdx = 0;
+  // Walk character-by-character: emit word-run tokens at their start
+  // positions, then emit individual CJK characters for positions that fall
+  // outside every word-run span.
+  let spanIdx = 0;
   for (let i = 0; i < text.length;) {
-    const cp = text.codePointAt(i) ?? 0;
-    const isCJK = (cp >= 0x4e00 && cp <= 0x9fff) || (cp >= 0x3400 && cp <= 0x4dbf) ||
-                  (cp >= 0x3040 && cp <= 0x309f) || (cp >= 0x30a0 && cp <= 0x30ff) ||
-                  (cp >= 0xac00 && cp <= 0xd7af);
-
-    // Advance asciiIdx past any spans that end before or at i.
-    while (asciiIdx < asciiSpans.length && asciiSpans[asciiIdx]!.end <= i) {
-      asciiIdx++;
+    // Advance spanIdx past any spans that end before or at i.
+    while (spanIdx < wordSpans.length && wordSpans[spanIdx]!.end <= i) {
+      spanIdx++;
     }
 
-    // If position i is inside an ASCII token span, emit the full ASCII token
-    // and jump past it.
-    if (asciiIdx < asciiSpans.length && i >= asciiSpans[asciiIdx]!.start && i < asciiSpans[asciiIdx]!.end) {
-      const span = asciiSpans[asciiIdx]!;
+    // If position i is inside a word-run span, emit the full token and jump
+    // past it.
+    if (spanIdx < wordSpans.length && i >= wordSpans[spanIdx]!.start && i < wordSpans[spanIdx]!.end) {
+      const span = wordSpans[spanIdx]!;
       const token = text.slice(span.start, span.end);
-      out.push({ text: token.toLowerCase(), offset: span.start, length: token.length });
+      out.push({ text: normalizeToken(token), offset: span.start, length: token.length });
       i = span.end;
-      asciiIdx++;
+      spanIdx++;
       continue;
     }
 
     // CJK: emit as individual character token.
-    if (isCJK) {
-      const charLen = cp > 0xffff ? 2 : 1; // surrogate pair
-      const charStr = text.slice(i, i + charLen);
-      out.push({ text: charStr.toLowerCase(), offset: i, length: charLen });
+    const cp = text.codePointAt(i) ?? 0;
+    const charLen = cp > 0xffff ? 2 : 1; // surrogate pair
+    const charStr = text.slice(i, i + charLen);
+    if (isCJKChar(charStr)) {
+      out.push({ text: normalizeToken(charStr), offset: i, length: charLen });
       i += charLen;
     } else {
       i++;
@@ -185,10 +270,7 @@ function tokenizeForScan(text: string): ScannedToken[] {
 
 function hasCJK(s: string): boolean {
   for (const ch of s) {
-    const cp = ch.codePointAt(0) ?? 0;
-    if ((cp >= 0x4e00 && cp <= 0x9fff) || (cp >= 0x3400 && cp <= 0x4dbf) ||
-        (cp >= 0x3040 && cp <= 0x309f) || (cp >= 0x30a0 && cp <= 0x30ff) ||
-        (cp >= 0xac00 && cp <= 0xd7af)) return true;
+    if (isCJKChar(ch)) return true;
   }
   return false;
 }
@@ -196,10 +278,7 @@ function hasCJK(s: string): boolean {
 function cjkCharCount(s: string): number {
   let count = 0;
   for (const ch of s) {
-    const cp = ch.codePointAt(0) ?? 0;
-    if ((cp >= 0x4e00 && cp <= 0x9fff) || (cp >= 0x3400 && cp <= 0x4dbf) ||
-        (cp >= 0x3040 && cp <= 0x309f) || (cp >= 0x30a0 && cp <= 0x30ff) ||
-        (cp >= 0xac00 && cp <= 0xd7af)) count++;
+    if (isCJKChar(ch)) count++;
   }
   return count;
 }
@@ -207,41 +286,46 @@ function cjkCharCount(s: string): number {
 /**
  * Tokenize a page title for gazetteer insertion.
  *
- * Word-run titles: Unicode letters/marks/numbers (excluding CJK) tokenization,
- *   lowercased — ASCII plus diacritic Latin scripts (Vietnamese, etc.).
+ * Word-run titles: TOKEN_RE tokenization, NFC-normalized and lowercased —
+ *   ASCII plus diacritic Latin scripts (Vietnamese, etc.).
  * CJK titles (no word-run content): split into individual characters —
  *   e.g. "纳瓦尔" → ["纳","瓦","尔"]. This allows normal multi-token
  *   maximal-munch matching to work with character-level CJK tokens
  *   produced by `tokenizeForScan`.
- * Mixed CJK+ASCII titles: ASCII parts tokenized normally, CJK parts
+ * Mixed CJK+word-run titles: word-run parts tokenized normally, CJK parts
  *   split into individual characters.
+ *
+ * Exported so tests can assert on TOKENIZATION rather than only on the
+ * resolved mention — a mention-only assertion passes even with a tokenizer
+ * that fragments the title and the body symmetrically.
  */
-function tokenizeTitle(title: string): string[] {
+export function tokenizeTitle(title: string): string[] {
   const tokens: string[] = [];
   TOKEN_RE.lastIndex = 0;
-  const hasAscii = TOKEN_RE.test(title);
-  if (hasAscii) {
-    // Mixed ASCII+CJK or pure ASCII: tokenize ASCII normally, then
-    // append individual CJK characters in order.
+  const hasWordRun = TOKEN_RE.test(title);
+  if (hasWordRun) {
+    // Mixed word-run+CJK or pure word-run: tokenize word runs normally,
+    // then append individual CJK characters in order.
     TOKEN_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
-    const asciiSpans: Array<{ start: number; end: number; text: string }> = [];
+    const wordSpans: Array<{ start: number; end: number; text: string }> = [];
     while ((m = TOKEN_RE.exec(title)) !== null) {
-      asciiSpans.push({ start: m.index, end: m.index + m[0].length, text: m[0].toLowerCase() });
+      wordSpans.push({ start: m.index, end: m.index + m[0].length, text: normalizeToken(m[0]) });
     }
-    let asciiIdx = 0;
+    let spanIdx = 0;
     for (let i = 0; i < title.length;) {
-      while (asciiIdx < asciiSpans.length && asciiSpans[asciiIdx]!.end <= i) asciiIdx++;
-      if (asciiIdx < asciiSpans.length && i >= asciiSpans[asciiIdx]!.start && i < asciiSpans[asciiIdx]!.end) {
-        tokens.push(asciiSpans[asciiIdx]!.text);
-        i = asciiSpans[asciiIdx]!.end;
-        asciiIdx++;
+      while (spanIdx < wordSpans.length && wordSpans[spanIdx]!.end <= i) spanIdx++;
+      if (spanIdx < wordSpans.length && i >= wordSpans[spanIdx]!.start && i < wordSpans[spanIdx]!.end) {
+        tokens.push(wordSpans[spanIdx]!.text);
+        i = wordSpans[spanIdx]!.end;
+        spanIdx++;
         continue;
       }
       const cp = title.codePointAt(i) ?? 0;
-      if (hasCJK(title[i]!)) {
-        const charLen = cp > 0xffff ? 2 : 1;
-        tokens.push(title.slice(i, i + charLen).toLowerCase());
+      const charLen = cp > 0xffff ? 2 : 1;
+      const charStr = title.slice(i, i + charLen);
+      if (isCJKChar(charStr)) {
+        tokens.push(normalizeToken(charStr));
         i += charLen;
       } else {
         i++;
@@ -249,12 +333,12 @@ function tokenizeTitle(title: string): string[] {
     }
     return tokens;
   }
-  // Pure CJK (no ASCII content): split into individual characters.
+  // Pure CJK (no word-run content): split into individual characters.
   if (hasCJK(title)) {
     for (let i = 0; i < title.length;) {
       const cp = title.codePointAt(i) ?? 0;
       const charLen = cp > 0xffff ? 2 : 1;
-      tokens.push(title.slice(i, i + charLen).toLowerCase());
+      tokens.push(normalizeToken(title.slice(i, i + charLen)));
       i += charLen;
     }
     return tokens;

--- a/test/by-mention.test.ts
+++ b/test/by-mention.test.ts
@@ -57,7 +57,9 @@ beforeEach(async () => {
 
 // Tiny gazetteer builder for pure-fn cases that don't need engine.
 function gazetteerFromEntries(entries: Omit<GazetteerEntry, 'tokens'>[]): Gazetteer {
-  const TOKEN_RE = /[a-zA-Z0-9]+/g;
+  // Mirror the production tokenizer: Unicode letters/marks/numbers excluding
+  // CJK (which is split char-level below). Keeps Vietnamese names whole.
+  const TOKEN_RE = /[[\p{L}\p{M}\p{N}]--[㐀-䶿一-鿿぀-ゟ゠-ヿ가-힯]]+/gv;
   const isCJK = (s: string): boolean => {
     const cp = s.codePointAt(0) ?? 0;
     return (cp >= 0x4e00 && cp <= 0x9fff) || (cp >= 0x3400 && cp <= 0x4dbf) ||
@@ -393,6 +395,102 @@ describe('findMentionedEntities — CJK cases', () => {
 });
 
 // ============================================================
+// Vietnamese (diacritic Latin) — entity extraction tests
+// ============================================================
+
+// Fictional Vietnamese names only (privacy rule: no real people in fixtures).
+// "Đà Nẵng" is a public city, not a person, and is the canonical đ-diacritic case.
+describe('findMentionedEntities — Vietnamese cases', () => {
+  test('VN multi-syllable name matches as a WHOLE (regression: no diacritic fragmentation)', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
+    ]);
+    const mentions = findMentionedEntities('Hôm nay mình học bài của thầy Nguyễn Văn Đức.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0]!.slug).toBe('people/nguyen-van-duc');
+    // The whole diacritic name is captured, not a fragment like "nguy".
+    expect(mentions[0]!.name).toBe('Nguyễn Văn Đức');
+  });
+
+  test('VN place name with đ/diacritics — "Đà Nẵng" matched', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'places/da-nang', source_id: 'default', title: 'Đà Nẵng' },
+    ]);
+    const mentions = findMentionedEntities('Gia đình mình chuyển tới Đà Nẵng năm ngoái.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0]!.slug).toBe('places/da-nang');
+    expect(mentions[0]!.name).toBe('Đà Nẵng');
+  });
+
+  test('VN diacritics are significant — "Hồng" title does NOT match diacritic-free "Hong"', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/le-thi-hong', source_id: 'default', title: 'Lê Thị Hồng' },
+    ]);
+    // Body uses the ASCII-typed variant "Le Thi Hong" — tokens differ, no false match.
+    const mentions = findMentionedEntities('Gặp Le Thi Hong hôm qua.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toEqual([]);
+  });
+
+  test('VN mixed with ASCII — Vietnamese name + ASCII company in one body', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/pham-quoc-bao', source_id: 'default', title: 'Phạm Quốc Bảo' },
+      { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
+    ]);
+    const mentions = findMentionedEntities('Phạm Quốc Bảo hợp tác với Acme.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(2);
+    const slugs = mentions.map(m => m.slug);
+    expect(slugs).toContain('people/pham-quoc-bao');
+    expect(slugs).toContain('companies/acme');
+  });
+
+  test('VN longest-match wins — "Nguyễn Văn Đức" beats a shorter "Nguyễn Văn" entry', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
+      { slug: 'people/nguyen-van', source_id: 'default', title: 'Nguyễn Văn' },
+    ]);
+    const mentions = findMentionedEntities('Bài giảng của Nguyễn Văn Đức rất hay.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0]!.slug).toBe('people/nguyen-van-duc');
+  });
+
+  test('VN first-mention-only cap — repeated name → single link', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
+    ]);
+    const body = 'Nguyễn Văn Đức nói. Sau đó Nguyễn Văn Đức nói tiếp.';
+    const mentions = findMentionedEntities(body, g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(1);
+  });
+
+  test('VN determinism — identical output across 10 calls', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
+      { slug: 'places/da-nang', source_id: 'default', title: 'Đà Nẵng' },
+    ]);
+    const body = 'Thầy Nguyễn Văn Đức ở Đà Nẵng. Nguyễn Văn Đức lần nữa.';
+    const refs = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      refs.add(JSON.stringify(findMentionedEntities(body, g, {
+        fromSlug: 'writing/post-1', fromSourceId: 'default',
+      })));
+    }
+    expect(refs.size).toBe(1);
+  });
+});
+
+// ============================================================
 // buildGazetteer — engine-backed tests
 // ============================================================
 
@@ -520,5 +618,19 @@ describe('buildGazetteer — engine integration', () => {
     });
     const g = await buildGazetteer(engine);
     expect(g.size).toBe(0);
+  });
+
+  test('VN person title enters gazetteer keyed on first diacritic-preserving token', async () => {
+    await engine.putPage('people/nguyen-van-duc', {
+      type: 'person', title: 'Nguyễn Văn Đức', compiled_truth: 'b', timeline: '', frontmatter: {},
+    });
+    const g = await buildGazetteer(engine);
+    // "Nguyễn Văn Đức" → ["nguyễn","văn","đức"], keyed on "nguyễn" (NOT fragmented to "nguy").
+    expect(g.has('nguyễn')).toBe(true);
+    const bucket = g.get('nguyễn')!;
+    expect(bucket[0]!.tokens).toEqual(['nguyễn', 'văn', 'đức']);
+    expect(bucket[0]!.slug).toBe('people/nguyen-van-duc');
+    // Regression guard: the old ASCII tokenizer would have keyed on "nguy".
+    expect(g.has('nguy')).toBe(false);
   });
 });

--- a/test/by-mention.test.ts
+++ b/test/by-mention.test.ts
@@ -33,6 +33,8 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import {
   buildGazetteer,
   findMentionedEntities,
+  tokenizeForScan,
+  tokenizeTitle,
   LINKABLE_ENTITY_TYPES,
   type Gazetteer,
   type GazetteerEntry,
@@ -56,31 +58,15 @@ beforeEach(async () => {
 });
 
 // Tiny gazetteer builder for pure-fn cases that don't need engine.
+//
+// Deliberately calls the PRODUCTION `tokenizeTitle` rather than re-declaring
+// the tokenizer. A duplicated copy makes every test here non-discriminating:
+// reverting the source tokenizer would leave the fixture on the new one, so
+// title and body would keep agreeing and the tests would pass either way.
 function gazetteerFromEntries(entries: Omit<GazetteerEntry, 'tokens'>[]): Gazetteer {
-  // Mirror the production tokenizer: Unicode letters/marks/numbers excluding
-  // CJK (which is split char-level below). Keeps Vietnamese names whole.
-  const TOKEN_RE = /[[\p{L}\p{M}\p{N}]--[㐀-䶿一-鿿぀-ゟ゠-ヿ가-힯]]+/gv;
-  const isCJK = (s: string): boolean => {
-    const cp = s.codePointAt(0) ?? 0;
-    return (cp >= 0x4e00 && cp <= 0x9fff) || (cp >= 0x3400 && cp <= 0x4dbf) ||
-           (cp >= 0x3040 && cp <= 0x309f) || (cp >= 0x30a0 && cp <= 0x30ff) ||
-           (cp >= 0xac00 && cp <= 0xd7af);
-  };
-  const hasCJKTitle = (s: string): boolean => [...s].some(isCJK);
-  const tokenize = (s: string): string[] => {
-    TOKEN_RE.lastIndex = 0;
-    if (!hasCJKTitle(s)) {
-      const out: string[] = [];
-      let m: RegExpExecArray | null;
-      while ((m = TOKEN_RE.exec(s)) !== null) out.push(m[0].toLowerCase());
-      return out;
-    }
-    // CJK: split into individual characters, lowercased.
-    return [...s].map(c => isCJK(c) ? c.toLowerCase() : '').filter(Boolean);
-  };
   const g: Gazetteer = new Map();
   for (const raw of entries) {
-    const tokens = tokenize(raw.title);
+    const tokens = tokenizeTitle(raw.title);
     if (tokens.length === 0) continue;
     const key = tokens[0]!;
     const entry: GazetteerEntry = { ...raw, tokens };
@@ -400,25 +386,42 @@ describe('findMentionedEntities — CJK cases', () => {
 
 // Fictional Vietnamese names only (privacy rule: no real people in fixtures).
 // "Đà Nẵng" is a public city, not a person, and is the canonical đ-diacritic case.
+//
+// Every case below asserts TOKENIZATION, not just the resolved mention. A
+// mention-only assertion does not discriminate: the previous ASCII tokenizer
+// fragmented the gazetteer title and the body symmetrically, so a 5-fragment
+// entry still matched a 5-fragment body run, and `Mention.name` is copied from
+// the untouched `title` column rather than derived from tokens.
 describe('findMentionedEntities — Vietnamese cases', () => {
   test('VN multi-syllable name matches as a WHOLE (regression: no diacritic fragmentation)', () => {
+    // Discriminating assertion: the ASCII tokenizer produced
+    // ['nguy','n','v','n','c'] for this title.
+    expect(tokenizeTitle('Nguyễn Văn Đức')).toEqual(['nguyễn', 'văn', 'đức']);
+    const body = 'Hôm nay mình học bài của thầy Nguyễn Văn Đức.';
+    expect(tokenizeForScan(body).map(t => t.text)).toContain('nguyễn');
+
     const g = gazetteerFromEntries([
       { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
     ]);
-    const mentions = findMentionedEntities('Hôm nay mình học bài của thầy Nguyễn Văn Đức.', g, {
+    const mentions = findMentionedEntities(body, g, {
       fromSlug: 'writing/post-1', fromSourceId: 'default',
     });
     expect(mentions).toHaveLength(1);
     expect(mentions[0]!.slug).toBe('people/nguyen-van-duc');
-    // The whole diacritic name is captured, not a fragment like "nguy".
     expect(mentions[0]!.name).toBe('Nguyễn Văn Đức');
   });
 
   test('VN place name with đ/diacritics — "Đà Nẵng" matched', () => {
+    // Discriminating assertion: the ASCII tokenizer produced ['n','ng'],
+    // which is what made this entity match 820 pages instead of 440.
+    expect(tokenizeTitle('Đà Nẵng')).toEqual(['đà', 'nẵng']);
+    const body = 'Gia đình mình chuyển tới Đà Nẵng năm ngoái.';
+    expect(tokenizeForScan(body).map(t => t.text)).toContain('nẵng');
+
     const g = gazetteerFromEntries([
       { slug: 'places/da-nang', source_id: 'default', title: 'Đà Nẵng' },
     ]);
-    const mentions = findMentionedEntities('Gia đình mình chuyển tới Đà Nẵng năm ngoái.', g, {
+    const mentions = findMentionedEntities(body, g, {
       fromSlug: 'writing/post-1', fromSourceId: 'default',
     });
     expect(mentions).toHaveLength(1);
@@ -426,7 +429,26 @@ describe('findMentionedEntities — Vietnamese cases', () => {
     expect(mentions[0]!.name).toBe('Đà Nẵng');
   });
 
+  test('VN NFD body matches an NFC gazetteer title (and the reverse)', () => {
+    const nfc = 'Nguyễn Văn';
+    const nfd = nfc.normalize('NFD');
+    expect(nfd).not.toBe(nfc);                       // fixture really is decomposed
+    expect(tokenizeTitle(nfd)).toEqual(tokenizeTitle(nfc));
+    expect(tokenizeTitle(nfd)).toEqual(['nguyễn', 'văn']);
+
+    const opts = { fromSlug: 'writing/post-1', fromSourceId: 'default' };
+    const gNfc = gazetteerFromEntries([{ slug: 'people/nvd', source_id: 'default', title: nfc }]);
+    expect(findMentionedEntities(`Thầy ${nfd} nói.`, gNfc, opts)).toHaveLength(1);
+
+    const gNfd = gazetteerFromEntries([{ slug: 'people/nvd', source_id: 'default', title: nfd }]);
+    expect(findMentionedEntities(`Thầy ${nfc} nói.`, gNfd, opts)).toHaveLength(1);
+  });
+
   test('VN diacritics are significant — "Hồng" title does NOT match diacritic-free "Hong"', () => {
+    // The title must survive tokenization intact for this to mean anything:
+    // under the ASCII tokenizer it became ['l','th','h','ng'] and missed for
+    // the wrong reason.
+    expect(tokenizeTitle('Lê Thị Hồng')).toEqual(['lê', 'thị', 'hồng']);
     const g = gazetteerFromEntries([
       { slug: 'people/le-thi-hong', source_id: 'default', title: 'Lê Thị Hồng' },
     ]);
@@ -438,11 +460,17 @@ describe('findMentionedEntities — Vietnamese cases', () => {
   });
 
   test('VN mixed with ASCII — Vietnamese name + ASCII company in one body', () => {
+    const body = 'Phạm Quốc Bảo hợp tác với Acme.';
+    // Discriminating: the ASCII tokenizer emitted ['ph','m','qu','c','b','o',
+    // 'h','p','t','c','v','i','acme'] here — only the ASCII control survived.
+    expect(tokenizeForScan(body).map(t => t.text))
+      .toEqual(['phạm', 'quốc', 'bảo', 'hợp', 'tác', 'với', 'acme']);
+
     const g = gazetteerFromEntries([
       { slug: 'people/pham-quoc-bao', source_id: 'default', title: 'Phạm Quốc Bảo' },
       { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
     ]);
-    const mentions = findMentionedEntities('Phạm Quốc Bảo hợp tác với Acme.', g, {
+    const mentions = findMentionedEntities(body, g, {
       fromSlug: 'writing/post-1', fromSourceId: 'default',
     });
     expect(mentions).toHaveLength(2);
@@ -452,6 +480,10 @@ describe('findMentionedEntities — Vietnamese cases', () => {
   });
 
   test('VN longest-match wins — "Nguyễn Văn Đức" beats a shorter "Nguyễn Văn" entry', () => {
+    // Both entries must share a real first token for maximal-munch to be
+    // exercised at all; under the ASCII tokenizer both keyed on 'nguy'.
+    expect(tokenizeTitle('Nguyễn Văn')).toEqual(['nguyễn', 'văn']);
+    expect(tokenizeTitle('Nguyễn Văn Đức')[0]).toBe('nguyễn');
     const g = gazetteerFromEntries([
       { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
       { slug: 'people/nguyen-van', source_id: 'default', title: 'Nguyễn Văn' },
@@ -468,6 +500,8 @@ describe('findMentionedEntities — Vietnamese cases', () => {
       { slug: 'people/nguyen-van-duc', source_id: 'default', title: 'Nguyễn Văn Đức' },
     ]);
     const body = 'Nguyễn Văn Đức nói. Sau đó Nguyễn Văn Đức nói tiếp.';
+    // The cap must be capping a WHOLE-name match, not a fragment run.
+    expect(tokenizeForScan(body).map(t => t.text).slice(0, 3)).toEqual(['nguyễn', 'văn', 'đức']);
     const mentions = findMentionedEntities(body, g, {
       fromSlug: 'writing/post-1', fromSourceId: 'default',
     });
@@ -480,6 +514,8 @@ describe('findMentionedEntities — Vietnamese cases', () => {
       { slug: 'places/da-nang', source_id: 'default', title: 'Đà Nẵng' },
     ]);
     const body = 'Thầy Nguyễn Văn Đức ở Đà Nẵng. Nguyễn Văn Đức lần nữa.';
+    expect(tokenizeForScan(body).map(t => t.text))
+      .toEqual(['thầy', 'nguyễn', 'văn', 'đức', 'ở', 'đà', 'nẵng', 'nguyễn', 'văn', 'đức', 'lần', 'nữa']);
     const refs = new Set<string>();
     for (let i = 0; i < 10; i++) {
       refs.add(JSON.stringify(findMentionedEntities(body, g, {
@@ -487,6 +523,68 @@ describe('findMentionedEntities — Vietnamese cases', () => {
       })));
     }
     expect(refs.size).toBe(1);
+  });
+});
+
+// ============================================================
+// Tokenizer boundaries — non-word glyphs
+// ============================================================
+
+// Guards for the two ways a Unicode tokenizer regresses against the ASCII one
+// it replaces. Both were found in review of the first version of this change,
+// which used /[[\p{L}\p{M}\p{N}]--[CJK]]+/gv: \p{M} let a token consist of
+// combining marks alone, and \p{N} minted tokens the ASCII regex never emitted.
+describe('tokenizer boundaries — marks and non-ASCII numerics', () => {
+  const opts = { fromSlug: 'writing/post-1', fromSourceId: 'default' };
+
+  test('a token can never be combining marks alone (U+FE0F does not become a key)', () => {
+    // VARIATION SELECTOR-16 is \p{Mn} and rides on most emoji. Allowing a
+    // mark-only token made every emoji-prefixed entity title key on a bare
+    // U+FE0F, collapsing them into one mutually-confusable bucket.
+    expect(tokenizeTitle('❤️ Health Notes')).toEqual(['health', 'notes']);
+    expect(tokenizeTitle('⭐️ Budget Notes')).toEqual(['budget', 'notes']);
+    expect(tokenizeForScan('❤️').map(t => t.text)).toEqual([]);
+
+    const g = gazetteerFromEntries([
+      { slug: 'companies/health-notes', source_id: 'default', title: '❤️ Health Notes' },
+      { slug: 'companies/budget-notes', source_id: 'default', title: '⭐️ Budget Notes' },
+    ]);
+    expect([...g.keys()].sort()).toEqual(['budget', 'health']);
+
+    // The plain-text link survives...
+    expect(findMentionedEntities('Plain health notes, no emoji.', g, opts).map(m => m.slug))
+      .toEqual(['companies/health-notes']);
+    // ...and an unrelated emoji in the body does not drag in the other entity.
+    expect(findMentionedEntities('Sprint ⚠️ health notes were fine.', g, opts).map(m => m.slug))
+      .toEqual(['companies/health-notes']);
+  });
+
+  test('non-ASCII numerics do not break strict token adjacency of an ASCII name', () => {
+    // findMentionedEntities requires an entry's tokens to be STRICTLY
+    // ADJACENT in the body, so any glyph that newly tokenizes between the
+    // words of "Acme Corp" silently kills a match that used to work.
+    const g = gazetteerFromEntries([
+      { slug: 'companies/acme-corp', source_id: 'default', title: 'Acme Corp' },
+    ]);
+    for (const body of [
+      'We met Acme Corp today.',    // control
+      'We met Acme¹ Corp today.',   // U+00B9 superscript one (No)
+      'Acme ½ Corp',                // U+00BD vulgar fraction (No)
+      'Acme １ Corp',                // U+FF11 fullwidth digit one (Nd)
+      'Acme ❤️ Corp',          // emoji + VS16 (So + Mn)
+    ]) {
+      expect(findMentionedEntities(body, g, opts)).toHaveLength(1);
+    }
+    // ASCII digits still tokenize exactly as /[a-zA-Z0-9]+/ did.
+    expect(tokenizeForScan('web3 and h2o').map(t => t.text)).toEqual(['web3', 'and', 'h2o']);
+  });
+
+  test('Han Extension A stays on the char-level path, as it was before', () => {
+    // src/core/cjk.ts scopes Ext-A out of CJK_SLUG_CHARS repo-wide, but this
+    // module's walkers have always counted it as CJK. by-mention appends it to
+    // the shared class in one place so the tokenizer and the walkers agree.
+    expect(tokenizeForScan('㐀㐁').map(t => t.text)).toEqual(['㐀', '㐁']);
+    expect(tokenizeTitle('纳瓦尔')).toEqual(['纳', '瓦', '尔']);
   });
 });
 

--- a/test/by-mention.test.ts
+++ b/test/by-mention.test.ts
@@ -579,12 +579,19 @@ describe('tokenizer boundaries — marks and non-ASCII numerics', () => {
     expect(tokenizeForScan('web3 and h2o').map(t => t.text)).toEqual(['web3', 'and', 'h2o']);
   });
 
-  test('Han Extension A stays on the char-level path, as it was before', () => {
-    // src/core/cjk.ts scopes Ext-A out of CJK_SLUG_CHARS repo-wide, but this
-    // module's walkers have always counted it as CJK. by-mention appends it to
-    // the shared class in one place so the tokenizer and the walkers agree.
-    expect(tokenizeForScan('㐀㐁').map(t => t.text)).toEqual(['㐀', '㐁']);
+  test('Han Extension A is no longer CJK here — aligned with cjk.ts scope', () => {
+    // Deliberate behaviour change. by-mention's walkers used to carry their
+    // own range copy covering Ext-A (U+3400–4DBF); cjk.ts scopes Ext-A out
+    // repo-wide, and this module now uses CJK_SLUG_CHARS verbatim. Ext-A
+    // therefore tokenizes as a word run instead of per character, and an
+    // Ext-A-only title is one sub-MIN_NAME_LENGTH token rather than N
+    // char-level ones. Search, chunking and slug grammar already ignore
+    // Ext-A, so this removes by-mention as the lone subsystem that disagreed.
+    expect(tokenizeForScan('㐀㐁').map(t => t.text)).toEqual(['㐀㐁']);
+    expect(tokenizeTitle('㐀㐁')).toEqual(['㐀㐁']);
+    // In-scope CJK is untouched: still char-level.
     expect(tokenizeTitle('纳瓦尔')).toEqual(['纳', '瓦', '尔']);
+    expect(tokenizeForScan('纳瓦尔说').map(t => t.text)).toEqual(['纳', '瓦', '尔', '说']);
   });
 });
 


### PR DESCRIPTION
## Problem

The by-mention entity scanner tokenizes with an ASCII-only regex:

```js
const TOKEN_RE = /[a-zA-Z0-9]+/g;   // src/core/by-mention.ts
```

Both `tokenizeForScan` (body text) and `tokenizeTitle` (gazetteer) share it, and neither folds diacritics. Every non-ASCII, non-CJK letter is dropped and the surrounding ASCII fragments become separate tokens, so Latin-script names with diacritics shred. Vietnamese is the motivating case:

```
"Nguyễn Văn Đức" -> nguy | n | v | n | c
"Đà Nẵng"        -> n | ng
```

The gazetteer then keys on garbage fragments and matching runs on 1–2 char tokens like `n`/`ng`. Two failure modes result: **false-positive explosion** (short fragments collide with unrelated text) and **diacritic collapse** (`Ngọc` == `Ngoc` == `Ngộc` -> `ng`+`c`, merging distinct entities). Net: `extract links --by-mention`, backlinks, entity timelines, and find-experts are all degraded for Vietnamese (and any diacritic Latin script).

This is **not** the problem `feat: CJK entity extraction` (#1637) solved. CJK needed char-level tokenization + min-length-2 because it has no word boundaries. Vietnamese is space-delimited; it only needs the tokenizer to stop discarding non-ASCII letters. Search is unaffected — it uses embeddings + the already-Unicode-aware `tokenizeTitle` in `search/title-match.ts`; this PR is specifically the entity-link graph.

## Fix

`TOKEN_RE` becomes a Unicode word-run tokenizer, with CJK excluded so it keeps flowing through the existing per-character path unchanged:

```js
const TOKEN_RE = new RegExp(
  `(?![${CJK_CHARS}])[\\p{L}0-9]` +
  `(?:(?![${CJK_CHARS}])[\\p{L}\\p{M}0-9])*`,
  'gu',
);
```

Four boundaries are deliberate, and each one was a real regression caught in review of this PR's first version (which used `/[[\p{L}\p{M}\p{N}]--[CJK]]+/gv`):

- **The lead must be a letter or ASCII digit**, so a token can never consist of combining marks alone. U+FE0F (VARIATION SELECTOR-16, category `Mn`) rides on most emoji, so a mark-only token would hijack the gazetteer key of every emoji-prefixed entity title — `❤️ Health Notes` keying on a bare U+FE0F instead of `health`, losing its plain-text links and collapsing all emoji-prefixed titles into one mutually-confusable bucket.
- **Combining marks are allowed after the lead.** NFD Vietnamese is base letter + mark, so excluding `\p{M}` would re-fragment the exact names this tokenizer exists to keep whole.
- **Digits are ASCII-only**, exactly as `/[a-zA-Z0-9]+/` was. `\p{N}` additionally mints tokens for `¹` `½` `１` (Nl/No/non-ASCII Nd), and `findMentionedEntities` requires an entry's tokens to be **strictly adjacent** in the body — so a superscript between the words of `Acme Corp` silently breaks a match that used to work.
- **Plain `u` flag, not `v`.** The CJK exclusion is a negative lookahead over the shared class, the same construction `src/core/think/gather.ts:203` already uses. No set-subtraction syntax, no es2024 target requirement.

Tokens are additionally **NFC-normalized**, so an NFD body matches an NFC gazetteer title and vice versa — without it the fix is inert for exactly the input it targets. Normalization is applied **per token, never over the whole text**: `Mention.offset` is contracted to index into the original body, which `extract-ner.ts` slices context windows from to infer link verbs, and normalizing up front would silently shift every offset.

The CJK class is `CJK_SLUG_CHARS` (`src/core/cjk.ts`), the repo-wide single source of truth since #3522, used verbatim. `TOKEN_RE`, `hasCJK()`, `cjkCharCount()` and both per-character walkers now derive from that one import, **replacing four inline copies of the ranges with none**.

That carries one deliberate behaviour change, called out because it is not free: this module's own copy of the ranges also covered Han Extension A (U+3400–4DBF), which `cjk.ts` scopes out repo-wide. Ext-A is therefore no longer char-level in by-mention — it tokenizes as a word run, and an Ext-A-only entity title becomes a single sub-4-character token that falls below `MIN_NAME_LENGTH` instead of qualifying under `MIN_CJK_NAME_LENGTH`. Search, chunking and slug grammar already ignore Ext-A, so this makes by-mention consistent with them instead of being the lone subsystem that disagreed. In-scope CJK is untouched. Happy to restore Ext-A here if that scope call is wrong.

Result:

```
"Nguyễn Văn Đức" -> nguyễn | văn | đức
"Đà Nẵng"        -> đà | nẵng
"纳瓦尔"          -> (excluded; char-level path emits 纳|瓦|尔 as before)
"㐀㐁"            -> 㐀㐁   (Ext-A; word run now, was char-level — see above)
"Acme Corp"      -> acme | corp   (unchanged)
"web3 and h2o"   -> web3 | and | h2o   (ASCII digits unchanged)
```

Diacritics stay significant (`Hồng` does not match `Hong`), matching the multilingual intent.

## Evidence (old vs new, on a 1,251-page Vietnamese corpus)

Re-measured against the **final** tokenizer in this PR, not the first version. Read-only: page bodies are read from a real brain and run through `findMentionedEntities` with a one-entity gazetteer built by each tokenizer. No links are written. **These are fresh-scan counts on a brain with no pre-existing `link_source='mentions'` rows** — see Known limitation below.

| Entity | OLD tokens | NEW tokens | OLD pages | NEW pages | substring presence |
|---|---|---|---|---|---|
| Đà Nẵng | `[n\|ng]` | `[đà\|nẵng]` | 799 | **431** | 433 |
| Nguyễn | `[nguy\|n]` | `[nguyễn]` | 260 | **97** | 97 |
| Unicity | `[unicity]` | `[unicity]` | 178 | **178** | 179 |
| Zalo | `[zalo]` | `[zalo]` | 244 | **244** | 251 |

OLD carried +85% false positives on `Đà Nẵng` and +168% on `Nguyễn`. Both ASCII controls are identical old vs new — the change is a no-op for ASCII, as intended.

The last column is crude case-insensitive substring presence, which is an **upper bound**, not ground truth — it counts occurrences the scanner is designed to skip. Every one of the 10 pages where substring hits and the tokenizer does not was classified, and all 10 are intentional:

- **9 are mentions that occur only inside code blocks**, which `findMentionedEntities` removes via `stripCodeBlocks` before scanning. Pre-existing behaviour, unrelated to this PR (e.g. `` `Đà Nẵng` in first 100 words `` inside backticks; a `contact:\n  zalo:` YAML fence).
- **1 is a compound word** — `AskTinaZalo` tokenizes as `asktinazalo`, which correctly does not match the entity `Zalo`.

There are no unexplained differences. `Nguyễn` matches substring presence exactly because it happens to have no code-block-only occurrences in this corpus.

(The earlier revision of this description quoted 820/440/271/187/258 against a 1,264-page corpus. Those were measured on 2026-07-29 with the first tokenizer; the corpus has since changed size. The numbers above supersede them.)

## Tests

`test/by-mention.test.ts`: 34 -> 46 tests. `bun test` on the 9 suites that touch `by-mention` or `cjk` -> 119 pass / 0 fail. `tsc --noEmit` clean. `check:privacy`, `check-test-real-names`, `check-test-isolation` -> exit 0. Fictional Vietnamese names only.

**Discrimination.** The fixture gazetteer builder now calls the production `tokenizeTitle` instead of re-declaring the tokenizer — a duplicated copy makes every test here non-discriminating, because reverting the source would leave the fixture on the new tokenizer and title/body would keep agreeing. Every Vietnamese case now asserts **tokenization**, not just the resolved mention: a mention-only assertion passes even under the old tokenizer, which fragmented title and body symmetrically (a 5-fragment gazetteer entry still matched a 5-fragment body run) while `Mention.name` is copied from the untouched `title` column.

Reverting `TOKEN_RE` to `/[a-zA-Z0-9]+/g` in the source **fails 9 of these tests** (8 Vietnamese + 1 `buildGazetteer`). In the first version of this PR it failed 1 of 8.

Three further tests guard the tokenizer's own boundaries — mark-only tokens, non-ASCII-numeric adjacency, and the Ext-A scope change. The first two pass on master by construction: they guard *this change*, not the original bug.

One reviewer case is deliberately **not** restored: a combining mark bound directly to a word (`Acme̶ Corp`, U+0336 inside the run) still does not match. A mark inside a word genuinely alters the word, and the only fix — NFKD + strip `\p{M}`, as `think/gather.ts` does — would destroy the diacritic significance this PR exists to establish. It is asserted as expected behaviour rather than left silent.

## Known limitation — existing `link_source='mentions'` rows are not cleaned up

`engine.addLinksBatch` is additive. The checkpoint's `gazetteerHash` does self-invalidate when the gazetteer keys change, so a re-scan genuinely happens — but the correct links are **added alongside** the false positives the old tokenizer already wrote. A brain that has already run `extract links --by-mention` therefore does not reach the numbers above by upgrading; those are fresh-scan figures.

This is deliberately **not** fixed here, because the correct cleanup is a larger design question than a tokenizer change:

- `link_source='mentions'` is a **shared namespace with two producers**. `extract-ner.ts` deliberately writes `link_source='mentions'` + `link_kind='typed_ner'` rather than minting new provenance. Deleting by `link_source` alone would wipe every NER-derived typed link; deleting only `link_kind != 'typed_ner'` would leave NER rows that were derived from the same bad gazetteer. Both producers need a coordinated purge + re-run.
- There is no bulk primitive to build on — the engine exposes only per-pair `removeLink(from, to, linkType?, linkSource?)`. A cleanup needs a new `BrainEngine` method implemented on both `postgres-engine.ts` and `pglite-engine.ts`, a new CLI flag, and a run of the `DATABASE_URL`-gated engine-parity suite.

Filed as #3674 so it can be reviewed as the write-path change it is.

## Notes

- `MIN_NAME_LENGTH = 4` still filters short single-token names the same across languages — left as-is; a language-aware min-length is a separate policy call.
- NFD Hangul remains unmatched against NFC Hangul titles. This is unchanged from master (which emitted no tokens at all for conjoining Jamo) and consistent with `cjk.ts`'s documented scope, which lists compatibility Jamo as out of scope.
- Han Ext-A is no longer treated as CJK by this module — see the Fix section. Deliberate, tested, and reversible if maintainers want by-mention to keep its wider class.
- `tokenizeForScan` and `tokenizeTitle` are now exported, solely so tests can assert on tokenization.
- Follow-up, analogous to the CJK commit's Chinese verb regexes: Vietnamese link-type inference (`sáng lập`->founded, `đầu tư`->invested_in, `cố vấn`->advises, `làm việc tại`->works_at) + date format `ngày D tháng M năm YYYY`. Not in this PR.
