### PR TITLE
fix(integrity): stop counting dead-link findings as review-queue entries (#3750)

### DIFF
--- a/src/commands/integrity.ts
+++ b/src/commands/integrity.ts
@@ -449,6 +449,7 @@ async function cmdAuto(args: string[]): Promise<void> {
   let bucketReview = 0;
   let bucketSkip = 0;
   let bucketErr = 0;
+  let bucketDeadLink = 0;
   let pagesProcessed = 0;
 
   const { createProgress } = await import('../core/progress.ts');
@@ -549,7 +550,13 @@ async function cmdAuto(args: string[]): Promise<void> {
                 hit: { slug, line: hit.line, rawLine: hit.url, phrase: 'dead-link' },
                 reason: `dead link: ${result.value.reason ?? 'unknown'}`,
               });
-              bucketReview++;
+              // Dead links have no confidence score and are never written to
+              // the review file (appendReview() is only called from the
+              // bare-tweet path above) — they land in the skip log via
+              // logSkip() a few lines up. Count them separately so the
+              // printed "Review queue" total only ever reflects what's
+              // actually in ~/.gbrain/integrity-review.md.
+              bucketDeadLink++;
             }
           } catch {
             /* transient; don't fail the run */
@@ -568,6 +575,7 @@ async function cmdAuto(args: string[]): Promise<void> {
     console.log(`Review queue (≥${reviewLower} <${confidenceThreshold}): ${bucketReview}`);
     console.log(`Skipped (<${reviewLower}): ${bucketSkip}`);
     if (bucketErr > 0) console.log(`Resolver errors: ${bucketErr}`);
+    if (bucketDeadLink > 0) console.log(`Dead links surfaced (see skipped log): ${bucketDeadLink}`);
     console.log(`\nReview queue: ${getReviewFile()}`);
     console.log(`Skipped log:  ${getLogFile()}`);
     console.log(`Progress:     ${getProgressFile()}`);


### PR DESCRIPTION
Addresses #3750.

The dead-link branch in `cmdAuto` (`src/commands/integrity.ts:535-558`)
called `logSkip()` (writing to `integrity.log.jsonl`) but incremented
`bucketReview`, the same counter fed by the bare-tweet path's
`appendReview()` calls (which write to `integrity-review.md`). The printed

    Review queue (≥0.5 <0.8): N

therefore counted findings that were never written to the review file.
`gbrain integrity review`, which reads the actual file, silently disagreed
with `auto`'s own summary for anyone who ran both.

## The change

Give dead-link findings their own counter (`bucketDeadLink`) instead of
borrowing `bucketReview`, and print it as its own line only when non-zero:

    Dead links surfaced (see skipped log): N

No change to the bare-tweet confidence bucketing (`bucketAuto` /
`bucketReview` / `bucketSkip` keep their existing meaning), no new CLI
flags or subcommands.

## No new automated test, and why

`test/integrity.test.ts`'s own header says the three-bucket `auto` path
"runs end-to-end in a manual smoke script against a real brain; the unit
tests here focus on the pure detection logic." `cmdAuto` isn't exported
and exercising it needs a live engine plus a mocked `url_reachable`
resolver — there's no existing harness for it. Flagging the gap rather
than adding new test infrastructure as part of a counter-attribution fix,
same reasoning as #3739.

## Verification

- `bun run typecheck` — clean.
- `bun test test/integrity.test.ts test/skills-integrity.test.ts` — 35
  pass / 0 fail (unaffected paths, confirms no regression in this file's
  existing coverage).
- Reproduced the bug live against a 2010-page brain with
  `gbrain integrity auto --skip-bare-tweet --fresh`: summary printed
  `Review queue (≥0.5 <0.8): 529` immediately followed by
  `ls ~/.gbrain/integrity-review.md` → `No such file or directory`
  (screenshot below).

---
## My human part:
When i was doing my nightly routine ; gbrain doctor score, i met integrity auto didn't reproduce any modifications.
Even thou i passed 2010 pages, appendReview didn't get called.

Screenshot:
<img width="561" height="491" alt="Image" src="https://github.com/user-attachments/assets/94577903-ffef-4f1d-aed5-4954823a15fb" />
