### PR TITLE
fix(export): scope tag + raw-data sidecar reads to the page's own source

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -108,7 +108,11 @@ export async function runExport(engine: BrainEngine, args: string[]) {
   let exported = 0;
 
   for (const page of pages) {
-    const tags = await engine.getTags(page.slug);
+    // Slugs are unique per source, not brain-wide, so both sidecar reads are
+    // pinned to the page's own source. Unscoped, `getTags` falls back to
+    // `source_id = 'default'` and stamps the default source's tags onto a
+    // same-slug page from another source (dropping its real ones).
+    const tags = await engine.getTags(page.slug, { sourceId: page.source_id });
     const md = serializeMarkdown(
       page.frontmatter,
       page.compiled_truth,
@@ -120,8 +124,13 @@ export async function runExport(engine: BrainEngine, args: string[]) {
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, md);
 
-    // Export raw data as sidecar JSON
-    const rawData = await engine.getRawData(page.slug);
+    // Export raw data as sidecar JSON. Unscoped, this matches the slug in
+    // EVERY source and the loop below merges the rows into one sidecar keyed
+    // by `rd.source`, so another source's raw data silently overwrites this
+    // page's own on a key collision.
+    const rawData = await engine.getRawData(page.slug, undefined, {
+      sourceId: page.source_id,
+    });
     if (rawData.length > 0) {
       const slugParts = page.slug.split('/');
       const rawDir = join(outDir, ...slugParts.slice(0, -1), '.raw');

--- a/test/storage-export.test.ts
+++ b/test/storage-export.test.ts
@@ -7,10 +7,14 @@
  * Tests use PGLite in-memory and a captured-output approach (process.exit
  * is intercepted) to verify the resolution chain produces the right
  * repoPath OR the right error.
+ *
+ * Also covers per-source scoping of the two sidecar reads in the export loop
+ * (tags + raw data), which are keyed by slug and so cross source boundaries
+ * unless pinned to the page's own source.
  */
 
 import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -142,5 +146,60 @@ describe('export --restore-only resolution chain (D5)', () => {
     await tryRunExport(['--dir', outDir]);
     expect(exitCode).toBeNull();
     expect(stdout.some((line) => line.includes('Exporting 0'))).toBe(true);
+  });
+});
+
+describe('export sidecar reads are scoped to the page owning source', () => {
+  // Both fixtures use the SAME slug in two sources — the only shape where a
+  // slug-keyed read can cross a boundary, since slugs are unique per source
+  // rather than brain-wide.
+  const SLUG = 'notes/shared';
+
+  beforeEach(async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('other', 'Other') ON CONFLICT DO NOTHING`,
+    );
+    for (const sourceId of ['default', 'other']) {
+      await engine.putPage(
+        SLUG,
+        { type: 'note', title: `${sourceId} title`, compiled_truth: 'body' },
+        { sourceId },
+      );
+      await engine.addTag(SLUG, `tag-${sourceId}`, { sourceId });
+      await engine.putRawData(SLUG, `feed-${sourceId}`, { owner: sourceId }, { sourceId });
+    }
+
+    // One slug means one output path, so the two pages overwrite each other
+    // and only the last one written survives on disk. Pin the export order
+    // (listPages defaults to updated_desc) so `other` is the survivor and the
+    // assertions below read a NON-default page — the only page whose sidecars
+    // an unscoped, `'default'`-defaulting read would get wrong.
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = updated_at + interval '1 hour' WHERE source_id = 'default'`,
+    );
+  });
+
+  test("a non-default page exports its own tags, not the default source's", async () => {
+    await tryRunExport(['--dir', outDir]);
+    expect(exitCode).toBeNull();
+
+    const md = readFileSync(join(outDir, SLUG + '.md'), 'utf-8');
+    // Guards the ordering assumption itself: if `default` ever wins the race
+    // the tag assertions stop discriminating, so fail loudly here instead.
+    expect(md).toContain('other title');
+    expect(md).toContain('tag-other');
+    expect(md).not.toContain('tag-default');
+  });
+
+  test('raw-data sidecars carry only the owning source rows', async () => {
+    await tryRunExport(['--dir', outDir]);
+    expect(exitCode).toBeNull();
+
+    // Unscoped, getRawData applies no source predicate at all: both sources'
+    // rows come back and the export loop merges them into a single object
+    // keyed by `rd.source`.
+    const raw = JSON.parse(readFileSync(join(outDir, 'notes', '.raw', 'shared.json'), 'utf-8'));
+    expect(Object.keys(raw)).toEqual(['feed-other']);
+    expect(raw['feed-other']).toEqual({ owner: 'other' });
   });
 });


### PR DESCRIPTION
## The bug

`gbrain export` reads two sidecars per page keyed by **slug alone**, but slugs are unique per `(source_id, slug)`, not brain-wide. On any multi-source brain, a slug present in more than one source exports the wrong metadata:

- `src/commands/export.ts:111` - `engine.getTags(page.slug)` with no opts. Both engines fall back to `source_id = 'default'` (`postgres-engine.ts:3786`, `pglite-engine.ts:3646`), so a page owned by another source is exported carrying the **default source's tags**, with its own tags dropped.
- `src/commands/export.ts:124` - `engine.getRawData(page.slug)` with no opts. This one applies **no source predicate at all** (the four-branch `else` at `postgres-engine.ts:4193`), so every source's raw data for that slug comes back and the loop below collapses the rows into one sidecar keyed by `rd.source` - a same-named raw source in another brain source silently overwrites this page's own.

Both engines already accept the scoping opts, and `Page.source_id` has been required and populated by `rowToPage` since v0.32.8. The export loop just never threaded it.

## The fix

Pass `{ sourceId: page.source_id }` at both call sites. No new flags, no behavior change on single-source brains (where `page.source_id` is `'default'` and the reads resolve identically).

## Tests

Two tests in `test/storage-export.test.ts`, fixtures on the only shape where the bug can appear: the same slug in two sources.

Discrimination verified - reverting `src/commands/export.ts` to master fails both, with the defect visible in the output:

```
Expected to contain: "tag-other"
Received: "---\ntype: note\ntitle: other title\ntags:\n  - tag-default\n---\n\nbody\n"
```

A page owned by source `other`, exported with the default source's tag and missing its own. The raw-data test fails on the extra `feed-default` key in `other`'s sidecar.

With the fix: 7 pass / 0 fail in that file, `tsc --noEmit` clean.

Note on the fixture: both pages share a slug, so they collide on one output path and only the last write survives. The test bumps the default page's `updated_at` to pin the `updated_desc` export order so the **non-default** page is the survivor, and asserts on its title first - otherwise the assertions would stop discriminating if that ordering ever changed, rather than failing.

## Unrelated observation

`test/storage-export.test.ts` times out its `beforeEach` under the default 5s budget on Windows - the `beforeAll` runs 120 PGLite migrations. Reproduces on untouched master; needs `--timeout 120000` locally. Not touched here.
