### PR TITLE
AGE-87: expose vector fallback and dedup public results

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -886,6 +886,11 @@ export async function embedQueryBounded(
   }
 }
 
+function vectorFailureReason(err: unknown): HybridSearchMeta['vector_fallback_reason'] {
+  const message = err instanceof Error ? err.message : String(err);
+  return /deadline|timeout|aborted/i.test(message) ? 'embed_timeout' : 'embed_error';
+}
+
 export async function hybridSearch(
   engine: BrainEngine,
   query: string,
@@ -1158,6 +1163,8 @@ export async function hybridSearch(
   // provider (Voyage, ZE) works fine.
   const { isAvailable } = await import('../ai/gateway.ts');
   const providerProbe = resolvedCol.embeddingModel || undefined;
+  let vectorFallbackReason: HybridSearchMeta['vector_fallback_reason'] =
+    isAvailable('embedding', providerProbe) ? 'ok' : 'provider_unavailable';
   // Image/both/unified routing embeds via the MULTIMODAL provider, not the
   // text provider — so a multimodal-only install (text provider absent) must
   // still reach the multimodal branch below. Probe the multimodal provider
@@ -1203,12 +1210,13 @@ export async function hybridSearch(
     }
     // T3/T4 — alias hop + evidence stamp even without an embedding provider
     // (the named-thing fix is most valuable exactly when vector is unavailable).
-    const noEmbedHopped = await applyAliasHop(engine, dedupResults(noEmbedResults), query, {
+    const noEmbedHopped = await applyAliasHop(engine, noEmbedResults, query, {
       sourceId: opts?.sourceId,
       sourceIds: opts?.sourceIds,
     });
-    stampEvidence(noEmbedHopped);
-    const noEmbedSliced = noEmbedHopped.slice(offset, offset + limit);
+    const noEmbedPresentation = dedupResults(noEmbedHopped, { maxPerPage: 1 });
+    stampEvidence(noEmbedPresentation);
+    const noEmbedSliced = noEmbedPresentation.slice(offset, offset + limit);
     // v0.32.3 search-lite: budget enforcement on the no-embedding-provider path.
     const { results: noEmbedBudgeted, meta: noEmbedBudgetMeta } = enforceTokenBudget(noEmbedSliced, resolvedMode.tokenBudget);
     await stampContentFlags(engine, noEmbedBudgeted);
@@ -1216,6 +1224,7 @@ export async function hybridSearch(
     lastRank1Score = noEmbedBudgeted[0] ? (noEmbedBudgeted[0].base_score ?? noEmbedBudgeted[0].score) : undefined;
     emitMeta({
       vector_enabled: false,
+      vector_fallback_reason: vectorFallbackReason,
       detail_resolved: detailResolved,
       expansion_applied: false,
       intent: suggestions.intent,
@@ -1417,9 +1426,20 @@ export async function hybridSearch(
       if (effectiveModality === 'both' && imageVectorList !== null) {
         vectorLists = [...vectorLists, imageVectorList];
       }
-    } catch {
-      // Embedding failure is non-fatal, fall back to keyword-only
+    } catch (err) {
+      // Embedding failure is non-fatal, but must remain observable.
+      vectorFallbackReason = vectorFailureReason(err);
+      console.error(`[hybrid] vector retrieval fallback: reason=${vectorFallbackReason}`);
     }
+  }
+
+  // A provider can accept the query embedding while returning no candidates.
+  // Treat that as a fallback rather than a successful empty vector arm.
+  if (vectorLists.length > 0 && vectorLists.every((list) => list.length === 0)) {
+    vectorLists = [];
+    vectorFallbackReason = 'empty_vector_results';
+  } else if (vectorLists.some((list) => list.length > 0)) {
+    vectorFallbackReason = 'ok';
   }
 
   if (vectorLists.length === 0) {
@@ -1445,12 +1465,13 @@ export async function hybridSearch(
       await runPostFusionStages(engine, fallbackResults, postFusionOpts);
       fallbackResults.sort((a, b) => b.score - a.score);
     }
-    const kwHopped = await applyAliasHop(engine, dedupResults(fallbackResults), query, {
+    const kwHopped = await applyAliasHop(engine, fallbackResults, query, {
       sourceId: opts?.sourceId,
       sourceIds: opts?.sourceIds,
     });
-    stampEvidence(kwHopped);
-    const kwSliced = kwHopped.slice(offset, offset + limit);
+    const kwPresentation = dedupResults(kwHopped, { maxPerPage: 1 });
+    stampEvidence(kwPresentation);
+    const kwSliced = kwPresentation.slice(offset, offset + limit);
     // v0.32.3 search-lite: budget enforcement on the keyword-fallback path too.
     const { results: kwBudgeted, meta: kwBudgetMeta } = enforceTokenBudget(kwSliced, resolvedMode.tokenBudget);
     await stampContentFlags(engine, kwBudgeted);
@@ -1458,6 +1479,7 @@ export async function hybridSearch(
     lastRank1Score = kwBudgeted[0] ? (kwBudgeted[0].base_score ?? kwBudgeted[0].score) : undefined;
     emitMeta({
       vector_enabled: false,
+      vector_fallback_reason: vectorFallbackReason,
       detail_resolved: detailResolved,
       expansion_applied: expansionApplied,
       intent: suggestions.intent,
@@ -1686,7 +1708,11 @@ export async function hybridSearch(
     autocutDecision = r.decision;
   }
 
-  const sliced = returnPool.slice(offset, offset + limit);
+  const presentationPool = dedupResults(returnPool, {
+    ...(dedupOpts ?? {}),
+    maxPerPage: 1,
+  });
+  const sliced = presentationPool.slice(offset, offset + limit);
   // v0.32.3 search-lite: budget enforcement at the main return path.
   // hybridSearchCached used to be the only place this fired; now bare
   // hybridSearch enforces it too so eval-replay + eval-longmemeval see
@@ -1697,6 +1723,7 @@ export async function hybridSearch(
   lastRank1Score = budgeted[0] ? (budgeted[0].base_score ?? budgeted[0].score) : undefined;
   emitMeta({
     vector_enabled: true,
+    vector_fallback_reason: 'ok',
     detail_resolved: detailResolved,
     expansion_applied: expansionApplied,
     intent: suggestions.intent,
@@ -1894,6 +1921,7 @@ export async function hybridSearchCached(
       // Emit meta describing the cache path.
       const cachedMeta: HybridSearchMeta = {
         vector_enabled: hit.meta?.vector_enabled ?? true,
+        vector_fallback_reason: hit.meta?.vector_fallback_reason ?? 'ok',
         detail_resolved: hit.meta?.detail_resolved ?? null,
         expansion_applied: hit.meta?.expansion_applied ?? false,
         intent: hit.meta?.intent,
@@ -1979,6 +2007,7 @@ export async function hybridSearchCached(
   // too (same drop class).
   const finalMeta: HybridSearchMeta = {
     vector_enabled: innerMeta?.vector_enabled ?? false,
+    vector_fallback_reason: innerMeta?.vector_fallback_reason ?? 'provider_unavailable',
     detail_resolved: innerMeta?.detail_resolved ?? null,
     expansion_applied: innerMeta?.expansion_applied ?? false,
     intent: innerMeta?.intent,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1613,6 +1613,13 @@ export interface EvalCaptureFailure {
 export interface HybridSearchMeta {
   /** True iff vector search actually ran. False when OPENAI_API_KEY missing or embed failed. */
   vector_enabled: boolean;
+  /** Why the vector arm was or was not usable for this call. */
+  vector_fallback_reason?:
+    | 'ok'
+    | 'provider_unavailable'
+    | 'embed_error'
+    | 'embed_timeout'
+    | 'empty_vector_results';
   /** Post-auto-detect detail level. */
   detail_resolved: 'low' | 'medium' | 'high' | null;
   /** True iff multi-query expansion (Haiku) actually fired and produced variants. */

--- a/test/dedup.test.ts
+++ b/test/dedup.test.ts
@@ -153,6 +153,17 @@ describe('edge cases', () => {
     const deduped = dedupResults(results, { maxPerPage: 3 });
     expect(deduped.filter(r => r.slug === 'a').length).toBeLessThanOrEqual(3);
   });
+
+  test('presentation policy can enforce one result per composite page key', () => {
+    const results = [
+      makeResult({ slug: 'a', source_id: 'wiki', chunk_id: 1, score: 0.9, chunk_text: 'a first distinct chunk' }),
+      makeResult({ slug: 'a', source_id: 'wiki', chunk_id: 2, score: 0.8, chunk_text: 'a second distinct chunk' }),
+      makeResult({ slug: 'a', source_id: 'other', type: 'person', chunk_id: 3, score: 0.7, chunk_text: 'a other source chunk' }),
+    ];
+    const presented = dedupResults(results, { maxPerPage: 1 });
+    expect(presented.filter(r => r.source_id === 'wiki' && r.slug === 'a')).toHaveLength(1);
+    expect(presented.filter(r => r.source_id === 'other' && r.slug === 'a')).toHaveLength(1);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────

--- a/test/hybrid-meta.serial.test.ts
+++ b/test/hybrid-meta.serial.test.ts
@@ -13,10 +13,15 @@
  * real embeddings to test the meta flag since we control the env).
  */
 
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { hybridSearch } from '../src/core/search/hybrid.ts';
 import type { PageInput, HybridSearchMeta } from '../src/core/types.ts';
+import {
+  __setEmbedTransportForTests,
+  configureGateway,
+  resetGateway,
+} from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 const savedKey = process.env.OPENAI_API_KEY;
@@ -39,6 +44,11 @@ afterAll(async () => {
   await engine.disconnect();
 });
 
+afterEach(() => {
+  __setEmbedTransportForTests(null);
+  resetGateway();
+});
+
 async function runWithMeta(query: string, opts: Parameters<typeof hybridSearch>[2] = {}): Promise<HybridSearchMeta | null> {
   let captured: HybridSearchMeta | null = null;
   await hybridSearch(engine, query, { ...opts, onMeta: (m) => { captured = m; } });
@@ -59,6 +69,59 @@ describe('hybridSearch onMeta callback — vector_enabled', () => {
     const meta = await runWithMeta('alice');
     expect(meta).not.toBeNull();
     expect(meta!.vector_enabled).toBe(false);
+    expect(meta!.vector_fallback_reason).toBe('provider_unavailable');
+  });
+
+  test('reports empty_vector_results when embedding succeeds but vector search is empty', async () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-test' },
+    });
+    __setEmbedTransportForTests((async ({ values }: any) => ({
+      embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)),
+    })) as any);
+    const meta = await runWithMeta('query with no embedded chunks');
+    expect(meta).not.toBeNull();
+    expect(meta!.vector_enabled).toBe(false);
+    expect(meta!.vector_fallback_reason).toBe('empty_vector_results');
+  });
+
+  test('reports embed_error when the query embedding transport fails', async () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-test' },
+    });
+    __setEmbedTransportForTests(async () => {
+      throw new Error('synthetic embedding failure');
+    });
+    const meta = await runWithMeta('query with embedding failure');
+    expect(meta).not.toBeNull();
+    expect(meta!.vector_enabled).toBe(false);
+    expect(meta!.vector_fallback_reason).toBe('embed_error');
+  });
+
+  test('reports ok when vector search returns candidates', async () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-test' },
+    });
+    __setEmbedTransportForTests((async ({ values }: any) => ({
+      embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)),
+    })) as any);
+    await engine.upsertChunks('people/alice-example', [{
+      chunk_index: 0,
+      chunk_text: 'Alice Example is a test person for hybrid-meta vector tests.',
+      chunk_source: 'compiled_truth',
+      embedding: new Float32Array(1536).fill(0.1),
+      token_count: 10,
+    }]);
+    const meta = await runWithMeta('alice vector');
+    expect(meta).not.toBeNull();
+    expect(meta!.vector_enabled).toBe(true);
+    expect(meta!.vector_fallback_reason).toBe('ok');
   });
 });
 


### PR DESCRIPTION
## Summary

- add explicit vector fallback metadata for unavailable providers, embedding errors/timeouts, empty vector results, and successful vector retrieval
- treat successful-but-empty vector retrieval as keyword fallback
- deduplicate public results to one result per `(source_id, slug)` on all three public return paths while preserving internal chunk recall
- add focused regression coverage

Authority/approval ranking changes are intentionally out of scope pending the local 12-query evaluation.

## Verification

- `npx tsc --noEmit`
- `npx bun test test/dedup.test.ts test/hybrid-meta.serial.test.ts` (25 passed, 0 failed)
- `git diff --check`

AGE-87
