### PR TITLE
fix(takes): resolve the page before writing markdown in `takes add`

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -210,6 +210,13 @@ async function cmdAdd(engine: BrainEngine, args: string[], sourceId?: string): P
   const brainDir = await resolveBrainDir(engine, dirArg ?? null);
 
   await withPageLock(slug, async () => {
+    // Resolve the page BEFORE touching the markdown. getPageId exits 1 when the
+    // page isn't in the brain; doing this after writeBody left a .md file
+    // carrying a take with no DB row — invisible to scorecard/calibration but
+    // present on disk, so a later `takes add` would number the next row past a
+    // take the DB never saw. update/supersede/resolve already resolve first.
+    const pageId = await getPageId(engine, slug, sourceId);
+
     const path = pageFilePath(brainDir, slug);
     const body = readBodyOrEmpty(path);
     const { body: nextBody, rowNum } = upsertTakeRow(body, {
@@ -217,8 +224,6 @@ async function cmdAdd(engine: BrainEngine, args: string[], sourceId?: string): P
     });
     writeBody(path, nextBody);
 
-    // Mirror to DB. Page may not be in DB yet if not synced — caller must run sync first.
-    const pageId = await getPageId(engine, slug, sourceId);
     await engine.addTakesBatch([{
       page_id: pageId, row_num: rowNum, claim, kind, holder, weight,
       since_date: since, source, active: true, superseded_by: null,

--- a/test/takes-command-source-scope.test.ts
+++ b/test/takes-command-source-scope.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -193,5 +193,81 @@ describe('gbrain takes CLI source scoping', () => {
     });
 
     expect(listCalls).toEqual([{ page_id: 11, active: true, limit: 500 }]);
+  });
+});
+
+describe('gbrain takes add — page validated before markdown is written', () => {
+  test('missing page leaves no orphaned .md on disk', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-takes-orphan-'));
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-takes-orphan-home-'));
+    tmpRoots.push(brainDir, home);
+    const { engine, added } = makeEngine();
+
+    // makeEngine returns [] for any slug other than shared/page, so getPageId
+    // takes its not-found path and exits 1.
+    const errs: string[] = [];
+    const errSpy = spyOn(console, 'error').mockImplementation((...a: unknown[]) => { errs.push(a.join(' ')); });
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+
+    let exited: string | null = null;
+    try {
+      await withEnv({ GBRAIN_SOURCE: undefined, GBRAIN_HOME: home }, async () => {
+        await runTakes(engine, [
+          'add',
+          'missing/page',
+          '--claim',
+          'Claim against a page that was never synced',
+          '--kind',
+          'bet',
+          '--who',
+          'council',
+          '--dir',
+          brainDir,
+        ]);
+      });
+    } catch (e) {
+      if (!(e as Error).message.startsWith('EXIT:')) throw e;
+      exited = (e as Error).message;
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    expect(exited).toBe('EXIT:1');
+    expect(errs.join('\n')).toContain('Page not found in brain: missing/page');
+    // Pre-fix the .md was written before getPageId ran, so the take survived
+    // on disk with no DB row — invisible to scorecard, but real enough to
+    // shift row numbering on the next add.
+    expect(existsSync(join(brainDir, 'missing/page.md'))).toBe(false);
+    expect(added).toEqual([]);
+  });
+
+  test('existing page still writes both markdown and DB', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-takes-ok-'));
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-takes-ok-home-'));
+    tmpRoots.push(brainDir, home);
+    const { engine, added } = makeEngine();
+
+    await withEnv({ GBRAIN_SOURCE: undefined, GBRAIN_HOME: home }, async () => {
+      await runTakes(engine, [
+        'add',
+        'shared/page',
+        '--claim',
+        'Claim against a real page',
+        '--kind',
+        'bet',
+        '--who',
+        'council',
+        '--dir',
+        brainDir,
+      ]);
+    });
+
+    expect(existsSync(join(brainDir, 'shared/page.md'))).toBe(true);
+    expect(readFileSync(join(brainDir, 'shared/page.md'), 'utf8')).toContain('Claim against a real page');
+    expect(added.flat()).toHaveLength(1);
+    expect(added.flat()[0]!.page_id).toBe(11);
   });
 });


### PR DESCRIPTION
`cmdAdd` writes the `.md` file first and resolves the page second:

```ts
writeBody(path, nextBody);

// Mirror to DB. Page may not be in DB yet if not synced — caller must run sync first.
const pageId = await getPageId(engine, slug, sourceId);
```

`getPageId` exits 1 when the slug is not in the brain. So adding a take against an unsynced or misspelled slug leaves a markdown file on disk carrying a take with no DB row. The command prints `Page not found in brain: <slug>` and exits 1, so the user reasonably believes nothing was recorded — but the fence is real, and it is:

- **invisible to `scorecard` / `calibration`**, which read the DB, yet
- **still counted for row numbering**, so a later successful `takes add` on that page starts past a row the DB never saw.

It is easy to hit on a Postgres brain whose markdown tree is partial or absent, because the read paths (`takes <slug>`, `scorecard`) query the DB directly and work fine — the mismatch only surfaces on the write path, and it surfaces as silent data loss rather than an error.

## Why cmdAdd specifically

`cmdUpdate`, `cmdSupersede`, and `cmdResolve` all already resolve the page before touching markdown. `cmdAdd` was the only outlier. The fix hoists the `getPageId` call to the top of the `withPageLock` callback so all four agree.

No behavior change on the success path: same file contents, same `addTakesBatch` payload, same row numbering. The only difference is that the failure path now leaves no on-disk residue.

## Tests

Two tests added to `test/takes-command-source-scope.test.ts`, reusing that file's existing mock-engine + tmpdir harness:

- **missing page leaves no orphaned `.md`** — asserts exit 1, the expected stderr, no file on disk, and no `addTakesBatch` call. **Fails on the parent commit** (the file exists there), passes here.
- **existing page still writes both markdown and DB** — guards the happy path so the reorder cannot silently break it. Passes on both.

`process.exit` / `console.error` are stubbed with `spyOn(...).mockRestore()` in a `finally`, matching the pattern already used in `test/config-get-plane.test.ts`.

- `bun run verify` — 34/34 green
- all 15 `takes-*` / `extract-takes-*` suites — 182 pass / 0 fail