### PR TITLE
fix(search): classify first-person "what do I know about X" as an entity query

### DIFF
--- a/src/core/search/query-intent.ts
+++ b/src/core/search/query-intent.ts
@@ -96,7 +96,7 @@ const ENTITY_PATTERNS = [
   /\boverview\b/i,
   /\bbackground\b/i,
   /\bprofile\b/i,
-  /\bwhat\s+do\s+(you|we)\s+know\b/i,
+  /\bwhat\s+do\s+(i|you|we)\s+know\b/i,
 ];
 
 const FULL_CONTEXT_PATTERNS = [

--- a/test/query-intent.test.ts
+++ b/test/query-intent.test.ts
@@ -33,6 +33,14 @@ describe('classifyQuery — entity / canonical queries → both axes off', () =>
     expect(r.suggestedSalience).toBe('off');
   });
 
+  test('"what do I know about widget-co" → entity, same as you/we phrasings', () => {
+    const r = classifyQuery('what do I know about widget-co');
+    expect(r.intent).toBe('entity');
+    expect(r.suggestedDetail).toBe('low');
+    expect(r.suggestedRecency).toBe('off');
+    expect(r.suggestedSalience).toBe('off');
+  });
+
   test('"history of X" → both off (canonical)', () => {
     const r = classifyQuery('history of acme corp');
     expect(r.suggestedRecency).toBe('off');


### PR DESCRIPTION
Fixes #3615.

`ENTITY_PATTERNS` matched `what do you know` and `what do we know` but not `what do I know`, so the first-person phrasing fell through to `intent: 'general'` with `suggestedDetail: undefined`, while the you/we phrasings returned `entity` / `low`. `autoDetectDetail` feeds `suggestedDetail` into the retrieval plan, so three interchangeable phrasings produced two different plans.

**Before and after** on `c6dc0adf`:

| query | before | after |
|---|---|---|
| `what do I know about widget-co` | `general` / `undefined` | `entity` / `low` |
| `what do you know about widget-co` | `entity` / `low` | unchanged |
| `what do we know about widget-co` | `entity` / `low` | unchanged |

**The change** is one character in the alternation: `(you|we)` becomes `(i|you|we)`. `query-intent.ts` has no imports and no I/O, so nothing outside the pattern list is reachable from this diff. I deliberately did not add the pattern to `CANONICAL_PATTERNS` - that would force both recency and salience off for hybrid phrasings like "prep me for acme - what do we know", which the module docblock says should keep them on, and no test covers it.

**Receipts.** The added test fails on unpatched master with `Expected: "entity", Received: "general"` and passes after. `bun test test/query-intent.test.ts test/query-intent-legacy.test.ts test/cross-modal-phase1.test.ts` is 102 pass / 0 fail. `tsc --noEmit` and `check:test-names` both clean. I did not run the full suite to completion - it provisions Postgres and applies 120 migrations, and this module touches neither.

**One note in the interest of not wasting your time:** of the four assertions in the new test, only `intent` and `suggestedDetail` change behavior. `suggestedRecency` and `suggestedSalience` already pass on unpatched master - they pin existing behavior rather than prove the fix. Happy to trim them if you would rather the test assert only what moved.
