### PR TITLE
fix(recipes): align the X secret name with the resolver — X_API_BEARER_TOKEN (#2789 defect 2)

### DIFF
--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -438,6 +438,14 @@ Free tier works for personal monitoring. Basic tier needed for keyword search.
 
 ## Troubleshooting
 
+**Upgrading from recipe v0.8.2 or earlier (token shows [missing] after upgrade):**
+- Older versions of this recipe named the token `X_BEARER_TOKEN`. The canonical
+  name is `X_API_BEARER_TOKEN` — the name the built-in `x_handle_to_tweet`
+  resolver reads. Rename the variable wherever you set it (shell profile, cron
+  environment, `.env`) — same value, new name. A collector installed under the
+  old name keeps running either way; the rename is what makes the integrations
+  dashboard and the resolver see the token.
+
 **API returns 403:**
 - Check your app has the right access level (Read or Read+Write)
 - Free tier apps can only use basic endpoints

--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -1,12 +1,12 @@
 ---
 id: x-to-brain
 name: X-to-Brain
-version: 0.8.2
+version: 0.8.3
 description: Twitter timeline, mentions, and keyword monitoring flow into brain pages. Tracks deletions, engagement velocity, OCR on images, and real-time alerts.
 category: sense
 requires: []
 secrets:
-  - name: X_BEARER_TOKEN
+  - name: X_API_BEARER_TOKEN
     description: X API v2 Bearer token (Basic tier minimum, $200/mo for full archive search)
     where: https://developer.x.com/en/portal/dashboard — create a project + app, copy the Bearer Token from "Keys and tokens"
   - name: X_HANDLE
@@ -16,7 +16,7 @@ health_checks:
   - type: http
     url: "https://api.x.com/2/users/by/username/$X_HANDLE"
     auth: bearer
-    auth_token: "$X_BEARER_TOKEN"
+    auth_token: "$X_API_BEARER_TOKEN"
     label: "X API"
 setup_time: 15 min
 cost_estimate: "$0-200/mo (Free tier: 1 app, read-only. Basic: $200/mo for search + higher limits)"
@@ -118,11 +118,11 @@ Tell the user:
 Note: Free tier gives read-only access with low limits. Basic tier ($200/mo)
 gives search/recent endpoint and higher limits. Pro tier gets full archive search."
 
-Set both `X_BEARER_TOKEN` and `X_HANDLE` in the environment. Validate immediately
+Set both `X_API_BEARER_TOKEN` and `X_HANDLE` in the environment. Validate immediately
 (app-only bearer tokens cannot call `/users/me` — that endpoint requires
 user-context OAuth — so validation uses the by-username lookup):
 ```bash
-curl -sf -H "Authorization: Bearer $X_BEARER_TOKEN" \
+curl -sf -H "Authorization: Bearer $X_API_BEARER_TOKEN" \
   "https://api.x.com/2/users/by/username/$X_HANDLE" \
   && echo "PASS: X API connected" \
   || echo "FAIL: X API token invalid"
@@ -138,7 +138,7 @@ starting with 'AAA...', (3) if you just created the app, the token is valid imme
 
 ```bash
 # Look up the user's X user ID from their handle
-curl -sf -H "Authorization: Bearer $X_BEARER_TOKEN" \
+curl -sf -H "Authorization: Bearer $X_API_BEARER_TOKEN" \
   "https://api.x.com/2/users/by/username/$X_HANDLE" | grep -o '"id":"[^"]*"'
 ```
 
@@ -210,7 +210,7 @@ The agent should review collected data 2-3x daily and run enrichment.
 
 ```bash
 mkdir -p ~/.gbrain/integrations/x-to-brain
-echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","event":"setup_complete","source_version":"0.8.2","status":"ok","details":{"user_id":"X_USER_ID"}}' >> ~/.gbrain/integrations/x-to-brain/heartbeat.jsonl
+echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","event":"setup_complete","source_version":"0.8.3","status":"ok","details":{"user_id":"X_USER_ID"}}' >> ~/.gbrain/integrations/x-to-brain/heartbeat.jsonl
 ```
 
 ## Production Patterns (v0.8.1)

--- a/src/commands/features.ts
+++ b/src/commands/features.ts
@@ -42,7 +42,7 @@ interface FeatureScanResult {
 const RECIPE_META = [
   { id: 'email-to-brain', name: 'Email to Brain', secrets: ['GMAIL_APP_PASSWORD'] },
   { id: 'calendar-to-brain', name: 'Calendar Sync', secrets: ['GOOGLE_CALENDAR_API_KEY'] },
-  { id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_BEARER_TOKEN'] },
+  { id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_API_BEARER_TOKEN'] },
   { id: 'twilio-voice-brain', name: 'Voice to Brain', secrets: ['TWILIO_AUTH_TOKEN'] },
   { id: 'meeting-sync', name: 'Meeting Sync', secrets: ['CIRCLEBACK_API_KEY'] },
   { id: 'credential-gateway', name: 'Credential Gateway', secrets: ['OAUTH_CLIENT_SECRET'] },

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -39,15 +39,31 @@ describe('x-to-brain secret name alignment (#2789)', () => {
     expect(src).toContain("{ id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_API_BEARER_TOKEN'] }");
   });
 
-  it('the x-to-brain recipe declares and uses only the canonical name', () => {
-    const recipe = read('../recipes/x-to-brain.md');
-    expect(recipe).toContain('X_API_BEARER_TOKEN');
-    // No occurrence of the legacy name. (Safe as a substring check: the
-    // canonical X_API_BEARER_TOKEN does not contain X_BEARER_TOKEN.)
-    expect(recipe).not.toContain('X_BEARER_TOKEN');
+  it('the x-to-brain recipe declares and uses only the canonical name', async () => {
+    const { parseRecipe } = await import('../src/commands/integrations.ts');
+    const raw = read('../recipes/x-to-brain.md');
+    const recipe = parseRecipe(raw, 'x-to-brain.md');
+    expect(recipe).not.toBeNull();
+    // Frontmatter: the declared secret is the canonical name.
+    const secretNames = recipe!.frontmatter.secrets.map(s => s.name);
+    expect(secretNames).toContain('X_API_BEARER_TOKEN');
+    expect(secretNames).not.toContain('X_BEARER_TOKEN');
+    // Health check: the bearer interpolation uses the canonical name.
+    const hc = recipe!.frontmatter.health_checks[0] as { auth_token?: string };
+    expect(hc.auth_token).toBe('$X_API_BEARER_TOKEN');
+    // Body: every $-interpolated token reference (curl examples etc.) is the
+    // canonical name — catches a third misspelled variant, not just the exact
+    // legacy string. (The legacy name may still appear as PROSE in the
+    // upgrade/migration note; only $VAR references are load-bearing.)
+    const tokenRefs = raw.match(/\$X_[A-Z_]*TOKEN\b/g) ?? [];
+    expect(tokenRefs.length).toBeGreaterThan(0);
+    for (const ref of tokenRefs) expect(ref).toBe('$X_API_BEARER_TOKEN');
   });
 
   it('the resolver reads the same env var the recipe documents', () => {
+    // Alignment guard (not a behavior test — resolver behavior is pinned in
+    // test/resolvers.test.ts): if the resolver's env name ever changes, this
+    // forces the recipe + registry to move with it.
     const resolver = read('../src/core/resolvers/builtin/x-api/handle-to-tweet.ts');
     expect(resolver).toContain('process.env.X_API_BEARER_TOKEN');
   });

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -23,6 +23,36 @@ describe('recipe metadata', () => {
   });
 });
 
+// #2789: the x-to-brain secret name must be the one the resolver actually
+// reads. The recipe + RECIPE_META used to pin X_BEARER_TOKEN while the
+// x_handle_to_tweet resolver reads only config x_api_bearer_token / env
+// X_API_BEARER_TOKEN — so no single name worked end-to-end. All three
+// surfaces must agree on the resolver's canonical name.
+describe('x-to-brain secret name alignment (#2789)', () => {
+  const read = (p: string) => {
+    const { readFileSync } = require('fs');
+    return readFileSync(new URL(p, import.meta.url), 'utf-8') as string;
+  };
+
+  it('features registry pins the resolver-canonical name', () => {
+    const src = read('../src/commands/features.ts');
+    expect(src).toContain("{ id: 'x-to-brain', name: 'X/Twitter to Brain', secrets: ['X_API_BEARER_TOKEN'] }");
+  });
+
+  it('the x-to-brain recipe declares and uses only the canonical name', () => {
+    const recipe = read('../recipes/x-to-brain.md');
+    expect(recipe).toContain('X_API_BEARER_TOKEN');
+    // No occurrence of the legacy name. (Safe as a substring check: the
+    // canonical X_API_BEARER_TOKEN does not contain X_BEARER_TOKEN.)
+    expect(recipe).not.toContain('X_BEARER_TOKEN');
+  });
+
+  it('the resolver reads the same env var the recipe documents', () => {
+    const resolver = read('../src/core/resolvers/builtin/x-api/handle-to-tweet.ts');
+    expect(resolver).toContain('process.env.X_API_BEARER_TOKEN');
+  });
+});
+
 // Test brain_score in BrainHealth type
 describe('BrainHealth type', () => {
   it('includes brain_score field', async () => {


### PR DESCRIPTION
Part of #2789 — this fixes **defect 2 only** (the X secret-name mismatch). Defect 1 (show/status config-plane folding) is a separate, independent PR, so neither uses a closing keyword; whichever lands second can close the issue manually.

## The bug

The `x-to-brain` recipe (`recipes/x-to-brain.md` frontmatter, health check, and curl examples) and the features registry (`src/commands/features.ts`) pin `X_BEARER_TOKEN`. The actual consumer — the built-in `x_handle_to_tweet` resolver — reads config `x_api_bearer_token` or env `X_API_BEARER_TOKEN` with **no fallback** to the recipe's name (`src/core/resolvers/builtin/x-api/handle-to-tweet.ts:getBearerToken`). Follow the recipe → the resolver can't see your token. Set the name the code reads → the integrations dashboard flags a healthy sense `[missing]`. There is no name both sides accept.

Confirmed on master (c6dc0adf): recipe/registry say `X_BEARER_TOKEN`; `getBearerToken` reads only `x_api_bearer_token` / `X_API_BEARER_TOKEN`.

## The fix

Rename the recipe + registry to the resolver's canonical **`X_API_BEARER_TOKEN`** (all 6 occurrences in the recipe — frontmatter secret, health-check `auth_token`, setup prose, and both curl examples — plus the `RECIPE_META` entry). Recipe version 0.8.2 → 0.8.3, matching the prior recipe-change convention (#3165), including the Step 7 heartbeat `source_version` example.

**Why this direction (least breakage):** `X_API_BEARER_TOKEN` is what the resolver, its tests, and `docs/designs/KNOWLEDGE_RUNTIME.md` already promise — every currently-working deployment uses it. `X_BEARER_TOKEN` never worked end-to-end through the resolver, so renaming the documented-but-dead side breaks no working setup. For the same reason no legacy fallback is added in the resolver: there is no working `X_BEARER_TOKEN`-through-the-resolver install to keep alive, and a permanent alias for a name that never worked is surface without a user.

## Known tradeoff: installs from recipe ≤0.8.2

The recipe's install flow builds a *standalone* `x-collector.mjs` whose cron env was set up under the old name — those collectors keep running after upgrade, but the integrations dashboard will flag the (renamed) secret `[missing]` until the operator renames the variable. Handled with an explicit upgrade note in the recipe's Troubleshooting section ("rename the variable — same value, new name") rather than a permanent alias in secret resolution: an alias for a name that never worked through the resolver is surface without an end state, the frontmatter secrets list can't express either-of, and the `[missing]` flag is itself the migration prompt (nothing stops working in the meantime). If you'd rather have a time-boxed alias instead, happy to add it.

## Deliberately NOT changed

`test/e2e/bench-vs-openclaw/tweet-ingest.bench.ts` still uses `X_BEARER_TOKEN` — it is a standalone benchmark with its own env contract that calls the X API directly (never through the resolver or recipe), so it is outside this mismatch.

## Proof

- New `describe('x-to-brain secret name alignment (#2789)')` in `test/features.test.ts` pins all three surfaces to the canonical name: registry entry, parsed recipe frontmatter (declared secret + health-check `auth_token`) plus every `$`-interpolated token reference in the body, and the resolver env read (alignment guard). Run against unmodified master: 2 of the 3 tests fail (registry + recipe); the third pins the alignment target and passes on both sides by design.
- `bun test test/features.test.ts test/integrations.test.ts` — 123 pass / 0 fail
- `bun run typecheck` — clean
- `bun run verify` — 33/33 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
