### PR TITLE
fix(chunkers): index C# file-scoped namespace body instead of silently dropping it

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -324,7 +324,7 @@ const TOP_LEVEL_TYPES: Partial<Record<SupportedCodeLanguage, Set<string>>> = {
   c_sharp: new Set([
     'method_declaration', 'class_declaration', 'interface_declaration',
     'struct_declaration', 'enum_declaration', 'namespace_declaration',
-    'using_directive', 'property_declaration',
+    'file_scoped_namespace_declaration', 'using_directive', 'property_declaration',
   ]),
   cpp: new Set([
     'function_definition', 'class_specifier', 'struct_specifier',

--- a/test/chunkers/code.test.ts
+++ b/test/chunkers/code.test.ts
@@ -424,3 +424,22 @@ describe('chunkCodeText — empty input', () => {
     expect(await chunkCodeText('   \n  ', 'foo.ts')).toEqual([]);
   });
 });
+
+describe('chunkCodeText — C# file-scoped namespace (#3601)', () => {
+  test('indexes the class body inside a file-scoped namespace', async () => {
+    const source = `using System;
+namespace Demo;
+
+public class OrderService
+{
+    public decimal ComputeRefund(decimal amount) => amount * 0.9m;
+}
+`;
+
+    const result = await chunkCodeText(source, 'OrderService.cs');
+    const text = result.map(chunk => chunk.text).join('\n');
+
+    expect(text).toContain('OrderService');
+    expect(text).toContain('ComputeRefund');
+  });
+});

--- a/test/chunkers/code.test.ts
+++ b/test/chunkers/code.test.ts
@@ -424,3 +424,45 @@ describe('chunkCodeText — empty input', () => {
     expect(await chunkCodeText('   \n  ', 'foo.ts')).toEqual([]);
   });
 });
+
+describe('chunkCodeText — C# file-scoped namespace (#3601)', () => {
+  const FILE_SCOPED = `using System;
+namespace Demo;
+
+public class OrderService
+{
+    public decimal ComputeRefund(decimal amount) => amount * 0.9m;
+    public void Ship(string id) => Console.WriteLine(id);
+}
+`;
+
+  const BLOCK_SCOPED = `using System;
+namespace Demo
+{
+    public class OrderService
+    {
+        public decimal ComputeRefund(decimal amount) => amount * 0.9m;
+        public void Ship(string id) => Console.WriteLine(id);
+    }
+}
+`;
+
+  test('file-scoped namespace body is indexed (class appears in chunks)', async () => {
+    const result = await chunkCodeText(FILE_SCOPED, 'OrderService.cs');
+    const allText = result.map(c => c.text).join('\n');
+    expect(allText).toContain('OrderService');
+    expect(allText).toContain('ComputeRefund');
+  });
+
+  test('file-scoped and block-scoped produce equivalent coverage', async () => {
+    const fileScopedResult = await chunkCodeText(FILE_SCOPED, 'OrderService.cs');
+    const blockScopedResult = await chunkCodeText(BLOCK_SCOPED, 'OrderService.cs');
+    const fileScopedText = fileScopedResult.map(c => c.text).join('\n');
+    const blockScopedText = blockScopedResult.map(c => c.text).join('\n');
+    // Both must contain the class body — neither should silently drop it.
+    expect(fileScopedText).toContain('OrderService');
+    expect(blockScopedText).toContain('OrderService');
+    expect(fileScopedText).toContain('ComputeRefund');
+    expect(blockScopedText).toContain('ComputeRefund');
+  });
+});


### PR DESCRIPTION
Fixes #3601.

`TOP_LEVEL_TYPES.c_sharp` at `src/core/chunkers/code.ts:324-328` lists `namespace_declaration` but not `file_scoped_namespace_declaration`. In a C# 10 file using the file-scoped form (`namespace Demo;`), the AST root's `namedChildren` are `[using_directive, file_scoped_namespace_declaration]`. Since `file_scoped_namespace_declaration` isn't in the set, the filter at `code.ts:623-624` (`root.namedChildren.filter(n => topLevelTypes.has(n.type))`) only matches `using_directive` — the entire class body inside the namespace node is never visited. The page is created and appears healthy (doctor is green, chunks exist), but contains only `using` lines.

**Before and after** on `f07e9dff`:

| scenario | before | after |
|---|---|---|
| `chunkCodeText` on file-scoped `namespace Demo;` with `OrderService` class | 1 chunk: `[C#] OrderService.cs:1-1 using directive System` — class body absent | chunks include `OrderService` and `ComputeRefund` |
| `chunkCodeText` on block-scoped `namespace Demo { ... }` | class body indexed (already worked) | unchanged |

**The fix** adds `'file_scoped_namespace_declaration'` to the `TOP_LEVEL_TYPES.c_sharp` set — one string in a `new Set([...])` initializer. This makes the file-scoped form produce the same namespace-body chunk the block-scoped `namespace_declaration` already produces. C# has no `NESTED_EMIT_CONFIG` entry, so no nested-emission interaction exists. I deliberately did not address the issue's secondary asks (debug warning for zero-symbol .cs files, call-edge extraction) — those overlap with feature request #3602 and are a distinct scope.

**Receipts.** The added test fails on unpatched master with `Expected to contain: "ComputeRefund", Received: "[C#] OrderService.cs:1-1 using directive System\n\nusing System;"` and passes after. `bun test test/chunkers/code.test.ts` is 33 pass / 0 fail. `tsc --noEmit` clean. `bun run verify` green (34/34 checks).

No version prefix — assigned at wave time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)