### PR TITLE
fix(links): resolve relative markdown links against the linking page's directory

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -43,7 +43,7 @@ import { slugifyPath } from './sync.ts';
 // PRE-wave code after this date reads as fresh and won't re-extract until
 // the page is next edited; no fixed watermark can cover code that keeps
 // running past it.
-export const LINK_EXTRACTOR_VERSION_TS = '2026-08-01T00:00:00Z';
+export const LINK_EXTRACTOR_VERSION_TS = '2026-08-04T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -75,6 +75,16 @@ export interface EntityRef {
    * LinkCandidate per resolved match.
    */
   needsResolution?: boolean;
+  /**
+   * Number of leading `../` segments on the original markdown link (0 when
+   * absent or for engine-slug refs). The match regex strips the `../` run, so
+   * this preserves the relative depth for callers that know the linking page's
+   * slug (`extractPageLinks`) to resolve the target against the page's own
+   * directory. Without it, `[x](../concepts/x.md)` from a nested page resolves
+   * as the root-relative `concepts/x` instead of `<page-dir-parent>/concepts/x`
+   * — the reason subtree-scoped / nested brains got zero cross-dir edges.
+   */
+  upLevels?: number;
 }
 
 /**
@@ -348,7 +358,18 @@ export function extractEntityRefs(content: string): EntityRef[] {
     const fullPath = match[2];
     const slug = fullPath;
     const dir = fullPath.split('/')[0];
-    refs.push({ name, slug, dir });
+    // The regex strips the leading `../` run from `fullPath`; recover its depth
+    // from the raw link target so extractPageLinks can resolve relative to the
+    // linking page's directory. `[x](path)` has no `](` collision because the
+    // capture stops before the first unescaped `)`.
+    const rawTarget = match[0].slice(match[0].indexOf('](') + 2, -1);
+    const up = rawTarget.match(/^(?:\.\.\/)+/);
+    const ref: EntityRef = { name, slug, dir };
+    // Only relative links carry depth; absolute / engine-slug refs keep the
+    // exact {name, slug, dir} shape (no upLevels key) so equality consumers
+    // are unaffected.
+    if (up) ref.upLevels = up[0].length / 3;
+    refs.push(ref);
     markdownRanges.push([match.index, match.index + match[0].length]);
   }
 
@@ -431,6 +452,29 @@ function maskRanges(content: string, ranges: Array<[number, number]>): string {
     for (let i = s; i < e && i < chars.length; i++) chars[i] = ' ';
   }
   return chars.join('');
+}
+
+/**
+ * Resolve a markdown ref's target against the LINKING page's directory when the
+ * original link was relative (had one or more `../`). Filesystem markdown links
+ * are relative to the file that contains them: `[x](../concepts/x.md)` from a
+ * page at `wiki/sources/foo` points at `wiki/concepts/x`, not the root-relative
+ * `concepts/x`. The match regex discards the `../` run, so `ref.upLevels` carries
+ * the depth and this reconstructs the absolute page slug.
+ *
+ * Backward-compatible: for a page one level below the root (`meetings/m` +
+ * `../people/alice` → `people/alice`) the parent walk lands exactly at the root,
+ * so the result is identical to the old `../`-stripping behavior. It only
+ * diverges — correctly — when the linking page is nested deeper than the `../`
+ * count unwinds, i.e. content under a prefix (subtree-scoped sources). An over-
+ * long `../` run clamps at the root. Absolute refs (upLevels 0, e.g. engine-slug
+ * `people/x` or `[[wikilinks]]`) are returned unchanged.
+ */
+function resolveRelativeSlug(pageSlug: string, ref: EntityRef): string {
+  if (!ref.upLevels || ref.upLevels <= 0) return ref.slug;
+  const dirSegs = pageSlug.includes('/') ? pageSlug.split('/').slice(0, -1) : [];
+  const keep = Math.max(0, dirSegs.length - ref.upLevels);
+  return [...dirSegs.slice(0, keep), ref.slug].join('/');
 }
 
 // ─── Link candidates (richer than EntityRef) ────────────────────
@@ -583,9 +627,13 @@ export async function extractPageLinks(
     // narrative prose where a partner's investment verbs appear once and
     // then portfolio companies are listed in subsequent sentences.
     const context = idx >= 0 ? excerpt(content, idx, 240) : ref.name;
+    // Relative markdown links resolve against THIS page's directory (fixes
+    // cross-dir edges for nested / subtree-scoped content); absolute refs pass
+    // through unchanged.
+    const targetSlug = resolveRelativeSlug(slug, ref);
     candidates.push({
-      targetSlug: ref.slug,
-      linkType: inferLinkType(pageType, context, content, ref.slug),
+      targetSlug,
+      linkType: inferLinkType(pageType, context, content, targetSlug),
       context,
       linkSource: 'markdown',
     });

--- a/test/link-extraction-relative-path.test.ts
+++ b/test/link-extraction-relative-path.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Relative markdown-link resolution — cross-dir links must resolve against the
+ * LINKING page's own directory, not the git root.
+ *
+ * The markdown-link regex strips the leading `../` run, so `extractPageLinks`
+ * historically resolved `[x](../concepts/x.md)` to the root-relative
+ * `concepts/x` regardless of where the linking page lived. For the canonical
+ * flat layout (entity dirs at the git root, pages one level down) that happens
+ * to be correct — `../` unwinds exactly to the root. But for content nested
+ * under a prefix — e.g. a source ingested with `--src-subpath wiki`, whose
+ * slugs are `wiki/concepts/x` — every cross-dir link missed: the target
+ * `concepts/x` doesn't exist, only `wiki/concepts/x` does, so `extract`/sync
+ * produced ZERO cross-dir edges (the graph showed only `contains` edges).
+ *
+ * Fix: preserve the `../` depth (`EntityRef.upLevels`) and resolve the target
+ * against the linking page's directory. Backward-compatible — a page one level
+ * below the root lands at the root, matching the old behavior; it only diverges
+ * (correctly) for deeper nesting. Every "wiki/..." case below FAILS on master.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+  extractPageLinks,
+  extractEntityRefs,
+  LINK_EXTRACTOR_VERSION_TS,
+  type SlugResolver,
+} from '../src/core/link-extraction.ts';
+
+const nullResolver: SlugResolver = { resolve: async () => null };
+
+describe('relative markdown-link resolution (nested / subtree-scoped content)', () => {
+  test('single ../ resolves against the linking page dir, keeping the prefix (was: dropped)', async () => {
+    const { candidates } = await extractPageLinks(
+      'wiki/sources/2026-04-03-memory',
+      'Builds on [Agent Memory](../concepts/agent-memory.md).',
+      {}, 'source', nullResolver, { skipFrontmatter: true },
+    );
+    const c = candidates.find(x => x.targetSlug === 'wiki/concepts/agent-memory');
+    expect(c).toBeDefined();
+    expect(c!.linkSource).toBe('markdown');
+    // The old root-relative miss must NOT be emitted.
+    expect(candidates.map(x => x.targetSlug)).not.toContain('concepts/agent-memory');
+  });
+
+  test('multiple ../ walk up multiple directory levels', async () => {
+    const { candidates } = await extractPageLinks(
+      'wiki/a/b/deep-page',
+      'See [X](../../concepts/x.md).',
+      {}, 'concept', nullResolver, { skipFrontmatter: true },
+    );
+    // dir = wiki/a/b ; up 2 -> wiki ; + concepts/x
+    expect(candidates.map(c => c.targetSlug)).toContain('wiki/concepts/x');
+  });
+
+  test('over-long ../ run clamps at the root', async () => {
+    const { candidates } = await extractPageLinks(
+      'wiki/foo',
+      'See [P](../../../people/alice.md).',
+      {}, 'concept', nullResolver, { skipFrontmatter: true },
+    );
+    expect(candidates.map(c => c.targetSlug)).toContain('people/alice');
+  });
+
+  test('absolute engine-slug refs (no ../) are unchanged', async () => {
+    const { candidates } = await extractPageLinks(
+      'wiki/sources/foo',
+      'See [C](concepts/agent-memory) for context.',
+      {}, 'source', nullResolver, { skipFrontmatter: true },
+    );
+    expect(candidates.map(c => c.targetSlug)).toContain('concepts/agent-memory');
+    expect(candidates.map(c => c.targetSlug)).not.toContain('wiki/sources/concepts/agent-memory');
+  });
+
+  test('extractEntityRefs records the ../ depth as upLevels', () => {
+    const refs = extractEntityRefs('[A](../../concepts/x.md) and [B](people/y)');
+    const a = refs.find(r => r.slug === 'concepts/x');
+    const b = refs.find(r => r.slug === 'people/y');
+    expect(a?.upLevels).toBe(2);
+    // Absolute refs carry no depth key (treated as 0).
+    expect(b?.upLevels ?? 0).toBe(0);
+  });
+
+  // ── regression pins: the canonical flat layout must NOT change ──────────
+
+  test('flat layout unchanged: one-level page + single ../ still resolves to root', async () => {
+    // notes/index is one level deep, so ../ops/... unwinds to the root exactly
+    // as before the fix (this is the #2576 case, kept green here).
+    const { candidates } = await extractPageLinks(
+      'notes/index', '[Pointer](../ops/services/pointer-agent.md) runs the fleet.',
+      {}, 'concept', nullResolver, { skipFrontmatter: true },
+    );
+    expect(candidates.map(c => c.targetSlug)).toContain('ops/services/pointer-agent');
+  });
+
+  test('flat layout unchanged: verb inference still fires on the resolved slug', async () => {
+    const { candidates } = await extractPageLinks(
+      'people/carol', 'Carol founded [Widget Co](../startups/widget-co.md) in 2024.',
+      {}, 'person', nullResolver, { skipFrontmatter: true },
+    );
+    const c = candidates.find(x => x.targetSlug === 'startups/widget-co');
+    expect(c).toBeDefined();
+    expect(c!.linkType).toBe('founded');
+  });
+
+  test('LINK_EXTRACTOR_VERSION_TS was bumped so stamped pages re-extract', () => {
+    // Behavior changed, so previously-stamped pages must re-sweep to pick up
+    // the newly-resolvable cross-dir edges.
+    expect(LINK_EXTRACTOR_VERSION_TS > '2026-08-01T00:00:00Z').toBe(true);
+  });
+});

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -60,7 +60,7 @@ describe('extractEntityRefs', () => {
   test('extracts filesystem-relative refs ([Name](../people/slug.md))', () => {
     const refs = extractEntityRefs('Met with [Alice Chen](../people/alice-chen.md) at the office.');
     expect(refs.length).toBe(1);
-    expect(refs[0]).toEqual({ name: 'Alice Chen', slug: 'people/alice-chen', dir: 'people' });
+    expect(refs[0]).toEqual({ name: 'Alice Chen', slug: 'people/alice-chen', dir: 'people', upLevels: 1 });
   });
 
   test('extracts engine-style slug refs ([Name](people/slug))', () => {


### PR DESCRIPTION
## Problem

`extractPageLinks` resolves relative markdown links (`[x](../concepts/x.md)`) as if they were root-relative, ignoring the directory the linking page actually lives in. The markdown-link regex matches `(?:\.\.\/)*` and **discards** the `../` run, so `[x](../concepts/x.md)` always yields the target `concepts/x` no matter where the linking page sits.

For the canonical flat layout (entity dirs at the git root, pages one level down) this happens to be correct — `../` unwinds exactly to the root. But when content is nested under a prefix — e.g. a source ingested with `--src-subpath <dir>`, whose slugs are `<dir>/concepts/x` — every cross-directory link misses: the extractor emits `concepts/x`, which doesn't exist; only `<dir>/concepts/x` does. `resolveCandidateSources` then drops the candidate (target not in the slug set), so `extract`/sync produce **zero** cross-dir edges and the graph shows only `contains` edges.

## Fix

Preserve the `../` depth on the ref (`EntityRef.upLevels`) and, in `extractPageLinks` (which already knows the linking page's slug), resolve the target against that page's own directory — standard filesystem-relative semantics.

- Backward-compatible: a page one level below the root lands exactly at the root, so results are identical to the old `../`-stripping behavior. It only diverges — correctly — when the page is nested deeper than the `../` count unwinds. An over-long `../` run clamps at the root. Absolute refs (engine-slug `people/x`, `[[wikilinks]]`) are unchanged.
- `upLevels` is only set for relative refs, so the `EntityRef` shape for absolute refs is untouched (no churn for equality consumers).
- Bumps `LINK_EXTRACTOR_VERSION_TS` so already-stamped pages re-sweep and pick up the newly-resolvable edges.

## Tests

New `test/link-extraction-relative-path.test.ts` covers single/multi `../`, over-long clamp, absolute-ref passthrough, and `upLevels` capture, plus regression pins that the flat layout (incl. the #2576 cases and verb inference) is unchanged. Updated the one existing `extractEntityRefs` case that now carries `upLevels: 1`.

All link-extraction suites pass. `bun run typecheck` clean. (One unrelated `backlinks.test.ts` dedupe case fails identically on `master` — pre-existing, different code path, no `../`.)
