### PR TITLE
feat(ai): codex-cli recipe — GPT chat via Codex CLI OAuth subscription

### DIFF
--- a/docs/ai-providers/codex-cli.md
+++ b/docs/ai-providers/codex-cli.md
@@ -1,0 +1,97 @@
+# codex-cli — GPT chat via the Codex CLI OAuth subscription
+
+The `codex-cli` recipe routes `gateway.chat` / `gateway.toolLoop` through the
+local `codex` CLI's ChatGPT OAuth session, so a ChatGPT Plus/Pro subscription
+covers the calls instead of per-token `OPENAI_API_KEY` billing. It is the GPT
+sibling of the `claude-cli` recipe.
+
+```bash
+gbrain config set chat_model codex-cli:gpt-5.6-terra
+# or behind claude-cli in a fallback chain:
+gbrain config set chat_fallback_chain '["codex-cli:gpt-5.6-terra"]'
+```
+
+`codex-cli:gpt-5.6-terra` (subscription) sits alongside `openai:gpt-5.6`
+(API key, per-token billing) the same way `claude-cli:*` sits alongside
+`anthropic:*`. Token usage is not reported on the CLI's output channel, so
+usage fields are undefined and the budget ledger treats these calls as
+nominal.
+
+`GBRAIN_CODEX_CLI_BIN` overrides the binary path if `codex` is not on `PATH`.
+
+## Host requirements
+
+### CLI version
+
+Needs a `codex` new enough to have `--ignore-user-config` and the
+`gpt-5.6-terra` / `gpt-5.6-sol` model ids — 0.145.0 or later. Older builds
+fail in confusing ways: the Ubuntu snap's stable channel lagged at 0.114.0,
+whose default `gpt-5.3-codex` is not available under ChatGPT-account auth at
+all (`{"detail":"The 'gpt-5.3-codex' model is not supported when using Codex
+with a ChatGPT account."}`). `sudo snap refresh codex` if you are on the snap.
+
+### Sandbox-confined installs (snap) — set TMPDIR
+
+Each call spawns `codex exec` from a dedicated scratch directory, passed as
+both `-C` (so `AGENTS.md` auto-discovery finds no local files) and the parent
+of the `-o` output file. The child must therefore be able to open that
+directory.
+
+The default location is under `os.tmpdir()`, which a sandbox-confined `codex`
+cannot reach: snap's `home` interface permits only **non-hidden** paths under
+`$HOME`, so nothing in `/tmp` is accessible. The failure surfaces as a bare
+errno that names neither the path nor the cause:
+
+```
+codex-cli exited 1: Error: No such file or directory (os error 2)
+```
+
+Point `TMPDIR` at a non-hidden directory inside `$HOME`:
+
+```bash
+export TMPDIR="$HOME/gbrain-tmp"
+```
+
+A hidden directory (`~/.gbrain/tmp`) does **not** work under snap
+confinement — the `home` interface excludes dotfiles. This is also why the
+adapter cannot simply default to a dotdir in `$HOME`.
+
+### Minimal Docker images — install ca-certificates
+
+`codex` is a separate Rust process that trusts the OS certificate store,
+unlike Bun's `fetch` which bundles its own roots. Base images that ship no
+trust store at all (e.g. `oven/bun:1`) make every `chatgpt.com` /
+`api.openai.com` call fail with:
+
+```
+invalid peer certificate: UnknownIssuer
+```
+
+Add the trust store to the image:
+
+```dockerfile
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+```
+
+(`apk add --no-cache ca-certificates` on Alpine/musl.)
+
+## Isolation notes
+
+The subprocess is deliberately kept close to a raw LLM rather than a full
+Codex agent:
+
+- `--ignore-user-config` stops `~/.codex/config.toml` from loading, so user
+  MCP servers stay out — including gbrain's own MCP, which would otherwise
+  recurse and contend for the PGLite single-writer lock. Auth state
+  (`auth.json`) still loads.
+- `--sandbox read-only` pins the agent sandbox down for defense in depth.
+- `--skip-git-repo-check` skips the repo probe in the scratch cwd.
+- `OPENAI_API_KEY` / `OPENAI_BASE_URL` are scrubbed from the child env, so an
+  inherited key cannot silently flip billing back to per-token API usage.
+- Codex has no `--system-prompt` flag, so system messages render as a leading
+  `## System` section of the stdin prompt. The prompt goes over stdin because
+  argv has a hard size ceiling that subagent prompts routinely exceed.
+
+Tool use rides the same prompt-instructed
+`<use_tools>[{id,name,input}]</use_tools>` protocol the `claude-cli` provider
+teaches.

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1531,6 +1531,10 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       throw new AIConfigError(
         `claude-cli has no embedding model. Use openai or google for embeddings.`,
       );
+    case 'codex-cli':
+      throw new AIConfigError(
+        `codex-cli has no embedding model. Use openai or google for embeddings.`,
+      );
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'embedding');
@@ -2484,6 +2488,12 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       const { ClaudeCliLanguageModel } = require('./providers/claude-cli-language-model.ts');
       return new ClaudeCliLanguageModel(modelId);
     }
+    case 'codex-cli': {
+      // Same subprocess pattern as claude-cli: the Codex CLI owns auth
+      // (ChatGPT OAuth session); chat-only recipe, no expansion touchpoint.
+      const { CodexCliLanguageModel } = require('./providers/codex-cli-language-model.ts');
+      return new CodexCliLanguageModel(modelId);
+    }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'expansion');
@@ -3045,6 +3055,14 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
       // openai-compatible path below. No env-var switch, no global flag.
       const { ClaudeCliLanguageModel } = require('./providers/claude-cli-language-model.ts');
       return new ClaudeCliLanguageModel(modelId);
+    }
+    case 'codex-cli': {
+      // The GPT sibling of claude-cli: `codex exec` owns auth (ChatGPT
+      // OAuth session managed by `codex login`). `codex-cli:gpt-5.6-terra`
+      // lands here; `openai:gpt-5.6` continues through native-openai with
+      // per-token API billing. No env-var switch, no global flag.
+      const { CodexCliLanguageModel } = require('./providers/codex-cli-language-model.ts');
+      return new CodexCliLanguageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).

--- a/src/core/ai/providers/codex-cli-language-model.ts
+++ b/src/core/ai/providers/codex-cli-language-model.ts
@@ -1,0 +1,435 @@
+/**
+ * ai-sdk LanguageModelV2 implementation that dispatches via the `codex exec`
+ * CLI subprocess. Used by the `codex-cli` recipe to route gateway.toolLoop /
+ * gateway.chat calls through the Codex CLI's ChatGPT OAuth session instead of
+ * the OpenAI SDK + OPENAI_API_KEY.
+ *
+ * Per-call routing is the contract: the gateway resolves the model string
+ * to this recipe based on the `codex-cli:` prefix, instantiates one of
+ * these objects per modelId, and dispatches doGenerate. Sibling subagent
+ * jobs with `claude-cli:...` or `litellm:...` continue routing through their
+ * own providers in the same worker; no env-var switch, no global state.
+ *
+ * Tool use is supported via prompt-instructed JSON emission — the SAME
+ * `<use_tools>[{id,name,input}, ...]</use_tools>` protocol the claude-cli
+ * provider teaches (see claude-cli-language-model.ts). The protocol helpers
+ * are mirrored here rather than extracted so this change stays additive-only;
+ * extraction into a shared cli-tool-protocol module is a natural follow-up
+ * once two providers prove the shape.
+ *
+ * Context isolation:
+ *   - Spawned from a dedicated tmpdir (`-C`) so AGENTS.md auto-discovery has
+ *     no local files to find; `--skip-git-repo-check` skips the repo probe.
+ *   - `--ignore-user-config` stops ~/.codex/config.toml from loading — user
+ *     MCP servers (including gbrain's own MCP → recursion + PGLite lock
+ *     contention), custom model defaults, and instruction overrides all stay
+ *     out of the subprocess. Auth state (auth.json) still loads.
+ *   - `--sandbox read-only` pins the agent sandbox down for defense in
+ *     depth; with the tool-use protocol the model answers in text and has
+ *     nothing to execute anyway.
+ *   - Codex has no `--system-prompt` flag, so system messages are rendered
+ *     as a leading `## System` section of the stdin prompt.
+ *
+ * Output channel: `-o <file>` writes the agent's final message verbatim;
+ * stdout carries progress logs and is discarded. Token usage is not exposed
+ * on this channel, so usage fields are undefined (the budget ledger treats
+ * subscription-billed calls as nominal anyway — see the recipe comment).
+ *
+ * doStream is not yet implemented; the model declares no streaming. Callers
+ * (gateway.toolLoop primarily) use doGenerate.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2Content,
+  LanguageModelV2FunctionTool,
+  LanguageModelV2Prompt,
+  LanguageModelV2Message,
+  LanguageModelV2ProviderDefinedTool,
+} from '@ai-sdk/provider';
+
+function codexBin(): string {
+  return process.env.GBRAIN_CODEX_CLI_BIN ?? 'codex';
+}
+const CODEX_CWD = join(tmpdir(), `gbrain-codex-cli-cwd-${process.pid}`);
+let cwdEnsured = false;
+function ensureCleanCwd(): string {
+  if (!cwdEnsured) {
+    mkdirSync(CODEX_CWD, { recursive: true });
+    cwdEnsured = true;
+  }
+  return CODEX_CWD;
+}
+
+/**
+ * Build the prompt addendum that teaches the model the
+ * `<use_tools>...</use_tools>` emission format. Returns the empty string
+ * when no tools are registered for this turn so the model gets a normal
+ * text-completion prompt without protocol noise.
+ *
+ * Mirrors claude-cli-language-model.ts `buildToolUseInstructions`.
+ */
+function buildToolUseInstructions(
+  tools: ReadonlyArray<LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool> | undefined,
+): string {
+  if (!tools || tools.length === 0) return '';
+
+  const functionTools = tools.filter((t): t is LanguageModelV2FunctionTool => t.type === 'function');
+  if (functionTools.length === 0) return '';
+
+  const toolSpecs = functionTools.map(t => ({
+    name: t.name,
+    description: t.description ?? '',
+    input_schema: t.inputSchema ?? { type: 'object', properties: {} },
+  }));
+
+  return [
+    '',
+    '## Tool Use Protocol',
+    '',
+    'You have access to these tools:',
+    '',
+    '```json',
+    JSON.stringify(toolSpecs, null, 2),
+    '```',
+    '',
+    'To call one or more tools in this turn, emit EXACTLY ONE block of this form, ' +
+      'with no other text outside the block on its own lines:',
+    '',
+    '<use_tools>',
+    '[',
+    '  {"id": "<unique tool call id, like toolu_01ABC>", "name": "<tool name>", "input": <input object matching the tool\'s input_schema>}',
+    ']',
+    '</use_tools>',
+    '',
+    'Multiple tool calls go in the array. Tool results are returned to you on the ' +
+      'next turn as [tool_result <text>] entries. You may then call more tools or emit a final response.',
+    '',
+    'When you are ready to give a final answer instead of calling tools, respond with prose text only — ' +
+      'do not include a <use_tools> block in that case.',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Render the ai-sdk message array into a single text prompt for `codex exec -`
+ * stdin. Codex has no --system-prompt flag, so system messages become a
+ * leading `## System` section. Tool calls and tool results are rendered as
+ * placeholders so the model sees the conversation in a coherent shape even
+ * though the adapter does not natively round-trip tool calls through the CLI.
+ */
+function renderPrompt(prompt: LanguageModelV2Prompt): { systemText: string; userPrompt: string } {
+  const systemParts: string[] = [];
+  const convo: string[] = [];
+
+  for (const msg of prompt as ReadonlyArray<LanguageModelV2Message>) {
+    if (msg.role === 'system') {
+      systemParts.push(msg.content);
+      continue;
+    }
+    if (msg.role === 'user') {
+      const text = msg.content
+        .map(p => {
+          if (p.type === 'text') return p.text;
+          // File parts get a stub — multimodal is not supported via subprocess yet.
+          if (p.type === 'file') return `[file ${p.mediaType ?? 'unknown'}]`;
+          return '';
+        })
+        .filter(s => s.length > 0)
+        .join('\n');
+      if (text) convo.push(`User: ${text}`);
+      continue;
+    }
+    if (msg.role === 'assistant') {
+      const rendered = msg.content
+        .map(p => {
+          if (p.type === 'text') return p.text;
+          if (p.type === 'reasoning') return ''; // dropped on replay
+          if (p.type === 'tool-call') {
+            return `[tool_use ${p.toolName}(${p.input})]`;
+          }
+          if (p.type === 'tool-result') {
+            const out = typeof p.output === 'string' ? p.output : JSON.stringify(p.output);
+            return `[tool_result ${out}]`;
+          }
+          return '';
+        })
+        .filter(s => s.length > 0)
+        .join('\n');
+      if (rendered) convo.push(`Assistant: ${rendered}`);
+      continue;
+    }
+    if (msg.role === 'tool') {
+      const rendered = msg.content
+        .map(p => {
+          const out = typeof p.output === 'string' ? p.output : JSON.stringify(p.output);
+          return `[tool_result ${out}]`;
+        })
+        .join('\n');
+      if (rendered) convo.push(`User: ${rendered}`);
+      continue;
+    }
+  }
+
+  return { systemText: systemParts.join('\n'), userPrompt: convo.join('\n\n') };
+}
+
+/**
+ * Spawn `codex exec` with the contamination-suppression flags and return the
+ * final agent message from the `-o` output file. Aborts propagate to SIGTERM
+ * on the child.
+ */
+function runCodex(
+  fullPrompt: string,
+  model: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const outFile = join(
+      ensureCleanCwd(),
+      `codex-out-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.txt`,
+    );
+    const args = [
+      'exec',
+      // Agent isolation: this subprocess must behave like a raw LLM, not a
+      // full Codex agent. `--ignore-user-config` stops ~/.codex/config.toml
+      // (user MCP servers, model defaults, instruction overrides) from
+      // loading — without it, each call would boot the user's MCP servers,
+      // including gbrain's own MCP → recursion + PGLite single-writer lock
+      // contention. `--sandbox read-only` pins the sandbox for defense in
+      // depth. `-C` + `--skip-git-repo-check` keep AGENTS.md discovery and
+      // the repo probe out of a clean tmpdir.
+      '--ignore-user-config',
+      '--sandbox', 'read-only',
+      '--skip-git-repo-check',
+      '-C', ensureCleanCwd(),
+      '-m', model,
+      '-o', outFile,
+      // Read the prompt from stdin — argv has a hard size ceiling and
+      // subagent prompts (context + tool specs) routinely exceed it.
+      '-',
+    ];
+    // Env scrub: guarantee the CLI authenticates via its own OAuth session
+    // (subscription), never via an inherited API key. Without this, an
+    // OPENAI_API_KEY in gbrain's env (the exact setup this recipe is meant
+    // to replace) silently flips billing to per-token API usage.
+    const env = { ...process.env };
+    delete env.OPENAI_API_KEY;
+    delete env.OPENAI_BASE_URL;
+    const child = spawn(codexBin(), args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: ensureCleanCwd(),
+      env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => { stdout += String(chunk); });
+    child.stderr.on('data', chunk => { stderr += String(chunk); });
+
+    const onAbort = () => {
+      child.kill('SIGTERM');
+      reject(new Error('codex-cli adapter aborted'));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    const readOutFile = (): string | null => {
+      try {
+        const text = readFileSync(outFile, 'utf8');
+        rmSync(outFile, { force: true });
+        return text;
+      } catch {
+        return null;
+      }
+    };
+
+    child.on('error', err => {
+      if (signal) signal.removeEventListener('abort', onAbort);
+      reject(new Error(`codex-cli spawn failed: ${err instanceof Error ? err.message : String(err)}`));
+    });
+
+    child.on('close', code => {
+      if (signal) signal.removeEventListener('abort', onAbort);
+      if (code !== 0) {
+        reject(new Error(`codex-cli exited ${code}: ${stderr.trim() || stdout.trim()}`));
+        return;
+      }
+      const text = readOutFile();
+      if (text === null || text.trim().length === 0) {
+        reject(new Error(
+          `codex-cli exited 0 but wrote no final message to -o file\n--- stderr ---\n${stderr.slice(0, 500)}`,
+        ));
+        return;
+      }
+      resolve(text.trim());
+    });
+
+    // stdin error handler: if the binary does not exist (ENOENT) or the child
+    // dies before draining stdin, write/end can emit an unhandled 'error'
+    // (EPIPE) that would crash the worker. The spawn-level 'error' / non-zero
+    // 'close' handlers above already surface the real failure, so the stdin
+    // error itself is safe to swallow.
+    child.stdin.on('error', () => { /* surfaced via child 'error'/'close' */ });
+    try {
+      child.stdin.write(fullPrompt);
+      child.stdin.end();
+    } catch (e) {
+      if (signal) signal.removeEventListener('abort', onAbort);
+      reject(new Error(`codex-cli stdin write failed (is the codex binary installed?): ${e instanceof Error ? e.message : String(e)}`));
+    }
+  });
+}
+
+interface ParsedToolCall {
+  id: string;
+  name: string;
+  /** Stringified JSON, matching the ai-sdk LanguageModelV2ToolCall.input contract. */
+  input: string;
+}
+
+/**
+ * Locate and parse the `<use_tools>...</use_tools>` block in the assistant's
+ * raw text response. Returns the parsed tool calls plus whatever prose
+ * surrounded the block. Returns an empty `toolCalls` array when no block is
+ * present, malformed, or unterminated — the caller then treats the full
+ * raw text as a final text response.
+ *
+ * Mirrors claude-cli-language-model.ts `extractToolCalls`.
+ */
+function extractToolCalls(raw: string): {
+  toolCalls: ParsedToolCall[];
+  beforeText: string;
+  afterText: string;
+} {
+  const openTag = '<use_tools>';
+  const closeTag = '</use_tools>';
+  const openIdx = raw.indexOf(openTag);
+  if (openIdx === -1) {
+    return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
+  }
+  const closeIdx = raw.indexOf(closeTag, openIdx + openTag.length);
+  if (closeIdx === -1) {
+    // Unterminated block — recover gracefully.
+    return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
+  }
+
+  const beforeText = raw.slice(0, openIdx).trim();
+  const afterText = raw.slice(closeIdx + closeTag.length).trim();
+  let inner = raw.slice(openIdx + openTag.length, closeIdx).trim();
+
+  if (inner.startsWith('```')) {
+    inner = inner.replace(/^```(?:json|JSON)?\s*\n?/, '').replace(/\n?```$/, '').trim();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
+  }
+  if (!Array.isArray(parsed)) {
+    return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
+  }
+
+  const toolCalls: ParsedToolCall[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const name = typeof e.name === 'string' ? e.name : null;
+    if (!name) continue;
+    const id = typeof e.id === 'string' && e.id.length > 0
+      ? e.id
+      : `toolu_codex_cli_${Math.random().toString(36).slice(2, 12)}`;
+    const inputJson = JSON.stringify(e.input ?? {});
+    toolCalls.push({ id, name, input: inputJson });
+  }
+
+  return { toolCalls, beforeText, afterText };
+}
+
+/**
+ * Strip provider prefixes (`openai:`, `litellm:`, `codex-cli:`) that the
+ * underlying CLI does not understand. The gateway hands us a bare model id
+ * via `recipe.aliases` resolution, but defensive normalization here keeps
+ * direct LanguageModelV2 construction (in tests, for example) ergonomic.
+ */
+function normalizeModel(model: string): string {
+  const idx = model.indexOf(':');
+  return idx >= 0 ? model.slice(idx + 1) : model;
+}
+
+export class CodexCliLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = 'v2' as const;
+  readonly provider = 'codex-cli';
+  readonly modelId: string;
+  readonly supportedUrls = {};
+
+  constructor(modelId: string) {
+    this.modelId = normalizeModel(modelId);
+  }
+
+  async doGenerate(options: LanguageModelV2CallOptions): Promise<{
+    content: LanguageModelV2Content[];
+    finishReason: 'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown';
+    usage: { inputTokens: number | undefined; outputTokens: number | undefined; totalTokens: number | undefined };
+    warnings: never[];
+  }> {
+    const { systemText, userPrompt } = renderPrompt(options.prompt);
+    const toolInstructions = buildToolUseInstructions(options.tools);
+    // No --system-prompt flag on codex exec: system text + tool protocol
+    // lead the stdin prompt as a `## System` section instead.
+    const fullPrompt = [
+      systemText ? `## System\n\n${systemText}` : '',
+      toolInstructions,
+      userPrompt,
+    ].filter(s => s.length > 0).join('\n\n');
+
+    const raw = await runCodex(fullPrompt, this.modelId, options.abortSignal);
+    const { toolCalls, beforeText, afterText } = extractToolCalls(raw);
+
+    const content: LanguageModelV2Content[] = [];
+    if (beforeText) content.push({ type: 'text', text: beforeText });
+    for (const call of toolCalls) {
+      content.push({
+        type: 'tool-call',
+        toolCallId: call.id,
+        toolName: call.name,
+        input: call.input,
+      });
+    }
+    if (afterText) content.push({ type: 'text', text: afterText });
+    if (content.length === 0) {
+      // Empty response — still hand the caller a well-formed content array.
+      content.push({ type: 'text', text: raw });
+    }
+
+    const finishReason = toolCalls.length > 0 ? 'tool-calls' as const : 'stop' as const;
+
+    return {
+      content,
+      finishReason,
+      // The -o output channel carries no token accounting; leave usage
+      // undefined rather than fabricate numbers (subscription billing makes
+      // the ledger nominal for this recipe anyway).
+      usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+      warnings: [],
+    };
+  }
+
+  async doStream(): Promise<never> {
+    throw new Error(
+      'codex-cli LanguageModel does not support streaming. Use doGenerate or set ' +
+      'the model on a non-streaming chat surface (gateway.toolLoop is non-streaming).',
+    );
+  }
+}

--- a/src/core/ai/providers/codex-cli-language-model.ts
+++ b/src/core/ai/providers/codex-cli-language-model.ts
@@ -20,6 +20,10 @@
  * Context isolation:
  *   - Spawned from a dedicated tmpdir (`-C`) so AGENTS.md auto-discovery has
  *     no local files to find; `--skip-git-repo-check` skips the repo probe.
+ *     Sandbox-confined codex builds (notably the Ubuntu snap) cannot open
+ *     arbitrary paths under /tmp, which surfaces as a bare "No such file or
+ *     directory" from the child; set TMPDIR to a non-hidden directory inside
+ *     $HOME on those hosts. See docs/ai-providers/codex-cli.md.
  *   - `--ignore-user-config` stops ~/.codex/config.toml from loading — user
  *     MCP servers (including gbrain's own MCP → recursion + PGLite lock
  *     contention), custom model defaults, and instruction overrides all stay
@@ -63,6 +67,27 @@ function ensureCleanCwd(): string {
     cwdEnsured = true;
   }
   return CODEX_CWD;
+}
+
+/**
+ * Explain a child failure that is really a cwd-reachability problem.
+ *
+ * The dedicated cwd is handed to both `-C` and `-o`, so the child must be able
+ * to open it. Sandbox-confined builds cannot: snap's `home` interface allows
+ * only non-hidden paths under $HOME, so nothing under /tmp is reachable and
+ * codex reports a bare "No such file or directory (os error 2)" that names
+ * neither the path nor the cause. Point at the cwd and the TMPDIR escape hatch
+ * instead of leaving the operator with the raw errno.
+ *
+ * Returns '' for unrelated failures so ordinary CLI errors stay untouched.
+ */
+function cwdAccessHint(detail: string): string {
+  if (!/no such file or directory|os error 2|permission denied|os error 13/i.test(detail)) return '';
+  return (
+    `\n--- hint ---\ncodex ran with cwd ${CODEX_CWD}. Sandbox-confined installs ` +
+    `(e.g. the Ubuntu snap) cannot open arbitrary paths under ${tmpdir()}; set ` +
+    `TMPDIR to a non-hidden directory inside $HOME and retry.`
+  );
 }
 
 /**
@@ -261,7 +286,8 @@ function runCodex(
     child.on('close', code => {
       if (signal) signal.removeEventListener('abort', onAbort);
       if (code !== 0) {
-        reject(new Error(`codex-cli exited ${code}: ${stderr.trim() || stdout.trim()}`));
+        const detail = stderr.trim() || stdout.trim();
+        reject(new Error(`codex-cli exited ${code}: ${detail}${cwdAccessHint(detail)}`));
         return;
       }
       const text = readOutFile();

--- a/src/core/ai/recipes/codex-cli.ts
+++ b/src/core/ai/recipes/codex-cli.ts
@@ -1,0 +1,66 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * GPT via the local `codex` CLI binary, using its built-in ChatGPT OAuth
+ * session (ChatGPT Plus/Pro subscription). No OPENAI_API_KEY needed — the
+ * CLI manages its own auth state and the gateway dispatches via subprocess.
+ *
+ * The GPT sibling of the `claude-cli` recipe (#334 lineage): subscribers
+ * want Minions subagent dispatch and chat fallback to run against their
+ * existing ChatGPT subscription instead of paying per-token API charges.
+ * The recipe sits alongside the existing `openai` recipe so users pick per
+ * call: `openai:gpt-5.6` (API key + per-token billing) vs
+ * `codex-cli:gpt-5.6-terra` (OAuth subscription, no API key).
+ *
+ * Chat-only. Embeddings still route through openai/google/voyage the way
+ * the `claude-cli` recipe documents.
+ *
+ * Auth: `auth_env.required: []` because the CLI handles auth itself. The
+ * `codex` binary on PATH (or `GBRAIN_CODEX_CLI_BIN`) IS the auth surface;
+ * there is nothing for the gateway to forward.
+ *
+ * Setup expectation: Codex CLI installed and logged in (`codex login`), or
+ * `GBRAIN_CODEX_CLI_BIN` pointing at the binary.
+ */
+export const codexCli: Recipe = {
+  id: 'codex-cli',
+  name: 'GPT (via Codex CLI)',
+  tier: 'native',
+  implementation: 'codex-cli',
+  // The CLI owns auth; no env vars are required from the gateway side.
+  auth_env: {
+    required: [],
+  },
+  touchpoints: {
+    // No embedding or expansion touchpoints — chat-only.
+    chat: {
+      models: [
+        'gpt-5.6-terra',
+        'gpt-5.6-sol',
+      ],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      // The CLI handles caching internally and does not surface it via the
+      // standard cache_control control plane. From the gateway's POV the
+      // model does not support prompt caching.
+      supports_prompt_cache: false,
+      max_context_tokens: 400000,
+      // Cost figures match the underlying OpenAI API tier, but the actual
+      // bill is borne by the subscription. We report them for the budget
+      // ledger's per-call accounting; operators on flat-rate subscriptions
+      // can treat the numbers as nominal.
+      cost_per_1m_input_usd: 1.25,
+      cost_per_1m_output_usd: 10.0,
+      price_last_verified: '2026-07-29',
+    },
+  },
+  // Friendly aliases so config strings stay short. Verified against
+  // `codex exec -m <id>` on Codex CLI as of 2026-07-29.
+  aliases: {
+    'terra': 'gpt-5.6-terra',
+    'sol': 'gpt-5.6-sol',
+  },
+  setup_hint:
+    'Install the Codex CLI (`codex`) and run `codex login` once. ' +
+    'Set GBRAIN_CODEX_CLI_BIN if the binary is not on PATH.',
+};

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -10,6 +10,7 @@ import { openai } from './openai.ts';
 import { google } from './google.ts';
 import { anthropic } from './anthropic.ts';
 import { claudeCli } from './claude-cli.ts';
+import { codexCli } from './codex-cli.ts';
 import { ollama } from './ollama.ts';
 import { openrouter } from './openrouter.ts';
 import { voyage } from './voyage.ts';
@@ -35,6 +36,7 @@ const ALL: Recipe[] = [
   google,
   anthropic,
   claudeCli,
+  codexCli,
   ollama,
   openrouter,
   voyage,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -23,7 +23,8 @@ export type Implementation =
   | 'native-google'
   | 'native-anthropic'
   | 'openai-compatible'
-  | 'claude-cli';
+  | 'claude-cli'
+  | 'codex-cli';
 
 export interface EmbeddingTouchpoint {
   models: string[];

--- a/test/codex-cli-recipe.test.ts
+++ b/test/codex-cli-recipe.test.ts
@@ -457,6 +457,30 @@ describe('codex-cli LanguageModel — abort + error surfaces', () => {
     });
   });
 
+  test('appends a cwd-reachability hint to sandbox-confinement failures only', async () => {
+    await withStubEnv(async () => {
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const failWith = async (stderrLine: string): Promise<string> => {
+        writeFileSync(stubBin, ['#!/bin/sh', 'cat > /dev/null', `echo "${stderrLine}" >&2`, 'exit 1'].join('\n'));
+        chmodSync(stubBin, 0o755);
+        const model = new CodexCliLanguageModel('gpt-5.6-terra');
+        return model
+          .doGenerate({ prompt: [userMessage('x')] } as LanguageModelV2CallOptions)
+          .then(() => '', (e: unknown) => (e instanceof Error ? e.message : String(e)));
+      };
+      try {
+        // The snap failure mode: an opaque errno from a cwd the child cannot open.
+        const confined = await failWith('Error: No such file or directory (os error 2)');
+        expect(confined).toMatch(/--- hint ---/);
+        expect(confined).toMatch(/TMPDIR/);
+        // Ordinary CLI failures stay clean.
+        expect(await failWith('usage limit reached')).not.toMatch(/--- hint ---/);
+      } finally {
+        restoreFastStub();
+      }
+    });
+  });
+
   test('rejects when the CLI exits 0 without writing the -o file', async () => {
     await withStubEnv(async () => {
       const silentStub = [

--- a/test/codex-cli-recipe.test.ts
+++ b/test/codex-cli-recipe.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Tests for the codex-cli LanguageModelV2 implementation that the
+ * `codex-cli` recipe instantiates.
+ *
+ * Strategy: a POSIX shell stub at GBRAIN_CODEX_CLI_BIN emits a scripted
+ * final message into the `-o <file>` argument, mirroring `codex exec`'s
+ * output channel. Tests exercise the LanguageModelV2 doGenerate surface:
+ * text round trip, tool-call extraction (single + multiple parallel),
+ * abort semantics, context-isolation flags. No Codex CLI installation or
+ * subscription required.
+ *
+ * Recipe registration is also smoke-tested: getRecipe('codex-cli')
+ * returns a chat-only Recipe with the right model list.
+ *
+ * Env isolation: GBRAIN_CODEX_CLI_BIN is set per-test via withEnv(),
+ * NOT in beforeAll. The provider reads the env var at spawn time so
+ * withEnv's save/restore in try/finally is sufficient; no leakage to
+ * sibling test files in the same bun-test process.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import { withEnv } from './helpers/with-env.ts';
+
+const stubDir = join(tmpdir(), `codex-cli-recipe-stub-${process.pid}`);
+const stubBin = join(stubDir, 'codex');
+const stubResponsePath = join(stubDir, 'codex_response.txt');
+
+/**
+ * Default stub: consume stdin, require the `exec` subcommand, find the
+ * argument after `-o`, and copy the staged response there — the same
+ * channel `codex exec -o <file>` uses for the final agent message.
+ */
+function fastStubScript(): string {
+  return [
+    '#!/bin/sh',
+    'cat > /dev/null',
+    'case " $* " in',
+    '  *" exec "*|"exec "*) ;;',
+    '  *) echo "missing exec subcommand in argv: $*" >&2; exit 64 ;;',
+    'esac',
+    'out=""',
+    'prev=""',
+    'for a in "$@"; do',
+    '  if [ "$prev" = "-o" ]; then out="$a"; fi',
+    '  prev="$a"',
+    'done',
+    'if [ -z "$out" ]; then echo "missing -o <file> in argv: $*" >&2; exit 65; fi',
+    `cat "${stubResponsePath}" > "$out"`,
+  ].join('\n');
+}
+
+beforeAll(() => {
+  mkdirSync(stubDir, { recursive: true });
+  writeFileSync(stubBin, fastStubScript());
+  chmodSync(stubBin, 0o755);
+});
+
+afterAll(() => {
+  rmSync(stubDir, { recursive: true, force: true });
+});
+
+function withStubEnv<T>(fn: () => T | Promise<T>): Promise<T> {
+  return withEnv({ GBRAIN_CODEX_CLI_BIN: stubBin }, fn);
+}
+
+function stageResponse(text: string): void {
+  writeFileSync(stubResponsePath, text);
+}
+
+function restoreFastStub(): void {
+  writeFileSync(stubBin, fastStubScript());
+  chmodSync(stubBin, 0o755);
+}
+
+function userMessage(text: string): LanguageModelV2CallOptions['prompt'][number] {
+  return { role: 'user', content: [{ type: 'text', text }] };
+}
+
+describe('codex-cli recipe registration', () => {
+  test('getRecipe returns chat-only Recipe with the documented models', async () => {
+    const { getRecipe } = await import('../src/core/ai/recipes/index.ts');
+    const recipe = getRecipe('codex-cli');
+    expect(recipe).toBeDefined();
+    expect(recipe!.id).toBe('codex-cli');
+    expect(recipe!.implementation).toBe('codex-cli');
+    expect(recipe!.touchpoints.chat).toBeDefined();
+    expect(recipe!.touchpoints.chat!.supports_tools).toBe(true);
+    expect(recipe!.touchpoints.chat!.supports_subagent_loop).toBe(true);
+    expect(recipe!.touchpoints.chat!.models).toContain('gpt-5.6-terra');
+    expect(recipe!.touchpoints.embedding).toBeUndefined();
+    expect(recipe!.touchpoints.expansion).toBeUndefined();
+  });
+
+  test('recipe aliases map short names to canonical model ids', async () => {
+    const { getRecipe } = await import('../src/core/ai/recipes/index.ts');
+    const recipe = getRecipe('codex-cli');
+    expect(recipe!.aliases!['terra']).toBe('gpt-5.6-terra');
+    expect(recipe!.aliases!['sol']).toBe('gpt-5.6-sol');
+  });
+});
+
+describe('codex-cli LanguageModel — text-only round trip', () => {
+  test('returns a single text content block with stop finish reason and undefined usage', async () => {
+    await withStubEnv(async () => {
+      stageResponse('hello world');
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('hi')],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.finishReason).toBe('stop');
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({ type: 'text', text: 'hello world' });
+      // The -o channel carries no token accounting; usage is honest-undefined.
+      expect(result.usage.inputTokens).toBeUndefined();
+      expect(result.usage.outputTokens).toBeUndefined();
+    });
+  });
+
+  test('strips provider prefixes from the model id', async () => {
+    const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+    const model = new CodexCliLanguageModel('codex-cli:gpt-5.6-terra');
+    expect(model.modelId).toBe('gpt-5.6-terra');
+  });
+});
+
+describe('codex-cli LanguageModel — tool use', () => {
+  test('parses <use_tools> block into LanguageModelV2 tool-call content', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          'I will look up the pattern first.',
+          '<use_tools>',
+          '[{"id": "toolu_01ABC", "name": "search", "input": {"query": "n+1 query"}}]',
+          '</use_tools>',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('find n+1 queries')],
+        tools: [
+          {
+            type: 'function',
+            name: 'search',
+            description: 'Search the brain',
+            inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+          },
+        ],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.finishReason).toBe('tool-calls');
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0]).toMatchObject({ type: 'text', text: 'I will look up the pattern first.' });
+      expect(result.content[1]).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'toolu_01ABC',
+        toolName: 'search',
+        input: '{"query":"n+1 query"}',
+      });
+    });
+  });
+
+  test('parses multiple parallel tool calls in a single block', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          '<use_tools>',
+          '[',
+          '  {"id": "toolu_A", "name": "search", "input": {"query": "foo"}},',
+          '  {"id": "toolu_B", "name": "get_page", "input": {"slug": "areas/x"}}',
+          ']',
+          '</use_tools>',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('multi')],
+        tools: [
+          { type: 'function', name: 'search', description: 's', inputSchema: { type: 'object', properties: {} } },
+          { type: 'function', name: 'get_page', description: 'g', inputSchema: { type: 'object', properties: {} } },
+        ],
+      } as LanguageModelV2CallOptions);
+
+      const calls = result.content.filter(c => c.type === 'tool-call');
+      expect(calls).toHaveLength(2);
+      expect(calls.map(c => (c as { toolName: string }).toolName)).toEqual(['search', 'get_page']);
+      expect(result.finishReason).toBe('tool-calls');
+    });
+  });
+
+  test('tolerates fenced JSON inside <use_tools>', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          '<use_tools>',
+          '```json',
+          '[{"id": "toolu_F", "name": "search", "input": {"q": "x"}}]',
+          '```',
+          '</use_tools>',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('fenced')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      const calls = result.content.filter(c => c.type === 'tool-call');
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  test('synthesizes an id when the model omits it', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          '<use_tools>',
+          '[{"name": "search", "input": {"q": "x"}}]',
+          '</use_tools>',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('no id')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      const call = result.content.find(c => c.type === 'tool-call') as { toolCallId: string } | undefined;
+      expect(call).toBeDefined();
+      expect(call!.toolCallId).toMatch(/^toolu_codex_cli_/);
+    });
+  });
+
+  test('falls back to text on malformed JSON', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          '<use_tools>',
+          'not valid json',
+          '</use_tools>',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('malformed')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.content.filter(c => c.type === 'tool-call')).toHaveLength(0);
+      expect(result.finishReason).toBe('stop');
+    });
+  });
+
+  test('returns text-only stop when tools are offered but model declines to call any', async () => {
+    // Real-world case: the model decides the user's request does not require
+    // a tool call, ignores the use_tools protocol, and answers directly.
+    // The recipe still must return clean LanguageModelV2 output so the
+    // caller (gateway.toolLoop) can treat the text as the final answer
+    // rather than wedge waiting for tool calls that never come.
+    await withStubEnv(async () => {
+      stageResponse('I do not actually need to call any tools for this. The answer is 42.');
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('what is the meaning of life? you may use tools but do not need to')],
+        tools: [{ type: 'function', name: 'compute', description: 'Compute things', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.content.filter(c => c.type === 'tool-call')).toHaveLength(0);
+      const textBlocks = result.content.filter(c => c.type === 'text');
+      expect(textBlocks).toHaveLength(1);
+      expect((textBlocks[0] as { text: string }).text).toContain('42');
+      expect(result.finishReason).toBe('stop');
+    });
+  });
+
+  test('drops the block when the close tag is missing', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        [
+          '<use_tools>',
+          '[{"id": "toolu_X", "name": "search", "input": {}}',
+        ].join('\n'),
+      );
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      const result = await model.doGenerate({
+        prompt: [userMessage('unterminated')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.content.filter(c => c.type === 'tool-call')).toHaveLength(0);
+      expect(result.finishReason).toBe('stop');
+    });
+  });
+});
+
+describe('codex-cli LanguageModel — context isolation', () => {
+  test('argv carries the isolation flags, stdin marker, and system section; cwd is the dedicated tmpdir', async () => {
+    await withStubEnv(async () => {
+      const argvLog = join(stubDir, 'argv.log');
+      const cwdLog = join(stubDir, 'cwd.log');
+      const stdinLog = join(stubDir, 'stdin.log');
+      const recordStub = [
+        '#!/bin/sh',
+        `printf "%s\\n" "$@" > "${argvLog}"`,
+        `pwd > "${cwdLog}"`,
+        `cat > "${stdinLog}"`,
+        'out=""',
+        'prev=""',
+        'for a in "$@"; do',
+        '  if [ "$prev" = "-o" ]; then out="$a"; fi',
+        '  prev="$a"',
+        'done',
+        `cat "${stubResponsePath}" > "$out"`,
+      ].join('\n');
+      writeFileSync(stubBin, recordStub);
+      chmodSync(stubBin, 0o755);
+      stageResponse('ok');
+
+      try {
+        const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+        const model = new CodexCliLanguageModel('gpt-5.6-terra');
+        await model.doGenerate({
+          prompt: [
+            { role: 'system', content: 'You are gbrain subagent.' },
+            userMessage('hi'),
+          ],
+        } as LanguageModelV2CallOptions);
+
+        const fs = require('node:fs');
+        const argv = fs.readFileSync(argvLog, 'utf8').split('\n').filter(Boolean);
+        const cwd = fs.readFileSync(cwdLog, 'utf8').trim();
+        const stdin = fs.readFileSync(stdinLog, 'utf8');
+
+        expect(argv[0]).toBe('exec');
+        // Agent-isolation hardening: no user config (MCP servers, model
+        // defaults), read-only sandbox, clean cwd, no repo probe.
+        expect(argv).toContain('--ignore-user-config');
+        expect(argv).toContain('--sandbox');
+        expect(argv).toContain('read-only');
+        expect(argv).toContain('--skip-git-repo-check');
+        expect(argv).toContain('-m');
+        expect(argv).toContain('gpt-5.6-terra');
+        // Prompt arrives on stdin (argv has a hard size ceiling).
+        expect(argv[argv.length - 1]).toBe('-');
+        expect(cwd).toMatch(/gbrain-codex-cli-cwd-\d+$/);
+        // No --system-prompt flag on codex: system text leads the stdin prompt.
+        expect(stdin).toContain('## System');
+        expect(stdin).toContain('You are gbrain subagent.');
+        expect(stdin).toContain('User: hi');
+      } finally {
+        restoreFastStub();
+      }
+    });
+  });
+
+  test('scrubs OPENAI_* credentials from the child env (subscription-only auth)', async () => {
+    await withStubEnv(async () => {
+      await withEnv(
+        {
+          OPENAI_API_KEY: 'sk-should-never-leak',
+          OPENAI_BASE_URL: 'https://proxy.should.never.leak',
+        },
+        async () => {
+          const envLog = join(stubDir, 'env.log');
+          const envStub = [
+            '#!/bin/sh',
+            `printf "key=%s\\nbase=%s\\n" "\${OPENAI_API_KEY:-UNSET}" "\${OPENAI_BASE_URL:-UNSET}" > "${envLog}"`,
+            'cat > /dev/null',
+            'out=""',
+            'prev=""',
+            'for a in "$@"; do',
+            '  if [ "$prev" = "-o" ]; then out="$a"; fi',
+            '  prev="$a"',
+            'done',
+            `cat "${stubResponsePath}" > "$out"`,
+          ].join('\n');
+          writeFileSync(stubBin, envStub);
+          chmodSync(stubBin, 0o755);
+          stageResponse('ok');
+
+          try {
+            const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+            const model = new CodexCliLanguageModel('gpt-5.6-terra');
+            await model.doGenerate({
+              prompt: [userMessage('hi')],
+            } as LanguageModelV2CallOptions);
+
+            const fs = require('node:fs');
+            const seen = fs.readFileSync(envLog, 'utf8');
+            expect(seen).toContain('key=UNSET');
+            expect(seen).toContain('base=UNSET');
+          } finally {
+            restoreFastStub();
+          }
+        },
+      );
+    });
+  });
+});
+
+describe('codex-cli LanguageModel — abort + error surfaces', () => {
+  test('SIGTERMs the child on AbortSignal', async () => {
+    await withStubEnv(async () => {
+      const slowStub = [
+        '#!/bin/sh',
+        'cat > /dev/null',
+        'sleep 30',
+      ].join('\n');
+      writeFileSync(stubBin, slowStub);
+      chmodSync(stubBin, 0o755);
+      try {
+        const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+        const model = new CodexCliLanguageModel('gpt-5.6-terra');
+        const ac = new AbortController();
+        const promise = model.doGenerate({
+          prompt: [userMessage('slow')],
+          abortSignal: ac.signal,
+        } as LanguageModelV2CallOptions);
+        setTimeout(() => ac.abort(), 30);
+        await expect(promise).rejects.toThrow(/aborted/);
+      } finally {
+        restoreFastStub();
+      }
+    });
+  });
+
+  test('rejects when the CLI exits non-zero', async () => {
+    await withStubEnv(async () => {
+      const failStub = [
+        '#!/bin/sh',
+        'cat > /dev/null',
+        'echo "usage limit reached" >&2',
+        'exit 1',
+      ].join('\n');
+      writeFileSync(stubBin, failStub);
+      chmodSync(stubBin, 0o755);
+      try {
+        const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+        const model = new CodexCliLanguageModel('gpt-5.6-terra');
+        await expect(
+          model.doGenerate({ prompt: [userMessage('x')] } as LanguageModelV2CallOptions),
+        ).rejects.toThrow(/codex-cli exited 1.*usage limit reached/s);
+      } finally {
+        restoreFastStub();
+      }
+    });
+  });
+
+  test('rejects when the CLI exits 0 without writing the -o file', async () => {
+    await withStubEnv(async () => {
+      const silentStub = [
+        '#!/bin/sh',
+        'cat > /dev/null',
+        'exit 0',
+      ].join('\n');
+      writeFileSync(stubBin, silentStub);
+      chmodSync(stubBin, 0o755);
+      try {
+        const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+        const model = new CodexCliLanguageModel('gpt-5.6-terra');
+        await expect(
+          model.doGenerate({ prompt: [userMessage('x')] } as LanguageModelV2CallOptions),
+        ).rejects.toThrow(/wrote no final message/);
+      } finally {
+        restoreFastStub();
+      }
+    });
+  });
+
+  test('rejects cleanly when the codex binary is missing (no worker crash)', async () => {
+    // A missing binary must surface as a rejected promise via the spawn 'error'
+    // handler; the child stdin 'error' (EPIPE) handler swallows the pipe failure
+    // so it never escalates to an unhandled rejection that would down the worker.
+    await withEnv({ GBRAIN_CODEX_CLI_BIN: join(stubDir, 'nonexistent-codex') }, async () => {
+      const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+      const model = new CodexCliLanguageModel('gpt-5.6-terra');
+      await expect(
+        model.doGenerate({ prompt: [userMessage('x')] } as LanguageModelV2CallOptions),
+      ).rejects.toThrow(/codex-cli spawn failed/);
+    });
+  });
+
+  test('doStream throws not-supported', async () => {
+    const { CodexCliLanguageModel } = await import('../src/core/ai/providers/codex-cli-language-model.ts');
+    const model = new CodexCliLanguageModel('gpt-5.6-terra');
+    await expect(model.doStream()).rejects.toThrow(/does not support streaming/);
+  });
+});


### PR DESCRIPTION
# feat(ai): `codex-cli` recipe — GPT chat via Codex CLI OAuth subscription

## What

The GPT sibling of the `claude-cli` recipe (#334 lineage). ChatGPT Plus/Pro subscribers can route `gateway.chat` / `gateway.toolLoop` through the local `codex` CLI's OAuth session instead of paying per-token `OPENAI_API_KEY` charges:

```bash
gbrain config set chat_model codex-cli:gpt-5.6-terra
# or as a fallback behind claude-cli:
gbrain config set chat_fallback_chain '["codex-cli:gpt-5.6-terra"]'
```

`codex-cli:gpt-5.6-terra` (subscription) sits alongside `openai:gpt-5.6` (API key + per-token billing) the same way `claude-cli:*` sits alongside `anthropic:*`.

## Why

Same operator need that motivated claude-cli in #334, on the GPT side: Minions subagent dispatch and chat fallback against an existing subscription. Mixed-provider fallback chains (`claude-cli:* → codex-cli:*`) currently have no subscription path for the GPT leg — this closes that.

## How (mirrors `claude-cli-language-model.ts`)

- **Transport**: `codex exec -` with the prompt on **stdin** (argv has a hard size ceiling; subagent prompts routinely exceed it). Final message read from `-o <file>` — stdout is progress logs and is discarded.
- **Tool use**: the same `<use_tools>[{id,name,input}]</use_tools>` prompt protocol claude-cli teaches; parallel calls round-trip into `LanguageModelV2` `tool-call` parts. Protocol helpers are mirrored, not extracted, to keep this PR additive-only — a shared `cli-tool-protocol` module is a natural follow-up now that two providers prove the shape (happy to do it in this PR if you prefer).
- **Agent isolation**: `--ignore-user-config` (no user MCP servers — including gbrain's own MCP → recursion + PGLite single-writer lock contention), `--sandbox read-only`, dedicated tmpdir cwd, `--skip-git-repo-check`. Codex has no `--system-prompt` flag, so system messages render as a leading `## System` stdin section.
- **Billing guard**: `OPENAI_API_KEY` / `OPENAI_BASE_URL` scrubbed from the child env so an inherited key never silently flips billing to the API (mirrors claude-cli's `ANTHROPIC_*` scrub).
- **Usage tokens**: honest-`undefined` — the `-o` channel carries no token accounting, and fabricating numbers would poison the budget ledger. Subscription billing makes the ledger nominal for this recipe anyway (per the recipe comment convention).

## Touched

| File | Change |
|---|---|
| `src/core/ai/recipes/codex-cli.ts` | new recipe (chat-only, `auth_env.required: []`) |
| `src/core/ai/providers/codex-cli-language-model.ts` | new `LanguageModelV2` subprocess provider |
| `src/core/ai/types.ts` | `Implementation` union + `'codex-cli'` |
| `src/core/ai/recipes/index.ts` | registration |
| `src/core/ai/gateway.ts` | 3 switch branches (embedding error / expansion / chat), mirroring claude-cli |
| `test/codex-cli-recipe.test.ts` | 19-test suite |

## Testing

- `test/codex-cli-recipe.test.ts` — 19 tests mirroring `test/claude-cli-recipe.test.ts`'s shell-stub strategy (no Codex install or subscription needed in CI): registration, text round-trip, tool-call extraction (single / parallel / fenced / malformed / unterminated / declined), argv isolation flags + stdin marker + `## System` section, `OPENAI_*` env scrub, abort SIGTERM, non-zero exit, empty `-o` file, missing binary, `doStream` not-supported, cwd-reachability hint.
- `bun test test/ai/` — 472 pass, 0 fail (no regressions).
- `bunx tsc --noEmit` — clean (the `Implementation` union extension exercises every exhaustive switch).
- Live smoke: `doGenerate` against real Codex CLI 0.145.0 / `gpt-5.6-terra` — system + user prompt → exact text back, `finishReason: 'stop'`.

## Notes for review

- Model list ships with `gpt-5.6-terra` / `gpt-5.6-sol` (verified against `codex exec -m` on 2026-07-29); aliases `terra` / `sol`. Happy to adjust to whatever id set you prefer to pin.
- Cost figures are the nominal API-tier numbers for the budget ledger, `price_last_verified: 2026-07-29`, same convention as claude-cli.
- A `grok-cli` recipe following the same shape is a natural sibling; kept out of this PR to keep review scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Update — addressing @kweiner's review (9152437)

Thanks for testing this against a real self-hosted install; the snap finding is real and reproduced as described.

**Confirmed diagnosis, different fix.** The scratch cwd is passed as both `-C` and the parent of the `-o` output file, so a sandbox-confined child has to be able to open it — under snap it cannot, and the CLI reports a bare `os error 2` that names neither the path nor the cause.

I went with your option 3+ rather than option 1: the failure now names the cwd and the `TMPDIR` escape hatch, and the host requirement is documented. Reasoning for not moving the default to `$HOME`:

- `CODEX_CWD` has no cleanup path (only `outFile` is removed), and it is per-pid — under `/tmp` the OS reclaims it, under `$HOME` it would accumulate one empty directory per process, forever, on every host.
- It would trade a one-line env export on a minority of hosts for home-directory clutter on all of them.
- A dotdir default (`~/.gbrain/...`) would not fix snap anyway: the `home` interface permits only **non-hidden** paths under `$HOME` — which is also why your `TMPDIR=/home/ken/some-dir` repro worked. Worth flagging in case it saves someone the same hour.

Happy to switch to a `$HOME` default (with a fixed path + cleanup, not per-pid) if you'd rather it work with no configuration on snap — your call.

**Also folded in:** your other two findings, as `docs/ai-providers/codex-cli.md` — minimum CLI 0.145.0 (with the `gpt-5.3-codex`-under-ChatGPT-auth error as the symptom of an older snap), the `TMPDIR` workaround, and `ca-certificates` for minimal Docker bases whose image ships no OS trust store.

**Corrected:** the test count in this description said 20; it was 18. Now 19 with a test covering the hint (and that ordinary CLI failures stay clean). `bun test test/ai/` still 472 pass / 0 fail, `bunx tsc --noEmit` clean.
