### PR TITLE
fix(test): give slow setup hooks a real timeout budget

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,10 @@ jobs:
       - name: Run JSONB double-encode parity tests on real Postgres
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gbrain_test
-        run: bun test test/e2e/op-checkpoint-jsonb-parity.test.ts test/e2e/jsonb-roundtrip.test.ts
+        # --timeout also raises bun's 5s default hook budget (beforeAll/afterAll
+        # do NOT inherit a test's third-arg timeout; verified on bun 1.3.x).
+        # Every runner script in scripts/ passes it; bare invocations must too.
+        run: bun test --timeout=60000 test/e2e/op-checkpoint-jsonb-parity.test.ts test/e2e/jsonb-roundtrip.test.ts
 
   tier1:
     name: Tier 1 (Mechanical)
@@ -88,7 +91,7 @@ jobs:
           bun-version: 1.3.13
       - run: bun install
       - name: Run Tier 1 E2E tests
-        run: bun test test/e2e/mechanical.test.ts test/e2e/mcp.test.ts
+        run: bun test --timeout=60000 test/e2e/mechanical.test.ts test/e2e/mcp.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gbrain_test
 
@@ -155,7 +158,7 @@ jobs:
           }
           EOF
       - name: Run Tier 2 skill tests
-        run: bun test test/e2e/skills.test.ts test/e2e/zeroentropy-live.test.ts
+        run: bun test --timeout=60000 test/e2e/skills.test.ts test/e2e/zeroentropy-live.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gbrain_test
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           bun-version: 1.3.13
       - run: bun install
-      - run: bun test
+      # --timeout matches every scripts/ runner and covers hook budgets too
+      # (bunfig.toml's timeout key is ignored by bun; hooks default to 5s).
+      - run: bun test --timeout=60000
       - run: bun run verify
       - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
       - name: Attest build provenance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,11 @@ jobs:
           key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
       - run: bun install
       - run: bun run verify
+      # Guard: no bare `bun test` in workflows/scripts — bun ignores
+      # bunfig.toml's timeout, and hooks (beforeAll/afterAll) get the 5s
+      # default regardless of per-test third-arg timeouts. Runs directly
+      # (not via verify's CHECKS array) to avoid a package.json edit.
+      - run: bash scripts/check-bun-test-timeout.sh
 
   serial-tests:
     # *.serial.test.ts at --max-concurrency=1. Lives in its own runner so

--- a/scripts/check-bun-test-timeout.sh
+++ b/scripts/check-bun-test-timeout.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# CI guard: every `bun test` invocation in workflows and runner scripts must
+# pass an explicit --timeout.
+#
+# Why: bun ignores bunfig.toml's `timeout` key (verified on 1.3.14), so a bare
+# `bun test` gets the 5000ms default for BOTH tests and beforeAll/beforeEach/
+# afterAll/afterEach hooks. Hooks do NOT inherit a test's third-arg timeout —
+# a file whose tests all declare `}, 30_000)` still has a 5s hook budget, and
+# slow setup (Postgres connect + migrations, PGLite cold start) flakes on
+# loaded CI runners with the signature `(unnamed) [5001ms] ... hook timed out`
+# (the #3545 jsonb-parity failure). The CLI --timeout flag is the one measured
+# mechanism that raises the hook budget uniformly; per-hook second-arg
+# timeouts work too but don't scale to ~400 slow hooks.
+#
+# Usage: scripts/check-bun-test-timeout.sh
+# Exit:  0 when clean, 1 when a bare `bun test` invocation is found.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+# Match executable `bun test` invocations. Exclude comment lines (#, //, *)
+# and lines that already carry --timeout anywhere.
+# Scope: workflows + runner scripts (the surfaces CI executes). package.json
+# script bodies route through scripts/ already; editing it is out of scope here.
+violations="$(grep -rnE '\bbun test\b' .github/workflows scripts 2>/dev/null \
+  | grep -v -- '--timeout' \
+  | grep -vE ':[[:space:]]*(#|//|\*)' \
+  | grep -v 'check-bun-test-timeout' \
+  || true)"
+
+if [ -n "$violations" ]; then
+  echo "FAIL: bare 'bun test' without --timeout (5s default kills slow setup hooks):" >&2
+  echo "$violations" >&2
+  echo "" >&2
+  echo "Add --timeout=60000 (see scripts/run-unit-shard.sh for the convention)." >&2
+  exit 1
+fi
+
+echo "OK: every bun test invocation passes an explicit --timeout."

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -162,8 +162,9 @@ for f in "${files[@]}"; do
   if [ -n "${DATABASE_URL:-}" ]; then
     psql "$DATABASE_URL" -At -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid != pg_backend_pid() AND datname = current_database()" >/dev/null 2>&1 || true
   fi
-  # Hard outer timeout (180s per file). bun's --timeout is per-test; if a
-  # PGLite WASM call hangs in beforeAll/afterAll, --timeout never fires and
+  # Hard outer timeout (180s per file). bun's --timeout covers tests AND
+  # hooks (measured on 1.3.14), but it's timer-based: a PGLite WASM call
+  # that blocks the event loop synchronously never lets the timer fire and
   # the file wedges indefinitely. gtimeout/timeout SIGKILLs the file so the
   # suite advances. gtimeout (macOS via coreutils) preferred; timeout (Linux)
   # fallback; bare bun (no outer cap) if neither is installed.

--- a/test/e2e/jsonb-roundtrip.test.ts
+++ b/test/e2e/jsonb-roundtrip.test.ts
@@ -26,8 +26,12 @@ if (skip) {
 }
 
 describeE2E('E2E: JSONB roundtrip — v0.12.1 reliability wave', () => {
-  beforeAll(async () => { await setupDB(); });
-  afterAll(async () => { await teardownDB(); });
+  // 60s hook budget: setupDB runs connect + the full migration chain, which
+  // exceeds bun's default 5s hook timeout on loaded CI runners. Hooks do NOT
+  // inherit a test's third-arg timeout (verified on bun 1.3.14) — they need
+  // their own second-arg budget. Same pattern as op-checkpoint-jsonb-parity.
+  beforeAll(async () => { await setupDB(); }, 60_000);
+  afterAll(async () => { await teardownDB(); }, 60_000);
 
   test('putPage writes frontmatter as object, not double-encoded string', async () => {
     const engine = getEngine();


### PR DESCRIPTION
## The bug class

bun ignores `bunfig.toml`'s `timeout` key, and `beforeAll`/`beforeEach`/`afterAll` hooks do **not** inherit a test's third-arg timeout. Under a bare `bun test`, every hook gets the 5000ms default even when every test in the file declares `}, 30_000)`. That's exactly what killed PR #3545's required `JSONB parity` job: `(unnamed) [5001.03ms] ... hook timed out` — the `beforeAll` running `setupDB()` (connect + full migration chain) on a loaded runner, not any test. Same family as #2943/#3537, which fixed test timeouts but not hooks.

## Measured mechanism (bun 1.3.14)

| Probe | Result |
|---|---|
| bare `bun test`, 6s hook, test declares `60_000` | hook killed at **5010ms** (CI signature reproduced) |
| `beforeAll(fn, 30_000)` | passes; and `beforeAll(fn, 2000)` with a 6s sleep is killed at **2000ms** — the arg is a real enforced budget |
| `bun test --timeout 30000`, 6s hook | passes; and `--timeout 6000` with an 8s hook is killed at **6000ms** — the CLI flag governs hooks too |

So two mechanisms work; the CLI flag is the uniform one. Every `scripts/` runner already passes `--timeout=60000` — the only unprotected invocations were the bare `bun test` lines in workflows.

## Changes

- **`.github/workflows/e2e.yml`** — all three jobs (jsonb-parity, tier1, tier2) now pass `--timeout=60000`.
- **`.github/workflows/release.yml`** — the bare full-suite `bun test` now passes `--timeout=60000`.
- **`test/e2e/jsonb-roundtrip.test.ts`** — per-hook `60_000` budgets on `beforeAll`/`afterAll` (belt-and-braces for the #2339 guard so bare local runs can't flake either; same pattern its sibling `op-checkpoint-jsonb-parity.test.ts` already carries). No assertion touched.
- **`scripts/check-bun-test-timeout.sh`** (new, run from test.yml's verify job) — fails CI on any future bare `bun test` in workflows/scripts. It immediately caught `release.yml` during development.
- **`scripts/run-e2e.sh`** — corrected a comment claiming `--timeout` is per-test-only (it covers hooks; the outer `gtimeout` remains necessary for sync-blocking WASM hangs where no timer can fire).

## Proof on the real file

Repro harness: pause the Postgres container so `setupDB()`'s connect blocks ~6s, run `bun test test/e2e/jsonb-roundtrip.test.ts` bare (exactly the CI job's invocation).

- **Before:** `(unnamed) [5001.81ms] — a beforeEach/afterEach hook timed out`, 0 pass / 1 fail — byte-for-byte the #3545 CI signature.
- **After:** identical 6s-stall condition, **5 pass** in 6.57s.
- CI-equivalent invocation (`bun test --timeout=60000` on both parity files): 8 pass / 0 fail.

## At-risk survey

396 slow before-hooks (PGLite cold start: 326, `setupDB`: 26, `initSchema`: 17, engine connect: 6, spawn/exec/corpus: 21) across 362 test files lack per-hook budgets. After this change every one of them runs only through `--timeout`-passing invocations (all `scripts/` runners + all workflows), enforced by the new guard — so per-file edits at that scale are unnecessary churn. The one file where a bare local run must never flake (the #2339 guard) got the per-hook budget.

`bun run typecheck` clean; `bun run verify` 32/32 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)