### PR TITLE
fix(dims): skip dimensions param when it equals qwen3-embedding native width

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -312,6 +312,19 @@ export function dimsProviderOptions(
       // widths hard-fail with a dim-mismatch error. Pattern match the bare
       // model name + any `:tag` (e.g. `qwen3-embedding:4b`, `qwen3-embedding:0.6b`).
       if (modelId === 'qwen3-embedding' || modelId.startsWith('qwen3-embedding:')) {
+        // Only send `dimensions` when it actually differs from the model's
+        // native width. Fixed-dim OpenAI-compatible backends serving this
+        // family (e.g. vLLM) reject the parameter outright with HTTP 400
+        // ("does not support matryoshka representation") even when the
+        // requested value equals the native size; omitting it in the equal
+        // case is semantically identical for Ollama and keeps vLLM working.
+        const QWEN3_EMBEDDING_NATIVE_DIMS: Record<string, number> = {
+          'qwen3-embedding': 1024,
+          'qwen3-embedding:0.6b': 1024,
+          'qwen3-embedding:4b': 2560,
+          'qwen3-embedding:8b': 4096,
+        };
+        if (QWEN3_EMBEDDING_NATIVE_DIMS[modelId] === dims) return undefined;
         return { openaiCompatible: { dimensions: dims } };
       }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric

--- a/test/ai/dims-qwen3-native.test.ts
+++ b/test/ai/dims-qwen3-native.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Qwen3-Embedding native-width dims suppression tests.
+ *
+ * Pins:
+ *  - dimsProviderOptions returns undefined when the configured dim equals
+ *    the model's native width (1024/2560/4096 for 0.6B/4B/8B) — fixed-dim
+ *    OpenAI-compatible backends serving this family (e.g. vLLM) reject the
+ *    `dimensions` parameter with HTTP 400 "does not support matryoshka
+ *    representation" even when the value equals the native size, and
+ *    omitting it in the equal case is a no-op for Ollama.
+ *  - Matryoshka truncation is preserved: a dim that differs from the native
+ *    width still emits { openaiCompatible: { dimensions } } for Ollama.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+
+describe('qwen3-embedding native-width suppression', () => {
+  test('bare model at native 1024 emits no dimensions param', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding', 1024)).toBeUndefined();
+  });
+
+  test('tagged variants at their native width emit no dimensions param', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding:0.6b', 1024)).toBeUndefined();
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding:4b', 2560)).toBeUndefined();
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 4096)).toBeUndefined();
+  });
+
+  test('non-native dim still requests Matryoshka truncation', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding', 512))
+      .toEqual({ openaiCompatible: { dimensions: 512 } });
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding:4b', 1024))
+      .toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('unknown tag falls through to sending the configured dim', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding:32b', 1024))
+      .toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+});


### PR DESCRIPTION
## Problem

The openai-compatible branch of `dimsProviderOptions` unconditionally emits `{ dimensions }` for the qwen3-embedding family (src/core/ai/dims.ts). The comment there says the family is supported on "Ollama (and any other openai-compatible provider serving it)", but fixed-dim backends serving this family — vLLM's OpenAI-compatible server being the common case — reject the parameter with HTTP 400 even when the requested value equals the model's native width:

```
{"error":{"message":"Model \"qwen3-embedding\" does not support matryoshka representation, changing output dimensions will lead to poor results.","type":"BadRequestError","code":400}}
```

This breaks every embed call (document-side and query-side alike) on such deployments.

## Repro

```bash
# vLLM serving qwen3-embedding (0.6B, native 1024):
curl -s http://localhost:8001/v1/embeddings -H 'Content-Type: application/json' \
  -d '{"model":"qwen3-embedding","input":"probe","dimensions":1024}'   # → 400
curl -s http://localhost:8001/v1/embeddings -H 'Content-Type: application/json' \
  -d '{"model":"qwen3-embedding","input":"probe"}'                      # → 200, 1024-wide vector
```

## Fix

Suppress the parameter when the configured dim equals the model's native width (0.6B=1024, 4B=2560, 8B=4096): a no-op for Ollama, a fix for vLLM. Non-native dims still emit the parameter, so Matryoshka truncation on Ollama keeps working; unknown tags conservatively keep the current behavior.

## Validation

- New `test/ai/dims-qwen3-native.test.ts`: two of its tests are red on master and green with this patch; `dims-zeroentropy.test.ts` and `dims-openai.test.ts` stay green (37 pass across the three files).
- Running in production against a vLLM 1024-dim deployment: embeds and hybrid search working after the patch, hard-failing before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
