### PR TITLE
fix(jobs): chronicle_extract must re-resolve models from the engine (#3387)

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -47,6 +47,15 @@ const GATEWAY_REFRESH_JOB_NAMES = new Set([
   'embed-backfill',
   'extract-takes-from-pages',
   'embed-catch-up',
+  // #3387: chronicle_extract calls the chat model, so it must re-resolve
+  // models from the ENGINE (the DB config plane) before running. Without
+  // this entry the job sees only the connect-time file/env config, so a
+  // model set via `gbrain config set` is silently ignored and
+  // extract-events.ts's `if (!isAvailable('chat')) return { events: [] }`
+  // returns a silent `no_events`. The bug is invisible when the model comes
+  // from an env var — which is why a live repro can pass while the reported
+  // (DB-plane) configuration still fails.
+  'chronicle_extract',
 ]);
 
 function registerBuiltinJob(

--- a/test/chronicle-extract-gateway-refresh.test.ts
+++ b/test/chronicle-extract-gateway-refresh.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #3387: `chronicle_extract` must re-resolve models from the ENGINE before it runs.
+ *
+ * `registerBuiltinJob` wraps a handler with `refreshGatewayForJob(engine)` only
+ * when its name is in `GATEWAY_REFRESH_JOB_NAMES`. That refresh calls
+ * `reconfigureGatewayWithEngine`, which resolves `models.chat` from the DB
+ * config plane (`resolveModel(engine, { configKey: 'models.chat', … })`),
+ * falling back to the file/env plane.
+ *
+ * Without the entry the job sees only the connect-time file/env config, so a
+ * chat model set with `gbrain config set` is silently ignored and
+ * `extract-events.ts` returns a silent `no_events`.
+ *
+ * WHY THE TEST IS SHAPED THIS WAY: the bug is invisible when the model comes
+ * from an environment variable, because the connect-time config already carries
+ * it. A reviewer ran the reporter's repro live, it passed, and they concluded
+ * not-a-bug for exactly that reason. Set membership IS the mechanism, so that
+ * is what this pins.
+ */
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const JOBS_SRC = readFileSync(resolve(import.meta.dir, '../src/commands/jobs.ts'), 'utf-8');
+
+/**
+ * Members of the GATEWAY_REFRESH_JOB_NAMES set literal.
+ * Scans only quoted entries on their own line, so prose in comments (which may
+ * legitimately contain quoted identifiers) cannot be mistaken for a member.
+ */
+function refreshSetMembers(): string[] {
+  const start = JOBS_SRC.indexOf('const GATEWAY_REFRESH_JOB_NAMES = new Set([');
+  if (start === -1) throw new Error('GATEWAY_REFRESH_JOB_NAMES not found — declaration moved?');
+  const end = JOBS_SRC.indexOf(']);', start);
+  if (end === -1) throw new Error('GATEWAY_REFRESH_JOB_NAMES has no terminator');
+  return JOBS_SRC.slice(start, end)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => !line.startsWith('//'))
+    .map((line) => /^'([^']+)',$/.exec(line))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => m[1]);
+}
+
+describe('#3387: chronicle_extract re-resolves models from the engine', () => {
+  test('chronicle_extract is in GATEWAY_REFRESH_JOB_NAMES', () => {
+    // Fails on master: 13 members, this is not one of them.
+    expect(refreshSetMembers()).toContain('chronicle_extract');
+  });
+
+  test('the refresh wrapper is what consults the DB config plane', () => {
+    // Pins the mechanism, so a refactor that drops the engine-aware refresh
+    // shows up here rather than as a mystery `no_events`.
+    expect(JOBS_SRC).toContain('GATEWAY_REFRESH_JOB_NAMES.has(name)');
+    expect(JOBS_SRC).toContain('refreshGatewayForJob(engine)');
+  });
+
+  test('every chat-calling job stays in the set', () => {
+    // Regression floor: each of these invokes a chat/expansion model and would
+    // silently ignore DB-plane model config if dropped from the set.
+    const members = refreshSetMembers();
+    const required = [
+      'chronicle_extract',
+      'extract_facts',
+      'extract-conversation-facts',
+      'synthesize',
+      'patterns',
+      'consolidate',
+      'extract-takes-from-pages',
+      'enrich',
+    ];
+    const missing = required.filter((n) => !members.includes(n));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #3387 (part 1).

## The bug

`registerBuiltinJob` (`src/commands/jobs.ts`) wraps a handler with `refreshGatewayForJob(engine)` **only** when its name is in `GATEWAY_REFRESH_JOB_NAMES`:

```ts
if (!GATEWAY_REFRESH_JOB_NAMES.has(name)) { worker.register(name, handler); return; }
worker.register(name, async (job) => { await refreshGatewayForJob(engine); return await handler(job); });
```

That refresh calls `reconfigureGatewayWithEngine` (`src/core/ai/gateway.ts:532`), which resolves `models.chat` **from the engine** — `resolveModel(engine, { configKey: 'models.chat', tier: 'reasoning', fallback: cfg.chat_model … })` — falling back to the file/env plane.

`chronicle_extract` was absent from the set. So it saw only connect-time file/env config, a model set with `gbrain config set` never reached the gateway, and `extract-events.ts:196`'s `if (!isAvailable('chat')) return { events: [] }` returned a silent `no_events`.

## Why it survived triage

Two independent reviews reached opposite verdicts. One **ran the reporter's repro live** — real key, `jobs submit chronicle_extract --follow` — got `{"status":"extracted","events_written":1}`, and concluded not-a-bug. The other traced it statically and said it was real.

Both were correct about different config planes: the live run's model came from an environment variable, which the connect-time config already carries, so the DB-plane path was never exercised. A passing live test genuinely could not see this.

## Tests

Pin set membership, because that **is** the mechanism, plus a floor listing every chat-calling job so the next one dropped from this hand-maintained list fails loudly rather than silently ignoring config.

**3 pass with the fix, 2 fail on master** (both membership assertions). `bun run typecheck` clean, `bun run verify" green.

## Scope

Part 1 only. Part 2 (the token cap) was largely fixed by #2606 — default raised 1500 → 4000, configurable via `chronicle.judge_max_tokens`, truncation surfaced instead of parsed as empty. Open PR #3478 adds split-and-retry but touches neither `jobs.ts` nor this set, so it does not fix part 1.

**The wider hazard**: this set is hand-maintained, so any job added without an entry silently ignores DB-plane model config. The maintainer chose the one-line fix over a full sweep for now; worth revisiting if another instance appears.