### PR TITLE
fix(extract): timeline bullet separator must be a spaced em/en-dash, not a bare hyphen

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -476,11 +476,26 @@ export async function extractLinksFromFile(
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
   const entries: ExtractedTimelineEntry[] = [];
 
-  // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
-  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
+  // Format 1: Bullet — - **YYYY-MM-DD** | [Source —] Summary
+  //
+  // The Source/Summary separator is a SPACED em- or en-dash (` — ` / ` – `). A
+  // bare or in-word hyphen is NOT a separator: it occurs inside words
+  // ("scale-incumbent", "follow-up") and phrases ("Reperks - Status"), and the
+  // previous `\s*[—–-]\s*` pattern matched the first hyphen anywhere, mis-filing
+  // the summary prefix as the source. That both corrupted the entry and, because
+  // the mangled (source, summary) tuple diverged from any cleanly-written row,
+  // defeated the (page_id, date, summary, source) dedup so re-syncs accumulated
+  // duplicate rows. A bullet with no spaced dash carries no source label — the
+  // whole text after `|` is the summary.
+  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+)$/gm;
+  const sourceSep = /\s+[—–]\s+/;
   let match;
   while ((match = bulletPattern.exec(content)) !== null) {
-    entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
+    const rest = match[2].trim();
+    const sep = rest.match(sourceSep);
+    const source = sep ? rest.slice(0, sep.index).trim() : '';
+    const summary = sep ? rest.slice((sep.index ?? 0) + sep[0].length).trim() : rest;
+    entries.push({ slug, date: match[1], source, summary });
   }
 
   // Format 2: Header — ### YYYY-MM-DD — Title

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -199,6 +199,37 @@ describe('extractTimelineFromContent', () => {
   });
 });
 
+describe('extractTimelineFromContent — in-word hyphen mis-split regression', () => {
+  // A bullet with no spaced dash has no `Source —` label: the whole text is the
+  // summary. The old `\s*[—–-]\s*` separator matched the first bare hyphen
+  // anywhere (inside "scale-incumbent"), mis-filing the summary prefix as the
+  // source, corrupting the entry and defeating the (page_id,date,summary,source)
+  // dedup so every re-sync accumulated a divergent duplicate.
+  it('does not split an unlabeled bullet at an in-word hyphen', () => {
+    const content = `- **2026-07-17** | Positioned as the scale-incumbent competitor [Source: User DM 2026-07-17 + web research]`;
+    const entries = extractTimelineFromContent(content, 'companies/regina-maria');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('');
+    expect(entries[0].summary).toBe('Positioned as the scale-incumbent competitor [Source: User DM 2026-07-17 + web research]');
+  });
+
+  it('does not split a hyphenated name into (source, summary)', () => {
+    const content = `- **2021-06-11** | [Viorica-Ioana Prunescu] confirmed the visit [Source: Gmail, 2021-06-11]`;
+    const entries = extractTimelineFromContent(content, 'companies/regina-maria');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('');
+    expect(entries[0].summary).toBe('[Viorica-Ioana Prunescu] confirmed the visit [Source: Gmail, 2021-06-11]');
+  });
+
+  it('splits a canonical bullet at the spaced em-dash, not an earlier single hyphen', () => {
+    const content = '- **2026-03-18** | Email re `Reperks - Status thread` — Week 11 status logged';
+    const entries = extractTimelineFromContent(content, 'companies/reperks');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('Email re `Reperks - Status thread`');
+    expect(entries[0].summary).toBe('Week 11 status logged');
+  });
+});
+
 describe('walkMarkdownFiles', () => {
   it('is a function', () => {
     expect(typeof walkMarkdownFiles).toBe('function');


### PR DESCRIPTION
The Format-1 bullet parser splits source/summary on `\s*[—–-]\s*`, a class that includes a bare hyphen-minus, with a non-greedy source group. On any bullet lacking the canonical `Source — ` prefix (and on canonical ones with an earlier in-word hyphen) it matches the first hyphen anywhere (`scale-incumbent`, `Viorica-Ioana`, `follow-up`), mis-filing the summary prefix as the source. The mangled (source, summary) tuple then diverges from cleanly-written rows, defeating the `(page_id, date, summary, source)` dedup, so re-syncs accumulate duplicates.

Fix: the separator is now a spaced em/en-dash only; a bullet with no such separator has no source label (the whole text is the summary). Regression tests included.

We have run this patch locally since mid-July (it is the carry we re-apply after every upgrade); this PR upstreams it so the carry can retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
