### PR TITLE
fix(import): keep stdout JSON-only under --json (#3637)

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -78,6 +78,17 @@ export async function runImport(
   const jsonOutput = args.includes('--json');
   const includeGitignored = args.includes('--include-gitignored') || opts.includeGitignored === true;
 
+  // #3637: under --json, stdout belongs to the JSON document alone. The
+  // informational lines below are useful — they just belong on the other
+  // channel, the same rule progress already follows (CLAUDE.md: "Progress
+  // always writes to stderr. Stdout stays clean for data output (--json
+  // payloads)"). Pre-fix, `import --json` prefixed the payload with
+  // "Found N markdown files", so JSON.parse of stdout failed outright.
+  const info = (msg: string): void => {
+    if (jsonOutput) console.error(msg);
+    else console.log(msg);
+  };
+
   // T7 (D9): refuse cleanly when init persisted the deferred-setup sentinel,
   // unless the user is explicitly skipping embedding via `--no-embed` (in
   // which case the chunks land without vectors and the user can backfill
@@ -225,7 +236,7 @@ export async function runImport(
   if (opts.exclude && opts.exclude.length > 0) {
     const beforeExclude = allFiles.length;
     allFiles = allFiles.filter(abs => !matchesAnyGlob(relative(dir, abs), opts.exclude));
-    console.log(
+    info(
       `Found ${allFiles.length} ${fileTypeLabel} files ` +
       `(${beforeExclude - allFiles.length} excluded by --exclude patterns)`,
     );
@@ -237,7 +248,7 @@ export async function runImport(
       );
     }
   } else {
-    console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
+    info(`Found ${allFiles.length} ${fileTypeLabel} files`);
   }
 
   // Sort newest-first so date-prefixed brain paths get embedded before older ones.
@@ -253,7 +264,7 @@ export async function runImport(
     const cp = loadCheckpoint(checkpointPath, dir);
     if (cp) {
       for (const p of cp.completedPaths) completed.add(p);
-      console.log(`Resuming from checkpoint: skipping ${completed.size} already-processed files`);
+      info(`Resuming from checkpoint: skipping ${completed.size} already-processed files`);
     }
   }
   const files = resumeFilter(allFiles, dir, completed);
@@ -261,7 +272,7 @@ export async function runImport(
   // Determine actual worker count
   const actualWorkers = workerCount > 1 ? workerCount : 1;
   if (actualWorkers > 1) {
-    console.log(`Using ${actualWorkers} parallel workers`);
+    info(`Using ${actualWorkers} parallel workers`);
   }
 
   let imported = 0;
@@ -475,7 +486,7 @@ export async function runImport(
   if (errors === 0) {
     clearCheckpoint(checkpointPath);
   } else if (existsSync(checkpointPath)) {
-    console.log(`  Checkpoint preserved (${errors} errors). Run again to retry failed files.`);
+    info(`  Checkpoint preserved (${errors} errors). Run again to retry failed files.`);
   }
 
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/test/import-json-stdout.serial.test.ts
+++ b/test/import-json-stdout.serial.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #3637 regression test: `gbrain import <dir> --json` must leave exactly one
+ * JSON document on stdout.
+ *
+ * Pre-fix, runImport's informational lines in src/commands/import.ts ("Found N
+ * markdown files" and its four siblings — --exclude variant, checkpoint resume,
+ * parallel workers, checkpoint preserved) went through console.log
+ * unconditionally, so stdout under --json read
+ * `Found 1 markdown files\n{"status":"success",...}` and JSON.parse failed at
+ * character 0. The reported consumer (gstack's memory-ingest, which runs
+ * `gbrain import <dir> --no-embed --json` and parses stdout) took the parse
+ * failure as "0 imported" while still recording every file as ingested, so the
+ * next run skipped them permanently — success reported, nothing imported, no
+ * retry.
+ *
+ * This is the documented contract, not a new one: CLAUDE.md's progress rules
+ * say "Stdout stays clean for data output (--json payloads)", and the comment
+ * above the progress reporter in import.ts says the same. The existing CI guard
+ * scripts/check-progress-to-stdout.sh only greps for
+ * `process.stdout.write('\r…)`, so plain console.log lines under --json were
+ * never covered.
+ *
+ * Spawn-level on purpose: the defect is in what reaches the process's stdout,
+ * which an in-process call of runImport cannot observe. Brain setup mirrors
+ * test/reindex-frontmatter-pglite-spawn.serial.test.ts — PGLite via a written
+ * config.json plus `init --migrate-only`, so no embedding provider is needed.
+ * Serial because it spawns subprocesses and writes a tmpdir.
+ */
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const REPO = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+
+async function runCli(
+  args: string[],
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // Scrub inherited GBRAIN_* so a developer's shell config (embedding model,
+  // pace mode, …) can't change what the spawned CLI does.
+  const base = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith('GBRAIN_')),
+  ) as Record<string, string>;
+  const proc = Bun.spawn(['bun', 'run', `${REPO}/src/cli.ts`, ...args], {
+    cwd: REPO,
+    env: { ...base, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const killer = setTimeout(() => {
+    try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+  }, timeoutMs);
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(killer);
+  }
+}
+
+function seedNotes(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  for (let i = 1; i <= 2; i++) {
+    writeFileSync(join(dir, `note${i}.md`), `# note ${i}\n\nbody ${i}\n`);
+  }
+  return dir;
+}
+
+describe('import --json stdout is parseable JSON (#3637)', () => {
+  test('--json puts one JSON document on stdout and the progress lines on stderr; human mode is unchanged', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-3637-'));
+    const jsonNotes = seedNotes('gbrain-3637-json-');
+    const humanNotes = seedNotes('gbrain-3637-human-');
+    try {
+      mkdirSync(join(home, '.gbrain'), { recursive: true });
+      writeFileSync(
+        join(home, '.gbrain', 'config.json'),
+        JSON.stringify({
+          engine: 'pglite',
+          database_path: join(home, '.gbrain', 'brain.pglite'),
+          embedding_dimensions: 1536,
+        }) + '\n',
+      );
+      const env = { HOME: home, GBRAIN_HOME: home };
+
+      const init = await runCli(['init', '--migrate-only'], env, 120_000);
+      if (init.exitCode !== 0) {
+        console.error('--- init stdout ---\n' + init.stdout);
+        console.error('--- init stderr ---\n' + init.stderr);
+      }
+      expect(init.exitCode).toBe(0);
+
+      // Pre-fix: stdout is "Found 2 markdown files\n{…}" and this JSON.parse
+      // throws "Unexpected token 'F'". Post-fix: stdout is the payload alone.
+      const json = await runCli(['import', jsonNotes, '--no-embed', '--json'], env, 120_000);
+      if (json.exitCode !== 0) {
+        console.error('--- import --json stdout ---\n' + json.stdout);
+        console.error('--- import --json stderr ---\n' + json.stderr);
+      }
+      expect(json.exitCode).toBe(0);
+      expect(json.stdout.trim().split('\n')).toHaveLength(1);
+      const parsed = JSON.parse(json.stdout);
+      expect(parsed.status).toBe('success');
+      expect(parsed.imported).toBe(2);
+      expect(parsed.total_files).toBe(2);
+      // The line is relocated, not deleted — an operator watching a terminal
+      // still sees it.
+      expect(json.stdout).not.toContain('Found 2 markdown files');
+      expect(json.stderr).toContain('Found 2 markdown files');
+
+      // Guard the other direction: without --json the human line stays on
+      // stdout, so this fix cannot be "fixed" by deleting the output.
+      const human = await runCli(['import', humanNotes, '--no-embed'], env, 120_000);
+      if (human.exitCode !== 0) {
+        console.error('--- import stdout ---\n' + human.stdout);
+        console.error('--- import stderr ---\n' + human.stderr);
+      }
+      expect(human.exitCode).toBe(0);
+      expect(human.stdout).toContain('Found 2 markdown files');
+      expect(human.stdout).toContain('Import complete');
+    } finally {
+      for (const d of [home, jsonNotes, humanNotes]) {
+        try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+      }
+    }
+  }, 480_000);
+});


### PR DESCRIPTION
**Why are you opening this? (human-written, required)**

I was importing a directory of markdown and parsing the --json output in a script and found that the import command pollutes stdout by printing progress messages before the JSON payload, killing the parser at character 0. Because the process exits 0, my script misread the failure as "0 imported" and marked the files as ingested. This caused me to lose a batch of notes silently because subsequent runs skipped them.

CLAUDE.md already mandates progress to stderr to keep stdout clean for JSON and this PR just makes the import tool follow that contract.

**Screenshot of gbrain in use (required)**

<img width="638" height="439" alt="Screenshot 2026-08-02 at 3 43 12 PM" src="https://github.com/user-attachments/assets/3d27c1e0-899a-4025-8486-1d3fa93458fa" />

Fixes #3637

## What was wrong

`gbrain import <dir> --json` wrote a human line to stdout ahead of the JSON payload, so
stdout did not parse:

```
$ gbrain import "$T" --no-embed --json 2>/dev/null
Found 1 markdown files
{"status":"success","duration_s":0.1,"imported":1,"skipped":0,"errors":0,"chunks":1,"total_files":1}
```

`json.loads(stdout)` fails at character 0, and gbrain exits 0, so a consumer parsing
stdout has no signal that anything went wrong.In my case that was worse than a lost result: my consumer read it as "0 imported" and still recorded every file as ingested, so the next run skipped them permanently.

runImport had five informational `console.log` calls that run before the payload -
src/commands/import.ts:228 (the `--exclude` variant), :240 (the one in the repro above),
:256 (checkpoint resume), :264 (parallel workers) and :478 (checkpoint preserved).

This is a documented contract, not a new one. CLAUDE.md's progress rules say "Progress
always writes to **stderr**. Stdout stays clean for data output (`--json` payloads...)",
and the comment at import.ts:283 says the same thing about this very function.
`scripts/check-progress-to-stdout.sh` did not catch it because it only greps for
``process.stdout.write('\r…)`` - the `\r`-progress anti-pattern - not `console.log` of
plain lines under `--json`.

## What changed

One local helper, used at those five sites:

```ts
const info = (msg: string): void => {
  if (jsonOutput) console.error(msg);
  else console.log(msg);
};
```

After the change, stdout under `--json` is:

```
{"status":"success","duration_s":0.1,"imported":2,"skipped":0,"errors":0,"chunks":2,"total_files":2}
```

and `Found 2 markdown files` is on stderr, where an operator watching a terminal still
sees it. The lines are relocated, not removed.

Nothing else moves. Human mode is byte-for-byte unchanged, the JSON payload itself is
untouched, and every remaining `console.log` in the file is already inside an
`if (jsonOutput)` branch or the human `else` branch.

`runImport` has three callers and they split two ways. The two programmatic ones build
their own argument arrays and never add `--json` - jobs.ts:1682 from `job.data.dir` /
`job.data.noEmbed`, sync.ts:3725 from `--no-embed` / `--include-gitignored` / `--workers`
at :3714-3717 - so `jsonOutput` is always false on both routes and their output is
unchanged. The third, cli.ts:1852, is the CLI dispatch and forwards the user's command line
verbatim; that is the path `--json` arrives on, and the one this change is for.

## Test

`test/import-json-stdout.serial.test.ts` - spawn-level, because the defect is in what
reaches the process's stdout and an in-process call of `runImport` cannot observe it.
PGLite brain set up the way `test/reindex-frontmatter-pglite-spawn.serial.test.ts` does
it, so no embedding provider is needed.

It pins both directions: with `--json`, stdout is exactly one line that `JSON.parse`s and
the informational line is on stderr; without `--json`, the line is still on stdout. The
second half matters - otherwise "fix" the test by deleting the output.

Verified red before, green after, on the same tree:

```
# src/commands/import.ts restored from upstream/master, test file in place
0 pass, 1 fail    expect(received).toHaveLength(expected)
                  Expected length: 1   Received length: 2

# patched
1 pass, 0 fail, 11 expect() calls
```

Surrounding suite on this branch:

```
12 import-related unit files ......... 117 pass, 0 fail (348 assertions)
2 import/sync serial files ..........  15 pass, 0 fail (101 assertions)
bunx tsc --noEmit .................... exit 0
bun run check:all .................... exit 0 (24 guards)
```

## What I did not verify

- The gstack consumer side.My bin/gstack-memory-ingest.ts:1419 behavior and
  the `~/.gstack/.transcript-ingest-state.json` bookkeeping are consistent with the parse
  failure I reproduced, but I did not run that repo.
- The `--exclude`, checkpoint-resume, parallel-workers and checkpoint-preserved lines
  (:228, :256, :264, :478) are fixed by the same helper and read correctly, but the test
  only exercises the :240 path. Constructing the other four under `--json` needs a
  multi-worker Postgres brain and a deliberately failed import; I judged that more test
  machinery than the fix warrants. If you would rather have them pinned, say so and I will
  add it.
- No e2e run (`DATABASE_URL` is unset on this machine), so the Postgres parallel-import
  route is covered by reading, not by execution.
