### PR TITLE
fix(serve): close PGLite on SIGTERM/SIGHUP in HTTP mode

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2595,5 +2595,23 @@ ${bootstrapFromEnv
 `);
   });
 
-  await waitForHttpServerLifecycle(httpServer);
+  // SIGTERM/SIGHUP route through process-cleanup's pass and then
+  // `process.exit`, which skips cli.ts's finally-teardown — so on those
+  // signals the PGLite write handle was never closed. An unclosed PGLite
+  // can leave the control file pointing at a checkpoint record whose WAL
+  // page never reached disk; every later start then dies with
+  // `PANIC: could not locate a valid checkpoint record` (surfaced as the
+  // misleading WASM-init hint) and the daemon crash-loops until a human
+  // intervenes. Registering the engine here gives abnormal termination
+  // the same clean close the SIGINT path already gets via the cli
+  // teardown. Deregistered on normal return so the cli finally remains
+  // the single owner of orderly shutdown.
+  const deregisterEngineCleanup = registerCleanup('pglite-engine-disconnect', () =>
+    engine.disconnect(),
+  );
+  try {
+    await waitForHttpServerLifecycle(httpServer);
+  } finally {
+    deregisterEngineCleanup();
+  }
 }


### PR DESCRIPTION
## Problem

In HTTP mode (`gbrain serve --http`), SIGTERM and SIGHUP terminate through `process-cleanup`'s pass and then `process.exit`, which skips cli.ts's finally-teardown. Result: the PGLite write handle is **never closed** on those signals — the cleanup pass releases the db-lock and closes the HTTP server, but not the engine.

An unclosed PGLite can leave the datadir's control file pointing at a checkpoint record whose WAL page never reached disk. Every subsequent start then dies with:

```
PANIC:  could not locate a valid checkpoint record
```

…surfaced to the operator only as the misleading "macOS WASM bug" init hint, so the daemon crash-loops under launchd/systemd until a human intervenes. The stdio path already guards this (serve.ts's `beginShutdown` → `engine.disconnect()`); HTTP mode has no equivalent.

Observed in production: a launchd-managed `serve --http` deployment hit this three times over ~3 weeks (daily maintenance scripts stop serve via `launchctl bootout` → SIGTERM). Each occurrence required manual `pg_resetwal` recovery. Data files were intact each time — only the WAL tail was lost.

## Fix

Register `engine.disconnect()` in the existing cleanup registry for the duration of the HTTP server lifetime, and deregister on normal return so orderly shutdown stays owned by the cli finally. Mirrors the clean close the stdio path (and HTTP's SIGINT path, via `waitForHttpServerLifecycle` → cli teardown) already gets.

One note for review: cleanups run in registration order, so the engine close registered here runs **before** the `http-server` close registered inside `waitForHttpServerLifecycle`. In-flight requests during the 3s abnormal-termination window may fail against a closing engine — which seemed acceptable for the abnormal path, where datadir consistency is the priority. Happy to rework the ordering (e.g. a wrapper registrar) if you'd rather sever sockets first.

## Testing

- `bun run typecheck` clean.
- Field-verified on the production deployment above (patched v0.42.44.0): SIGTERM now logs a graceful close and the datadir passes an open-test after stop; before the patch the same stop sequence reproducibly left the PANIC state after write-heavy sessions.

## Possible follow-up (separate issue?)

Even with a graceful close, we measured cases (PGLite 0.4.3 under Bun) where `db.close()` did not durably sync the WAL tail — the control file pointed at a checkpoint record absent from on-disk WAL after a clean `close()`. If reproducible on your side, an explicit `CHECKPOINT` (or a durability-sync) inside engine disconnect might be worth considering; happy to file separately with details.
