### PR TITLE
feat(embeddings): EmbeddingGemma query-side task prefix (model-required, silently missing)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1687,6 +1687,64 @@ export interface EmbedOpts {
   dimensions?: number;
 }
 
+/**
+ * EmbeddingGemma asymmetric task prefixes.
+ *
+ * WHY. EmbeddingGemma is trained with asymmetric task prompts. Queries are
+ * meant to arrive as `task: search result | query: {text}` and documents as
+ * `title: {title|none} | text: {text}`. gbrain already distinguishes the two
+ * (`embedQuery()` threads inputType:'query', `embed()` threads 'document'),
+ * but that signal is only consumed by `dimsProviderOptions` as a wire FIELD
+ * for hosted asymmetric providers (NVIDIA NIM, ZE zembed-1). Ollama models
+ * need it as TEXT, and nothing applied it — `grep -rn "task: search result"
+ * src/` returned zero hits.
+ *
+ * Measured on this brain (61.5k chunks) before the patch:
+ *   "my dog Ladybird is old and sick"        -> llama-cpp docs      0.3585
+ *   same query, prefixed                     -> people/ladybird     0.8081
+ * Unprefixed, the correct page did not appear at all. Long document-shaped
+ * queries were fine, which is why a title->body bench and an end-to-end
+ * smoke test both passed while short questions silently returned garbage.
+ *
+ * QUERY SIDE ONLY, deliberately. The corpus was embedded RAW on 2026-08-01.
+ * Prefixing documents now would put queries and stored vectors in different
+ * spaces — strictly worse than the current asymmetry, which measures 0.8081.
+ * Turning DOC_PREFIX on requires a full re-embed of every chunk; the map
+ * below carries the string so that migration is a one-line change, not a
+ * rediscovery.
+ */
+const EMBEDDING_TASK_PREFIXES: Array<{
+  match: RegExp;
+  query: (t: string) => string;
+  /** Enabling this REQUIRES re-embedding the whole corpus. See note above. */
+  document?: (t: string) => string;
+}> = [
+  {
+    match: /embeddinggemma/i,
+    query: t => `task: search result | query: ${t}`,
+    // document: t => `title: none | text: ${t}`,  // needs full re-embed
+  },
+];
+
+/**
+ * Apply a model's task prefix to each input. No-op for every model without an
+ * entry, and for document-side calls (no `document` fn is enabled today), so
+ * the default path is byte-identical to upstream.
+ *
+ * @internal exported for tests.
+ */
+export function applyEmbeddingTaskPrefix(
+  modelId: string,
+  inputType: 'query' | 'document' | undefined,
+  texts: string[],
+): string[] {
+  const rule = EMBEDDING_TASK_PREFIXES.find(r => r.match.test(modelId));
+  if (!rule) return texts;
+  const fn = inputType === 'query' ? rule.query : rule.document;
+  if (!fn) return texts;
+  return texts.map(t => fn(t));
+}
+
 export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32Array[]> {
   if (!texts || texts.length === 0) return [];
 
@@ -1698,7 +1756,14 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const resolveTarget = opts?.embeddingModel ?? getEmbeddingModel();
   const tracker = __budgetStore.getStore() ?? null;
   const { model, recipe, modelId } = await resolveEmbeddingProvider(resolveTarget);
-  const truncated = texts.map(t => (t ?? '').slice(0, MAX_CHARS));
+  // LOCAL PATCH: task prefix is applied BEFORE truncation-to-MAX_CHARS is
+  // measured downstream, so the added tokens are counted in the batch budget
+  // rather than silently overflowing it.
+  const truncated = applyEmbeddingTaskPrefix(
+    modelId,
+    opts?.inputType,
+    texts.map(t => (t ?? '').slice(0, MAX_CHARS)),
+  );
 
   // Reserve up front for the worst-case batch token count. Embeddings have
   // no output rate, so maxOutputTokens=0. record() at the end uses the


### PR DESCRIPTION
**Why are you opening this? (human-written, required)**

> _[DUSTIN — type 3-4 rough sentences here in your own words, then mark the PR "Ready for review". What you were doing, what went wrong, why it matters. Their rules explicitly prefer rough grammar and reject anything AI-written or AI-polished, so just talk.]_

**Screenshot of gbrain in use (required)**

![gbrain EmbeddingGemma task-prefix, live run](https://raw.githubusercontent.com/cogpros/gbrain/pr-assets/gbrain-pr-screenshot.png)

Live run on a real brain (61k chunks, `embeddinggemma:300m-qat-q8_0`, 768d): health check green, the patched gateway function exercised (query prefixed, document untouched), and a short conversational query retrieving correctly. Scores at the bottom are from the same corpus, same document, measured before/after: a short query that scored 0.3585 raw — with the correct page absent from results — scores 0.8081 prefixed, correct page ranked #1.

**What changed**

EmbeddingGemma is trained with asymmetric task prompts: queries are meant to arrive as `task: search result | query: {text}`. The gateway already threads `inputType` (`'query'` via `embedQuery`, `'document'` via `embed`) but dropped it before the model call, so short conversational queries embed in the wrong space and silently under-retrieve — no error is ever thrown.

This adds `applyEmbeddingTaskPrefix` in `src/core/ai/gateway.ts`: query-side only, gated to `/embeddinggemma/i` model ids. Every other model takes the existing path byte-for-byte. The document side is deliberately untouched — enabling it would put queries and existing stored vectors in different spaces until a full corpus re-embed, so it's declared in the rules table but commented off, with a comment explaining the constraint.

**How it was tested**

- Live corpus: 61,564 chunks re-queried; the failing short-query case repaired 0.3585 → 0.8081 with documents held constant, retrieval regression checked on unrelated queries (no rank changes observed outside the repaired class).
- The function is exercised directly (screenshot): query gets the prefix, document passes through unchanged, non-EmbeddingGemma models unaffected.
- A downstream health check runs this in production daily (marker + call-site + behavior assertions: definition present, invocation present, query prefixed, document untouched) — it caught that a definition-only grep is not proof of behavior, so the check exercises the live function.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — code and PR body; the intent paragraph above is human-written per CONTRIBUTING.
