### PR TITLE
v0.42.68.0 perf(test): bound PGLite unit-suite memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ AGENTS.local.md
 
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar
+test/fixtures/pglite-snapshot.metadata.json
 test/fixtures/pglite-snapshot.version
 
 # Private brain reports — never check these in (per CLAUDE.md privacy rule)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,13 +11,23 @@ Seven test command tiers, each with a clear scope:
 
 | Command | What it runs | Wallclock | When to use |
 |---|---|---|---|
-| `bun run test` | Parallel unit-test fast loop. 8-shard fan-out via `scripts/run-unit-parallel.sh`, then a serial pass over `*.serial.test.ts`. Excludes `*.slow.test.ts` and `test/e2e/*`. No pre-checks, no typecheck. | ~85s on a Mac dev box (3650+ tests) | Inner edit loop. Default. |
+| `bun run test` | Parallel unit-test fast loop. 3-shard fan-out via `scripts/run-unit-parallel.sh`; each shard recycles Bun after bounded file batches, then a serial pass over `*.serial.test.ts`. Excludes `*.slow.test.ts` and `test/e2e/*`. Builds and validates a pre-migrated PGLite snapshot before fan-out. No pre-checks, no typecheck. | Host-dependent | Inner edit loop. Default. |
 | `bun run verify` | CI's authoritative pre-test gate set, fanned out in parallel by `scripts/run-verify-parallel.sh`: the full `check:*` battery (~30 checks — privacy, jsonb, progress, source-id, test-isolation, wasm, …) plus `bun run typecheck`. The `CHECKS` array in that script is the single source of truth — CI literally calls `bun run verify` in a dedicated job. | ~16s (parallel; typecheck dominates) | Before pushing; before `/ship`. |
 | `bun run test:full` | `verify && bun run test && bun run test:slow && [smart e2e]`. The local equivalent of "everything CI runs." Smart e2e: runs e2e only when `DATABASE_URL` is set; else loud skip notice to stderr. | ~3-5min depending on slow + e2e | Pre-merge sanity, before opening a PR. |
 | `bun run test:slow` | Just the `*.slow.test.ts` set (intentional cold-path correctness checks). | seconds-to-minutes | When touching slow-path code. |
 | `bun run test:serial` | Just the `*.serial.test.ts` set (cross-file-contention quarantine; one bun process per file for true module-registry isolation). | ~1s per quarantined file | Debugging a specific quarantined file. |
 | `bun run test:e2e` | Real Postgres E2E. Requires Docker + `DATABASE_URL`. Sequential. | ~5-10min | Pre-ship; nightly. |
 | `bun run check:all` | The historical pre-check scripts (22, chained sequentially in package.json). Overlaps `verify` heavily but is NOT a superset — `verify`'s `CHECKS` array in `scripts/run-verify-parallel.sh` (~30 entries incl. typecheck) is the authoritative gate; `check:all` keeps a few local-only extras (trailing-newline, exports-count, no-legacy-getconnection). | ~10s | Local-only sweep for the extras. |
+
+#### Unit-runner memory controls
+
+The fast-loop runner limits retained PGLite/WASM memory in two complementary ways:
+
+- `GBRAIN_TEST_BATCH_SIZE` (default `10`) limits files per Bun process. The process exits after each batch so its WASM high-water memory returns to the OS. `--batch-size N` overrides it locally. Cold migration/bootstrap coverage uses the stricter `GBRAIN_TEST_COLD_BATCH_SIZE` (default `2`).
+- `run-unit-parallel.sh` builds `test/fixtures/pglite-snapshot.tar` once and exports `GBRAIN_PGLITE_SNAPSHOT` to all snapshot-safe batches. Metadata binds the tar checksum to the rendered embedding schema and migration handlers. Stale, corrupt, or profile-incompatible fixtures fall back to cold `initSchema()` with a warning.
+- Migration/bootstrap files run in dedicated cold batches with `GBRAIN_PGLITE_SNAPSHOT` cleared. Set `GBRAIN_PGLITE_SNAPSHOT=off` to force the complete fast loop cold for debugging.
+
+Snapshot files are generated and gitignored. Rebuild manually with `bun run build:pglite-snapshot`; the default builder profile matches `bun test` (`openai:text-embedding-3-large`, 1536 dimensions). Alternate controlled profiles may use `GBRAIN_PGLITE_SNAPSHOT_DIMS`, `GBRAIN_PGLITE_SNAPSHOT_MODEL`, and `GBRAIN_PGLITE_SNAPSHOT_PATH`.
 
 ### Shell dispatch and Windows
 

--- a/scripts/build-pglite-snapshot.ts
+++ b/scripts/build-pglite-snapshot.ts
@@ -7,11 +7,11 @@
 // 1-3 seconds of cold init and load the post-schema state directly.
 //
 // Output: test/fixtures/pglite-snapshot.tar (binary, gitignored)
-//         test/fixtures/pglite-snapshot.version (hex SHA256 of MIGRATIONS SQL)
+//         test/fixtures/pglite-snapshot.metadata.json (gitignored)
 //
-// The version file lets the engine detect snapshot staleness — if the tar's
-// recorded version doesn't match the current MIGRATIONS hash, the engine
-// ignores the snapshot and runs a normal initSchema.
+// Metadata binds the tar checksum to the runtime-rendered test schema and full
+// migration semantics. A mismatch makes the engine ignore the snapshot and
+// run normal initSchema.
 //
 // Run: bun run scripts/build-pglite-snapshot.ts
 //      (or: bun run build:pglite-snapshot)
@@ -22,21 +22,31 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import * as crypto from "node:crypto";
 
-import { PGLiteEngine, computeSnapshotSchemaHash } from "../src/core/pglite-engine.ts";
+import { PGLiteEngine, createSnapshotMetadata } from "../src/core/pglite-engine.ts";
 import { MIGRATIONS } from "../src/core/migrate.ts";
-import { PGLITE_SCHEMA_SQL } from "../src/core/pglite-schema.ts";
-
-function computeSchemaHash(): string {
-  return computeSnapshotSchemaHash(MIGRATIONS, PGLITE_SCHEMA_SQL, crypto);
-}
+import { getPGLiteSchema } from "../src/core/pglite-schema.ts";
+import { configureGateway } from "../src/core/ai/gateway.ts";
 
 async function main() {
-  const fixturePath = "test/fixtures/pglite-snapshot.tar";
-  const versionPath = "test/fixtures/pglite-snapshot.version";
+  const fixturePath = process.env.GBRAIN_PGLITE_SNAPSHOT_PATH || "test/fixtures/pglite-snapshot.tar";
+  const replacedMetadataPath = fixturePath.replace(/\.tar(?:\.gz)?$/, ".metadata.json");
+  const metadataPath = replacedMetadataPath === fixturePath
+    ? `${fixturePath}.metadata.json`
+    : replacedMetadataPath;
   mkdirSync(dirname(fixturePath), { recursive: true });
 
-  const schemaHash = computeSchemaHash();
-  console.log(`[build-pglite-snapshot] schema hash: ${schemaHash.slice(0, 16)}...`);
+  // `bun run` does not load bunfig's test preload. Build explicitly with the
+  // same legacy profile used by `bun test`; tests that choose another profile
+  // receive a metadata mismatch and safely cold-initialize.
+  const dims = Number(process.env.GBRAIN_PGLITE_SNAPSHOT_DIMS || "1536");
+  const model = process.env.GBRAIN_PGLITE_SNAPSHOT_MODEL || "openai:text-embedding-3-large";
+  if (!Number.isInteger(dims) || dims <= 0) {
+    throw new Error(`invalid GBRAIN_PGLITE_SNAPSHOT_DIMS: ${process.env.GBRAIN_PGLITE_SNAPSHOT_DIMS}`);
+  }
+  configureGateway({ embedding_dimensions: dims, embedding_model: model, env: { ...process.env } });
+  const renderedSchema = getPGLiteSchema(dims, model);
+
+  console.log(`[build-pglite-snapshot] profile: ${model} / ${dims}d`);
   console.log(`[build-pglite-snapshot] booting PGLite (in-memory)...`);
   const engine = new PGLiteEngine();
 
@@ -53,12 +63,13 @@ async function main() {
   const dump = await engine.db.dumpDataDir("none");
   const buffer = Buffer.from(await dump.arrayBuffer());
 
+  const metadata = createSnapshotMetadata(buffer, MIGRATIONS, renderedSchema, crypto);
   writeFileSync(fixturePath, buffer);
-  writeFileSync(versionPath, schemaHash + "\n");
+  writeFileSync(metadataPath, JSON.stringify(metadata, null, 2) + "\n");
   await engine.disconnect();
 
   console.log(`[build-pglite-snapshot] wrote ${fixturePath} (${buffer.length} bytes)`);
-  console.log(`[build-pglite-snapshot] wrote ${versionPath}`);
+  console.log(`[build-pglite-snapshot] wrote ${metadataPath}`);
 }
 
 await main();

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -236,12 +236,8 @@ bash scripts/check-progress-to-stdout.sh
 bash scripts/check-trailing-newline.sh
 bash scripts/check-wasm-embedded.sh
 bun run typecheck
-echo \"[runner] Tier 3: building PGLite snapshot fixture (cached across reruns)\"
-if [ ! -f test/fixtures/pglite-snapshot.tar ] || [ ! -f test/fixtures/pglite-snapshot.version ]; then
-  bun run build:pglite-snapshot
-else
-  echo \"[runner] snapshot fixture exists; engine will validate hash at load time\"
-fi
+echo \"[runner] Tier 3: building PGLite snapshot fixture\"
+bun run build:pglite-snapshot
 export GBRAIN_PGLITE_SNAPSHOT=test/fixtures/pglite-snapshot.tar
 echo \"[runner] resolving E2E file selection (--diff aware)\"
 ${DIFF_E2E_PREP}

--- a/scripts/run-serial-tests.sh
+++ b/scripts/run-serial-tests.sh
@@ -41,10 +41,23 @@ echo "[serial-tests] running ${#files[@]} file(s), one bun process per file"
 fail_count=0
 failed_files=()
 for f in "${files[@]}"; do
-  if ! bun test --max-concurrency=1 --timeout=60000 "$f"; then
-    fail_count=$((fail_count + 1))
-    failed_files+=("$f")
-  fi
+  # Migration/bootstrap contracts must exercise a genuinely empty data dir;
+  # the pre-migrated snapshot would turn initSchema() into a no-op. Keep this
+  # list aligned with run-unit-shard.sh's cold-path classifier.
+  case "$f" in
+    test/*migrat*.serial.test.ts|test/*bootstrap*.serial.test.ts|test/unified-multimodal.serial.test.ts)
+      if ! GBRAIN_PGLITE_SNAPSHOT= bun test --max-concurrency=1 --timeout=60000 "$f"; then
+        fail_count=$((fail_count + 1))
+        failed_files+=("$f")
+      fi
+      ;;
+    *)
+      if ! bun test --max-concurrency=1 --timeout=60000 "$f"; then
+        fail_count=$((fail_count + 1))
+        failed_files+=("$f")
+      fi
+      ;;
+  esac
 done
 
 if [ "$fail_count" -gt 0 ]; then

--- a/scripts/run-unit-parallel.sh
+++ b/scripts/run-unit-parallel.sh
@@ -9,12 +9,15 @@
 # prefixes, prints loud stderr banner if any failures, exit non-zero.
 #
 # Usage:
-#   bash scripts/run-unit-parallel.sh [--shards N] [--max-concurrency N] [--dry-run]
+#   bash scripts/run-unit-parallel.sh [--shards N] [--max-concurrency N] [--batch-size N] [--dry-run]
 #
 # Env overrides:
 #   SHARDS=N                     same as --shards
 #   GBRAIN_TEST_SHARD_TIMEOUT    per-shard wallclock cap, seconds (default 600)
 #   GBRAIN_TEST_MAX_CONCURRENCY  passed through to bun test (default 4)
+#   GBRAIN_TEST_BATCH_SIZE       files per recycled Bun process (default 10)
+#   GBRAIN_TEST_COLD_BATCH_SIZE  migration/bootstrap files per process (default 2)
+#   GBRAIN_PGLITE_SNAPSHOT=off   disable the local pre-migrated snapshot
 #
 # Output files (workspace-local; falls back to /tmp if .context/ unwritable):
 #   .context/test-failures.log   failure blocks (cleared at start)
@@ -42,6 +45,7 @@ detect_cpus() {
 # ──────────────────────────────────────────────────────────────────────────
 SHARDS_OVERRIDE=""
 MAX_CONCURRENCY_OVERRIDE=""
+BATCH_SIZE_OVERRIDE=""
 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -49,6 +53,8 @@ while [ $# -gt 0 ]; do
     --shards=*) SHARDS_OVERRIDE="${1#*=}"; shift ;;
     --max-concurrency) MAX_CONCURRENCY_OVERRIDE="$2"; shift 2 ;;
     --max-concurrency=*) MAX_CONCURRENCY_OVERRIDE="${1#*=}"; shift ;;
+    --batch-size) BATCH_SIZE_OVERRIDE="$2"; shift 2 ;;
+    --batch-size=*) BATCH_SIZE_OVERRIDE="${1#*=}"; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -58,26 +64,23 @@ N="${SHARDS_OVERRIDE:-${SHARDS:-$(detect_cpus)}}"
 if ! printf '%s' "$N" | grep -qE '^[0-9]+$' || [ "$N" -lt 1 ]; then
   echo "ERROR: invalid shard count: $N" >&2; exit 2
 fi
-# v0.40.10 flake-hardening: clamp default to 4 (was 8) to match CI's
-# test-shard.sh fan-out. At 8-shard parallel on Apple Silicon we observed
-# shard 5 SIGKILL during source-health.test.ts's PGLite migration replay —
-# 8 parallel PGLite WASM inits contend severely on the lockfile, and the
-# 92-migration replay × 8 simultaneous can wedge past even 900s. CI uses
-# 4 and is stable. Trade ~2x wallclock for reliability + parity with CI's
-# fan-out. Override via --shards N or SHARDS=N (still capped at 8).
+# Memory-safe local default: four concurrent 10-file PGLite batches reached
+# 4.42 GiB and started swapping on a 12 GiB host. Three keeps the same fan-out
+# architecture while leaving cgroup headroom. Explicit overrides remain
+# available for larger CI hosts (hard-capped at 8).
 [ "$N" -gt 8 ] && N=8
-if [ -z "${SHARDS_OVERRIDE:-}" ] && [ -z "${SHARDS:-}" ] && [ "$N" -gt 4 ]; then
-  N=4
+if [ -z "${SHARDS_OVERRIDE:-}" ] && [ -z "${SHARDS:-}" ] && [ "$N" -gt 3 ]; then
+  N=3
 fi
 
 INTRA_CONC="${MAX_CONCURRENCY_OVERRIDE:-${GBRAIN_TEST_MAX_CONCURRENCY:-4}}"
-# v0.40.10 flake-hardening: bump per-shard cap 600 → 1500 (was 900). At
-# 4-shard default each shard runs 159 files / ~2420 tests with internal
-# wallclock 960-1020s. The 900s value (sized for 8-shard's ~80 files /
-# 1100 tests at 620-770s) false-killed shard 1 at 900s even though it
-# had completed in 968s. 1500s cap gives ~55% headroom over observed
-# 4-shard wallclock; real hangs still hit it. Override via
-# GBRAIN_TEST_SHARD_TIMEOUT=N.
+BATCH_SIZE="${BATCH_SIZE_OVERRIDE:-${GBRAIN_TEST_BATCH_SIZE:-10}}"
+if ! printf '%s' "$BATCH_SIZE" | grep -qE '^[0-9]+$' || [ "$BATCH_SIZE" -lt 1 ]; then
+  echo "ERROR: invalid batch size: $BATCH_SIZE" >&2; exit 2
+fi
+# Per-shard wallclock cap. Recycled processes add bounded startup overhead, so
+# retain the existing 1500s safety margin; real hangs still terminate here.
+# Override via GBRAIN_TEST_SHARD_TIMEOUT=N.
 SHARD_TIMEOUT="${GBRAIN_TEST_SHARD_TIMEOUT:-1500}"
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -109,7 +112,7 @@ elif command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
 fi
 
 START_TS=$(date +%s)
-echo "[unit-parallel] N=$N shards | --max-concurrency=$INTRA_CONC | timeout=${SHARD_TIMEOUT}s | logs=$LOG_DIR" >&2
+echo "[unit-parallel] N=$N shards | batch-size=$BATCH_SIZE | --max-concurrency=$INTRA_CONC | timeout=${SHARD_TIMEOUT}s | logs=$LOG_DIR" >&2
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "[unit-parallel] dry-run: would spawn $N shards with the above settings."
@@ -118,6 +121,23 @@ if [ "$DRY_RUN" = "1" ]; then
       | sed "s|^|  [s$i] |"
   done
   exit 0
+fi
+
+# Build one compatible pre-migrated fixture before fan-out. `ci-local` may
+# already provide an explicit path; direct/local `bun run test` gets the same
+# acceleration automatically. A build failure is fail-open because process
+# batching still bounds memory and snapshots are never authoritative.
+if [ "${GBRAIN_PGLITE_SNAPSHOT:-}" = "off" ]; then
+  unset GBRAIN_PGLITE_SNAPSHOT
+elif [ -z "${GBRAIN_PGLITE_SNAPSHOT:-}" ] && [ -f scripts/build-pglite-snapshot.ts ]; then
+  SNAPSHOT_LOG="$LOG_DIR/snapshot-build.log"
+  if bun run build:pglite-snapshot > "$SNAPSHOT_LOG" 2>&1; then
+    export GBRAIN_PGLITE_SNAPSHOT="test/fixtures/pglite-snapshot.tar"
+    echo "[unit-parallel] PGLite snapshot ready: $GBRAIN_PGLITE_SNAPSHOT" >&2
+  else
+    unset GBRAIN_PGLITE_SNAPSHOT
+    echo "[unit-parallel] WARN: snapshot build failed; continuing with cold init (log: $SNAPSHOT_LOG)" >&2
+  fi
 fi
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -131,12 +151,12 @@ for i in $(seq 1 "$N"); do
     if [ -n "$TIMEOUT_BIN" ]; then
       "$TIMEOUT_BIN" "${SHARD_TIMEOUT}s" \
         env SHARD="$i/$N" \
-        bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" \
+        bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" --batch-size="$BATCH_SIZE" \
         > "$SHARD_LOG" 2>&1
       rc=$?
     else
       env SHARD="$i/$N" \
-        bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" \
+        bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" --batch-size="$BATCH_SIZE" \
         > "$SHARD_LOG" 2>&1 &
       pid=$!
       ( sleep "$SHARD_TIMEOUT" && kill -TERM "$pid" 2>/dev/null && \
@@ -178,11 +198,8 @@ grep_count() {
   echo "${n:-0}"
 }
 
-# bun_summary_count: parses Bun's summary lines (one per `bun test` invocation
-# inside a shard — there's only one when we pass an explicit file list).
-# Looks for ` N pass` / ` N fail` / ` N skip` patterns and sums them across
-# all summary blocks the shard emitted. `bun test` prints these near the end
-# of its output. Format: leading whitespace + integer + space + label.
+# bun_summary_count: parses Bun's summary lines (one per recycled batch
+# invocation inside a shard) and sums them across all summary blocks.
 bun_summary_count() {
   local label="$1"; local file="$2"
   if [ ! -f "$file" ]; then echo 0; return; fi
@@ -205,6 +222,19 @@ shard_total_files() {
   echo "${n:-0}"
 }
 
+shard_total_batches() {
+  local file="$1"
+  [ -f "$file" ] || { echo 0; return; }
+  local n
+  n=$(sed -n 's/^\[unit-shard .*\] running [0-9][0-9]* files in \([0-9][0-9]*\) batch(es).*/\1/p' "$file" 2>/dev/null | head -1)
+  echo "${n:-0}"
+}
+
+shard_completed_batches() {
+  local file="$1"
+  grep_count '^Ran [0-9]+ tests across' "$file"
+}
+
 # shard_pglite_init_count: count "Schema version" lines as a proxy for "test
 # files initialized so far." Each PGLite-using test file's beforeAll triggers
 # one initSchema() which prints this. Undercounts because not every test file
@@ -213,8 +243,7 @@ shard_total_files() {
 # only a final shard-end summary).
 shard_pglite_init_count() {
   local file="$1"
-  [ -f "$file" ] || { echo 0; return; }
-  grep -cE 'Schema version [0-9]+ → [0-9]+' "$file" 2>/dev/null || echo 0
+  grep_count 'Schema version [0-9]+ → [0-9]+' "$file"
 }
 
 # log_size_kb: total stderr+stdout written by the shard so far. Strictly
@@ -259,16 +288,18 @@ heartbeat() {
         local lf="$LOG_DIR/shard-$i.log"
         if [ -f "$lf" ]; then
           # Bun's default reporter has no per-file progress markers, only a
-          # final shard-end summary, so we surface three complementary signals
-          # mid-run: (1) PGLite initSchema() count as a "files started" proxy,
-          # (2) total files this shard was assigned (from the runner banner),
-          # (3) log size in KB as a strictly-monotonic liveness signal.
+          # final shard-end summary, so we surface four complementary signals
+          # mid-run: (1) completed recycled batches, (2) PGLite cold
+          # initSchema() count, (3) total files assigned, and (4) log size in
+          # KB as a strictly-monotonic liveness signal.
           local total; total=$(shard_total_files "$lf")
+          local batches; batches=$(shard_total_batches "$lf")
+          local completed; completed=$(shard_completed_batches "$lf")
           local pglite; pglite=$(shard_pglite_init_count "$lf")
           local kb; kb=$(log_size_kb "$lf")
           local et; et=$(fmt_elapsed "$hb_elapsed")
           if [ "$total" -gt 0 ]; then
-            line="$line [s$i: ~${pglite}/${total}f ${kb}KB ${et}]"
+            line="$line [s$i: b${completed}/${batches} ~${pglite}/${total}f ${kb}KB ${et}]"
           else
             line="$line [s$i: starting ${kb}KB ${et}]"
           fi

--- a/scripts/run-unit-shard.sh
+++ b/scripts/run-unit-shard.sh
@@ -9,8 +9,9 @@
 # the runner container, each pinned to its own postgres shard for the
 # downstream E2E phase.
 #
-# Sequential bun processes within a shard (one bun test invocation with the
-# shard's file list); parallel across shards (4 of these run concurrently).
+# Sequential bounded Bun batches within a shard; parallel across shards.
+# Recycling the Bun process after each batch returns PGLite/WASM high-water
+# memory to the OS instead of retaining it for the shard's entire file list.
 
 set -euo pipefail
 
@@ -19,15 +20,28 @@ cd "$(dirname "$0")/.."
 # --max-concurrency=N is forwarded to `bun test`. v0.26.4: invoked by
 # run-unit-parallel.sh; safe to call without (defaults to bun's default cap).
 MAX_CONC=""
+BATCH_SIZE="${GBRAIN_TEST_BATCH_SIZE:-10}"
+COLD_BATCH_SIZE="${GBRAIN_TEST_COLD_BATCH_SIZE:-2}"
 DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --max-concurrency) MAX_CONC="$2"; shift 2 ;;
     --max-concurrency=*) MAX_CONC="${1#*=}"; shift ;;
+    --batch-size) BATCH_SIZE="$2"; shift 2 ;;
+    --batch-size=*) BATCH_SIZE="${1#*=}"; shift ;;
     --dry-run-list) DRY_RUN=1; shift ;;
     *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+if ! printf '%s' "$BATCH_SIZE" | grep -qE '^[0-9]+$' || [ "$BATCH_SIZE" -lt 1 ]; then
+  echo "ERROR: invalid batch size: $BATCH_SIZE" >&2
+  exit 2
+fi
+if ! printf '%s' "$COLD_BATCH_SIZE" | grep -qE '^[0-9]+$' || [ "$COLD_BATCH_SIZE" -lt 1 ]; then
+  echo "ERROR: invalid cold batch size: $COLD_BATCH_SIZE" >&2
+  exit 2
+fi
 
 # All non-E2E test files, sorted for deterministic shard splits.
 # Tier 4: *.slow.test.ts is "always-slow" (cold-path correctness checks);
@@ -71,8 +85,76 @@ if [ "$DRY_RUN" = "1" ]; then
   exit 0
 fi
 
-echo "[unit-shard ${SHARD:-(unsharded)}] running ${#files[@]} files"
-if [ -n "$MAX_CONC" ]; then
-  exec bun test --max-concurrency="$MAX_CONC" --timeout=60000 "${files[@]}"
+total_files=${#files[@]}
+snapshot_files=()
+cold_files=()
+snapshot_count=0
+cold_count=0
+for file in "${files[@]}"; do
+  cold_path=0
+  case "$file" in
+    test/*migrat*.test.ts|test/bootstrap.test.ts|test/schema-bootstrap-coverage.test.ts|test/embedding-dim-check.test.ts)
+      cold_path=1
+      ;;
+  esac
+  # Some older cold-path contracts carry an in-file opt-out instead of a
+  # migration-oriented filename. Detect that exact marker so they run in an
+  # isolated cold batch rather than clearing the snapshot for neighboring
+  # files in the same Bun process.
+  if [ "$cold_path" -eq 0 ] && grep -q 'delete process\.env\.GBRAIN_PGLITE_SNAPSHOT' "$file" 2>/dev/null; then
+    cold_path=1
+  fi
+  if [ "$cold_path" -eq 1 ]; then
+    cold_files+=("$file")
+    cold_count=$((cold_count + 1))
+  else
+    snapshot_files+=("$file")
+    snapshot_count=$((snapshot_count + 1))
+  fi
+done
+
+total_batches=$((
+  (snapshot_count + BATCH_SIZE - 1) / BATCH_SIZE
+  + (cold_count + COLD_BATCH_SIZE - 1) / COLD_BATCH_SIZE
+))
+echo "[unit-shard ${SHARD:-(unsharded)}] running $total_files files in $total_batches batch(es), batch-size=$BATCH_SIZE, cold-batch-size=$COLD_BATCH_SIZE, cold-path=$cold_count"
+
+batch_n=0
+run_group() {
+  local mode="$1"
+  local limit="$2"
+  shift 2
+  local group=("$@")
+  local group_total=${#group[@]}
+  local offset=0
+  local batch
+  while [ "$offset" -lt "$group_total" ]; do
+    batch_n=$((batch_n + 1))
+    batch=("${group[@]:offset:limit}")
+    echo "[unit-shard ${SHARD:-(unsharded)}] batch $batch_n/$total_batches mode=$mode running ${#batch[@]} files"
+    local rc=0
+    if [ "$mode" = "cold" ]; then
+      if [ -n "$MAX_CONC" ]; then
+        GBRAIN_PGLITE_SNAPSHOT= bun test --max-concurrency="$MAX_CONC" --timeout=60000 "${batch[@]}" || rc=$?
+      else
+        GBRAIN_PGLITE_SNAPSHOT= bun test --timeout=60000 "${batch[@]}" || rc=$?
+      fi
+    elif [ -n "$MAX_CONC" ]; then
+      bun test --max-concurrency="$MAX_CONC" --timeout=60000 "${batch[@]}" || rc=$?
+    else
+      bun test --timeout=60000 "${batch[@]}" || rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+      echo "[unit-shard ${SHARD:-(unsharded)}] ABORTED after failed batch $batch_n/$total_batches rc=$rc; remaining batches were not run" >&2
+      return "$rc"
+    fi
+    offset=$((offset + limit))
+  done
+}
+
+if [ "$snapshot_count" -gt 0 ]; then
+  run_group snapshot "$BATCH_SIZE" "${snapshot_files[@]}"
 fi
-exec bun test --timeout=60000 "${files[@]}"
+if [ "$cold_count" -gt 0 ]; then
+  run_group cold "$COLD_BATCH_SIZE" "${cold_files[@]}"
+fi

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2,6 +2,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { vector } from '@electric-sql/pglite/vector';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 import type { Transaction } from '@electric-sql/pglite';
+import packageManifest from '../../package.json';
 import type {
   BrainEngine,
   BatchOpts,
@@ -39,7 +40,7 @@ import {
 } from './search/recency-decay.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import { runMigrations } from './migrate.ts';
-import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
+import { getPGLiteSchema } from './pglite-schema.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
 import { SOURCE_CONFIG_OBJECT_SQL } from './source-config-sql.ts';
@@ -92,63 +93,102 @@ import { hasCJK, escapeLikePattern } from './cjk.ts';
 type PGLiteDB = PGlite;
 
 // Tier 3 snapshot fast-restore. Reads a tar dump produced by
-// `bun run scripts/build-pglite-snapshot.ts`. Snapshot is matched against
-// the current MIGRATIONS hash via a sidecar `.version` file; on mismatch we
-// silently fall through to a normal initSchema (snapshot is just an
-// optimization, never authoritative).
+// `bun run scripts/build-pglite-snapshot.ts`. Metadata binds the tar bytes to
+// the runtime-rendered schema and full migration semantics; any mismatch is a
+// cold-init fallback because snapshots are accelerators, never authority.
 let _snapshotWarnLogged = false;
-function tryLoadSnapshot(snapshotPath: string): Blob | null {
+function snapshotMetadataPath(snapshotPath: string): string {
+  const replaced = snapshotPath.replace(/\.tar(?:\.gz)?$/, '.metadata.json');
+  return replaced === snapshotPath ? `${snapshotPath}.metadata.json` : replaced;
+}
+
+function warnSnapshotFallback(message: string): void {
+  if (_snapshotWarnLogged) return;
+  // eslint-disable-next-line no-console
+  console.warn(`[pglite] ${message} — using normal init.`);
+  _snapshotWarnLogged = true;
+}
+
+function tryLoadSnapshot(snapshotPath: string, renderedSchemaSQL: string): Blob | null {
   try {
     // Lazy require so production builds without these imports don't crash.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fs = require('node:fs') as typeof import('node:fs');
     const crypto = require('node:crypto') as typeof import('node:crypto');
     const { MIGRATIONS } = require('./migrate.ts') as typeof import('./migrate.ts');
-    const { PGLITE_SCHEMA_SQL } = require('./pglite-schema.ts') as typeof import('./pglite-schema.ts');
 
     if (!fs.existsSync(snapshotPath)) {
-      if (!_snapshotWarnLogged) {
-        // eslint-disable-next-line no-console
-        console.warn(`[pglite] GBRAIN_PGLITE_SNAPSHOT set but file missing: ${snapshotPath} — using normal init.`);
-        _snapshotWarnLogged = true;
-      }
+      warnSnapshotFallback(`GBRAIN_PGLITE_SNAPSHOT set but file missing: ${snapshotPath}`);
       return null;
     }
-    const versionPath = snapshotPath.replace(/\.tar(?:\.gz)?$/, '.version');
-    if (!fs.existsSync(versionPath)) {
-      if (!_snapshotWarnLogged) {
-        // eslint-disable-next-line no-console
-        console.warn(`[pglite] snapshot version file missing: ${versionPath} — using normal init.`);
-        _snapshotWarnLogged = true;
-      }
+    const metadataPath = snapshotMetadataPath(snapshotPath);
+    if (!fs.existsSync(metadataPath)) {
+      warnSnapshotFallback(`snapshot metadata missing: ${metadataPath}`);
       return null;
     }
-    const expectedHash = computeSnapshotSchemaHash(MIGRATIONS, PGLITE_SCHEMA_SQL, crypto);
-    const actualHash = fs.readFileSync(versionPath, 'utf8').trim();
-    if (expectedHash !== actualHash) {
-      if (!_snapshotWarnLogged) {
-        // eslint-disable-next-line no-console
-        console.warn(`[pglite] snapshot stale (schema hash mismatch) — using normal init. Rebuild with: bun run build:pglite-snapshot`);
-        _snapshotWarnLogged = true;
-      }
-      return null;
-    }
+
     const buf = fs.readFileSync(snapshotPath);
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as unknown;
+    if (!isSnapshotMetadataCompatible(metadata, buf, MIGRATIONS, renderedSchemaSQL, crypto)) {
+      warnSnapshotFallback('snapshot metadata/schema/tar mismatch; rebuild with: bun run build:pglite-snapshot');
+      return null;
+    }
     return new Blob([buf]);
   } catch {
-    // Any failure -> fall through to normal init. Never block tests.
+    // Any read/parse/hash failure -> cold init. Never block tests.
+    warnSnapshotFallback('snapshot could not be validated');
     return null;
   }
 }
 
+type SnapshotMigration = {
+  version: number;
+  name: string;
+  sql?: string;
+  sqlFor?: { pglite?: string };
+  transaction?: boolean;
+  idempotent?: boolean;
+  handler?: (...args: any[]) => unknown;
+  verify?: (...args: any[]) => unknown;
+};
+
+export interface PgliteSnapshotMetadata {
+  format: 2;
+  compatibilityHash: string;
+  runtimeHash: string;
+  pgliteVersion: string;
+  tarSha256: string;
+}
+
+// Bump this format whenever non-migration bootstrap logic changes the physical
+// database state captured by build-pglite-snapshot.ts. The explicit gate is
+// intentional: helper dependencies cannot be fingerprinted reliably from
+// Function#toString alone.
+const PGLITE_SNAPSHOT_FORMAT = 2 as const;
+const PGLITE_PACKAGE_VERSION = packageManifest.dependencies['@electric-sql/pglite'];
+
+function computeSnapshotRuntimeHash(crypto: typeof import('node:crypto')): string {
+  const hash = crypto.createHash('sha256');
+  hash.update(`snapshot-format:${PGLITE_SNAPSHOT_FORMAT}\n`);
+  hash.update(`pglite-package:${PGLITE_PACKAGE_VERSION}\n`);
+  hash.update(PGlite.create.toString());
+  for (const extension of [vector, pg_trgm]) {
+    hash.update('\n');
+    hash.update(extension.name);
+    hash.update('\t');
+    hash.update(extension.setup.toString());
+  }
+  return hash.digest('hex');
+}
+
 export function computeSnapshotSchemaHash(
-  migrations: Array<{ version: number; name: string; sql?: string; sqlFor?: { pglite?: string } }>,
-  schemaSQL: string,
+  migrations: SnapshotMigration[],
+  renderedSchemaSQL: string,
   crypto: typeof import('node:crypto'),
 ): string {
   const hash = crypto.createHash('sha256');
-  hash.update('schema:');
-  hash.update(schemaSQL);
+  hash.update('rendered-schema:');
+  hash.update(renderedSchemaSQL);
   hash.update('\nmigrations:\n');
   for (const m of migrations) {
     hash.update(String(m.version));
@@ -158,9 +198,62 @@ export function computeSnapshotSchemaHash(
     hash.update(m.sql ?? '');
     hash.update('\t');
     hash.update(m.sqlFor?.pglite ?? '');
+    hash.update('\t');
+    hash.update(String(m.transaction ?? true));
+    hash.update('\t');
+    hash.update(String(m.idempotent ?? true));
+    hash.update('\t');
+    hash.update(m.handler?.toString() ?? '');
+    hash.update('\t');
+    hash.update(m.verify?.toString() ?? '');
     hash.update('\n');
   }
   return hash.digest('hex');
+}
+
+export function createSnapshotMetadata(
+  tarBytes: Uint8Array,
+  migrations: SnapshotMigration[],
+  renderedSchemaSQL: string,
+  crypto: typeof import('node:crypto'),
+): PgliteSnapshotMetadata {
+  return {
+    format: PGLITE_SNAPSHOT_FORMAT,
+    compatibilityHash: computeSnapshotSchemaHash(migrations, renderedSchemaSQL, crypto),
+    runtimeHash: computeSnapshotRuntimeHash(crypto),
+    pgliteVersion: PGLITE_PACKAGE_VERSION,
+    tarSha256: crypto.createHash('sha256').update(tarBytes).digest('hex'),
+  };
+}
+
+export function isSnapshotMetadataCompatible(
+  metadata: unknown,
+  tarBytes: Uint8Array,
+  migrations: SnapshotMigration[],
+  renderedSchemaSQL: string,
+  crypto: typeof import('node:crypto'),
+): metadata is PgliteSnapshotMetadata {
+  if (!metadata || typeof metadata !== 'object') return false;
+  const candidate = metadata as Partial<PgliteSnapshotMetadata>;
+  if (candidate.format !== PGLITE_SNAPSHOT_FORMAT) return false;
+  const expected = createSnapshotMetadata(tarBytes, migrations, renderedSchemaSQL, crypto);
+  return candidate.compatibilityHash === expected.compatibilityHash
+    && candidate.runtimeHash === expected.runtimeHash
+    && candidate.pgliteVersion === expected.pgliteVersion
+    && candidate.tarSha256 === expected.tarSha256;
+}
+
+async function resolveRenderedPgliteSchema(): Promise<string> {
+  let dims: number = DEFAULT_EMBEDDING_DIMENSIONS;
+  let model: string = DEFAULT_EMBEDDING_MODEL;
+  try {
+    // Keep the gateway lazy: its static closure is large, and evaluation inside
+    // this try/catch preserves the unconfigured-gateway default fallback.
+    const gw = await import('./ai/gateway.ts'); // engine-dynamic-import-ok
+    dims = gw.getEmbeddingDimensions();
+    model = gw.getEmbeddingModel();
+  } catch { /* gateway not configured — use defaults */ }
+  return getPGLiteSchema(dims, model);
 }
 
 /**
@@ -305,6 +398,7 @@ export class PGLiteEngine implements BrainEngine {
   // Lifecycle
   async connect(config: EngineConfig): Promise<void> {
     this._savedConfig = config; // #2034: remember for reconnect()
+    this._snapshotLoaded = false;
     const dataDir = config.database_path || undefined; // undefined = in-memory
 
     // Acquire file lock to prevent concurrent PGLite access (crashes with Aborted())
@@ -316,12 +410,12 @@ export class PGLiteEngine implements BrainEngine {
 
     // Tier 3: optional snapshot fast-restore. Only applies to in-memory
     // engines (no persistent dataDir). The snapshot was built from a fresh
-    // `initSchema()` run; if the version file matches the current MIGRATIONS
-    // hash, load the dump and skip the schema replay. Mismatch or missing
-    // file silently falls back to normal init.
+    // `initSchema()` run; metadata must match the runtime-rendered schema,
+    // migration semantics, and tar checksum. Any mismatch falls back cold.
     let loadDataDir: Blob | undefined;
     if (!dataDir && process.env.GBRAIN_PGLITE_SNAPSHOT) {
-      const snapshotResult = tryLoadSnapshot(process.env.GBRAIN_PGLITE_SNAPSHOT);
+      const renderedSchemaSQL = await resolveRenderedPgliteSchema();
+      const snapshotResult = tryLoadSnapshot(process.env.GBRAIN_PGLITE_SNAPSHOT, renderedSchemaSQL);
       if (snapshotResult) {
         loadDataDir = snapshotResult;
         this._snapshotLoaded = true;
@@ -334,22 +428,37 @@ export class PGLiteEngine implements BrainEngine {
     // a snapshot/restore around these awaits does NOT contain them. That is
     // why the CLI's exit paths read gbrain's own verdict
     // (cli-force-exit.ts currentExitCode), never ambient process.exitCode.
+    const createDb = (snapshotDataDir?: Blob) => preservingProcessExitCode(() =>
+      PGlite.create({
+        dataDir,
+        loadDataDir: snapshotDataDir,
+        extensions: { vector, pg_trgm },
+      }),
+    );
     try {
-      this._db = await preservingProcessExitCode(() =>
-        PGlite.create({
-          dataDir,
-          loadDataDir,
-          extensions: { vector, pg_trgm },
-        }),
-      );
+      this._db = await createDb(loadDataDir);
     } catch (err) {
+      let initError = err;
+      if (loadDataDir) {
+        // The metadata may be valid while the tar is incompatible with the
+        // installed PGLite runtime. Retry from an empty data dir before
+        // surfacing an init failure; snapshots must never block correctness.
+        warnSnapshotFallback('snapshot restore failed');
+        this._snapshotLoaded = false;
+        try {
+          this._db = await createDb(undefined);
+          return;
+        } catch (coldErr) {
+          initError = coldErr;
+        }
+      }
       // v0.13.1: any PGLite.create() failure becomes actionable. v0.41.8.0
       // (#1340): the previous error hint hardcoded the macOS 26.3 link, but
       // the same crash shape can come from Bun's vfs (`/$$bunfs/root` is
       // read-only on older macOS + Bun 1.3.x, so PGLite can't extract its
       // pglite.data WASM payload). Route the hint by failure shape so
       // users get the right next step.
-      const original = stringifyPgliteInitError(err); // #2674
+      const original = stringifyPgliteInitError(initError); // #2674
       const verdict = classifyPgliteInitError(original);
       const wrapped = new Error(buildPgliteInitErrorMessage(verdict, original));
       // Release the lock so a fresh process can try again; leaking the lock
@@ -429,25 +538,7 @@ export class PGLiteEngine implements BrainEngine {
     // installs and modern brains.
     await this.applyForwardReferenceBootstrap();
 
-    // Resolve embedding dim/model from gateway. v0.37 fix wave: fallbacks
-    // track the canonical defaults in `ai/defaults.ts` (zeroentropyai:zembed-1
-    // / 1280d) instead of the stale v0.13 OpenAI literals, AND we store the
-    // full `provider:model` string in the DB config table — consumers like
-    // ze-switch, doctor, and recommendation-context expect the provider
-    // prefix. (Round-1 CDX-4 + A.8.)
-    let dims: number = DEFAULT_EMBEDDING_DIMENSIONS;
-    let model: string = DEFAULT_EMBEDDING_MODEL;
-    try {
-      // Keep the gateway lazy: its static closure is large, and evaluation inside
-      // this try/catch preserves the unconfigured-gateway default fallback.
-      const gw = await import('./ai/gateway.ts'); // engine-dynamic-import-ok
-      // Both accessors THROW when the gateway is unconfigured (they never
-      // return falsy), so the catch below is the only fallback path (#3461).
-      dims = gw.getEmbeddingDimensions();
-      model = gw.getEmbeddingModel();
-    } catch { /* gateway not configured — use defaults */ }
-
-    await this.db.exec(getPGLiteSchema(dims, model));
+    await this.db.exec(await resolveRenderedPgliteSchema());
 
     const { applied } = await runMigrations(this);
     if (applied > 0) {

--- a/test/pglite-snapshot-metadata.test.ts
+++ b/test/pglite-snapshot-metadata.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import * as crypto from 'node:crypto';
+import {
+  computeSnapshotSchemaHash,
+  createSnapshotMetadata,
+  isSnapshotMetadataCompatible,
+} from '../src/core/pglite-engine.ts';
+
+const schema1536 = 'CREATE TABLE chunks (embedding vector(1536));';
+
+function migration(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 2,
+    name: 'fixture',
+    sql: '',
+    transaction: true,
+    idempotent: true,
+    handler: async () => { /* fixture-v1 */ },
+    verify: async () => true,
+    ...overrides,
+  };
+}
+
+describe('PGLite snapshot compatibility metadata', () => {
+  it('changes the compatibility hash when rendered schema changes', () => {
+    const a = computeSnapshotSchemaHash([migration()], schema1536, crypto);
+    const b = computeSnapshotSchemaHash([migration()], 'CREATE TABLE chunks (embedding vector(1280));', crypto);
+    expect(a).not.toBe(b);
+  });
+
+  it('changes the compatibility hash when a migration handler changes', () => {
+    const a = computeSnapshotSchemaHash(
+      [migration({ handler: async () => 1 })],
+      schema1536,
+      crypto,
+    );
+    const b = computeSnapshotSchemaHash(
+      [migration({ handler: async () => 2 })],
+      schema1536,
+      crypto,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('changes the compatibility hash when verify/transaction semantics change', () => {
+    const a = computeSnapshotSchemaHash([migration()], schema1536, crypto);
+    const b = computeSnapshotSchemaHash(
+      [migration({ transaction: false, verify: async () => false })],
+      schema1536,
+      crypto,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('rejects metadata when runtime/extension fingerprint changes', () => {
+    const tar = Buffer.from('valid snapshot bytes');
+    const metadata = createSnapshotMetadata(tar, [migration()], schema1536, crypto);
+    const changed = { ...metadata, runtimeHash: '0'.repeat(64) };
+    expect(isSnapshotMetadataCompatible(changed, tar, [migration()], schema1536, crypto)).toBe(false);
+  });
+
+  it('rejects metadata from another exact PGLite package version', () => {
+    const tar = Buffer.from('valid snapshot bytes');
+    const metadata = createSnapshotMetadata(tar, [migration()], schema1536, crypto);
+    const changed = { ...metadata, pgliteVersion: '0.0.0' };
+    expect(isSnapshotMetadataCompatible(changed, tar, [migration()], schema1536, crypto)).toBe(false);
+  });
+
+  it('rejects metadata when tar bytes are corrupted', () => {
+    const tar = Buffer.from('valid snapshot bytes');
+    const metadata = createSnapshotMetadata(tar, [migration()], schema1536, crypto);
+    expect(isSnapshotMetadataCompatible(metadata, tar, [migration()], schema1536, crypto)).toBe(true);
+    expect(isSnapshotMetadataCompatible(metadata, Buffer.from('corrupt'), [migration()], schema1536, crypto)).toBe(false);
+  });
+});

--- a/test/pglite-snapshot.serial.test.ts
+++ b/test/pglite-snapshot.serial.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+let root = '';
+let snapshotPath = '';
+let metadataPath = '';
+let previousSnapshot: string | undefined;
+
+async function vectorType(engine: PGLiteEngine): Promise<string> {
+  const result = await engine.db.query<{ formatted: string }>(`
+    SELECT format_type(a.atttypid, a.atttypmod) AS formatted
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    WHERE c.relname = 'content_chunks' AND a.attname = 'embedding'
+  `);
+  return result.rows[0]?.formatted ?? '';
+}
+
+describe('PGLite snapshot restore contract', () => {
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'gbrain-pglite-snapshot-'));
+    snapshotPath = join(root, 'fixture.tar');
+    metadataPath = join(root, 'fixture.metadata.json');
+    previousSnapshot = process.env.GBRAIN_PGLITE_SNAPSHOT;
+
+    const result = spawnSync('bun', ['run', 'scripts/build-pglite-snapshot.ts'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, GBRAIN_PGLITE_SNAPSHOT_PATH: snapshotPath },
+    });
+    if (result.status !== 0) {
+      throw new Error(`snapshot builder failed (${result.status}):\n${result.stdout}\n${result.stderr}`);
+    }
+    process.env.GBRAIN_PGLITE_SNAPSHOT = snapshotPath;
+  });
+
+  afterAll(() => {
+    if (previousSnapshot === undefined) delete process.env.GBRAIN_PGLITE_SNAPSHOT;
+    else process.env.GBRAIN_PGLITE_SNAPSHOT = previousSnapshot;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('loads the test-profile snapshot with a 1536-dimensional schema', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      expect((engine as unknown as { _snapshotLoaded: boolean })._snapshotLoaded).toBe(true);
+      await engine.initSchema();
+      expect(await vectorType(engine)).toBe('vector(1536)');
+    } finally {
+      await engine.disconnect();
+    }
+  });
+
+  it('resets the snapshot marker on a later cold connect', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    expect((engine as unknown as { _snapshotLoaded: boolean })._snapshotLoaded).toBe(true);
+    await engine.disconnect();
+
+    delete process.env.GBRAIN_PGLITE_SNAPSHOT;
+    try {
+      await engine.connect({});
+      expect((engine as unknown as { _snapshotLoaded: boolean })._snapshotLoaded).toBe(false);
+    } finally {
+      await engine.disconnect();
+      process.env.GBRAIN_PGLITE_SNAPSHOT = snapshotPath;
+    }
+  });
+
+  it('cold-initializes when metadata is stale', async () => {
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as { compatibilityHash: string };
+    metadata.compatibilityHash = '0'.repeat(64);
+    writeFileSync(metadataPath, JSON.stringify(metadata));
+
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      expect((engine as unknown as { _snapshotLoaded: boolean })._snapshotLoaded).toBe(false);
+      await engine.initSchema();
+      expect(await vectorType(engine)).toBe('vector(1536)');
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});

--- a/test/scripts/run-unit-parallel.test.ts
+++ b/test/scripts/run-unit-parallel.test.ts
@@ -244,3 +244,12 @@ describe('failing-on-purpose', () => {
     }
   });
 });
+
+describe('run-unit-parallel.sh heartbeat contracts', () => {
+  it('uses the single-value grep helper when snapshot batches emit no schema lines', () => {
+    const source = readFileSync(PARALLEL_SH_SRC, 'utf-8');
+    const body = source.match(/shard_pglite_init_count\(\) \{([\s\S]*?)\n\}/)?.[1] ?? '';
+    expect(body).toContain("grep_count 'Schema version");
+    expect(body).not.toContain('|| echo 0');
+  });
+});

--- a/test/scripts/run-unit-shard.test.ts
+++ b/test/scripts/run-unit-shard.test.ts
@@ -14,11 +14,14 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { execFileSync } from 'child_process';
-import { resolve } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 
 const REPO_ROOT = resolve(import.meta.dir, '..', '..');
 const SHARD_SH = resolve(REPO_ROOT, 'scripts/run-unit-shard.sh');
+const SERIAL_SH = resolve(REPO_ROOT, 'scripts/run-serial-tests.sh');
 
 function dryRunList(): string[] {
   const out = execFileSync('bash', [SHARD_SH, '--dry-run-list'], {
@@ -52,5 +55,149 @@ describe('run-unit-shard.sh exclusion symmetry', () => {
     const files = dryRunList();
     const leaks = files.filter(f => f.startsWith('test/e2e/'));
     expect(leaks).toEqual([]);
+  });
+});
+
+describe('run-unit-shard.sh bounded process batches', () => {
+  it('runs every selected file exactly once across fresh Bun batches', () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-unit-batches-'));
+    try {
+      mkdirSync(join(root, 'scripts'), { recursive: true });
+      mkdirSync(join(root, 'test'), { recursive: true });
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      copyFileSync(SHARD_SH, join(root, 'scripts', 'run-unit-shard.sh'));
+      chmodSync(join(root, 'scripts', 'run-unit-shard.sh'), 0o755);
+
+      for (let i = 1; i <= 6; i++) {
+        writeFileSync(join(root, 'test', `${i}.test.ts`), '// fixture\n');
+      }
+      writeFileSync(join(root, 'test', 'migrate.test.ts'), '// cold fixture\n');
+      writeFileSync(join(root, 'test', 'embedding-dim-check.test.ts'), '// fresh-schema fixture\n');
+
+      const callsPath = join(root, 'bun-calls.txt');
+      writeFileSync(
+        join(root, 'bin', 'bun'),
+        `#!/usr/bin/env bash\nprintf 'snapshot=%s args=%s\\n' "\${GBRAIN_PGLITE_SNAPSHOT-}" "$*" >> "${callsPath}"\n`,
+      );
+      chmodSync(join(root, 'bin', 'bun'), 0o755);
+
+      const result = spawnSync('bash', [join(root, 'scripts', 'run-unit-shard.sh'), '--batch-size', '3'], {
+        cwd: root,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${join(root, 'bin')}:${process.env.PATH ?? ''}`,
+          SHARD: '',
+          GBRAIN_PGLITE_SNAPSHOT: '/tmp/fixture.tar',
+        },
+      });
+      expect(result.status).toBe(0);
+
+      const calls = readFileSync(callsPath, 'utf-8').trim().split('\n');
+      expect(calls).toHaveLength(3);
+      expect(calls.map(line => line.match(/test\/(?:[0-9]+|migrate|embedding-dim-check)\.test\.ts/g)?.length ?? 0)).toEqual([3, 3, 2]);
+      const selected = calls.flatMap(line => line.match(/test\/(?:[0-9]+|migrate|embedding-dim-check)\.test\.ts/g) ?? []).sort();
+      expect(selected).toEqual([
+        ...Array.from({ length: 6 }, (_, i) => `test/${i + 1}.test.ts`),
+        'test/embedding-dim-check.test.ts',
+        'test/migrate.test.ts',
+      ]);
+      expect(calls.filter(line => /test\/(?:migrate|embedding-dim-check)\.test\.ts/.test(line))[0]).toStartWith('snapshot= args=');
+      expect(calls.filter(line => /test\/[0-9]+\.test\.ts/.test(line)).every(line => line.startsWith('snapshot=/tmp/fixture.tar args='))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stops the shard after a failed batch and reports unrun batches', () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-unit-batch-failure-'));
+    try {
+      mkdirSync(join(root, 'scripts'), { recursive: true });
+      mkdirSync(join(root, 'test'), { recursive: true });
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      copyFileSync(SHARD_SH, join(root, 'scripts', 'run-unit-shard.sh'));
+      chmodSync(join(root, 'scripts', 'run-unit-shard.sh'), 0o755);
+      for (let i = 1; i <= 4; i++) writeFileSync(join(root, 'test', `${i}.test.ts`), '// fixture\n');
+
+      const callsPath = join(root, 'bun-calls.txt');
+      const markerPath = join(root, 'failed-once');
+      writeFileSync(
+        join(root, 'bin', 'bun'),
+        `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${callsPath}"\nif [ ! -f "${markerPath}" ]; then touch "${markerPath}"; exit 7; fi\n`,
+      );
+      chmodSync(join(root, 'bin', 'bun'), 0o755);
+
+      const result = spawnSync('bash', [join(root, 'scripts', 'run-unit-shard.sh'), '--batch-size', '2'], {
+        cwd: root,
+        encoding: 'utf-8',
+        env: { ...process.env, PATH: `${join(root, 'bin')}:${process.env.PATH ?? ''}`, SHARD: '' },
+      });
+      expect(result.status).toBe(7);
+      expect(readFileSync(callsPath, 'utf-8').trim().split('\n')).toHaveLength(1);
+      expect(result.stderr).toContain('ABORTED after failed batch 1/2 rc=7');
+      expect(result.stderr).toContain('remaining batches were not run');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a zero batch size before launching Bun', () => {
+    const result = spawnSync('bash', [SHARD_SH, '--batch-size', '0'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, SHARD: '' },
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid batch size');
+  });
+
+  it('rejects a zero cold-path batch size before launching Bun', () => {
+    const result = spawnSync('bash', [SHARD_SH], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, SHARD: '', GBRAIN_TEST_COLD_BATCH_SIZE: '0' },
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid cold batch size');
+  });
+});
+
+describe('run-serial-tests.sh cold-path snapshot opt-out', () => {
+  it('clears snapshot env for migration contracts but preserves it for normal serial files', () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-serial-snapshot-'));
+    try {
+      mkdirSync(join(root, 'scripts'), { recursive: true });
+      mkdirSync(join(root, 'test'), { recursive: true });
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      copyFileSync(SERIAL_SH, join(root, 'scripts', 'run-serial-tests.sh'));
+      chmodSync(join(root, 'scripts', 'run-serial-tests.sh'), 0o755);
+      writeFileSync(join(root, 'test', 'normal.serial.test.ts'), '// fixture\n');
+      writeFileSync(join(root, 'test', 'apply-migrations.serial.test.ts'), '// fixture\n');
+      writeFileSync(join(root, 'test', 'unified-multimodal.serial.test.ts'), '// fixture\n');
+
+      const callsPath = join(root, 'bun-calls.txt');
+      writeFileSync(
+        join(root, 'bin', 'bun'),
+        `#!/usr/bin/env bash\nprintf 'snapshot=%s args=%s\\n' "\${GBRAIN_PGLITE_SNAPSHOT-}" "$*" >> "${callsPath}"\n`,
+      );
+      chmodSync(join(root, 'bin', 'bun'), 0o755);
+
+      const result = spawnSync('bash', [join(root, 'scripts', 'run-serial-tests.sh')], {
+        cwd: root,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${join(root, 'bin')}:${process.env.PATH ?? ''}`,
+          GBRAIN_PGLITE_SNAPSHOT: '/tmp/fixture.tar',
+        },
+      });
+      expect(result.status).toBe(0);
+      const calls = readFileSync(callsPath, 'utf-8').trim().split('\n');
+      expect(calls.find(line => line.includes('normal.serial.test.ts'))).toStartWith('snapshot=/tmp/fixture.tar args=');
+      expect(calls.find(line => line.includes('apply-migrations.serial.test.ts'))).toStartWith('snapshot= args=');
+      expect(calls.find(line => line.includes('unified-multimodal.serial.test.ts'))).toStartWith('snapshot= args=');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Bounds Bun/PGLite unit-suite memory without converting hundreds of tests or switching the PGLite production path to another engine.

- Recycles each logical shard through sequential Bun batches instead of keeping one WASM heap alive for the entire shard.
- Builds one pre-migrated PGLite snapshot with the same runtime-rendered test schema used by `initSchema()`, including the 1536-dimensional test profile.
- Validates snapshots against schema/migration semantics, handler source, migration flags, exact PGLite package version, extension identity, and tar checksum.
- Falls back observably to cold initialization for missing, stale, incompatible, or corrupt snapshots.
- Keeps migration/bootstrap contracts on the cold path and resets snapshot state across reconnects.
- Uses conservative defaults measured on a 12 GiB host: 3 shards, 10 normal files/process, 2 cold files/process, 1500s shard cap.
- Improves heartbeat reporting for recycled batches and aggregates multiple Bun summary blocks correctly.

Related: #3631 adds TERM-to-KILL escalation for timeout-resistant shard descendants. It is intentionally not part of this PR's diff.

## Measurements

Representative 41-file bounded benchmark:

| Files/process | Wall time | Max RSS |
|---:|---:|---:|
| 5 | 34.49s | 1,149,440 KiB |
| 10 | 32.97s | 1,036,796 KiB |
| 20 | 31.13s | 1,229,484 KiB |
| 40 | 31.04s | 1,783,492 KiB |

`10` kept wall time within 6.2% of `40` while using about 42% less peak RSS.

A bounded broad run with the final `3 × 10` defaults completed the runner in 15:24 with:

- systemd cgroup memory peak: **3.1 GiB**
- swap peak: **0 B**
- OOM / OOM-kill: **none**
- observed result: 9,434 passed, 8 failed

The eight failures reproduce when their files are run separately, including on the cold path where applicable; this PR does not modify those test files or their production targets. The broad measurement was run while #3631 was stacked locally. This commit was then rebased directly onto `master` and the focused checks below were rerun.

For comparison, the prior `4 × 10` bounded run reached about 4.42 GiB and started swapping, so it was stopped and the default fan-out was reduced to 3.

## Verification

- `bun test test/pglite-snapshot-metadata.test.ts test/scripts/run-unit-shard.test.ts test/scripts/run-unit-parallel.test.ts` — **24 passed, 0 failed**
- bounded `test/pglite-snapshot.serial.test.ts` + `test/source-health.test.ts` — passed
- `bunx tsc --noEmit --pretty false --incremental false` — passed
- Bash syntax checks for the modified runners/build scripts — passed
- `bun run verify` — **33/33 checks passed**
- snapshot mismatch/corruption fallback smoke — passed

## Risks and safeguards

- Snapshot loading is test-only and opt-in through `GBRAIN_PGLITE_SNAPSHOT`.
- Metadata format changes invalidate old snapshots instead of trusting them.
- Exact PGLite package-version mismatch and checksum mismatch force cold initialization.
- Migration/bootstrap tests bypass the snapshot; tests that explicitly clear the snapshot environment are detected and isolated into cold batches.
- A failed batch stops the rest of that shard and logs how many batches were not run, preserving fail-fast behavior without presenting a partial shard as complete.
