### PR TITLE
test(openclaw): inspect runtime in plugin loader E2E

### DIFF
--- a/test/e2e/openclaw-plugin-load-real.test.ts
+++ b/test/e2e/openclaw-plugin-load-real.test.ts
@@ -18,7 +18,8 @@
  *      ship to ClawHub).
  *   2. `openclaw plugins install --link` against an isolated `--profile`
  *      directory.
- *   3. `openclaw plugins inspect <id> --json` reads our default-export shape
+ *   3. `openclaw plugins inspect <id> --runtime --json` imports the plugin and
+ *      reads our default-export shape
  *      back from the runtime registry (`status: 'loaded'`, `imported: true`,
  *      id/name/description match).
  *   4. `openclaw config set plugins.slots.contextEngine gbrain-context` →
@@ -167,7 +168,7 @@ describe('openclaw-plugin-load-real (Tier 2 e2e)', () => {
   it.skipIf(SKIP)(
     'openclaw imports the entry file and reports status=loaded',
     () => {
-      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--json'], { timeoutMs: 30_000 });
+      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--runtime', '--json'], { timeoutMs: 30_000 });
       expect(r.exitCode).toBe(0);
 
       const inspect = JSON.parse(r.stdout);
@@ -183,7 +184,7 @@ describe('openclaw-plugin-load-real (Tier 2 e2e)', () => {
   it.skipIf(SKIP)(
     'default export carries the expected id / name / description metadata',
     () => {
-      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--json'], { timeoutMs: 30_000 });
+      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--runtime', '--json'], { timeoutMs: 30_000 });
       expect(r.exitCode).toBe(0);
       const inspect = JSON.parse(r.stdout);
 
@@ -198,22 +199,15 @@ describe('openclaw-plugin-load-real (Tier 2 e2e)', () => {
   it.skipIf(SKIP)(
     'register(api) ran without producing error-level diagnostics',
     () => {
-      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--json'], { timeoutMs: 30_000 });
+      const r = runOpenclaw(['plugins', 'inspect', PLUGIN_ID, '--runtime', '--json'], { timeoutMs: 30_000 });
       expect(r.exitCode).toBe(0);
       const inspect = JSON.parse(r.stdout);
 
       const errors = (inspect.diagnostics ?? []).filter((d: { level: string }) => d.level === 'error');
       expect(errors).toEqual([]);
 
-      // The trust warning is expected for --link installs — it's openclaw
-      // telling the operator that --link bypasses install-record provenance.
-      // We assert it's there so a future openclaw change that elevates it to
-      // error-level surfaces here too.
-      const warns = (inspect.diagnostics ?? []).filter((d: { level: string }) => d.level === 'warn');
-      const hasTrustWarning = warns.some((d: { message: string }) =>
-        d.message.includes('install/load-path provenance'),
-      );
-      expect(hasTrustWarning).toBe(true);
+      // Linked installs may or may not emit provenance warnings depending on
+      // the OpenClaw version. Registration errors are the stable contract.
     },
   );
 


### PR DESCRIPTION
## Summary

- run `plugins inspect` with `--runtime` when the E2E asserts imported plugin state
- stop requiring the version-dependent linked-install provenance warning
- document that the E2E reads runtime metadata rather than cold manifest metadata

Closes #3741.

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL -u GBRAIN_DIRECT_DATABASE_URL bun test test/e2e/openclaw-plugin-load-real.test.ts` — 6 pass, 0 fail
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL -u GBRAIN_DIRECT_DATABASE_URL bun run typecheck` — pass
- `bun run verify` — 33/34 checks pass; the existing macOS `check:wasm` process is terminated with exit 137
