### PR TITLE
fix(cli): route `takes --help` to its own usage block instead of the generic stub

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,6 +121,12 @@ const CLI_ONLY_SELF_HELP = new Set([
   // --help` print the migration flags from runMigrateEmbeddings. `migrate`
   // (engine transfer) keeps its own dispatch too.
   'migrate', 'retrieval-upgrade',
+  // `gbrain takes --help` printed the generic one-line stub, so the nine
+  // subcommands (add/update/supersede/resolve/scorecard/calibration/revisit/
+  // extract/search) were undiscoverable from the CLI — the detailed usage
+  // block in runTakes (src/commands/takes.ts) was unreachable. Same holdout
+  // pattern as `capture`, `sync`, and `schema` above.
+  'takes',
 ]);
 
 // v114 (#1941): alias -> operation lookup, kept separate from `cliOps` so
@@ -1735,6 +1741,16 @@ async function handleCliOnly(command: string, args: string[]) {
   if (command === 'enrich' && (args.includes('--help') || args.includes('-h'))) {
     const { runEnrich } = await import('./commands/enrich.ts');
     await runEnrich(null as never, args);
+    return;
+  }
+
+  // Same pattern for `takes --help`. 'takes' is now in CLI_ONLY_SELF_HELP so
+  // the generic stub stays out of the way; this pre-engine-bind branch exposes
+  // the subcommand usage block without a configured brain. runTakes' help path
+  // returns before touching the engine.
+  if (command === 'takes' && (args.includes('--help') || args.includes('-h'))) {
+    const { runTakes } = await import('./commands/takes.ts');
+    await runTakes(null as never, args);
     return;
   }
 

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -140,3 +140,37 @@ describe('#1175 — main `gbrain --help` SOURCES block matches the real subcomma
     expect(stdout).toMatch(/^\s*sources --help\s/m);
   });
 });
+
+describe('`gbrain takes --help` reaches the detailed subcommand block', () => {
+  test('every mutate + read subcommand is listed', () => {
+    const { stdout, status } = runCli(['takes', '--help']);
+    expect(status).toBe(0);
+    // Pre-fix these were undiscoverable from the CLI: `takes` was in CLI_ONLY
+    // but not CLI_ONLY_SELF_HELP, so the generic stub fired before runTakes.
+    expect(stdout).toContain('takes add');
+    expect(stdout).toContain('takes update');
+    expect(stdout).toContain('takes supersede');
+    expect(stdout).toContain('takes resolve');
+    expect(stdout).toContain('takes scorecard');
+    expect(stdout).toContain('takes calibration');
+    expect(stdout).toContain('takes search');
+  });
+
+  test('output is NOT the generic short-circuit fallback', () => {
+    const { stdout } = runCli(['takes', '--help']);
+    // Pre-fix output was exactly: "Usage: gbrain takes\n\ngbrain takes - run
+    // gbrain --help for the full command list."
+    expect(stdout).not.toContain('run gbrain --help for the full command list');
+    expect(stdout).not.toMatch(/^Usage: gbrain takes\s*$/m);
+    expect(stdout.split('\n').length).toBeGreaterThan(10);
+  });
+
+  test('help works with no brain configured (pre-engine-bind branch)', () => {
+    // runCli points GBRAIN_HOME at a nonexistent dir. Without the pre-engine
+    // branch this printed "No brain configured. Run: gbrain init".
+    const { stdout, status } = runCli(['takes', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).not.toContain('No brain configured');
+    expect(stdout).toContain('--dir <path>');
+  });
+});


### PR DESCRIPTION
Repro on a fresh checkout:

```
$ gbrain takes --help
Usage: gbrain takes

gbrain takes - run gbrain --help for the full command list.
```

`takes` is in `CLI_ONLY` but missing from `CLI_ONLY_SELF_HELP`, so the generic short-circuit in `main()` fires before `runTakes` can print its own help. The detailed usage block in `src/commands/takes.ts` is unreachable from the CLI, which makes `add` / `update` / `supersede` / `resolve` / `scorecard` / `calibration` / `search` undiscoverable without reading the source.

This is the same holdout pattern already fixed for `capture` (v0.39.3.0 WARN-5), `sync` (v0.37 CDX2-12), and `schema` (v0.40.6.0) — and it needs the same two parts those did:

1. Add `takes` to `CLI_ONLY_SELF_HELP` so the generic stub stays out of the way.
2. Add a pre-engine-bind `--help` branch in `handleCliOnly`. The dispatch case still binds an engine, so part 1 alone turns the stub into `No brain configured. Run: gbrain init` on a fresh tmpdir. `runTakes` returns from its help path before touching the engine, so it takes `null` exactly like `runEnrich` / `runSync`.

## Tests

Three tests added to `test/cli-help-discoverability.test.ts`, next to the existing `capture` / `sync` cases and using the same `runCli` subprocess harness (`GBRAIN_HOME` pointed at a nonexistent dir, so the no-brain case is covered).

All three **fail on the parent commit** and pass here — verified by stashing the `src/cli.ts` change and re-running (10 pass / 3 fail → 13 pass / 0 fail).

- `bun run verify` — 34/34 green
- `bun test test/cli.test.ts test/cli-args.test.ts test/cli-dispatch-thin-client.test.ts test/takes-command-source-scope.test.ts test/takes-mcp-allowlist.serial.test.ts` — 54 pass / 0 fail

No behavior change outside the `--help` path.