### PR TITLE
fix(ai): enforce embedding-only OpenAI API key scope

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -310,6 +310,11 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
       }
     }
 
+    if (key === 'openai_api_key_scope' && value !== 'all' && value !== 'embedding_only') {
+      console.error('[config] openai_api_key_scope must be "all" or "embedding_only"');
+      process.exit(1);
+    }
+
     // v0.40.3.0 (D3 + Phase 2B): capture the OLD search.mode BEFORE the
     // setConfig so summarizeTransition() can classify the kind correctly.
     // Read fails silently → oldMode null → treated as broadening.

--- a/src/commands/eval-cross-modal.ts
+++ b/src/commands/eval-cross-modal.ts
@@ -21,8 +21,9 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { createHash } from 'crypto';
 
-import { gbrainPath, loadConfig } from '../core/config.ts';
+import { gbrainPath, loadConfig, type GBrainConfig } from '../core/config.ts';
 import { configureGateway, isAvailable } from '../core/ai/gateway.ts';
+import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
 import { runWithLimit } from '../core/worker-pool.ts';
 import { resolveCycleDefault, cycleDefaultSuffix } from '../core/eval/cycle-default.ts';
 import {
@@ -265,31 +266,9 @@ function isTTY(): boolean {
  */
 function configureGatewayForCli(): boolean {
   const config = loadConfig();
-  if (!config) {
-    // No config file is fine for the eval command — env vars alone may serve.
-    // We still call configureGateway so gateway recipes can read the env map.
-    configureGateway({
-      embedding_model: undefined,
-      embedding_dimensions: undefined,
-      expansion_model: undefined,
-      chat_model: undefined,
-      chat_fallback_chain: undefined,
-      base_urls: undefined,
-      provider_chat_options: undefined,
-      env: { ...process.env },
-    });
-    return true;
-  }
-  configureGateway({
-    embedding_model: config.embedding_model,
-    embedding_dimensions: config.embedding_dimensions,
-    expansion_model: config.expansion_model,
-    chat_model: config.chat_model,
-    chat_fallback_chain: config.chat_fallback_chain,
-    base_urls: config.provider_base_urls,
-    provider_chat_options: config.provider_chat_options,
-    env: { ...process.env },
-  });
+  // Use the canonical builder so credential-purpose policy cannot drift from
+  // the normal CLI path. An absent file still permits env-only providers.
+  configureGateway(buildGatewayConfig(config ?? ({ engine: 'postgres' } as GBrainConfig)));
   return true;
 }
 

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -71,6 +71,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   if (process.env.OPENROUTER_BASE_URL) envBaseUrls['openrouter'] = process.env.OPENROUTER_BASE_URL;
 
   return {
+    openai_api_key_scope: c.openai_api_key_scope,
     embedding_model: c.embedding_model,
     embedding_dimensions: c.embedding_dimensions,
     embedding_multimodal_model: c.embedding_multimodal_model,

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -47,6 +47,7 @@ import type {
   TouchpointKind,
 } from './types.ts';
 import { resolveRecipe, assertTouchpoint, parseModelId } from './model-resolver.ts';
+import { isOpenAIApiKeyRestricted } from './openai-key-scope.ts';
 import {
   OPENROUTER_CACHE_HEADER,
   openrouterRequiresExplicitPromptCache,
@@ -469,6 +470,7 @@ export function recipeSupportsStructuredOutputs(recipe: Recipe): boolean {
 /** Configure the gateway. Called by cli.ts#connectEngine. Clears cached models. */
 export function configureGateway(config: AIGatewayConfig): void {
   _config = {
+    openai_api_key_scope: config.openai_api_key_scope,
     embedding_model: config.embedding_model ?? DEFAULT_EMBEDDING_MODEL,
     // #1292/D6: do NOT fabricate a default here. Every gateway-internal reader
     // already applies `?? DEFAULT_EMBEDDING_DIMENSIONS` (getEmbeddingDimensions,
@@ -964,6 +966,8 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     if (!modelStr) return false;
     const { recipe } = resolveRecipe(modelStr);
 
+    if (!isCredentialScopeAllowed(recipe, touchpoint, _config)) return false;
+
     // Recipe must actually support the requested touchpoint.
     // Anthropic declares only expansion + chat (no embedding model); requesting
     // embedding from an anthropic-configured brain is unavailable regardless of auth.
@@ -977,6 +981,30 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
   } catch {
     return false;
   }
+}
+
+function isCredentialScopeAllowed(
+  recipe: Recipe,
+  touchpoint: TouchpointKind,
+  cfg: AIGatewayConfig | null,
+): boolean {
+  return !(
+    recipe.id === 'openai'
+    && isOpenAIApiKeyRestricted(cfg?.openai_api_key_scope)
+    && touchpoint !== 'embedding'
+  );
+}
+
+function assertCredentialScopeAllowed(
+  recipe: Recipe,
+  touchpoint: TouchpointKind,
+  cfg: AIGatewayConfig,
+): void {
+  if (isCredentialScopeAllowed(recipe, touchpoint, cfg)) return;
+  throw new AIConfigError(
+    `OPENAI_API_KEY is restricted to embedding requests; refusing OpenAI ${touchpoint}.`,
+    'Use a non-OpenAI-API provider for reasoning, or explicitly change openai_api_key_scope only if API-funded reasoning is intended.',
+  );
 }
 
 // ---- Embedding ----
@@ -2457,6 +2485,7 @@ async function resolveExpansionProvider(modelStr: string): Promise<{ model: any;
 }
 
 function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  assertCredentialScopeAllowed(recipe, 'expansion', cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
@@ -3019,6 +3048,7 @@ async function resolveChatProvider(modelStr: string): Promise<{ model: any; reci
 }
 
 function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  assertCredentialScopeAllowed(recipe, 'chat', cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;

--- a/src/core/ai/openai-key-scope.ts
+++ b/src/core/ai/openai-key-scope.ts
@@ -1,0 +1,14 @@
+/** Credential-purpose policy for the key carried in OPENAI_API_KEY. */
+export type OpenAIApiKeyScope = 'all' | 'embedding_only';
+
+export function isValidOpenAIApiKeyScope(value: unknown): value is OpenAIApiKeyScope {
+  return value === 'all' || value === 'embedding_only';
+}
+
+/**
+ * Unknown values fail closed. Undefined preserves the historical unrestricted
+ * default for installations that have not opted into credential scoping.
+ */
+export function isOpenAIApiKeyRestricted(value: unknown): boolean {
+  return value !== undefined && value !== 'all';
+}

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -1,3 +1,5 @@
+import type { OpenAIApiKeyScope } from './openai-key-scope.ts';
+
 /**
  * AI provider types.
  *
@@ -402,6 +404,8 @@ export interface Recipe {
 }
 
 export interface AIGatewayConfig {
+  /** Policy boundary for the credential in env.OPENAI_API_KEY. */
+  openai_api_key_scope?: OpenAIApiKeyScope;
   /** Current embedding model as "provider:modelId" (e.g. "openai:text-embedding-3-large"). */
   embedding_model?: string;
   /** Target embedding dims. Gateway asserts returned embeddings match this. */

--- a/src/core/claw-test/runners/openclaw.ts
+++ b/src/core/claw-test/runners/openclaw.ts
@@ -17,6 +17,8 @@ import { execSync } from 'child_process';
 import { statSync } from 'fs';
 import type { AgentRunner, DetectResult, InvokeOpts, InvokeResult } from '../agent-runner.ts';
 import { spawnWithCapture } from '../transcript-capture.ts';
+import { loadConfig } from '../../config.ts';
+import { isOpenAIApiKeyRestricted } from '../../ai/openai-key-scope.ts';
 
 const DEFAULT_AGENT_NAME = 'default';
 /** Allow-list for env propagation when spawning openclaw. */
@@ -79,6 +81,10 @@ export class OpenClawRunner implements AgentRunner {
       if (typeof v === 'string') baseEnv[key] = v;
     }
     const env: Record<string, string> = { ...baseEnv, ...opts.env };
+    if (isOpenAIApiKeyRestricted(loadConfig()?.openai_api_key_scope)) {
+      // Caller overrides cannot smuggle the embeddings-only credential into a child agent.
+      delete env.OPENAI_API_KEY;
+    }
 
     const result = await spawnWithCapture(detected.binPath, args, {
       cwd: opts.cwd,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'f
 import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
 import type { EngineConfig, EmbeddingColumnConfig } from './types.ts';
+import type { OpenAIApiKeyScope } from './ai/openai-key-scope.ts';
 
 /**
  * Where is the active DB URL coming from? Pure introspection, no connection
@@ -30,6 +31,12 @@ export interface GBrainConfig {
   database_url?: string;
   database_path?: string;
   openai_api_key?: string;
+  /**
+   * Restrict OPENAI_API_KEY to embedding calls. When set to
+   * `embedding_only`, native OpenAI chat and query-expansion routes fail
+   * closed even when a caller supplies an explicit `openai:*` model.
+   */
+  openai_api_key_scope?: OpenAIApiKeyScope;
   anthropic_api_key?: string;
   /**
    * ZeroEntropy API key. v0.37 fix wave (CDX2-5+6): ZE became the default
@@ -723,6 +730,7 @@ export async function loadConfigWithEngine(
     return Object.keys(out).length > 0 ? out : undefined;
   }
 
+  const dbOpenAIKeyScope = await dbStr('openai_api_key_scope');
   const dbMultimodal = await dbBool('embedding_multimodal');
   const dbMultimodalModel = await dbStr('embedding_multimodal_model');
   const dbOcr = await dbBool('embedding_image_ocr');
@@ -739,6 +747,10 @@ export async function loadConfigWithEngine(
   // sync loadConfig() already setting the field. For each flag, prefer the
   // existing fileConfig value when defined; otherwise fall through to DB.
   const merged: GBrainConfig = { ...fileConfig };
+  if (merged.openai_api_key_scope === undefined && dbOpenAIKeyScope !== undefined) {
+    // Malformed DB values fail closed rather than silently restoring API-funded reasoning.
+    merged.openai_api_key_scope = dbOpenAIKeyScope === 'all' ? 'all' : 'embedding_only';
+  }
   if (merged.embedding_multimodal === undefined && dbMultimodal !== undefined) {
     merged.embedding_multimodal = dbMultimodal;
   }
@@ -915,6 +927,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'database_url',
   'database_path',
   'openai_api_key',
+  'openai_api_key_scope',
   'anthropic_api_key',
   'zeroentropy_api_key',
   'openrouter_api_key',

--- a/src/core/transcription.ts
+++ b/src/core/transcription.ts
@@ -8,6 +8,8 @@
 
 import { statSync, readFileSync, rmSync } from 'fs';
 import { basename, extname, join } from 'path';
+import { loadConfig } from './config.ts';
+import { isOpenAIApiKeyRestricted } from './ai/openai-key-scope.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,6 +66,9 @@ export async function transcribe(
 
   // Determine provider and API key
   const provider = config.provider || detectProvider();
+  if (provider === 'openai' && isOpenAIApiKeyRestricted(loadConfig()?.openai_api_key_scope)) {
+    throw new Error('OPENAI_API_KEY is restricted to embedding requests; refusing OpenAI transcription.');
+  }
   const apiKey = config.apiKey || getApiKey(provider);
   if (!apiKey) {
     const envVar = provider === 'groq' ? 'GROQ_API_KEY' : 'OPENAI_API_KEY';

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -100,6 +100,16 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
 });
 
 describe('buildGatewayConfig config-plane API-key folding', () => {
+  test('openai_api_key_scope passes through to the gateway policy', async () => {
+    await withEnv({ OPENAI_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        openai_api_key: 'sk-embedding-only',
+        openai_api_key_scope: 'embedding_only',
+      } as unknown as GBrainConfig);
+      expect(cfg.openai_api_key_scope).toBe('embedding_only');
+    });
+  });
+
   test('openrouter_api_key folds into gateway env as OPENROUTER_API_KEY', async () => {
     await withEnv({ OPENROUTER_API_KEY: undefined }, async () => {
       const cfg = buildGatewayConfig({

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -242,6 +242,43 @@ describe('chat touchpoint — gateway config plumbing', () => {
     configureGateway({ chat_model: 'voyage:voyage-3', env: { VOYAGE_API_KEY: 'fake' } });
     expect(isAvailable('chat')).toBe(false);
   });
+
+  test('embedding-only OpenAI key scope rejects native OpenAI chat, including an explicit override', async () => {
+    configureGateway({
+      chat_model: 'anthropic:claude-sonnet-4-6',
+      openai_api_key_scope: 'embedding_only',
+      env: { OPENAI_API_KEY: 'fake', ANTHROPIC_API_KEY: 'fake' },
+    });
+
+    expect(isAvailable('chat', 'openai:gpt-5.2')).toBe(false);
+    await expect(chat({
+      model: 'openai:gpt-5.2',
+      messages: [{ role: 'user', content: 'must not reach OpenAI chat' }],
+    })).rejects.toThrow('OPENAI_API_KEY is restricted to embedding requests');
+  });
+
+  test('embedding-only OpenAI key scope keeps OpenAI embeddings available but blocks expansion', () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      expansion_model: 'openai:gpt-5.2',
+      openai_api_key_scope: 'embedding_only',
+      env: { OPENAI_API_KEY: 'fake' },
+    });
+
+    expect(isAvailable('embedding')).toBe(true);
+    expect(isAvailable('expansion')).toBe(false);
+  });
+
+  test('malformed OpenAI key scope fails closed', () => {
+    configureGateway({
+      chat_model: 'openai:gpt-5.2',
+      expansion_model: 'openai:gpt-5.2',
+      openai_api_key_scope: 'typo' as any,
+      env: { OPENAI_API_KEY: 'fake' },
+    });
+    expect(isAvailable('chat')).toBe(false);
+    expect(isAvailable('expansion')).toBe(false);
+  });
 });
 
 describe('chat touchpoint — config alias resolution', () => {

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -64,6 +64,20 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
     expect(merged?.embedding_image_ocr_model).toBe('openai:gpt-4o-mini');
   });
 
+  test('DB-plane OpenAI key scope round-trips and malformed values fail closed', async () => {
+    const restricted = await loadConfigWithEngine(
+      makeEngine({ openai_api_key_scope: 'embedding_only' }),
+      { engine: 'pglite' },
+    );
+    expect(restricted?.openai_api_key_scope).toBe('embedding_only');
+
+    const malformed = await loadConfigWithEngine(
+      makeEngine({ openai_api_key_scope: 'typo' }),
+      { engine: 'pglite' },
+    );
+    expect(malformed?.openai_api_key_scope).toBe('embedding_only');
+  });
+
   test('file/env precedence: file value wins over DB value', async () => {
     const base: GBrainConfig = {
       engine: 'pglite',


### PR DESCRIPTION
## Summary
- add `openai_api_key_scope` with `embedding_only` enforcement at the central AI gateway
- block native OpenAI chat and expansion, including explicit model overrides and cross-modal eval
- block direct OpenAI Whisper transcription and prevent child OpenClaw agents from inheriting the restricted credential
- merge the policy from the DB config plane and validate CLI writes
- fail closed on malformed configured scope values while preserving backward compatibility when the setting is absent

## Security rationale
`OPENAI_API_KEY` was previously a generic provider credential shared by embeddings, expansion, chat, transcription, and spawned agents. A deployment using the key exclusively for embeddings had no technical boundary preventing API-funded reasoning.

## Verification
- `bun run verify`: 33/33 checks passed
- focused security/config/transcription/runner suite: 92 passed, 0 failed
- `git diff --check`: passed

No credential values are included in this change.