### PR TITLE
fix(test): repair typecheck failures introduced by #3598 and #3599

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -57,8 +57,10 @@ import { registerCleanup } from '../core/process-cleanup.ts';
  */
 export const HEALTH_TIMEOUT_MS = 3000;
 
-type HttpServerLifecycle = Pick<HttpServer, 'listening' | 'once' | 'off' | 'close'>;
-type SignalSource = Pick<NodeJS.Process, 'once' | 'off'>;
+/** Exported so tests can type their structural fakes exactly (#3599). */
+export type HttpServerLifecycle = Pick<HttpServer, 'listening' | 'once' | 'off' | 'close'>;
+/** Exported so tests can type their structural fakes exactly (#3599). */
+export type SignalSource = Pick<NodeJS.Process, 'once' | 'off'>;
 type CleanupRegistrar = typeof registerCleanup;
 
 /**
@@ -200,7 +202,8 @@ export type ProbeHealthResult =
   | { ok: true; status: 200; body: { status: 'ok'; version: string; engine: string; [k: string]: unknown } }
   | { ok: false; status: 503; body: { error: 'service_unavailable'; error_description: string } };
 
-type AdminSseResponse = Pick<Response, 'setHeader' | 'flushHeaders' | 'write'>;
+/** Exported so tests can type their structural fakes exactly (#3598). */
+export type AdminSseResponse = Pick<Response, 'setHeader' | 'flushHeaders' | 'write'>;
 
 /**
  * Complete the admin EventSource handshake immediately.

--- a/test/admin-sse-handshake.test.ts
+++ b/test/admin-sse-handshake.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { openAdminSseStream } from '../src/commands/serve-http.ts';
+import { openAdminSseStream, type AdminSseResponse } from '../src/commands/serve-http.ts';
 
 describe('admin SSE handshake', () => {
   test('flushes a protocol-valid comment immediately after the headers', () => {
@@ -19,7 +19,7 @@ describe('admin SSE handshake', () => {
         calls.push(`write:${String(chunk)}`);
         return true;
       },
-    });
+    } as unknown as AdminSseResponse);
 
     expect(headers).toEqual(new Map([
       ['Content-Type', 'text/event-stream'],

--- a/test/serve-http-lifecycle.test.ts
+++ b/test/serve-http-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { EventEmitter } from 'events';
-import { waitForHttpServerLifecycle } from '../src/commands/serve-http.ts';
+import { waitForHttpServerLifecycle, type HttpServerLifecycle } from '../src/commands/serve-http.ts';
 
 class FakeHttpServer extends EventEmitter {
   listening = true;
@@ -25,8 +25,8 @@ describe('HTTP server lifecycle', () => {
     let deregistered = false;
     let resolved = false;
 
-    const lifecycle = waitForHttpServerLifecycle(server, {
-      signals,
+    const lifecycle = waitForHttpServerLifecycle(server as unknown as HttpServerLifecycle, {
+      signals: signals as unknown as NodeJS.Process,
       register(_name, fn) {
         cleanup = fn;
         return () => { deregistered = true; };
@@ -49,8 +49,8 @@ describe('HTTP server lifecycle', () => {
     const server = new FakeHttpServer();
     const signals = new EventEmitter();
 
-    const lifecycle = waitForHttpServerLifecycle(server, {
-      signals,
+    const lifecycle = waitForHttpServerLifecycle(server as unknown as HttpServerLifecycle, {
+      signals: signals as unknown as NodeJS.Process,
       register() {
         return () => {};
       },


### PR DESCRIPTION
## Summary

PRs #3598 (admin SSE handshake) and #3599 (HTTP server lifecycle retention) introduced test files with type errors that make `tsc --noEmit` fail on master.

### Changes

- **Export** `AdminSseResponse`, `HttpServerLifecycle`, and `SignalSource` from `src/commands/serve-http.ts` so test fakes can reference the structural types directly.
- **Import** the newly-exported types in the corresponding test files.
- **Cast** structural fakes through `as unknown as T` where the fake return types (`EventEmitter`, plain object) cannot structurally satisfy the full Node/Express originals.

### Test plan

- `bun tsc --noEmit` now passes cleanly (0 errors).
- Both test files pass: `bun test test/admin-sse-handshake.test.ts test/serve-http-lifecycle.test.ts` — 3/3 pass.