### PR TITLE
v0.42.67.1 fix(search): preserve floored query embed budgets (#2028)

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -867,11 +867,12 @@ export async function embedQueryBounded(
   embedOpts: { embeddingModel?: string; dimensions?: number } | undefined,
   dl: QueryEmbedDeadline,
 ): Promise<Float32Array> {
-  const p = embedQuery(text, { ...(embedOpts ?? {}), abortSignal: dl.signal });
-  p.catch(() => { /* swallow the loser's late rejection */ });
   // Floor the budget so a healthy embed isn't starved when the shared absolute
   // deadline was mostly consumed by prior work (codex). Still bounded overall.
   const remaining = Math.max(MIN_QUERY_EMBED_BUDGET_MS, dl.deadlineAt - Date.now());
+  const signal = AbortSignal.timeout(remaining);
+  const p = embedQuery(text, { ...(embedOpts ?? {}), abortSignal: signal });
+  p.catch(() => { /* swallow the loser's late rejection */ });
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(

--- a/test/search/query-embed-deadline.test.ts
+++ b/test/search/query-embed-deadline.test.ts
@@ -74,6 +74,23 @@ describe('embedQueryBounded — query-embed deadline', () => {
     expect(elapsed).toBeLessThan(3500);
   });
 
+  test('an already-aborted shared signal does not starve a healthy embed', async () => {
+    const vec = Array.from({ length: 1024 }, () => 0.2);
+    const seen: boolean[] = [];
+    __setEmbedTransportForTests(async (opts) => {
+      seen.push(Boolean(opts.abortSignal?.aborted));
+      await new Promise(resolve => setTimeout(resolve, 25));
+      return { embeddings: [vec], usage: { tokens: 1 } } as any;
+    });
+
+    const dl = { signal: AbortSignal.abort(), deadlineAt: Date.now() - 5 };
+    const out = await embedQueryBounded('q', undefined, dl);
+
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out.length).toBe(1024);
+    expect(seen).toEqual([false]);
+  });
+
   test('resolves with the embedding when the transport returns in time', async () => {
     const vec = Array.from({ length: 1024 }, () => 0.1);
     __setEmbedTransportForTests(async () => ({ embeddings: [vec], usage: { tokens: 1 } }) as any);


### PR DESCRIPTION
## Summary

Fixes #2028 by making the query-time embed wrapper give each embed call its own abort signal based on the floored remaining budget.

Previously `embedQueryBounded` computed the 2s minimum budget, but it passed the original shared `AbortSignal` into `embedQuery` before that floor mattered. If expansion or an earlier cache embed had already spent the shared deadline, the provider saw an already-aborted signal and a healthy fast embed could fail immediately, forcing keyword-only fallback.

## Changes

- Derive a fresh per-call `AbortSignal.timeout(remaining)` after applying the minimum query embed budget.
- Keep the existing `Promise.race` timeout so providers that ignore aborts are still bounded.
- Add a regression test where the shared signal is already aborted but the provider returns quickly when given the floored 2s budget.

## Verification

- `bun test --timeout 30000 test/search/query-embed-deadline.test.ts` - 4 pass
- `bun run check:privacy` - pass
- `bun run check:test-isolation` - pass
- `bun run check:wasm` - pass
- `bun run check:admin-build` - pass
- `bun run check:proposal-pii && bun run check:no-pii-agent-voice && bun run check:fixture-privacy` - pass
- `bun run check:jsonb && bun run check:source-id-projection && bun run check:engine-dynamic-import` - pass
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5434/gbrain_test bun test --timeout 30000 test/e2e/search-exclude.test.ts test/e2e/search-quality.test.ts test/e2e/search-swamp.test.ts` - 31 pass

Local note: the full `bun run verify` wrapper still timed out on `typecheck` in this constrained macOS environment; a direct `bun run typecheck` also ran for over 11 minutes without emitting diagnostics before I stopped it. The focused search checks above are green.
