### PR TITLE
fix(sync): reject NUL bytes before code import

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -1157,6 +1157,9 @@ export async function importCodeFile(
   opts: { noEmbed?: boolean; force?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   const slug = slugifyCodePath(relativePath);
+  if (content.indexOf('\0') !== -1) {
+    return { slug, status: 'skipped', chunks: 0, error: 'Content contains null bytes (likely binary corruption)' };
+  }
   const lang = detectCodeLanguage(relativePath) || 'unknown';
   const title = `${relativePath} (${lang})`;
   const sourceId = opts.sourceId;

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -140,6 +140,22 @@ This is the compiled truth.
     expect((engine as any)._calls.length).toBe(0);
   });
 
+  test('rejects code files containing NUL bytes before database writes', async () => {
+    const filePath = join(TMP, 'binary-fixture.ts');
+    writeFileSync(filePath, Buffer.concat([
+      Buffer.from('const fixture = "text";\n'.repeat(500)),
+      Buffer.from([0]),
+      Buffer.from('binary tail'),
+    ]));
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'src/binary-fixture.ts', { noEmbed: true });
+
+    expect(result.status).toBe('skipped');
+    expect(result.error).toContain('Content contains null bytes');
+    expect((engine as any)._calls.length).toBe(0);
+  });
+
   test('rejects frontmatter slug that does not match the file path', async () => {
     // In a shared brain where contributors can land PRs, this prevents a
     // poisoned notes/random.md from declaring `slug: people/elon` in its


### PR DESCRIPTION
## Summary

- reject NUL-bearing code content before guardrails, chunking, or database writes
- keep sync fail-closed using the existing `NULL_BYTES` failure-ledger classification
- cover a NUL beyond the capture command's 8 KB sniff window

## Reproduction

`gbrain sync --strategy auto --no-embed` attempted to index tracked `.ts` and `.kt` binary fixtures. PostgreSQL rejected each write with `invalid byte sequence for encoding "UTF8": 0x00`, leaving the source checkpoint blocked and the error classified as `UNKNOWN`.

## Verification

- regression before fix: expected `skipped`, received `imported`
- `bun test test/import-file.test.ts`: 29 pass, 0 fail
- `git diff --check`

The broader sync-failure suite was also run; its writable-ledger cases fail under the read-only home sandbox (`EROFS`), while all pure classification checks pass.
