### PR TITLE
fix(recipes): drop the retired gemini-2.0 family from the Google recipe

### DIFF
--- a/docs/eval-takes-quality.md
+++ b/docs/eval-takes-quality.md
@@ -31,7 +31,7 @@ receipt file from disk and re-renders it. The other modes need the brain.
 | `--budget-usd N` | unset | Abort before next call's projected cost would exceed cap. Models without a `pricing.ts` entry fail loud (codex #4). |
 | `--source db|fs` | `db` | `fs` is reserved for v0.33+. |
 | `--slug-prefix P` | unset | Filter takes to pages whose slug starts with P. |
-| `--models a,b,c` | `openai:gpt-5.2,anthropic:claude-opus-4-7,google:gemini-2.0-flash` | Comma-separated panel. |
+| `--models a,b,c` | `openai:gpt-5.2,anthropic:claude-opus-4-7,google:gemini-2.5-flash` | Comma-separated panel. |
 | `--json` | off | Emit the full receipt to stdout. |
 
 ## Receipt JSON shape (`schema_version: 1`)
@@ -50,7 +50,7 @@ receipt file from disk and re-renders it. The other modes need the brain.
   },
   "prompt_sha8": "abcd1234",
   "models_sha8": "abcd1234",
-  "models": ["openai:gpt-5.2", "anthropic:claude-opus-4-7", "google:gemini-2.0-flash"],
+  "models": ["openai:gpt-5.2", "anthropic:claude-opus-4-7", "google:gemini-2.5-flash"],
   "cycles_run": 3,
   "successes_per_cycle": [3, 3, 2],
   "verdict": "pass",

--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -29,22 +29,24 @@ export const google: Recipe = {
       safety_factor: 0.8,
     },
     expansion: {
-      models: ['gemini-2.0-flash', 'gemini-2.0-flash-lite'],
-      cost_per_1m_tokens_usd: 0.10,
-      price_last_verified: '2026-04-20',
+      models: ['gemini-2.5-flash', 'gemini-2.5-flash-lite'],
+      cost_per_1m_tokens_usd: 0.30,
+      price_last_verified: '2026-08-02',
     },
     chat: {
-      // gemini-1.5-pro was retired by Google (#3510) — deliberately NOT
-      // listed. Default-slot guard tests validate hardcoded defaults against
-      // this list, so re-adding a dead model here masks dead defaults.
-      models: ['gemini-2.0-flash-exp', 'gemini-2.0-flash'],
+      // Retired by Google and deliberately NOT listed: gemini-1.5-pro
+      // (#3510) and the whole gemini-2.0 family — flash, flash-lite, and
+      // flash-exp all answer 404 on generateContent. Default-slot guard
+      // tests validate hardcoded defaults against this list, so re-adding a
+      // dead model here masks dead defaults.
+      models: ['gemini-2.5-flash', 'gemini-2.5-flash-lite'],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,
-      max_context_tokens: 1000000, // Gemini 2.0 Flash
+      max_context_tokens: 1000000, // Gemini 2.5 Flash
       cost_per_1m_input_usd: 0.30,
-      cost_per_1m_output_usd: 1.20,
-      price_last_verified: '2026-04-20',
+      cost_per_1m_output_usd: 2.50,
+      price_last_verified: '2026-08-02',
     },
   },
   setup_hint: 'Get an API key at https://aistudio.google.com/apikey, then `export GOOGLE_GENERATIVE_AI_API_KEY=...`',

--- a/src/core/cycle/grade-takes.ts
+++ b/src/core/cycle/grade-takes.ts
@@ -219,7 +219,7 @@ export interface GradeTakesOpts extends BasePhaseOpts {
   /**
    * E2 ensemble judges. When useEnsemble=true and the single-model verdict
    * is borderline, all three judges are called in parallel via Promise.allSettled.
-   * Defaults to [openai:gpt-5.2, anthropic:claude-sonnet-4-6, google:gemini-2.0-flash]
+   * Defaults to [openai:gpt-5.2, anthropic:claude-sonnet-4-6, google:gemini-2.5-flash]
    * via defaultJudge with model-string overrides. Tests inject deterministic
    * judges.
    */

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -88,11 +88,16 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   // usage/audit rows still price. Not a valid default — it's deliberately
   // absent from the google recipe's chat list.
   'google:gemini-1.5-pro':                { input:  1.25, output:  5.00 },
-  // Gemini 2.0 Flash: $0.10 in / $0.40 out (verified 2026-06-03). Reconciled
-  // from a stale $0.30/$1.20 entry that had drifted in takes-quality-eval.
-  // `gemini-2-flash` kept as an alias for the legacy id spelling.
+  // The whole `gemini-2.0` family was retired the same way; kept for the same
+  // reason, and equally absent from the recipe's chat list. `gemini-2-flash`
+  // is the legacy id spelling of `gemini-2.0-flash` — keep the pair in
+  // lockstep (the drift guard asserts they agree).
   'google:gemini-2.0-flash':              { input:  0.10, output:  0.40 },
   'google:gemini-2-flash':                { input:  0.10, output:  0.40 },
+  // Gemini 2.5 Flash / Flash-Lite: the live successors, and what the recipe
+  // lists today. Rates from Google's published pricing (2026-08-02).
+  'google:gemini-2.5-flash':              { input:  0.30, output:  2.50 },
+  'google:gemini-2.5-flash-lite':         { input:  0.10, output:  0.40 },
 
   // ── Together / DeepSeek (cross-modal-eval panel) ───────────────────────
   'together:meta-llama/Llama-3.3-70B-Instruct-Turbo': { input: 0.88, output: 0.88 },

--- a/src/core/takes-quality-eval/pricing.ts
+++ b/src/core/takes-quality-eval/pricing.ts
@@ -42,8 +42,11 @@ const SUPPORTED_MODELS = [
   'anthropic:claude-sonnet-5',
   'anthropic:claude-sonnet-4-6',
   'anthropic:claude-haiku-4-5',
-  // gemini-1.5-pro was retired by Google (#3510); gemini-2.0-flash replaces
-  // it in DEFAULT_MODEL_PANEL. `gemini-2-flash` stays as the legacy alias.
+  // gemini-2.5-flash holds the DEFAULT_MODEL_PANEL slot; gemini-1.5-pro
+  // (#3510) and the gemini-2.0 family before it were retired by Google. The
+  // retired ids stay listed so a `--models` run over historical results still
+  // budget-gates, but they are no longer reachable defaults.
+  'google:gemini-2.5-flash',
   'google:gemini-2.0-flash',
   'google:gemini-2-flash',
 ] as const;

--- a/src/core/takes-quality-eval/runner.ts
+++ b/src/core/takes-quality-eval/runner.ts
@@ -38,12 +38,13 @@ import { DEFAULT_CYCLES_NONTTY } from '../eval/cycle-default.ts';
  * be listed in its recipe's chat touchpoint AND in the SUPPORTED_MODELS
  * pricing allowlist — pinned by test/default-model-panels.test.ts.
  * google:gemini-1.5-pro (retired by Google) and openai:gpt-4o (dropped from
- * the OpenAI recipe's chat list) sat here dead until #3510.
+ * the OpenAI recipe's chat list) sat here dead until #3510; gemini-2.0-flash
+ * replaced the former and was itself retired before it was ever swept.
  */
 export const DEFAULT_MODEL_PANEL = [
   'openai:gpt-5.2',
   'anthropic:claude-opus-4-7',
-  'google:gemini-2.0-flash',
+  'google:gemini-2.5-flash',
 ] as const;
 
 export interface RunOpts {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -162,7 +162,7 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint accepts chat for chat-capable native + openai-compat providers', () => {
     expect(() => assertTouchpoint(getRecipe('anthropic')!, 'chat', 'claude-opus-4-7')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('openai')!, 'chat', 'gpt-5.2')).not.toThrow();
-    expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.0-flash')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.5-flash')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-v4-flash')).not.toThrow();
     // Legacy id retired by DeepSeek 2026-07-24 (#1255): still passes local
     // validation (openai-compat tier), rejection surfaces at the provider.

--- a/test/default-model-panels.test.ts
+++ b/test/default-model-panels.test.ts
@@ -46,3 +46,39 @@ describe('takes-quality DEFAULT_MODEL_PANEL ↔ recipe consistency', () => {
     expect(providers.size).toBe(3);
   });
 });
+
+/**
+ * The guard above only bites while recipes list LIVE models, so the recipe
+ * lists need a guard of their own. Every id here answered 404 on a real
+ * `generateContent` call; re-adding one to quiet a failing default would put
+ * the panel guard back to sleep, which is how gemini-2.0-flash came to
+ * replace the retired 1.5-pro and then sit dead in its place.
+ */
+describe('google recipe lists no retired model', () => {
+  const RETIRED = [
+    'gemini-1.5-pro',
+    'gemini-2.0-flash',
+    'gemini-2.0-flash-lite',
+    'gemini-2.0-flash-exp',
+  ];
+
+  test('neither the chat nor the expansion touchpoint offers a dead model', () => {
+    const google = getRecipe('google');
+    expect(google).toBeDefined();
+    const offered = [
+      ...(google!.touchpoints.chat?.models ?? []),
+      ...(google!.touchpoints.expansion?.models ?? []),
+    ];
+    expect(offered.length).toBeGreaterThan(0);
+    for (const dead of RETIRED) {
+      expect(offered, `"${dead}" is retired and answers 404`).not.toContain(dead);
+    }
+  });
+
+  test('every model the google recipe offers is priced', () => {
+    const google = getRecipe('google')!;
+    for (const model of google.touchpoints.chat?.models ?? []) {
+      expect(canonicalLookup(`google:${model}`), `google:${model} unpriced`).toBeDefined();
+    }
+  });
+});

--- a/test/eval-takes-quality-pricing.test.ts
+++ b/test/eval-takes-quality-pricing.test.ts
@@ -13,7 +13,7 @@ describe('getPricing — fail-closed contract', () => {
   test('returns pricing for the default 3-model panel', () => {
     expect(getPricing('openai:gpt-5.2')).toBeDefined();
     expect(getPricing('anthropic:claude-opus-4-7')).toBeDefined();
-    expect(getPricing('google:gemini-2.0-flash')).toBeDefined();
+    expect(getPricing('google:gemini-2.5-flash')).toBeDefined();
   });
 
   test('retired google:gemini-1.5-pro is no longer in the allowlist (#3510)', () => {

--- a/test/eval-takes-quality-runner.serial.test.ts
+++ b/test/eval-takes-quality-runner.serial.test.ts
@@ -176,9 +176,9 @@ describe('runner — budget cap (codex review #4)', () => {
     const r = await runEval(engine, {
       limit: 5,
       cycles: 3,
-      // gemini-2.0-flash (not the retired 1.5-pro) — the budget path
-      // pre-flights getPricing, which is allowlist-gated (#3510).
-      models: ['openai:gpt-4o', 'anthropic:claude-opus-4-7', 'google:gemini-2.0-flash'],
+      // gemini-2.5-flash (not the retired 1.5-pro or 2.0 family) — the
+      // budget path pre-flights getPricing, which is allowlist-gated (#3510).
+      models: ['openai:gpt-4o', 'anthropic:claude-opus-4-7', 'google:gemini-2.5-flash'],
       budgetUsd: 0.05, // tighter than projected per-cycle cost (~$0.109)
     });
     // No cycle ever ran successfully because pre-flight aborted cycle 1.

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -61,6 +61,13 @@ describe('CANONICAL_PRICING — table integrity', () => {
       CANONICAL_PRICING['google:gemini-2.0-flash'],
     );
   });
+
+  // Retired ids stay priced so historical usage/audit rows still resolve;
+  // the live successors have to be priced for anything new to be estimated.
+  test('the live Gemini ids are priced alongside the retired ones', () => {
+    expect(CANONICAL_PRICING['google:gemini-2.5-flash']).toEqual({ input: 0.3, output: 2.5 });
+    expect(CANONICAL_PRICING['google:gemini-2.5-flash-lite']).toEqual({ input: 0.1, output: 0.4 });
+  });
 });
 
 describe('canonicalLookup — id normalization', () => {


### PR DESCRIPTION
## The bug

Every chat and expansion model the Google recipe declares is dead. Verified against the live API on 2026-08-02 with a real `generateContent` call per id:

| model | recipe slot | result |
|---|---|---|
| `gemini-2.0-flash-exp` | chat | **HTTP 404** |
| `gemini-2.0-flash` | chat, expansion | **HTTP 404** |
| `gemini-2.0-flash-lite` | expansion | **HTTP 404** |
| `gemini-2.5-flash` | - | live |
| `gemini-2.5-flash-lite` | - | live |

`gemini-embedding-001` is unaffected and still live.

This is the same failure #3510 / #3531 fixed for `gemini-1.5-pro`, one generation later: `gemini-2.0-flash` was put in as the replacement and has since been retired itself. A brain configured on Google gets a 404 on every `think`, and `DEFAULT_MODEL_PANEL` in the takes-quality eval names a model that cannot answer.

Note `ListModels` still advertises the whole `gemini-2.0` family, so the endpoint list is not a reliable signal here - only a real call is.

## The fix

Follows #3531's shape exactly.

- **Recipe** (`src/core/ai/recipes/google.ts`): chat and expansion both move to `['gemini-2.5-flash', 'gemini-2.5-flash-lite']`. Chat output price corrected 1.20 -> 2.50 and expansion 0.10 -> 0.30 to match 2.5-flash. The existing "deliberately NOT listed" comment is extended to name the 2.0 family, keeping the rule that a dead model never goes back in the list to quiet a failing default.
- **Pricing** (`src/core/model-pricing.ts`): the retired 2.0 ids **stay**, matching how 1.5-pro and `deepseek-chat` are handled, so historical usage and audit rows still price. The live 2.5 ids are added.
- **Hardcoded defaults**: `DEFAULT_MODEL_PANEL` (`takes-quality-eval/runner.ts`), the takes-quality allowlist (`takes-quality-eval/pricing.ts`), and the ensemble-judge doc comment (`cycle/grade-takes.ts`) move to `gemini-2.5-flash`.
- **Docs**: `docs/eval-takes-quality.md` panel examples.

## Tests

`test/default-model-panels.test.ts` already guards defaults against the recipe lists, but its own header notes it "only works if recipes list LIVE models" - and nothing was guarding *that*. Added the missing half: a test asserting the Google recipe offers none of the four known-retired ids, plus one asserting every chat model it does offer is priced.

Discrimination verified - reverting `recipes/google.ts` and `takes-quality-eval/runner.ts` to master fails three tests:

```
(fail) google recipe lists no retired model > neither the chat nor the expansion touchpoint offers a dead model
(fail) google recipe lists no retired model > every model the google recipe offers is priced
(fail) chat touchpoint - model resolver + aliases > assertTouchpoint accepts chat for chat-capable native + openai-compat providers
```

With the change: 79 pass / 0 fail across the five affected files plus the takes-quality runner suite. `tsc --noEmit` clean.

## Known gap, recorded rather than hidden

Model **liveness** is live-verified per the table above. Model **prices** are not - `gemini-2.5-flash` at $0.30/$2.50 and `gemini-2.5-flash-lite` at $0.10/$0.40 come from Google's published pricing, not an API call, since there's no endpoint to check them against. Same class of gap #3531 disclosed, in the opposite direction: that PR verified prices but not retirement.

`gemini-2.5-pro` and `gemini-3.5-flash` also answered live and are deliberately **not** added - substituting dead models one-for-one is the fix here, and adding capability is a separate call for you to make.
