### PR TITLE
fix(extract): stop asserting works_at from bare people/->companies/ adjacency (#3466)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -349,7 +349,13 @@ function inferTypeByDir(fromDir: string, toDir: string, frontmatter?: Record<str
   const to = toDir.split('/')[0];
   if (from === 'people' && to === 'companies') {
     if (Array.isArray(frontmatter?.founded)) return 'founded';
-    return 'works_at';
+    // #3466: bare people/ -> companies/ adjacency is not evidence of
+    // employment, so it gets the neutral 'mentions' verb instead of
+    // 'works_at'. Real works_at edges still come from the two paths that
+    // read actual evidence: the company:/companies: frontmatter fields
+    // (FRONTMATTER_LINK_MAP) and employment phrasing in prose
+    // (inferLinkType in link-extraction.ts).
+    return 'mentions';
   }
   if (from === 'people' && to === 'deals') return 'involved_in';
   if (from === 'deals' && to === 'companies') return 'deal_for';

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -28,10 +28,11 @@ import { ensureWellFormed } from './text-safe.ts';
  * OR updated_at > links_extracted_at`. It is an ISO-8601 string (NOT a number) —
  * the column is TIMESTAMPTZ and the predicate binds it as `::timestamptz`.
  */
-// 2026-07-10: bumped for the #2576 --stale nullResolver fix — sweeps before it
-// stamped pages with their bare wikilinks silently dropped; the bump re-flags
-// them so the fixed sweep re-extracts.
-export const LINK_EXTRACTOR_VERSION_TS = '2026-07-10T00:00:00Z';
+// 2026-07-30: bumped for the #3466 inferTypeByDir fix — unevidenced
+// people/ -> companies/ adjacency now infers 'mentions' instead of
+// 'works_at'; the bump re-flags stamped pages so the next --stale sweep
+// re-extracts them under the corrected inference.
+export const LINK_EXTRACTOR_VERSION_TS = '2026-07-30T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -97,11 +97,24 @@ describe('extractLinksFromFile', () => {
     expect(links).toEqual([]);
   });
 
-  it('infers link type from directory structure', async () => {
+  it('people -> companies adjacency without evidence infers mentions, not works_at (#3466)', async () => {
+    // The content carries no employment language, so the directory pair alone
+    // must not assert a specific employment claim. Evidence-based works_at
+    // still flows through the company: frontmatter path (covered above) and
+    // prose inference in link-extraction.ts.
     const content = 'See [Brex](../companies/brex.md).';
     const allSlugs = new Set(['people/pedro', 'companies/brex']);
     const links = await extractLinksFromFile(content, 'people/pedro.md', allSlugs);
-    expect(links[0].link_type).toBe('works_at');
+    expect(links).toHaveLength(1);
+    expect(links[0].link_type).toBe('mentions');
+  });
+
+  it('people -> companies with founded frontmatter infers founded', async () => {
+    const content = '---\nfounded: [brex]\n---\nSee [Brex](../companies/brex.md).';
+    const allSlugs = new Set(['people/pedro', 'companies/brex']);
+    const links = await extractLinksFromFile(content, 'people/pedro.md', allSlugs);
+    expect(links).toHaveLength(1);
+    expect(links[0].link_type).toBe('founded');
   });
 
   it('infers deal_for type for deals -> companies', async () => {


### PR DESCRIPTION
Fixes #3466.

## Summary

`inferTypeByDir` (`src/commands/extract.ts`) typed every markdown link from a `people/` page to a `companies/` page as `works_at`, with no evidence — it only sees the directory pair, so it structurally cannot know whether the page said anything about employment. On non-startup brains this mints false employment claims at scale (19,497 rows on the reporter's brain).

This lands the shape the maintainer said they'd take when closing #3495: a bare `return 'mentions'` for the unevidenced case, the test update, and the `LINK_EXTRACTOR_VERSION_TS` bump. No evidence heuristic, no new relation kind, no config knob.

## Changes

- **`src/commands/extract.ts`** — the unevidenced `people/ → companies/` case now returns the neutral `mentions` verb. The evidence-gated `founded` branch (frontmatter `founded:` array) is unchanged, as are the other dir pairs.
- **`src/core/link-extraction.ts`** — bump `LINK_EXTRACTOR_VERSION_TS` to `2026-07-30T00:00:00Z` so previously-stamped pages are re-flagged stale and re-extract under the corrected inference on the next `gbrain extract --stale` sweep (per the constant's own doc comment; midnight-UTC-of-bump-date convention, kept in the past so stamp-freshness semantics hold).
- **`test/extract.test.ts`** — the old `infers link type from directory structure` test encoded the buggy behavior; it now pins the contract (`mentions`, not `works_at`, for bare adjacency) and adds coverage for the `founded` evidence path.

Real employment edges are unaffected: the two paths that read actual evidence — the `company:`/`companies:` frontmatter fields via `FRONTMATTER_LINK_MAP`, and employment phrasing in prose via `inferLinkType` — are untouched.

## Migration note (honest scope)

`addLinksBatch` is additive (`ON CONFLICT DO NOTHING`), so the version bump makes stamped pages re-extract with the corrected inference, but it does **not** delete `works_at` rows already written by the old inference. Retroactive cleanup of existing wrongly-typed edges is a separate reconcile concern and is deliberately out of scope here.

## Testing

- `bun test test/extract.test.ts test/extract-fs.test.ts test/extract-stale.test.ts` — 70 pass / 0 fail
- `bun test test/extract-db.test.ts test/link-extraction.test.ts test/extract-incremental.test.ts test/sync-inline-extract-stamps.serial.test.ts test/doctor-links-extraction-lag.test.ts test/link-inference-pack.test.ts test/reconcile-links.serial.test.ts` — 219 pass / 0 fail
- `bun run typecheck` — clean
- `bun run verify` — 33/33 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
