### PR TITLE
fix(autopilot): generated wrapper carries Homebrew bin paths

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -1329,7 +1329,7 @@ source ~/.zshrc 2>/dev/null || source ~/.bashrc 2>/dev/null || true
 # lockfile that blocks every subsequent tick. Prepending ~/.bun/bin here
 # keeps the wrapper self-contained regardless of which init file the OS
 # loaded.
-export PATH="$HOME/.bun/bin:$PATH"
+export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 exec '${safeGbrainPath}' autopilot --repo '${safeRepoPath}'
 `;
   writeFileSync(wrapperPath, wrapper, { mode: 0o755 });


### PR DESCRIPTION
The launchd wrapper that `gbrain autopilot --install` generates execs gbrain (a `#!/usr/bin/env bun` script) with only `~/.bun/bin` prepended to PATH. On machines where bun is Homebrew-installed (`/opt/homebrew/bin/bun`), launchd's bare PATH can't find it and the service crash-loops with exit 127 / `env: bun: No such file or directory`.

One-line fix in the wrapper template: prepend `/opt/homebrew/bin:/usr/local/bin` alongside `~/.bun/bin`. Hit in production on a Homebrew-bun Mac 2026-08-01; the patched wrapper has run the daemon cleanly since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)