### PR TITLE
fix(embed): stop infinite-retry congestion collapse against local embedding servers

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -10,6 +10,31 @@ import { slog, serr } from '../core/console-prefix.ts';
 import { filterOutEmbedSkipped } from '../core/embed-skip.ts';
 import { runSlidingPool } from '../core/worker-pool.ts';
 
+/**
+ * Failure quarantine for the --stale path. A page whose embed fails keeps
+ * its NULL chunks, so every stale pass re-sends the identical request — a
+ * page that fails deterministically (e.g. always outlives a local server's
+ * timeout) is retried forever, and against a serial embedding server the
+ * abandoned work compounds into congestion collapse. After
+ * GBRAIN_EMBED_QUARANTINE_AFTER consecutive failures (default 3) a page is
+ * skipped for the rest of this process; a success resets its counter.
+ * Process-lifetime by design: a long-lived autopilot stops re-sending
+ * doomed pages every cycle, while a restart (or frontmatter.embed_skip for
+ * a permanent block) lets the operator retry deliberately.
+ * Keyed `${source_id}::${slug}` to match the stale-batch grouping.
+ */
+const _embedFailureCounts = new Map<string, number>();
+
+/** Test seam: clear quarantine state between test runs. */
+export function _resetEmbedQuarantineForTest(): void {
+  _embedFailureCounts.clear();
+}
+
+function embedQuarantineThreshold(): number {
+  const raw = parseInt(process.env.GBRAIN_EMBED_QUARANTINE_AFTER || '3', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 3;
+}
+
 export interface EmbedOpts {
   /** Embed ALL pages (every chunk). */
   all?: boolean;
@@ -683,7 +708,12 @@ async function embedAllStale(
         else byKey.set(key, [row]);
       }
 
-      const keys = Array.from(byKey.keys());
+      const QUARANTINE_AFTER = embedQuarantineThreshold();
+      const allKeys = Array.from(byKey.keys());
+      const keys = allKeys.filter(k => (_embedFailureCounts.get(k) ?? 0) < QUARANTINE_AFTER);
+      if (keys.length < allKeys.length) {
+        serr(`\n  [embed] skipping ${allKeys.length - keys.length} page(s) quarantined after ${QUARANTINE_AFTER} consecutive failed embed attempts (this process); set frontmatter.embed_skip to skip permanently, or restart to retry`);
+      }
       result.total_chunks += batch.length;
 
       async function embedOneKey(key: string) {
@@ -715,11 +745,17 @@ async function embedAllStale(
             await engine.setPageEmbeddingSignature(slug, { sourceId: keySourceId, signature });
           }
           result.embedded += stale.length;
+          _embedFailureCounts.delete(key);
         } catch (e: unknown) {
           // Budget-fired aborts are expected on the way out; don't spam
           // per-page "Error embedding" lines when we're shutting down.
           if (budgetSignal.aborted) return;
           serr(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
+          const failures = (_embedFailureCounts.get(key) ?? 0) + 1;
+          _embedFailureCounts.set(key, failures);
+          if (failures === QUARANTINE_AFTER) {
+            serr(`\n  [embed] ${slug}: ${failures} consecutive failed attempt(s) — quarantined for the rest of this process`);
+          }
         }
         totalProcessedPages++;
         result.pages_processed++;

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1309,7 +1309,15 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const expected = effectiveDims;
 
   const embedding = recipe.touchpoints?.embedding;
-  const maxBatchTokens = embedding?.max_batch_tokens;
+  // GBRAIN_EMBED_MAX_BATCH_TOKENS: operator-declared cap for recipes that
+  // ship without one (ollama/llama-server/litellm declare no_batch_cap
+  // because real capacity depends on the operator's local server). Without
+  // any cap, a page's entire chunk set goes out as ONE request — on a
+  // serial local server that can outlive the embed timeout and starve the
+  // queue. Recipe-declared caps always win; invalid values are ignored.
+  const envCapRaw = parseInt(process.env.GBRAIN_EMBED_MAX_BATCH_TOKENS ?? '', 10);
+  const envCap = Number.isFinite(envCapRaw) && envCapRaw > 0 ? envCapRaw : undefined;
+  const maxBatchTokens = embedding?.max_batch_tokens ?? envCap;
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)

--- a/test/ai/embed-env-batch-cap.test.ts
+++ b/test/ai/embed-env-batch-cap.test.ts
@@ -26,6 +26,7 @@ import {
   embed,
   __setEmbedTransportForTests,
 } from '../../src/core/ai/gateway.ts';
+import { withEnv } from '../helpers/with-env.ts';
 
 function fakeEmbeddings(values: string[], dims: number): { embeddings: number[][] } {
   return {
@@ -46,87 +47,86 @@ function configureOllama(): void {
 const ENV_KEY = 'GBRAIN_EMBED_MAX_BATCH_TOKENS';
 
 describe('GBRAIN_EMBED_MAX_BATCH_TOKENS env cap for no_batch_cap recipes', () => {
-  let savedEnv: string | undefined;
-
   beforeEach(() => {
-    savedEnv = process.env[ENV_KEY];
-    delete process.env[ENV_KEY];
     resetGateway();
   });
 
   afterEach(() => {
-    if (savedEnv === undefined) delete process.env[ENV_KEY];
-    else process.env[ENV_KEY] = savedEnv;
     __setEmbedTransportForTests(null);
   });
 
   test('env cap set → ollama batches are pre-split and each stays within the token budget', async () => {
-    process.env[ENV_KEY] = '1000';
-    configureOllama();
+    await withEnv({ [ENV_KEY]: '1000' }, async () => {
+      configureOllama();
 
-    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
-    __setEmbedTransportForTests(stub as any);
+      const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+      __setEmbedTransportForTests(stub as any);
 
-    // 10 texts × 2000 chars = 500 tokens each at the default 4 chars/token.
-    // Budget 1000 tokens → at most 2 texts per batch (fewer if the safety
-    // factor tightens it) → at least 5 transport calls, never 1.
-    const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
-    const result = await embed(texts);
+      // 10 texts × 2000 chars = 500 tokens each at the default 4 chars/token.
+      // Budget 1000 tokens → at most 2 texts per batch (fewer if the safety
+      // factor tightens it) → at least 5 transport calls, never 1.
+      const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
+      const result = await embed(texts);
 
-    expect(result).toHaveLength(10);
-    expect(stub.mock.calls.length).toBeGreaterThan(1);
-    for (const [arg] of stub.mock.calls) {
-      const batch = (arg as { values: string[] }).values;
-      const batchChars = batch.reduce((s, t) => s + t.length, 0);
-      // 1000 tokens × 4 chars/token = 4000 chars absolute ceiling per batch.
-      expect(batchChars).toBeLessThanOrEqual(4000);
-    }
+      expect(result).toHaveLength(10);
+      expect(stub.mock.calls.length).toBeGreaterThan(1);
+      for (const [arg] of stub.mock.calls) {
+        const batch = (arg as { values: string[] }).values;
+        const batchChars = batch.reduce((s, t) => s + t.length, 0);
+        // 1000 tokens × 4 chars/token = 4000 chars absolute ceiling per batch.
+        expect(batchChars).toBeLessThanOrEqual(4000);
+      }
+    });
   });
 
   test('env cap absent → single transport call (existing fast-path preserved)', async () => {
-    configureOllama();
+    await withEnv({ [ENV_KEY]: undefined }, async () => {
+      configureOllama();
 
-    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
-    __setEmbedTransportForTests(stub as any);
+      const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+      __setEmbedTransportForTests(stub as any);
 
-    const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
-    const result = await embed(texts);
+      const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
+      const result = await embed(texts);
 
-    expect(stub).toHaveBeenCalledTimes(1);
-    expect(result).toHaveLength(10);
+      expect(stub).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(10);
+    });
   });
 
   test.each(['0', '-5', 'abc', ''])('invalid env value %j → fast path unchanged', async (bad) => {
-    process.env[ENV_KEY] = bad;
-    configureOllama();
+    await withEnv({ [ENV_KEY]: bad }, async () => {
+      configureOllama();
 
-    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
-    __setEmbedTransportForTests(stub as any);
+      const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+      __setEmbedTransportForTests(stub as any);
 
-    const result = await embed(['a'.repeat(8000), 'b'.repeat(8000)]);
-    expect(stub).toHaveBeenCalledTimes(1);
-    expect(result).toHaveLength(2);
+      const result = await embed(['a'.repeat(8000), 'b'.repeat(8000)]);
+      expect(stub).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(2);
+    });
   });
 
   test('recipe-declared max_batch_tokens wins over a larger env value', async () => {
     // Voyage declares max_batch_tokens=120000 with safety_factor 0.5 →
     // 60K-token effective budget. A huge env value must NOT loosen it.
-    process.env[ENV_KEY] = '99000000';
-    configureGateway({
-      embedding_model: 'voyage:voyage-3-large',
-      embedding_dimensions: 1024,
-      env: { VOYAGE_API_KEY: 'sk-fake' },
+    await withEnv({ [ENV_KEY]: '99000000' }, async () => {
+      configureGateway({
+        embedding_model: 'voyage:voyage-3-large',
+        embedding_dimensions: 1024,
+        env: { VOYAGE_API_KEY: 'sk-fake' },
+      });
+
+      const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1024));
+      __setEmbedTransportForTests(stub as any);
+
+      // 20 texts × 8000 chars (= MAX_CHARS, so no truncation) = 8000 tokens
+      // each at voyage's 1 char/token density → 160K tokens total against a
+      // 60K effective budget → must split into >1 call. If the env value
+      // (99M) leaked past the recipe cap, everything would fit in 1 call.
+      const texts = Array.from({ length: 20 }, (_, i) => `${i % 10}`.repeat(8000));
+      await embed(texts);
+      expect(stub.mock.calls.length).toBeGreaterThan(1);
     });
-
-    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1024));
-    __setEmbedTransportForTests(stub as any);
-
-    // 20 texts × 8000 chars (= MAX_CHARS, so no truncation) = 8000 tokens
-    // each at voyage's 1 char/token density → 160K tokens total against a
-    // 60K effective budget → must split into >1 call. If the env value
-    // (99M) leaked past the recipe cap, everything would fit in 1 call.
-    const texts = Array.from({ length: 20 }, (_, i) => `${i % 10}`.repeat(8000));
-    await embed(texts);
-    expect(stub.mock.calls.length).toBeGreaterThan(1);
   });
 });

--- a/test/ai/embed-env-batch-cap.test.ts
+++ b/test/ai/embed-env-batch-cap.test.ts
@@ -1,0 +1,132 @@
+/**
+ * GBRAIN_EMBED_MAX_BATCH_TOKENS — operator-declared batch cap for
+ * no_batch_cap recipes (ollama, llama-server, litellm).
+ *
+ * Why: local inference servers (ollama with `-np 1`) process one request
+ * at a time and keep computing client-aborted requests. Without a batch
+ * cap, embed() sends a page's ENTIRE chunk set as one request; a request
+ * that outlives the embed timeout is retried forever by the stale-page
+ * loop while the server grinds abandoned work — a self-sustaining
+ * congestion collapse (observed 2026-07-29/30: 6,900+ timeouts, ~4 cores
+ * pinned). The recipes deliberately declare `no_batch_cap: true` because
+ * real capacity depends on the operator's hardware — so the cap is an
+ * operator env knob, mirroring GBRAIN_EMBED_CONCURRENCY.
+ *
+ * Coverage:
+ *  - env cap set + no_batch_cap recipe → pre-split into bounded batches
+ *  - env cap absent → existing single-call fast path (regression guard)
+ *  - invalid env values (0, negative, garbage) → fast path unchanged
+ *  - recipe-declared max_batch_tokens still wins over the env knob
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  configureGateway,
+  resetGateway,
+  embed,
+  __setEmbedTransportForTests,
+} from '../../src/core/ai/gateway.ts';
+
+function fakeEmbeddings(values: string[], dims: number): { embeddings: number[][] } {
+  return {
+    embeddings: values.map((_, i) =>
+      Array.from({ length: dims }, (_, j) => (j === 0 ? i : 0.1)),
+    ),
+  };
+}
+
+function configureOllama(): void {
+  configureGateway({
+    embedding_model: 'ollama:nomic-embed-text',
+    embedding_dimensions: 768,
+    env: {},
+  });
+}
+
+const ENV_KEY = 'GBRAIN_EMBED_MAX_BATCH_TOKENS';
+
+describe('GBRAIN_EMBED_MAX_BATCH_TOKENS env cap for no_batch_cap recipes', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    resetGateway();
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    __setEmbedTransportForTests(null);
+  });
+
+  test('env cap set → ollama batches are pre-split and each stays within the token budget', async () => {
+    process.env[ENV_KEY] = '1000';
+    configureOllama();
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+    __setEmbedTransportForTests(stub as any);
+
+    // 10 texts × 2000 chars = 500 tokens each at the default 4 chars/token.
+    // Budget 1000 tokens → at most 2 texts per batch (fewer if the safety
+    // factor tightens it) → at least 5 transport calls, never 1.
+    const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(10);
+    expect(stub.mock.calls.length).toBeGreaterThan(1);
+    for (const [arg] of stub.mock.calls) {
+      const batch = (arg as { values: string[] }).values;
+      const batchChars = batch.reduce((s, t) => s + t.length, 0);
+      // 1000 tokens × 4 chars/token = 4000 chars absolute ceiling per batch.
+      expect(batchChars).toBeLessThanOrEqual(4000);
+    }
+  });
+
+  test('env cap absent → single transport call (existing fast-path preserved)', async () => {
+    configureOllama();
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(2000));
+    const result = await embed(texts);
+
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(10);
+  });
+
+  test.each(['0', '-5', 'abc', ''])('invalid env value %j → fast path unchanged', async (bad) => {
+    process.env[ENV_KEY] = bad;
+    configureOllama();
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 768));
+    __setEmbedTransportForTests(stub as any);
+
+    const result = await embed(['a'.repeat(8000), 'b'.repeat(8000)]);
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+  });
+
+  test('recipe-declared max_batch_tokens wins over a larger env value', async () => {
+    // Voyage declares max_batch_tokens=120000 with safety_factor 0.5 →
+    // 60K-token effective budget. A huge env value must NOT loosen it.
+    process.env[ENV_KEY] = '99000000';
+    configureGateway({
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_dimensions: 1024,
+      env: { VOYAGE_API_KEY: 'sk-fake' },
+    });
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1024));
+    __setEmbedTransportForTests(stub as any);
+
+    // 20 texts × 8000 chars (= MAX_CHARS, so no truncation) = 8000 tokens
+    // each at voyage's 1 char/token density → 160K tokens total against a
+    // 60K effective budget → must split into >1 call. If the env value
+    // (99M) leaked past the recipe cap, everything would fit in 1 call.
+    const texts = Array.from({ length: 20 }, (_, i) => `${i % 10}`.repeat(8000));
+    await embed(texts);
+    expect(stub.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/test/embed-quarantine.serial.test.ts
+++ b/test/embed-quarantine.serial.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Embed failure quarantine (--stale path).
+ *
+ * Why: a page whose embed fails is only logged; its chunks stay NULL, so
+ * every autopilot cycle re-sends the exact same doomed request forever.
+ * Against a serial local embedding server (ollama `-np 1`) that keeps
+ * computing client-aborted requests, this self-sustains into a congestion
+ * collapse (observed 2026-07-29/30: 6,900+ timeouts, pages retried 29×,
+ * ~4 CPU cores pinned for days). The quarantine gives the loop a give-up
+ * point: after N consecutive failed attempts in one process, the page is
+ * skipped until the process restarts (or the operator sets
+ * frontmatter.embed_skip permanently).
+ *
+ * Coverage:
+ *  - page failing GBRAIN_EMBED_QUARANTINE_AFTER (default 3) consecutive
+ *    runs is skipped on the next run
+ *  - a success resets the counter (transient blips never quarantine)
+ *  - the threshold is operator-tunable via env
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let totalPoisonCalls = 0;
+let embedShouldFail = true;
+
+mock.module('../src/core/embedding.ts', () => ({
+  embedBatch: async (texts: string[]) => {
+    if (texts.some(t => t.includes('POISON'))) {
+      totalPoisonCalls++;
+      if (embedShouldFail) throw new Error('[embed(ollama:nomic-embed-text)] The operation timed out.');
+    }
+    return texts.map(() => new Float32Array(1536));
+  },
+  currentEmbeddingSignature: () => 'test:model:1536',
+}));
+
+const { runEmbed, _resetEmbedQuarantineForTest } = await import('../src/commands/embed.ts');
+
+const { __setEmbedTransportForTests } = await import('../src/core/ai/gateway.ts');
+__setEmbedTransportForTests(async () => ({ embeddings: [], usage: { tokens: 0 } } as any));
+
+function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
+  const calls: { method: string; args: any[] }[] = [];
+  const track = (method: string) => (...args: any[]) => {
+    calls.push({ method, args });
+    if (overrides[method]) return overrides[method](...args);
+    return Promise.resolve(null);
+  };
+  const engine = new Proxy({} as any, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (overrides[prop]) return overrides[prop];
+      return track(prop);
+    },
+  });
+  return engine;
+}
+
+const POISON_ROWS = [
+  { page_id: 1, chunk_index: 0, source_id: 'default', slug: 'poison', chunk_text: 'POISON chunk one', token_count: 4 },
+  { page_id: 1, chunk_index: 1, source_id: 'default', slug: 'poison', chunk_text: 'POISON chunk two', token_count: 4 },
+];
+
+function poisonEngine(): BrainEngine {
+  return mockEngine({
+    countStaleChunks: async () => POISON_ROWS.length,
+    listStaleChunks: async (opts: { afterPageId: number }) =>
+      opts.afterPageId === 0 ? POISON_ROWS : [],
+    invalidateStaleSignatureEmbeddings: async () => 0,
+    getChunks: async () => POISON_ROWS.map(r => ({
+      chunk_index: r.chunk_index, chunk_text: r.chunk_text,
+      chunk_source: 'compiled_truth', token_count: r.token_count,
+    })),
+    upsertChunks: async () => {},
+    setPageEmbeddingSignature: async () => {},
+  });
+}
+
+beforeEach(() => {
+  totalPoisonCalls = 0;
+  embedShouldFail = true;
+  _resetEmbedQuarantineForTest?.();
+});
+
+afterEach(() => {
+  delete process.env.GBRAIN_EMBED_QUARANTINE_AFTER;
+  delete process.env.GBRAIN_EMBED_CONCURRENCY;
+});
+
+describe('embed --stale failure quarantine', () => {
+  test('page failing 3 consecutive runs is quarantined on the 4th', async () => {
+    const engine = poisonEngine();
+
+    for (let run = 1; run <= 3; run++) {
+      await runEmbed(engine, ['--stale']);
+      expect(totalPoisonCalls).toBe(run); // one attempt per run, no more
+    }
+
+    await runEmbed(engine, ['--stale']);
+    // Quarantined: run 4 must NOT send the doomed page to the provider.
+    expect(totalPoisonCalls).toBe(3);
+  });
+
+  test('a success resets the failure counter', async () => {
+    const engine = poisonEngine();
+
+    await runEmbed(engine, ['--stale']); // fail #1
+    await runEmbed(engine, ['--stale']); // fail #2
+    embedShouldFail = false;
+    await runEmbed(engine, ['--stale']); // success → counter resets
+    embedShouldFail = true;
+    await runEmbed(engine, ['--stale']); // fail #1 (fresh count)
+    // Without reset the page would already be quarantined here (3 cumulative
+    // failures) and this run would add no call. With reset it must attempt.
+    expect(totalPoisonCalls).toBe(4);
+
+    await runEmbed(engine, ['--stale']); // fail #2
+    await runEmbed(engine, ['--stale']); // fail #3 → quarantine
+    await runEmbed(engine, ['--stale']); // skipped
+    expect(totalPoisonCalls).toBe(6);
+  });
+
+  test('threshold is tunable via GBRAIN_EMBED_QUARANTINE_AFTER', async () => {
+    process.env.GBRAIN_EMBED_QUARANTINE_AFTER = '1';
+    const engine = poisonEngine();
+
+    await runEmbed(engine, ['--stale']); // fail #1 → quarantine immediately
+    await runEmbed(engine, ['--stale']); // skipped
+    expect(totalPoisonCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Two operator-tunable fixes for a failure mode where `embed --stale` (and the autopilot cycle that calls it) can never finish against a local embedding server:

1. **`GBRAIN_EMBED_MAX_BATCH_TOKENS`** (gateway): fills the pre-split budget for recipes that declare `no_batch_cap: true` (ollama, llama-server, litellm). Recipe-declared caps still win; invalid values are ignored. Mirrors the existing `GBRAIN_EMBED_CONCURRENCY` operator-knob pattern — the recipes stay cap-free by design since real capacity depends on the operator's hardware.
2. **Failure quarantine** (`embed --stale`): after `GBRAIN_EMBED_QUARANTINE_AFTER` consecutive failed attempts (default 3), a page is skipped for the rest of the process; success resets the counter. Restart or `frontmatter.embed_skip` retries/blocks deliberately.

## Why

Observed in production (8-core VPS, ollama 0.32.1 CPU-only, nomic-embed-text, `-np 1`):

- With no batch cap, a page's entire chunk set ships as ONE request. On a serial server a request can outlive any client timeout.
- The timeout aborts the client side only — ollama keeps computing the abandoned request.
- The failed page stays stale, so every cycle re-sends the identical doomed request: 6,900+ logged timeouts, individual pages retried 29×, ~4 cores pinned for days, backfill never finishing.
- The existing halving rescue only fires on token-limit errors, never on timeouts, so nothing bounded the request size.

With `GBRAIN_EMBED_MAX_BATCH_TOKENS=2048`, the same brain drained its 39K-chunk backlog cleanly — including the three pages that had failed 21–29 times each.

## Tests

- `test/ai/embed-env-batch-cap.test.ts` — env cap splits batches within budget; absent/invalid env preserves the single-call fast path; recipe caps win over the env knob.
- `test/embed-quarantine.serial.test.ts` — quarantine after N consecutive failed runs; success resets the counter; threshold tunable via env.
- Written test-first (both watched failing before implementation). `bun test test/ai/` (330), `test/embed.serial.test.ts` (26), `test/embed-helper-migration.test.ts`, typecheck — all green.

## Notes

- No VERSION/CHANGELOG bump — left to the maintainer's release wave per docs/RELEASING.md.
- Quarantine is process-lifetime state only (no schema change); a persistent variant would need an attempts column and felt too invasive for a first pass — happy to follow up if wanted.