### PR TITLE
test(build-llms): compare bundle content, not line endings

### DIFF
--- a/test/build-llms.test.ts
+++ b/test/build-llms.test.ts
@@ -7,6 +7,17 @@ import { SECTIONS, FULL_SIZE_BUDGET } from "../scripts/llms-config";
 
 const repoRoot = join(import.meta.dir, "..");
 
+// Compare bundle CONTENT, not bytes. On Windows `core.autocrlf=true` (the
+// Git-for-Windows installer default) checks the committed bundles out as CRLF,
+// while the generator emits its own scaffolding as LF — so a byte compare fails
+// on a checkout with zero real drift. `.gitattributes` can't fix this here: it
+// pins `*.sh` (and `*.md`), not the `.txt` bundles, and a pin only affects
+// FUTURE checkouts anyway, so contributors cloned before it landed stay broken.
+// Linux CI checks out LF, so this is an identity transform there and can never
+// be caught upstream. Normalizing keeps the staleness signal intact — any real
+// content change still fails.
+const normalizeEol = (s: string) => s.replace(/\r\n/g, "\n");
+
 describe("build-llms generator", () => {
   // Case 1 — every config path resolves on disk. Catches rename-induced 404s.
   test("every configured path exists on disk", () => {
@@ -63,8 +74,9 @@ describe("build-llms generator", () => {
 
     const helpMsg =
       "Run `bun run build:llms` and commit the updated output before shipping.";
-    expect(committedLlms, helpMsg).toBe(llmsTxt);
-    expect(committedFull, helpMsg).toBe(llmsFullTxt);
+    // Line endings normalized on both sides — see normalizeEol above.
+    expect(normalizeEol(committedLlms), helpMsg).toBe(normalizeEol(llmsTxt));
+    expect(normalizeEol(committedFull), helpMsg).toBe(normalizeEol(llmsFullTxt));
   });
 
   // Case 5 — content contract. Prevents silent removal of critical sections or


### PR DESCRIPTION
## Summary

Fix the `build-llms` freshness test on Windows by comparing normalized bundle content rather than checkout-specific CRLF bytes.

With `core.autocrlf=true`, Git checks the committed `.txt` bundles out as CRLF while the generator emits LF scaffolding. The previous byte comparison therefore failed on a clean Windows checkout with a zero-line diff, even though `git diff --quiet -- llms.txt llms-full.txt` reported no content drift.

The test now normalizes `\r\n` to `\n` on both sides of both Case 4 assertions. Lone `\r` bytes remain significant, so the change neutralizes only the checkout artifact. This is intentionally an in-test fix rather than a `.gitattributes` pin, because it also repairs existing clones without requiring a forced re-checkout.

## Tests

- `bun test test/build-llms.test.ts --timeout=120000` (`12 pass`, `0 fail`) with the checked-out bundles still containing CR bytes
- Negative control: appending a sentinel to both committed bundles still fails Case 4 and prints the sentinel
- Negative control: appending a sentinel to inlined `docs/guides/push-context.md` while leaving the bundles stale still fails Case 4 and prints the sentinel
- `bun run typecheck`

## Scope

- One test-only file
- No generated-bundle changes
- No version or changelog changes; release numbering remains with the maintainer fix-wave process
