### PR TITLE
fix(import): checkpoint on a time interval and before preserve, not only every 100 files

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -268,6 +268,12 @@ export async function runImport(
   let skipped = 0;
   let errors = 0;
   let processed = 0;
+  // Time-based checkpoint floor (see the save site below). Chunking cost scales
+  // with paragraph count, not bytes, so a single reference-style file can take
+  // many minutes; a count-only trigger leaves that work undurable.
+  const CHECKPOINT_MAX_INTERVAL_MS = 120_000;
+  let lastCheckpointMs = Date.now();
+  let lastCheckpointSize = completed.size;
   let chunksCreated = 0;
   const importedSlugs: string[] = [];
   const errorCounts: Record<string, number> = {};
@@ -343,7 +349,17 @@ export async function runImport(
     // Save checkpoint every 100 SUCCESSFUL adds (not every 100 processed).
     // Failed files never enter `completed`, so a flaky file can't push the
     // checkpoint past it — the next run will retry it.
-    if (completed.size > 0 && completed.size % 100 === 0) {
+    // ...and ALSO save on a time interval. On a corpus with an expensive tail
+    // `completed` can advance ~1 file per several minutes, so the next
+    // 100-boundary may be hours away; any kill before it discards every file
+    // since the last boundary and the run can never converge.
+    const nowMs = Date.now();
+    const dueByCount = completed.size > 0 && completed.size % 100 === 0;
+    const dueByTime = completed.size > lastCheckpointSize
+      && nowMs - lastCheckpointMs >= CHECKPOINT_MAX_INTERVAL_MS;
+    if (dueByCount || dueByTime) {
+      lastCheckpointMs = nowMs;
+      lastCheckpointSize = completed.size;
       const cpDir = gbrainPath();
       if (!existsSync(cpDir)) {
         try { const { mkdirSync } = await import('fs'); mkdirSync(cpDir, { recursive: true }); }
@@ -427,6 +443,30 @@ export async function runImport(
     if (count > 5) {
       console.error(`  ${count} files failed: ${err.slice(0, 100)}`);
     }
+  }
+
+  // Final checkpoint save BEFORE the clear/preserve decision below. The
+  // periodic triggers above are gated on a 100-file boundary or an interval,
+  // so a run that ends between them would otherwise leave its tail unsaved.
+  // This must run before clearCheckpoint() so a clean run still ends with no
+  // checkpoint file — it only makes the ERROR path's preserved checkpoint
+  // complete.
+  if (errors > 0 && completed.size > lastCheckpointSize) {
+    try {
+      const cpDir = gbrainPath();
+      if (!existsSync(cpDir)) {
+        const { mkdirSync } = await import('fs');
+        mkdirSync(cpDir, { recursive: true });
+      }
+      saveCheckpoint(checkpointPath, {
+        schema_version: 1,
+        owner: 'gbrain',
+        kind: 'import',
+        dir,
+        completedPaths: Array.from(completed),
+        timestamp: new Date().toISOString(),
+      });
+    } catch { /* non-fatal: the next run simply redoes the tail */ }
   }
 
   // Clear checkpoint on clean completion. On error, the path-based checkpoint

--- a/test/import-resume.test.ts
+++ b/test/import-resume.test.ts
@@ -20,7 +20,7 @@
  *     `afterAll`) per CLAUDE.md test-isolation rules R3 + R4.
  */
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync, realpathSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync, realpathSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -145,6 +145,59 @@ describe('runImport checkpoint resume — v0.33.2 path-based', () => {
 
       // After clean completion the checkpoint is cleaned up so the next
       // run doesn't think it needs to resume.
+      expect(existsSync(cpPath)).toBe(false);
+    });
+  }, 30_000);
+
+  test('interrupted run preserves its tail below the 100-file boundary', async () => {
+    // The periodic checkpoint save fires on `completed.size % 100 === 0`. With
+    // fewer than 100 successful files there is no boundary to hit, so before
+    // the final save every completed file in a run that ends with errors was
+    // discarded and re-done on the next invocation. On a corpus whose files
+    // are individually expensive, `completed` can advance ~1 per several
+    // minutes, putting the next boundary hours away — the run then never
+    // converges under repeated kills.
+    await withEnv({ GBRAIN_HOME: workspace }, async () => {
+      // Three small good files (well under the 100-boundary) plus one that
+      // exceeds the content-sanity block threshold. That throws, so `errors`
+      // is non-zero and the checkpoint is PRESERVED rather than cleared —
+      // note a SLUG_MISMATCH would NOT work here: it is a soft `failures`
+      // entry that leaves `errors` at 0, so upstream clears the checkpoint.
+      writeBrainFile('people/alice.md', validMarkdown('people/alice'));
+      writeBrainFile('people/carol.md', validMarkdown('people/carol'));
+      writeBrainFile('people/dave.md', validMarkdown('people/dave'));
+      // A file the reader cannot open raises inside importFile, which is the
+      // path that increments `errors` (a SLUG_MISMATCH would NOT work: it is
+      // a soft `failures` entry leaving `errors` at 0, so upstream clears the
+      // checkpoint rather than preserving it).
+      writeBrainFile('people/unreadable.md', validMarkdown('people/unreadable'));
+      chmodSync(join(brainDir, 'people/unreadable.md'), 0o000);
+
+      const result = await runImport(engine, [brainDir, '--no-embed']);
+      expect(result.errors).toBeGreaterThan(0);
+
+      // The checkpoint exists AND carries the successful files, even though
+      // no 100-boundary was ever crossed.
+      expect(existsSync(cpPath)).toBe(true);
+      const cp = JSON.parse(readFileSync(cpPath, 'utf8'));
+      expect(cp.completedPaths).toContain('people/alice.md');
+      expect(cp.completedPaths).toContain('people/carol.md');
+      expect(cp.completedPaths).toContain('people/dave.md');
+      // The failed file must still be absent so the next run retries it.
+      expect(cp.completedPaths).not.toContain('people/unreadable.md');
+    });
+  }, 30_000);
+
+  test('clean completion still leaves no checkpoint (final save must not resurrect it)', async () => {
+    // Guards the ordering of the final save: it runs BEFORE the
+    // clear/preserve decision and only on the error path, so a fully clean
+    // run must still end with no checkpoint file.
+    await withEnv({ GBRAIN_HOME: workspace }, async () => {
+      writeBrainFile('x.md', validMarkdown('x'));
+      writeBrainFile('y.md', validMarkdown('y'));
+
+      const result = await runImport(engine, [brainDir, '--no-embed']);
+      expect(result.errors).toBe(0);
       expect(existsSync(cpPath)).toBe(false);
     });
   }, 30_000);


### PR DESCRIPTION
## Problem

`runImport` saves its resume checkpoint only when `completed.size % 100 === 0`. There is no time-based save, and no save before the clear/preserve decision.

On a corpus whose files are individually expensive, the next 100-boundary can be **hours** of work away — so a run killed before reaching it discards every file completed since the last boundary, and the import can never converge under a supervisor that bounds runtime.

## Measurements

From a 2,207-file markdown corpus on the Postgres engine:

- Chunking cost tracks **paragraph count**, not bytes. Reference-style pages (dictionaries, textbooks — tens of thousands of short entries) cost roughly **10x** a prose page of the same size.
- One 21k-paragraph file took **~11 minutes on its own**.
- At that rate `completed` advances about **one file per ten minutes**, putting the next 100-boundary **~16 hours** out.
- Under a supervisor that kills long runs, the import made **zero durable progress** across repeated attempts: the checkpoint sat at 1600 completed while the process burned ~30 minutes of real work each pass.

## Changes

**1. Save on a time interval as well as the count boundary.** Save when EITHER `completed.size % 100 === 0` OR `CHECKPOINT_MAX_INTERVAL_MS` (120s) has elapsed since the last save and at least one new file completed. Progress becomes durable independently of per-file cost.

**2. Save once more immediately BEFORE the existing clear/preserve block**, gated on `errors > 0` so it matches that block's preserve condition exactly. A run that ends between triggers otherwise leaves its tail unsaved.

Ordering matters here and is covered by a test: the final save runs *before* `clearCheckpoint()`, so a **clean run still ends with no checkpoint file**. It only makes the error path's already-preserved checkpoint complete.

## Tests

Both in `test/import-resume.test.ts`:

- **`interrupted run preserves its tail below the 100-file boundary`** — three good files plus one that raises, asserting the preserved checkpoint carries all three. **Fails without the fix.**
- **`clean completion still leaves no checkpoint`** — pins the ordering so the final save cannot resurrect a checkpoint on a clean run.

### Note for reviewers

A `SLUG_MISMATCH` fixture does **not** exercise this path — it is a soft `failures` entry that leaves `errors` at 0, so the checkpoint is cleared rather than preserved. The test uses a file that raises during import instead. (This cost me a debugging cycle; flagging it so it doesn't cost one in review.)

## Verification

| Gate | Result |
|---|---|
| `bun test` (import suites) | 45 pass / 0 fail |
| `bun run typecheck` | clean |
| `bun run check:all` | clean |
| `scripts/check-test-isolation.sh` | OK |

Reverting the source change makes the new test fail, and restoring it makes it pass — the test genuinely gates the fix.

## Scope

+95 / −2 across `src/commands/import.ts` and `test/import-resume.test.ts`. No schema, config, or API surface change.

Related but distinct: #1794 / #1980 fixed the same *class* of non-convergence on the **sync** path (the `last_commit` anchor, `src/core/op-checkpoint.ts`); that work never touched `src/commands/import.ts`, which still has the count-only trigger.