### PR TITLE
fix(cycle): extract_atoms writes atoms outside the chunk/embed pipeline, making every atom invisible to search

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -6,14 +6,16 @@
 //      pages already extracted by content hash — see "Idempotency" below).
 //   2. Dedup by content_hash; transcripts win on collision.
 //   3. Per work-item, ask Haiku for 1-3 atoms.
-//   4. Write each atom via engine.putPage(slug, page, {sourceId})
-//      with sourceId threaded so federated brains route correctly.
+//   4. Write each atom via importFromContent(slug, markdown, {sourceId})
+//      with sourceId threaded so federated brains route correctly. The
+//      canonical import path (not engine.putPage) is what chunks and embeds
+//      the page — see the write site below and #2163.
 //
 // Idempotency (per-atom, via deterministic slug):
 //   Each atom's slug is `atoms/<source-date>/<stem>-<title-hash>` — built from
 //   the SOURCE date (the transcript's own date / the page slug), NOT the run
 //   date, plus a 6-char hash of the title. Re-extracting the same atom resolves
-//   to the SAME slug, so engine.putPage upserts in place instead of minting a
+//   to the SAME slug, so the import upserts in place instead of minting a
 //   duplicate. This closes three bugs in one scheme:
 //     - PR #1414's page-side re-extraction.
 //     - The cross-day transcript duplicate: append-only transcripts grow daily,
@@ -51,7 +53,9 @@ import type { BrainEngine } from '../engine.ts';
 import type { PhaseResult } from '../cycle.ts';
 import type { GBrainConfig } from '../config.ts';
 import type { ProgressReporter } from '../progress.ts';
-import { chat as gatewayChat, withBudgetTracker } from '../ai/gateway.ts';
+import { chat as gatewayChat, withBudgetTracker, isAvailable } from '../ai/gateway.ts';
+import { importFromContent } from '../import-file.ts';
+import { serializeMarkdown } from '../markdown.ts';
 import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budget-tracker.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
@@ -681,32 +685,38 @@ export async function runPhaseExtractAtoms(
             item.kind === 'transcript'
               ? { source_path: item.filePath }
               : { source_slug: item.slug };
-          // v0.41.2.1 D9 #1 — thread sourceId through every putPage so
-          // atoms land in the source we discovered them from. Pre-fix
-          // the third arg was missing and atoms always wrote to 'default'.
-          await engine.putPage(
-            slug,
+          // Serialize to markdown and import via the canonical pipeline so
+          // the atom is chunked (+ embedded when a provider is configured).
+          // engine.putPage is a bare page-row upsert that never chunks, so
+          // atoms written through it never reached content_chunks and were
+          // invisible to search — the same defect #2163 fixed for concept
+          // pages in synthesize-concepts.ts, which was never applied here.
+          //
+          // `type: 'atom'` rides in frontmatter, which parseMarkdown honours
+          // as an explicit override ahead of path inference, so the page type
+          // survives the round-trip. sourceId stays threaded (v0.41.2.1 D9 #1)
+          // so atoms still land in the source they were discovered from.
+          const md = serializeMarkdown(
             {
-              title: atom.title,
-              type: 'atom',
-              compiled_truth: atom.body,
-              frontmatter: {
-                type: 'atom',
-                atom_type: atom.atom_type,
-                ...originFrontmatter,
-                source_hash: item.contentHash.slice(0, 16),
-                ...(atom.source_quote && { source_quote: atom.source_quote }),
-                ...(atom.lesson && { lesson: atom.lesson }),
-                ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
-                ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
-                ...(atom.emotional_register && { emotional_register: atom.emotional_register }),
-                extracted_at: new Date().toISOString(),
-                extracted_by: 'extract_atoms-v0.41.2.1',
-              },
-              timeline: '',
+              atom_type: atom.atom_type,
+              ...originFrontmatter,
+              source_hash: item.contentHash.slice(0, 16),
+              ...(atom.source_quote && { source_quote: atom.source_quote }),
+              ...(atom.lesson && { lesson: atom.lesson }),
+              ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
+              ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
+              ...(atom.emotional_register && { emotional_register: atom.emotional_register }),
+              extracted_at: new Date().toISOString(),
+              extracted_by: 'extract_atoms-v0.41.2.1',
             },
-            { sourceId },
+            atom.body,
+            '',
+            { type: 'atom', title: atom.title, tags: [] },
           );
+          await importFromContent(engine, slug, md, {
+            sourceId,
+            noEmbed: !isAvailable('embedding'),
+          });
           totalAtomsExtracted++;
         }
       } else {

--- a/test/extract-atoms-chunk-embed.test.ts
+++ b/test/extract-atoms-chunk-embed.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression: extract_atoms wrote atoms with `engine.putPage`, a bare
+ * `INSERT INTO pages ... ON CONFLICT` that never chunks or embeds. Atom pages
+ * therefore never reached `content_chunks` and were invisible to search — the
+ * same defect #2163 fixed for concept pages in synthesize-concepts.ts, which
+ * was never applied one layer down.
+ *
+ * The fix routes atoms through `serializeMarkdown` -> `importFromContent`,
+ * which means atom content now makes a round-trip through YAML frontmatter
+ * that the raw row-write bypassed. These tests lock the invariants that trip
+ * on: page type, the grounding frontmatter propose_takes depends on, and
+ * LLM-authored text that is hostile to YAML/frontmatter parsing.
+ *
+ * Pure functions only. No DB, no model calls.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { serializeMarkdown, parseMarkdown } from '../src/core/markdown.ts';
+
+/** Mirrors the write site in extract-atoms.ts. */
+function roundTrip(atom: {
+  title: string;
+  body: string;
+  atom_type?: string;
+  source_quote?: string;
+  lesson?: string;
+  concepts?: string[];
+  source_slug?: string;
+}) {
+  const md = serializeMarkdown(
+    {
+      atom_type: atom.atom_type ?? "insight",
+      ...(atom.source_slug && { source_slug: atom.source_slug }),
+      source_hash: 'abc123def4567890',
+      ...(atom.source_quote && { source_quote: atom.source_quote }),
+      ...(atom.lesson && { lesson: atom.lesson }),
+      ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
+      extracted_at: '2026-08-02T00:00:00.000Z',
+      extracted_by: 'extract_atoms-v0.41.2.1',
+    },
+    atom.body,
+    '',
+    { type: 'atom', title: atom.title, tags: [] },
+  );
+  // filePath is deliberately omitted: the atom slug is not a real file, so
+  // nothing but the explicit frontmatter `type:` can carry the page type.
+  return { md, parsed: parseMarkdown(md) };
+}
+
+describe('atom markdown round-trip — page type', () => {
+  test("explicit frontmatter type: atom survives with no filePath to infer from", () => {
+    const { parsed } = roundTrip({ title: 'Pilots de-risk procurement', body: 'A short claim.' });
+    expect(parsed.type).toBe('atom');
+  });
+
+  test('explicit type wins over a filePath that would infer something else', () => {
+    const { md } = roundTrip({ title: 'Pilots de-risk procurement', body: 'A short claim.' });
+    // meetings/ is a seeded path prefix; the frontmatter must still win, or
+    // re-importing an atom would silently retype it and break `type='atom'`.
+    expect(parseMarkdown(md, 'meetings/2026-08-02-standup.md').type).toBe('atom');
+  });
+});
+
+describe('atom markdown round-trip — grounding frontmatter', () => {
+  test('source_quote, lesson, concepts and source_slug all survive', () => {
+    const { parsed } = roundTrip({
+      title: 'Benchmarks decide agent selection',
+      body: 'The buyer picked on measured latency, not brand.',
+      atom_type: 'insight',
+      source_quote: 'We ran both and took the faster one.',
+      lesson: 'Measured evidence beats vendor claims.',
+      concepts: ['agent-evaluation', 'procurement'],
+      source_slug: '2026-06-02-polaris-stefan',
+    });
+    expect(parsed.frontmatter.source_quote).toBe('We ran both and took the faster one.');
+    expect(parsed.frontmatter.lesson).toBe('Measured evidence beats vendor claims.');
+    expect(parsed.frontmatter.concepts).toEqual(['agent-evaluation', 'procurement']);
+    expect(parsed.frontmatter.source_slug).toBe('2026-06-02-polaris-stefan');
+    expect(parsed.frontmatter.atom_type).toBe('insight');
+  });
+
+  test('body is preserved as compiled_truth', () => {
+    const body = 'Procurement stalls when the pilot has no exit criteria.';
+    expect(roundTrip({ title: 'Exit criteria', body }).parsed.compiled_truth.trim()).toBe(body);
+  });
+});
+
+describe('atom markdown round-trip — LLM text hostile to YAML', () => {
+  // Atom titles/quotes are model-authored free text. The raw row-write never
+  // serialized them; the import path does, so these must be quoted correctly.
+  test('a title containing a colon does not corrupt the frontmatter', () => {
+    const { parsed } = roundTrip({
+      title: 'Discovery: the part buyers actually pay for',
+      body: 'A claim.',
+    });
+    expect(parsed.type).toBe('atom');
+    expect(parsed.title).toBe('Discovery: the part buyers actually pay for');
+  });
+
+  test('a quote containing quotes and a hash survives', () => {
+    const q = 'He said "no", then asked about #pricing.';
+    expect(roundTrip({ title: 'Objection', body: 'A claim.', source_quote: q })
+      .parsed.frontmatter.source_quote).toBe(q);
+  });
+
+  test('a body containing a --- rule does not truncate the atom or leak frontmatter', () => {
+    const body = 'First point.\n\n---\n\nSecond point.';
+    const { parsed } = roundTrip({ title: 'Two points', body });
+    expect(parsed.type).toBe('atom');
+    expect(parsed.compiled_truth).toContain('First point.');
+    expect(parsed.frontmatter.extracted_by).toBe('extract_atoms-v0.41.2.1');
+  });
+
+  test('a title that is purely numeric stays a string', () => {
+    expect(roundTrip({ title: '2026', body: 'A claim.' }).parsed.title).toBe('2026');
+  });
+});
+
+describe("atom frontmatter must not contain undefined", () => {
+  // js-yaml throws on undefined, so every OPTIONAL atom field at the write
+  // site has to use a conditional spread rather than a bare assignment. The
+  // old engine.putPage row-write silently tolerated undefined; the import
+  // path does not. atom_type is safe to assign unconditionally only because
+  // parseAtomsResponse drops any atom missing it — see the !atomType guard.
+  test("serializeMarkdown throws if an optional field is passed as undefined", () => {
+    expect(() =>
+      serializeMarkdown({ lesson: undefined }, "body", "", {
+        type: "atom",
+        title: "t",
+        tags: [],
+      }),
+    ).toThrow();
+  });
+
+  test("a conditional spread omits the key instead, which is safe", () => {
+    const lesson: string | undefined = undefined;
+    const md = serializeMarkdown({ ...(lesson ? { lesson } : {}) }, "body", "", {
+      type: "atom",
+      title: "t",
+      tags: [],
+    });
+    expect(parseMarkdown(md).frontmatter.lesson).toBeUndefined();
+    expect(parseMarkdown(md).type).toBe("atom");
+  });
+});


### PR DESCRIPTION
extract_atoms persists each atom with engine.putPage, which is a bare
INSERT INTO pages ... ON CONFLICT. It never chunks and never embeds, so
atom pages never reach content_chunks and cannot be returned by search.

This is the same defect #2163 fixed for concept pages in
synthesize-concepts.ts, which serializes to markdown and imports through
the canonical pipeline. The fix was never applied one layer down.

On my brain this left 3,942 atom pages with 0 rows in content_chunks.
Atoms carry source_quote, lesson and source_slug, so the richest and
most grounded layer was the one layer retrieval could not see. It fails
silently: rows exist, counts look right, the cycle reports ok, and
searches return the concept summary of the atom instead, which looks
like a reasonable answer.

Route atoms through serializeMarkdown -> importFromContent, keeping
sourceId threaded (v0.41.2.1 D9 #1). type: 'atom' rides in frontmatter,
which parseMarkdown honours as an explicit override ahead of path
inference, so the page type survives the round-trip.

Verified on a live brain: 72 newly extracted atoms produced 72 chunks
and 72 embeddings (previously 0), all 4,014 atom pages still have
type='atom', source_quote/lesson/source_slug are preserved, and atoms
are now returned by gbrain search.

Tests cover the round-trip invariants this introduces, since atom text
is model-authored and now passes through YAML: page type survival
(including against a filePath that would infer otherwise), grounding
frontmatter, titles containing colons, quotes containing quotes and
hashes, bodies containing --- rules, and numeric-looking titles. Two
further tests pin that optional fields must use a conditional spread,
because js-yaml throws on undefined where the old row-write tolerated
it — atom_type is safe to assign unconditionally only because
parseAtomsResponse drops atoms missing it.

---

Same shape as the fix in #2163, applied where it was missed. Sibling file `synthesize-concepts.ts` already routes concept pages through `importFromContent` for exactly this reason; `extract-atoms.ts` still used the bare row writer.

`bun run typecheck` clean. 156 tests pass across the extract-atoms, cycle-synthesize and doctor-backlog suites, including 10 new ones.

Note for existing installs: this fixes writes going forward. Atoms already on disk stay unchunked until re-imported (`forceRechunk`), so a backfill is needed to make historical atoms searchable.