### PR TITLE
fix(skills): advertise usable tools on stdio transport

### DIFF
--- a/src/core/skill-catalog.ts
+++ b/src/core/skill-catalog.ts
@@ -295,6 +295,7 @@ export function confineManifestPath(skillsDir: string, entry: ManifestEntry): st
 function opCallableByCaller(op: Operation, ctx: OperationContext): boolean {
   if (ctx.remote === false) return true; // local CLI — OS is the trust boundary
   if (op.localOnly) return false; // not reachable over a remote transport
+  if (ctx.transport === 'stdio') return true; // auth-less local pipe — dispatch enforces no scopes
   return hasScope(ctx.auth?.scopes ?? [], op.scope ?? 'read');
 }
 

--- a/test/skill-catalog-transports.test.ts
+++ b/test/skill-catalog-transports.test.ts
@@ -54,7 +54,7 @@ function unpack(res: { content: { text: string }[]; isError?: boolean }): {
 async function call(
   name: string,
   params: Record<string, unknown>,
-  opts: { remote: boolean; auth?: AuthInfo },
+  opts: { remote: boolean; auth?: AuthInfo; transport?: 'stdio' },
 ) {
   return unpack(await dispatchToolCall(engine, name, params, { sourceId: 'default', ...opts }));
 }
@@ -136,6 +136,35 @@ describe('get_skill over dispatch', () => {
       const r = await call('get_skill', { name: 'nope' }, { remote: false });
       expect(r.isError).toBe(true);
       expect(r.body.error).toBe('page_not_found');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3635: stdio transport must see usable_tools, not empty
+// ---------------------------------------------------------------------------
+
+describe('stdio transport — catalog advertises tools as usable (#3635)', () => {
+  test('list_skills over stdio reports brain-ops tools in usable_tools', async () => {
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await engine.setConfig('mcp.publish_skills', 'true');
+      const r = await call('list_skills', {}, { remote: true, transport: 'stdio' });
+      expect(r.isError).toBe(false);
+      const bo = r.body.skills.find((s: any) => s.name === 'brain-ops');
+      expect(bo.usable_tools).toContain('search');
+      expect(bo.usable_tools).toContain('put_page');
+      expect(bo.unavailable_tools).not.toContain('search');
+      expect(bo.unavailable_tools).not.toContain('put_page');
+    });
+  });
+
+  test('localOnly ops remain unavailable on stdio', async () => {
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await engine.setConfig('mcp.publish_skills', 'true');
+      const r = await call('list_skills', {}, { remote: true, transport: 'stdio' });
+      expect(r.isError).toBe(false);
+      const allUsable = r.body.skills.flatMap((s: any) => s.usable_tools);
+      expect(allUsable).not.toContain('purge_deleted_pages');
     });
   });
 });


### PR DESCRIPTION
Fixes #3635.

`opCallableByCaller()` at `src/core/skill-catalog.ts:295-299` requires `hasScope(ctx.auth?.scopes ?? [], op.scope)` for any remote caller. The stdio MCP pipe is `remote: true` with no auth (`ctx.auth` is undefined), so `ctx.auth?.scopes ?? []` resolves to `[]` and `hasScope([], 'read')` is false — every op fails the check. Meanwhile `src/mcp/dispatch.ts:237` enforces no scopes on stdio, so every op actually executes. The result: `list_skills` reports all tools in `unavailable_tools` with `usable_tools: []`, and the instruction text tells the agent not to call them, while in reality the tools all work.

**Before and after** on `f07e9df`:

| scenario | before | after |
|---|---|---|
| `list_skills` over stdio | `usable_tools: []`, all tools in `unavailable_tools` | `usable_tools` contains all non-localOnly ops (search, put_page, etc.) |
| `localOnly` ops over stdio | Listed unavailable (catalog) but execute (dispatch) | Listed unavailable — catalog agrees with what dispatch *should* enforce |
| HTTP-remote with OAuth scopes | Scope-gated split (read → search/query, admin → all) | Unchanged |

**The fix** adds one line after the `op.localOnly` check: `if (ctx.transport === 'stdio') return true;`. Placed AFTER `localOnly` so those ops remain unadvertised — matching the intended posture that stdio is trusted but not fully local. This is advertisement honesty, not a trust grant: dispatch already runs everything on stdio.

Deliberately left unchanged: the deeper inconsistency where stdio dispatch doesn't enforce `localOnly` (verified in the issue — `purge_deleted_pages` executes over stdio). That's a separate product decision for the maintainer and a different issue.

**Receipts.** The added test fails on unpatched master with `Expected to contain: "search" / Received: []` and passes after. `bun test test/skill-catalog-transports.test.ts` is 10 pass / 0 fail. `bun run verify` is 34/34 clean.

No version prefix — assigned at wave time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)