### PR TITLE
fix(import): scope pre-write existence check and read-back to the write namespace

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -569,7 +569,14 @@ export async function importFromContent(
   // #1035: fetch the existing page BEFORE the hash compute so (a) the type
   // preservation below participates in the hash (a no-op re-put stays a
   // hash-match skip) and (b) the hash short-circuit below reuses this row.
-  const existing = await engine.getPage(slug, sourceId ? { sourceId } : undefined);
+  // Existence check must target the same namespace the writes below target.
+  // putPage/createVersion default sourceId to 'default', but an unscoped
+  // getPage matches a same-slug row from ANY source (LIMIT 1). When another
+  // source owns the slug and no default-source row exists, `existing` is
+  // truthy while tx.createVersion(slug) scoped to default finds 0 rows and
+  // throws, aborting the whole import (crashes synthesize_concepts in every
+  // dream cycle on multi-source brains).
+  const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
 
   // #2044: remote get_page intentionally strips private facts rows. A
   // documented get_page -> edit -> put_page round-trip can therefore arrive
@@ -1002,7 +1009,10 @@ async function verifyPageReadable(
   sourceId: string | undefined,
   caller: string,
 ): Promise<void> {
-  const readBack = await engine.getPage(slug, sourceId ? { sourceId } : undefined);
+  // Same namespace scoping as the pre-write existence check: an unscoped
+  // read-back can match a same-slug row owned by ANOTHER source and fail
+  // with a false 'stale content_hash' desync error.
+  const readBack = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
   if (!readBack) {
     // Log to ingest_log before throwing so the failure is durable and
     // agent-inspectable, not just a transient stderr message.
@@ -1236,7 +1246,14 @@ export async function importCodeFile(
     .update(JSON.stringify({ title, type: 'code', content, lang, chunker_version: CHUNKER_VERSION }))
     .digest('hex');
 
-  const existing = await engine.getPage(slug, sourceId ? { sourceId } : undefined);
+  // Existence check must target the same namespace the writes below target.
+  // putPage/createVersion default sourceId to 'default', but an unscoped
+  // getPage matches a same-slug row from ANY source (LIMIT 1). When another
+  // source owns the slug and no default-source row exists, `existing` is
+  // truthy while tx.createVersion(slug) scoped to default finds 0 rows and
+  // throws, aborting the whole import (crashes synthesize_concepts in every
+  // dream cycle on multi-source brains).
+  const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
   if (!opts.force && existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0 };
   }
@@ -1735,7 +1752,9 @@ export async function importImageFile(
   const buf = readFileSync(filePath);
   const hash = createHash('sha256').update(buf).digest('hex');
 
-  const existing = await engine.getPage(imageSlug, sourceOpts);
+  // Same namespace-mismatch fix as importParsedFile above: scope the
+  // existence check to the namespace the writes target.
+  const existing = await engine.getPage(imageSlug, sourceOpts ?? { sourceId: 'default' });
   if (existing?.content_hash === hash) {
     return { slug: imageSlug, status: 'skipped', chunks: 0 };
   }

--- a/test/import-existence-source-scope.test.ts
+++ b/test/import-existence-source-scope.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from 'bun:test';
+import { importFromContent } from '../src/core/import-file.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+/**
+ * Regression: the pre-write existence check in importFromContent must be
+ * scoped to the SAME namespace the writes target.
+ *
+ * putPage/createVersion default sourceId to 'default', but the existence
+ * check used to run unscoped (`sourceId ? { sourceId } : undefined`), which
+ * matches a same-slug row from ANY source (LIMIT 1). On a multi-source brain
+ * where another source owns the slug and no default-source row exists,
+ * `existing` came back truthy → tx.createVersion(slug) scoped to default
+ * found 0 rows → threw `createVersion failed: page "<slug>" (source=default)
+ * not found`, aborting the import. This crashed synthesize_concepts in every
+ * dream cycle (concepts are written to the default namespace) as soon as one
+ * synthesized concept slug collided with a row owned by another source.
+ */
+
+// Source-aware mock engine: simulates the real (source_id, slug) keyed pages
+// table. getPage honors opts.sourceId exactly like the real engine (scoped →
+// exact match; unscoped → any source, LIMIT 1). createVersion mirrors the
+// real engine's failure mode: throws when no row exists at
+// (sourceId ?? 'default', slug).
+function sourceAwareMockEngine(seed: { sourceId: string; slug: string; content_hash?: string }[] = []) {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const pageStore = new Map<string, { slug: string; source_id: string; content_hash: string; title: string; type: string; frontmatter: Record<string, unknown> }>();
+  const key = (sourceId: string, slug: string) => `${sourceId}\u0000${slug}`;
+  for (const s of seed) {
+    pageStore.set(key(s.sourceId, s.slug), {
+      slug: s.slug,
+      source_id: s.sourceId,
+      content_hash: s.content_hash ?? 'seeded-hash',
+      title: s.slug,
+      type: 'concept',
+      frontmatter: {},
+    });
+  }
+
+  const engine = new Proxy({} as Record<string, unknown>, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (prop === 'getTags') return () => Promise.resolve([]);
+      if (prop === 'getPage') {
+        return async (slug: string, opts?: { sourceId?: string }) => {
+          calls.push({ method: 'getPage', args: [slug, opts] });
+          if (opts?.sourceId) return pageStore.get(key(opts.sourceId, slug)) ?? null;
+          // Unscoped: any source, LIMIT 1 (matches the real engine).
+          for (const row of pageStore.values()) {
+            if (row.slug === slug) return row;
+          }
+          return null;
+        };
+      }
+      if (prop === 'putPage') {
+        return async (slug: string, page: { content_hash?: string; title?: string; type?: string; frontmatter?: Record<string, unknown> }, opts?: { sourceId?: string }) => {
+          calls.push({ method: 'putPage', args: [slug, page, opts] });
+          const sourceId = opts?.sourceId ?? 'default';
+          pageStore.set(key(sourceId, slug), {
+            slug,
+            source_id: sourceId,
+            content_hash: page.content_hash ?? '',
+            title: page.title ?? '',
+            type: page.type ?? '',
+            frontmatter: page.frontmatter ?? {},
+          });
+          return undefined;
+        };
+      }
+      if (prop === 'createVersion') {
+        return async (slug: string, opts?: { sourceId?: string }) => {
+          calls.push({ method: 'createVersion', args: [slug, opts] });
+          const sourceId = opts?.sourceId ?? 'default';
+          if (!pageStore.has(key(sourceId, slug))) {
+            throw new Error(`createVersion failed: page "${slug}" (source=${sourceId}) not found`);
+          }
+          return { id: 1, page_id: 1 };
+        };
+      }
+      if (prop === 'transaction') return async (fn: (tx: BrainEngine) => Promise<unknown>) => fn(engine as unknown as BrainEngine);
+      return (...args: unknown[]) => {
+        calls.push({ method: prop, args });
+        return Promise.resolve(null);
+      };
+    },
+  });
+  return engine as unknown as BrainEngine & { _calls: { method: string; args: unknown[] }[] };
+}
+
+const CONTENT = `---
+type: concept
+title: Scope Test
+---
+
+Body for the source-scope regression test.
+`;
+
+describe('importFromContent existence-check source scoping', () => {
+  test('same slug owned by another source: import to default succeeds as a NEW page (no createVersion)', async () => {
+    const engine = sourceAwareMockEngine([
+      { sourceId: 'other-source', slug: 'concepts/scope-test' },
+    ]);
+
+    // Pre-fix this threw: unscoped existence check found the other-source row,
+    // then createVersion scoped to default found nothing.
+    const result = await importFromContent(engine, 'concepts/scope-test', CONTENT, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    const versionCalls = engine._calls.filter(c => c.method === 'createVersion');
+    expect(versionCalls.length).toBe(0); // no default-source row existed → new page, no snapshot
+    const putCall = engine._calls.find(c => c.method === 'putPage');
+    expect(putCall).toBeTruthy();
+  });
+
+  test('existence check is scoped to default when no sourceId is given', async () => {
+    const engine = sourceAwareMockEngine();
+    await importFromContent(engine, 'concepts/scope-test', CONTENT, { noEmbed: true });
+
+    const firstGet = engine._calls.find(c => c.method === 'getPage');
+    expect(firstGet).toBeTruthy();
+    expect((firstGet!.args[1] as { sourceId?: string })?.sourceId).toBe('default');
+  });
+
+  test('existing default-source page still gets a version snapshot', async () => {
+    const engine = sourceAwareMockEngine([
+      { sourceId: 'default', slug: 'concepts/scope-test' },
+    ]);
+    const result = await importFromContent(engine, 'concepts/scope-test', CONTENT, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    const versionCalls = engine._calls.filter(c => c.method === 'createVersion');
+    expect(versionCalls.length).toBe(1);
+  });
+
+  test('explicit sourceId path is unchanged: scoped check + scoped snapshot', async () => {
+    const engine = sourceAwareMockEngine([
+      { sourceId: 'other-source', slug: 'concepts/scope-test' },
+    ]);
+    const result = await importFromContent(engine, 'concepts/scope-test', CONTENT, {
+      noEmbed: true,
+      sourceId: 'other-source',
+    });
+
+    expect(result.status).toBe('imported');
+    const versionCalls = engine._calls.filter(c => c.method === 'createVersion');
+    expect(versionCalls.length).toBe(1);
+    expect((versionCalls[0].args[1] as { sourceId?: string })?.sourceId).toBe('other-source');
+  });
+});


### PR DESCRIPTION
## Bug

`importFromContent` / `importFile` / `importImageFile` default their writes (`putPage`/`createVersion`) to source `default`, but the pre-write existence check ran **unscoped** (`sourceId ? { sourceId } : undefined`), which matches a same-slug row from **any** source (`LIMIT 1`).

On a multi-source brain where another source owns the slug and no default-source row exists:

1. `existing` comes back truthy (foreign-source row),
2. `tx.createVersion(slug)` scoped to `default` finds 0 rows,
3. the import throws `createVersion failed: page "<slug>" (source=default) not found` and the whole operation aborts.

In practice this crashed `synthesize_concepts` in **every** dream cycle (concept pages are written to the default namespace) as soon as one synthesized concept slug collided with a row owned by another source — `last_full_cycle_at` never stamped, so `cycle_freshness` degraded permanently on all sources.

The post-write read-back guard (`verifyPageReadable`) had the same unscoped `getPage`: it can match another source's row and fail with a false "stale content_hash" desync error.

## Fix

Existence check (markdown + code + image paths) and the read-back guard now use `{ sourceId: sourceId ?? 'default' }` so the check and the write always agree on the namespace. Explicit-`sourceId` callers are unchanged.

## Tests

`test/import-existence-source-scope.test.ts` — source-aware mock engine keyed on `(source_id, slug)` whose `createVersion` mirrors the real engine's failure mode:

- crash repro: foreign-source slug + default-namespace write now imports as a NEW page (no snapshot),
- existence check is scoped to `default` when no `sourceId` is given,
- existing default-source page still gets its version snapshot,
- explicit-`sourceId` path unchanged (scoped check + scoped snapshot).

`bun test` on the import suite: 74 pass / 0 fail (import-file, content-sanity, image, dedup, new file).

Verified live on a 4-source deployment: previously every `dream --source <s>` died at `synthesize_concepts` with the error above; with this patch cycles complete and stamp `last_full_cycle_at`.