### PR TITLE
v0.42.67.0 fix(search): harden semantic cache scope isolation

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2046,16 +2046,25 @@ function rrfKey(r: SearchResult): string {
  * cache only saw scalar `sourceId`; a federated query fell through to
  * `'default'` and could cross-serve an unrelated scope.
  *
- *   - federated (sourceIds set) → `__set__:` + sorted, comma-joined ids
- *     (order-independent; two different source-sets get distinct keys)
- *   - scalar sourceId           → the id itself (single-source unchanged)
- *   - unscoped                  → `'default'` (single-source brains unchanged)
+ * Every shape uses type-tagged canonical JSON. Federated IDs are deduplicated
+ * and sorted, so set order is irrelevant without reintroducing delimiter or
+ * scalar-vs-set collisions. This intentionally cold-misses legacy cache rows
+ * once; they remain harmless, become unreadable under the existing per-row
+ * TTL, and are removable by the stock cache-prune path.
  */
 export function cacheScopeKey(opts?: { sourceId?: string; sourceIds?: string[] }): string {
+  // Empty sourceIds is deliberately not a federated scope. Both engines use
+  // the same length>0 contract and fall through to scalar/unscoped behavior.
   if (opts?.sourceIds && opts.sourceIds.length > 0) {
-    return '__set__:' + [...opts.sourceIds].sort().join(',');
+    return `scope:v1:${JSON.stringify({
+      kind: 'set',
+      sourceIds: [...new Set(opts.sourceIds)].sort(),
+    })}`;
   }
-  return opts?.sourceId ?? 'default';
+  if (opts?.sourceId !== undefined) {
+    return `scope:v1:${JSON.stringify({ kind: 'single', sourceId: opts.sourceId })}`;
+  }
+  return `scope:v1:${JSON.stringify({ kind: 'default' })}`;
 }
 
 /**

--- a/test/cache-scope-key.test.ts
+++ b/test/cache-scope-key.test.ts
@@ -12,20 +12,24 @@ import { describe, test, expect } from 'bun:test';
 import { cacheScopeKey } from '../src/core/search/hybrid.ts';
 
 describe('cacheScopeKey', () => {
-  test('unscoped → default (single-source unchanged)', () => {
-    expect(cacheScopeKey(undefined)).toBe('default');
-    expect(cacheScopeKey({})).toBe('default');
+  test('unscoped → canonical default scope', () => {
+    expect(cacheScopeKey(undefined)).toBe('scope:v1:{"kind":"default"}');
+    expect(cacheScopeKey({})).toBe('scope:v1:{"kind":"default"}');
+    expect(cacheScopeKey({ sourceIds: [] })).toBe('scope:v1:{"kind":"default"}');
   });
 
-  test('scalar sourceId → itself (single-source unchanged)', () => {
-    expect(cacheScopeKey({ sourceId: 'host' })).toBe('host');
+  test('scalar sourceId → typed canonical scalar scope', () => {
+    expect(cacheScopeKey({ sourceId: 'host' }))
+      .toBe('scope:v1:{"kind":"single","sourceId":"host"}');
   });
 
   test('federated sourceIds → order-independent set key', () => {
     const k1 = cacheScopeKey({ sourceIds: ['team-b', 'team-a', 'host'] });
     const k2 = cacheScopeKey({ sourceIds: ['host', 'team-a', 'team-b'] });
     expect(k1).toBe(k2); // order does not matter
-    expect(k1).toBe('__set__:host,team-a,team-b');
+    expect(k1).toBe(
+      'scope:v1:{"kind":"set","sourceIds":["host","team-a","team-b"]}',
+    );
   });
 
   test('different source-sets do NOT share a key', () => {
@@ -38,5 +42,17 @@ describe('cacheScopeKey', () => {
     const set = cacheScopeKey({ sourceIds: ['host'] });
     const scalar = cacheScopeKey({ sourceId: 'host' });
     expect(set).not.toBe(scalar); // a 1-element set still cannot serve a scalar read
+  });
+
+  test('delimiter-like and type-like source ids cannot collide', () => {
+    expect(cacheScopeKey({ sourceIds: ['a,b'] }))
+      .not.toBe(cacheScopeKey({ sourceIds: ['a', 'b'] }));
+    expect(cacheScopeKey({ sourceIds: ['a', 'b'] }))
+      .not.toBe(cacheScopeKey({ sourceId: '__set__:a,b' }));
+  });
+
+  test('duplicate federated ids normalize to set identity', () => {
+    expect(cacheScopeKey({ sourceIds: ['team-a', 'host', 'team-a'] }))
+      .toBe(cacheScopeKey({ sourceIds: ['host', 'team-a'] }));
   });
 });


### PR DESCRIPTION
## Summary

- harden semantic query-cache isolation across default, scalar, and federated source scopes
- canonicalize federated source-set identity
- add focused regression coverage for scope separation

## Status

Closed pending additional cache-invalidation coverage. This change is not ready
to merge.

The next revision must prove that source-scoped and schema-change invalidation
clears every compatible cache-scope representation without affecting unrelated
sources.
