### PR TITLE
fix(think): name the resolved provider's credential in the no-LLM message

### DIFF
--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -26,6 +26,7 @@ import { resolveCitations, type ParsedCitation } from './cite-render.ts';
 import { resolveOwnerHolder } from '../owner-holder.ts';
 import { resolveModel } from '../model-config.ts';
 import { chat as gatewayChat, probeChatModel, type ChatResult } from '../ai/gateway.ts';
+import { resolveRecipe } from '../ai/model-resolver.ts';
 import { AIConfigError } from '../ai/errors.ts';
 import { normalizeModelId } from '../model-id.ts';
 import { hasAnthropicKey } from '../ai/anthropic-key.ts';
@@ -488,7 +489,7 @@ export async function runThink(
         question: opts.question,
         answer: modelProblem
           ? `(model "${modelUsed}" not usable — ${detail}${fix})`
-          : '(no LLM available — set ANTHROPIC_API_KEY or pass `client`)',
+          : `(no LLM available — ${missingCredentialHint(modelUsed)}, or pass \`client\`)`,
         citations: [],
         gaps: [
           modelProblem
@@ -814,6 +815,34 @@ function mapStopReason(s: ChatResult['stopReason']): 'end_turn' | 'max_tokens' |
 }
 
 /**
+ * Credential advice for the provider the model actually resolves to.
+ *
+ * The sentinel below is surfaced verbatim as the user's answer, so naming a
+ * fixed provider sends operators to the wrong credential whenever think is
+ * configured off Anthropic: a missing Google key produced "set
+ * ANTHROPIC_API_KEY", which is not the fix. Both the env var and the key page
+ * come from the recipe, so a new provider needs no change here.
+ *
+ * Falls back to the Anthropic wording when the id doesn't resolve to a recipe
+ * (`resolveRecipe` throws on an unknown provider) — Anthropic is still the
+ * default provider for a bare model id, so it remains the best guess when
+ * there's nothing better to say.
+ */
+function missingCredentialHint(modelStr: string): string {
+  try {
+    const { recipe } = resolveRecipe(normalizeModelId(modelStr));
+    const envVar = recipe.auth_env?.required?.[0];
+    if (envVar) {
+      const keys = recipe.auth_env?.setup_url ? `; keys: ${recipe.auth_env.setup_url}` : '';
+      return `set ${envVar} for ${recipe.name} via gbrain config or env${keys}`;
+    }
+  } catch {
+    // Unknown provider — nothing better to offer than the default.
+  }
+  return 'set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env';
+}
+
+/**
  * Sentinel Message returned when gateway.chat throws AIConfigError (typically
  * missing API key for the resolved provider). The caller's JSON parser will
  * fail on this text, fall through to `LLM_OUTPUT_NOT_JSON`, and surface the
@@ -833,7 +862,7 @@ function buildGracefulMessage(modelStr: string): {
     type: 'message',
     role: 'assistant',
     model: modelStr,
-    content: [{ type: 'text', text: '(no LLM available — set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env)' }],
+    content: [{ type: 'text', text: `(no LLM available — ${missingCredentialHint(modelStr)})` }],
     usage: { input_tokens: 0, output_tokens: 0 },
     stop_reason: 'end_turn',
   };
@@ -848,5 +877,6 @@ export const __thinkAdapter = {
   chatResultToMessage,
   mapStopReason,
   buildGracefulMessage,
+  missingCredentialHint,
   hasAnthropicKey,
 };

--- a/test/think-gateway-adapter.test.ts
+++ b/test/think-gateway-adapter.test.ts
@@ -215,4 +215,37 @@ describe('think gateway adapter — graceful fallback shape', () => {
     expect(m.usage.output_tokens).toBe(0);
     expect(m.stop_reason).toBe('end_turn');
   });
+
+  // The sentinel is surfaced verbatim as the user's answer, so it has to name
+  // the credential that would actually fix the run. Naming Anthropic on a
+  // Google-configured brain sends operators to the wrong key entirely.
+  test('the sentinel names the resolved provider credential, not Anthropic', () => {
+    const m = __thinkAdapter.buildGracefulMessage('google:gemini-2.5-flash');
+    expect(m.content[0].text).toContain('GOOGLE_GENERATIVE_AI_API_KEY');
+    expect(m.content[0].text).not.toContain('ANTHROPIC_API_KEY');
+  });
+
+  test('each provider gets its own env var and key page', () => {
+    expect(__thinkAdapter.missingCredentialHint('openai:gpt-5.2')).toContain('OPENAI_API_KEY');
+    expect(__thinkAdapter.missingCredentialHint('deepseek:deepseek-chat')).toContain(
+      'DEEPSEEK_API_KEY',
+    );
+    expect(__thinkAdapter.missingCredentialHint('google:gemini-2.5-flash')).toContain(
+      'aistudio.google.com',
+    );
+  });
+
+  test('an anthropic model still gets the Anthropic wording', () => {
+    expect(__thinkAdapter.missingCredentialHint('anthropic:claude-opus-4-7')).toContain(
+      'ANTHROPIC_API_KEY',
+    );
+  });
+
+  test('an unresolvable provider falls back rather than throwing', () => {
+    // resolveRecipe throws on an unknown provider; the sentinel path must
+    // still produce an answer, since its whole job is degrading gracefully.
+    expect(__thinkAdapter.missingCredentialHint('not-a-provider:some-model')).toContain(
+      'ANTHROPIC_API_KEY',
+    );
+  });
 });


### PR DESCRIPTION
## The bug

When `think` degrades gracefully because a provider credential is missing, it tells the user to set an **Anthropic** key regardless of which provider the model actually resolves to:

```ts
// src/core/think/index.ts:836
content: [{ type: 'text', text: '(no LLM available - set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env)' }],
```

That string is surfaced verbatim as the user's answer. On a brain configured with `models.default = google:gemini-2.5-flash` and no Google key, the answer to every question becomes "set ANTHROPIC_API_KEY" - advice that cannot fix the run and sends operators to check a credential that isn't involved. The same hardcoding sits on the no-client path at `:491` ("set ANTHROPIC_API_KEY or pass `client`").

The information needed was already in hand: both sites have the resolved model string, and every recipe already declares `auth_env.required` plus a `setup_url`.

## The fix

One helper, `missingCredentialHint(modelStr)`, resolves the model to its recipe and names that provider's env var and key page. Both sites call it. A new provider needs no change here - the advice comes from its recipe.

Unresolvable ids fall back to the previous Anthropic wording, since Anthropic is still the default provider for a bare model id and there's nothing better to say. The sentinel path exists to degrade gracefully, so it must not throw.

**Deliberately unchanged:** the `NO_ANTHROPIC_API_KEY` warning code. It's a machine-readable contract that consumers key on, and its name being provider-specific is a separate call. Only the human-facing prose moves.

## Tests

Four tests in `test/think-gateway-adapter.test.ts`. Discrimination verified - stubbing the helper back to a constant Anthropic string fails two:

```
(fail) the sentinel names the resolved provider credential, not Anthropic
(fail) each provider gets its own env var and key page
```

The other two are fallback guards (an Anthropic model still gets Anthropic wording; an unknown provider falls back rather than throwing) and pass either way by design - they exist to catch a future change that breaks the default path, not to prove this one.

20 pass / 0 fail in that file, 31 pass / 0 fail in `think-pipeline.serial.test.ts`, `tsc --noEmit` clean.

## Context

Found while running a brain on Google. Companion to #3760, which retires the dead `gemini-2.0` models that produced the failure in the first place - a 404 from Google surfaced to the user as "set your Anthropic key". The two are independent and can land in either order.
