### PR TITLE
fix(ci): release build gates on the artifact, not a serial re-run of the whole suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,19 @@ jobs:
         with:
           bun-version: 1.3.13
       - run: bun install
-      # --timeout matches every scripts/ runner and covers hook budgets too
-      # (bunfig.toml's timeout key is ignored by bun; hooks default to 5s).
-      - run: bun test --timeout=60000
-      - run: bun run verify
+      # No test re-run here: the Test workflow already gated this exact SHA at
+      # merge (10 shards + E2E). Re-running the whole suite serially on the
+      # release runner is a flakier duplicate gate — it blocked the first
+      # release on ambient-env tests (run 30698650484). The build job's gate
+      # is the artifact itself: compile, then smoke-test the binary.
       - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
+      - name: Smoke-test the compiled binary
+        run: |
+          chmod +x bin/${{ matrix.artifact }}
+          out="$(./bin/${{ matrix.artifact }} --version)"
+          echo "binary reports: $out"
+          v="$(tr -d '[:space:]' < VERSION)"
+          case "$out" in *"$v"*) echo "version matches VERSION file" ;; *) echo "binary version '$out' does not contain '$v'" >&2; exit 1 ;; esac
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:


### PR DESCRIPTION
The first Release workflow run (30698650484) failed before publishing anything: the build job re-ran the full unit suite serially on the release runner — a different environment from the sharded Test workflow that had already gated the exact merge SHA — and died on ambient-environment tests (the hybrid multimodal routing pair plus a 46s migrate flake). The macOS build was cancelled by the matrix, the release job skipped, and v0.42.71.0 never published. The #3573 gatekeeper review predicted exactly this failure mode.

Fix: the build job now compiles and **smoke-tests the binary** — `--version` output must contain the VERSION file's value — which validates the actual release artifact, something the test suite never did. The Test workflow remains the code gate; it ran green on the same SHA.

No VERSION bump: after merge, a `workflow_dispatch` run repairs and publishes v0.42.71.0 via the workflow's existing idempotent-repair path (release absent/partial → rebuild and publish).

`test/release-workflow.test.ts` green (it pins the asset/tag contract, not the removed step).