### PR TITLE
fix admin SSE handshake through reverse proxies

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -135,6 +135,24 @@ export type ProbeHealthResult =
   | { ok: true; status: 200; body: { status: 'ok'; version: string; engine: string; [k: string]: unknown } }
   | { ok: false; status: 503; body: { error: 'service_unavailable'; error_description: string } };
 
+type AdminSseResponse = Pick<Response, 'setHeader' | 'flushHeaders' | 'write'>;
+
+/**
+ * Complete the admin EventSource handshake immediately.
+ *
+ * `flushHeaders()` alone can leave reverse proxies and browsers waiting for
+ * the first response body bytes. An SSE comment is protocol-valid, ignored by
+ * EventSource consumers, and makes the stream observable end-to-end without
+ * fabricating an application event.
+ */
+export function openAdminSseStream(res: AdminSseResponse): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+  res.write(': connected\n\n');
+}
+
 /**
  * Pure async health probe. Races `engine.getStats()` against a timeout,
  * returns a tagged result. No Express coupling — easy to unit-test with a
@@ -1632,10 +1650,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // SSE live activity feed
   // ---------------------------------------------------------------------------
   app.get('/admin/events', requireAdmin, (req: Request, res: Response) => {
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.flushHeaders();
+    openAdminSseStream(res);
 
     sseClients.add(res);
     req.on('close', () => sseClients.delete(res));

--- a/test/admin-sse-handshake.test.ts
+++ b/test/admin-sse-handshake.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { openAdminSseStream } from '../src/commands/serve-http.ts';
+
+describe('admin SSE handshake', () => {
+  test('flushes a protocol-valid comment immediately after the headers', () => {
+    const calls: string[] = [];
+    const headers = new Map<string, string>();
+
+    openAdminSseStream({
+      setHeader(name: string, value: string | number | readonly string[]) {
+        headers.set(name, String(value));
+        calls.push(`header:${name}`);
+        return this;
+      },
+      flushHeaders() {
+        calls.push('flush');
+      },
+      write(chunk: unknown) {
+        calls.push(`write:${String(chunk)}`);
+        return true;
+      },
+    });
+
+    expect(headers).toEqual(new Map([
+      ['Content-Type', 'text/event-stream'],
+      ['Cache-Control', 'no-cache'],
+      ['Connection', 'keep-alive'],
+    ]));
+    expect(calls).toEqual([
+      'header:Content-Type',
+      'header:Cache-Control',
+      'header:Connection',
+      'flush',
+      'write:: connected\n\n',
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

Send a protocol-valid SSE comment immediately after flushing the `/admin/events` response headers.

The route now uses a small exported handshake helper with a focused regression test that pins header order and the initial `: connected` frame.

## Why

With only `flushHeaders()`, some reverse-proxy (like Traefik) and browser combinations keep the EventSource request in an indeterminate state until the first body bytes arrive. The admin dashboard remains stuck on `Connecting…` even though authentication and routing succeeded.

An SSE comment is ignored by EventSource consumers, but establishes the response stream end-to-end without fabricating an application event.

## Validation

- `bun test test/admin-sse-handshake.test.ts test/admin-sse-eventsource.test.ts` — 2 passed
- `bun run typecheck` — passed
- `bun test test/e2e/serve-http-oauth.test.ts` — HTTP server exercised; 35 passed, 2 unrelated baseline failures:
  - SPA fallback requires a built local admin bundle
  - existing public-client revoke fixture inserts text into a `text[]` column

## Production evidence

This exact initial SSE comment was validated behind Traefik and browser cookie authentication, where it changed the admin dashboard from permanently `Connecting…` to a live activity connection.
