### PR TITLE
fix(sync): surface swallowed updateSlug failures in the rename path (#3056)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2876,8 +2876,16 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       const newSlug = resolveSlugForPath(to);
       try {
         await engine.updateSlug(oldSlug, newSlug, renameOpts);
-      } catch {
-        // Slug doesn't exist or collision, treat as add
+      } catch (e) {
+        // Slug doesn't exist or collision — fall back to add. #3056: the old
+        // row (if any) is NOT reconciled by this fallback, so a silent miss
+        // here reads as a clean rename while a duplicate row may remain.
+        // Surface the error so the incident is self-diagnosing.
+        console.error(
+          `[sync] rename: updateSlug "${oldSlug}" → "${newSlug}" failed `
+          + `(${e instanceof Error ? e.message : String(e)}); treating as add — `
+          + `the previous row may remain at "${oldSlug}"`,
+        );
       }
       // Reimport at new path (picks up content changes). Wrapped to match the
       // deletes/adds loops: a malformed renamed file is recorded to failedFiles

--- a/test/sync-rename-updateslug-diagnostic.test.ts
+++ b/test/sync-rename-updateslug-diagnostic.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #3056 — sync's rename path: a failed engine.updateSlug was swallowed by an
+ * empty catch. The run then falls back to importFile (creating a NEW row for
+ * the new path) while the OLD row stays behind, live and orphaned — nothing
+ * logged, nothing counted, page total unchanged, so it reads as a clean
+ * rename.
+ *
+ * Behavioral pin: when updateSlug throws (here: rename destination slug
+ * already occupied by another row → unique (source_id, slug) violation), the
+ * sync run emits a diagnostic on stderr naming the old slug, the new slug,
+ * and the error, instead of silence.
+ */
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+let engine: PGLiteEngine;
+let repoPath: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+afterEach(() => {
+  if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+});
+
+describe('sync rename updateSlug failure diagnostic (#3056)', () => {
+  test('a swallowed updateSlug failure is reported to stderr, not silent', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-rename-diag-'));
+    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'topics'), { recursive: true });
+    writeFileSync(join(repoPath, 'topics/old-name.md'), [
+      '---',
+      'type: concept',
+      'title: Old Name',
+      '---',
+      '',
+      'Stable body so git detects the move as a rename (R100).',
+    ].join('\n'));
+    execSync('git add -A && git commit -m initial', { cwd: repoPath, stdio: 'pipe' });
+
+    const first = await performSync(engine, { repoPath, noPull: true, noEmbed: true });
+    expect(first.added).toBe(1);
+
+    // Occupy the rename DESTINATION slug so updateSlug hits the unique
+    // (source_id, slug) constraint — the divergence class #3056 describes.
+    await engine.executeRaw(
+      `INSERT INTO pages (source_id, slug, source_path, type, title, compiled_truth, timeline, frontmatter)
+       VALUES ('default', 'topics/new-name', 'somewhere-else.md', 'note', 'Squatter', 'body', '', '{}'::jsonb)`,
+    );
+
+    execSync('git mv topics/old-name.md topics/new-name.md', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git commit -m rename', { cwd: repoPath, stdio: 'pipe' });
+
+    const errLines: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errLines.push(args.map(String).join(' ')); };
+    try {
+      await performSync(engine, { repoPath, noPull: true, noEmbed: true });
+    } finally {
+      console.error = origError;
+    }
+
+    const diagnostic = errLines.find(l =>
+      l.includes('updateSlug') && l.includes('topics/old-name') && l.includes('topics/new-name'));
+    expect(diagnostic).toBeDefined();
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

`sync`'s rename loop caught `engine.updateSlug` errors with an empty `catch` and silently fell back to `importFile` — creating a new row for the new path while the old row stayed behind, live and orphaned. Nothing logged, nothing counted, page totals unchanged: the failed rename read as a clean rename. The reporter lost time to this twice and could not determine WHY updateSlug missed, because the error that would have explained it was discarded.

## Fix

Log the caught error to stderr with old slug, new slug, and the error message (`[sync] rename: updateSlug "a" → "b" failed (...); treating as add — the previous row may remain at "a"`). This matches the record-the-failure standard the neighboring adds/deletes loops in the same function already follow (their comments explicitly call it out). Fallback behavior is unchanged — this is the diagnostic the issue's suggestion #1 asked for.

## Discrimination proof

`test/sync-rename-updateslug-diagnostic.test.ts` drives a real git rename (R100) through `performSync` where the destination slug is already occupied — `updateSlug` hits the unique `(source_id, slug)` violation, the exact divergence class from the report. On unmodified master: **fails behaviorally** (no stderr line naming the slugs — pure silence). With the fix: passes.

Neighboring suites green (`sync-rename-batch`, `sync.test` — 73 pass). `bun run typecheck` clean; `bun run verify` 32/32 green.

Closes #3056

🤖 Generated with [Claude Code](https://claude.com/claude-code)