### PR TITLE
feat(doctor): stale_mentions — surface by-mention links the gazetteer no longer produces

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6511,6 +6511,79 @@ export async function buildChecks(
     checks.push({ name: 'orphan_ratio', status: 'warn', message: 'Could not check orphan ratio' });
   }
 
+  // 9c. stale_mentions — auto-linked mentions the current gazetteer no
+  // longer produces (issue #3674).
+  //
+  // `extract links --by-mention` writes through addLinksBatch, which is
+  // purely additive, and put_page reconciliation deliberately excludes
+  // 'mentions'. So a link survives its own justification: rewrite a body so
+  // it stops naming the entity, delete or retype the entity page, or change
+  // the tokenizer, and the row stays. Re-running the scan does not help —
+  // it adds today's correct links ALONGSIDE the old ones.
+  //
+  // READ-ONLY by design. There is no repair path yet (a scoped
+  // delete-then-insert needs a new bulk engine method on both backends,
+  // coordinated with extract-ner's link_kind='typed_ner' rows and the
+  // resume checkpoint), so this check makes the drift visible and stops
+  // there rather than shipping a destructive write nobody reviewed.
+  // No RemediationStep for the same reason.
+  //
+  // Never 'fail': the data is wrong but a per-pair `gbrain unlink`
+  // workaround exists, which is the p2 bar.
+  progress.heartbeat('stale_mentions');
+  const staleMentionsHb = startHeartbeat(progress, 're-deriving by-mention links…');
+  try {
+    const { scanStaleMentions } = await import('../core/by-mention.ts');
+    const res = await scanStaleMentions(engine);
+    // Say what was NOT covered rather than implying the whole brain was.
+    const coverage = res.pagesScanned < res.totalPagesWithMentions
+      ? ` (sampled ${res.pagesScanned} of ${res.totalPagesWithMentions} pages carrying mentions links)`
+      : '';
+
+    if (res.totalPagesWithMentions === 0) {
+      checks.push({
+        name: 'stale_mentions',
+        status: 'ok',
+        message: 'No by-mention links in this brain.',
+      });
+    } else if (res.staleLinks === 0) {
+      checks.push({
+        name: 'stale_mentions',
+        status: 'ok',
+        message: `Re-derived ${res.linksScanned} by-mention link(s) across ${res.pagesScanned} page(s)${coverage}; all still follow from the current gazetteer.`,
+      });
+    } else {
+      const kinds = Object.entries(res.staleByKind)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, n]) => `${n} ${k}`)
+        .join(', ');
+      const eg = res.examples.map(e => `${e.from} -> ${e.to}`).join(', ');
+      // An empty gazetteer makes EVERY mentions row unreproducible, which is
+      // a different diagnosis from ordinary drift — name it, or the operator
+      // reads "everything is stale" and starts deleting real links.
+      const why = res.emptyGazetteer
+        ? 'This brain currently has NO linkable entity pages, so every mentions row is unreproducible — check whether entity pages were deleted or retyped before treating these as garbage. '
+        : '';
+      checks.push({
+        name: 'stale_mentions',
+        status: 'warn',
+        message:
+          `${res.staleLinks} of ${res.linksScanned} by-mention link(s) no longer follow from the current gazetteer${coverage} (${kinds}). ` +
+          `${why}Re-running the scan will NOT remove them — the write path is additive. ` +
+          `Remove individually with: gbrain unlink <from> <to> --link-type mentions --link-source mentions. ` +
+          `e.g. ${eg}`,
+      });
+    }
+  } catch (e) {
+    checks.push({
+      name: 'stale_mentions',
+      status: 'warn',
+      message: `stale-mentions scan skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  } finally {
+    staleMentionsHb();
+  }
+
   // 10. Integrity sample scan (v0.13 knowledge runtime).
   // Read-only — no network, no writes, no resolver calls. Samples the first
   // 500 pages by slug order and surfaces bare-tweet + dead-link counts as a

--- a/src/core/by-mention.ts
+++ b/src/core/by-mention.ts
@@ -519,3 +519,177 @@ export function findMentionedEntities(
 
   return out;
 }
+
+// ============================================================
+// Stale-mention detection (read-only)
+// ============================================================
+
+/** One `link_source='mentions'` row the current gazetteer no longer produces. */
+export interface StaleMention {
+  from: string;
+  to: string;
+  /** `link_kind` as stored; NULL rows (legacy / pre-v98) report as 'plain'. */
+  kind: string;
+}
+
+export interface StaleMentionsScan {
+  /** Live pages carrying at least one `link_source='mentions'` row. */
+  totalPagesWithMentions: number;
+  /** Pages actually re-scanned (bounded by `opts.limit`). */
+  pagesScanned: number;
+  /** `mentions` rows on the scanned pages. */
+  linksScanned: number;
+  /** Of those, rows whose target the current gazetteer no longer produces. */
+  staleLinks: number;
+  /** Stale counts split by `link_kind` — `typed_ner` rows come from extract-ner. */
+  staleByKind: Record<string, number>;
+  /** True when the brain has NO linkable entity pages at all. */
+  emptyGazetteer: boolean;
+  /** First few stale rows, for an operator-facing message. */
+  examples: StaleMention[];
+}
+
+const STALE_MENTIONS_DEFAULT_LIMIT = 500;
+const STALE_MENTIONS_MAX_EXAMPLES = 5;
+
+/**
+ * Re-derive what `extract links --by-mention` would produce today and report
+ * `link_source='mentions'` rows that no longer follow from the current
+ * gazetteer + page bodies.
+ *
+ * STRICTLY READ-ONLY. This deletes nothing and writes nothing; it exists so
+ * the drift is visible, because the scan's write path (`addLinksBatch`) is
+ * purely additive. Re-running the scan adds today's correct links ALONGSIDE
+ * rows left by an older gazetteer, an older tokenizer, or a body that has
+ * since stopped mentioning the entity — nothing ever removes those.
+ *
+ * A row is counted stale when the current scan does not produce its
+ * (source_id, slug) target from the page's body. That test is deliberately
+ * target-based rather than kind-based, so it covers `link_kind='typed_ner'`
+ * rows too: extract-ner derives those from the same mention set, so a target
+ * this scan no longer yields cannot have a live verb-typed edge either. The
+ * converse does NOT hold — a still-produced target says nothing about
+ * whether the stored verb is still right — so `typed_ner` counts are
+ * reported separately rather than folded into one number.
+ *
+ * Bounded by `limit` (default 500) in slug order for determinism. The
+ * returned `totalPagesWithMentions` is the unbounded figure so callers can
+ * say what was and was not covered instead of implying full coverage.
+ */
+export async function scanStaleMentions(
+  engine: BrainEngine,
+  opts: { limit?: number } = {},
+): Promise<StaleMentionsScan> {
+  const limit = opts.limit ?? STALE_MENTIONS_DEFAULT_LIMIT;
+
+  const totalRow = await engine.executeRaw<{ count: number }>(
+    `SELECT COUNT(DISTINCT l.from_page_id)::int AS count
+       FROM links l
+       JOIN pages p ON p.id = l.from_page_id
+      WHERE l.link_source = 'mentions'
+        AND p.deleted_at IS NULL`,
+    [],
+  );
+  const totalPagesWithMentions = totalRow[0]?.count ?? 0;
+
+  const empty: StaleMentionsScan = {
+    totalPagesWithMentions,
+    pagesScanned: 0,
+    linksScanned: 0,
+    staleLinks: 0,
+    staleByKind: {},
+    emptyGazetteer: false,
+    examples: [],
+  };
+  if (totalPagesWithMentions === 0) return empty;
+
+  const gazetteer = await buildGazetteer(engine);
+
+  // Same bounded page set for both queries so the link rows and the bodies
+  // can never describe different pages.
+  const scannedCte =
+    `WITH scanned AS (
+       SELECT p.id
+         FROM pages p
+        WHERE p.deleted_at IS NULL
+          AND EXISTS (
+            SELECT 1 FROM links l
+             WHERE l.from_page_id = p.id AND l.link_source = 'mentions'
+          )
+        ORDER BY p.slug
+        LIMIT $1
+     )`;
+
+  const bodies = await engine.executeRaw<{
+    id: number; slug: string; source_id: string | null; body: string;
+  }>(
+    `${scannedCte}
+     SELECT p.id, p.slug, p.source_id,
+            COALESCE(p.compiled_truth, '') || E'\n\n' || COALESCE(p.timeline, '') AS body
+       FROM pages p
+       JOIN scanned s ON s.id = p.id
+      ORDER BY p.slug`,
+    [limit],
+  );
+
+  const rows = await engine.executeRaw<{
+    from_id: number; from_slug: string; to_slug: string;
+    to_source_id: string | null; link_kind: string | null;
+  }>(
+    `${scannedCte}
+     SELECT l.from_page_id AS from_id, f.slug AS from_slug,
+            t.slug AS to_slug, t.source_id AS to_source_id, l.link_kind
+       FROM links l
+       JOIN scanned s ON s.id = l.from_page_id
+       JOIN pages f ON f.id = l.from_page_id
+       JOIN pages t ON t.id = l.to_page_id
+      WHERE l.link_source = 'mentions'
+      ORDER BY f.slug, t.slug`,
+    [limit],
+  );
+
+  const byPage = new Map<number, typeof rows>();
+  for (const r of rows) {
+    const bucket = byPage.get(r.from_id);
+    if (bucket) bucket.push(r);
+    else byPage.set(r.from_id, [r]);
+  }
+
+  const staleByKind: Record<string, number> = {};
+  const examples: StaleMention[] = [];
+  let staleLinks = 0;
+
+  for (const page of bodies) {
+    const stored = byPage.get(page.id);
+    if (!stored || stored.length === 0) continue;
+
+    const fromSourceId = page.source_id ?? 'default';
+    const produced = new Set(
+      findMentionedEntities(page.body, gazetteer, {
+        fromSlug: page.slug,
+        fromSourceId,
+      }).map(m => `${m.source_id}::${m.slug}`),
+    );
+
+    for (const row of stored) {
+      const key = `${row.to_source_id ?? 'default'}::${row.to_slug}`;
+      if (produced.has(key)) continue;
+      staleLinks++;
+      const kind = row.link_kind ?? 'plain';
+      staleByKind[kind] = (staleByKind[kind] ?? 0) + 1;
+      if (examples.length < STALE_MENTIONS_MAX_EXAMPLES) {
+        examples.push({ from: page.slug, to: row.to_slug, kind });
+      }
+    }
+  }
+
+  return {
+    totalPagesWithMentions,
+    pagesScanned: bodies.length,
+    linksScanned: rows.length,
+    staleLinks,
+    staleByKind,
+    emptyGazetteer: gazetteer.size === 0,
+    examples,
+  };
+}

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -105,6 +105,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'scraper_junk_pages',
   'source_config_shape',
   'source_routing_health',
+  'stale_mentions',
   'stub_guard_24h',
   'sync_failures',
   'sync_freshness',

--- a/test/doctor-stale-mentions.test.ts
+++ b/test/doctor-stale-mentions.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for `scanStaleMentions` (src/core/by-mention.ts) and the doctor
+ * `stale_mentions` check that formats it — issue #3674.
+ *
+ * The gap being covered: `extract links --by-mention` writes through
+ * addLinksBatch, which is additive, and put_page reconciliation deliberately
+ * excludes 'mentions'. So a mentions row outlives its own justification, and
+ * re-running the scan adds correct links alongside the stale ones instead of
+ * replacing them. This check is the read-only half — it makes the drift
+ * visible; it must never delete anything.
+ *
+ * Hermetic via PGLite.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { scanStaleMentions } from '../src/core/by-mention.ts';
+import { runDoctor, type DoctorReport } from '../src/commands/doctor.ts';
+import { setCliOptions } from '../src/core/cli-options.ts';
+import { BRAIN_CHECK_NAMES, categorizeCheck } from '../src/core/doctor-categories.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  setCliOptions({ quiet: true, progressJson: false, progressInterval: 1000, explain: false, timeoutMs: null });
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+  restoreCli();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM links');
+  await engine.executeRaw('DELETE FROM pages');
+  await engine.executeRaw("DELETE FROM sources WHERE id != 'default'");
+});
+
+async function putEntity(slug: string, title: string): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'company', title, compiled_truth: `${title} is a company.`,
+    timeline: '', frontmatter: {},
+  });
+}
+
+async function putNote(slug: string, body: string): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'note', title: slug, compiled_truth: body, timeline: '', frontmatter: {},
+  });
+}
+
+async function link(from: string, to: string, kind: string | null = 'plain'): Promise<void> {
+  await engine.addLinksBatch([{
+    from_slug: from, to_slug: to, link_type: 'mentions',
+    link_source: 'mentions', ...(kind === null ? {} : { link_kind: kind }),
+  }]);
+}
+
+async function countLinks(): Promise<number> {
+  const r = await engine.executeRaw<{ count: number }>(
+    `SELECT COUNT(*)::int AS count FROM links WHERE link_source = 'mentions'`, []);
+  return r[0]?.count ?? 0;
+}
+
+describe('scanStaleMentions', () => {
+  test('empty brain — nothing to report, no gazetteer build implied', async () => {
+    const res = await scanStaleMentions(engine);
+    expect(res.totalPagesWithMentions).toBe(0);
+    expect(res.staleLinks).toBe(0);
+    expect(res.pagesScanned).toBe(0);
+  });
+
+  test('a link the current gazetteer still produces is NOT stale', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+
+    const res = await scanStaleMentions(engine);
+    expect(res.totalPagesWithMentions).toBe(1);
+    expect(res.linksScanned).toBe(1);
+    expect(res.staleLinks).toBe(0);
+    expect(res.emptyGazetteer).toBe(false);
+  });
+
+  test('body rewritten so it no longer names the entity — link goes stale', async () => {
+    // This is the exact reproduction in the issue: put_page reconciliation
+    // excludes 'mentions', so rewriting the body leaves the row behind.
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+    await putNote('notes/meeting', 'Met with nobody today. Quiet day.');
+
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(1);
+    expect(res.staleByKind).toEqual({ plain: 1 });
+    expect(res.examples).toEqual([
+      { from: 'notes/meeting', to: 'companies/acme-example', kind: 'plain' },
+    ]);
+  });
+
+  test('entity page soft-deleted — link goes stale', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() WHERE slug = 'companies/acme-example'`, []);
+
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(1);
+    // Deleting the only entity empties the gazetteer — the caller needs to
+    // distinguish that from ordinary drift.
+    expect(res.emptyGazetteer).toBe(true);
+  });
+
+  test('typed_ner rows are counted, and reported separately from plain', async () => {
+    // extract-ner shares link_source='mentions' with link_kind='typed_ner',
+    // which is precisely why a cleanup cannot delete by link_source alone.
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example', 'plain');
+    await engine.addLinksBatch([{
+      from_slug: 'notes/meeting', to_slug: 'companies/acme-example',
+      link_type: 'works_at', link_source: 'mentions', link_kind: 'typed_ner',
+    }]);
+    await putNote('notes/meeting', 'Met with nobody today. Quiet day.');
+
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(2);
+    expect(res.staleByKind).toEqual({ plain: 1, typed_ner: 1 });
+  });
+
+  test('legacy NULL link_kind reports as plain, not as a missing bucket', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example', null);
+    await putNote('notes/meeting', 'Nothing here.');
+
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(1);
+    expect(res.staleByKind).toEqual({ plain: 1 });
+  });
+
+  test('is strictly read-only — a stale row is still there afterwards', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+    await putNote('notes/meeting', 'Nothing here.');
+
+    expect(await countLinks()).toBe(1);
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(1);
+    expect(await countLinks()).toBe(1);   // the check must not repair
+    // Idempotent: a second run reports the same thing.
+    expect((await scanStaleMentions(engine)).staleLinks).toBe(1);
+    expect(await countLinks()).toBe(1);
+  });
+
+  test('limit bounds the scan and totalPagesWithMentions stays unbounded', async () => {
+    // Coverage must be disclosable — a bounded scan that reported the bounded
+    // total would read as full coverage.
+    await putEntity('companies/acme-example', 'Acme Example');
+    for (const n of ['a', 'b', 'c']) {
+      await putNote(`notes/${n}`, 'Nothing here.');
+      await link(`notes/${n}`, 'companies/acme-example');
+    }
+    const res = await scanStaleMentions(engine, { limit: 2 });
+    expect(res.totalPagesWithMentions).toBe(3);
+    expect(res.pagesScanned).toBe(2);
+    expect(res.linksScanned).toBe(2);
+    expect(res.staleLinks).toBe(2);
+  });
+
+  test('self-link and cross-source guards are honoured, as in the real scan', async () => {
+    // findMentionedEntities suppresses both, so neither can ever be produced
+    // — a stored row of either shape is stale by construction.
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Acme Example is great.');
+    await link('notes/meeting', 'companies/acme-example');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('other', 'other') ON CONFLICT DO NOTHING`, []);
+    await engine.executeRaw(
+      `UPDATE pages SET source_id = 'other' WHERE slug = 'companies/acme-example'`, []);
+
+    const res = await scanStaleMentions(engine);
+    expect(res.staleLinks).toBe(1);   // cross-source: no longer produced
+  });
+});
+
+// ============================================================
+// Doctor surface — the check is emitted, worded, and categorized
+// ============================================================
+
+let stdoutBuffer: string[] = [];
+const origLog = console.log;
+const origErr = console.error;
+const origExit = process.exit;
+
+function captureCli(): void {
+  stdoutBuffer = [];
+  console.log = (msg?: unknown) => { stdoutBuffer.push(typeof msg === 'string' ? msg : String(msg)); };
+  console.error = () => {};
+  (process as { exit: unknown }).exit = (() => { throw new Error('__exit'); }) as unknown as typeof process.exit;
+}
+
+function restoreCli(): void {
+  console.log = origLog;
+  console.error = origErr;
+  (process as { exit: unknown }).exit = origExit;
+}
+
+async function runDoctorJson(): Promise<DoctorReport> {
+  captureCli();
+  try {
+    // No --fast: stale_mentions sits in the DB-checks group that --fast skips.
+    await runDoctor(engine, ['--json']);
+  } catch (e) {
+    if (!(e instanceof Error && e.message === '__exit')) throw e;
+  } finally {
+    restoreCli();
+  }
+  for (let i = stdoutBuffer.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(stdoutBuffer[i]!);
+      if (parsed && typeof parsed === 'object' && 'checks' in parsed) return parsed as DoctorReport;
+    } catch { /* skip non-JSON lines */ }
+  }
+  throw new Error('No DoctorReport JSON found in stdout');
+}
+
+describe('runDoctor — stale_mentions check', () => {
+  test('clean brain → ok, and the check is actually present', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+
+    const check = (await runDoctorJson()).checks.find(c => c.name === 'stale_mentions');
+    expect(check).toBeDefined();
+    expect(check!.status).toBe('ok');
+  });
+
+  test('drifted brain → warn, names the additive write path and the workaround', async () => {
+    await putEntity('companies/acme-example', 'Acme Example');
+    await putNote('notes/meeting', 'Met with Acme Example about the widget deal.');
+    await link('notes/meeting', 'companies/acme-example');
+    await putNote('notes/meeting', 'Met with nobody today. Quiet day.');
+
+    const check = (await runDoctorJson()).checks.find(c => c.name === 'stale_mentions');
+    expect(check!.status).toBe('warn');
+    // The operator has to learn two things from this message or it is useless:
+    // that re-running the scan will NOT fix it, and what to do instead.
+    expect(check!.message).toContain('will NOT remove them');
+    expect(check!.message).toContain('gbrain unlink');
+    expect(check!.message).toContain('notes/meeting -> companies/acme-example');
+    // Read-only: no repair is offered, because none exists yet (#3674).
+    expect(check!.remediation ?? []).toEqual([]);
+  });
+
+  test('is categorized — not silently degraded to meta', () => {
+    expect(BRAIN_CHECK_NAMES.has('stale_mentions')).toBe(true);
+    expect(categorizeCheck('stale_mentions')).toBe('brain');
+  });
+});


### PR DESCRIPTION
Read-only first step for #3674, which you triaged p2 and endorsed this shape for:

> Low-risk first step is its option (3): a read-only doctor check that counts `link_source='mentions'` rows whose (from_page, to_page) pair the current gazetteer scan would not produce […] making the problem visible with no write path.

## Problem

`extract links --by-mention` writes through `addLinksBatch`, which is purely additive, and `put_page` reconciliation deliberately excludes `'mentions'` (`operations.ts:1329-1333`). A mentions row therefore outlives its own justification — rewrite a body so it stops naming the entity, delete or retype the entity page, or change the tokenizer, and the row stays. Re-running the scan does not help: it adds today's correct links *alongside* the old ones. Nothing surfaces the drift, so it compounds silently and feeds relational retrieval and graph walks.

## What this adds

`scanStaleMentions(engine, { limit })` in `src/core/by-mention.ts` rebuilds the gazetteer, re-derives mentions for the pages that carry mentions rows, and reports rows whose target the current scan no longer produces. A `stale_mentions` doctor check formats it.

```
stale_mentions  warn  3 of 12 by-mention link(s) no longer follow from the current
                      gazetteer (2 plain, 1 typed_ner). Re-running the scan will NOT
                      remove them — the write path is additive. Remove individually
                      with: gbrain unlink <from> <to> --link-type mentions
                      --link-source mentions. e.g. notes/meeting -> companies/acme
```

## Design choices worth reviewing

- **Strictly read-only, and tested as such.** No repair path, no `RemediationStep`. The real fix is a per-page scoped delete-then-insert needing a new bulk engine method on *both* backends, coordinated with extract-ner's `typed_ner` rows and the resume checkpoint. Shipping that as a side effect of a doctor check would be a destructive write nobody asked to review. #3674 stays open for it.
- **Staleness is target-based, not kind-based**, so it covers `link_kind='typed_ner'`: extract-ner derives those from the same mention set, so a target this scan no longer yields cannot have a live verb-typed edge either. The converse does *not* hold — a still-produced target says nothing about whether the stored verb is still right — so `typed_ner` counts are reported separately rather than folded into one number.
- **Bounded at 500 pages** in slug order, and the message states what was *not* covered (`sampled N of M pages carrying mentions links`) rather than implying a full sweep.
- **Empty gazetteer is called out separately.** It makes every mentions row unreproducible, which is a different diagnosis from ordinary drift; without saying so, an operator reads "everything is stale" and starts deleting real links.
- **Never `fail`, only `warn`** — wrong data with a per-pair `gbrain unlink` workaround is the p2 bar.
- **Early-returns after one COUNT** when the brain has no mentions rows, so brains that never ran by-mention pay almost nothing.
- Registered in `doctor-categories.ts` (BRAIN) so the categorization drift guard stays green.

## Tests

+12 in `test/doctor-stale-mentions.test.ts`: your exact reproduction from the issue (body rewritten, row survives), soft-deleted entity, `typed_ner` split, legacy NULL `link_kind`, read-only + idempotency, `limit` vs unbounded total, cross-source guard, plus doctor-surface coverage that the check is emitted, warns with the additive-write-path wording and the workaround, and is categorized.

## Verified / not verified

- `tsc --noEmit` — exit 0.
- All **47** doctor test files + `by-mention`, `cjk`, `e2e/orphan-reduction` — **416 pass / 4 fail**.
- The 4 failures are load-dependent timeouts in `doctor.test.ts` (`graph_signals_coverage`, `link_resolution_opportunity`, in-progress-sync-lock) and `doctor-orphan-ratio.test.ts` (`auto_chronicle` volume). All pass when those files run alone. **`origin/master` produces the identical 4** — 404 pass / 4 fail, same test names, same durations (5.3/5.3/7.0/7.2s vs 5.8/5.3/7.1/7.4s). Pre-existing, verified by running the baseline rather than assumed.
- `check:privacy`, `check-test-real-names`, `check-test-isolation` — exit 0.
- NOT run: the full `bun test` suite (it does not complete in a reasonable window on this machine), and the `DATABASE_URL`-gated engine-parity suite. Neither is implicated — this adds no engine method and no write path; the two new queries are plain reads through `executeRaw`.
