### PR TITLE
fix(doctor): distinguish a damaged PGLite store from a broken runtime (#2674)

### DIFF
--- a/docs/progress-events.md
+++ b/docs/progress-events.md
@@ -134,6 +134,9 @@ sync that calls import emits `sync.import.<file>`, not `import.<file>`.
 Stable phase names shipped in v0.15.2:
 
 - `doctor.db_checks` (umbrella for all DB-side doctor checks)
+- `doctor.pglite_probe` (the #2674 scratch-store probe; only when PGLite init
+  failed or `--probe-pglite` was passed — a cold start can take 5–20s, so the
+  heartbeat is the only sign of life)
 - `orphans.scan`
 - `embed.pages`
 - `extract.links_fs`, `extract.timeline_fs`, `extract.links_db`, `extract.timeline_db`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2475,7 +2475,7 @@ SETUP
   migrate embeddings --to <p:model>  Re-embed onto another embedding provider
   upgrade                            Self-update
   check-update [--json]              Check for new versions
-  doctor [--json] [--fast]            Health check (resolver, skills, pgvector, RLS, embeddings)
+  doctor [--json] [--fast] [--probe-pglite]  Health check (resolver, skills, pgvector, RLS, embeddings; --probe-pglite runs the scratch-store probe)
   integrations [subcommand]          Manage integration recipes (senses + reflexes)
 
 PAGES

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -627,6 +627,93 @@ export async function checkSourceConfigShape(engine: BrainEngine): Promise<Check
   }
 }
 
+/**
+ * #2674 — pglite_scratch_probe: distinguish a damaged PGLite store from a
+ * broken WASM runtime.
+ *
+ * PGLite reports only `Aborted()` to JS (the PANIC goes to its own stderr),
+ * so when init fails, the error string cannot say WHICH of the two it is.
+ * The probe initializes a throwaway store in a temp dir, round-trips a row,
+ * and reads the outcome:
+ *
+ *   - scratch works, real init failed → the runtime is fine; YOUR STORE is
+ *     damaged. Recovery: restore a backup or `gbrain reinit-pglite` (markdown
+ *     is unaffected — the DB holds derived data a re-sync rebuilds).
+ *   - scratch fails too → the runtime cannot start on this machine; report
+ *     OS + Bun versions on #223.
+ *
+ * COST GATE: a PGLite cold start is 5–20s on loaded machines, so this never
+ * runs on a routine `gbrain doctor`. It runs only when (a) the real PGLite
+ * engine actually failed to open (engine=null, not --fast, configured engine
+ * is pglite), or (b) the operator asks with `--probe-pglite`.
+ *
+ * `probeFn` is a test seam so message routing can be pinned without paying
+ * four real cold starts.
+ */
+export async function checkPgliteScratchProbe(opts: {
+  realInitFailed: boolean;
+  realStorePath?: string;
+  probeFn?: () => Promise<import('../core/pglite-engine.ts').PgliteScratchProbeResult>;
+}): Promise<Check> {
+  const name = 'pglite_scratch_probe';
+  try {
+    const probe =
+      opts.probeFn ??
+      (async () => {
+        const { probePgliteScratchStore } = await import('../core/pglite-engine.ts');
+        return probePgliteScratchStore(opts.realStorePath);
+      });
+    const r = await probe();
+    const secs = (r.duration_ms / 1000).toFixed(1);
+    if (r.ok) {
+      if (opts.realInitFailed) {
+        return {
+          name,
+          status: 'fail',
+          message:
+            `A scratch PGLite store initialized, wrote and read back fine on this machine (${secs}s), ` +
+            `so the runtime is healthy and YOUR STORE is damaged — NOT the macOS WASM bug (#223), not a lock. ` +
+            `Your markdown is unaffected: the DB holds derived data (chunks, embeddings, links, facts) that a re-sync rebuilds. ` +
+            `Recover: restore a backup of the store directory, or run \`gbrain reinit-pglite\` (wipes + re-inits + re-syncs).`,
+          details: { scratch_ok: true, duration_ms: r.duration_ms },
+        };
+      }
+      return {
+        name,
+        status: 'ok',
+        message: `PGLite runtime healthy: scratch store round-trip in ${secs}s.`,
+        details: { scratch_ok: true, duration_ms: r.duration_ms },
+      };
+    }
+    const errLine = (r.error ?? 'unknown error').split('\n')[0];
+    if (opts.realInitFailed) {
+      return {
+        name,
+        status: 'fail',
+        message:
+          `A fresh scratch PGLite store ALSO failed to start (${secs}s), so the WASM runtime cannot run ` +
+          `on this machine — your store is not necessarily damaged. Report your OS and Bun versions on ` +
+          `https://github.com/garrytan/gbrain/issues/223. Scratch error: ${errLine}`,
+        details: { scratch_ok: false, duration_ms: r.duration_ms, error: r.error, verdict: r.verdict },
+      };
+    }
+    return {
+      name,
+      status: 'warn',
+      message:
+        `Your real store opened, but a fresh scratch PGLite store failed to initialize (${secs}s) — ` +
+        `new stores can't be created on this machine. Report your OS and Bun versions on ` +
+        `https://github.com/garrytan/gbrain/issues/223. Scratch error: ${errLine}`,
+      details: { scratch_ok: false, duration_ms: r.duration_ms, error: r.error, verdict: r.verdict },
+    };
+  } catch (e) {
+    // Includes the never-touch-the-real-store guard refusal. The probe not
+    // running is a diagnostic gap, not a diagnosis — warn, don't fail.
+    const msg = e instanceof Error ? e.message : String(e);
+    return { name, status: 'warn', message: `scratch probe could not run: ${msg}` };
+  }
+}
+
 export async function doctorReportRemote(engine: BrainEngine): Promise<DoctorReport> {
   const checks: Check[] = [];
 
@@ -646,6 +733,13 @@ export async function doctorReportRemote(engine: BrainEngine): Promise<DoctorRep
       status: 'fail',
       message: e instanceof Error ? e.message : String(e),
     });
+    // #2674: on PGLite, a dead connection is exactly the ambiguous case the
+    // scratch probe exists for — pay its cold start only on this failure path.
+    if (engine.kind === 'pglite') {
+      let realStorePath: string | undefined;
+      try { realStorePath = loadConfig()?.database_path; } catch { /* no config */ }
+      checks.push(await checkPgliteScratchProbe({ realInitFailed: true, realStorePath }));
+    }
     // Without a connection, every other check is meaningless — short-circuit.
     return computeDoctorReport(checks);
   }
@@ -5684,6 +5778,34 @@ export async function buildChecks(
     }
   } catch {
     // Filesystem read failure is non-fatal.
+  }
+
+  // --- PGLite scratch-store probe (#2674) ---
+  //
+  // Gated hard on cost (a PGLite cold start is 5–20s): runs ONLY when the
+  // real PGLite engine failed to open (engine=null while the config says
+  // pglite and the caller didn't choose --fast), or when explicitly asked
+  // for with --probe-pglite. A routine healthy `gbrain doctor` never pays it.
+  {
+    const probeRequested = args.includes('--probe-pglite');
+    let cfgForProbe: ReturnType<typeof loadConfig> = null;
+    try { cfgForProbe = loadConfig(); } catch { /* no config — nothing to probe */ }
+    const pgliteInitFailed = !engine && !fastMode && cfgForProbe?.engine === 'pglite';
+    if (probeRequested || pgliteInitFailed) {
+      progress.start('doctor.pglite_probe');
+      const stopHb = startHeartbeat(progress, 'pglite scratch-store probe (cold start, can take 5–20s)…');
+      try {
+        checks.push(
+          await checkPgliteScratchProbe({
+            realInitFailed: pgliteInitFailed,
+            realStorePath: cfgForProbe?.database_path,
+          }),
+        );
+      } finally {
+        stopHb();
+        progress.finish();
+      }
+    }
   }
 
   // --- DB checks (skip if --fast or no engine) ---

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -98,6 +98,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'ocr_health',
   'orphan_ratio',
   'oversized_pages',
+  'pglite_scratch_probe',
   'quarantined_pages',
   'raw_provenance',
   'flagged_pages',

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -266,6 +266,95 @@ async function preservingProcessExitCode<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * #2674 — the scratch-store probe, the diagnostic half of the issue.
+ *
+ * PGLite reports only `Aborted()` to JS and prints the real PANIC (e.g.
+ * `could not locate a valid checkpoint record`) to its own stderr, so from
+ * the JS-visible error alone a damaged store is indistinguishable from a
+ * broken WASM runtime. The one thing that CAN tell them apart is opening a
+ * throwaway store on the same machine:
+ *
+ *   - scratch store works → the runtime is healthy; the REAL store is damaged.
+ *   - scratch store fails too → the runtime cannot start here at all.
+ *
+ * Stderr capture: PGLite 0.4.3 exposes no print/printErr hook on
+ * `PGliteOptions` (checked: only `debug`, which still writes to the
+ * process's own stderr), so we deliberately do NOT try to intercept the
+ * PANIC text — monkey-patching process.stderr.write around an async WASM
+ * init is exactly the hack the classifier comments warn against. The
+ * probe's ok/fail outcome carries the diagnosis instead; `verdict` is
+ * populated from the JS-visible error for callers that want it.
+ *
+ * Runs the SAME code path as the real engine (PGlite.create + vector +
+ * pg_trgm) but deliberately NOT PGLiteEngine.connect(): connect wraps
+ * failures in buildPgliteInitErrorMessage, whose hint text would then
+ * pollute re-classification of the probe error.
+ *
+ * Safety: the scratch dir comes from mkdtemp under os.tmpdir() and is
+ * additionally checked against `realStorePath` (refuses any overlap in
+ * either direction) — a bug here must never touch the brain being
+ * diagnosed. The dir is removed in a finally, success or failure.
+ */
+export interface PgliteScratchProbeResult {
+  ok: boolean;
+  duration_ms: number;
+  /** JS-visible error when ok=false (the PANIC itself lands on stderr, not here). */
+  error?: string;
+  verdict?: PgliteInitFailure;
+}
+
+export async function probePgliteScratchStore(
+  realStorePath?: string,
+): Promise<PgliteScratchProbeResult> {
+  const { mkdtemp, rm } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join, resolve, sep } = await import('node:path');
+
+  const scratchDir = await mkdtemp(join(tmpdir(), 'gbrain-pglite-probe-'));
+  if (realStorePath) {
+    const real = resolve(realStorePath);
+    const scratch = resolve(scratchDir);
+    if (scratch === real || scratch.startsWith(real + sep) || real.startsWith(scratch + sep)) {
+      await rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+      throw new Error(
+        `refusing to probe: scratch dir ${scratch} overlaps the real store ${real}`,
+      );
+    }
+  }
+
+  const started = Date.now();
+  let db: PGlite | null = null;
+  try {
+    db = await preservingProcessExitCode(() =>
+      PGlite.create({
+        dataDir: join(scratchDir, 'store'),
+        extensions: { vector, pg_trgm },
+      }),
+    );
+    await db.query(`CREATE TABLE scratch_probe (id int PRIMARY KEY, note text)`);
+    await db.query(`INSERT INTO scratch_probe VALUES (1, 'ok')`);
+    const res = await db.query<{ note: string }>(`SELECT note FROM scratch_probe WHERE id = 1`);
+    if (res.rows[0]?.note !== 'ok') {
+      throw new Error(`scratch store read-back mismatch: ${JSON.stringify(res.rows)}`);
+    }
+    return { ok: true, duration_ms: Date.now() - started };
+  } catch (err) {
+    const message = stringifyPgliteInitError(err);
+    return {
+      ok: false,
+      duration_ms: Date.now() - started,
+      error: message,
+      verdict: classifyPgliteInitError(message),
+    };
+  } finally {
+    if (db) {
+      try { await db.close(); } catch { /* probe store — nothing to save */ }
+    }
+    await rm(scratchDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 export class PGLiteEngine implements BrainEngine {
   readonly kind = 'pglite' as const;
   private _db: PGLiteDB | null = null;

--- a/test/doctor-pglite-scratch-probe.test.ts
+++ b/test/doctor-pglite-scratch-probe.test.ts
@@ -1,0 +1,208 @@
+// #2674 — pglite_scratch_probe: distinguish a damaged PGLite store from a
+// broken WASM runtime.
+//
+// The load-bearing fact: PGLite reports only `Aborted()` to JS and prints the
+// real PANIC (`could not locate a valid checkpoint record …`) to its own
+// stderr, so the init-error classifier can never discriminate the two cases
+// from the default path. The scratch-store probe is the only thing that can:
+// a throwaway store that opens fine proves the runtime is healthy and the
+// REAL store is damaged.
+//
+// Pinned contracts:
+//   - COST GATE: the probe never runs on a routine healthy doctor. It runs
+//     only when PGLite init actually failed (engine=null + config engine is
+//     pglite + not --fast) or on explicit `--probe-pglite`.
+//   - Discrimination messaging: scratch-ok + real-init-failed names the STORE
+//     (recovery: reinit-pglite / restore backup; markdown unaffected);
+//     scratch-fail names the RUNTIME (report OS + Bun on #223).
+//   - Cleanup: the scratch temp dir is removed on success AND failure.
+//   - Never-touch-the-real-store guard: overlap with the real store path is
+//     refused before any PGLite work.
+//   - Cross-surface parity: BOTH buildChecks() and doctorReportRemote() emit
+//     the check on the PGLite connection-failure path.
+//
+// NOTE: the buildChecks / doctorReportRemote tests import only symbols that
+// exist on master, so on an unmodified master checkout they fail
+// BEHAVIORALLY (the check is absent from the emitted list), not via a
+// missing export.
+
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { buildChecks, doctorReportRemote, type Check } from '../src/commands/doctor.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+const PROBE_TIMEOUT = 90_000; // PGLite cold start is 5–20s on loaded machines
+
+function findCheck(checks: Check[], name: string): Check | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+function scratchDirsInTmp(): Set<string> {
+  return new Set(readdirSync(tmpdir()).filter((d) => d.startsWith('gbrain-pglite-probe-')));
+}
+
+/** GBRAIN_HOME parent dir whose .gbrain/config.json declares a pglite engine. */
+function makePgliteHome(): { home: string; storePath: string } {
+  const home = mkdtempSync(join(tmpdir(), 'gbrain-probe-home-'));
+  const dotGbrain = join(home, '.gbrain');
+  mkdirSync(dotGbrain, { recursive: true });
+  const storePath = join(dotGbrain, 'brain.pglite');
+  writeFileSync(
+    join(dotGbrain, 'config.json'),
+    JSON.stringify({ engine: 'pglite', database_path: storePath }),
+  );
+  return { home, storePath };
+}
+
+const NO_DB_ENV = { GBRAIN_DATABASE_URL: undefined, DATABASE_URL: undefined };
+
+describe('pglite_scratch_probe — buildChecks gating (#2674)', () => {
+  test(
+    'PGLite init failure (engine=null, pglite config) → probe runs; healthy runtime blames THE STORE',
+    async () => {
+      const { home } = makePgliteHome();
+      await withEnv({ ...NO_DB_ENV, GBRAIN_HOME: home }, async () => {
+        const before = scratchDirsInTmp();
+        const checks = await buildChecks(null, ['--scope=brain'], 'config-file-path');
+        const check = findCheck(checks, 'pglite_scratch_probe');
+        expect(check).toBeDefined();
+        // On this (healthy) machine the scratch store works, so the verdict
+        // is: runtime fine, YOUR STORE is damaged.
+        expect(check!.status).toBe('fail');
+        expect(check!.message).toContain('YOUR STORE is damaged');
+        expect(check!.message).toContain('reinit-pglite');
+        expect(check!.message).toContain('markdown is unaffected');
+        expect(check!.message).not.toContain('cannot run');
+        // Cleanup: no leaked scratch dirs.
+        const after = scratchDirsInTmp();
+        for (const d of after) expect(before.has(d)).toBe(true);
+      });
+    },
+    PROBE_TIMEOUT,
+  );
+
+  test('cost gate: --fast never pays the probe, even with a failed pglite engine', async () => {
+    const { home } = makePgliteHome();
+    await withEnv({ ...NO_DB_ENV, GBRAIN_HOME: home }, async () => {
+      const checks = await buildChecks(null, ['--fast', '--scope=brain'], 'config-file-path');
+      expect(findCheck(checks, 'pglite_scratch_probe')).toBeUndefined();
+    });
+  });
+
+  test('cost gate: engine=null with a NON-pglite config does not probe', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-probe-home-'));
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'postgres', database_url: 'postgres://localhost/nope' }),
+    );
+    await withEnv({ ...NO_DB_ENV, GBRAIN_HOME: home }, async () => {
+      const checks = await buildChecks(null, ['--scope=brain'], 'config-file-path');
+      expect(findCheck(checks, 'pglite_scratch_probe')).toBeUndefined();
+    });
+  });
+
+  test(
+    'on demand: --probe-pglite with no init failure reports the runtime as healthy (ok)',
+    async () => {
+      const { home } = makePgliteHome();
+      await withEnv({ ...NO_DB_ENV, GBRAIN_HOME: home }, async () => {
+        // --fast keeps the walk cheap; the explicit flag still wins.
+        const checks = await buildChecks(null, ['--fast', '--probe-pglite', '--scope=brain'], 'config-file-path');
+        const check = findCheck(checks, 'pglite_scratch_probe');
+        expect(check).toBeDefined();
+        expect(check!.status).toBe('ok');
+        expect(check!.message).toContain('runtime healthy');
+      });
+    },
+    PROBE_TIMEOUT,
+  );
+});
+
+describe('pglite_scratch_probe — doctorReportRemote parity (#2674)', () => {
+  test(
+    'a dead PGLite connection on the remote surface triggers the probe',
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), 'gbrain-probe-home-'));
+      await withEnv({ ...NO_DB_ENV, GBRAIN_HOME: home }, async () => {
+        const stub = {
+          kind: 'pglite',
+          getStats: async () => {
+            throw new Error('Aborted(). Build with -sASSERTIONS for more info.');
+          },
+        } as unknown as BrainEngine;
+        const report = await doctorReportRemote(stub);
+        const check = findCheck(report.checks, 'pglite_scratch_probe');
+        expect(check).toBeDefined();
+        expect(check!.status).toBe('fail');
+        expect(check!.message).toContain('YOUR STORE is damaged');
+      });
+    },
+    PROBE_TIMEOUT,
+  );
+
+  test('a dead POSTGRES connection on the remote surface does not probe', async () => {
+    const stub = {
+      kind: 'postgres',
+      getStats: async () => {
+        throw new Error('connection refused');
+      },
+    } as unknown as BrainEngine;
+    const report = await doctorReportRemote(stub);
+    expect(findCheck(report.checks, 'pglite_scratch_probe')).toBeUndefined();
+  });
+});
+
+describe('probePgliteScratchStore — probe internals (#2674)', () => {
+  test('never-touch-the-real-store guard refuses overlap and leaks nothing', async () => {
+    const { probePgliteScratchStore } = await import('../src/core/pglite-engine.ts');
+    const before = scratchDirsInTmp();
+    // The scratch dir lives under tmpdir(), so a "real store" AT tmpdir()
+    // must trip the overlap guard before any PGLite work happens.
+    await expect(probePgliteScratchStore(tmpdir())).rejects.toThrow(/refusing to probe/);
+    const after = scratchDirsInTmp();
+    for (const d of after) expect(before.has(d)).toBe(true);
+  });
+
+  test('verdict routing: probe failure result surfaces classifier verdict + error', async () => {
+    // Message routing via the probeFn test seam — no cold start needed.
+    const { checkPgliteScratchProbe } = await import('../src/commands/doctor.ts');
+
+    // real init failed + scratch failed too → runtime is broken, ask for OS/Bun.
+    const runtimeBroken = await checkPgliteScratchProbe({
+      realInitFailed: true,
+      probeFn: async () => ({
+        ok: false,
+        duration_ms: 1234,
+        error: 'Aborted(). Build with -sASSERTIONS for more info.',
+        verdict: 'unknown' as const,
+      }),
+    });
+    expect(runtimeBroken.status).toBe('fail');
+    expect(runtimeBroken.message).toContain('runtime cannot run');
+    expect(runtimeBroken.message).toContain('issues/223');
+    expect(runtimeBroken.message).toContain('OS and Bun versions');
+    expect(runtimeBroken.message).not.toContain('YOUR STORE is damaged');
+
+    // healthy real store + scratch failed → warn, still runtime-facing.
+    const scratchOnly = await checkPgliteScratchProbe({
+      realInitFailed: false,
+      probeFn: async () => ({ ok: false, duration_ms: 10, error: 'boom' }),
+    });
+    expect(scratchOnly.status).toBe('warn');
+    expect(scratchOnly.message).toContain('real store opened');
+
+    // probeFn throwing (e.g. the overlap guard) → warn, not a diagnosis.
+    const guardTrip = await checkPgliteScratchProbe({
+      realInitFailed: true,
+      probeFn: async () => {
+        throw new Error('refusing to probe: overlap');
+      },
+    });
+    expect(guardTrip.status).toBe('warn');
+    expect(guardTrip.message).toContain('could not run');
+  });
+});


### PR DESCRIPTION
## What

The diagnostic half of #2674 — the `doctor` probe the reporter explicitly asked for. PR #3519 (open) fixed the messaging half; this PR adds the check that turns the ambiguous failure into a verdict.

**The load-bearing constraint:** PGLite reports only `Aborted()` to JS and prints the real PANIC (`could not locate a valid checkpoint record …`) to its own stderr. From the JS-visible string, a damaged store and a broken WASM runtime are byte-identical — which is how a store with WAL damage spent 17 days blamed on the macOS 26.3 bug. The scratch-store probe is the only thing that can tell them apart.

New `pglite_scratch_probe` check: initialize a throwaway store in a temp dir, write and read back a row, report:

- **scratch works** → the runtime is healthy; **your store is damaged**. Recovery: restore a backup or `gbrain reinit-pglite` — markdown is unaffected, the DB holds derived data a re-sync rebuilds.
- **scratch fails too** → the runtime cannot start on this machine; report OS + Bun versions on #223.

Verified end to end against a synthetically damaged store:

```
[FAIL] pglite_scratch_probe → A scratch PGLite store initialized, wrote and read back
fine on this machine (1.6s), so the runtime is healthy and YOUR STORE is damaged —
NOT the macOS WASM bug (#223), not a lock. Your markdown is unaffected: ...
Recover: restore a backup of the store directory, or run `gbrain reinit-pglite` ...
```

## Design decisions

- **Cost gate.** A PGLite cold start is 5–20s on loaded machines, so the probe never runs on a routine healthy `gbrain doctor`. It fires only when (a) PGLite init actually failed (engine=null, config engine is pglite, not `--fast`) — the moment the diagnosis is needed and its cost is trivially justified — or (b) on explicit `--probe-pglite`. Both gates are pinned by tests.
- **Cross-surface parity.** Wired into BOTH `buildChecks()` (with a new `doctor.pglite_probe` heartbeat phase so agents see life during the cold start — documented in `docs/progress-events.md`) and `doctorReportRemote()` (on the PGLite connection-failure short-circuit only, so the remote surface pays the cold start only when already broken). Registered in `BRAIN_CHECK_NAMES`; the categories drift guard passes.
- **Cleanup.** The scratch dir comes from `mkdtemp` under `os.tmpdir()` and is removed in a `finally` — success, failure, or guard refusal. Tests assert no leaked `gbrain-pglite-probe-*` dirs on both paths.
- **Never touch the real store.** Beyond the structural guarantee (mkdtemp under tmpdir), the probe refuses to run if the scratch path overlaps the configured store path in either direction, before any PGLite work. A guard refusal surfaces as a `warn` ("probe could not run"), never as a diagnosis.
- **Stderr capture: not done, deliberately.** PGLite 0.4.3 exposes no print/printErr hook on `PGliteOptions` (checked the shipped types: only `debug`, which still writes to the process's own stderr). Intercepting would mean monkey-patching `process.stderr.write` around an async WASM init while the doctor's own progress reporter writes to stderr — exactly the hack to avoid. The probe's ok/fail outcome carries the diagnosis instead; the JS-visible error is still fed to `classifyPgliteInitError` and surfaced in `details.verdict`, so once #3519's `wal-corrupt` verdict lands, any caller that does see richer text gets the precise classification for free.
- **Coordination with #3519.** Based on master, not on #3519's branch. The only shared file is `src/core/pglite-engine.ts`; this PR adds a standalone function between `preservingProcessExitCode` and the engine class — outside every hunk #3519 touches — so the two merge cleanly in either order, and none of #3519's messaging changes are duplicated. The probe intentionally uses `PGlite.create` directly rather than `PGLiteEngine.connect`, both for raw errors (connect wraps failures in `buildPgliteInitErrorMessage`, whose hint text would pollute re-classification) and to stay independent of #3519's message changes.

## Proof: tests fail on master behaviorally

New `test/doctor-pglite-scratch-probe.test.ts` imports only master-existing symbols at top level (`buildChecks`, `doctorReportRemote`). Against an unmodified master checkout (git archive of `origin/master` + the test file):

```
✗ PGLite init failure (engine=null, pglite config) → probe runs; ...
    expect(check).toBeDefined()  Received: undefined
✗ on demand: --probe-pglite with no init failure reports the runtime as healthy (ok)
    expect(check).toBeDefined()  Received: undefined
✗ a dead PGLite connection on the remote surface triggers the probe
    expect(check).toBeDefined()  Received: undefined
3 pass, 5 fail
```

The check is genuinely absent from both surfaces on master — not a missing-export failure. With this branch: 8 pass, 0 fail.

## Verification

- `bun run typecheck` clean
- `bun run verify` 32/32 green
- Related suites green: doctor-categories drift guard, pglite-init-classifier, doctor, doctor-behavioral, doctor-embedding-env-override, doctor-cli-smoke, doctor-scope-filter, sync-failures (220 tests)
- llms bundle freshness test green (no CLAUDE.md edits)

Closes the diagnostic half of #2674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)