### PR TITLE
fix(mcp): reject sources_add path on remote transport

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4020,11 +4020,12 @@ const sources_add: Operation = {
     const isLocal = ctx.remote === false;
     const remotePath = isLocal ? (p.path as string | undefined) ?? null : null;
     const remoteCloneDir = isLocal ? (p.clone_dir as string | undefined) : undefined;
-    if (!isLocal && (p.path !== undefined || p.clone_dir !== undefined)) {
-      ctx.logger.warn(
-        '[sources_add] ignoring path/clone_dir overrides on HTTP MCP transport ' +
-          '(remote callers can only register a remote --url; the clone path is ' +
-          'fixed under $GBRAIN_HOME/clones/).',
+    if (!isLocal && p.path !== undefined) {
+      throw new OperationError(
+        'invalid_params',
+        'sources_add: path is not honored over MCP (security confinement). ' +
+          'Register with --url instead, or run `gbrain sources add --path ...` on the host CLI.',
+        'Use --url to register a remote source, or run the command locally with --path.',
       );
     }
 

--- a/test/sources-mcp.test.ts
+++ b/test/sources-mcp.test.ts
@@ -281,19 +281,18 @@ describe('sources_add — remote callers ignore path/clone_dir overrides', () =>
     });
   });
 
-  test('remote sources_admin: path override (without url) gets nulled', async () => {
+  test('remote sources_admin: path override (without url) is rejected with an error', async () => {
     await withEnv({ GBRAIN_HOME, PATH: fakePath() }, async () => {
       const op = findOp('sources_add');
       const ctx = ctxRemote(['sources_admin']);
-      // Without a URL and with a remote-supplied path, the path is dropped.
-      // The op then has neither path nor url, which is fine — it creates a
-      // pure DB-only source row (local_path=null).
-      const row = (await op.handler(ctx, {
+      // Remote callers must not silently succeed when passing path — the call
+      // should fail so the client knows the source was NOT registered with a
+      // usable local_path. Silent success + null local_path means sync --all
+      // skips the source forever (#3645).
+      await expect(op.handler(ctx, {
         id: 'attack-path',
         path: '/etc',
-      })) as any;
-      // local_path was nulled — /etc is NOT registered as a source.
-      expect(row.local_path).toBeNull();
+      })).rejects.toThrow(/path.*clone_dir.*not honored|confinement/i);
     });
   });
 


### PR DESCRIPTION
Fixes #3645.

`sources_add` on a remote MCP transport accepts `path` without error, but silently nullifies it (`src/core/operations.ts:4020-4021` sets `remotePath = null` when `!isLocal`). The source row is then registered with `local_path = null`. This is a quiet failure: the client receives a success response, but the source is permanently broken — `sync --all` skips any source where `local_path` is null and `remote_url` is absent.

The existing code at `operations.ts:4023` logged a warning to `ctx.logger.warn()`, but stderr warnings are invisible to MCP clients (the protocol only surfaces the return value and JSON-RPC errors). The issue correctly identifies that this should be a hard rejection so the client knows the source was NOT registered.

**Before and after** on `f07e9df`:

| scenario | before | after |
|---|---|---|
| Remote caller passes `path` without `url` | Succeeds with `local_path: null` — dead source | Throws `OperationError('invalid_params')` with remediation hint |
| Remote caller passes `clone_dir` with `url` | Silently uses safe default path (working source) | Same — unchanged |
| Local CLI passes `path` | Honored (trusted) | Same — unchanged |

**The fix** replaces the `ctx.logger.warn(...)` with `throw new OperationError('invalid_params', ...)` when `!isLocal && p.path !== undefined`. The `clone_dir` case is deliberately left as a silent override (not a rejection) because it still produces a functional source when paired with `url` — the clone just lands at the safe default under `$GBRAIN_HOME/clones/` instead of the attacker-supplied path. Rejecting `clone_dir+url` would be a breaking change for clients that pass both.

**Receipts.** The added test fails on unpatched master with `Expected promise that rejects / Received promise that resolved: Promise { <resolved> }` and passes after. `bun test test/sources-mcp.test.ts` is 21 pass / 0 fail. `bun run verify` is 34/34 clean.

Note for maintainer: if the intent is to also reject `clone_dir` (even with `url`), expanding the condition to `p.path !== undefined || p.clone_dir !== undefined` is one line — but it changes behavior for any client that currently passes both `url` and `clone_dir`. Leaving that decision to the core team.

No version prefix — assigned at wave time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)