### PR TITLE
fix(cli): route thin-client CLI-only commands before connect

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,20 @@ export function bigintToStringReplacer(_key: string, value: unknown): unknown {
 
 // CLI-only commands that bypass the operation layer
 export const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'maintain', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'reconcile-links', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'calibration', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'retrieval-upgrade', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch', 'reindex-search-vector', 'backfill']);
+
+// Thin-client CLI-only commands that already have remote-MCP branches inside
+// their handlers. They must bypass connectEngine() so the client does not
+// replay migrations locally before the handler can route remotely.
+const THIN_CLIENT_ROUTED_CLI_ONLY = new Set([
+  'graph-query',
+  'salience',
+  'anomalies',
+  'think',
+  'recall',
+  'forget',
+  'whoknows',
+  'founder',
+]);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -1796,6 +1810,52 @@ async function handleCliOnly(command: string, args: string[]) {
         return;
       }
       refuseThinClient('jobs', cfgJobs!.remote_mcp!.mcp_url);
+    }
+  }
+
+  const cfgThinClient = loadConfig();
+  if (cfgThinClient && isThinClient(cfgThinClient) && THIN_CLIENT_ROUTED_CLI_ONLY.has(command)) {
+    switch (command) {
+      case 'graph-query': {
+        const { runGraphQuery } = await import('./commands/graph-query.ts');
+        await runGraphQuery(null, args);
+        return;
+      }
+      case 'salience': {
+        const { runSalience } = await import('./commands/salience.ts');
+        await runSalience(null, args);
+        return;
+      }
+      case 'anomalies': {
+        const { runAnomalies } = await import('./commands/anomalies.ts');
+        await runAnomalies(null, args);
+        return;
+      }
+      case 'think': {
+        const { runThinkCli } = await import('./commands/think.ts');
+        await runThinkCli(null, args);
+        return;
+      }
+      case 'recall': {
+        const { runRecall } = await import('./commands/recall.ts');
+        await runRecall(null, args);
+        return;
+      }
+      case 'forget': {
+        const { runForget } = await import('./commands/recall.ts');
+        await runForget(null, args);
+        return;
+      }
+      case 'whoknows': {
+        const { runWhoknows } = await import('./commands/whoknows.ts');
+        await runWhoknows(null, args);
+        return;
+      }
+      case 'founder': {
+        const { runFounder } = await import('./commands/founder-scorecard.ts');
+        await runFounder(null, args);
+        return;
+      }
     }
   }
 

--- a/src/commands/anomalies.ts
+++ b/src/commands/anomalies.ts
@@ -63,7 +63,7 @@ Options:
   --help, -h           Show this help
 `;
 
-export async function runAnomalies(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runAnomalies(engine: BrainEngine | null, args: string[]): Promise<void> {
   const parsed = parseArgs(args);
   if ('help' in parsed) {
     console.log(HELP);
@@ -80,6 +80,7 @@ export async function runAnomalies(engine: BrainEngine, args: string[]): Promise
     }, { timeoutMs: 30_000 });
     rows = unpackToolResult<Awaited<ReturnType<BrainEngine['findAnomalies']>>>(raw);
   } else {
+    if (!engine) throw new Error('gbrain anomalies requires a local engine');
     rows = await engine.findAnomalies({
       since: parsed.since,
       lookback_days: parsed.lookbackDays,

--- a/src/commands/founder-scorecard.ts
+++ b/src/commands/founder-scorecard.ts
@@ -227,7 +227,7 @@ function parseArgs(args: string[]): RunOpts | { help: true } | { error: string }
   return { ...(opts as RunOpts), entitySlug: positional[0] };
 }
 
-export async function runFounder(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runFounder(engine: BrainEngine | null, args: string[]): Promise<void> {
   const parsed = parseArgs(args);
   if ('help' in parsed) {
     console.log(HELP);
@@ -296,6 +296,7 @@ export async function runFounder(engine: BrainEngine, args: string[]): Promise<v
       takes: [],
     });
   } else {
+    if (!engine) throw new Error('gbrain founder requires a local engine');
     // Local: full pipeline. Get the trajectory + the entity's resolved takes.
     // v0.40.2.0: kind:'metric' is explicit clarity (downstream math already
     // skips NULL-metric rows so this is a no-op behaviorally; surfaces

--- a/src/commands/graph-query.ts
+++ b/src/commands/graph-query.ts
@@ -127,7 +127,7 @@ async function countForeignEdges(
   }
 }
 
-export async function runGraphQuery(engine: BrainEngine, argv: string[]) {
+export async function runGraphQuery(engine: BrainEngine | null, argv: string[]) {
   const args = parseArgs(argv);
   if (args.showHelp || !args.slug) {
     printHelp();
@@ -149,6 +149,7 @@ export async function runGraphQuery(engine: BrainEngine, argv: string[]) {
     }, { timeoutMs: 30_000 });
     paths = unpackToolResult<GraphPath[]>(raw);
   } else {
+    if (!engine) throw new Error('gbrain graph-query requires a local engine');
     paths = await engine.traversePaths(args.slug, {
       depth: args.depth,
       linkType: args.linkType,
@@ -161,6 +162,7 @@ export async function runGraphQuery(engine: BrainEngine, argv: string[]) {
     // Still report foreign edges so the user knows they exist in other
     // sources even when the scoped traversal returned nothing.
     if (!args.includeForeign && !isThinClient(cfg)) {
+      if (!engine) throw new Error('gbrain graph-query requires a local engine');
       const foreign = await countForeignEdges(engine, args.slug, args.direction);
       if (foreign > 0) {
         console.error(
@@ -179,6 +181,7 @@ export async function runGraphQuery(engine: BrainEngine, argv: string[]) {
   // (engine query not available); local path runs the count and prints
   // the footer when there are hidden edges AND the user didn't opt in.
   if (!args.includeForeign && !isThinClient(cfg)) {
+    if (!engine) throw new Error('gbrain graph-query requires a local engine');
     const foreign = await countForeignEdges(engine, args.slug, args.direction);
     if (foreign > 0) {
       console.error(

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -180,7 +180,7 @@ function validateAndNormalizeFlags(flags: ParsedFlags): void {
 }
 
 async function resolveSourceForRecall(
-  engine: BrainEngine,
+  engine: BrainEngine | null,
   flagValue: string,
   thinClient: boolean,
 ): Promise<string> {
@@ -197,6 +197,7 @@ async function resolveSourceForRecall(
   // pre-v0.32 "query whatever source the user typed and let it return
   // empty" behavior so existing tests + scripts keep working while
   // recall still benefits from the env/dotfile resolution chain.
+  if (!engine) throw new Error('gbrain recall requires a local engine');
   try {
     return await resolveSourceId(engine, flagValue !== 'default' ? flagValue : null);
   } catch (e) {
@@ -207,7 +208,7 @@ async function resolveSourceForRecall(
   }
 }
 
-export async function runRecall(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runRecall(engine: BrainEngine | null, args: string[]): Promise<void> {
   const flags = parseFlags(args);
   validateAndNormalizeFlags(flags);
 
@@ -231,7 +232,7 @@ export async function runRecall(engine: BrainEngine, args: string[]): Promise<vo
 }
 
 async function runRecallOnce(
-  engine: BrainEngine,
+  engine: BrainEngine | null,
   flags: ParsedFlags,
   sourceId: string,
   thinClient: boolean,
@@ -280,6 +281,7 @@ async function runRecallOnce(
     rows = unpacked.facts.map(remoteFactToRow);
     pendingCount = unpacked.pending_consolidation_count;
   } else {
+    if (!engine) throw new Error('gbrain recall requires a local engine');
     rows = await fetchRowsLocal(engine, flags, sourceId, resolvedSince);
     if (flags.pending) {
       pendingCount = await engine.countUnconsolidatedFacts(sourceId);
@@ -392,7 +394,7 @@ function renderRollup(rollup: Array<{ entity_slug: string; count: number }>): st
 }
 
 async function runWatchLoop(
-  engine: BrainEngine,
+  engine: BrainEngine | null,
   flags: ParsedFlags,
   sourceId: string,
   thinClient: boolean,
@@ -538,7 +540,7 @@ function factRowToJson(r: FactRow): Record<string, unknown> {
   };
 }
 
-export async function runForget(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runForget(engine: BrainEngine | null, args: string[]): Promise<void> {
   const idArg = args.find(a => /^\d+$/.test(a));
   if (!idArg) {
     process.stderr.write('Usage: gbrain forget <fact-id> [--reason <text>]\n');
@@ -574,6 +576,7 @@ export async function runForget(engine: BrainEngine, args: string[]): Promise<vo
   // page's `## Facts` fence and survives `gbrain rebuild`. Legacy rows
   // fall back to the legacy DB-only expire path; the helper handles
   // the fallback internally.
+  if (!engine) throw new Error('gbrain forget requires a local engine');
   const { forgetFactInFence } = await import('../core/facts/forget.ts');
   const result = await forgetFactInFence(engine, id, { reason });
 

--- a/src/commands/salience.ts
+++ b/src/commands/salience.ts
@@ -63,7 +63,7 @@ Options:
   --help, -h          Show this help
 `;
 
-export async function runSalience(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runSalience(engine: BrainEngine | null, args: string[]): Promise<void> {
   const parsed = parseArgs(args);
   if ('help' in parsed) {
     console.log(HELP);
@@ -84,6 +84,7 @@ export async function runSalience(engine: BrainEngine, args: string[]): Promise<
     }, { timeoutMs: 30_000 });
     rows = unpackToolResult<Awaited<ReturnType<BrainEngine['getRecentSalience']>>>(raw);
   } else {
+    if (!engine) throw new Error('gbrain salience requires a local engine');
     rows = await engine.getRecentSalience({
       days: parsed.days,
       limit: parsed.limit,

--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -42,7 +42,7 @@ export function computeThinkCostUsd(
   );
 }
 
-export async function runThinkCli(engine: BrainEngine, args: string[]): Promise<void> {
+export async function runThinkCli(engine: BrainEngine | null, args: string[]): Promise<void> {
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     console.log(`Usage: gbrain think "<question>" [options]
 
@@ -130,6 +130,7 @@ prints what would have been the input (exit 0).
     }, { timeoutMs: 180_000 });
     result = unpackToolResult<any>(raw);
   } else {
+    if (!engine) throw new Error('gbrain think requires a local engine');
     try {
       result = await runThink(engine, {
         question, anchor, rounds, save, take, model, since, until,

--- a/src/commands/whoknows.ts
+++ b/src/commands/whoknows.ts
@@ -304,7 +304,7 @@ Examples:
 `;
 
 export async function runWhoknows(
-  engine: BrainEngine,
+  engine: BrainEngine | null,
   args: string[],
 ): Promise<void> {
   const parsed = parseArgs(args);
@@ -331,6 +331,7 @@ export async function runWhoknows(
     }, { timeoutMs: 30_000 });
     results = unpackToolResult<WhoknowsResult[]>(raw);
   } else {
+    if (!engine) throw new Error('gbrain whoknows requires a local engine');
     // v0.40.6.0 T1.5 wiring (D4): consult the active pack for expert
     // types. Pack-load failure → empty filter (NOT hardcoded defaults
     // per the silent-violation bug class Finding 1.3 closed). Local

--- a/test/thin-client-cli-routed-commands.serial.test.ts
+++ b/test/thin-client-cli-routed-commands.serial.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Thin-client routed CLI-only commands must work with a null local engine.
+ *
+ * This locks the pre-connectEngine seam: if handleCliOnly reverts to opening
+ * a local engine on thin clients, these commands will throw before the remote
+ * MCP branch can run.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { GBrainConfig } from '../src/core/config.ts';
+
+const remoteConfig = {
+  remote_mcp: { mcp_url: 'http://thin-client.test/mcp' },
+} as GBrainConfig;
+
+const callRemoteTool = mock(async (_config: unknown, toolName: string) => ({ toolName }));
+const unpackToolResult = mock((raw: { toolName: string }) => {
+  switch (raw.toolName) {
+    case 'get_recent_salience':
+      return [{
+        slug: 'people/alice',
+        title: 'Alice',
+        score: 1,
+        emotional_weight: 0.5,
+        take_count: 0,
+      }];
+    case 'think':
+      return {
+        answer: 'remote answer',
+        gaps: [],
+        warnings: [],
+        modelUsed: 'anthropic:claude-sonnet-4-5',
+        pagesGathered: 0,
+        takesGathered: 0,
+        graphHits: 0,
+        citations: [],
+      };
+    case 'traverse_graph':
+      return [];
+    default:
+      throw new Error(`unexpected tool ${raw.toolName}`);
+  }
+});
+
+mock.module('../src/core/config.ts', () => ({
+  loadConfig: () => remoteConfig,
+  isThinClient: () => true,
+}));
+
+mock.module('../src/core/mcp-client.ts', () => ({
+  callRemoteTool,
+  unpackToolResult,
+}));
+
+const { runSalience } = await import('../src/commands/salience.ts');
+const { runGraphQuery } = await import('../src/commands/graph-query.ts');
+const { runThinkCli } = await import('../src/commands/think.ts');
+
+beforeEach(() => {
+  callRemoteTool.mockClear();
+  unpackToolResult.mockClear();
+});
+
+describe('thin-client routed CLI-only commands', () => {
+  test('salience uses the remote MCP path with a null engine', async () => {
+    await runSalience(null, ['--json']);
+
+    expect(callRemoteTool.mock.calls).toHaveLength(1);
+    expect(callRemoteTool.mock.calls[0][1]).toBe('get_recent_salience');
+    expect(unpackToolResult.mock.calls).toHaveLength(1);
+  });
+
+  test('graph-query uses the remote MCP path with a null engine', async () => {
+    await runGraphQuery(null, ['people/alice', '--depth', '1']);
+
+    expect(callRemoteTool.mock.calls).toHaveLength(1);
+    expect(callRemoteTool.mock.calls[0][1]).toBe('traverse_graph');
+    expect(unpackToolResult.mock.calls).toHaveLength(1);
+  });
+
+  test('think uses the remote MCP path with a null engine', async () => {
+    await runThinkCli(null, ['what', 'needs', 'checking', '--json']);
+
+    expect(callRemoteTool.mock.calls).toHaveLength(1);
+    expect(callRemoteTool.mock.calls[0][1]).toBe('think');
+    expect(unpackToolResult.mock.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fix thin-client CLI-only commands that already have remote MCP branches so they bypass connectEngine() before local migration replay. Focused regression coverage added for salience, graph-query, and think. dream remains host-only.