### PR TITLE
fix(export): thread sourceId filter via --source

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2619,6 +2619,7 @@ IMPORT/EXPORT
   export [--dir ./out/]              Export to markdown
   export --restore-only [--repo <p>] Restore missing supabase-only files
         [--type T] [--slug-prefix S] With optional filters
+        [--source ID]                Scope to one source (default: every source)
 
 FILES
   files list [slug]                  List stored files

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -108,7 +108,11 @@ export async function runExport(engine: BrainEngine, args: string[]) {
   let exported = 0;
 
   for (const page of pages) {
-    const tags = await engine.getTags(page.slug);
+    // Slugs are unique per source, not brain-wide, so both sidecar reads are
+    // pinned to the page's own source. Unscoped, `getTags` falls back to
+    // `source_id = 'default'` and stamps the default source's tags onto a
+    // same-slug page from another source (dropping its real ones).
+    const tags = await engine.getTags(page.slug, { sourceId: page.source_id });
     const md = serializeMarkdown(
       page.frontmatter,
       page.compiled_truth,
@@ -120,8 +124,13 @@ export async function runExport(engine: BrainEngine, args: string[]) {
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, md);
 
-    // Export raw data as sidecar JSON
-    const rawData = await engine.getRawData(page.slug);
+    // Export raw data as sidecar JSON. Unscoped, this matches the slug in
+    // EVERY source and the loop below merges the rows into one sidecar keyed
+    // by `rd.source`, so another source's raw data silently overwrites this
+    // page's own on a key collision.
+    const rawData = await engine.getRawData(page.slug, undefined, {
+      sourceId: page.source_id,
+    });
     if (rawData.length > 0) {
       const slugParts = page.slug.split('/');
       const rawDir = join(outDir, ...slugParts.slice(0, -1), '.raw');

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -5,7 +5,11 @@ import { serializeMarkdown } from '../core/markdown.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import { loadStorageConfig, isDbOnly } from '../core/storage-config.ts';
-import { getDefaultSourcePath } from '../core/source-resolver.ts';
+import {
+  ALL_SOURCES,
+  getDefaultSourcePath,
+  resolveSourceWithTier,
+} from '../core/source-resolver.ts';
 import type { PageType } from '../core/types.ts';
 
 export async function runExport(engine: BrainEngine, args: string[]) {
@@ -21,7 +25,25 @@ export async function runExport(engine: BrainEngine, args: string[]) {
   const slugPrefixIdx = args.indexOf('--slug-prefix');
   const slugPrefix = slugPrefixIdx !== -1 ? args[slugPrefixIdx + 1] : undefined;
 
+  const sourceIdx = args.indexOf('--source');
+  const explicitSource = sourceIdx !== -1 ? args[sourceIdx + 1] : undefined;
+
   const restoreOnly = args.includes('--restore-only');
+
+  // EXPLICIT-ONLY, matching `doctor` and `orphans`: the flag is resolved
+  // through the canonical chain but ONLY when it was actually passed. Calling
+  // the resolver unconditionally would let GBRAIN_SOURCE or a `.gbrain-source`
+  // dotfile silently narrow a bare `gbrain export` to one source, which for a
+  // command whose output is a backup means silent data loss at restore time.
+  // Resolving the explicit value still buys the #1712 loud-fail on an unknown
+  // or malformed id, so a typo can't quietly export zero pages.
+  let sourceFilter: string | undefined;
+  if (explicitSource) {
+    const { source_id } = await resolveSourceWithTier(engine, explicitSource);
+    // `__all__` means "span every source" — the no-filter default, not a
+    // source literally named `__all__`.
+    sourceFilter = source_id === ALL_SOURCES ? undefined : source_id;
+  }
 
   // Resolution chain (D5): explicit --repo → typed sources.getDefault() →
   // hard-error for restore-only paths (never fall through to cwd).
@@ -63,6 +85,11 @@ export async function runExport(engine: BrainEngine, args: string[]) {
   const filters: import('../core/types.ts').PageFilters = { limit: 100000 };
   if (typeFilter) filters.type = typeFilter;
   if (slugPrefix) filters.slugPrefix = slugPrefix;
+  // --source scopes the export to a single source. listPages applies
+  // `WHERE p.source_id = $N` via PageFilters.sourceId; omitting the flag keeps
+  // the existing all-sources behavior. Set on `filters` so both the normal and
+  // --restore-only paths (which spread `...filters`) inherit the scope.
+  if (sourceFilter) filters.sourceId = sourceFilter;
 
   let pages: import('../core/types.ts').Page[];
 
@@ -98,7 +125,8 @@ export async function runExport(engine: BrainEngine, args: string[]) {
   if (restoreOnly) {
     console.log(`Restoring ${pages.length} db_only pages to ${outDir}/`);
   } else {
-    console.log(`Exporting ${pages.length} pages to ${outDir}/`);
+    const scope = sourceFilter ? ` from source '${sourceFilter}'` : '';
+    console.log(`Exporting ${pages.length} pages${scope} to ${outDir}/`);
   }
 
   // Progress on stderr so stdout stays clean for scripts parsing counts.

--- a/test/storage-export.test.ts
+++ b/test/storage-export.test.ts
@@ -7,10 +7,14 @@
  * Tests use PGLite in-memory and a captured-output approach (process.exit
  * is intercepted) to verify the resolution chain produces the right
  * repoPath OR the right error.
+ *
+ * Also covers per-source scoping of the two sidecar reads in the export loop
+ * (tags + raw data), which are keyed by slug and so cross source boundaries
+ * unless pinned to the page's own source.
  */
 
 import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -142,5 +146,60 @@ describe('export --restore-only resolution chain (D5)', () => {
     await tryRunExport(['--dir', outDir]);
     expect(exitCode).toBeNull();
     expect(stdout.some((line) => line.includes('Exporting 0'))).toBe(true);
+  });
+});
+
+describe('export sidecar reads are scoped to the page owning source', () => {
+  // Both fixtures use the SAME slug in two sources — the only shape where a
+  // slug-keyed read can cross a boundary, since slugs are unique per source
+  // rather than brain-wide.
+  const SLUG = 'notes/shared';
+
+  beforeEach(async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('other', 'Other') ON CONFLICT DO NOTHING`,
+    );
+    for (const sourceId of ['default', 'other']) {
+      await engine.putPage(
+        SLUG,
+        { type: 'note', title: `${sourceId} title`, compiled_truth: 'body' },
+        { sourceId },
+      );
+      await engine.addTag(SLUG, `tag-${sourceId}`, { sourceId });
+      await engine.putRawData(SLUG, `feed-${sourceId}`, { owner: sourceId }, { sourceId });
+    }
+
+    // One slug means one output path, so the two pages overwrite each other
+    // and only the last one written survives on disk. Pin the export order
+    // (listPages defaults to updated_desc) so `other` is the survivor and the
+    // assertions below read a NON-default page — the only page whose sidecars
+    // an unscoped, `'default'`-defaulting read would get wrong.
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = updated_at + interval '1 hour' WHERE source_id = 'default'`,
+    );
+  });
+
+  test("a non-default page exports its own tags, not the default source's", async () => {
+    await tryRunExport(['--dir', outDir]);
+    expect(exitCode).toBeNull();
+
+    const md = readFileSync(join(outDir, SLUG + '.md'), 'utf-8');
+    // Guards the ordering assumption itself: if `default` ever wins the race
+    // the tag assertions stop discriminating, so fail loudly here instead.
+    expect(md).toContain('other title');
+    expect(md).toContain('tag-other');
+    expect(md).not.toContain('tag-default');
+  });
+
+  test('raw-data sidecars carry only the owning source rows', async () => {
+    await tryRunExport(['--dir', outDir]);
+    expect(exitCode).toBeNull();
+
+    // Unscoped, getRawData applies no source predicate at all: both sources'
+    // rows come back and the export loop merges them into a single object
+    // keyed by `rd.source`.
+    const raw = JSON.parse(readFileSync(join(outDir, 'notes', '.raw', 'shared.json'), 'utf-8'));
+    expect(Object.keys(raw)).toEqual(['feed-other']);
+    expect(raw['feed-other']).toEqual({ owner: 'other' });
   });
 });

--- a/test/storage-export.test.ts
+++ b/test/storage-export.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExport } from '../src/commands/export.ts';
 import { __resetMissingStorageWarning } from '../src/core/storage-config.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 let tmp: string;
@@ -279,14 +280,9 @@ describe('export --source (scope to a single source)', () => {
 
     // Export output is a backup; letting the env var or a `.gbrain-source`
     // dotfile narrow a bare run silently drops pages from the archive.
-    const prior = process.env.GBRAIN_SOURCE;
-    process.env.GBRAIN_SOURCE = 'src-x';
-    try {
+    await withEnv({ GBRAIN_SOURCE: 'src-x' }, async () => {
       await tryRunExport(['--dir', outDir]);
-    } finally {
-      if (prior === undefined) delete process.env.GBRAIN_SOURCE;
-      else process.env.GBRAIN_SOURCE = prior;
-    }
+    });
 
     expect(exitCode).toBeNull();
     expect(existsSync(join(outDir, 'notes/y-only.md'))).toBe(true);

--- a/test/storage-export.test.ts
+++ b/test/storage-export.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -201,5 +201,94 @@ describe('export sidecar reads are scoped to the page owning source', () => {
     const raw = JSON.parse(readFileSync(join(outDir, 'notes', '.raw', 'shared.json'), 'utf-8'));
     expect(Object.keys(raw)).toEqual(['feed-other']);
     expect(raw['feed-other']).toEqual({ owner: 'other' });
+  });
+});
+
+describe('export --source (scope to a single source)', () => {
+  async function seedTwoSources(): Promise<void> {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('src-x', 'Source X'), ('src-y', 'Source Y') ON CONFLICT DO NOTHING`,
+    );
+    await engine.putPage(
+      'notes/x-only',
+      { type: 'note', title: 'X only', compiled_truth: 'belongs to src-x', frontmatter: {} },
+      { sourceId: 'src-x' },
+    );
+    await engine.putPage(
+      'notes/y-only',
+      { type: 'note', title: 'Y only', compiled_truth: 'belongs to src-y', frontmatter: {} },
+      { sourceId: 'src-y' },
+    );
+  }
+
+  test('exports only the named source, omitting pages from other sources', async () => {
+    await seedTwoSources();
+
+    await tryRunExport(['--dir', outDir, '--source', 'src-x']);
+
+    expect(exitCode).toBeNull();
+    expect(existsSync(join(outDir, 'notes/x-only.md'))).toBe(true);
+    expect(existsSync(join(outDir, 'notes/y-only.md'))).toBe(false);
+    // The scope is reflected in the count line for operator visibility.
+    expect(stdout.some((line) => line.includes("from source 'src-x'"))).toBe(true);
+  });
+
+  test('without --source, exports pages from every source (backward compatible)', async () => {
+    await seedTwoSources();
+
+    await tryRunExport(['--dir', outDir]);
+
+    expect(exitCode).toBeNull();
+    expect(existsSync(join(outDir, 'notes/x-only.md'))).toBe(true);
+    expect(existsSync(join(outDir, 'notes/y-only.md'))).toBe(true);
+  });
+
+  test('an unknown source id is a hard error, not a silent empty export', async () => {
+    await seedTwoSources();
+
+    // #1712: the failure mode this guards is `--source src-xx` exporting zero
+    // pages and reporting success, which reads as "the brain is empty".
+    await expect(runExport(engine, ['--dir', outDir, '--source', 'src-xx'])).rejects.toThrow(
+      /not found/i,
+    );
+    expect(existsSync(join(outDir, 'notes/x-only.md'))).toBe(false);
+  });
+
+  test('a malformed source id is rejected before any page query', async () => {
+    await seedTwoSources();
+
+    await expect(runExport(engine, ['--dir', outDir, '--source', 'Not A Source'])).rejects.toThrow(
+      /Invalid --source/i,
+    );
+  });
+
+  test('--source __all__ spans every source rather than matching a literal id', async () => {
+    await seedTwoSources();
+
+    // The sentinel resolves to ALL_SOURCES, which must clear the filter -
+    // passing it through as a source id would match nothing.
+    await tryRunExport(['--dir', outDir, '--source', '__all__']);
+
+    expect(exitCode).toBeNull();
+    expect(existsSync(join(outDir, 'notes/x-only.md'))).toBe(true);
+    expect(existsSync(join(outDir, 'notes/y-only.md'))).toBe(true);
+  });
+
+  test('an absent --source does NOT consult GBRAIN_SOURCE (bare export stays brain-wide)', async () => {
+    await seedTwoSources();
+
+    // Export output is a backup; letting the env var or a `.gbrain-source`
+    // dotfile narrow a bare run silently drops pages from the archive.
+    const prior = process.env.GBRAIN_SOURCE;
+    process.env.GBRAIN_SOURCE = 'src-x';
+    try {
+      await tryRunExport(['--dir', outDir]);
+    } finally {
+      if (prior === undefined) delete process.env.GBRAIN_SOURCE;
+      else process.env.GBRAIN_SOURCE = prior;
+    }
+
+    expect(exitCode).toBeNull();
+    expect(existsSync(join(outDir, 'notes/y-only.md'))).toBe(true);
   });
 });


### PR DESCRIPTION
Rebased onto fresh master and reworked against the review. Retitled from `feat` to `fix` per the review's own read: `PageFilters.sourceId` is already honored by both engines and `export` simply never threads it, so a multi-source export flattens by slug today.

**Stacked on #3755.** The cross-source leak found in review (`getTags` / `getRawData` unscoped in the export loop) is a master bug, present with or without this flag - `getTags` falls back to `source_id = 'default'` and `getRawData` applies no source predicate at all. It is fixed separately in #3755 with its own discriminating tests; this branch sits on top and no longer carries it. Please take #3755 first.

## Changes since the reviewed version

**1. The flag now resolves through the canonical chain (#1712 loud-fail).** `resolveSourceWithTier(engine, explicitSource)` replaces the bare `args.indexOf` read, so an unknown or malformed id is a hard error instead of a successful zero-page export, and the `__all__` sentinel spans every source rather than being passed through as a source id that matches nothing.

**2. Resolution stays EXPLICIT-ONLY - the resolver runs only when the flag was actually passed.** The review asked for `GBRAIN_SOURCE` / dotfile / path-match to be honored too. I've deliberately not done that, matching two existing commands that made the same call for the same reason:

- `src/commands/doctor.ts:4721` - *"EXPLICIT-ONLY by design - a raw flag parse, NOT resolveSourceWithTier. The tier resolver would pick a default source when `--source` is absent and silently scope a bare `gbrain doctor` to one source."*
- `src/commands/orphans.ts:226` - same reasoning, same wording.

Export has the identical hazard with worse consequences: its output is an archive, so an ambient dotfile narrowing a bare `gbrain export` drops pages from a backup silently, and the loss only surfaces at restore time. Happy to switch if you'd rather export match `sync`/`capture` instead - it's a one-line change - but the default-safety argument reads stronger here than anywhere else in the CLI.

**3. `--source` is documented** in the export help block (`src/cli.ts:2622`).

## Tests

Six tests in `test/storage-export.test.ts`. Discrimination verified by stubbing the resolver call back to the raw `args.indexOf` parse - three fail:

```
(fail) an unknown source id is a hard error, not a silent empty export
(fail) a malformed source id is rejected before any page query
(fail) --source __all__ spans every source rather than matching a literal id
```

The scoping tests (`--source` exports one source; bare export still exports all) discriminate against removing the `filters.sourceId` wire, as before.

One test does NOT discriminate and is a regression guard rather than a proof: *"an absent `--source` does not consult GBRAIN_SOURCE"* passes both before and after, because the raw parse also ignored the env var. It's there to fail if someone later moves the resolver call out of the `if (explicitSource)` branch.

13 pass / 0 fail in that file, `tsc --noEmit` clean.

## Notes

- `test/cli.test.ts` shows 8 pass / 10 fail here, identical on untouched master - pre-existing and environmental, not from this branch.
- `test/storage-export.test.ts` needs `--timeout 120000` locally; its `beforeAll` runs 120 PGLite migrations and blows the default 5s hook budget on Windows. Also reproduces on master.
