### PR TITLE
fix(sources): gate harden --dry-run pull step on dryRun flag

### DIFF
--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -890,6 +890,8 @@ export async function hardenBrainRepo(opts: HardenOpts): Promise<DurabilityRepor
   // Refuse on detached HEAD — pushing to a wrong ref is worse than not pushing.
   if (currentBranch(repoPath) === 'HEAD') {
     push('pull', { status: 'needs_attention', detail: 'detached HEAD — checkout a branch before hardening' });
+  } else if (dryRun) {
+    push('pull', { status: 'skipped', detail: `dry-run — would fetch + pull --rebase origin/${branch}` });
   } else {
     // 1. pull current state
     try { push('pull', pullDetail(divergenceSafePull(repoPath, branch))); }

--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -672,6 +672,8 @@ export async function hardenBrainRepo(opts: HardenOpts): Promise<DurabilityRepor
   // Refuse on detached HEAD — pushing to a wrong ref is worse than not pushing.
   if (currentBranch(repoPath) === 'HEAD') {
     push('pull', { status: 'needs_attention', detail: 'detached HEAD — checkout a branch before hardening' });
+  } else if (dryRun) {
+    push('pull', { status: 'skipped', detail: `dry-run — would fetch + pull --rebase origin/${branch}` });
   } else {
     // 1. pull current state
     try { push('pull', pullDetail(divergenceSafePull(repoPath, branch))); }

--- a/test/brain-repo-durability.serial.test.ts
+++ b/test/brain-repo-durability.serial.test.ts
@@ -172,6 +172,27 @@ describe('hardenBrainRepo', () => {
     expect(existsSync(join(work, 'scripts', 'brain-commit-push.sh'))).toBe(false);
   });
 
+  test('dry-run does not fetch or pull from origin', async () => {
+    const secondClone = mkdtempSync(join(root, 'pusher-'));
+    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, secondClone], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'config', 'user.email', 't@t.t'], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'config', 'user.name', 'tester'], { stdio: 'ignore' });
+    writeFileSync(join(secondClone, 'upstream.md'), 'new upstream content\n');
+    execFileSync('git', ['-C', secondClone, 'add', 'upstream.md'], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'commit', '-qm', 'advance origin'], { stdio: 'ignore' });
+    execFileSync('git', ['-c', 'protocol.file.allow=always', '-C', secondClone, 'push', '-q', 'origin', 'main'], { stdio: 'ignore' });
+
+    const headBefore = git(work, 'rev-parse', 'HEAD');
+    const trackingBefore = git(work, 'rev-parse', 'refs/remotes/origin/main');
+    const report = await harden({ dryRun: true });
+
+    expect(git(work, 'rev-parse', 'HEAD')).toBe(headBefore);
+    expect(existsSync(join(work, 'upstream.md'))).toBe(false);
+    expect(git(work, 'rev-parse', 'refs/remotes/origin/main')).toBe(trackingBefore);
+    expect(existsSync(join(work, '.git', 'FETCH_HEAD'))).toBe(false);
+    expect(report.steps.find(step => step.step === 'pull')?.status).toBe('skipped');
+  });
+
   test('dry-run does not chmod an already-current helper (#3736)', async () => {
     await harden(); // real run installs scripts/brain-commit-push.sh at 0o755
     const helperPath = join(work, 'scripts', 'brain-commit-push.sh');

--- a/test/brain-repo-durability.serial.test.ts
+++ b/test/brain-repo-durability.serial.test.ts
@@ -169,6 +169,29 @@ describe('hardenBrainRepo', () => {
     expect(commitCount(work)).toBe(before);
     expect(existsSync(join(work, 'scripts', 'brain-commit-push.sh'))).toBe(false);
   });
+
+  test('dry-run does not fetch or pull from origin (no network, no working-tree mutation)', async () => {
+    // Advance origin with a new commit that the working tree does not have.
+    const secondClone = mkdtempSync(join(root, 'pusher-'));
+    execFileSync('git', ['-c', 'protocol.file.allow=always', 'clone', '-q', bare, secondClone], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'config', 'user.email', 't@t.t'], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'config', 'user.name', 'tester'], { stdio: 'ignore' });
+    writeFileSync(join(secondClone, 'upstream.md'), 'new upstream content\n');
+    execFileSync('git', ['-C', secondClone, 'add', 'upstream.md'], { stdio: 'ignore' });
+    execFileSync('git', ['-C', secondClone, 'commit', '-qm', 'advance origin'], { stdio: 'ignore' });
+    execFileSync('git', ['-c', 'protocol.file.allow=always', '-C', secondClone, 'push', '-q', 'origin', 'main'], { stdio: 'ignore' });
+
+    const headBefore = git(work, 'rev-parse', 'HEAD');
+    const r = await harden({ dryRun: true });
+
+    // Working tree must not have advanced — no fetch, no pull.
+    expect(git(work, 'rev-parse', 'HEAD')).toBe(headBefore);
+    expect(existsSync(join(work, 'upstream.md'))).toBe(false);
+
+    // The pull step should report skipped (dry-run), not ok/advanced.
+    const pull = r.steps.find(s => s.step === 'pull');
+    expect(pull?.status).toBe('skipped');
+  });
 });
 
 describe('unhardenBrainRepo', () => {

--- a/test/brain-repo-durability.serial.test.ts
+++ b/test/brain-repo-durability.serial.test.ts
@@ -182,11 +182,18 @@ describe('hardenBrainRepo', () => {
     execFileSync('git', ['-c', 'protocol.file.allow=always', '-C', secondClone, 'push', '-q', 'origin', 'main'], { stdio: 'ignore' });
 
     const headBefore = git(work, 'rev-parse', 'HEAD');
+    const trackingBefore = git(work, 'rev-parse', 'refs/remotes/origin/main');
     const r = await harden({ dryRun: true });
 
     // Working tree must not have advanced — no fetch, no pull.
     expect(git(work, 'rev-parse', 'HEAD')).toBe(headBefore);
     expect(existsSync(join(work, 'upstream.md'))).toBe(false);
+
+    // Tracking ref unchanged — proves fetch itself was skipped, not just pull.
+    expect(git(work, 'rev-parse', 'refs/remotes/origin/main')).toBe(trackingBefore);
+
+    // FETCH_HEAD absent — no network call happened at all.
+    expect(existsSync(join(work, '.git', 'FETCH_HEAD'))).toBe(false);
 
     // The pull step should report skipped (dry-run), not ok/advanced.
     const pull = r.steps.find(s => s.step === 'pull');


### PR DESCRIPTION
Fixes #3692.

`hardenBrainRepo` runs `divergenceSafePull(repoPath, branch)` at `src/core/brain-repo-durability.ts:677` before any `dryRun` check, so `gbrain sources harden <id> --dry-run` performs a live `git fetch` + `git pull --rebase` against the user's brain working tree. On a repo with local unpushed commits, that rewrites history under a flag whose entire purpose is to avoid performing operations. Steps 2-7 all gate on `dryRun`; step 1 was missed.

**Before and after** on `f07e9dff`:

| scenario | before | after |
|---|---|---|
| `harden <id> --dry-run` with origin ahead | pull executes, HEAD advances, `upstream.md` materializes | pull skipped, HEAD unchanged, report says "would fetch + pull" |
| `harden <id> --dry-run` with local unpushed commits + origin ahead | local commit rebased to new SHA | HEAD unchanged, no history rewrite |

**The fix** adds an `else if (dryRun)` branch at line 676 that reports the pull step as `skipped` with a descriptive detail string, matching the step-7 verify pattern at line 709-710. The existing detached-HEAD guard (line 673) is untouched. I deliberately did not address the two side-notes in the issue (the `--help` stub, filed separately as #3686; and the SSH-remote/PAT inertness) — those are independent concerns.

**Receipts.** The added test fails on unpatched master with `Expected: "<sha-before>", Received: "<sha-after>"` (HEAD advanced) and passes after. `bun test test/brain-repo-durability.serial.test.ts -t "dry-run"` is 2 pass / 0 fail. `tsc --noEmit` clean. `bun run verify` green (34/34 checks). The pre-existing failure in "installs hook" is environment-dependent (push-probe can't push with `http.followRedirects=false` in a bare-local test setup) and fails identically on unpatched master — confirmed not introduced by this change.

Title carries no version prefix: the landing version is /ship's at land time, not something a contributor can know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)