### PR TITLE
fix(cycle): stop extract_atoms silently skipping all work on unpriced models

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -223,6 +223,17 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   return null;
 }
 
+/**
+ * True when the budget tracker can price this model, i.e. when setting a cost
+ * cap is meaningful. Callers that apply a *default* cap (rather than one the
+ * user asked for) should skip the cap when this returns false — otherwise
+ * `reserve()` hard-fails with BudgetExhausted(reason:'no_pricing') and the
+ * caller silently does no work.
+ */
+export function isModelPriceable(modelId: string, kind: BudgetKind): boolean {
+  return lookupPricing(modelId, kind) !== null;
+}
+
 function costForUsage(modelId: string, inputTokens: number, outputTokens: number, kind: BudgetKind): number | null {
   const p = lookupPricing(modelId, kind);
   if (!p) return null;

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -52,7 +52,7 @@ import type { PhaseResult } from '../cycle.ts';
 import type { GBrainConfig } from '../config.ts';
 import type { ProgressReporter } from '../progress.ts';
 import { chat as gatewayChat, withBudgetTracker } from '../ai/gateway.ts';
-import { BudgetExhausted, BudgetTracker } from '../budget/budget-tracker.ts';
+import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budget-tracker.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
@@ -549,8 +549,21 @@ export async function runPhaseExtractAtoms(
   } catch {
     // Keep safe defaults: Haiku + $0.30.
   }
+  // A cost cap is only meaningful for a model the tracker can price.
+  // BudgetTracker.reserve() hard-fails with BudgetExhausted(reason:'no_pricing')
+  // when the model is absent from the pricing maps AND a cap is set; with no cap
+  // it warns once and proceeds. Because this phase always set a cap, every
+  // non-Anthropic model tripped that hard-fail on the first item, latched
+  // `budgetExhausted`, and skipped the entire workload while reporting ok.
+  const priceable = isModelPriceable(extractModel, 'chat');
+  if (!priceable) {
+    console.error(
+      `[extract_atoms] model "${extractModel}" is not in the pricing maps; ` +
+        `running without a cost gate (a cap cannot be enforced on an unpriced model).`,
+    );
+  }
   const budgetTracker = new BudgetTracker({
-    maxCostUsd: budgetCap,
+    maxCostUsd: priceable ? budgetCap : undefined,
     label: 'cycle.extract_atoms',
   });
 
@@ -726,7 +739,16 @@ export async function runPhaseExtractAtoms(
 
   return {
     phase: 'extract_atoms',
-    status: failures.length > 0 ? 'warn' : 'ok',
+    // A phase that skipped every work item and produced nothing did not
+    // succeed, even though skips are not failures and leave failures[] empty.
+    // Reporting 'ok' there hides a total no-op behind a green status.
+    status:
+      failures.length > 0 ||
+      (work.length > 0 &&
+        totalAtomsExtracted === 0 &&
+        transcriptsSkipped + pagesSkipped === work.length)
+        ? 'warn'
+        : 'ok',
     duration_ms: 0,
     summary:
       `extract_atoms: ${totalAtomsExtracted} atoms from ` +

--- a/test/extract-atoms-unpriced-model.test.ts
+++ b/test/extract-atoms-unpriced-model.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { isModelPriceable } from '../src/core/budget/budget-tracker.ts';
+
+// Regression: extract_atoms applied its DEFAULT cost cap unconditionally.
+// BudgetTracker.reserve() hard-fails with BudgetExhausted(reason:'no_pricing')
+// when a model is absent from the pricing maps AND a cap is set, so the first
+// work item threw, `budgetExhausted` latched, and every remaining item was
+// skipped — while the phase still reported status 'ok' with an empty failures[].
+// Anthropic users never saw it; every Groq / local-llama / OpenRouter user did.
+describe('isModelPriceable', () => {
+  test('priced Anthropic chat models are priceable', () => {
+    expect(isModelPriceable('claude-haiku-4-5-20251001', 'chat')).toBe(true);
+  });
+
+  test('unknown providers are not priceable, so a default cap must be skipped', () => {
+    expect(isModelPriceable('litellm:gemma4-12b', 'chat')).toBe(false);
+    expect(isModelPriceable('llama-server:local-model', 'chat')).toBe(false);
+  });
+
+  test('is a pure predicate — no throw on unusual model ids', () => {
+    expect(() => isModelPriceable('', 'chat')).not.toThrow();
+    expect(() => isModelPriceable('provider-with-no-colon', 'chat')).not.toThrow();
+  });
+});


### PR DESCRIPTION
`extract_atoms` extracts nothing and reports success whenever the configured model is not in the pricing maps. Every Groq, local llama-server, OpenRouter and OpenCode Go user hits this; no Anthropic user does.

## Cause

`BudgetTracker.reserve()` hard-fails with `BudgetExhausted(reason:'no_pricing')` when a model is absent from the pricing maps **and** a cap is set. With no cap it warns once and proceeds.

`extract_atoms` always set a cap (`DEFAULT_BUDGET_USD = 0.3`), so on an unpriced model the first `reserve()` throws, the catch latches `budgetExhausted`, and every remaining item is skipped. Skips are not failures, so `failures[]` stays empty and the phase returns `status: 'ok'`.

## Observed

v0.42.67.0, Postgres 17, schema v125. `doctor` reported `1506 page(s) pending` indefinitely.

Instrumenting discovery showed it working correctly — 50 rows returned with the full 18-type allowlist resolved from the active pack. Then:

```
work=50 budgetCap=5 model=litellm:gemma4-12b
item kind=page spent=0 exhausted=false
item kind=page spent=0 exhausted=true
item kind=page spent=0 exhausted=true   (x48)
```

`exhausted` latches after the first item while `spent` is still 0 against a $5 cap. Dropping the cap for unpriced models produced atoms on the first run.

## Changes

- Export `isModelPriceable()` from `budget-tracker.ts`; skip the **default** cap when it returns false. A cap cannot be enforced on a model that cannot be priced, so the real choice is between silently skipping the workload and running with a logged warning. This mirrors the existing `FREE_LOCAL_RERANK_PROVIDERS` escape hatch that keeps the rerank path from tripping the same hard-fail.
- Return `warn` instead of `ok` when every work item was skipped and nothing was extracted.

A user-specified cap on a priceable model is unchanged.

## Follow-up worth considering

This PR does not distinguish a **user-specified** cap from a **defaulted** one. Arguably the more precise fix is to keep the `no_pricing` hard-fail when the operator explicitly asked for a cap (the safety property it was written for) and skip it only for defaults. That needs a `BudgetTracker` API change to carry that intent, so I kept this PR narrow. Happy to extend it if you'd prefer that shape.

## Tests

- `bun run typecheck` — exit 0
- 98 pass / 0 fail across the 11 existing atom + budget test files
- New `test/extract-atoms-unpriced-model.test.ts` — 3 tests covering the predicate

## Related

- #2117 — `gbrain-base-v2` ships no `phases:` declaration, gating `extract_atoms` off before it can reach this. Both must be fixed for atoms to flow on a derived pack.
- #1531 — same visible symptom (0 atoms, clean exit) but a different cause; that one is a Postgres discovery failure. Discovery is confirmed healthy here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
