### PR TITLE
fix(files): display zero-byte file sizes

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -16,7 +16,7 @@ interface FileRecord {
   filename: string;
   storage_path: string;
   mime_type: string | null;
-  size_bytes: number;
+  size_bytes: number | bigint | string | null;
   content_hash: string;
   metadata: Record<string, unknown>;
   created_at: string;
@@ -40,6 +40,14 @@ function getMimeType(filePath: string): string | null {
 function fileHash(filePath: string): string {
   const content = readFileSync(filePath);
   return createHash('sha256').update(content).digest('hex');
+}
+
+export function formatFileSizeKb(rawSizeBytes: number | bigint | string | null): string {
+  if (rawSizeBytes == null) return '?';
+  const sizeBytes = Number(rawSizeBytes);
+  return Number.isFinite(sizeBytes) && sizeBytes >= 0
+    ? `${Math.round(sizeBytes / 1024)}KB`
+    : '?';
 }
 
 export async function runFiles(engine: BrainEngine, args: string[]) {
@@ -116,7 +124,7 @@ async function listFiles(engine: BrainEngine, slug?: string) {
 
   console.log(`${rows.length} file(s):`);
   for (const row of rows) {
-    const size = row.size_bytes ? `${Math.round(Number(row.size_bytes) / 1024)}KB` : '?';
+    const size = formatFileSizeKb(row.size_bytes as FileRecord['size_bytes']);
     console.log(`  ${row.page_slug || '(unlinked)'} / ${row.filename}  [${size}, ${row.mime_type || '?'}]`);
   }
 }

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -4,7 +4,7 @@ import { join, basename } from 'path';
 import { createHash } from 'crypto';
 import { extname } from 'path';
 import { tmpdir } from 'os';
-import { collectFiles } from '../src/commands/files.ts';
+import { collectFiles, formatFileSizeKb } from '../src/commands/files.ts';
 import { operationsByName } from '../src/core/operations.ts';
 import * as db from '../src/core/db.ts';
 
@@ -49,6 +49,25 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(TMP, { recursive: true, force: true });
+});
+
+describe('formatFileSizeKb', () => {
+  test('formats number, bigint, and string database values', () => {
+    expect(formatFileSizeKb(35 * 1024)).toBe('35KB');
+    expect(formatFileSizeKb(35n * 1024n)).toBe('35KB');
+    expect(formatFileSizeKb('35840')).toBe('35KB');
+  });
+
+  test('preserves zero-byte files instead of reporting an unknown size', () => {
+    expect(formatFileSizeKb(0)).toBe('0KB');
+    expect(formatFileSizeKb(0n)).toBe('0KB');
+  });
+
+  test('reports missing or invalid sizes as unknown', () => {
+    expect(formatFileSizeKb(null)).toBe('?');
+    expect(formatFileSizeKb('not-a-number')).toBe('?');
+    expect(formatFileSizeKb(-1)).toBe('?');
+  });
 });
 
 describe('getMimeType', () => {


### PR DESCRIPTION
## Problem

PR #472 fixed Postgres `BIGINT` serialization by normalizing file sizes to `Number`, but the CLI display still uses a truthiness check:

```ts
row.size_bytes ? ... : "?"
```

That reports a valid zero-byte attachment as an unknown size. The local `FileRecord` type also still says `number`, even though this direct SQL path may receive `bigint`, stringified bigint, or `null` depending on the engine/driver.

## Fix

- Add a small `formatFileSizeKb` boundary helper for database file-size values.
- Preserve `0`/`0n` as `0KB`.
- Continue returning `?` for missing, non-finite, invalid, or negative values.
- Make the local row type reflect the values the CLI can actually receive.

## Context

This is the current-master refinement of commit [`d2fce136`](https://github.com/garrytan/gbrain/commit/d2fce13662cbced9174fb36a6768dca598665afa), originally validated on a remote Postgres-backed GBrain host. The broader BigInt failure from that commit was already solved more completely by #472; this PR intentionally keeps only the remaining zero-byte display and type-safety gap.

## Verification

- `bun test test/files.test.ts`: 27 passed, 0 failed
- `bun ./node_modules/typescript/bin/tsc --noEmit`: passed
- `git diff --check`: passed
