### PR TITLE
fix(sources): stop harden --dry-run from chmodding an already-current helper (#3736)

### DIFF
--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -394,8 +394,9 @@ function installHelper(repoPath: string, dryRun: boolean): { status: StepStatus;
   const helperPath = join(repoPath, HELPER_REL);
   const script = renderCommitPushHelper();
   if (existsSync(helperPath) && readFileSync(helperPath, 'utf-8') === script) {
-    // Ensure exec bit even when content is current.
-    try { chmodSync(helperPath, 0o755); } catch { /* */ }
+    // Ensure exec bit even when content is current — but not in dry-run: a
+    // preview must not mutate permissions (#3736).
+    if (!dryRun) { try { chmodSync(helperPath, 0o755); } catch { /* */ } }
     return { status: 'ok', detail: `${HELPER_REL} already current` };
   }
   if (dryRun) return { status: 'fixed', detail: `would write ${HELPER_REL} (dry-run)` };

--- a/test/brain-repo-durability.serial.test.ts
+++ b/test/brain-repo-durability.serial.test.ts
@@ -169,6 +169,22 @@ describe('hardenBrainRepo', () => {
     expect(commitCount(work)).toBe(before);
     expect(existsSync(join(work, 'scripts', 'brain-commit-push.sh'))).toBe(false);
   });
+
+  test('dry-run does not chmod an already-current helper (#3736)', async () => {
+    await harden(); // real run installs scripts/brain-commit-push.sh at 0o755
+    const helperPath = join(work, 'scripts', 'brain-commit-push.sh');
+    chmodSync(helperPath, 0o644); // simulate perms drifting away from +x, content unchanged
+    await harden({ dryRun: true });
+    expect(statSync(helperPath).mode & 0o777).toBe(0o644); // untouched — preview must not mutate
+  });
+
+  test('non-dry-run restores the exec bit on an already-current helper', async () => {
+    await harden();
+    const helperPath = join(work, 'scripts', 'brain-commit-push.sh');
+    chmodSync(helperPath, 0o644);
+    await harden();
+    expect(statSync(helperPath).mode & 0o111).toBeTruthy(); // exec bit restored
+  });
 });
 
 describe('unhardenBrainRepo', () => {


### PR DESCRIPTION
Addresses #3736.

## What this changes

`installHelper()` in `src/core/brain-repo-durability.ts` ran `chmodSync(helperPath, 0o755)` on the "already current" early-return path — three lines *above* the `dryRun` check — so `gbrain sources harden <id> --dry-run` mutated the helper's file mode even though the guard exists. This is the same class as #3594 (destructive call sits above the dry-run early-return) and a second, independent instance inside `hardenBrainRepo` alongside #3692 (which gated the step-1 `pull`, not this step-4 chmod).

```diff
   if (existsSync(helperPath) && readFileSync(helperPath, 'utf-8') === script) {
-    // Ensure exec bit even when content is current.
-    try { chmodSync(helperPath, 0o755); } catch { /* */ }
+    // Ensure exec bit even when content is current — but not in dry-run: a
+    // preview must not mutate permissions (#3736).
+    if (!dryRun) { try { chmodSync(helperPath, 0o755); } catch { /* */ } }
     return { status: 'ok', detail: `${HELPER_REL} already current` };
   }
```

The non-dry-run write path later in the same function is untouched — real hardening still writes and chmods exactly as before.

## Discriminating power (test fails without the fix)

`test/brain-repo-durability.serial.test.ts` adds two tests under `describe('hardenBrainRepo', ...)`, following the file's existing style (real git fixtures, no mocks):

- **`dry-run does not chmod an already-current helper (#3736)`** — hardens for real, manually drifts the helper to `0o644`, re-hardens with `dryRun: true`, asserts the mode is still `0o644` (untouched). This is the load-bearing assertion — it fails on unpatched `master` because the early-return path chmods back to `0o755` regardless of `dryRun`.
- **`non-dry-run restores the exec bit on an already-current helper`** — control: same drift, then a real (non-dry-run) re-harden, asserts the exec bit comes back. Confirms the fix didn't silently break real hardening.

## Verification

- `bun test test/brain-repo-durability.serial.test.ts` — 21 pass, 0 fail, 49 `expect()` calls
- `bun run typecheck` — clean
- Diff: 2 files changed, +19/-2 (1 commit)
