### PR TITLE
docs(integrity): correct the --dry-run line in the subcommand comment (#3738)

### DIFF
--- a/src/commands/integrity.ts
+++ b/src/commands/integrity.ts
@@ -12,7 +12,7 @@
  * Subcommands:
  *   gbrain integrity check              Read-only report to stdout
  *   gbrain integrity auto               Three-bucket repair with confidence
- *   gbrain integrity --dry-run          Same as auto, no writes
+ *   gbrain integrity auto --dry-run     Same as auto, no writes
  *
  * Three-bucket confidence (contract with x_handle_to_tweet resolver):
  *   >= 0.8 → auto-repair through BrainWriter transaction


### PR DESCRIPTION
Addresses #3738.

The subcommand comment at the top of `src/commands/integrity.ts` listed a form the CLI rejects:

```
 *   gbrain integrity --dry-run          Same as auto, no writes
```

`runIntegrity` dispatches on `sub` (`:210` `check`, `:214` `auto`) and parses `--dry-run` at `:414`, inside the `auto` path. Running the documented form exits 1:

```
$ gbrain integrity --dry-run
Unknown subcommand: --dry-run
Usage: gbrain integrity <subcommand> [options]
```

The runtime help was already right — it shows `--dry-run` indented under `auto [options]`. Only the comment disagreed, and it is the first thing a reader sees when opening the file.

## The change

One line. `gbrain integrity --dry-run` → `gbrain integrity auto --dry-run`, keeping the column alignment of the surrounding block.

## No test, and why

This is a comment-only change, so there is no test that fails without it. I am flagging that explicitly rather than letting it read as an oversight — the repo asks contributors for a test that goes red without the fix, and I cannot produce one here.

The alternative direction *would* be testable: make `integrity --dry-run` an accepted alias for `auto --dry-run`, then spawn the CLI and assert exit code 0 plus an unchanged brain. I did not do that, because it widens the CLI's accepted surface and that is a design call that belongs to you rather than to a drive-by doc fix. #3738 lays out both options; say the word and I will redo this as the alias version, or drop the line entirely if that is what you would rather have.

## Verification

- `bun run typecheck` — clean.
- Reproduced the error output above against the installed binary at v0.42.71.0, and re-read the comment from `git show upstream/master:src/commands/integrity.ts` to confirm it is still present on `f07e9dff`.

