### PR TITLE
feat(export): standalone exporter writing conversation pages back to envelope-v0 (closes the #3549 round trip)

### DIFF
--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Export gbrain conversation pages to an envelope-v0 file (a JSON serialization
+ * of AI chat history; format spec: github.com/memvelope/memvelope). The
+ * counterpart of scripts/envelope-to-gbrain.mjs - that script reads the format,
+ * this one writes it.
+ *
+ * Usage:
+ *   node scripts/gbrain-to-envelope.mjs <pagesDir> [out.mve.json]
+ *
+ * Zero dependencies. Deterministic. No network. It does NOT call gbrain - it
+ * only reads Markdown files. Point it at a `gbrain export --dir` output tree, at
+ * a brain repo, or at the directory envelope-to-gbrain.mjs wrote.
+ *
+ * Input selection:
+ *   - Walks <pagesDir> recursively for *.md, in sorted path order. Dot
+ *     directories are skipped.
+ *   - Takes only pages whose frontmatter `type` is `conversation`. Everything
+ *     else is skipped and counted on stderr.
+ *   - Reads turns out of the body in the shape envelope-to-gbrain.mjs writes:
+ *     `**Me** (<ts> · <message id>):` and `**Assistant** (...)`. A page whose
+ *     body no longer carries those headers yields no messages and is skipped:
+ *     envelope-v0 requires at least one message per conversation.
+ *   - The body is cut at the `<!-- timeline -->` sentinel that
+ *     src/core/markdown.ts writes, so a page's timeline never becomes message
+ *     text.
+ *   - Frontmatter is read line by line, top-level plain scalars only. A block
+ *     scalar (`key: |`) is treated as absent rather than guessed at. That is
+ *     enough for the six keys the importer writes and avoids a YAML dependency.
+ *
+ * What survives the round trip envelope -> envelope-to-gbrain.mjs -> here. On
+ * test/fixtures/memvelope/sample.mve.json the output is deep-equal to the
+ * input, which covers:
+ *   - conversation id and title
+ *   - message id, role, timestamp and text, verbatim
+ *   - meta.source_provider
+ *   - meta.conversation_count and meta.message_count, recomputed and equal
+ * A probe envelope built to carry the cases the fixture does not adds:
+ *   - a null conversation id, which stays null
+ *   - a `---` rule inside a message, and a message that ends on one
+ *
+ * What does not survive. Each of these was measured on a probe envelope built
+ * to carry it, not assumed:
+ *   - `conversation.created_at` and `conversation.updated_at`. The page keeps
+ *     only `date`, the first 10 characters of created_at, which is a day and
+ *     not a date-time. Both fields are taken here from the first and last
+ *     message timestamps instead. A conversation whose created_at was
+ *     09:00:00Z with a first message at 10:00:00Z comes back as 10:00:00Z, and
+ *     one whose first message has no timestamp comes back null.
+ *   - `meta.source_export_date`. Never written to a page. Omitted here, which
+ *     is what the spec asks for when the value is unknown.
+ *   - Any other key. envelope-v0 allows additional properties at every level,
+ *     the page carries none of them, and they are gone at meta, conversation
+ *     and message level alike.
+ *   - Conversation order. Output follows sorted file path, so a conversation
+ *     listed first but dated last moves to the end.
+ *   - Leading and trailing whitespace in message text, trimmed.
+ *   - A message that is only whitespace. Dropped, with a warning, because
+ *     envelope-v0 requires text of at least one character. meta.message_count
+ *     follows what was written, so it drops too.
+ *   - Anything before the first turn header, including the `# Title` heading.
+ *   - Text that itself contains a line shaped like a turn header. It splits
+ *     into two messages, and the second one's id comes from that line.
+ *   - CRLF line endings, normalized to LF on read.
+ *   - One source_provider per file. An envelope names a single provider, so a
+ *     page set spanning several keeps the first in sorted path order and warns.
+ *
+ * A page with no `memvelope_conversation_id` emits `id: null` rather than a
+ * synthesized id. envelope-v0 permits null there and tells converters not to
+ * invent one.
+ *
+ * Memory: the whole page set is held in memory (no streaming), same posture as
+ * the importer.
+ *
+ * Verify:
+ *   node scripts/envelope-to-gbrain.mjs test/fixtures/memvelope/sample.mve.json /tmp/pages
+ *   node scripts/gbrain-to-envelope.mjs /tmp/pages /tmp/out.mve.json
+ *     -> expect "wrote 1 conversation(s), 4 message(s)"
+ *   bun test test/gbrain-to-envelope.test.ts
+ *
+ * STATUS: verified against gbrain v0.42.72.1 on 2026-08-02. The sample fixture
+ * round-trips through the importer and back deep-equal, and the output
+ * validates against the published envelope-v0 JSON Schema. It also round-trips
+ * deep-equal the long way: imported, put into a PGLite brain, written back out
+ * by `gbrain export --dir`, then read here. That path rewrites the frontmatter
+ * quoting and key order and leaves the body alone, so the turn headers survive
+ * the trip through the database.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [, , pagesDir, outPath = './envelope.mve.json'] = process.argv;
+if (!pagesDir) {
+  console.error('usage: node gbrain-to-envelope.mjs <pagesDir> [out.mve.json]');
+  process.exit(1);
+}
+
+let dirStat;
+try {
+  dirStat = statSync(pagesDir);
+} catch {
+  console.error(`cannot read ${pagesDir}`);
+  process.exit(1);
+}
+if (!dirStat.isDirectory()) {
+  console.error(`${pagesDir} is not a directory`);
+  process.exit(1);
+}
+
+// Sorted at every level, so the output is a function of the page set and not of
+// the order the filesystem hands back. `gbrain export` writes nested by slug,
+// the importer writes flat; both are covered by the same walk.
+function markdownFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))) {
+    if (entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...markdownFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.md')) found.push(full);
+  }
+  return found;
+}
+
+// Frontmatter is the block between the first `---` line and the next one. A
+// page without that block is not a gbrain page and is skipped rather than
+// guessed at.
+function splitPage(content) {
+  const lines = content.split('\n');
+  if (lines[0] !== '---') return null;
+  const close = lines.indexOf('---', 1);
+  if (close === -1) return null;
+  return { front: lines.slice(1, close), body: lines.slice(close + 1).join('\n') };
+}
+
+// Top-level plain scalars only. gbrain writes these through js-yaml, which
+// quotes with single quotes; the importer writes them through JSON.stringify,
+// which quotes with double quotes. Both are read here, along with the unquoted
+// form. Indented lines belong to a nested value and never match, so a list or a
+// block scalar cannot contribute a key.
+function parseFrontmatter(lines) {
+  const out = {};
+  for (const line of lines) {
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(line);
+    if (!m) continue;
+    const key = m[1];
+    const raw = m[2].trim();
+    if (raw === '' || raw === '|' || raw === '|-' || raw === '>' || raw === '>-') continue;
+    if (raw === 'null' || raw === '~') {
+      out[key] = null;
+      continue;
+    }
+    if (raw.startsWith('"')) {
+      try {
+        out[key] = JSON.parse(raw);
+        continue;
+      } catch {
+        // Fall through to the raw form rather than dropping the field.
+      }
+    }
+    if (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2) {
+      out[key] = raw.slice(1, -1).replace(/''/g, "'");
+      continue;
+    }
+    out[key] = raw;
+  }
+  return out;
+}
+
+// The turn header the importer writes. The timestamp group is lazy so the first
+// middle dot separates it from the message id, which leaves an id free to
+// contain one.
+const TURN_HEADER = /^\*\*(Me|Assistant)\*\* \((.*?) · (.*)\):$/gm;
+const TIMELINE_SENTINEL = '<!-- timeline -->';
+
+function readMessages(body, onEmpty) {
+  const sentinel = body.indexOf(TIMELINE_SENTINEL);
+  const text = sentinel === -1 ? body : body.slice(0, sentinel);
+  const headers = [...text.matchAll(TURN_HEADER)];
+  const messages = [];
+  for (const [i, h] of headers.entries()) {
+    const start = h.index + h[0].length;
+    const end = i + 1 < headers.length ? headers[i + 1].index : text.length;
+    let raw = text.slice(start, end);
+    // Between two turns the importer writes exactly one `---` separator line.
+    // Strip that one occurrence, never a `---` the message itself ended with
+    // after the last turn.
+    if (i + 1 < headers.length) raw = raw.replace(/\n\n---\n\n$/, '');
+    const messageText = raw.trim();
+    if (messageText === '') {
+      onEmpty(h[3]);
+      continue;
+    }
+    messages.push({
+      id: h[3],
+      role: h[1] === 'Me' ? 'user' : 'assistant',
+      // The importer writes the literal `no timestamp` when the envelope had
+      // none. Read it back as the null the schema asks for, not as prose.
+      ts: h[2] === 'no timestamp' ? null : h[2],
+      text: messageText,
+    });
+  }
+  return messages;
+}
+
+const files = markdownFiles(pagesDir);
+const conversations = [];
+const providers = [];
+const seenIds = new Set();
+let skippedNotConversation = 0;
+let skippedNoFrontmatter = 0;
+let skippedNoMessages = 0;
+let droppedEmptyMessages = 0;
+let messageCount = 0;
+
+for (const file of files) {
+  // Normalize to LF up front. Every match below is line-anchored, so a page
+  // saved with CRLF would otherwise fail to parse as a whole and be reported as
+  // frontmatter-less. The cost is stated in the header: CRLF inside a message
+  // comes back as LF.
+  const page = splitPage(readFileSync(file, 'utf8').replace(/\r\n/g, '\n'));
+  if (!page) {
+    skippedNoFrontmatter += 1;
+    continue;
+  }
+  const front = parseFrontmatter(page.front);
+  if (front.type !== 'conversation') {
+    skippedNotConversation += 1;
+    continue;
+  }
+  const messages = readMessages(page.body, (id) => {
+    droppedEmptyMessages += 1;
+    console.warn(`warning: ${file} - message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
+  });
+  if (messages.length === 0) {
+    skippedNoMessages += 1;
+    console.warn(`warning: ${file} - no speaker turns found; skipped (envelope-v0 requires at least one message per conversation).`);
+    continue;
+  }
+  if (typeof front.source === 'string' && front.source !== '') providers.push(front.source);
+  // Never synthesize. An absent id is null, which the schema permits and the
+  // spec requires of converters.
+  const id = typeof front.memvelope_conversation_id === 'string' ? front.memvelope_conversation_id : null;
+  // envelope-v0 says ids should be unique within an envelope and that consumers
+  // must tolerate duplicates. Emit both conversations and say so, rather than
+  // dropping one to keep the field clean.
+  if (id !== null && seenIds.has(id)) {
+    console.warn(`warning: ${file} - conversation id ${JSON.stringify(id)} already used by another page; both are emitted.`);
+  }
+  if (id !== null) seenIds.add(id);
+  conversations.push({
+    id,
+    title: typeof front.title === 'string' && front.title !== '' ? front.title : 'Untitled conversation',
+    // The page's `date` is a day, not a date-time, so it cannot fill these.
+    // First and last message timestamps are the only date-times on the page.
+    created_at: messages[0].ts,
+    updated_at: messages[messages.length - 1].ts,
+    messages,
+  });
+  messageCount += messages.length;
+}
+
+const distinctProviders = [...new Set(providers)];
+if (distinctProviders.length > 1) {
+  console.warn(`warning: pages name ${distinctProviders.length} source providers (${distinctProviders.join(', ')}); an envelope carries one. Using ${JSON.stringify(distinctProviders[0])}.`);
+}
+const envelope = {
+  memvelope: 'envelope-v0',
+  meta: {
+    source_provider: distinctProviders[0] || 'unknown',
+    conversation_count: conversations.length,
+    message_count: messageCount,
+  },
+  conversations,
+};
+
+writeFileSync(outPath, JSON.stringify(envelope, null, 2) + '\n');
+console.log(`wrote ${conversations.length} conversation(s), ${messageCount} message(s) to ${outPath}`);
+// Every page that did not become a conversation is accounted for on stderr, so
+// a mistargeted directory reads as a diagnosis rather than an empty file.
+if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || droppedEmptyMessages) {
+  console.warn(`scanned ${files.length} markdown file(s): ${skippedNoFrontmatter} without frontmatter, ${skippedNotConversation} not type conversation, ${skippedNoMessages} without speaker turns, ${droppedEmptyMessages} empty message(s) dropped.`);
+}

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -252,15 +252,17 @@
  * literal `unknown` - required because meta.source_provider cannot be
  * omitted, defined by no provider registry - warned on stderr naming the
  * token, in `out.unknown.mve.json` when named providers are present or at
- * the asked-for path when nothing in the set names one. The round trip back
- * through envelope-to-gbrain.mjs is clean in both directions: each envelope
- * re-imports into the very directory it came from, because check 2 matches
- * per-conversation ids and refreshes each page in place, byte-identical. The
- * one residue sits on the placeholder: re-importing the `unknown` envelope
- * stamps the literal `source: "unknown"` onto pages that had no key - the
- * importer writes `source:` unconditionally on every page - which is the
- * placeholder saying exactly what is known, not a named provider claiming
- * pages that never claimed it.
+ * the asked-for path when nothing in the set names one. Round trip,
+ * measured: every conversation carrying a `memvelope_conversation_id`
+ * re-imports into the very directory it came from and refreshes its page in
+ * place, byte-identical - check 2 matches per-conversation ids - so no
+ * page's `source:` changes hands. The residue sits on id-less pages: a
+ * native gbrain page has no memvelope id, its conversation travels as
+ * `id: null`, and re-importing the `unknown` envelope cannot find the
+ * original page to refresh - it writes a NEW positional page
+ * (`<date>-conv-N.md`) carrying `source: "unknown"` and leaves the original
+ * untouched. A duplicate page, never a falsified one - the importer's
+ * standing behavior for a null id, not new here.
  *
  * Memory: the whole page set is held in memory (no streaming), same posture as
  * the importer.
@@ -295,6 +297,19 @@
  * real timeline - the probe's quoted sentinel was blank-padded, the one
  * spacing gbrain preserves, so those movements do not show above; they are
  * gbrain's, not this reader's.
+ *
+ * STATUS ADDENDUM, 2026-08-04, after the rebase onto the master that merged
+ * the importer (#3788): the short path above re-verified against the merged
+ * importer - the sample fixture round-trips deep-equal, zero stderr. The
+ * per-provider fan-out measured on a mixed directory (chatgpt + claude
+ * imports plus a native source-less page): three envelopes, every one
+ * schema-conforming; re-importing all three into the same directory left
+ * both id-carrying pages byte-identical and the native page untouched, plus
+ * the one documented duplicate a null id mints. The sentinel closure is
+ * canonical-path-invisible by construction: gbrain's serializer emits only
+ * `<!-- timeline -->` (measured 2026-08-03 against a real brain), so the
+ * decorated and bare-rule forms arrive only on hand-edited or legacy pages -
+ * which is where they were exporting a timeline as message text.
  *
  * Conformance in CI is checked by test/gbrain-to-envelope.test.ts, which
  * validates against the published envelope-v0 JSON Schema vendored

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -17,56 +17,115 @@
  *     directories are skipped.
  *   - Takes only pages whose frontmatter `type` is `conversation`. Everything
  *     else is skipped and counted on stderr.
- *   - Reads turns out of the body in the shape envelope-to-gbrain.mjs writes:
- *     `**Me** (<ts> · <message id>):` and `**Assistant** (...)`. A page whose
- *     body no longer carries those headers yields no messages and is skipped:
- *     envelope-v0 requires at least one message per conversation.
- *   - Fenced code blocks (``` or ~~~, up to three leading spaces) are not
- *     scanned for turn headers, timeline sentinels or the H1 - but a fence
- *     reaches only to the end of the turn it opened in. A fence still open at
- *     the next turn header, or at the end of the page, is read as ordinary text
- *     instead, with a warning naming the line it opened on. Both are the same
- *     trade: a fence must never be allowed to swallow the turns after it, and a
- *     spurious extra message is a far smaller failure than a turn deleted in
- *     silence. `**Me** (…):` written at column 0 inside a still-open fence is
- *     taken as the next turn only when the blank / `---` / blank separator this
- *     script's own importer writes between turns sits directly above it; that
- *     separator is the one signal on the page that tells a real boundary from a
- *     transcript pasted into a code block.
- *   - The body is cut at a gbrain timeline sentinel - a line that is exactly
- *     `<!-- timeline -->`, `<!--timeline-->` or `--- timeline ---` after
- *     trimming - so a page's timeline never becomes message text. Only a
- *     sentinel with no speaker turn after it is treated as a boundary; a line
- *     that merely quotes one, mid-sentence or above a later turn, is message
- *     text and is reported rather than cut at. The fourth form gbrain's own
- *     parser accepts (a bare `---` followed by `## Timeline`) is deliberately
- *     NOT recognized here, because `---` is also the separator this script's
- *     own importer writes between two turns.
- *   - Frontmatter is read line by line: top-level scalars only, in the plain,
- *     single-quoted, double-quoted (escapes decoded, including `\U` beyond the
- *     BMP), folded (`>`) and literal (`|`) block forms. Block chomping is
- *     honored: `-` strips the trailing newline, the default clips to one, `+`
- *     keeps them. Sequences, nested mappings and comments are ignored - none of
- *     the four keys this script reads (`type`, `title`, `source`,
- *     `memvelope_conversation_id`) is ever written as one - which is what keeps
- *     it free of a YAML dependency.
- *   - `title` falls back to the body's first H1 when frontmatter carries none,
- *     the same precedence gbrain's own parser uses (src/core/markdown.ts,
- *     inferTitleFromBody), and only then to `Untitled conversation`.
- *   - `title`, `source` and `memvelope_conversation_id` are trimmed, which
- *     matters only for a block scalar: its chomping indicator can leave a
- *     trailing newline on a value that never carried one.
  *
- * What survives the round trip envelope -> envelope-to-gbrain.mjs -> here. On
- * test/fixtures/memvelope/sample.mve.json the output is deep-equal to the
- * input, which covers:
- *   - conversation id and title
- *   - message id, role, timestamp and text, verbatim
+ * TWO PAGE SHAPES, TOLD APART BY THE `messages:` FRONTMATTER KEY.
+ *
+ * The importer writes per-message identity into frontmatter:
+ *
+ *   messages:
+ *     - id: "m1"
+ *       ts: "2025-11-02T14:22:51.000Z"
+ *
+ * and a body whose turn headers carry a speaker and a minute-resolution UTC
+ * wall clock, nothing else:
+ *
+ *   **Me** (2025-11-02 14:22):
+ *
+ * A page CARRYING the `messages:` key is read that way: `messages[i]` is the
+ * i-th turn of the body, so the id and the full RFC 3339 `ts` come from the
+ * array, and the body header supplies only the speaker and the text. A page
+ * WITHOUT the key is read the legacy way the pre-2026-08-02 importer wrote:
+ * `**Me** (<ts> · <message id>):`, identity parsed out of the header
+ * parenthetical. The legacy path is unchanged; everything it got right it
+ * still gets right, and everything prose could do to it - break a header with
+ * a newline id, miss a match over one trailing space, forge a boundary with a
+ * header-shaped line - it can still do. Those defects are CLOSED only on the
+ * recorded path, because identity moved somewhere message text cannot reach.
+ *
+ * HOW A RECORDED PAGE'S TURNS ARE FOUND. The positional join is only sound if
+ * the body anchors exactly as many turns as the array records, so boundaries
+ * are not taken on shape alone. For each recorded message the expected header
+ * clock is recomputed from its `ts` - the same derivation the importer used to
+ * write it (headerClock below is copied verbatim from envelope-to-gbrain.mjs;
+ * keep them in lockstep) - and a header-shaped line is a boundary ONLY when
+ * its clock equals the clock expected for the next unfilled position. A
+ * header-shaped line carrying any other clock is message text, reported on
+ * stderr and kept in place. So forging a boundary from prose requires
+ * predicting the next message's minute, not merely producing the shape - and
+ * a page whose body still does not anchor one turn per recorded message is
+ * SKIPPED, loudly, naming both numbers, rather than joined wrong.
+ *
+ * The recorded-path header is matched strictly - `**Me** (YYYY-MM-DD HH:MM):`
+ * or `**Assistant** (...)`, two-digit fields, one space, no text after the
+ * colon - with one tolerance: trailing spaces or tabs after the colon.
+ * gbrain's own `imessage-slack` pattern (the one these headers are written
+ * for) tolerates them too, and one trailing space added by an editor used to
+ * absorb the whole turn into its neighbour in silence.
+ *
+ * What a recorded page REFUSES loudly (skipped, counted, named on stderr)
+ * rather than guesses about:
+ *   - a `messages:` value this script cannot read back as an array of
+ *     `{id, ts}` items (anything but `[]`, or block items carrying both keys);
+ *   - a recorded id that is not a string under YAML core-schema reading
+ *     (`id: null`, an unquoted number or boolean, a flow collection).
+ *     envelope-v0 requires a string message id, and inventing one is exactly
+ *     the synthesis the spec forbids;
+ *   - `messages: []` - envelope-v0 requires at least one message;
+ *   - a body anchoring more or fewer turns than the array records.
+ *
+ * Fenced code blocks (``` or ~~~, up to three leading spaces) are not scanned
+ * for turn headers, timeline sentinels or the H1 - but a fence reaches only to
+ * the end of the turn it opened in. On the recorded path the signal that ends
+ * one is the same clock rule as everywhere else: a fence still open at a line
+ * whose header clock matches the next expected turn has provably swallowed a
+ * real boundary, so the fence loses - it is read as ordinary text, with a
+ * warning naming the line it opened on. The same demotion applies to a fence
+ * still open at the end of the page. Both are the same trade: a fence must
+ * never be allowed to swallow the turns after it, and a spurious stretch of
+ * ordinary text is a far smaller failure than a turn deleted in silence. On
+ * the legacy path the fence-versus-boundary signal is the blank / `---` /
+ * blank separator the old importer wrote between turns, as before.
+ *
+ * The body is cut at a gbrain timeline sentinel - a line that is exactly
+ * `<!-- timeline -->`, `<!--timeline-->` or `--- timeline ---` after
+ * trimming - so a page's timeline never becomes message text. Only a sentinel
+ * with no accepted turn after it is treated as a boundary; one with turns
+ * below it is message text and is reported rather than cut at. A sentinel
+ * standing alone on its line INSIDE the final message still cuts - from this
+ * side of the page it is indistinguishable from gbrain's real delimiter - and
+ * the cut is what the timeline note on stderr is counting. The fourth form
+ * gbrain's own parser accepts (a bare `---` followed by `## Timeline`) is
+ * deliberately NOT recognized here, because `---` is also the legacy
+ * turn separator.
+ *
+ * Frontmatter is read line by line: top-level scalars only, in the plain,
+ * single-quoted, double-quoted (escapes decoded, including `\U` beyond the
+ * BMP), folded (`>`) and literal (`|`) block forms - plus, alone among
+ * nested structures, the `messages:` block sequence described above. Items
+ * accept the importer's JSON-quoted scalars, the single-quoted / plain forms
+ * gbrain's js-yaml rewrite produces, `null`, and block scalars; member keys
+ * beyond `id` and `ts` are ignored so a future third field does not break the
+ * read; a quoted scalar that does not close on its own line is refused (js-yaml
+ * folds long values into block scalars rather than wrapping quotes, so that
+ * shape indicates a page this script does not understand).
+ *
+ * `title` falls back to the body's first H1 when frontmatter carries none,
+ * the same precedence gbrain's own parser uses (src/core/markdown.ts,
+ * inferTitleFromBody), and only then to `Untitled conversation`.
+ * `title`, `source` and `memvelope_conversation_id` are trimmed, which
+ * matters only for a block scalar: its chomping indicator can leave a
+ * trailing newline on a value that never carried one. Recorded ids and
+ * timestamps are NOT trimmed - they are the record, and the record is
+ * verbatim.
+ *
+ * What survives the round trip envelope -> envelope-to-gbrain.mjs -> here,
+ * measured on the recorded format (see STATUS for the corpus):
+ *   - conversation id and title, including a null id
+ *   - message id, role, timestamp and text, verbatim - including ids carrying
+ *     newlines, YAML syntax, or a whole frontmatter block, and timestamps at
+ *     full sub-second resolution with their original offsets
  *   - meta.source_provider
  *   - meta.conversation_count and meta.message_count, recomputed and equal
- * A probe envelope built to carry the cases the fixture does not adds:
- *   - a null conversation id, which stays null
- *   - a `---` rule inside a message, and a message that ends on one
  *
  * What does not survive. Each of these was measured on a probe envelope or a
  * probe page built to carry it, not assumed:
@@ -85,27 +144,29 @@
  *     listed first but dated last moves to the end.
  *   - Leading and trailing whitespace in message text, trimmed.
  *   - A message that is only whitespace. Dropped, with a warning, because
- *     envelope-v0 requires text of at least one character. meta.message_count
- *     follows what was written, so it drops too.
- *   - Anything before the first turn header except the `# Title` heading, which
- *     is read as the title fallback described above.
+ *     envelope-v0 requires text of at least one character. On the recorded
+ *     path its `{id, ts}` entry is dropped with it, so the join stays aligned.
+ *     meta.message_count follows what was written, so it drops too.
+ *   - Anything before the first turn header except the `# Title` heading,
+ *     which is read as the title fallback described above.
  *   - A gbrain timeline section. envelope-v0 has no field for it. Every page
  *     that carried one is counted on stderr.
- *   - Text that itself contains a line shaped like a turn header, OUTSIDE a
- *     fenced block. It still splits into two messages, and the second one's id
- *     comes from that line. Inside a fenced block that opens and closes within
- *     one turn it does not split, and the line is reported on stderr as having
- *     been read as sample text. The remaining ambiguity is a fenced block whose
- *     content itself carries the blank / `---` / blank turn separator: that
- *     does split, and is reported.
- *   - A turn timestamp that is not a strict RFC 3339 `date-time` - which is
- *     what the schema's `format: date-time` names, and what a header-shaped
- *     line lifted out of prose produces. Emitted as null, with a warning,
- *     rather than as a value that fails validation. That includes a second of
- *     60 anywhere but the instant a leap second is inserted; see
- *     asRfc3339DateTime below. The literal `no timestamp` the importer writes
- *     for an absent timestamp becomes null silently: that is the agreed
- *     spelling, not a loss.
+ *   - A recorded `ts` that is not a strict RFC 3339 `date-time` - which is
+ *     what the schema's `format: date-time` names. Emitted as null, with a
+ *     warning, rather than as a value that fails validation. That includes a
+ *     second of 60 anywhere but the instant a leap second is inserted; see
+ *     asRfc3339DateTime below. A recorded `ts: null` stays null, silently -
+ *     that is the agreed spelling of "the export had no timestamp", not a
+ *     loss. On the legacy path the same rule judges the header parenthetical,
+ *     and the literal `no timestamp` is the agreed null there.
+ *   - A message whose text contains a line that matches the next expected
+ *     header exactly - speaker shape and the very minute the following
+ *     message is recorded at. That line still splits the message, the real
+ *     header below it is then read as prose, and both halves land in the
+ *     wrong turn's text; ids and timestamps stay correct, nothing is deleted,
+ *     and the misread header is reported on stderr. This is the residue of
+ *     defect D2: the boundary signal is the recorded clock, so only text that
+ *     forges the right clock at the right position can still confuse it.
  *   - CRLF line endings, normalized to LF on read.
  *   - One source_provider per file. An envelope names a single provider, so a
  *     page set spanning several keeps the first in sorted path order and warns.
@@ -128,8 +189,7 @@
  *     -> expect "wrote 1 conversation(s), 4 message(s)"
  *   bun test test/gbrain-to-envelope.test.ts
  *
- * STATUS: verified against gbrain v0.42.72.1 on 2026-08-02. The sample fixture
- * round-trips through the importer and back deep-equal. Conformance in CI is
+ * STATUS: see the test file and findings for 2026-08-02. Conformance in CI is
  * checked by test/gbrain-to-envelope.test.ts, which validates against the
  * published envelope-v0 JSON Schema vendored byte-for-byte at
  * test/fixtures/memvelope/envelope-v0.schema.json (sha256
@@ -138,23 +198,7 @@
  * the memvelope package). The test walks those bytes with a draft-07 subset it
  * implements in full and refuses any keyword it does not, so a constraint added
  * upstream turns the suite red instead of going unchecked. No validator
- * dependency is added; the D4 and R4 regression tests guard both halves.
- *
- * The long path was re-run on 2026-08-02 after this file's turn parser was
- * rewritten a second time (the fence-per-turn fix below), against a throwaway
- * PGLite brain under a redirected HOME: envelope -> envelope-to-gbrain.mjs ->
- * `gbrain import` -> `gbrain export --dir` -> here. A two-conversation probe
- * carrying a 94-character title, an 85-character id, a message quoting
- * `<!-- timeline -->` mid-sentence, a 23:59:60Z leap second, three fences that
- * span a turn boundary and one balanced 4-backtick nest came back with all 8
- * messages, and every id, role, timestamp and message text identical to the
- * envelope it started from. The only field that moved is the documented one:
- * `updated_at`, which is taken from the last message. That path is what
- * produced three of the bugs this parser handles: `gbrain export --dir`
- * serializes frontmatter through js-yaml at the default lineWidth of 80, so a
- * title or id of 80-odd characters arrives as a folded block scalar (measured:
- * the first fold is at 80 characters of `key: value`), and the body is handed
- * back verbatim, quoted sentinel and all.
+ * dependency is added.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
@@ -271,6 +315,26 @@ function decodeDoubleQuoted(raw) {
   return out;
 }
 
+// A single-quoted scalar is complete when its closing quote is the last
+// character and every interior quote is one half of an escaped `''` pair.
+function isCompleteSingleQuoted(raw) {
+  if (raw.length < 2 || !raw.startsWith("'") || !raw.endsWith("'")) return false;
+  let i = 1;
+  while (i < raw.length) {
+    if (raw[i] !== "'") {
+      i += 1;
+      continue;
+    }
+    if (i === raw.length - 1) return true;
+    if (raw[i + 1] === "'") {
+      i += 2;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
 // A block scalar's content, given its already-dedented lines. Folded (`>`)
 // joins a paragraph's lines with a space and turns a blank line into a
 // newline; a more-indented line keeps its breaks. Literal (`|`) keeps every
@@ -300,12 +364,54 @@ function joinBlockScalar(contentLines, style, chomping, trailingBlanks) {
   return value === '' ? '' : `${value}\n`;
 }
 
+/** A block scalar header (`>-`, `|`, `>2-`, ...) or null. */
+function blockScalarHeader(raw) {
+  const block = /^([|>])([+-]?[0-9]?|[0-9][+-]?)$/.exec(raw);
+  if (!block) return null;
+  return {
+    style: block[1],
+    chomping: raw.includes('+') ? 'keep' : raw.includes('-') ? 'strip' : 'clip',
+    explicit: /[0-9]/.exec(raw),
+  };
+}
+
+/** Reads the indented block below `lines[headerIdx]` as a block scalar whose
+ *  owner key sits at indentation `ownerLead`. Returns the value and the index
+ *  of the first line after the block. */
+function readBlockScalar(lines, headerIdx, header, ownerLead) {
+  // A YAML indentation indicator is relative to the owner node; at the top
+  // level (ownerLead 0) that is the absolute column, matching the previous
+  // behavior of this parser exactly.
+  let indent = header.explicit ? ownerLead + Number(header.explicit[0]) : -1;
+  const collected = [];
+  let j = headerIdx + 1;
+  for (; j < lines.length; j += 1) {
+    if (lines[j].trim() === '') {
+      collected.push('');
+      continue;
+    }
+    const lead = lines[j].length - lines[j].trimStart().length;
+    if (lead <= ownerLead) break;
+    if (indent === -1) indent = lead;
+    if (lead < indent) break;
+    collected.push(lines[j].slice(indent));
+  }
+  let trailingBlanks = 0;
+  while (collected.length > 0 && collected[collected.length - 1] === '') {
+    collected.pop();
+    trailingBlanks += 1;
+  }
+  return { value: joinBlockScalar(collected, header.style, header.chomping, trailingBlanks), next: j };
+}
+
 // Top-level scalars only. gbrain writes these through js-yaml, which quotes
 // with single quotes, escapes with double quotes, and folds anything long into
 // a block scalar; the importer writes them through JSON.stringify, which quotes
 // with double quotes. All of those are read here, along with the unquoted form.
 // A line that is indented belongs to a nested value or to a block scalar's
-// content and is never read as a key.
+// content and is never read as a key. The one nested structure this script
+// understands - the `messages:` sequence - is read by parseMessagesRecord,
+// separately, over the same lines.
 function parseFrontmatter(lines) {
   const out = {};
   for (let i = 0; i < lines.length; i += 1) {
@@ -315,32 +421,11 @@ function parseFrontmatter(lines) {
     const raw = m[2].trim();
 
     // `key: >-`, `key: |`, `key: >2-`: the value is the indented block below.
-    const block = /^([|>])([+-]?[0-9]?|[0-9][+-]?)$/.exec(raw);
+    const block = blockScalarHeader(raw);
     if (block) {
-      const style = block[1];
-      const chomping = raw.includes('+') ? 'keep' : raw.includes('-') ? 'strip' : 'clip';
-      const explicit = /[0-9]/.exec(raw);
-      let indent = explicit ? Number(explicit[0]) : -1;
-      const collected = [];
-      let j = i + 1;
-      for (; j < lines.length; j += 1) {
-        if (lines[j].trim() === '') {
-          collected.push('');
-          continue;
-        }
-        const lead = lines[j].length - lines[j].trimStart().length;
-        if (lead === 0) break;
-        if (indent === -1) indent = lead;
-        if (lead < indent) break;
-        collected.push(lines[j].slice(indent));
-      }
-      let trailingBlanks = 0;
-      while (collected.length > 0 && collected[collected.length - 1] === '') {
-        collected.pop();
-        trailingBlanks += 1;
-      }
-      out[key] = joinBlockScalar(collected, style, chomping, trailingBlanks);
-      i = j - 1;
+      const scalar = readBlockScalar(lines, i, block, 0);
+      out[key] = scalar.value;
+      i = scalar.next - 1;
       continue;
     }
 
@@ -362,10 +447,183 @@ function parseFrontmatter(lines) {
   return out;
 }
 
-// The turn header the importer writes, matched one line at a time so a fenced
-// block can be excluded. The timestamp group is lazy so the first middle dot
-// separates it from the message id, which leaves an id free to contain one.
+// What a plain (unquoted) YAML scalar means under the core schema js-yaml
+// reads and writes: null, boolean and number forms are not strings. The
+// importer JSON-quotes every string it takes from an envelope and js-yaml
+// re-quotes any string that LOOKS like one of these on the way back out, so an
+// unquoted `id: 123` really is a number and refusing it is correct - reading
+// it as the string "123" would fabricate an id the record does not hold.
+// (`yes`, `no`, `on`, `off` are strings under the core schema, and stay
+// strings here.)
+const PLAIN_NON_STRING =
+  /^(true|false|True|False|TRUE|FALSE|[-+]?\d[\d_]*|0x[\dA-Fa-f]+|0o[0-7]+|[-+]?(\.\d+|\d[\d_]*(\.[\d_]*)?)([eE][-+]?\d+)?|[-+]?\.(inf|Inf|INF)|\.(nan|NaN|NAN))$/;
+
+/** Decodes one scalar value from a `messages:` item member line. Returns
+ *  `{ value }` (string or null) or `{ error }` when the raw text is not a
+ *  scalar this script can stand behind. */
+function decodeMemberScalar(raw) {
+  if (raw === '' || raw === 'null' || raw === '~' || raw === 'Null' || raw === 'NULL') return { value: null };
+  if (raw.startsWith('"')) {
+    if (isCompleteDoubleQuoted(raw)) return { value: decodeDoubleQuoted(raw) };
+    return { error: 'a double-quoted scalar that does not close on its own line' };
+  }
+  if (raw.startsWith("'")) {
+    if (isCompleteSingleQuoted(raw)) return { value: raw.slice(1, -1).replace(/''/g, "'") };
+    return { error: 'a single-quoted scalar that does not close on its own line' };
+  }
+  if (raw.startsWith('[') || raw.startsWith('{') || raw.startsWith('&') || raw.startsWith('*') || raw.startsWith('!')) {
+    return { error: `a value this script does not read (${JSON.stringify(raw)})` };
+  }
+  if (PLAIN_NON_STRING.test(raw)) return { value: { nonString: raw } };
+  return { value: raw };
+}
+
+/**
+ * The `messages:` record, read out of the frontmatter lines: the per-message
+ * identity the importer writes and gbrain's serializer rewrites (values and
+ * order intact, quoting style not - so this parser accepts both quotings and
+ * the block-scalar form js-yaml folds long values into).
+ *
+ * Returns `{ present: false }` when the page carries no `messages:` key - a
+ * page written before this format existed - `{ present: true, items }` when
+ * the record reads cleanly, and `{ present: true, error }` when the key is
+ * there but this script cannot stand behind what it read. The error case must
+ * never fall back to the legacy path: a page that declares a record it cannot
+ * deliver is not a legacy page, it is an unreadable one.
+ */
+function parseMessagesRecord(lines) {
+  let at = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^messages: ?/.test(lines[i]) || lines[i] === 'messages:') {
+      if (at !== -1) return { present: true, error: 'the messages key appears twice' };
+      at = i;
+    }
+  }
+  if (at === -1) return { present: false };
+
+  const inline = (/^messages: ?(.*)$/.exec(lines[at]))[1].trim();
+  if (inline === '[]') return { present: true, items: [] };
+  if (inline !== '') return { present: true, error: `an inline value this script does not read (${JSON.stringify(inline)})` };
+
+  const items = [];
+  let itemLead = -1;
+  let current = null;
+  let i = at + 1;
+  for (; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const lead = line.length - line.trimStart().length;
+    // A new top-level key ends the sequence.
+    if (lead === 0) break;
+
+    const item = /^(\s+)- (.*)$/.exec(line);
+    if (item && (itemLead === -1 || item[1].length === itemLead)) {
+      if (itemLead === -1) itemLead = item[1].length;
+      current = {};
+      items.push(current);
+      const first = readMember(item[2].trim(), itemLead + 2);
+      if (first.error) return { present: true, error: first.error };
+      continue;
+    }
+    if (current === null) return { present: true, error: `a line before the first item (${JSON.stringify(line)})` };
+    if (lead <= itemLead) return { present: true, error: `an indentation this script does not read (${JSON.stringify(line)})` };
+    const member = readMember(line.trim(), lead);
+    if (member.error) return { present: true, error: member.error };
+  }
+
+  // One member line, already trimmed, belonging to `current`. `memberLead` is
+  // the column its key starts at, needed when its value is a block scalar.
+  function readMember(text, memberLead) {
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(text);
+    if (!m) return { error: `an item line that is not a key: value pair (${JSON.stringify(text)})` };
+    const key = m[1];
+    const raw = m[2].trim();
+    if (key !== 'id' && key !== 'ts') {
+      // A future third field. Skip its value, block scalar and all.
+      const block = blockScalarHeader(raw);
+      if (block) i = readBlockScalar(lines, i, block, memberLead).next - 1;
+      return {};
+    }
+    if (key in current) return { error: `the ${key} key appears twice in one item` };
+    const block = blockScalarHeader(raw);
+    if (block) {
+      const scalar = readBlockScalar(lines, i, block, memberLead);
+      current[key] = scalar.value;
+      i = scalar.next - 1;
+      return {};
+    }
+    const decoded = decodeMemberScalar(raw);
+    if (decoded.error) return { error: `${key}: ${decoded.error}` };
+    current[key] = decoded.value;
+    return {};
+  }
+
+  for (const [n, item] of items.entries()) {
+    if (!('id' in item) || !('ts' in item)) {
+      return { present: true, error: `item ${n + 1} does not carry both id and ts` };
+    }
+  }
+  return { present: true, items };
+}
+
+// ---------------------------------------------------------------------------
+// The header-clock derivation, copied VERBATIM from envelope-to-gbrain.mjs so
+// the expected clock recomputed here is the clock the importer wrote. If one
+// of these functions changes, change both files - the round-trip tests fail
+// loudly (a clock mismatch skips the page) if they drift.
+// ---------------------------------------------------------------------------
+
+/** The date a turn header is allowed to carry: exactly `YYYY-MM-DD`. */
+const HEADER_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** What `deriveDateContext()` in gbrain's conversation parser falls back to when
+ *  a page carries no date at all. */
+const EPOCH_DATE = '1970-01-01';
+
+/** The RFC 3339 shapes the importer will read a wall clock out of.
+ *  Groups: 1=Y 2=M 3=D 4=hh 5=mm, then an optional offset 6=sign 7=hh 8=mm. */
+const TS_SHAPE =
+  /^(\d{4})-(\d{2})-(\d{2})[Tt ](\d{2}):(\d{2})(?::\d{2}(?:\.\d+)?)?(?:[Zz]|([+-])(\d{2}):?(\d{2}))?$/;
+
+/**
+ * The `YYYY-MM-DD HH:MM` a turn header carries, or null when the message's `ts`
+ * cannot supply one. 24-hour, and UTC - see envelope-to-gbrain.mjs for the
+ * full reasoning; this copy exists so the expected boundary clock is derived
+ * from the recorded `ts` by the exact function that wrote it.
+ */
+function headerClock(ts) {
+  if (typeof ts !== 'string') return null;
+  const m = TS_SHAPE.exec(ts.trim());
+  if (m === null) return null;
+  const [, year, month, day, hour, minute, sign, offsetHour, offsetMinute] = m;
+  const [y, mo, d, h, mi] = [year, month, day, hour, minute].map(Number);
+  if (h > 23 || mi > 59) return null;
+  const utc = new Date(0);
+  utc.setUTCFullYear(y, mo - 1, d);
+  utc.setUTCHours(h, mi, 0, 0);
+  if (utc.getUTCFullYear() !== y || utc.getUTCMonth() !== mo - 1 || utc.getUTCDate() !== d) {
+    return null;
+  }
+  if (sign === undefined) return `${year}-${month}-${day} ${hour}:${minute}`;
+  const [oh, om] = [offsetHour, offsetMinute].map(Number);
+  if (oh > 23 || om > 59) return null;
+  utc.setUTCMinutes(utc.getUTCMinutes() - (oh * 60 + om) * (sign === '-' ? -1 : 1));
+  const pad = (n, width = 2) => String(n).padStart(width, '0');
+  return `${pad(utc.getUTCFullYear(), 4)}-${pad(utc.getUTCMonth() + 1)}-${pad(utc.getUTCDate())} ${pad(utc.getUTCHours())}:${pad(utc.getUTCMinutes())}`;
+}
+
+// ---------------------------------------------------------------------------
+// Body reading - shared pieces.
+// ---------------------------------------------------------------------------
+
+// The legacy turn header, matched one line at a time so a fenced block can be
+// excluded. The timestamp group is lazy so the first middle dot separates it
+// from the message id, which leaves an id free to contain one.
 const TURN_HEADER = /^\*\*(Me|Assistant)\*\* \((.*?) · (.*)\):$/;
+// The recorded-format turn header: speaker and minute-resolution clock, no
+// identity. Strict except for trailing whitespace, which gbrain's own
+// `imessage-slack` pattern also tolerates - and which used to absorb a turn.
+const RECORDED_HEADER = /^\*\*(Me|Assistant)\*\* \((\d{4}-\d{2}-\d{2} \d{2}:\d{2})\):[ \t]*$/;
 // A whole line, after trimming - never a substring. A message that quotes the
 // sentinel mid-sentence is prose, and cutting there destroys every later turn.
 const TIMELINE_SENTINELS = new Set(['<!-- timeline -->', '<!--timeline-->', '--- timeline ---']);
@@ -417,11 +675,11 @@ function asRfc3339DateTime(value) {
 
 const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
 
-// The separator envelope-to-gbrain.mjs writes between two turns: a blank line,
-// a `---` rule, a blank line. It is the one structural signal on the page that
-// separates a real turn boundary from a transcript pasted into a code block,
-// and it decides the only case fence state cannot decide on its own - a
-// header-shaped line reached while a fence is open.
+// The separator the LEGACY importer wrote between two turns: a blank line, a
+// `---` rule, a blank line. On the legacy path it is the one structural signal
+// on the page that separates a real turn boundary from a transcript pasted
+// into a code block, and it decides the only case fence state cannot decide on
+// its own - a header-shaped line reached while a fence is open.
 function precededByTurnSeparator(lines, i) {
   return i >= 3
     && lines[i - 1].trim() === ''
@@ -488,6 +746,59 @@ function scanFencesAndHeaders(lines, warn) {
   }
 }
 
+// The recorded-path twin of scanPass. Boundaries are accepted by position:
+// a header-shaped line is boundary k only when its clock is the one expected
+// for position k. The same rule is the fence-demotion signal - a fence still
+// open at a line carrying the next expected clock has swallowed a real
+// boundary, so the fence loses.
+function scanRecordedPass(lines, expected, disabled) {
+  const fenced = new Array(lines.length).fill(false);
+  const boundaries = [];
+  const proseHeaders = [];
+  const quotedHeaders = [];
+  let open = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const fence = FENCE_LINE.exec(lines[i]);
+    if (open === null) {
+      const header = RECORDED_HEADER.exec(lines[i]);
+      if (header) {
+        if (boundaries.length < expected.length && header[2] === expected[boundaries.length]) {
+          boundaries.push({ line: i, speaker: header[1] });
+        } else {
+          proseHeaders.push(i);
+        }
+        continue;
+      }
+      if (fence && !disabled.has(i) && !(fence[1][0] === '`' && fence[2].includes('`'))) {
+        open = { char: fence[1][0], len: fence[1].length, at: i };
+        fenced[i] = true;
+      }
+      continue;
+    }
+    const header = RECORDED_HEADER.exec(lines[i]);
+    if (header && boundaries.length < expected.length && header[2] === expected[boundaries.length]) {
+      return { reopen: { at: open.at, spanningAt: i } };
+    }
+    if (header) quotedHeaders.push(i);
+    fenced[i] = true;
+    if (fence && fence[1][0] === open.char && fence[1].length >= open.len && fence[2].trim() === '') open = null;
+  }
+  if (open !== null) return { reopen: { at: open.at, spanningAt: -1 } };
+  return { reopen: null, fenced, boundaries, proseHeaders, quotedHeaders };
+}
+
+function scanRecordedFences(lines, expected, warn) {
+  const disabled = new Set();
+  for (;;) {
+    const pass = scanRecordedPass(lines, expected, disabled);
+    if (pass.reopen === null) return pass;
+    disabled.add(pass.reopen.at);
+    warn(pass.reopen.spanningAt === -1
+      ? `an unclosed code fence opens at body line ${pass.reopen.at + 1}; read as ordinary text so the turns after it are not lost.`
+      : `the code fence opened at body line ${pass.reopen.at + 1} is still open at the turn header on body line ${pass.reopen.spanningAt + 1}; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
+  }
+}
+
 // gbrain's own title precedence, minus the filename fallback this script must
 // not use: frontmatter `title:` first, then the body's first H1.
 function titleFromBody(lines, fenced) {
@@ -497,6 +808,49 @@ function titleFromBody(lines, fenced) {
     if (m) return m[1].replace(/\s+#+\s*$/, '').trim();
   }
   return '';
+}
+
+// The timeline cut and the slice-into-messages step, shared by both paths.
+// `anchors` carries each accepted boundary's line; `build` turns a boundary and
+// its raw text into a message or null (null = dropped, already warned).
+function cutAndSlice(lines, anchors, fenced, warn, stripLegacySeparator, build) {
+  const sentinels = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (fenced[i]) continue;
+    if (TIMELINE_SENTINELS.has(lines[i].trim())) sentinels.push(i);
+  }
+
+  // Cut only at a sentinel that no accepted turn follows. gbrain writes the
+  // timeline after the whole body, so a sentinel with turns below it is a
+  // message quoting the marker - the case that used to destroy every later
+  // turn in silence.
+  const lastAnchor = anchors.length > 0 ? anchors[anchors.length - 1].line : -1;
+  let cut = lines.length;
+  let hasTimeline = false;
+  for (const at of sentinels) {
+    if (at > lastAnchor) {
+      cut = at;
+      hasTimeline = true;
+      break;
+    }
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} has speaker turns after it, so it is message text and not a timeline boundary; the body was not cut there.`);
+  }
+
+  const messages = [];
+  for (const [i, anchor] of anchors.entries()) {
+    const hasNext = i + 1 < anchors.length;
+    const end = hasNext ? anchors[i + 1].line : cut;
+    let raw = lines.slice(anchor.line + 1, end).join('\n');
+    if (hasNext && stripLegacySeparator) {
+      // Between two turns the legacy importer wrote exactly one `---`
+      // separator line. Strip that one occurrence, never a `---` the message
+      // itself ended with after the last turn.
+      raw = `${raw}\n`.replace(/\n\n---\n\n$/, '');
+    }
+    const message = build(anchor, i, raw.trim());
+    if (message !== null) messages.push(message);
+  }
+  return { messages, hasTimeline };
 }
 
 function readPageBody(body, warn) {
@@ -509,52 +863,17 @@ function readPageBody(body, warn) {
     warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} sits inside a fenced code block, so it was read as sample text and not as a turn.`);
   }
 
-  const sentinels = [];
-  for (let i = 0; i < lines.length; i += 1) {
-    if (fenced[i]) continue;
-    if (TIMELINE_SENTINELS.has(lines[i].trim())) sentinels.push(i);
-  }
-
-  // Cut only at a sentinel that no speaker turn follows. gbrain writes the
-  // timeline after the whole body, so a sentinel with turns below it is a
-  // message quoting the marker - the case that used to destroy every later
-  // turn in silence.
-  const lastHeader = headers.length > 0 ? headers[headers.length - 1].line : -1;
-  let cut = lines.length;
-  let hasTimeline = false;
-  for (const at of sentinels) {
-    if (at > lastHeader) {
-      cut = at;
-      hasTimeline = true;
-      break;
-    }
-    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} has speaker turns after it, so it is message text and not a timeline boundary; the body was not cut there.`);
-  }
-
-  const messages = [];
   let droppedEmpty = 0;
   let nulledTimestamps = 0;
-  for (const [i, header] of headers.entries()) {
-    const hasNext = i + 1 < headers.length;
-    const end = hasNext ? headers[i + 1].line : cut;
-    // Rebuild the exact slice between two headers, trailing newline included,
-    // so the separator strip below sees what the importer wrote.
-    let raw = lines.slice(header.line + 1, end).join('\n');
-    if (hasNext) {
-      // Between two turns the importer writes exactly one `---` separator line.
-      // Strip that one occurrence, never a `---` the message itself ended with
-      // after the last turn.
-      raw = `${raw}\n`.replace(/\n\n---\n\n$/, '');
-    }
+  const { messages, hasTimeline } = cutAndSlice(lines, headers, fenced, warn, true, (header, _i, text) => {
     const id = header.match[3];
-    const text = raw.trim();
     if (text === '') {
       droppedEmpty += 1;
       warn(`message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
-      continue;
+      return null;
     }
-    // The importer writes the literal `no timestamp` when the envelope had
-    // none. Read it back as the null the schema asks for, not as prose.
+    // The legacy importer wrote the literal `no timestamp` when the envelope
+    // had none. Read it back as the null the schema asks for, not as prose.
     let ts = null;
     if (header.match[2] !== NO_TIMESTAMP) {
       ts = asRfc3339DateTime(header.match[2]);
@@ -563,10 +882,63 @@ function readPageBody(body, warn) {
         warn(`message ${JSON.stringify(id)} carries ${JSON.stringify(header.match[2])} where a turn header's timestamp goes; it is not an RFC 3339 date-time, so ts was written as null.`);
       }
     }
-    messages.push({ id, role: header.match[1] === 'Me' ? 'user' : 'assistant', ts, text });
-  }
+    return { id, role: header.match[1] === 'Me' ? 'user' : 'assistant', ts, text };
+  });
 
   return { messages, title: titleFromBody(lines, fenced), hasTimeline, droppedEmpty, nulledTimestamps };
+}
+
+/**
+ * The recorded path: identity from the frontmatter record, speaker and text
+ * from the body. Returns `{ mismatch, anchored }` when the body does not
+ * anchor exactly one turn per recorded message - the caller skips the page
+ * loudly; a positional join over the wrong count assigns real ids to the
+ * wrong text, which is worse than refusing.
+ */
+function readRecordedBody(body, record, pageDate, warn) {
+  const lines = body.split('\n');
+  // The clock the importer wrote for each recorded message: derived from its
+  // `ts` where one is usable, else the page-date fallback the importer used.
+  const expected = record.map((r) => {
+    const clock = headerClock(r.ts);
+    return clock === null ? `${pageDate} 00:00` : clock;
+  });
+  const { fenced, boundaries, proseHeaders, quotedHeaders } = scanRecordedFences(lines, expected, warn);
+
+  for (const at of quotedHeaders) {
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} sits inside a fenced code block, so it was read as sample text and not as a turn.`);
+  }
+  for (const at of proseHeaders) {
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} is shaped like a turn header but does not carry the clock the messages record expects next, so it was read as prose.`);
+  }
+
+  if (boundaries.length !== record.length) {
+    return { mismatch: true, anchored: boundaries.length };
+  }
+
+  let droppedEmpty = 0;
+  let nulledTimestamps = 0;
+  const { messages, hasTimeline } = cutAndSlice(lines, boundaries, fenced, warn, false, (anchor, i, text) => {
+    const { id, ts } = record[i];
+    if (text === '') {
+      // The `{id, ts}` entry is dropped with its turn, so the join between the
+      // remaining turns and their entries stays aligned.
+      droppedEmpty += 1;
+      warn(`message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
+      return null;
+    }
+    let outTs = null;
+    if (ts !== null) {
+      outTs = asRfc3339DateTime(ts);
+      if (outTs === null) {
+        nulledTimestamps += 1;
+        warn(`message ${JSON.stringify(id)} records ${JSON.stringify(ts)} as its timestamp; it is not an RFC 3339 date-time, so ts was written as null.`);
+      }
+    }
+    return { id, role: anchor.speaker === 'Me' ? 'user' : 'assistant', ts: outTs, text };
+  });
+
+  return { mismatch: false, messages, title: titleFromBody(lines, fenced), hasTimeline, droppedEmpty, nulledTimestamps };
 }
 
 const files = markdownFiles(pagesDir);
@@ -576,6 +948,8 @@ const seenIds = new Set();
 let skippedNotConversation = 0;
 let skippedNoFrontmatter = 0;
 let skippedNoMessages = 0;
+let skippedUnreadableRecord = 0;
+let skippedJoinMismatch = 0;
 let droppedEmptyMessages = 0;
 let droppedTimelines = 0;
 let nulledTimestamps = 0;
@@ -597,7 +971,46 @@ for (const file of files) {
     continue;
   }
   const warn = (message) => console.warn(`warning: ${file} - ${message}`);
-  const read = readPageBody(page.body, warn);
+
+  let read;
+  const record = parseMessagesRecord(page.front);
+  if (record.present) {
+    if (record.error) {
+      skippedUnreadableRecord += 1;
+      warn(`the messages record could not be read (${record.error}); skipped rather than joined wrong.`);
+      continue;
+    }
+    if (record.items.length === 0) {
+      skippedNoMessages += 1;
+      warn('the messages record is empty; skipped (envelope-v0 requires at least one message per conversation).');
+      continue;
+    }
+    const badId = record.items.findIndex((item) => typeof item.id !== 'string');
+    if (badId !== -1) {
+      skippedUnreadableRecord += 1;
+      const shown = record.items[badId].id === null ? 'null' : JSON.stringify(record.items[badId].id.nonString);
+      warn(`messages[${badId}] records ${shown} where its id goes; envelope-v0 requires a string message id and inventing one is the synthesis the spec forbids, so the page was skipped.`);
+      continue;
+    }
+    // A non-string `ts` (an unquoted number, say) is what the importer writes
+    // for a non-conforming envelope; it is not a clock the header could have
+    // been derived from, so it takes the fallback-clock path and comes back
+    // null like every other unusable timestamp.
+    const items = record.items.map((item) => ({
+      id: item.id,
+      ts: typeof item.ts === 'string' || item.ts === null ? item.ts : item.ts.nonString,
+    }));
+    const pageDate = typeof front.date === 'string' && HEADER_DATE.test(front.date) ? front.date : EPOCH_DATE;
+    read = readRecordedBody(page.body, items, pageDate, warn);
+    if (read.mismatch) {
+      skippedJoinMismatch += 1;
+      warn(`the frontmatter records ${record.items.length} message(s) but the body anchors ${read.anchored} turn(s); a positional join over unequal counts would assign identity to the wrong text, so the page was skipped.`);
+      continue;
+    }
+  } else {
+    read = readPageBody(page.body, warn);
+  }
+
   droppedEmptyMessages += read.droppedEmpty;
   nulledTimestamps += read.nulledTimestamps;
   if (read.hasTimeline) droppedTimelines += 1;
@@ -662,8 +1075,8 @@ writeFileSync(outPath, JSON.stringify(envelope, null, 2) + '\n');
 console.log(`wrote ${conversations.length} conversation(s), ${messageCount} message(s) to ${outPath}`);
 // Every page that did not become a conversation is accounted for on stderr, so
 // a mistargeted directory reads as a diagnosis rather than an empty file.
-if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || droppedEmptyMessages) {
-  console.warn(`scanned ${files.length} markdown file(s): ${skippedNoFrontmatter} without frontmatter, ${skippedNotConversation} not type conversation, ${skippedNoMessages} without speaker turns, ${droppedEmptyMessages} empty message(s) dropped.`);
+if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || skippedUnreadableRecord || skippedJoinMismatch || droppedEmptyMessages) {
+  console.warn(`scanned ${files.length} markdown file(s): ${skippedNoFrontmatter} without frontmatter, ${skippedNotConversation} not type conversation, ${skippedNoMessages} without speaker turns, ${skippedUnreadableRecord} with a messages record that could not be read, ${skippedJoinMismatch} whose body does not match their messages record, ${droppedEmptyMessages} empty message(s) dropped.`);
 }
 // Two losses that leave the output conforming and would otherwise be invisible.
 if (droppedTimelines) {

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -8,6 +8,11 @@
  * Usage:
  *   node scripts/gbrain-to-envelope.mjs <pagesDir> [out.mve.json]
  *
+ *   A single-provider page set writes [out.mve.json] itself. A set spanning
+ *   several providers writes one envelope per provider beside it
+ *   (out.chatgpt.mve.json, out.claude.mve.json, ...), each named on stdout
+ *   with its own counts; see the source_provider notes below.
+ *
  * Zero dependencies. Deterministic. No network. It does NOT call gbrain - it
  * only reads Markdown files. Point it at a `gbrain export --dir` output tree, at
  * a brain repo, or at the directory envelope-to-gbrain.mjs wrote.
@@ -163,7 +168,8 @@
  *   - message id, role, timestamp and text, verbatim - including ids carrying
  *     newlines, YAML syntax, or a whole frontmatter block, and timestamps at
  *     full sub-second resolution with their original offsets
- *   - meta.source_provider
+ *   - meta.source_provider, per envelope: every conversation travels in the
+ *     envelope of its own page's `source:`
  *   - meta.conversation_count and meta.message_count, recomputed and equal
  *
  * What does not survive. Each of these was measured on a probe envelope or a
@@ -222,17 +228,39 @@
  *     current header's own clock, and a null-or-unusable `ts` makes it the
  *     page date at 00:00 - visible on the page itself.
  *   - CRLF line endings, normalized to LF on read.
- *   - One source_provider per file. An envelope names a single provider, so a
- *     page set spanning several keeps the first in sorted path order and warns.
  *
  * A page with no `memvelope_conversation_id` emits `id: null` rather than a
  * synthesized id. envelope-v0 permits null there and tells converters not to
  * invent one.
  *
- * `meta.source_provider` is required by envelope-v0 and cannot be omitted, so a
- * page set where no page carries a `source:` key falls back to the literal
- * `unknown` - which no provider registry defines - and says so on stderr,
- * naming the token it wrote.
+ * `meta.source_provider` names ONE provider for a whole envelope, so a page
+ * set spanning several is written as one envelope per provider - a mixed
+ * directory cannot be described by one file without falsifying someone's
+ * `source:`. (This script used to keep the first provider in sorted path
+ * order for everyone; re-importing that envelope stamped the winner onto
+ * every losing page's `source:` at exit 0, and envelope-v0 carries no
+ * per-conversation provider field that could keep the truth.) The filename
+ * token is the provider with everything outside [A-Za-z0-9._-] replaced by
+ * `-`, deduplicated case-insensitively, so a hostile `source:` cannot steer
+ * the write and case-only twins still get two files. A single-provider set is
+ * unchanged: one file, at the path asked for.
+ *
+ * Pages carrying no `source:` key are their own group, never folded into a
+ * named provider's envelope - absence of evidence is not membership, and the
+ * fold would stamp the neighbour's provider onto them at re-import, the same
+ * falsification through absence rather than collision. They ride under the
+ * literal `unknown` - required because meta.source_provider cannot be
+ * omitted, defined by no provider registry - warned on stderr naming the
+ * token, in `out.unknown.mve.json` when named providers are present or at
+ * the asked-for path when nothing in the set names one. The round trip back
+ * through envelope-to-gbrain.mjs is clean in both directions: each envelope
+ * re-imports into the very directory it came from, because check 2 matches
+ * per-conversation ids and refreshes each page in place, byte-identical. The
+ * one residue sits on the placeholder: re-importing the `unknown` envelope
+ * stamps the literal `source: "unknown"` onto pages that had no key - the
+ * importer writes `source:` unconditionally on every page - which is the
+ * placeholder saying exactly what is known, not a named provider claiming
+ * pages that never claimed it.
  *
  * Memory: the whole page set is held in memory (no streaming), same posture as
  * the importer.
@@ -1258,8 +1286,11 @@ function readRecordedBody(body, record, pageDate, warn) {
 }
 
 const files = markdownFiles(pagesDir);
-const conversations = [];
-const providers = [];
+// provider (the page's trimmed `source:`, or null when it carries none) ->
+// { conversations, messageCount }. Insertion order is first appearance in
+// sorted path order - what the old "first provider" collapse meant by first;
+// the difference is that nobody wins anymore.
+const groups = new Map();
 const seenIds = new Set();
 let skippedNotConversation = 0;
 let skippedNoFrontmatter = 0;
@@ -1270,7 +1301,6 @@ let skippedJoinMismatch = 0;
 let droppedEmptyMessages = 0;
 let droppedTimelines = 0;
 let nulledTimestamps = 0;
-let messageCount = 0;
 
 for (const file of files) {
   // Normalize to LF up front. Every match below is line-anchored, so a page
@@ -1343,7 +1373,7 @@ for (const file of files) {
     warn('no speaker turns found; skipped (envelope-v0 requires at least one message per conversation).');
     continue;
   }
-  if (typeof front.source === 'string' && front.source.trim() !== '') providers.push(front.source.trim());
+  const provider = typeof front.source === 'string' && front.source.trim() !== '' ? front.source.trim() : null;
   // Never synthesize. An absent id is null, which the schema permits and the
   // spec requires of converters.
   // VERBATIM, not trimmed. The importer records the id verbatim precisely so
@@ -1365,7 +1395,12 @@ for (const file of files) {
   // title that js-yaml folded into a block scalar has a second way home.
   const title = (typeof front.title === 'string' && front.title.trim() !== '' ? front.title.trim() : read.title)
     || 'Untitled conversation';
-  conversations.push({
+  let group = groups.get(provider);
+  if (group === undefined) {
+    group = { conversations: [], messageCount: 0 };
+    groups.set(provider, group);
+  }
+  group.conversations.push({
     id,
     title,
     // The page's `date` is a day, not a date-time, so it cannot fill these.
@@ -1374,37 +1409,86 @@ for (const file of files) {
     updated_at: read.messages[read.messages.length - 1].ts,
     messages: read.messages,
   });
-  messageCount += read.messages.length;
+  group.messageCount += read.messages.length;
 }
 
-const distinctProviders = [...new Set(providers)];
-if (distinctProviders.length > 1) {
-  console.warn(`warning: pages name ${distinctProviders.length} source providers (${distinctProviders.join(', ')}); an envelope carries one. Using ${JSON.stringify(distinctProviders[0])}.`);
-}
-// envelope-v0 requires meta.source_provider, so it cannot be omitted the way
-// meta.source_export_date is. Minting a token no registry defines is a guess,
-// and a guess gets reported like every other lossy edge in this script.
-if (distinctProviders.length === 0) {
-  // Two different situations, two true statements: pages with no source: key
-  // at all, versus sourced pages that were all skipped before they could
-  // contribute one - telling the second audience to "set source:" would be
-  // advice about a key they already set.
-  console.warn(sawSourceKey
-    ? `warning: every page carrying a \`source:\` key was skipped before it could contribute one, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Fix the skipped pages to name the real provider.`
-    : `warning: no page carries a \`source:\` key, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
-}
-const envelope = {
-  memvelope: 'envelope-v0',
-  meta: {
-    source_provider: distinctProviders[0] || FALLBACK_PROVIDER,
-    conversation_count: conversations.length,
-    message_count: messageCount,
-  },
-  conversations,
-};
+// One envelope per provider. meta.source_provider names ONE provider for a
+// whole envelope, so a mixed directory cannot be described by one file without
+// falsifying someone's `source:` - the old collapse-to-first did exactly that,
+// and re-importing the collapsed envelope stamped the winner onto every losing
+// page at exit 0, with nothing on disk retaining the truth. Pages with no
+// `source:` at all are their own group under the placeholder: absence of
+// evidence is not membership in whichever provider the directory also holds,
+// and folding them in would be the same falsification arriving through
+// absence rather than collision.
+const named = [...groups.keys()].filter((p) => p !== null);
 
-writeFileSync(outPath, JSON.stringify(envelope, null, 2) + '\n');
-console.log(`wrote ${conversations.length} conversation(s), ${messageCount} message(s) to ${outPath}`);
+function envelopeFor(provider, group) {
+  return {
+    memvelope: 'envelope-v0',
+    meta: {
+      source_provider: provider ?? FALLBACK_PROVIDER,
+      conversation_count: group.conversations.length,
+      message_count: group.messageCount,
+    },
+    conversations: group.conversations,
+  };
+}
+
+// `out.mve.json` -> `out.<token>.mve.json`, keeping whichever json suffix the
+// operator chose. The token is the provider with everything outside
+// [A-Za-z0-9._-] replaced by `-`, so a hostile `source:` cannot steer the
+// write out of the output directory, then deduplicated case-insensitively so
+// providers differing only by case still get two files on the
+// case-insensitive filesystems macOS ships - and the same two names
+// everywhere else.
+function providerOutPath(basePath, token) {
+  const mve = /^(.*)\.mve\.json$/.exec(basePath);
+  if (mve) return `${mve[1]}.${token}.mve.json`;
+  const json = /^(.*)\.json$/.exec(basePath);
+  if (json) return `${json[1]}.${token}.json`;
+  return `${basePath}.${token}`;
+}
+
+if (groups.size <= 1) {
+  // A single-provider page set (or an empty one): one file, the same name and
+  // the same words as before the fan-out existed.
+  const provider = named[0] ?? null;
+  const group = groups.get(provider) ?? { conversations: [], messageCount: 0 };
+  // envelope-v0 requires meta.source_provider, so it cannot be omitted the way
+  // meta.source_export_date is. Minting a token no registry defines is a
+  // guess, and a guess gets reported like every other lossy edge here.
+  if (provider === null) {
+    // Two different situations, two true statements: pages with no source: key
+    // at all, versus sourced pages that were all skipped before they could
+    // contribute one - telling the second audience to "set source:" would be
+    // advice about a key they already set.
+    console.warn(sawSourceKey
+      ? `warning: every page carrying a \`source:\` key was skipped before it could contribute one, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Fix the skipped pages to name the real provider.`
+      : `warning: no page carries a \`source:\` key, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
+  }
+  writeFileSync(outPath, JSON.stringify(envelopeFor(provider, group), null, 2) + '\n');
+  console.log(`wrote ${group.conversations.length} conversation(s), ${group.messageCount} message(s) to ${outPath}`);
+} else {
+  if (named.length > 1) {
+    console.warn(`note: pages name ${named.length} source providers (${named.join(', ')}); wrote one envelope per provider.`);
+  }
+  const usedTokens = new Set();
+  const ordered = groups.has(null) ? [...named, null] : named;
+  for (const provider of ordered) {
+    const group = groups.get(provider);
+    const base = (provider ?? FALLBACK_PROVIDER).replace(/[^A-Za-z0-9._-]/g, '-');
+    let token = base;
+    for (let n = 2; usedTokens.has(token.toLowerCase()); n += 1) token = `${base}-${n}`;
+    usedTokens.add(token.toLowerCase());
+    const file = providerOutPath(outPath, token);
+    if (provider === null) {
+      console.warn(`warning: ${group.conversations.length} page(s) carry no \`source:\` key; their conversation(s) were written to ${file} with the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
+    }
+    writeFileSync(file, JSON.stringify(envelopeFor(provider, group), null, 2) + '\n');
+    console.log(`wrote ${group.conversations.length} conversation(s), ${group.messageCount} message(s) to ${file} (provider ${JSON.stringify(provider ?? FALLBACK_PROVIDER)})`);
+  }
+}
 // Every page that did not become a conversation is accounted for on stderr, so
 // a mistargeted directory reads as a diagnosis rather than an empty file.
 if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || skippedUnreadableRecord || skippedJoinMismatch || droppedEmptyMessages) {

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -84,7 +84,17 @@
  * never be allowed to swallow the turns after it, and a spurious stretch of
  * ordinary text is a far smaller failure than a turn deleted in silence. On
  * the legacy path the fence-versus-boundary signal is the blank / `---` /
- * blank separator the old importer wrote between turns, as before.
+ * blank separator the old importer wrote between turns, as before - and note
+ * the demotion's reach, which an earlier revision of this header overstated:
+ * the separator decides only WHETHER a spanning fence loses. Once it has
+ * lost, every header-shaped line it had covered is read as an ordinary turn
+ * header, separator above it or not, so a header-shaped line quoted inside
+ * the demoted stretch does become a turn. (Measured: a fence spanning one
+ * separator-preceded header with a separatorless header-shaped line above it
+ * yields three messages, the middle one lifted from the quoted line, with the
+ * demotion warned on stderr.) On the recorded path the same demotion is
+ * narrower: an exposed line still becomes a boundary only by carrying the
+ * next expected clock.
  *
  * The body is cut at a gbrain timeline sentinel - a line that is exactly
  * `<!-- timeline -->`, `<!--timeline-->` or `--- timeline ---` after
@@ -189,16 +199,36 @@
  *     -> expect "wrote 1 conversation(s), 4 message(s)"
  *   bun test test/gbrain-to-envelope.test.ts
  *
- * STATUS: see the test file and findings for 2026-08-02. Conformance in CI is
- * checked by test/gbrain-to-envelope.test.ts, which validates against the
- * published envelope-v0 JSON Schema vendored byte-for-byte at
- * test/fixtures/memvelope/envelope-v0.schema.json (sha256
+ * STATUS: measured 2026-08-02 against gbrain v0.42.72.1, on two paths - the
+ * short one (envelope -> envelope-to-gbrain.mjs -> here) and the long one
+ * through a throwaway HOME-redirected PGLite brain (envelope -> importer ->
+ * `gbrain import` -> `gbrain export --dir` -> here), so the pages read are
+ * the ones gbrain's own parseMarkdown / serializeMarkdown pair really
+ * produces. The repo's sample fixture round-trips deep-equal on both paths
+ * with zero stderr bytes. A 3-conversation / 17-message probe - ids carrying
+ * an embedded newline, a whole `---`/`type:`/`---` block, a middle dot,
+ * trailing space, emoji, and a folding-length 79-character value; timestamps
+ * with microseconds, a +05:30 offset, and null; two messages sharing one
+ * minute; a whole-line quoted sentinel mid-conversation; fences spanning
+ * turns - comes back with 17/17 messages and every id, role, ts and text
+ * verbatim on both paths. gbrain's serializer hands the array back as
+ * literal (`|-`) block-scalar ids, a folded (`>-`) long id, single-quoted
+ * timestamps and reordered top-level keys; all of it reads. The only fields
+ * that moved are the documented ones: created_at / updated_at (replaced by
+ * the first and last message timestamps) and one message's trailing newline
+ * (trimmed).
+ *
+ * Conformance in CI is checked by test/gbrain-to-envelope.test.ts, which
+ * validates against the published envelope-v0 JSON Schema vendored
+ * byte-for-byte at test/fixtures/memvelope/envelope-v0.schema.json (sha256
  * 423813d563de394cde2798848e90fdadc85ba52458f5c18b1da897e6c8ae52b9, identical
  * across memvelope.com, raw.githubusercontent.com/memvelope/memvelope@main and
  * the memvelope package). The test walks those bytes with a draft-07 subset it
  * implements in full and refuses any keyword it does not, so a constraint added
  * upstream turns the suite red instead of going unchecked. No validator
- * dependency is added.
+ * dependency is added. Both round-trip outputs above additionally validate
+ * under ajv + ajv-formats in full mode, with the validator first proven
+ * non-trivial on a known-bad document.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
@@ -641,9 +671,11 @@ const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 // long as it names that instant: the RFC's own example set has
 // `1990-12-31T15:59:60-08:00`. So the check normalizes the offset away and asks
 // whether the UTC time-of-day is 23:59. `2026-02-01T09:00:60Z` and
-// `2026-12-31T23:59:60+01:00` both fail it, and both are rejected by ajv 8.20.0
-// + ajv-formats 3.0.1 in strict/full mode - which is what a consumer validating
-// the published schema runs, and what this bound was measured against.
+// `2026-12-31T23:59:60+01:00` both fail it, and both are rejected by ajv +
+// ajv-formats 3.0.1 in strict/full mode - which is what a consumer validating
+// the published schema runs. The whole 11-value boundary set was measured
+// against ajv 8.20.0 on 2026-08-02 and re-measured against 8.18.0 the same
+// day; both agree with this function value for value.
 function asRfc3339DateTime(value) {
   if (typeof value !== 'string') return null;
   const m = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.exec(value);
@@ -1079,8 +1111,12 @@ if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || skipp
   console.warn(`scanned ${files.length} markdown file(s): ${skippedNoFrontmatter} without frontmatter, ${skippedNotConversation} not type conversation, ${skippedNoMessages} without speaker turns, ${skippedUnreadableRecord} with a messages record that could not be read, ${skippedJoinMismatch} whose body does not match their messages record, ${droppedEmptyMessages} empty message(s) dropped.`);
 }
 // Two losses that leave the output conforming and would otherwise be invisible.
+// Worded as what happened - a cut at a sentinel - not as an assertion that a
+// timeline was really there: a message that ends by quoting the sentinel on
+// its own line is cut identically, and a note claiming it "carried a timeline"
+// would be false about that page.
 if (droppedTimelines) {
-  console.warn(`note: ${droppedTimelines} page(s) carried a gbrain timeline section; envelope-v0 has no field for it, so it was not exported.`);
+  console.warn(`note: ${droppedTimelines} page(s) were cut at a timeline sentinel; envelope-v0 has no field for a timeline, so nothing after the sentinel was exported.`);
 }
 if (nulledTimestamps) {
   console.warn(`note: ${nulledTimestamps} turn timestamp(s) were not RFC 3339 date-times and were written as null.`);

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -45,9 +45,10 @@
  * HOW A RECORDED PAGE'S TURNS ARE FOUND. The positional join is only sound if
  * the body anchors exactly as many turns as the array records, so boundaries
  * are not taken on shape alone. For each recorded message the expected header
- * clock is recomputed from its `ts` - the same derivation the importer used to
- * write it (headerClock below is copied verbatim from envelope-to-gbrain.mjs;
- * keep them in lockstep) - and a header-shaped line is a boundary ONLY when
+ * clock is recomputed from its `ts` - the same derivation the importer used
+ * to write it (headerClock below is a code-identical copy from
+ * envelope-to-gbrain.mjs, comments elided; keep them in lockstep) - and a
+ * header-shaped line is a boundary ONLY when
  * its clock equals the clock expected for the next unfilled position. A
  * header-shaped line carrying any other clock is message text, reported on
  * stderr and kept in place. So forging a boundary from prose requires
@@ -75,14 +76,19 @@
  *
  * Fenced code blocks (``` or ~~~, up to three leading spaces) are not scanned
  * for turn headers, timeline sentinels or the H1 - but a fence reaches only to
- * the end of the turn it opened in. On the recorded path the signal that ends
- * one is the same clock rule as everywhere else: a fence still open at a line
- * whose header clock matches the next expected turn has provably swallowed a
- * real boundary, so the fence loses - it is read as ordinary text, with a
- * warning naming the line it opened on. The same demotion applies to a fence
- * still open at the end of the page. Both are the same trade: a fence must
- * never be allowed to swallow the turns after it, and a spurious stretch of
- * ordinary text is a far smaller failure than a turn deleted in silence. On
+ * the end of the turn it opened in. On the recorded path the scan runs in two
+ * phases so that balanced fences genuinely win: the first pass honors every
+ * fence that closes, keeping even a quoted line that carries the next
+ * expected clock as sample text - a pasted transcript quoting this very
+ * conversation must not steal a boundary from outside its fence. Only when
+ * that pass anchors fewer turns than the record holds is a fence plausibly
+ * swallowing a real boundary, and the scan reruns with the demotion rule
+ * armed: a fence still open at a line carrying the next expected clock loses
+ * - it is read as ordinary text, with a warning naming the line it opened on.
+ * A fence still open at the end of the page is demoted in either phase. All
+ * of it is the same trade: a fence must never be allowed to swallow the
+ * turns after it, and a spurious stretch of ordinary text is a far smaller
+ * failure than a turn deleted in silence. On
  * the legacy path the fence-versus-boundary signal is the blank / `---` /
  * blank separator the old importer wrote between turns, as before - and note
  * the demotion's reach, which an earlier revision of this header overstated:
@@ -111,22 +117,34 @@
  * Frontmatter is read line by line: top-level scalars only, in the plain,
  * single-quoted, double-quoted (escapes decoded, including `\U` beyond the
  * BMP), folded (`>`) and literal (`|`) block forms - plus, alone among
- * nested structures, the `messages:` block sequence described above. Items
- * accept the importer's JSON-quoted scalars, the single-quoted / plain forms
- * gbrain's js-yaml rewrite produces, `null`, and block scalars; member keys
- * beyond `id` and `ts` are ignored so a future third field does not break the
- * read; a quoted scalar that does not close on its own line is refused (js-yaml
- * folds long values into block scalars rather than wrapping quotes, so that
- * shape indicates a page this script does not understand).
+ * nested structures, the `messages:` block sequence described above. A UTF-8
+ * BOM is stripped and CRLF normalized before any of it, as gray-matter does.
+ * Trailing `# comments` are stripped the way js-yaml strips them - a reader
+ * that kept them read `type: conversation # imported` as a different type
+ * and `id: # placeholder` as an invented string id. Items accept the
+ * importer's JSON-quoted scalars, the single-quoted / plain / block-scalar
+ * forms gbrain's js-yaml rewrite produces (including `|-` literal ids
+ * carrying newlines and whitespace-only content lines, verified against
+ * js-yaml's own emissions), items at column 0 or indented, and `null`;
+ * member keys beyond `id` and `ts` are ignored so a future third field does
+ * not break the read; a quoted scalar that does not close on its own line is
+ * refused (js-yaml folds long values into block scalars rather than wrapping
+ * quotes, so that shape indicates a page this script does not understand).
+ * One stated limit: this line reader is more PERMISSIVE than js-yaml - a
+ * page whose frontmatter js-yaml rejects outright (an unknown escape, a
+ * plain scalar opening with `@` or a backtick) may still export here under
+ * this reader's simpler rules, where gbrain itself would call the page a
+ * parse error.
  *
  * `title` falls back to the body's first H1 when frontmatter carries none,
  * the same precedence gbrain's own parser uses (src/core/markdown.ts,
- * inferTitleFromBody), and only then to `Untitled conversation`.
- * `title`, `source` and `memvelope_conversation_id` are trimmed, which
- * matters only for a block scalar: its chomping indicator can leave a
- * trailing newline on a value that never carried one. Recorded ids and
- * timestamps are NOT trimmed - they are the record, and the record is
- * verbatim.
+ * inferTitleFromBody), and only then to `Untitled conversation` - a
+ * whitespace-only title takes that fallback too, so a conversation titled
+ * with pure whitespace comes back renamed. `title` and `source` are trimmed;
+ * `memvelope_conversation_id` is VERBATIM, like the recorded message ids and
+ * timestamps - the importer records ids verbatim precisely so that values
+ * differing only by surrounding whitespace stay distinct, and trimming here
+ * would collapse them back together on the way out.
  *
  * What survives the round trip envelope -> envelope-to-gbrain.mjs -> here,
  * measured on the recorded format (see STATUS for the corpus):
@@ -158,9 +176,13 @@
  *     path its `{id, ts}` entry is dropped with it, so the join stays aligned.
  *     meta.message_count follows what was written, so it drops too.
  *   - Anything before the first turn header except the `# Title` heading,
- *     which is read as the title fallback described above.
- *   - A gbrain timeline section. envelope-v0 has no field for it. Every page
- *     that carried one is counted on stderr.
+ *     which is read as the title fallback described above. Reported on
+ *     stderr when non-blank content is dropped this way.
+ *   - Everything after a timeline sentinel that no accepted turn follows -
+ *     a real gbrain timeline, or the tail of a final message that quoted
+ *     the sentinel. envelope-v0 has no field for a timeline. Each cut is
+ *     warned per page, naming the body line, and tallied in the closing
+ *     note.
  *   - A recorded `ts` that is not a strict RFC 3339 `date-time` - which is
  *     what the schema's `format: date-time` names. Emitted as null, with a
  *     warning, rather than as a value that fails validation. That includes a
@@ -169,14 +191,22 @@
  *     that is the agreed spelling of "the export had no timestamp", not a
  *     loss. On the legacy path the same rule judges the header parenthetical,
  *     and the literal `no timestamp` is the agreed null there.
- *   - A message whose text contains a line that matches the next expected
- *     header exactly - speaker shape and the very minute the following
- *     message is recorded at. That line still splits the message, the real
- *     header below it is then read as prose, and both halves land in the
- *     wrong turn's text; ids and timestamps stay correct, nothing is deleted,
- *     and the misread header is reported on stderr. This is the residue of
- *     defect D2: the boundary signal is the recorded clock, so only text that
- *     forges the right clock at the right position can still confuse it.
+ *   - A message whose text contains a line shaped like a turn header and
+ *     carrying the very minute the NEXT message is recorded at. That line
+ *     still steals the boundary, and the damage is worse than a tidy split:
+ *     the forged line itself is consumed as the boundary (those bytes are
+ *     deleted from the text); the stolen turn's ROLE comes from the forged
+ *     line's speaker, not from any record, so an assistant message can come
+ *     back as user or vice versa; the real header below is read as prose
+ *     into the wrong turn's text; and a message left with NO text - one
+ *     whose whole text was the forged line - is dropped outright with its
+ *     `{id, ts}` entry, taking created_at/updated_at with it when it sat at
+ *     an end. Every step is warned on stderr, and the ids and timestamps of
+ *     the surviving messages stay aligned. This is the residue of defect D2,
+ *     and the bar for forging is lower than "predict the future": two
+ *     messages inside one minute make the next expected clock equal the
+ *     current header's own clock, and a null-or-unusable `ts` makes it the
+ *     page date at 00:00 - visible on the page itself.
  *   - CRLF line endings, normalized to LF on read.
  *   - One source_provider per file. An envelope names a single provider, so a
  *     page set spanning several keeps the first in sorted path order and warns.
@@ -216,7 +246,13 @@
  * timestamps and reordered top-level keys; all of it reads. The only fields
  * that moved are the documented ones: created_at / updated_at (replaced by
  * the first and last message timestamps) and one message's trailing newline
- * (trimmed).
+ * (trimmed). One long-path caveat sits UPSTREAM of this script: gbrain's own
+ * parse/serialize pair re-spaces a whole-line HTML comment inside message
+ * text (blank lines inserted around a sentinel written tight against its
+ * neighbours) and swallows a sentinel on the last line of a body with no
+ * real timeline - the probe's quoted sentinel was blank-padded, the one
+ * spacing gbrain preserves, so those movements do not show above; they are
+ * gbrain's, not this reader's.
  *
  * Conformance in CI is checked by test/gbrain-to-envelope.test.ts, which
  * validates against the published envelope-v0 JSON Schema vendored
@@ -390,7 +426,11 @@ function joinBlockScalar(contentLines, style, chomping, trailingBlanks) {
     }
   }
   if (chomping === 'strip') return value;
-  if (chomping === 'keep') return value + '\n'.repeat(1 + trailingBlanks);
+  if (chomping === 'keep') {
+    // The final content line contributes one break only if there IS content:
+    // `|+` over a single empty line is the value "\n", not "\n\n".
+    return value + '\n'.repeat(trailingBlanks + (contentLines.length > 0 ? 1 : 0));
+  }
   return value === '' ? '' : `${value}\n`;
 }
 
@@ -417,7 +457,11 @@ function readBlockScalar(lines, headerIdx, header, ownerLead) {
   let j = headerIdx + 1;
   for (; j < lines.length; j += 1) {
     if (lines[j].trim() === '') {
-      collected.push('');
+      // A whitespace-only line's content beyond the block indent is real:
+      // js-yaml writes the ` ` segment of "a\n \nb" as indent plus one space,
+      // and collapsing it to an empty line silently corrupted the value. At
+      // or below the indent (or before the indent is known) it is empty.
+      collected.push(indent !== -1 && lines[j].length > indent ? lines[j].slice(indent) : '');
       continue;
     }
     const lead = lines[j].length - lines[j].trimStart().length;
@@ -445,10 +489,14 @@ function readBlockScalar(lines, headerIdx, header, ownerLead) {
 function parseFrontmatter(lines) {
   const out = {};
   for (let i = 0; i < lines.length; i += 1) {
-    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(lines[i]);
+    // The `s` flag lets `.` cross U+2028/U+2029. JSON.stringify does not
+    // escape those two line terminators, so a conforming envelope value can
+    // put one RAW inside a frontmatter line; without the flag the line
+    // silently failed to parse and the id or title vanished with zero stderr.
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/s.exec(lines[i]);
     if (!m) continue;
     const key = m[1];
-    const raw = m[2].trim();
+    const raw = stripTrailingComment(m[2].trim());
 
     // `key: >-`, `key: |`, `key: >2-`: the value is the indented block below.
     const block = blockScalarHeader(raw);
@@ -477,16 +525,55 @@ function parseFrontmatter(lines) {
   return out;
 }
 
-// What a plain (unquoted) YAML scalar means under the core schema js-yaml
-// reads and writes: null, boolean and number forms are not strings. The
-// importer JSON-quotes every string it takes from an envelope and js-yaml
-// re-quotes any string that LOOKS like one of these on the way back out, so an
-// unquoted `id: 123` really is a number and refusing it is correct - reading
-// it as the string "123" would fabricate an id the record does not hold.
-// (`yes`, `no`, `on`, `off` are strings under the core schema, and stay
-// strings here.)
+// What a plain (unquoted) YAML scalar means to js-yaml 3.14's default schema
+// - the reader and writer gbrain actually uses: null, boolean and number
+// forms are not strings. The importer JSON-quotes every string it takes from
+// an envelope and js-yaml re-quotes any string that LOOKS like one of these
+// on the way back out, so an unquoted `id: 123` really is a number and
+// refusing it is correct - reading it as the string "123" would fabricate an
+// id the record does not hold. js-yaml 3.14 also reads binary (`0b1010`) and
+// sexagesimal (`190:20:30`) integers and sexagesimal floats, so those refuse
+// too. (`yes`, `no`, `on`, `off` are strings to js-yaml 3.14's default
+// schema, and stay strings here.)
 const PLAIN_NON_STRING =
-  /^(true|false|True|False|TRUE|FALSE|[-+]?\d[\d_]*|0x[\dA-Fa-f]+|0o[0-7]+|[-+]?(\.\d+|\d[\d_]*(\.[\d_]*)?)([eE][-+]?\d+)?|[-+]?\.(inf|Inf|INF)|\.(nan|NaN|NAN))$/;
+  /^(true|false|True|False|TRUE|FALSE|[-+]?\d[\d_]*|[-+]?0b[01_]+|0x[\dA-Fa-f_]+|0o[0-7_]+|[-+]?\d[\d_]*(:[0-5]?\d)+(\.[\d_]*)?|[-+]?(\.\d+|\d[\d_]*(\.[\d_]*)?)([eE][-+]?\d+)?|[-+]?\.(inf|Inf|INF)|\.(nan|NaN|NAN))$/;
+
+// A YAML comment starts at a `#` that opens the value or follows whitespace,
+// outside any quoted run. js-yaml strips comments on read, so a reader that
+// kept them was inventing values: `type: conversation # imported` must read
+// as `conversation`, and `id: # placeholder` is a null id, not the string
+// "# placeholder".
+function stripTrailingComment(raw) {
+  if (raw.startsWith('#')) return '';
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (quote === '"') {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') quote = null;
+      continue;
+    }
+    if (quote === "'") {
+      if (ch === "'") {
+        if (raw[i + 1] === "'") i += 1;
+        else quote = null;
+      }
+      continue;
+    }
+    // A quote only opens a quoted scalar at the start of the value; later it
+    // is ordinary content of a plain scalar.
+    if (i === 0 && (ch === '"' || ch === "'")) {
+      quote = ch;
+      continue;
+    }
+    if (ch === '#' && (raw[i - 1] === ' ' || raw[i - 1] === '\t')) {
+      return raw.slice(0, i).trim();
+    }
+  }
+  return raw;
+}
 
 /** Decodes one scalar value from a `messages:` item member line. Returns
  *  `{ value }` (string or null) or `{ error }` when the raw text is not a
@@ -531,7 +618,7 @@ function parseMessagesRecord(lines) {
   }
   if (at === -1) return { present: false };
 
-  const inline = (/^messages: ?(.*)$/.exec(lines[at]))[1].trim();
+  const inline = stripTrailingComment((/^messages: ?(.*)$/s.exec(lines[at]))[1].trim());
   if (inline === '[]') return { present: true, items: [] };
   if (inline !== '') return { present: true, error: `an inline value this script does not read (${JSON.stringify(inline)})` };
 
@@ -543,10 +630,11 @@ function parseMessagesRecord(lines) {
     const line = lines[i];
     if (line.trim() === '') continue;
     const lead = line.length - line.trimStart().length;
-    // A new top-level key ends the sequence.
-    if (lead === 0) break;
 
-    const item = /^(\s+)- (.*)$/.exec(line);
+    // Items may sit at column 0 (valid YAML, the noArrayIndent style) or
+    // indented (what the importer and js-yaml's default write); the first
+    // item fixes the indent for the rest.
+    const item = /^(\s*)- (.*)$/s.exec(line);
     if (item && (itemLead === -1 || item[1].length === itemLead)) {
       if (itemLead === -1) itemLead = item[1].length;
       current = {};
@@ -555,6 +643,8 @@ function parseMessagesRecord(lines) {
       if (first.error) return { present: true, error: first.error };
       continue;
     }
+    // A new top-level key ends the sequence.
+    if (lead === 0) break;
     if (current === null) return { present: true, error: `a line before the first item (${JSON.stringify(line)})` };
     if (lead <= itemLead) return { present: true, error: `an indentation this script does not read (${JSON.stringify(line)})` };
     const member = readMember(line.trim(), lead);
@@ -564,10 +654,10 @@ function parseMessagesRecord(lines) {
   // One member line, already trimmed, belonging to `current`. `memberLead` is
   // the column its key starts at, needed when its value is a block scalar.
   function readMember(text, memberLead) {
-    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(text);
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/s.exec(text);
     if (!m) return { error: `an item line that is not a key: value pair (${JSON.stringify(text)})` };
     const key = m[1];
-    const raw = m[2].trim();
+    const raw = stripTrailingComment(m[2].trim());
     if (key !== 'id' && key !== 'ts') {
       // A future third field. Skip its value, block scalar and all.
       const block = blockScalarHeader(raw);
@@ -597,10 +687,11 @@ function parseMessagesRecord(lines) {
 }
 
 // ---------------------------------------------------------------------------
-// The header-clock derivation, copied VERBATIM from envelope-to-gbrain.mjs so
-// the expected clock recomputed here is the clock the importer wrote. If one
-// of these functions changes, change both files - the round-trip tests fail
-// loudly (a clock mismatch skips the page) if they drift.
+// The header-clock derivation, a code-identical copy from
+// envelope-to-gbrain.mjs (that file's longer comments elided) so the expected
+// clock recomputed here is the clock the importer wrote. If one of these
+// functions changes, change both files - the round-trip tests fail loudly (a
+// clock mismatch skips the page) if they drift.
 // ---------------------------------------------------------------------------
 
 /** The date a turn header is allowed to carry: exactly `YYYY-MM-DD`. */
@@ -705,7 +796,7 @@ function asRfc3339DateTime(value) {
   return value;
 }
 
-const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/s;
 
 // The separator the LEGACY importer wrote between two turns: a blank line, a
 // `---` rule, a blank line. On the legacy path it is the one structural signal
@@ -780,10 +871,12 @@ function scanFencesAndHeaders(lines, warn) {
 
 // The recorded-path twin of scanPass. Boundaries are accepted by position:
 // a header-shaped line is boundary k only when its clock is the one expected
-// for position k. The same rule is the fence-demotion signal - a fence still
-// open at a line carrying the next expected clock has swallowed a real
-// boundary, so the fence loses.
-function scanRecordedPass(lines, expected, disabled) {
+// for position k. When `demoteOnClock` is set, that same rule is the
+// fence-demotion signal - a fence still open at a line carrying the next
+// expected clock loses; when it is not set, such a line stays sample text.
+// A fence still open at the end of the body is demoted either way (it would
+// otherwise mask the timeline and title scans with no turn to bound it).
+function scanRecordedPass(lines, expected, disabled, demoteOnClock) {
   const fenced = new Array(lines.length).fill(false);
   const boundaries = [];
   const proseHeaders = [];
@@ -808,7 +901,7 @@ function scanRecordedPass(lines, expected, disabled) {
       continue;
     }
     const header = RECORDED_HEADER.exec(lines[i]);
-    if (header && boundaries.length < expected.length && header[2] === expected[boundaries.length]) {
+    if (demoteOnClock && header && boundaries.length < expected.length && header[2] === expected[boundaries.length]) {
       return { reopen: { at: open.at, spanningAt: i } };
     }
     if (header) quotedHeaders.push(i);
@@ -819,16 +912,35 @@ function scanRecordedPass(lines, expected, disabled) {
   return { reopen: null, fenced, boundaries, proseHeaders, quotedHeaders };
 }
 
+// Two phases, so that balanced fences genuinely win. Phase 1 honors every
+// fence that closes: even a quoted line carrying the next expected clock
+// stays sample text inside one - a pasted transcript quoting this very
+// conversation must not steal a boundary from outside its fence. Only when
+// phase 1 anchors fewer turns than the record holds is a fence plausibly
+// swallowing a real boundary, and phase 2 reruns the scan with the
+// clock-demotion rule armed. Warnings are buffered per phase and only the
+// phase whose result is used speaks.
 function scanRecordedFences(lines, expected, warn) {
-  const disabled = new Set();
-  for (;;) {
-    const pass = scanRecordedPass(lines, expected, disabled);
-    if (pass.reopen === null) return pass;
-    disabled.add(pass.reopen.at);
-    warn(pass.reopen.spanningAt === -1
-      ? `an unclosed code fence opens at body line ${pass.reopen.at + 1}; read as ordinary text so the turns after it are not lost.`
-      : `the code fence opened at body line ${pass.reopen.at + 1} is still open at the turn header on body line ${pass.reopen.spanningAt + 1}; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
+  const runPhase = (demoteOnClock) => {
+    const disabled = new Set();
+    const buffered = [];
+    for (;;) {
+      const pass = scanRecordedPass(lines, expected, disabled, demoteOnClock);
+      if (pass.reopen === null) return { pass, buffered };
+      disabled.add(pass.reopen.at);
+      buffered.push(pass.reopen.spanningAt === -1
+        ? `an unclosed code fence opens at body line ${pass.reopen.at + 1}; read as ordinary text so the turns after it are not lost.`
+        : `the code fence opened at body line ${pass.reopen.at + 1} is still open at the turn header on body line ${pass.reopen.spanningAt + 1}; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
+    }
+  };
+  const first = runPhase(false);
+  if (first.pass.boundaries.length === expected.length) {
+    for (const message of first.buffered) warn(message);
+    return first.pass;
   }
+  const second = runPhase(true);
+  for (const message of second.buffered) warn(message);
+  return second.pass;
 }
 
 // gbrain's own title precedence, minus the filename fallback this script must
@@ -836,7 +948,7 @@ function scanRecordedFences(lines, expected, warn) {
 function titleFromBody(lines, fenced) {
   for (let i = 0; i < lines.length; i += 1) {
     if (fenced[i]) continue;
-    const m = /^#(?!#)\s+(.+?)\s*$/.exec(lines[i]);
+    const m = /^#(?!#)\s+(.+?)\s*$/s.exec(lines[i]);
     if (m) return m[1].replace(/\s+#+\s*$/, '').trim();
   }
   return '';
@@ -846,6 +958,25 @@ function titleFromBody(lines, fenced) {
 // `anchors` carries each accepted boundary's line; `build` turns a boundary and
 // its raw text into a message or null (null = dropped, already warned).
 function cutAndSlice(lines, anchors, fenced, warn, stripLegacySeparator, build) {
+  // Body content ahead of the first turn header (except the H1, which is the
+  // title fallback) is not exported - a documented loss, but it was the one
+  // loss class with no stderr trace at all, so it is reported here.
+  if (anchors.length > 0) {
+    let h1Seen = false;
+    const preamble = [];
+    for (let i = 0; i < anchors[0].line; i += 1) {
+      if (fenced[i] || lines[i].trim() === '') continue;
+      if (!h1Seen && /^#(?!#)\s+/.test(lines[i])) {
+        h1Seen = true;
+        continue;
+      }
+      preamble.push(i);
+    }
+    if (preamble.length > 0) {
+      warn(`${preamble.length} line(s) of body content before the first turn header were not exported (first at body line ${preamble[0] + 1}).`);
+    }
+  }
+
   const sentinels = [];
   for (let i = 0; i < lines.length; i += 1) {
     if (fenced[i]) continue;
@@ -863,9 +994,13 @@ function cutAndSlice(lines, anchors, fenced, warn, stripLegacySeparator, build) 
     if (at > lastAnchor) {
       cut = at;
       hasTimeline = true;
+      // Named per page, not only tallied in the aggregate note: the tail cut
+      // away here may be a real gbrain timeline or the end of a message that
+      // quoted the sentinel - either way the operator can find the page.
+      warn(`the body was cut at the timeline sentinel on body line ${at + 1}; nothing after it was exported.`);
       break;
     }
-    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} has speaker turns after it, so it is message text and not a timeline boundary; the body was not cut there.`);
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} has speaker turns after it, so it is not a timeline boundary; the body was not cut there.`);
   }
 
   const messages = [];
@@ -954,9 +1089,12 @@ function readRecordedBody(body, record, pageDate, warn) {
     const { id, ts } = record[i];
     if (text === '') {
       // The `{id, ts}` entry is dropped with its turn, so the join between the
-      // remaining turns and their entries stays aligned.
+      // remaining turns and their entries stays aligned. Worded as what this
+      // side can see: the SOURCE message may well have had text - a message
+      // whose whole text was consumed as a forged boundary, or cut away at a
+      // sentinel, lands here too, and "has no text" would be false about it.
       droppedEmpty += 1;
-      warn(`message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
+      warn(`no text remained for message ${JSON.stringify(id)} between its turn header and the next boundary; dropped (envelope-v0 requires at least one character). If the source message had text, it was consumed as a boundary line or cut at a sentinel.`);
       return null;
     }
     let outTs = null;
@@ -992,7 +1130,11 @@ for (const file of files) {
   // saved with CRLF would otherwise fail to parse as a whole and be reported as
   // frontmatter-less. The cost is stated in the header: CRLF inside a message
   // comes back as LF.
-  const page = splitPage(readFileSync(file, 'utf8').replace(/\r\n/g, '\n'));
+  // A UTF-8 BOM is stripped like CRLF is normalized: gray-matter strips it
+  // too, so a BOM page is a first-class conversation to gbrain, and refusing
+  // to see its frontmatter made the whole conversation vanish into the
+  // "without frontmatter" count.
+  const page = splitPage(readFileSync(file, 'utf8').replace(/^﻿/, '').replace(/\r\n/g, '\n'));
   if (!page) {
     skippedNoFrontmatter += 1;
     continue;
@@ -1054,11 +1196,13 @@ for (const file of files) {
   if (typeof front.source === 'string' && front.source.trim() !== '') providers.push(front.source.trim());
   // Never synthesize. An absent id is null, which the schema permits and the
   // spec requires of converters.
-  // Trimmed for the same reason the title is: a block scalar's chomping can
-  // leave a trailing newline on a value that never had one, and an id has to
-  // compare equal to the one the envelope carried.
+  // VERBATIM, not trimmed. The importer records the id verbatim precisely so
+  // that two ids differing only by surrounding whitespace stay distinct -
+  // trimming here re-collapsed them on the way out, the exact ambiguity that
+  // once let one import destroy another. (Blank-or-absent still maps to null:
+  // the importer never writes the key for an id that trims to nothing.)
   const id = typeof front.memvelope_conversation_id === 'string' && front.memvelope_conversation_id.trim() !== ''
-    ? front.memvelope_conversation_id.trim()
+    ? front.memvelope_conversation_id
     : null;
   // envelope-v0 says ids should be unique within an envelope and that consumers
   // must tolerate duplicates. Emit both conversations and say so, rather than

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -21,12 +21,41 @@
  *     `**Me** (<ts> · <message id>):` and `**Assistant** (...)`. A page whose
  *     body no longer carries those headers yields no messages and is skipped:
  *     envelope-v0 requires at least one message per conversation.
- *   - The body is cut at the `<!-- timeline -->` sentinel that
- *     src/core/markdown.ts writes, so a page's timeline never becomes message
- *     text.
- *   - Frontmatter is read line by line, top-level plain scalars only. A block
- *     scalar (`key: |`) is treated as absent rather than guessed at. That is
- *     enough for the six keys the importer writes and avoids a YAML dependency.
+ *   - Fenced code blocks (``` or ~~~, up to three leading spaces) are not
+ *     scanned for turn headers, timeline sentinels or the H1 - but a fence
+ *     reaches only to the end of the turn it opened in. A fence still open at
+ *     the next turn header, or at the end of the page, is read as ordinary text
+ *     instead, with a warning naming the line it opened on. Both are the same
+ *     trade: a fence must never be allowed to swallow the turns after it, and a
+ *     spurious extra message is a far smaller failure than a turn deleted in
+ *     silence. `**Me** (…):` written at column 0 inside a still-open fence is
+ *     taken as the next turn only when the blank / `---` / blank separator this
+ *     script's own importer writes between turns sits directly above it; that
+ *     separator is the one signal on the page that tells a real boundary from a
+ *     transcript pasted into a code block.
+ *   - The body is cut at a gbrain timeline sentinel - a line that is exactly
+ *     `<!-- timeline -->`, `<!--timeline-->` or `--- timeline ---` after
+ *     trimming - so a page's timeline never becomes message text. Only a
+ *     sentinel with no speaker turn after it is treated as a boundary; a line
+ *     that merely quotes one, mid-sentence or above a later turn, is message
+ *     text and is reported rather than cut at. The fourth form gbrain's own
+ *     parser accepts (a bare `---` followed by `## Timeline`) is deliberately
+ *     NOT recognized here, because `---` is also the separator this script's
+ *     own importer writes between two turns.
+ *   - Frontmatter is read line by line: top-level scalars only, in the plain,
+ *     single-quoted, double-quoted (escapes decoded, including `\U` beyond the
+ *     BMP), folded (`>`) and literal (`|`) block forms. Block chomping is
+ *     honored: `-` strips the trailing newline, the default clips to one, `+`
+ *     keeps them. Sequences, nested mappings and comments are ignored - none of
+ *     the four keys this script reads (`type`, `title`, `source`,
+ *     `memvelope_conversation_id`) is ever written as one - which is what keeps
+ *     it free of a YAML dependency.
+ *   - `title` falls back to the body's first H1 when frontmatter carries none,
+ *     the same precedence gbrain's own parser uses (src/core/markdown.ts,
+ *     inferTitleFromBody), and only then to `Untitled conversation`.
+ *   - `title`, `source` and `memvelope_conversation_id` are trimmed, which
+ *     matters only for a block scalar: its chomping indicator can leave a
+ *     trailing newline on a value that never carried one.
  *
  * What survives the round trip envelope -> envelope-to-gbrain.mjs -> here. On
  * test/fixtures/memvelope/sample.mve.json the output is deep-equal to the
@@ -39,8 +68,8 @@
  *   - a null conversation id, which stays null
  *   - a `---` rule inside a message, and a message that ends on one
  *
- * What does not survive. Each of these was measured on a probe envelope built
- * to carry it, not assumed:
+ * What does not survive. Each of these was measured on a probe envelope or a
+ * probe page built to carry it, not assumed:
  *   - `conversation.created_at` and `conversation.updated_at`. The page keeps
  *     only `date`, the first 10 characters of created_at, which is a day and
  *     not a date-time. Both fields are taken here from the first and last
@@ -58,9 +87,25 @@
  *   - A message that is only whitespace. Dropped, with a warning, because
  *     envelope-v0 requires text of at least one character. meta.message_count
  *     follows what was written, so it drops too.
- *   - Anything before the first turn header, including the `# Title` heading.
- *   - Text that itself contains a line shaped like a turn header. It splits
- *     into two messages, and the second one's id comes from that line.
+ *   - Anything before the first turn header except the `# Title` heading, which
+ *     is read as the title fallback described above.
+ *   - A gbrain timeline section. envelope-v0 has no field for it. Every page
+ *     that carried one is counted on stderr.
+ *   - Text that itself contains a line shaped like a turn header, OUTSIDE a
+ *     fenced block. It still splits into two messages, and the second one's id
+ *     comes from that line. Inside a fenced block that opens and closes within
+ *     one turn it does not split, and the line is reported on stderr as having
+ *     been read as sample text. The remaining ambiguity is a fenced block whose
+ *     content itself carries the blank / `---` / blank turn separator: that
+ *     does split, and is reported.
+ *   - A turn timestamp that is not a strict RFC 3339 `date-time` - which is
+ *     what the schema's `format: date-time` names, and what a header-shaped
+ *     line lifted out of prose produces. Emitted as null, with a warning,
+ *     rather than as a value that fails validation. That includes a second of
+ *     60 anywhere but the instant a leap second is inserted; see
+ *     asRfc3339DateTime below. The literal `no timestamp` the importer writes
+ *     for an absent timestamp becomes null silently: that is the agreed
+ *     spelling, not a loss.
  *   - CRLF line endings, normalized to LF on read.
  *   - One source_provider per file. An envelope names a single provider, so a
  *     page set spanning several keeps the first in sorted path order and warns.
@@ -68,6 +113,11 @@
  * A page with no `memvelope_conversation_id` emits `id: null` rather than a
  * synthesized id. envelope-v0 permits null there and tells converters not to
  * invent one.
+ *
+ * `meta.source_provider` is required by envelope-v0 and cannot be omitted, so a
+ * page set where no page carries a `source:` key falls back to the literal
+ * `unknown` - which no provider registry defines - and says so on stderr,
+ * naming the token it wrote.
  *
  * Memory: the whole page set is held in memory (no streaming), same posture as
  * the importer.
@@ -79,12 +129,32 @@
  *   bun test test/gbrain-to-envelope.test.ts
  *
  * STATUS: verified against gbrain v0.42.72.1 on 2026-08-02. The sample fixture
- * round-trips through the importer and back deep-equal, and the output
- * validates against the published envelope-v0 JSON Schema. It also round-trips
- * deep-equal the long way: imported, put into a PGLite brain, written back out
- * by `gbrain export --dir`, then read here. That path rewrites the frontmatter
- * quoting and key order and leaves the body alone, so the turn headers survive
- * the trip through the database.
+ * round-trips through the importer and back deep-equal. Conformance in CI is
+ * checked by test/gbrain-to-envelope.test.ts, which validates against the
+ * published envelope-v0 JSON Schema vendored byte-for-byte at
+ * test/fixtures/memvelope/envelope-v0.schema.json (sha256
+ * 423813d563de394cde2798848e90fdadc85ba52458f5c18b1da897e6c8ae52b9, identical
+ * across memvelope.com, raw.githubusercontent.com/memvelope/memvelope@main and
+ * the memvelope package). The test walks those bytes with a draft-07 subset it
+ * implements in full and refuses any keyword it does not, so a constraint added
+ * upstream turns the suite red instead of going unchecked. No validator
+ * dependency is added; the D4 and R4 regression tests guard both halves.
+ *
+ * The long path was re-run on 2026-08-02 after this file's turn parser was
+ * rewritten a second time (the fence-per-turn fix below), against a throwaway
+ * PGLite brain under a redirected HOME: envelope -> envelope-to-gbrain.mjs ->
+ * `gbrain import` -> `gbrain export --dir` -> here. A two-conversation probe
+ * carrying a 94-character title, an 85-character id, a message quoting
+ * `<!-- timeline -->` mid-sentence, a 23:59:60Z leap second, three fences that
+ * span a turn boundary and one balanced 4-backtick nest came back with all 8
+ * messages, and every id, role, timestamp and message text identical to the
+ * envelope it started from. The only field that moved is the documented one:
+ * `updated_at`, which is taken from the last message. That path is what
+ * produced three of the bugs this parser handles: `gbrain export --dir`
+ * serializes frontmatter through js-yaml at the default lineWidth of 80, so a
+ * title or id of 80-odd characters arrives as a folded block scalar (measured:
+ * the first fold is at 80 characters of `key: value`), and the body is handed
+ * back verbatim, quoted sentinel and all.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
@@ -133,30 +203,155 @@ function splitPage(content) {
   return { front: lines.slice(1, close), body: lines.slice(close + 1).join('\n') };
 }
 
-// Top-level plain scalars only. gbrain writes these through js-yaml, which
-// quotes with single quotes; the importer writes them through JSON.stringify,
-// which quotes with double quotes. Both are read here, along with the unquoted
-// form. Indented lines belong to a nested value and never match, so a list or a
-// block scalar cannot contribute a key.
+// YAML double-quoted scalars carry escapes JSON does not: `\U0001F680` for an
+// astral code point, `\x41`, `\N`, `\_`. js-yaml reaches for this form whenever
+// a string holds a tab or a non-printable, which includes any emoji - common in
+// vendor conversation titles. Decoding it here is the difference between the
+// real title and the literal text `"\U0001F680 ..."`, quotes and all.
+const SIMPLE_ESCAPES = {
+  '0': '\0', a: '\x07', b: '\b', t: '\t', '\t': '\t', n: '\n', v: '\v', f: '\f',
+  r: '\r', e: '\x1b', ' ': ' ', '"': '"', '/': '/', '\\': '\\', N: '\x85',
+  _: '\xa0', L: '\u2028', P: '\u2029',
+};
+
+function isCompleteDoubleQuoted(raw) {
+  if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) return false;
+  // The closing quote must not itself be escaped, and no unescaped quote may
+  // appear before it - otherwise this is a fragment and not a whole scalar.
+  let escaped = false;
+  for (let i = 1; i < raw.length; i += 1) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (raw[i] === '\\') escaped = true;
+    else if (raw[i] === '"') return i === raw.length - 1;
+  }
+  return false;
+}
+
+function decodeDoubleQuoted(raw) {
+  const inner = raw.slice(1, -1);
+  let out = '';
+  for (let i = 0; i < inner.length; i += 1) {
+    if (inner[i] !== '\\') {
+      out += inner[i];
+      continue;
+    }
+    const esc = inner[i + 1];
+    if (esc === undefined) {
+      out += '\\';
+      break;
+    }
+    i += 1;
+    if (esc in SIMPLE_ESCAPES) {
+      out += SIMPLE_ESCAPES[esc];
+      continue;
+    }
+    const width = esc === 'x' ? 2 : esc === 'u' ? 4 : esc === 'U' ? 8 : 0;
+    if (width === 0) {
+      // An escape YAML does not define. Keep both characters rather than
+      // inventing a decoding.
+      out += `\\${esc}`;
+      continue;
+    }
+    const digits = inner.slice(i + 1, i + 1 + width);
+    if (digits.length !== width || !/^[0-9A-Fa-f]+$/.test(digits)) {
+      out += `\\${esc}`;
+      continue;
+    }
+    const code = parseInt(digits, 16);
+    if (code > 0x10ffff) {
+      out += `\\${esc}${digits}`;
+    } else {
+      out += String.fromCodePoint(code);
+    }
+    i += width;
+  }
+  return out;
+}
+
+// A block scalar's content, given its already-dedented lines. Folded (`>`)
+// joins a paragraph's lines with a space and turns a blank line into a
+// newline; a more-indented line keeps its breaks. Literal (`|`) keeps every
+// break as written.
+function joinBlockScalar(contentLines, style, chomping, trailingBlanks) {
+  let value;
+  if (style === '|') {
+    value = contentLines.join('\n');
+  } else {
+    value = '';
+    for (let i = 0; i < contentLines.length; i += 1) {
+      const line = contentLines[i];
+      if (i === 0) {
+        value = line;
+        continue;
+      }
+      const prev = contentLines[i - 1];
+      if (line === '' || prev === '') {
+        value += line === '' ? '\n' : line;
+        continue;
+      }
+      value += (/^\s/.test(line) || /^\s/.test(prev) ? '\n' : ' ') + line;
+    }
+  }
+  if (chomping === 'strip') return value;
+  if (chomping === 'keep') return value + '\n'.repeat(1 + trailingBlanks);
+  return value === '' ? '' : `${value}\n`;
+}
+
+// Top-level scalars only. gbrain writes these through js-yaml, which quotes
+// with single quotes, escapes with double quotes, and folds anything long into
+// a block scalar; the importer writes them through JSON.stringify, which quotes
+// with double quotes. All of those are read here, along with the unquoted form.
+// A line that is indented belongs to a nested value or to a block scalar's
+// content and is never read as a key.
 function parseFrontmatter(lines) {
   const out = {};
-  for (const line of lines) {
-    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(line);
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*): ?(.*)$/.exec(lines[i]);
     if (!m) continue;
     const key = m[1];
     const raw = m[2].trim();
-    if (raw === '' || raw === '|' || raw === '|-' || raw === '>' || raw === '>-') continue;
+
+    // `key: >-`, `key: |`, `key: >2-`: the value is the indented block below.
+    const block = /^([|>])([+-]?[0-9]?|[0-9][+-]?)$/.exec(raw);
+    if (block) {
+      const style = block[1];
+      const chomping = raw.includes('+') ? 'keep' : raw.includes('-') ? 'strip' : 'clip';
+      const explicit = /[0-9]/.exec(raw);
+      let indent = explicit ? Number(explicit[0]) : -1;
+      const collected = [];
+      let j = i + 1;
+      for (; j < lines.length; j += 1) {
+        if (lines[j].trim() === '') {
+          collected.push('');
+          continue;
+        }
+        const lead = lines[j].length - lines[j].trimStart().length;
+        if (lead === 0) break;
+        if (indent === -1) indent = lead;
+        if (lead < indent) break;
+        collected.push(lines[j].slice(indent));
+      }
+      let trailingBlanks = 0;
+      while (collected.length > 0 && collected[collected.length - 1] === '') {
+        collected.pop();
+        trailingBlanks += 1;
+      }
+      out[key] = joinBlockScalar(collected, style, chomping, trailingBlanks);
+      i = j - 1;
+      continue;
+    }
+
+    if (raw === '') continue;
     if (raw === 'null' || raw === '~') {
       out[key] = null;
       continue;
     }
-    if (raw.startsWith('"')) {
-      try {
-        out[key] = JSON.parse(raw);
-        continue;
-      } catch {
-        // Fall through to the raw form rather than dropping the field.
-      }
+    if (isCompleteDoubleQuoted(raw)) {
+      out[key] = decodeDoubleQuoted(raw);
+      continue;
     }
     if (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2) {
       out[key] = raw.slice(1, -1).replace(/''/g, "'");
@@ -167,40 +362,211 @@ function parseFrontmatter(lines) {
   return out;
 }
 
-// The turn header the importer writes. The timestamp group is lazy so the first
-// middle dot separates it from the message id, which leaves an id free to
-// contain one.
-const TURN_HEADER = /^\*\*(Me|Assistant)\*\* \((.*?) · (.*)\):$/gm;
-const TIMELINE_SENTINEL = '<!-- timeline -->';
+// The turn header the importer writes, matched one line at a time so a fenced
+// block can be excluded. The timestamp group is lazy so the first middle dot
+// separates it from the message id, which leaves an id free to contain one.
+const TURN_HEADER = /^\*\*(Me|Assistant)\*\* \((.*?) · (.*)\):$/;
+// A whole line, after trimming - never a substring. A message that quotes the
+// sentinel mid-sentence is prose, and cutting there destroys every later turn.
+const TIMELINE_SENTINELS = new Set(['<!-- timeline -->', '<!--timeline-->', '--- timeline ---']);
+const NO_TIMESTAMP = 'no timestamp';
+const FALLBACK_PROVIDER = 'unknown';
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-function readMessages(body, onEmpty) {
-  const sentinel = body.indexOf(TIMELINE_SENTINEL);
-  const text = sentinel === -1 ? body : body.slice(0, sentinel);
-  const headers = [...text.matchAll(TURN_HEADER)];
-  const messages = [];
-  for (const [i, h] of headers.entries()) {
-    const start = h.index + h[0].length;
-    const end = i + 1 < headers.length ? headers[i + 1].index : text.length;
-    let raw = text.slice(start, end);
-    // Between two turns the importer writes exactly one `---` separator line.
-    // Strip that one occurrence, never a `---` the message itself ended with
-    // after the last turn.
-    if (i + 1 < headers.length) raw = raw.replace(/\n\n---\n\n$/, '');
-    const messageText = raw.trim();
-    if (messageText === '') {
-      onEmpty(h[3]);
+// Strict RFC 3339 `date-time`, the profile the schema's `format: date-time`
+// names. Shape first, then real calendar and clock bounds, so `2026-02-30` and
+// `T25:00:00` are rejected rather than passed through. Returns the value when it
+// conforms, else null.
+//
+// Second 60 is a leap second, and RFC 3339 5.6 permits it only at the instant a
+// leap second is inserted - midnight UTC. The local clock may read anything, as
+// long as it names that instant: the RFC's own example set has
+// `1990-12-31T15:59:60-08:00`. So the check normalizes the offset away and asks
+// whether the UTC time-of-day is 23:59. `2026-02-01T09:00:60Z` and
+// `2026-12-31T23:59:60+01:00` both fail it, and both are rejected by ajv 8.20.0
+// + ajv-formats 3.0.1 in strict/full mode - which is what a consumer validating
+// the published schema runs, and what this bound was measured against.
+function asRfc3339DateTime(value) {
+  if (typeof value !== 'string') return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.exec(value);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  if (month < 1 || month > 12) return null;
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  if (day < 1 || day > (month === 2 && leap ? 29 : DAYS_IN_MONTH[month - 1])) return null;
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  const second = Number(m[6]);
+  if (hour > 23 || minute > 59 || second > 60) return null;
+  const offset = m[8];
+  let offsetMinutes = 0;
+  if (offset !== 'Z' && offset !== 'z') {
+    const offsetHour = Number(offset.slice(1, 3));
+    const offsetMinute = Number(offset.slice(4, 6));
+    if (offsetHour > 23 || offsetMinute > 59) return null;
+    offsetMinutes = (offset[0] === '-' ? -1 : 1) * (offsetHour * 60 + offsetMinute);
+  }
+  if (second === 60) {
+    const utcMinuteOfDay = (((hour * 60 + minute - offsetMinutes) % 1440) + 1440) % 1440;
+    if (utcMinuteOfDay !== 23 * 60 + 59) return null;
+  }
+  return value;
+}
+
+const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+
+// The separator envelope-to-gbrain.mjs writes between two turns: a blank line,
+// a `---` rule, a blank line. It is the one structural signal on the page that
+// separates a real turn boundary from a transcript pasted into a code block,
+// and it decides the only case fence state cannot decide on its own - a
+// header-shaped line reached while a fence is open.
+function precededByTurnSeparator(lines, i) {
+  return i >= 3
+    && lines[i - 1].trim() === ''
+    && lines[i - 2].trim() === '---'
+    && lines[i - 3].trim() === '';
+}
+
+// One left-to-right pass producing the fence mask and the turn headers
+// together, so that a fence can never hide a header belonging to a LATER turn.
+// `disabled` holds the fence openers already proven not to close inside their
+// own turn; those read as ordinary text. Returns `{ reopen }` when it meets such
+// an opener, and the caller disables it and runs the pass again.
+function scanPass(lines, disabled) {
+  const fenced = new Array(lines.length).fill(false);
+  const headers = [];
+  const quotedHeaders = [];
+  let open = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const fence = FENCE_LINE.exec(lines[i]);
+    if (open === null) {
+      const header = TURN_HEADER.exec(lines[i]);
+      if (header) {
+        headers.push({ line: i, match: header });
+        continue;
+      }
+      // A backtick fence's info string may not itself contain a backtick.
+      if (fence && !disabled.has(i) && !(fence[1][0] === '`' && fence[2].includes('`'))) {
+        open = { char: fence[1][0], len: fence[1].length, at: i };
+        fenced[i] = true;
+      }
       continue;
     }
-    messages.push({
-      id: h[3],
-      role: h[1] === 'Me' ? 'user' : 'assistant',
-      // The importer writes the literal `no timestamp` when the envelope had
-      // none. Read it back as the null the schema asks for, not as prose.
-      ts: h[2] === 'no timestamp' ? null : h[2],
-      text: messageText,
-    });
+    if (TURN_HEADER.test(lines[i])) {
+      // A fence's reach ends with the turn it opened in. A header carrying the
+      // separator above it belongs to the next turn, so the fence is the thing
+      // that is wrong and it loses: masking on from here would delete that
+      // turn's id, role and timestamp outright and swallow its text into the
+      // turn above, which is the loss no count in the output contradicts.
+      if (precededByTurnSeparator(lines, i)) return { reopen: { at: open.at, spanningAt: i } };
+      quotedHeaders.push(i);
+    }
+    fenced[i] = true;
+    if (fence && fence[1][0] === open.char && fence[1].length >= open.len && fence[2].trim() === '') open = null;
   }
-  return messages;
+  // A fence left open at the end of the body would mask everything after it.
+  if (open !== null) return { reopen: { at: open.at, spanningAt: -1 } };
+  return { reopen: null, fenced, headers, quotedHeaders };
+}
+
+// The fence mask and the turn headers. A fence that cannot close inside its own
+// turn is demoted to ordinary text and the pass is rerun without it, which is
+// the same trade the unclosed case already made: a spurious extra message is a
+// far smaller failure than a silently truncated conversation. Each rerun
+// disables one more opener, so the loop runs at most once per fence line.
+function scanFencesAndHeaders(lines, warn) {
+  const disabled = new Set();
+  for (;;) {
+    const pass = scanPass(lines, disabled);
+    if (pass.reopen === null) return pass;
+    disabled.add(pass.reopen.at);
+    warn(pass.reopen.spanningAt === -1
+      ? `an unclosed code fence opens at body line ${pass.reopen.at + 1}; read as ordinary text so the turns after it are not lost.`
+      : `the code fence opened at body line ${pass.reopen.at + 1} is still open at the turn header on body line ${pass.reopen.spanningAt + 1}; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
+  }
+}
+
+// gbrain's own title precedence, minus the filename fallback this script must
+// not use: frontmatter `title:` first, then the body's first H1.
+function titleFromBody(lines, fenced) {
+  for (let i = 0; i < lines.length; i += 1) {
+    if (fenced[i]) continue;
+    const m = /^#(?!#)\s+(.+?)\s*$/.exec(lines[i]);
+    if (m) return m[1].replace(/\s+#+\s*$/, '').trim();
+  }
+  return '';
+}
+
+function readPageBody(body, warn) {
+  const lines = body.split('\n');
+  const { fenced, headers, quotedHeaders } = scanFencesAndHeaders(lines, warn);
+
+  // Reported for the same reason a quoted timeline sentinel is: the script made
+  // a call about what a line means, and the operator gets to see it.
+  for (const at of quotedHeaders) {
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} sits inside a fenced code block, so it was read as sample text and not as a turn.`);
+  }
+
+  const sentinels = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (fenced[i]) continue;
+    if (TIMELINE_SENTINELS.has(lines[i].trim())) sentinels.push(i);
+  }
+
+  // Cut only at a sentinel that no speaker turn follows. gbrain writes the
+  // timeline after the whole body, so a sentinel with turns below it is a
+  // message quoting the marker - the case that used to destroy every later
+  // turn in silence.
+  const lastHeader = headers.length > 0 ? headers[headers.length - 1].line : -1;
+  let cut = lines.length;
+  let hasTimeline = false;
+  for (const at of sentinels) {
+    if (at > lastHeader) {
+      cut = at;
+      hasTimeline = true;
+      break;
+    }
+    warn(`the line \`${lines[at].trim()}\` at body line ${at + 1} has speaker turns after it, so it is message text and not a timeline boundary; the body was not cut there.`);
+  }
+
+  const messages = [];
+  let droppedEmpty = 0;
+  let nulledTimestamps = 0;
+  for (const [i, header] of headers.entries()) {
+    const hasNext = i + 1 < headers.length;
+    const end = hasNext ? headers[i + 1].line : cut;
+    // Rebuild the exact slice between two headers, trailing newline included,
+    // so the separator strip below sees what the importer wrote.
+    let raw = lines.slice(header.line + 1, end).join('\n');
+    if (hasNext) {
+      // Between two turns the importer writes exactly one `---` separator line.
+      // Strip that one occurrence, never a `---` the message itself ended with
+      // after the last turn.
+      raw = `${raw}\n`.replace(/\n\n---\n\n$/, '');
+    }
+    const id = header.match[3];
+    const text = raw.trim();
+    if (text === '') {
+      droppedEmpty += 1;
+      warn(`message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
+      continue;
+    }
+    // The importer writes the literal `no timestamp` when the envelope had
+    // none. Read it back as the null the schema asks for, not as prose.
+    let ts = null;
+    if (header.match[2] !== NO_TIMESTAMP) {
+      ts = asRfc3339DateTime(header.match[2]);
+      if (ts === null) {
+        nulledTimestamps += 1;
+        warn(`message ${JSON.stringify(id)} carries ${JSON.stringify(header.match[2])} where a turn header's timestamp goes; it is not an RFC 3339 date-time, so ts was written as null.`);
+      }
+    }
+    messages.push({ id, role: header.match[1] === 'Me' ? 'user' : 'assistant', ts, text });
+  }
+
+  return { messages, title: titleFromBody(lines, fenced), hasTimeline, droppedEmpty, nulledTimestamps };
 }
 
 const files = markdownFiles(pagesDir);
@@ -211,6 +577,8 @@ let skippedNotConversation = 0;
 let skippedNoFrontmatter = 0;
 let skippedNoMessages = 0;
 let droppedEmptyMessages = 0;
+let droppedTimelines = 0;
+let nulledTimestamps = 0;
 let messageCount = 0;
 
 for (const file of files) {
@@ -228,46 +596,62 @@ for (const file of files) {
     skippedNotConversation += 1;
     continue;
   }
-  const messages = readMessages(page.body, (id) => {
-    droppedEmptyMessages += 1;
-    console.warn(`warning: ${file} - message ${JSON.stringify(id)} has no text; dropped (envelope-v0 requires at least one character).`);
-  });
-  if (messages.length === 0) {
+  const warn = (message) => console.warn(`warning: ${file} - ${message}`);
+  const read = readPageBody(page.body, warn);
+  droppedEmptyMessages += read.droppedEmpty;
+  nulledTimestamps += read.nulledTimestamps;
+  if (read.hasTimeline) droppedTimelines += 1;
+  if (read.messages.length === 0) {
     skippedNoMessages += 1;
-    console.warn(`warning: ${file} - no speaker turns found; skipped (envelope-v0 requires at least one message per conversation).`);
+    warn('no speaker turns found; skipped (envelope-v0 requires at least one message per conversation).');
     continue;
   }
-  if (typeof front.source === 'string' && front.source !== '') providers.push(front.source);
+  if (typeof front.source === 'string' && front.source.trim() !== '') providers.push(front.source.trim());
   // Never synthesize. An absent id is null, which the schema permits and the
   // spec requires of converters.
-  const id = typeof front.memvelope_conversation_id === 'string' ? front.memvelope_conversation_id : null;
+  // Trimmed for the same reason the title is: a block scalar's chomping can
+  // leave a trailing newline on a value that never had one, and an id has to
+  // compare equal to the one the envelope carried.
+  const id = typeof front.memvelope_conversation_id === 'string' && front.memvelope_conversation_id.trim() !== ''
+    ? front.memvelope_conversation_id.trim()
+    : null;
   // envelope-v0 says ids should be unique within an envelope and that consumers
   // must tolerate duplicates. Emit both conversations and say so, rather than
   // dropping one to keep the field clean.
   if (id !== null && seenIds.has(id)) {
-    console.warn(`warning: ${file} - conversation id ${JSON.stringify(id)} already used by another page; both are emitted.`);
+    warn(`conversation id ${JSON.stringify(id)} already used by another page; both are emitted.`);
   }
   if (id !== null) seenIds.add(id);
+  // Frontmatter first, then the body's H1 - gbrain's own precedence - so a
+  // title that js-yaml folded into a block scalar has a second way home.
+  const title = (typeof front.title === 'string' && front.title.trim() !== '' ? front.title.trim() : read.title)
+    || 'Untitled conversation';
   conversations.push({
     id,
-    title: typeof front.title === 'string' && front.title !== '' ? front.title : 'Untitled conversation',
+    title,
     // The page's `date` is a day, not a date-time, so it cannot fill these.
     // First and last message timestamps are the only date-times on the page.
-    created_at: messages[0].ts,
-    updated_at: messages[messages.length - 1].ts,
-    messages,
+    created_at: read.messages[0].ts,
+    updated_at: read.messages[read.messages.length - 1].ts,
+    messages: read.messages,
   });
-  messageCount += messages.length;
+  messageCount += read.messages.length;
 }
 
 const distinctProviders = [...new Set(providers)];
 if (distinctProviders.length > 1) {
   console.warn(`warning: pages name ${distinctProviders.length} source providers (${distinctProviders.join(', ')}); an envelope carries one. Using ${JSON.stringify(distinctProviders[0])}.`);
 }
+// envelope-v0 requires meta.source_provider, so it cannot be omitted the way
+// meta.source_export_date is. Minting a token no registry defines is a guess,
+// and a guess gets reported like every other lossy edge in this script.
+if (distinctProviders.length === 0) {
+  console.warn(`warning: no page carries a \`source:\` key, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
+}
 const envelope = {
   memvelope: 'envelope-v0',
   meta: {
-    source_provider: distinctProviders[0] || 'unknown',
+    source_provider: distinctProviders[0] || FALLBACK_PROVIDER,
     conversation_count: conversations.length,
     message_count: messageCount,
   },
@@ -280,4 +664,11 @@ console.log(`wrote ${conversations.length} conversation(s), ${messageCount} mess
 // a mistargeted directory reads as a diagnosis rather than an empty file.
 if (skippedNoFrontmatter || skippedNotConversation || skippedNoMessages || droppedEmptyMessages) {
   console.warn(`scanned ${files.length} markdown file(s): ${skippedNoFrontmatter} without frontmatter, ${skippedNotConversation} not type conversation, ${skippedNoMessages} without speaker turns, ${droppedEmptyMessages} empty message(s) dropped.`);
+}
+// Two losses that leave the output conforming and would otherwise be invisible.
+if (droppedTimelines) {
+  console.warn(`note: ${droppedTimelines} page(s) carried a gbrain timeline section; envelope-v0 has no field for it, so it was not exported.`);
+}
+if (nulledTimestamps) {
+  console.warn(`note: ${nulledTimestamps} turn timestamp(s) were not RFC 3339 date-times and were written as null.`);
 }

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -76,19 +76,22 @@
  *
  * Fenced code blocks (``` or ~~~, up to three leading spaces) are not scanned
  * for turn headers, timeline sentinels or the H1 - but a fence reaches only to
- * the end of the turn it opened in. On the recorded path the scan runs in two
- * phases so that balanced fences genuinely win: the first pass honors every
- * fence that closes, keeping even a quoted line that carries the next
- * expected clock as sample text - a pasted transcript quoting this very
- * conversation must not steal a boundary from outside its fence. Only when
- * that pass anchors fewer turns than the record holds is a fence plausibly
- * swallowing a real boundary, and the scan reruns with the demotion rule
- * armed: a fence still open at a line carrying the next expected clock loses
- * - it is read as ordinary text, with a warning naming the line it opened on.
- * A fence still open at the end of the page is demoted in either phase. All
- * of it is the same trade: a fence must never be allowed to swallow the
- * turns after it, and a spurious stretch of ordinary text is a far smaller
- * failure than a turn deleted in silence. On
+ * the end of the turn it opened in. On the recorded path the scan runs in
+ * stages so that balanced fences genuinely win: the first honors every fence
+ * that closes, keeping even a quoted line that carries the next expected
+ * clock as sample text - a pasted transcript quoting this very conversation
+ * must not steal a boundary from outside its fence. Only when that stage
+ * anchors fewer turns than the record holds is some fence plausibly
+ * swallowing a real boundary, and then each fence is tried ALONE: the fence
+ * to lose is the one whose demotion by itself anchors every recorded turn,
+ * which is what keeps a balanced fence that merely quotes a boundary from
+ * being demoted when a different fence caused the shortfall. Only if no
+ * single demotion suffices does a greedy pass demote every fence still open
+ * at a next-expected-clock line. Each demotion is warned, naming the line
+ * the fence opened on; a fence still open at the end of the page is demoted
+ * in every stage. All of it is the same trade: a fence must never be allowed
+ * to swallow the turns after it, and a spurious stretch of ordinary text is
+ * a far smaller failure than a turn deleted in silence. On
  * the legacy path the fence-versus-boundary signal is the blank / `---` /
  * blank separator the old importer wrote between turns, as before - and note
  * the demotion's reach, which an earlier revision of this header overstated:
@@ -528,15 +531,80 @@ function parseFrontmatter(lines) {
 // What a plain (unquoted) YAML scalar means to js-yaml 3.14's default schema
 // - the reader and writer gbrain actually uses: null, boolean and number
 // forms are not strings. The importer JSON-quotes every string it takes from
-// an envelope and js-yaml re-quotes any string that LOOKS like one of these
+// an envelope and js-yaml re-quotes any string that resolves to one of these
 // on the way back out, so an unquoted `id: 123` really is a number and
 // refusing it is correct - reading it as the string "123" would fabricate an
-// id the record does not hold. js-yaml 3.14 also reads binary (`0b1010`) and
-// sexagesimal (`190:20:30`) integers and sexagesimal floats, so those refuse
-// too. (`yes`, `no`, `on`, `off` are strings to js-yaml 3.14's default
-// schema, and stay strings here.)
-const PLAIN_NON_STRING =
-  /^(true|false|True|False|TRUE|FALSE|[-+]?\d[\d_]*|[-+]?0b[01_]+|0x[\dA-Fa-f_]+|0o[0-7_]+|[-+]?\d[\d_]*(:[0-5]?\d)+(\.[\d_]*)?|[-+]?(\.\d+|\d[\d_]*(\.[\d_]*)?)([eE][-+]?\d+)?|[-+]?\.(inf|Inf|INF)|\.(nan|NaN|NAN))$/;
+// id the record does not hold. The int and float checks below are ports of
+// js-yaml 3.14's own resolveYamlInteger / resolveYamlFloat (an approximating
+// regex here once refused `089` - a STRING to js-yaml, which its dumper
+// re-emits unquoted - and dropped the whole conversation after one brain
+// cycle). js-yaml's octal is the 1.1 leading-zero form, `0o` is a string,
+// trailing underscores make a string, and `yes`/`no`/`on`/`off` are strings.
+const DEC_DIGIT = /[0-9]/;
+
+function isJsYamlInteger(data) {
+  const max = data.length;
+  let index = 0;
+  let hasDigits = false;
+  if (max === 0) return false;
+  let ch = data[index];
+  if (ch === '-' || ch === '+') ch = data[(index += 1)];
+  if (ch === '0') {
+    if (index + 1 === max) return true;
+    ch = data[(index += 1)];
+    if (ch === 'b') {
+      for (index += 1; index < max; index += 1) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (ch !== '0' && ch !== '1') return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+    if (ch === 'x') {
+      for (index += 1; index < max; index += 1) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (!/[0-9a-fA-F]/.test(ch)) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+    for (; index < max; index += 1) {
+      ch = data[index];
+      if (ch === '_') continue;
+      if (!/[0-7]/.test(ch)) return false;
+      hasDigits = true;
+    }
+    return hasDigits && ch !== '_';
+  }
+  if (ch === '_') return false;
+  for (; index < max; index += 1) {
+    ch = data[index];
+    if (ch === '_') continue;
+    if (ch === ':') break;
+    if (!DEC_DIGIT.test(ch)) return false;
+    hasDigits = true;
+  }
+  if (!hasDigits || ch === '_') return false;
+  if (ch !== ':') return true;
+  return /^(:[0-5]?[0-9])+$/.test(data.slice(index));
+}
+
+const JS_YAML_FLOAT = new RegExp(
+  '^(?:[-+]?(?:0|[1-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?' +
+  '|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?' +
+  '|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*' +
+  '|[-+]?\\.(?:inf|Inf|INF)' +
+  '|\\.(?:nan|NaN|NAN))$',
+);
+
+function isPlainNonString(data) {
+  if (data === 'true' || data === 'True' || data === 'TRUE') return true;
+  if (data === 'false' || data === 'False' || data === 'FALSE') return true;
+  if (isJsYamlInteger(data)) return true;
+  return JS_YAML_FLOAT.test(data) && data[data.length - 1] !== '_';
+}
 
 // A YAML comment starts at a `#` that opens the value or follows whitespace,
 // outside any quoted run. js-yaml strips comments on read, so a reader that
@@ -547,18 +615,25 @@ function stripTrailingComment(raw) {
   if (raw.startsWith('#')) return '';
   let quote = null;
   let escaped = false;
+  let closedQuoted = false;
   for (let i = 0; i < raw.length; i += 1) {
     const ch = raw[i];
     if (quote === '"') {
       if (escaped) escaped = false;
       else if (ch === '\\') escaped = true;
-      else if (ch === '"') quote = null;
+      else if (ch === '"') {
+        quote = null;
+        closedQuoted = true;
+      }
       continue;
     }
     if (quote === "'") {
       if (ch === "'") {
         if (raw[i + 1] === "'") i += 1;
-        else quote = null;
+        else {
+          quote = null;
+          closedQuoted = true;
+        }
       }
       continue;
     }
@@ -568,7 +643,10 @@ function stripTrailingComment(raw) {
       quote = ch;
       continue;
     }
-    if (ch === '#' && (raw[i - 1] === ' ' || raw[i - 1] === '\t')) {
+    // In a plain scalar a comment needs whitespace before the '#'; after a
+    // closed quoted scalar YAML ends the value at a '#' with or without one
+    // ('"a"# c' reads as "a" to js-yaml).
+    if (ch === '#' && (closedQuoted || raw[i - 1] === ' ' || raw[i - 1] === '\t')) {
       return raw.slice(0, i).trim();
     }
   }
@@ -591,7 +669,7 @@ function decodeMemberScalar(raw) {
   if (raw.startsWith('[') || raw.startsWith('{') || raw.startsWith('&') || raw.startsWith('*') || raw.startsWith('!')) {
     return { error: `a value this script does not read (${JSON.stringify(raw)})` };
   }
-  if (PLAIN_NON_STRING.test(raw)) return { value: { nonString: raw } };
+  if (isPlainNonString(raw)) return { value: { nonString: raw } };
   return { value: raw };
 }
 
@@ -881,6 +959,7 @@ function scanRecordedPass(lines, expected, disabled, demoteOnClock) {
   const boundaries = [];
   const proseHeaders = [];
   const quotedHeaders = [];
+  const openers = [];
   let open = null;
   for (let i = 0; i < lines.length; i += 1) {
     const fence = FENCE_LINE.exec(lines[i]);
@@ -895,7 +974,8 @@ function scanRecordedPass(lines, expected, disabled, demoteOnClock) {
         continue;
       }
       if (fence && !disabled.has(i) && !(fence[1][0] === '`' && fence[2].includes('`'))) {
-        open = { char: fence[1][0], len: fence[1].length, at: i };
+        open = { char: fence[1][0], len: fence[1].length, at: i, entry: { at: i, closedAt: -1 } };
+        openers.push(open.entry);
         fenced[i] = true;
       }
       continue;
@@ -906,23 +986,34 @@ function scanRecordedPass(lines, expected, disabled, demoteOnClock) {
     }
     if (header) quotedHeaders.push(i);
     fenced[i] = true;
-    if (fence && fence[1][0] === open.char && fence[1].length >= open.len && fence[2].trim() === '') open = null;
+    if (fence && fence[1][0] === open.char && fence[1].length >= open.len && fence[2].trim() === '') {
+      open.entry.closedAt = i;
+      open = null;
+    }
   }
   if (open !== null) return { reopen: { at: open.at, spanningAt: -1 } };
-  return { reopen: null, fenced, boundaries, proseHeaders, quotedHeaders };
+  return { reopen: null, fenced, boundaries, proseHeaders, quotedHeaders, openers };
 }
 
-// Two phases, so that balanced fences genuinely win. Phase 1 honors every
-// fence that closes: even a quoted line carrying the next expected clock
-// stays sample text inside one - a pasted transcript quoting this very
-// conversation must not steal a boundary from outside its fence. Only when
-// phase 1 anchors fewer turns than the record holds is a fence plausibly
-// swallowing a real boundary, and phase 2 reruns the scan with the
-// clock-demotion rule armed. Warnings are buffered per phase and only the
-// phase whose result is used speaks.
+// Balanced fences genuinely win, in two stages. Stage 1 honors every fence
+// that closes: even a quoted line carrying the next expected clock stays
+// sample text inside one - a pasted transcript quoting this very
+// conversation must not steal a boundary from outside its fence. (Fences
+// still open at the end of the body are demoted in every stage.) Only when
+// stage 1 anchors fewer turns than the record holds is some fence plausibly
+// swallowing a real boundary - and then each fence is tried ALONE: the fence
+// to lose is the one whose demotion by itself anchors every recorded turn.
+// Trying them one at a time is what keeps a balanced fence that merely
+// QUOTES a boundary from being demoted when a different fence caused the
+// shortfall: demoting the quoting fence cannot recover the turn the other
+// fence swallowed, so its trial fails and the right fence is found. Only if
+// no single demotion suffices (two swallowing fences, or a genuinely
+// mismatched body) does the greedy clock-armed demotion run as a last
+// resort. Warnings are buffered per attempt and only the attempt whose
+// result is used speaks.
 function scanRecordedFences(lines, expected, warn) {
-  const runPhase = (demoteOnClock) => {
-    const disabled = new Set();
+  const runToCompletion = (seed, demoteOnClock) => {
+    const disabled = new Set(seed);
     const buffered = [];
     for (;;) {
       const pass = scanRecordedPass(lines, expected, disabled, demoteOnClock);
@@ -933,12 +1024,26 @@ function scanRecordedFences(lines, expected, warn) {
         : `the code fence opened at body line ${pass.reopen.at + 1} is still open at the turn header on body line ${pass.reopen.spanningAt + 1}; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
     }
   };
-  const first = runPhase(false);
+  const first = runToCompletion([], false);
   if (first.pass.boundaries.length === expected.length) {
     for (const message of first.buffered) warn(message);
     return first.pass;
   }
-  const second = runPhase(true);
+  for (const opener of first.pass.openers) {
+    // The opener and its closer are disabled TOGETHER: dropping only the
+    // opener re-pairs every later fence line (the old closer becomes a new
+    // opener), which let a wrong trial anchor the right COUNT of turns on
+    // the wrong lines. Removing the pair leaves every other fence exactly
+    // where the first stage saw it, so a wrong trial genuinely fails.
+    const seed = opener.closedAt === -1 ? [opener.at] : [opener.at, opener.closedAt];
+    const trial = runToCompletion(seed, false);
+    if (trial.pass.boundaries.length === expected.length) {
+      warn(`the code fence opened at body line ${opener.at + 1} hides the header of a recorded turn; a fence does not span a turn, so it was read as ordinary text and that turn was kept.`);
+      for (const message of trial.buffered) warn(message);
+      return trial.pass;
+    }
+  }
+  const second = runToCompletion([], true);
   for (const message of second.buffered) warn(message);
   return second.pass;
 }
@@ -1118,6 +1223,7 @@ const seenIds = new Set();
 let skippedNotConversation = 0;
 let skippedNoFrontmatter = 0;
 let skippedNoMessages = 0;
+let sawSourceKey = false;
 let skippedUnreadableRecord = 0;
 let skippedJoinMismatch = 0;
 let droppedEmptyMessages = 0;
@@ -1144,6 +1250,9 @@ for (const file of files) {
     skippedNotConversation += 1;
     continue;
   }
+  // Noted before any skip below, so the no-provider warning can tell "no page
+  // carries a source: key" apart from "the pages that carry one were skipped".
+  if (typeof front.source === 'string' && front.source.trim() !== '') sawSourceKey = true;
   const warn = (message) => console.warn(`warning: ${file} - ${message}`);
 
   let read;
@@ -1235,7 +1344,13 @@ if (distinctProviders.length > 1) {
 // meta.source_export_date is. Minting a token no registry defines is a guess,
 // and a guess gets reported like every other lossy edge in this script.
 if (distinctProviders.length === 0) {
-  console.warn(`warning: no page carries a \`source:\` key, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
+  // Two different situations, two true statements: pages with no source: key
+  // at all, versus sourced pages that were all skipped before they could
+  // contribute one - telling the second audience to "set source:" would be
+  // advice about a key they already set.
+  console.warn(sawSourceKey
+    ? `warning: every page carrying a \`source:\` key was skipped before it could contribute one, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Fix the skipped pages to name the real provider.`
+    : `warning: no page carries a \`source:\` key, and envelope-v0 requires meta.source_provider; wrote the placeholder ${JSON.stringify(FALLBACK_PROVIDER)}, which is not a registered provider token. Set \`source:\` on the pages to name the real provider.`);
 }
 const envelope = {
   memvelope: 'envelope-v0',

--- a/scripts/gbrain-to-envelope.mjs
+++ b/scripts/gbrain-to-envelope.mjs
@@ -105,17 +105,25 @@
  * narrower: an exposed line still becomes a boundary only by carrying the
  * next expected clock.
  *
- * The body is cut at a gbrain timeline sentinel - a line that is exactly
- * `<!-- timeline -->`, `<!--timeline-->` or `--- timeline ---` after
- * trimming - so a page's timeline never becomes message text. Only a sentinel
- * with no accepted turn after it is treated as a boundary; one with turns
- * below it is message text and is reported rather than cut at. A sentinel
- * standing alone on its line INSIDE the final message still cuts - from this
- * side of the page it is indistinguishable from gbrain's real delimiter - and
- * the cut is what the timeline note on stderr is counting. The fourth form
- * gbrain's own parser accepts (a bare `---` followed by `## Timeline`) is
- * deliberately NOT recognized here, because `---` is also the legacy
- * turn separator.
+ * The body is cut at a gbrain timeline sentinel, in all four forms gbrain's
+ * own findTimelineSplitIndex accepts (src/core/markdown.ts, mirrored in
+ * timelineSentinelAt below): `<!-- timeline -->`, `<!--timeline-->`, the
+ * decorated rule under /^---\s+timeline\s+---$/i in any case and spacing, and
+ * a bare `---` with content above it whose next non-blank line is a
+ * `## Timeline` or `## History` heading. So a page's timeline never becomes
+ * message text under any spelling gbrain itself would split on. Only a
+ * sentinel with no accepted turn after it is treated as a boundary; one with
+ * turns below it is message text and is reported rather than cut at - where
+ * gbrain's parser cuts at the FIRST hit and truncates every turn below, the
+ * one deliberate divergence, made because a quoted sentinel must not delete
+ * the turns after it. A sentinel standing alone on its line INSIDE the final
+ * message still cuts - from this side of the page it is indistinguishable
+ * from gbrain's real delimiter, and gbrain's own parser reads that page the
+ * same way - and the cut is what the timeline note on stderr is counting.
+ * The bare-`---` form is safe against the legacy turn separator because of
+ * its heading lookahead: a separator's next non-blank line is a turn header,
+ * never the Timeline/History heading, and a final message ending in a plain
+ * `---` with prose (or nothing) below keeps its bytes.
  *
  * Frontmatter is read line by line: top-level scalars only, in the plain,
  * single-quoted, double-quoted (escapes decoded, including `\U` beyond the
@@ -183,8 +191,11 @@
  *     stderr when non-blank content is dropped this way.
  *   - Everything after a timeline sentinel that no accepted turn follows -
  *     a real gbrain timeline, or the tail of a final message that quoted
- *     the sentinel. envelope-v0 has no field for a timeline. Each cut is
- *     warned per page, naming the body line, and tallied in the closing
+ *     the sentinel - in any of the four forms above, the bare-`---` form
+ *     included: a final message that legitimately ends with `---` and a
+ *     `## Timeline` heading is cut, because gbrain's own parser reads that
+ *     page the same way. envelope-v0 has no field for a timeline. Each cut
+ *     is warned per page, naming the body line, and tallied in the closing
  *     note.
  *   - A recorded `ts` that is not a strict RFC 3339 `date-time` - which is
  *     what the schema's `format: date-time` names. Emitted as null, with a
@@ -825,7 +836,37 @@ const TURN_HEADER = /^\*\*(Me|Assistant)\*\* \((.*?) · (.*)\):$/;
 const RECORDED_HEADER = /^\*\*(Me|Assistant)\*\* \((\d{4}-\d{2}-\d{2} \d{2}:\d{2})\):[ \t]*$/;
 // A whole line, after trimming - never a substring. A message that quotes the
 // sentinel mid-sentence is prose, and cutting there destroys every later turn.
+// gbrain's findTimelineSplitIndex (src/core/markdown.ts) accepts four forms;
+// the set holds the exact spellings, DECORATED_SENTINEL the case/space-tolerant
+// `--- timeline ---` family, and timelineSentinelAt adds the fourth - a bare
+// `---` whose next non-blank line is a `## Timeline`/`## History` heading.
 const TIMELINE_SENTINELS = new Set(['<!-- timeline -->', '<!--timeline-->', '--- timeline ---']);
+const DECORATED_SENTINEL = /^---\s+timeline\s+---$/i;
+const TIMELINE_HEADING = /^##\s+(timeline|history)\b/i;
+
+// Decision-identical to gbrain's own reading (findTimelineSplitIndex; keep in
+// lockstep like headerClock): a bare `---` is a sentinel only when something
+// stands above it and the next non-blank line is the Timeline/History heading.
+// The two conditions are checked heading-first here because a legacy body puts
+// a `---` separator between every pair of turns, and the lookahead ends at the
+// very next non-blank line where the leading-content scan walks the whole
+// prefix. The caller keeps its fence mask: a fenced line is sample text, never
+// a candidate - the one deliberate divergence from gbrain's fence-blind parser,
+// and it predates this predicate.
+function timelineSentinelAt(lines, i) {
+  const trimmed = lines[i].trim();
+  if (TIMELINE_SENTINELS.has(trimmed) || DECORATED_SENTINEL.test(trimmed)) return true;
+  if (trimmed !== '---') return false;
+  for (let j = i + 1; j < lines.length; j += 1) {
+    const next = lines[j].trim();
+    if (next.length === 0) continue;
+    if (!TIMELINE_HEADING.test(next)) return false;
+    // gbrain skips a rule with nothing above it, so a body OPENING on
+    // `---` + `## Timeline` is content there and stays content here.
+    return lines.slice(0, i).join('\n').trim().length > 0;
+  }
+  return false;
+}
 const NO_TIMESTAMP = 'no timestamp';
 const FALLBACK_PROVIDER = 'unknown';
 const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
@@ -1085,7 +1126,7 @@ function cutAndSlice(lines, anchors, fenced, warn, stripLegacySeparator, build) 
   const sentinels = [];
   for (let i = 0; i < lines.length; i += 1) {
     if (fenced[i]) continue;
-    if (TIMELINE_SENTINELS.has(lines[i].trim())) sentinels.push(i);
+    if (timelineSentinelAt(lines, i)) sentinels.push(i);
   }
 
   // Cut only at a sentinel that no accepted turn follows. gbrain writes the

--- a/test/fixtures/memvelope/envelope-v0.schema.json
+++ b/test/fixtures/memvelope/envelope-v0.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://memvelope.com/schema/envelope-v0.schema.json",
+  "title": "Memvelope Envelope v0",
+  "description": "A lossless, provider-neutral archive of AI conversations, and a pure function of the source export. Layer 1 of the Memvelope standard.",
+  "type": "object",
+  "required": [
+    "memvelope",
+    "meta",
+    "conversations"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "memvelope": {
+      "const": "envelope-v0",
+      "description": "Format + version tag; identifies the file. The reference serializer emits it first for human scanability, but key order is normative only through the canonical serialization profile; readers locate this field by name, never by position."
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "source_provider",
+        "conversation_count",
+        "message_count"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "source_provider": {
+          "type": "string",
+          "description": "Lowercase registered token for the source provider. Registered values: \"chatgpt\", \"claude\". New tokens are registered by PR against SPEC.md."
+        },
+        "source_export_date": {
+          "type": "string",
+          "anyOf": [
+            {
+              "format": "date"
+            },
+            {
+              "format": "date-time"
+            }
+          ],
+          "description": "ISO 8601 date (YYYY-MM-DD) or datetime the source export was produced; date-only when the export states only a date. Present only when the export itself states one; omitted (not null) otherwise."
+        },
+        "conversation_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "message_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "conversations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "created_at",
+          "updated_at",
+          "messages"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The source conversation id copied verbatim, or null if the export didn't provide one. Converters must not synthesize ids. Ids should be unique within an envelope; consumers must tolerate null and duplicates."
+          },
+          "title": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "role",
+                "ts",
+                "text"
+              ],
+              "additionalProperties": true,
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Conversation-positional id (m1, m2, ...), stable within this envelope and meaningful only within its conversation."
+                },
+                "role": {
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ],
+                  "description": "Only real conversation turns. Tool/system/thinking content is excluded."
+                },
+                "ts": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Original timestamp from the export, or null if absent."
+                },
+                "text": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Message prose after the normative trim-and-join extraction rules."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -1300,6 +1300,75 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.exported.stderr).toContain('read as prose');
   });
 
+  // --- Pins for two round-3 header overclaims, corrected 2026-08-02. -------
+  // In both cases the code was right and the documentation was not; these pin
+  // the behavior the header now states, so the corrected claims stay true.
+
+  test('legacy path: a demoted fence exposes every header-shaped line it covered, separator or not', async () => {
+    // The old header said a header-shaped line inside a still-open fence is
+    // taken as a turn "only when" the blank / `---` / blank separator sits
+    // above it. Measured: the separator decides whether the fence loses; once
+    // it has lost, an exposed separatorless header-shaped line becomes a turn
+    // too. That is the deliberate spurious-message-over-silent-loss trade,
+    // and the header now says so.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Demotion reach', 'source: chatgpt', 'memvelope_conversation_id: c-reach'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'before fence',
+          '',
+          `${FENCE}js`,
+          'inside the fence, no separator above the next line',
+          '**Assistant** (fake-ts · forged-id):',
+          'still inside what was the fence',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'real second turn',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    const messages = result.envelope.conversations[0].messages as Array<{ id: string; ts: string | null }>;
+    expect(messages.map((m) => m.id)).toEqual(['m1', 'forged-id', 'm2']);
+    expect(messages[1].ts).toBeNull();
+    expect(result.stderr).toContain('is still open at the turn header');
+  });
+
+  test('the timeline-cut note claims a cut, not a timeline the page may not have carried', async () => {
+    // The old note said the page "carried a gbrain timeline section". A final
+    // message that ends by quoting the sentinel on its own line is cut
+    // identically - from this side of the page the two cases cannot be told
+    // apart - so the note now states only what happened: a cut, and where the
+    // loss is. The text after the sentinel is the price, and it is paid
+    // loudly rather than reported falsely.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Quoted at the end', 'source: chatgpt', 'memvelope_conversation_id: c-endquote'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'The marker gbrain uses is this, on its own line:',
+          '',
+          '<!-- timeline -->',
+          '',
+          'and this sentence is cut away with the pseudo-timeline.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].messages[0].text).toBe('The marker gbrain uses is this, on its own line:');
+    expect(result.stderr).toContain('were cut at a timeline sentinel');
+    expect(result.stderr).not.toContain('carried a gbrain timeline');
+  });
+
   // --- The recorded (frontmatter-identity) path's own contract. -------------
 
   /** A recorded-format page in the exact shape the importer writes. */

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -1137,6 +1137,481 @@ describe('gbrain-to-envelope exporter', () => {
     expect(isRfc3339DateTime('2026-12-31T23:59:60+05:30')).toBe(false);
   });
 
+  // --- Red-first regression tests for J, C and D2 on the frontmatter-identity
+  // format. Each was run against the exporter as of the importer-f5 merge
+  // (ccaed050) and FAILED there - the old exporter reads identity out of
+  // `**Me** (<ts> · <id>):` headers, a shape the new importer no longer writes -
+  // so each pins that the rebuild actually closed its defect rather than
+  // documenting it as non-survival.
+  //
+  // J, C and D2 all existed because identity lived in prose, where message text
+  // could break or forge it. Identity now lives in the frontmatter `messages:`
+  // array, which measured hostile-id probing (17 values, including an embedded
+  // newline and a whole `---`/`type:`/`---` block) shows message content cannot
+  // reach.
+
+  /** Writes an envelope to a temp file and round-trips it through the real
+   *  in-tree importer, then the exporter - the actual producer, not a
+   *  hand-transcription of its output. */
+  async function roundTripEnvelope(envelope: unknown) {
+    const envelopePath = join(tempDir(), 'probe.mve.json');
+    writeFileSync(envelopePath, JSON.stringify(envelope, null, 2) + '\n');
+    return roundTrip(envelopePath);
+  }
+
+  test('J: hostile message ids - embedded newline included - survive the round trip verbatim', async () => {
+    // Pre-rebuild: an id containing a newline broke the header line the old
+    // importer wrote it into, the header no longer matched, and the turn was
+    // silently absorbed into the previous one - the last silent loss reachable
+    // from a well-formed envelope. Ids now ride in frontmatter as JSON-quoted
+    // scalars, so no id value can break the line that carries it.
+    const HOSTILE_IDS = [
+      'm\n1',
+      '---\ntype: hacked\n---',
+      'a: b',
+      '- leading dash',
+      'id with trailing space ',
+      'mid · dot',
+      '"quoted" \\ and emoji \u{1F680}',
+    ];
+    const messages = HOSTILE_IDS.map((id, i) => ({
+      id,
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      ts: `2026-02-01T09:0${i}:1${i}.000Z`,
+      text: `turn ${i + 1} text`,
+    }));
+    const result = await roundTripEnvelope({
+      memvelope: 'envelope-v0',
+      meta: { source_provider: 'chatgpt', conversation_count: 1, message_count: messages.length },
+      conversations: [
+        {
+          id: 'c-hostile-ids',
+          title: 'Hostile ids',
+          created_at: '2026-02-01T09:00:10.000Z',
+          updated_at: '2026-02-01T09:06:16.000Z',
+          messages,
+        },
+      ],
+    });
+
+    expect(result.imported.exitCode).toBe(0);
+    expect(result.exported.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: messages.length });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; ts: string; text: string }>;
+    // Verbatim, every one - not trimmed, not truncated at the newline, not
+    // reassigned to a neighbouring turn.
+    expect(out.map((m) => m.id)).toEqual(HOSTILE_IDS);
+    expect(out.map((m) => m.text)).toEqual(messages.map((m) => m.text));
+    expect(out.map((m) => m.ts)).toEqual(messages.map((m) => m.ts));
+  });
+
+  test('C: a turn header mangled with one trailing space still anchors its turn', async () => {
+    // Pre-rebuild: the old header regex was `$`-anchored with no trailing-space
+    // tolerance, so one space added by an editor or a sync absorbed the whole
+    // turn into its neighbour, silently. gbrain's own `imessage-slack` pattern
+    // (src/core/conversation-parser/builtins.ts) tolerates trailing whitespace
+    // after the colon, so the exporter now does too - and if a header is
+    // mangled past recognition entirely, the frontmatter count no longer
+    // matches the body and the page is refused loudly instead of joined wrong.
+    const result = await exportPages({
+      'a.md': [
+        '---',
+        'type: conversation',
+        'title: "Trailing space"',
+        'date: "2026-02-01"',
+        'source: "chatgpt"',
+        'memvelope_conversation_id: "c-trailing"',
+        'origin: memvelope/envelope-v0',
+        'messages:',
+        '  - id: "m1"',
+        '    ts: "2026-02-01T09:00:00.000Z"',
+        '  - id: "m2"',
+        '    ts: "2026-02-01T09:05:00.000Z"',
+        '---',
+        '# Trailing space',
+        '',
+        '**Me** (2026-02-01 09:00):',
+        '',
+        'first turn',
+        '',
+        '**Assistant** (2026-02-01 09:05): ', // <- the one trailing space
+        '',
+        'second turn',
+        '',
+      ].join('\n'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; role: string; text: string }>;
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(out[1].text).toBe('second turn');
+    expect(out[0].text).not.toContain('second turn');
+  });
+
+  test('D2: a header-shaped line in unfenced prose no longer splits the message', async () => {
+    // Pre-rebuild: any line shaped like a turn header split the message in two
+    // and the second half's identity was lifted straight out of prose. A
+    // boundary now has to carry the clock derived from the NEXT frontmatter
+    // `ts` - a value message text would have to predict to forge - so this
+    // line, whose clock matches no expected turn, stays prose. Driven through
+    // the real importer: the forged line arrives in the body exactly the way a
+    // real conversation about page formats would put it there.
+    const FORGED = '**Assistant** (2099-12-31 23:59):';
+    const messages = [
+      {
+        id: 'm1',
+        role: 'user' as const,
+        ts: '2026-02-01T09:00:00.000Z',
+        text: `Here is the header shape I keep seeing:\n\n${FORGED}\n\nCan you parse it?`,
+      },
+      { id: 'm2', role: 'assistant' as const, ts: '2026-02-01T09:05:00.000Z', text: 'Yes - and it must stay prose.' },
+    ];
+    const result = await roundTripEnvelope({
+      memvelope: 'envelope-v0',
+      meta: { source_provider: 'chatgpt', conversation_count: 1, message_count: 2 },
+      conversations: [
+        {
+          id: 'c-forged-header',
+          title: 'Forged header',
+          created_at: '2026-02-01T09:00:00.000Z',
+          updated_at: '2026-02-01T09:05:00.000Z',
+          messages,
+        },
+      ],
+    });
+
+    expect(result.imported.exitCode).toBe(0);
+    expect(result.exported.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; ts: string | null; text: string }>;
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm2']);
+    // The forged line is still IN the text - not a boundary, and not deleted.
+    expect(out[0].text).toContain(FORGED);
+    expect(out[0].text).toContain('Can you parse it?');
+    // No identity was forged from it: the line survives as text, but no
+    // timestamp field anywhere in the document carries its clock.
+    expect(out.map((m) => m.ts)).toEqual(['2026-02-01T09:00:00.000Z', '2026-02-01T09:05:00.000Z']);
+    for (const { value } of timestampsIn(result.envelope)) {
+      expect(String(value)).not.toContain('2099');
+    }
+    // And the operator is told a header-shaped line was read as prose.
+    expect(result.exported.stderr).toContain('read as prose');
+  });
+
+  // --- The recorded (frontmatter-identity) path's own contract. -------------
+
+  /** A recorded-format page in the exact shape the importer writes. */
+  function recordedPage(opts: {
+    title?: string;
+    id?: string;
+    record: string[];
+    body: string;
+    date?: string;
+  }): string {
+    return [
+      '---',
+      'type: conversation',
+      `title: ${JSON.stringify(opts.title ?? 'Recorded')}`,
+      `date: ${JSON.stringify(opts.date ?? '2026-02-01')}`,
+      'source: "chatgpt"',
+      ...(opts.id ? [`memvelope_conversation_id: ${JSON.stringify(opts.id)}`] : []),
+      'origin: memvelope/envelope-v0',
+      ...opts.record,
+      '---',
+      `# ${opts.title ?? 'Recorded'}`,
+      '',
+      opts.body,
+      '',
+    ].join('\n');
+  }
+
+  const RECORD_2 = [
+    'messages:',
+    '  - id: "m1"',
+    '    ts: "2026-02-01T09:00:00.000Z"',
+    '  - id: "m2"',
+    '    ts: "2026-02-01T09:05:00.000Z"',
+  ];
+  const BODY_2 = [
+    '**Me** (2026-02-01 09:00):',
+    '',
+    'first turn',
+    '',
+    '**Assistant** (2026-02-01 09:05):',
+    '',
+    'second turn',
+  ].join('\n');
+
+  test('recorded path: the quoting styles gbrain re-serializes to still read', async () => {
+    // gbrain's serializeMarkdown re-emits the array semantically, not
+    // textually: plain unquoted ids, single-quoted timestamps. Both must read
+    // identically to the importer's JSON-quoted originals.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-requoted',
+        record: [
+          'messages:',
+          '  - id: m1',
+          "    ts: '2026-02-01T09:00:00.000Z'",
+          '  - id: m2',
+          "    ts: '2026-02-01T09:05:00.000Z'",
+        ],
+        body: BODY_2,
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; ts: string }>;
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(out.map((m) => m.ts)).toEqual(['2026-02-01T09:00:00.000Z', '2026-02-01T09:05:00.000Z']);
+  });
+
+  test('recorded path: a body anchoring fewer turns than the record is refused loudly', async () => {
+    // A positional join over unequal counts assigns real ids to the wrong
+    // text. Refusing is the only honest option, and it has to say both
+    // numbers so the operator can find the missing turn.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-short',
+        record: RECORD_2,
+        body: '**Me** (2026-02-01 09:00):\n\nonly turn',
+      }),
+      'b.md': recordedPage({ id: 'c-ok', record: RECORD_2, body: BODY_2 }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    // The sound page still exports; the unsound one is skipped, not guessed.
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    expect(result.envelope.conversations[0].id).toBe('c-ok');
+    expect(result.stderr).toContain('records 2 message(s)');
+    expect(result.stderr).toContain('anchors 1 turn(s)');
+    expect(result.stderr).toContain('1 whose body does not match their messages record');
+  });
+
+  test('recorded path: a null or non-string recorded id is refused loudly, never invented', async () => {
+    const nullId = recordedPage({
+      id: 'c-nullid',
+      record: ['messages:', '  - id: null', '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    // An unquoted number is a YAML number, not a string - reading it as the
+    // string "123" would fabricate an id the record does not hold.
+    const numericId = recordedPage({
+      id: 'c-numid',
+      record: ['messages:', '  - id: 123', '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({ 'a.md': nullId, 'b.md': numericId });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('messages[0] records null');
+    expect(result.stderr).toContain('messages[0] records "123"');
+    expect(result.stderr).toContain('2 with a messages record that could not be read');
+  });
+
+  test('recorded path: an empty or unreadable messages record is refused loudly', async () => {
+    const empty = recordedPage({
+      id: 'c-empty',
+      record: ['messages: []'],
+      body: 'No turns at all.',
+    });
+    const unreadable = recordedPage({
+      id: 'c-unreadable',
+      record: ['messages: not an array'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const missingTs = recordedPage({
+      id: 'c-missing-ts',
+      record: ['messages:', '  - id: "m1"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({ 'a.md': empty, 'b.md': unreadable, 'c.md': missingTs });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('the messages record is empty');
+    expect(result.stderr).toContain('could not be read');
+    expect(result.stderr).toContain('does not carry both id and ts');
+  });
+
+  test('recorded path: ts null takes the page-date fallback clock and stays null', async () => {
+    // The importer writes `<date> 00:00` in the header when a message's ts is
+    // null or unusable; the exporter expects the same clock, joins on it, and
+    // the recorded null comes back as the null the schema permits.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-nullts',
+        record: [
+          'messages:',
+          '  - id: "m1"',
+          '    ts: null',
+          '  - id: "m2"',
+          '    ts: "2026-02-01T09:05:00.000Z"',
+        ],
+        body: [
+          '**Me** (2026-02-01 00:00):',
+          '',
+          'no timestamp on this one',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'this one has one',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ ts: string | null }>;
+    expect(out[0].ts).toBeNull();
+    expect(out[1].ts).toBe('2026-02-01T09:05:00.000Z');
+    expect(result.envelope.conversations[0].created_at).toBeNull();
+  });
+
+  test('recorded path: a recorded ts that is not RFC 3339 is emitted as null, loudly', async () => {
+    // TS_SHAPE reads a wall clock out of `2026-02-01T09:00` (no seconds), so
+    // the header join works - but the schema's date-time requires seconds, so
+    // the value itself cannot ship. Null plus a warning, like every other
+    // non-conforming timestamp.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-badts',
+        record: ['messages:', '  - id: "m1"', '    ts: "2026-02-01T09:00"'],
+        body: '**Me** (2026-02-01 09:00):\n\na turn',
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 1 });
+    expect(result.envelope.conversations[0].messages[0].ts).toBeNull();
+    expect(result.stderr).toContain('"2026-02-01T09:00"');
+    expect(result.stderr).toContain('not an RFC 3339 date-time');
+  });
+
+  test('recorded path: a fence spanning a turn boundary loses to the recorded clock', async () => {
+    // The R1 rule, re-anchored: the legacy separator is gone from this format,
+    // so the signal that a fence has swallowed a boundary is the next expected
+    // clock appearing inside it. The fence is demoted, the turn is kept, and
+    // the operator is told.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-fencespan',
+        record: RECORD_2,
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'I pasted half a block by mistake:',
+          '',
+          `${FENCE}js`,
+          "const widget = 'acme-example';",
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'The block above me never closed.',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(out[1].text).toBe('The block above me never closed.');
+    expect(out[0].text).not.toContain('never closed');
+    expect(result.stderr).toContain('is still open at the turn header');
+  });
+
+  test('recorded path: a header quoted in a closed fence is sample text, not a turn', async () => {
+    // The quoted-transcript case: the fence opens and closes inside one turn,
+    // so even a line carrying a REAL upcoming clock stays sample text - the
+    // fence is balanced, and balanced fences win.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-quotedfence',
+        record: RECORD_2,
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'The page format looks like this:',
+          '',
+          FENCE,
+          '**Assistant** (2027-01-01 12:00):',
+          FENCE,
+          '',
+          'Right?',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'Right.',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ text: string }>;
+    expect(out[0].text).toContain('(2027-01-01 12:00)');
+    expect(out[0].text).toContain('Right?');
+    expect(out[1].text).toBe('Right.');
+    expect(result.stderr).toContain('read as sample text');
+  });
+
+  test('recorded path: an empty turn drops its record entry too, keeping the join aligned', async () => {
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-emptyturn',
+        record: [
+          'messages:',
+          '  - id: "m1"',
+          '    ts: "2026-02-01T09:00:00.000Z"',
+          '  - id: "m2"',
+          '    ts: "2026-02-01T09:05:00.000Z"',
+          '  - id: "m3"',
+          '    ts: "2026-02-01T09:10:00.000Z"',
+        ],
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'first turn',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          '**Me** (2026-02-01 09:10):',
+          '',
+          'third turn',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    // m2 dropped WITH its entry: m3 keeps its own id and text, not m2's.
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm3']);
+    expect(out[1].text).toBe('third turn');
+    expect(result.stderr).toContain('"m2" has no text; dropped');
+  });
+
+  test('recorded path: a new-format body without its record is skipped loudly, not guessed', async () => {
+    // A page carrying clock-only headers but NO messages key has no identity
+    // source at all - the legacy parser cannot read these headers, and there
+    // is no record to join. It lands in the legacy path and is skipped as
+    // turnless, which is loud and honest.
+    const result = await exportPages({
+      'a.md': recordedPage({ id: 'c-recordless', record: [], body: BODY_2 }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('no speaker turns found');
+  });
+
   test('a missing directory argument or unreadable path exits 1', async () => {
     const noArgs = await run(EXPORTER_PATH, []);
     expect(noArgs.exitCode).toBe(1);

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -1643,7 +1643,7 @@ describe('gbrain-to-envelope exporter', () => {
     const out2 = closesLater.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
     expect(out2.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
     expect(out2[1].text).toBe('The fence above is still open here.');
-    expect(closesLater.stderr).toContain('is still open at the turn header');
+    expect(closesLater.stderr).toContain('hides the header of a recorded turn');
   });
 
   test('recorded path: a header quoted in a closed fence is sample text, not a turn', async () => {
@@ -2004,6 +2004,148 @@ describe('gbrain-to-envelope exporter', () => {
     expect(isRfc3339Date('0000-02-30')).toBe(false);
     // The 1900-mapping would also have accepted 1900's non-leap February.
     expect(isRfc3339DateTime('1900-02-29T00:00:00Z')).toBe(false);
+  });
+
+  // --- Round-2 gate pins: the fixes' own fixes. -----------------------------
+
+  test('G12: plain-scalar typing is js-yaml 3.14\'s, exactly - "089" is a string, "017" is a number', async () => {
+    // An approximating regex refused "089" - a STRING to js-yaml, which its
+    // dumper re-emits unquoted - so a conversation with that id survived the
+    // importer and died at the exporter after one brain cycle. The typing is
+    // now a port of js-yaml's own resolvers. Strings export; numbers refuse.
+    const page = (name: string, idLine: string) => recordedPage({
+      id: name,
+      record: ['messages:', `  - id: ${idLine}`, '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({
+      'a.md': page('c-089', '089'), // not octal (8), not decimal (leading 0): a string
+      'b.md': page('c-0o17', '0o17'), // js-yaml 3 has no 0o form: a string
+      'c.md': page('c-underscore', '123_'), // trailing underscore: a string
+      'd.md': page('c-octal', '017'), // 1.1 leading-zero octal: a NUMBER
+      'e.md': page('c-signedhex', '-0x1F'), // signed hex: a NUMBER
+      'f.md': page('c-dotfloat', '._5'), // dot-float with underscore: a NUMBER
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 3, messages: 3 });
+    const byConv = Object.fromEntries(
+      (result.envelope.conversations as Array<{ id: string; messages: Array<{ id: string }> }>).map((c) => [c.id, c.messages[0].id]),
+    );
+    expect(byConv['c-089']).toBe('089');
+    expect(byConv['c-0o17']).toBe('0o17');
+    expect(byConv['c-underscore']).toBe('123_');
+    expect(result.stderr).toContain('"017"');
+    expect(result.stderr).toContain('"-0x1F"');
+    expect(result.stderr).toContain('"._5"');
+  });
+
+  test('G13: the fence that loses is the fence that swallowed the turn, not a balanced one quoting it', async () => {
+    // With greedy demotion, a balanced fence quoting the next expected clock
+    // was demoted first when a LATER fence caused the shortfall - the quote
+    // stole the boundary and flipped the stolen turn's role. Each fence is
+    // now tried alone, and only the one whose demotion recovers every
+    // recorded turn loses.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-rightfence',
+        record: [
+          'messages:',
+          '  - id: "m1"',
+          '    ts: "2026-02-01T09:00:00.000Z"',
+          '  - id: "m2"',
+          '    ts: "2026-02-01T09:05:00.000Z"',
+          '  - id: "m3"',
+          '    ts: "2026-02-01T09:10:00.000Z"',
+        ],
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'a quoted transcript:',
+          '',
+          FENCE,
+          '**Assistant** (2026-02-01 09:05):',
+          'quoted, inside a BALANCED fence',
+          FENCE,
+          '',
+          'end of quote',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'real second turn, and half a paste:',
+          '',
+          FENCE,
+          'const half = true;',
+          '',
+          '**Me** (2026-02-01 09:10):',
+          '',
+          'real third turn, closing the paste:',
+          '',
+          FENCE,
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 3 });
+    const out = result.envelope.conversations[0].messages as Array<{ id: string; role: string; text: string }>;
+    expect(out.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+    // The balanced fence kept its quote; the spanning fence lost.
+    expect(out[0].text).toContain('quoted, inside a BALANCED fence');
+    expect(out[1].text).toContain('real second turn');
+    expect(out[2].text).toContain('real third turn');
+    expect(result.stderr).toContain('hides the header of a recorded turn');
+  });
+
+  test('G14: a comment straight after a closing quote ends the value', async () => {
+    // YAML ends a quoted scalar's value at a '#' with or without whitespace
+    // after the closing quote. Keeping it made `"a"# c` a silent garbage
+    // conversation id at top level and a falsely-refused member below.
+    const result = await exportPages({
+      'a.md': [
+        '---',
+        'type: conversation',
+        'title: "Quote comment"',
+        'date: "2026-02-01"',
+        'source: "chatgpt"',
+        'memvelope_conversation_id: "a"# c',
+        'messages:',
+        '  - id: "m1"# first',
+        '    ts: "2026-02-01T09:00:00.000Z"',
+        '---',
+        '# Quote comment',
+        '',
+        '**Me** (2026-02-01 09:00):',
+        '',
+        'a turn',
+        '',
+      ].join('\n'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 1 });
+    expect(result.envelope.conversations[0].id).toBe('a');
+    expect(result.envelope.conversations[0].messages[0].id).toBe('m1');
+  });
+
+  test('G15: the no-provider warning does not claim pages lack a source: key they carry', async () => {
+    // A sourced page skipped for an unreadable record contributed no
+    // provider; the warning then asserted "no page carries a source: key" -
+    // false, with advice about a key that was already set.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-sourced-skipped',
+        record: ['messages: not an array'],
+        body: '**Me** (2026-02-01 09:00):\n\na turn',
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('was skipped before it could contribute one');
+    expect(result.stderr).not.toContain('no page carries');
   });
 
   test('a missing directory argument or unreadable path exits 1', async () => {

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -6,7 +6,7 @@
  */
 import { afterAll, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -79,7 +79,11 @@ async function exportPages(pages: Record<string, string>) {
   const result = await run(EXPORTER_PATH, [pagesDir, outPath]);
   return {
     ...result,
-    envelope: result.exitCode === 0 ? JSON.parse(readFileSync(outPath, 'utf8')) : null,
+    pagesDir,
+    outPath,
+    // A multi-provider directory writes per-provider files instead of outPath;
+    // those tests read their own files, so a missing outPath is null here.
+    envelope: result.exitCode === 0 && existsSync(outPath) ? JSON.parse(readFileSync(outPath, 'utf8')) : null,
   };
 }
 
@@ -615,9 +619,13 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.stderr).toContain('already used by another page');
   });
 
-  test('pages naming different providers warn and keep the first', async () => {
-    // An envelope carries one source_provider. A page set spanning two is a
-    // real structural loss, so it is reported instead of resolved silently.
+  test('pages naming different providers write one envelope per provider', async () => {
+    // An envelope carries one source_provider. This script used to collapse a
+    // mixed set to the first provider in sorted path order, and re-importing
+    // that envelope stamped the winner onto every losing page - check 2 saw a
+    // legitimate refresh and overwrote `source:` at exit 0, with nothing on
+    // disk retaining the truth. A mixed set now fans out, one conforming
+    // envelope per provider, each file named for the provider it carries.
     const page = (id: string, source: string) =>
       gbrainPage(
         ['type: conversation', `title: ${id}`, `source: ${source}`, `memvelope_conversation_id: ${id}`].join('\n'),
@@ -629,9 +637,21 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.envelope.meta.source_provider).toBe('chatgpt');
+    // outPath itself is NOT written: there is no single envelope that could
+    // describe this directory without falsifying someone's provider.
+    expect(existsSync(result.outPath)).toBe(false);
+    const dir = join(result.outPath, '..');
+    const cg = JSON.parse(readFileSync(join(dir, 'out.chatgpt.mve.json'), 'utf8'));
+    const cl = JSON.parse(readFileSync(join(dir, 'out.claude.mve.json'), 'utf8'));
+    assertEnvelopeV0(cg, { conversations: 1, messages: 2 });
+    assertEnvelopeV0(cl, { conversations: 1, messages: 2 });
+    expect(cg.meta.source_provider).toBe('chatgpt');
+    expect(cg.conversations.map((c: any) => c.id)).toEqual(['c-a']);
+    expect(cl.meta.source_provider).toBe('claude');
+    expect(cl.conversations.map((c: any) => c.id)).toEqual(['c-b']);
     expect(result.stderr).toContain('source providers');
-    expect(result.envelope.conversations).toHaveLength(2);
+    expect(result.stdout).toContain(`wrote 1 conversation(s), 2 message(s) to ${join(dir, 'out.chatgpt.mve.json')}`);
+    expect(result.stdout).toContain(`wrote 1 conversation(s), 2 message(s) to ${join(dir, 'out.claude.mve.json')}`);
   });
 
   // --- Regression tests for six verified defects. -------------------------
@@ -2146,6 +2166,158 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.envelope.conversations).toHaveLength(0);
     expect(result.stderr).toContain('was skipped before it could contribute one');
     expect(result.stderr).not.toContain('no page carries');
+  });
+
+  // --- Sweep 2.2: one envelope per provider. --------------------------------
+  // The mainstream memvelope pitch is merging several vendors' history into
+  // one directory. These tests pin the per-provider fan-out end to end: the
+  // full circle back through the importer, the sourceless residue, the
+  // untouched single-provider path, and the filename token rules.
+
+  const providerEnvelope = (provider: string, id: string, text: string) => ({
+    memvelope: 'envelope-v0',
+    meta: { source_provider: provider, conversation_count: 1, message_count: 1 },
+    conversations: [
+      {
+        id,
+        title: `From ${provider}`,
+        created_at: '2026-02-01T09:00:00.000Z',
+        updated_at: '2026-02-01T09:00:00.000Z',
+        messages: [{ id: 'm1', role: 'user', ts: '2026-02-01T09:00:00.000Z', text }],
+      },
+    ],
+  });
+
+  test('a mixed-provider directory round-trips with no page\'s source falsified', async () => {
+    // The full circle the defect lived on: two providers' envelopes imported
+    // into ONE directory, exported, and re-imported into the same directory.
+    // Byte-identical pages after the circle is the strongest form of "no
+    // page's `source:` changed hands" - check 2 matches per-conversation ids,
+    // sees a refresh carrying the same truth, and rewrites the same bytes.
+    const dir = tempDir();
+    const pagesDir = join(dir, 'pages');
+    const cgIn = join(dir, 'cg.mve.json');
+    const clIn = join(dir, 'cl.mve.json');
+    writeFileSync(cgIn, JSON.stringify(providerEnvelope('chatgpt', 'c-cg', 'hello from chatgpt')));
+    writeFileSync(clIn, JSON.stringify(providerEnvelope('claude', 'c-cl', 'hello from claude')));
+    expect((await run(IMPORTER_PATH, [cgIn, pagesDir])).exitCode).toBe(0);
+    expect((await run(IMPORTER_PATH, [clIn, pagesDir])).exitCode).toBe(0);
+
+    const snapshot = new Map<string, string>();
+    for (const name of readdirSync(pagesDir)) {
+      if (name.endsWith('.md')) snapshot.set(name, readFileSync(join(pagesDir, name), 'utf8'));
+    }
+    expect(snapshot.size).toBe(2);
+
+    const outPath = join(dir, 'out.mve.json');
+    const exported = await run(EXPORTER_PATH, [pagesDir, outPath]);
+    expect(exported.exitCode).toBe(0);
+    expect(existsSync(outPath)).toBe(false);
+
+    const cgOut = join(dir, 'out.chatgpt.mve.json');
+    const clOut = join(dir, 'out.claude.mve.json');
+    const cgEnv = JSON.parse(readFileSync(cgOut, 'utf8'));
+    const clEnv = JSON.parse(readFileSync(clOut, 'utf8'));
+    assertEnvelopeV0(cgEnv, { conversations: 1, messages: 1 });
+    assertEnvelopeV0(clEnv, { conversations: 1, messages: 1 });
+    // Field for field, each per-provider envelope is the one that went in.
+    expect(cgEnv).toEqual(providerEnvelope('chatgpt', 'c-cg', 'hello from chatgpt'));
+    expect(clEnv).toEqual(providerEnvelope('claude', 'c-cl', 'hello from claude'));
+
+    expect((await run(IMPORTER_PATH, [cgOut, pagesDir])).exitCode).toBe(0);
+    expect((await run(IMPORTER_PATH, [clOut, pagesDir])).exitCode).toBe(0);
+    expect(readdirSync(pagesDir).filter((n) => n.endsWith('.md'))).toHaveLength(2);
+    for (const [name, bytes] of snapshot) {
+      expect(readFileSync(join(pagesDir, name), 'utf8')).toBe(bytes);
+    }
+  });
+
+  test('pages with no source: land in their own unknown envelope, never a named provider\'s', async () => {
+    // Absence of a `source:` key is not membership in whichever provider the
+    // directory also holds: folding these pages into the chatgpt envelope
+    // would stamp `source: "chatgpt"` onto them at re-import - the same
+    // falsification the per-provider split exists to stop, arriving through
+    // absence instead of collision. They travel under the documented
+    // placeholder instead, loudly.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Sourced', 'source: chatgpt', 'memvelope_conversation_id: c-a'].join('\n'),
+        TURNS,
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: Sourceless', 'memvelope_conversation_id: c-b'].join('\n'),
+        TURNS,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(result.outPath)).toBe(false);
+    const dir = join(result.outPath, '..');
+    const cg = JSON.parse(readFileSync(join(dir, 'out.chatgpt.mve.json'), 'utf8'));
+    const unk = JSON.parse(readFileSync(join(dir, 'out.unknown.mve.json'), 'utf8'));
+    assertEnvelopeV0(cg, { conversations: 1, messages: 2 });
+    assertEnvelopeV0(unk, { conversations: 1, messages: 2 });
+    expect(cg.meta.source_provider).toBe('chatgpt');
+    expect(cg.conversations.map((c: any) => c.id)).toEqual(['c-a']);
+    expect(unk.meta.source_provider).toBe('unknown');
+    expect(unk.conversations.map((c: any) => c.id)).toEqual(['c-b']);
+    expect(result.stderr).toContain('carry no `source:` key');
+    expect(result.stderr).toContain('"unknown"');
+  });
+
+  test('a single-provider directory is unchanged: one file, the same name and words as before', async () => {
+    // The compatibility half of the fan-out. One provider - however many
+    // pages - keeps today's behavior byte for byte: outPath itself, the same
+    // stdout line, and a silent stderr.
+    const page = (id: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${id}`, 'source: chatgpt', `memvelope_conversation_id: ${id}`].join('\n'),
+        TURNS,
+      );
+    const result = await exportPages({
+      'a.md': page('c-a'),
+      'b.md': page('c-b'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(result.outPath)).toBe(true);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    expect(result.envelope.meta.source_provider).toBe('chatgpt');
+    expect(existsSync(join(result.outPath, '..', 'out.chatgpt.mve.json'))).toBe(false);
+    expect(result.stdout).toContain(`wrote 2 conversation(s), 4 message(s) to ${result.outPath}`);
+    expect(result.stdout).not.toContain('provider "');
+    expect(result.stderr).toBe('');
+  });
+
+  test('filename tokens are sanitized and case-colliding providers get distinct files', async () => {
+    // meta.source_provider stays verbatim; only the FILENAME token is
+    // sanitized (anything outside [A-Za-z0-9._-] becomes '-', so a provider
+    // cannot steer the write outside the output directory) and deduplicated
+    // case-insensitively, so 'ChatGPT' and 'chatgpt' pages survive as two
+    // files even on the case-insensitive filesystems macOS ships - and the
+    // names come out the same on every platform.
+    const page = (id: string, source: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${id}`, `source: ${source}`, `memvelope_conversation_id: ${id}`].join('\n'),
+        TURNS,
+      );
+    const result = await exportPages({
+      'a.md': page('c-a', 'ChatGPT'),
+      'b.md': page('c-b', 'chatgpt'),
+      'c.md': page('c-c', 'open ai/gpt'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    const dir = join(result.outPath, '..');
+    const first = JSON.parse(readFileSync(join(dir, 'out.ChatGPT.mve.json'), 'utf8'));
+    const second = JSON.parse(readFileSync(join(dir, 'out.chatgpt-2.mve.json'), 'utf8'));
+    const third = JSON.parse(readFileSync(join(dir, 'out.open-ai-gpt.mve.json'), 'utf8'));
+    expect(first.meta.source_provider).toBe('ChatGPT');
+    expect(first.conversations.map((c: any) => c.id)).toEqual(['c-a']);
+    expect(second.meta.source_provider).toBe('chatgpt');
+    expect(second.conversations.map((c: any) => c.id)).toEqual(['c-b']);
+    expect(third.meta.source_provider).toBe('open ai/gpt');
+    expect(third.conversations.map((c: any) => c.id)).toEqual(['c-c']);
   });
 
   // --- Sweep 2.9: all four gbrain timeline-sentinel forms. ------------------

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Pins the envelope-v0 exporter contract: conforming output, honest handling of
+ * the fields a gbrain page cannot carry, deterministic ordering, and loud
+ * skipping. The mirror of test/envelope-to-gbrain.test.ts - the corpus is built
+ * by running the importer on its own fixture, so the round trip is the test.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const IMPORTER_PATH = join(import.meta.dir, '..', 'scripts', 'envelope-to-gbrain.mjs');
+const EXPORTER_PATH = join(import.meta.dir, '..', 'scripts', 'gbrain-to-envelope.mjs');
+const FIXTURE_PATH = join(import.meta.dir, 'fixtures', 'memvelope', 'sample.mve.json');
+const TEMP_DIRS: string[] = [];
+
+afterAll(() => {
+  for (const dir of TEMP_DIRS) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-to-envelope-'));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+// Both scripts are plain Node-compatible ESM; Bun executes them directly in CI
+// without a separate node toolchain.
+async function run(script: string, args: string[]) {
+  const proc = Bun.spawn([process.execPath, script, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  await proc.exited;
+  return {
+    exitCode: proc.exitCode,
+    stdout: await new Response(proc.stdout).text(),
+    stderr: await new Response(proc.stderr).text(),
+  };
+}
+
+/** Runs the importer, then the exporter, and returns both results plus the parsed envelope. */
+async function roundTrip(envelopePath = FIXTURE_PATH) {
+  const pagesDir = join(tempDir(), 'pages');
+  const outPath = join(tempDir(), 'out.mve.json');
+  const imported = await run(IMPORTER_PATH, [envelopePath, pagesDir]);
+  const exported = await run(EXPORTER_PATH, [pagesDir, outPath]);
+  return {
+    imported,
+    exported,
+    pagesDir,
+    outPath,
+    envelope: exported.exitCode === 0 ? JSON.parse(readFileSync(outPath, 'utf8')) : null,
+  };
+}
+
+/** Runs the exporter over a directory of pages written by the test itself. */
+async function exportPages(pages: Record<string, string>) {
+  const pagesDir = join(tempDir(), 'pages');
+  const outPath = join(tempDir(), 'out.mve.json');
+  for (const [name, content] of Object.entries(pages)) {
+    const full = join(pagesDir, name);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, content);
+  }
+  const result = await run(EXPORTER_PATH, [pagesDir, outPath]);
+  return {
+    ...result,
+    envelope: result.exitCode === 0 ? JSON.parse(readFileSync(outPath, 'utf8')) : null,
+  };
+}
+
+/**
+ * Structural conformance against envelope-v0 as published (JSON Schema draft-07
+ * at memvelope.com/schema/envelope-v0.schema.json). Every constraint the schema
+ * states is asserted here rather than paraphrased: required keys, types, the
+ * role enum, `minItems: 1` on messages, `minLength: 1` on text, and the integer
+ * minimums on the meta counts. Written out longhand so the test needs no
+ * validator dependency, matching the scripts' own zero-dependency posture.
+ */
+function assertEnvelopeV0(doc: unknown): void {
+  expect(doc).toBeObject();
+  const env = doc as Record<string, unknown>;
+  expect(env.memvelope).toBe('envelope-v0');
+
+  expect(env.meta).toBeObject();
+  const meta = env.meta as Record<string, unknown>;
+  expect(typeof meta.source_provider).toBe('string');
+  expect(Number.isInteger(meta.conversation_count)).toBe(true);
+  expect(meta.conversation_count as number).toBeGreaterThanOrEqual(0);
+  expect(Number.isInteger(meta.message_count)).toBe(true);
+  expect(meta.message_count as number).toBeGreaterThanOrEqual(0);
+  // Optional, and the spec says omitted rather than null when unknown.
+  if ('source_export_date' in meta) expect(typeof meta.source_export_date).toBe('string');
+
+  expect(Array.isArray(env.conversations)).toBe(true);
+  const conversations = env.conversations as Array<Record<string, unknown>>;
+  for (const c of conversations) {
+    for (const key of ['id', 'title', 'created_at', 'updated_at', 'messages']) {
+      expect(c).toHaveProperty(key);
+    }
+    expect(c.id === null || typeof c.id === 'string').toBe(true);
+    expect(typeof c.title).toBe('string');
+    expect(c.created_at === null || typeof c.created_at === 'string').toBe(true);
+    expect(c.updated_at === null || typeof c.updated_at === 'string').toBe(true);
+    expect(Array.isArray(c.messages)).toBe(true);
+    const messages = c.messages as Array<Record<string, unknown>>;
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    for (const m of messages) {
+      for (const key of ['id', 'role', 'ts', 'text']) {
+        expect(m).toHaveProperty(key);
+      }
+      expect(typeof m.id).toBe('string');
+      expect(['user', 'assistant']).toContain(m.role as string);
+      expect(m.ts === null || typeof m.ts === 'string').toBe(true);
+      expect(typeof m.text).toBe('string');
+      expect((m.text as string).length).toBeGreaterThanOrEqual(1);
+    }
+  }
+  // The counts are part of the document, so they get checked against it.
+  expect(meta.conversation_count).toBe(conversations.length);
+  expect(meta.message_count).toBe(
+    conversations.reduce((n, c) => n + (c.messages as unknown[]).length, 0),
+  );
+}
+
+/** The page shape gbrain itself writes: js-yaml frontmatter, unquoted scalars. */
+function gbrainPage(front: string, body: string): string {
+  return `---\n${front}\n---\n\n${body}\n`;
+}
+
+const TURNS = [
+  '**Me** (2026-02-01T09:00:00.000Z · m1):',
+  '',
+  'alice-example asked about the widget-co rollout.',
+  '',
+  '---',
+  '',
+  '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+  '',
+  'Start with the acme-example owner.',
+].join('\n');
+
+describe('gbrain-to-envelope exporter', () => {
+  test('sample envelope round-trips to a conforming envelope and reports counts', async () => {
+    const result = await roundTrip();
+
+    expect(result.imported.exitCode).toBe(0);
+    expect(result.exported.exitCode).toBe(0);
+    expect(result.exported.stdout).toContain('wrote 1 conversation(s), 4 message(s)');
+    assertEnvelopeV0(result.envelope);
+  });
+
+  test('round trip preserves ids, titles, roles, text, timestamps and provider', async () => {
+    const result = await roundTrip();
+    const source = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+
+    expect(result.exported.exitCode).toBe(0);
+    // The whole document, not a field spot-check: on this fixture the round trip
+    // is exact, so any future loss shows up here rather than in a gap between
+    // the fields someone remembered to assert.
+    expect(result.envelope).toEqual({
+      memvelope: 'envelope-v0',
+      meta: {
+        source_provider: 'chatgpt',
+        conversation_count: 1,
+        message_count: 4,
+      },
+      conversations: source.conversations,
+    });
+  });
+
+  test('output is deterministic across repeated runs', async () => {
+    const first = await roundTrip();
+    const second = await roundTrip();
+
+    expect(first.exported.exitCode).toBe(0);
+    expect(second.exported.exitCode).toBe(0);
+    expect(readFileSync(first.outPath, 'utf8')).toBe(readFileSync(second.outPath, 'utf8'));
+  });
+
+  test('reads the frontmatter style gbrain itself writes, including nested slug directories', async () => {
+    // `gbrain export` serializes through js-yaml: plain unquoted scalars, a
+    // single-quoted date, and one file per slug under its slug directory. The
+    // importer writes flat files with JSON-quoted values. Both are the same
+    // page set and both must read.
+    const result = await exportPages({
+      'conversations/2026-02-01-c-nested.md': gbrainPage(
+        [
+          'type: conversation',
+          'title: Rollout notes',
+          "date: '2026-02-01'",
+          'origin: memvelope/envelope-v0',
+          'source: chatgpt',
+          'memvelope_conversation_id: c-nested',
+        ].join('\n'),
+        `# Rollout notes\n\n${TURNS}`,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.meta.source_provider).toBe('chatgpt');
+    expect(result.envelope.conversations[0].id).toBe('c-nested');
+    expect(result.envelope.conversations[0].title).toBe('Rollout notes');
+    expect(result.envelope.conversations[0].messages).toHaveLength(2);
+  });
+
+  test('created_at and updated_at come from the first and last message timestamps', async () => {
+    // The page keeps only `date`, a day. It cannot carry either date-time, so
+    // both are taken from the messages. This is a documented lossy edge, pinned
+    // here so it stays deliberate.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Timestamps', "date: '2026-02-01'", 'source: chatgpt'].join('\n'),
+        TURNS,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].created_at).toBe('2026-02-01T09:00:00.000Z');
+    expect(result.envelope.conversations[0].updated_at).toBe('2026-02-01T09:05:00.000Z');
+  });
+
+  test('a turn written without a timestamp becomes null, not the literal text', async () => {
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: No timestamp', 'source: chatgpt'].join('\n'),
+        '**Me** (no timestamp · m1):\n\nalice-example wrote with no timestamp.',
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.conversations[0].messages[0].ts).toBeNull();
+    expect(result.envelope.conversations[0].created_at).toBeNull();
+  });
+
+  test('a page without a conversation id emits null rather than a synthesized id', async () => {
+    // envelope-v0 permits a null id and tells converters not to invent one, so
+    // the positional filename must never leak into the id field.
+    const result = await exportPages({
+      '2026-02-01-conv-1.md': gbrainPage(
+        ['type: conversation', 'title: No id', 'source: chatgpt'].join('\n'),
+        TURNS,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.conversations[0].id).toBeNull();
+    expect(JSON.stringify(result.envelope)).not.toContain('conv-1');
+  });
+
+  test('pages that are not conversations are skipped and accounted for', async () => {
+    const result = await exportPages({
+      'people/alice-example.md': gbrainPage('type: person\ntitle: alice-example', 'A person page.'),
+      'no-frontmatter.md': 'Just a body, no frontmatter at all.\n',
+      'conversations/keep.md': gbrainPage(
+        ['type: conversation', 'title: Keep me', 'source: chatgpt', 'memvelope_conversation_id: c-keep'].join('\n'),
+        TURNS,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(1);
+    expect(result.envelope.conversations[0].id).toBe('c-keep');
+    expect(result.stderr).toContain('1 not type conversation');
+    expect(result.stderr).toContain('1 without frontmatter');
+  });
+
+  test('a conversation page with no speaker turns is skipped loudly', async () => {
+    // envelope-v0 requires at least one message per conversation, so a page
+    // whose body no longer carries turn headers cannot be emitted at all.
+    // Silence here would produce a conforming envelope that quietly lost a
+    // conversation.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Compiled away', 'source: chatgpt'].join('\n'),
+        'A summary of the conversation, with the speaker turns gone.',
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('no speaker turns found');
+    expect(result.stdout).toContain('wrote 0 conversation(s)');
+  });
+
+  test('an empty turn is dropped loudly rather than emitted', async () => {
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Empty turn', 'source: chatgpt'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'acme-example replied to an empty turn.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.conversations[0].messages).toHaveLength(1);
+    expect(result.envelope.meta.message_count).toBe(1);
+    expect(result.stderr).toContain('has no text; dropped');
+  });
+
+  test('a horizontal rule inside a message survives; the turn separator does not leak in', async () => {
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Rules', 'source: chatgpt'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'before the rule',
+          '',
+          '---',
+          '',
+          'after the rule',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'fund-a replied.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].messages).toHaveLength(2);
+    expect(result.envelope.conversations[0].messages[0].text).toBe('before the rule\n\n---\n\nafter the rule');
+  });
+
+  test('a timeline section never becomes message text', async () => {
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: With timeline', 'source: chatgpt'].join('\n'),
+        `${TURNS}\n\n<!-- timeline -->\n\n- 2026-02-02: gbrain added a timeline entry.`,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].messages).toHaveLength(2);
+    expect(JSON.stringify(result.envelope)).not.toContain('added a timeline entry');
+  });
+
+  test('conversations are emitted in sorted path order', async () => {
+    // Deterministic, and not the source envelope's array order. Pinned so the
+    // documented ordering loss is a decision rather than an accident.
+    const page = (id: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${id}`, 'source: chatgpt', `memvelope_conversation_id: ${id}`].join('\n'),
+        TURNS,
+      );
+    const result = await exportPages({
+      '2026-03-09-c-later.md': page('c-later'),
+      '2026-03-01-c-earlier.md': page('c-earlier'),
+      'nested/2026-03-05-c-middle.md': page('c-middle'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Files at a level come before that level's subdirectories here only because
+    // a digit sorts before `n`; the rule is one sort over entry names, applied
+    // at every level.
+    expect(result.envelope.conversations.map((c: { id: string }) => c.id)).toEqual([
+      'c-earlier',
+      'c-later',
+      'c-middle',
+    ]);
+  });
+
+  test('a page saved with CRLF line endings still parses', async () => {
+    // Every match in the script is line-anchored, so without normalization a
+    // CRLF page reads as having no frontmatter and disappears into the skip
+    // count.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: CRLF', 'source: chatgpt', 'memvelope_conversation_id: c-crlf'].join('\n'),
+        TURNS,
+      ).replace(/\n/g, '\r\n'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.conversations[0].id).toBe('c-crlf');
+    expect(result.envelope.conversations[0].messages).toHaveLength(2);
+    expect(JSON.stringify(result.envelope)).not.toContain('\\r');
+  });
+
+  test('two pages sharing a conversation id warn and both are emitted', async () => {
+    // envelope-v0 says ids should be unique and that consumers must tolerate
+    // duplicates. Dropping one to keep the field clean would lose a
+    // conversation, so both ship and the collision is reported.
+    const page = (title: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${title}`, 'source: chatgpt', 'memvelope_conversation_id: c-repeat'].join('\n'),
+        TURNS,
+      );
+    const result = await exportPages({ 'a.md': page('First'), 'b.md': page('Second') });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope);
+    expect(result.envelope.conversations).toHaveLength(2);
+    expect(result.stderr).toContain('already used by another page');
+  });
+
+  test('pages naming different providers warn and keep the first', async () => {
+    // An envelope carries one source_provider. A page set spanning two is a
+    // real structural loss, so it is reported instead of resolved silently.
+    const page = (id: string, source: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${id}`, `source: ${source}`, `memvelope_conversation_id: ${id}`].join('\n'),
+        TURNS,
+      );
+    const result = await exportPages({
+      'a.md': page('c-a', 'chatgpt'),
+      'b.md': page('c-b', 'claude'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.meta.source_provider).toBe('chatgpt');
+    expect(result.stderr).toContain('source providers');
+    expect(result.envelope.conversations).toHaveLength(2);
+  });
+
+  test('a missing directory argument or unreadable path exits 1', async () => {
+    const noArgs = await run(EXPORTER_PATH, []);
+    expect(noArgs.exitCode).toBe(1);
+    expect(noArgs.stderr).toContain('usage:');
+
+    const missing = await run(EXPORTER_PATH, [join(tempDir(), 'nope'), join(tempDir(), 'out.json')]);
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain('cannot read');
+
+    const notADir = join(tempDir(), 'file.md');
+    writeFileSync(notADir, 'x\n');
+    const file = await run(EXPORTER_PATH, [notADir, join(tempDir(), 'out.json')]);
+    expect(file.exitCode).toBe(1);
+    expect(file.stderr).toContain('not a directory');
+  });
+});

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -2148,6 +2148,161 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.stderr).not.toContain('no page carries');
   });
 
+  // --- Sweep 2.9: all four gbrain timeline-sentinel forms. ------------------
+  // gbrain's findTimelineSplitIndex (src/core/markdown.ts) accepts four forms:
+  // the two comment spellings, `--- timeline ---` under /^---\s+timeline\s+---$/i,
+  // and a bare `---` whose next non-blank line is a `## Timeline`/`## History`
+  // heading. The exporter knew three exact strings, so the case/space-tolerant
+  // decorated variants and the bare-`---` fallback cut in gbrain but exported
+  // as message text here. Each closed form joins the discipline the known forms
+  // already had: fence-masked candidates, a cut only past the last accepted
+  // turn, and a stderr line for the cut and for the refusal alike.
+
+  test('form 3 variants gbrain accepts (case, spacing) cut like the exact string', async () => {
+    const timelineTail = (sentinel: string) => `${TURNS}\n\n${sentinel}\n\n- 2026-02-02: gbrain added a timeline entry.`;
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Uppercase sentinel', 'source: chatgpt', 'memvelope_conversation_id: c-upper'].join('\n'),
+        timelineTail('--- TIMELINE ---'),
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: Wide sentinel', 'source: chatgpt', 'memvelope_conversation_id: c-wide'].join('\n'),
+        timelineTail('---   timeline   ---'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    expect(JSON.stringify(result.envelope)).not.toContain('added a timeline entry');
+    expect(JSON.stringify(result.envelope)).not.toContain('TIMELINE');
+    expect(result.stderr).toContain('cut at the timeline sentinel');
+  });
+
+  test('form 4 - a bare --- above a Timeline or History heading cuts, as gbrain reads it', async () => {
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Bare rule form', 'source: chatgpt', 'memvelope_conversation_id: c-t4'].join('\n'),
+        `${TURNS}\n\n---\n\n## Timeline\n\n- 2026-02-02: gbrain added a timeline entry.`,
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: History heading', 'source: chatgpt', 'memvelope_conversation_id: c-hist'].join('\n'),
+        `${TURNS}\n\n---\n\n## History of the rollout\n\n- 2026-02-02: gbrain added a timeline entry.`,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    expect(JSON.stringify(result.envelope)).not.toContain('added a timeline entry');
+    expect(JSON.stringify(result.envelope)).not.toContain('## Timeline');
+    expect(JSON.stringify(result.envelope)).not.toContain('## History');
+    const texts = result.envelope.conversations.flatMap((c: any) => c.messages.map((m: any) => m.text));
+    for (const text of texts) expect(text).not.toContain('---');
+    expect(result.stderr).toContain('cut at the timeline sentinel');
+  });
+
+  test('form 4 does not fire without its heading: a trailing --- stays message text', async () => {
+    // The old header called bare `---` unrecognizable because it is also the
+    // legacy turn separator. The heading lookahead is what makes it safe: a
+    // rule with anything else below it - prose, or a heading the \b rejects -
+    // is still message text, byte for byte.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Rule then prose', 'source: chatgpt', 'memvelope_conversation_id: c-rule'].join('\n'),
+        `${TURNS}\n\n---\n\nNot a heading, only prose after a rule.`,
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: Rule then near-heading', 'source: chatgpt', 'memvelope_conversation_id: c-near'].join('\n'),
+        `${TURNS}\n\n---\n\n## Timelines are lists, not the Timeline heading`,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    const [a, b] = result.envelope.conversations as Array<{ messages: Array<{ text: string }> }>;
+    expect(a.messages[1].text).toContain('---');
+    expect(a.messages[1].text).toContain('Not a heading, only prose after a rule.');
+    expect(b.messages[1].text).toContain('## Timelines are lists');
+    expect(result.stderr).not.toContain('cut at the timeline sentinel');
+  });
+
+  test('new sentinel forms follow the only-terminal rule: quoted mid-conversation they warn and do not cut', async () => {
+    // The mirror of D1 for the closed forms. gbrain's own parser cuts at the
+    // FIRST hit and truncates every turn below it - the upstream defect this
+    // exporter deliberately does not copy. A decorated or bare-rule sentinel
+    // with accepted turns after it is prose, kept, and reported.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Quoted decorated', 'source: chatgpt', 'memvelope_conversation_id: c-q3'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'gbrain also accepts this spelling:',
+          '',
+          '--- TIMELINE ---',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'And turns after it must survive.',
+        ].join('\n'),
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: Quoted bare rule', 'source: chatgpt', 'memvelope_conversation_id: c-q4'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'The fallback form looks like this:',
+          '',
+          '---',
+          '',
+          '## Timeline',
+          '',
+          'and gbrain reads a real one only after the last turn.',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'And turns after it must survive.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    const [a, b] = result.envelope.conversations as Array<{ messages: Array<{ text: string }> }>;
+    expect(a.messages[0].text).toContain('--- TIMELINE ---');
+    expect(a.messages[1].text).toContain('must survive');
+    expect(b.messages[0].text).toContain('## Timeline');
+    expect(b.messages[0].text).toContain('---');
+    expect(b.messages[1].text).toContain('must survive');
+    expect(result.stderr).toContain('is not a timeline boundary');
+    expect(result.stderr).not.toContain('cut at the timeline sentinel');
+  });
+
+  test('the tight comment and exact decorated forms cut too (all four forms covered)', async () => {
+    // Forms 1 and 2 plus the exact decorated string predate this sweep; pinned
+    // here so the "all four forms" claim has a receipt per form, not a set
+    // membership nobody exercises.
+    const timelineTail = (sentinel: string) => `${TURNS}\n\n${sentinel}\n\n- 2026-02-02: gbrain added a timeline entry.`;
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Tight comment', 'source: chatgpt', 'memvelope_conversation_id: c-tight'].join('\n'),
+        timelineTail('<!--timeline-->'),
+      ),
+      'b.md': gbrainPage(
+        ['type: conversation', 'title: Exact decorated', 'source: chatgpt', 'memvelope_conversation_id: c-exact'].join('\n'),
+        timelineTail('--- timeline ---'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
+    expect(JSON.stringify(result.envelope)).not.toContain('added a timeline entry');
+    expect(result.stderr).toContain('cut at the timeline sentinel');
+  });
+
   test('a missing directory argument or unreadable path exits 1', async () => {
     const noArgs = await run(EXPORTER_PATH, []);
     expect(noArgs.exitCode).toBe(1);

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -275,7 +275,13 @@ function isRfc3339DateTime(value: unknown): boolean {
   const month = Number(m[2]);
   const day = Number(m[3]);
   if (month < 1 || month > 12) return false;
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  // Explicit leap math, not Date.UTC: Date.UTC applies the two-digit-year
+  // rule, mapping year 0 to 1900, so 0000-02-29 - a real date in RFC 3339's
+  // proleptic Gregorian calendar (year 0 % 400 === 0), accepted by
+  // ajv-formats - was falsely rejected. The exporter's own check always had
+  // the explicit math; the two now agree on this too.
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = month === 2 && leap ? 29 : [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
   if (day < 1 || day > daysInMonth) return false;
   const hour = Number(m[4]);
   const minute = Number(m[5]);
@@ -300,10 +306,13 @@ function isRfc3339Date(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (!m) return false;
+  const year = Number(m[1]);
   const month = Number(m[2]);
   if (month < 1 || month > 12) return false;
   const day = Number(m[3]);
-  return day >= 1 && day <= new Date(Date.UTC(Number(m[1]), month, 0)).getUTCDate();
+  // Explicit leap math for the same year-0 reason as isRfc3339DateTime above.
+  const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  return day >= 1 && day <= (month === 2 && leap ? 29 : [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1]);
 }
 
 /** Every timestamp the document emits, labelled by where it came from. */
@@ -1563,11 +1572,12 @@ describe('gbrain-to-envelope exporter', () => {
 
   test('recorded path: a fence spanning a turn boundary loses to the recorded clock', async () => {
     // The R1 rule, re-anchored: the legacy separator is gone from this format,
-    // so the signal that a fence has swallowed a boundary is the next expected
-    // clock appearing inside it. The fence is demoted, the turn is kept, and
-    // the operator is told.
+    // so the signal that a fence has swallowed a boundary is coming up short
+    // on turns. A fence that never closes at all is demoted as unclosed; a
+    // fence that closes in a LATER turn is demoted at the swallowed header.
+    // Either way the turns are kept and the operator is told.
     const FENCE = '```';
-    const result = await exportPages({
+    const neverCloses = await exportPages({
       'a.md': recordedPage({
         id: 'c-fencespan',
         record: RECORD_2,
@@ -1586,13 +1596,54 @@ describe('gbrain-to-envelope exporter', () => {
       }),
     });
 
-    expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
-    const out = result.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    expect(neverCloses.exitCode).toBe(0);
+    assertEnvelopeV0(neverCloses.envelope, { conversations: 1, messages: 2 });
+    const out = neverCloses.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
     expect(out.map((m) => m.id)).toEqual(['m1', 'm2']);
     expect(out[1].text).toBe('The block above me never closed.');
     expect(out[0].text).not.toContain('never closed');
-    expect(result.stderr).toContain('is still open at the turn header');
+    // Body line 7: the recordedPage helper's H1 and blank line sit above.
+    expect(neverCloses.stderr).toContain('an unclosed code fence opens at body line 7');
+
+    const closesLater = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-fencespan-later',
+        record: [
+          'messages:',
+          '  - id: "m1"',
+          '    ts: "2026-02-01T09:00:00.000Z"',
+          '  - id: "m2"',
+          '    ts: "2026-02-01T09:05:00.000Z"',
+          '  - id: "m3"',
+          '    ts: "2026-02-01T09:10:00.000Z"',
+        ],
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'half a paste:',
+          '',
+          `${FENCE}js`,
+          'const half = true;',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'The fence above is still open here.',
+          '',
+          '**Me** (2026-02-01 09:10):',
+          '',
+          'And here is the rest:',
+          '',
+          FENCE,
+        ].join('\n'),
+      }),
+    });
+
+    expect(closesLater.exitCode).toBe(0);
+    assertEnvelopeV0(closesLater.envelope, { conversations: 1, messages: 3 });
+    const out2 = closesLater.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    expect(out2.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+    expect(out2[1].text).toBe('The fence above is still open here.');
+    expect(closesLater.stderr).toContain('is still open at the turn header');
   });
 
   test('recorded path: a header quoted in a closed fence is sample text, not a turn', async () => {
@@ -1664,7 +1715,7 @@ describe('gbrain-to-envelope exporter', () => {
     // m2 dropped WITH its entry: m3 keeps its own id and text, not m2's.
     expect(out.map((m) => m.id)).toEqual(['m1', 'm3']);
     expect(out[1].text).toBe('third turn');
-    expect(result.stderr).toContain('"m2" has no text; dropped');
+    expect(result.stderr).toContain('no text remained for message "m2"');
   });
 
   test('recorded path: a new-format body without its record is skipped loudly, not guessed', async () => {
@@ -1679,6 +1730,280 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.exitCode).toBe(0);
     expect(result.envelope.conversations).toHaveLength(0);
     expect(result.stderr).toContain('no speaker turns found');
+  });
+
+  // --- Regressions for the adversarial-gate findings of 2026-08-02/03. -----
+  // Each of these reproduced against the rebuild's first cut; each is pinned
+  // so the fix stays fixed.
+
+  test('G1: U+2028/U+2029 in ids and titles survive - JSON leaves them raw and the reader must cross them', async () => {
+    // JSON.stringify escapes \n and \r but NOT U+2028/U+2029, so a conforming
+    // envelope value puts a raw LineTerminator inside a frontmatter line.
+    // JavaScript's `.` cannot cross those two characters without the `s`
+    // flag, so the id/title lines silently failed to parse: the conversation
+    // id exported as null and the title as the fallback with ZERO stderr -
+    // defect J's mechanism, one encoding layer down.
+    const LS = ' ';
+    const PS = ' ';
+    const result = await roundTripEnvelope({
+      memvelope: 'envelope-v0',
+      meta: { source_provider: 'chatgpt', conversation_count: 1, message_count: 2 },
+      conversations: [
+        {
+          id: `c${LS}real`,
+          title: `Half${PS}Title`,
+          created_at: '2026-02-01T09:00:00.000Z',
+          updated_at: '2026-02-01T09:05:00.000Z',
+          messages: [
+            { id: `a${LS}b`, role: 'user', ts: '2026-02-01T09:00:00.000Z', text: 'first' },
+            { id: 'm2', role: 'assistant', ts: '2026-02-01T09:05:00.000Z', text: 'second' },
+          ],
+        },
+      ],
+    });
+
+    expect(result.imported.exitCode).toBe(0);
+    expect(result.exported.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    expect(result.envelope.conversations[0].id).toBe(`c${LS}real`);
+    expect(result.envelope.conversations[0].title).toBe(`Half${PS}Title`);
+    expect(result.envelope.conversations[0].messages.map((m: { id: string }) => m.id)).toEqual([`a${LS}b`, 'm2']);
+  });
+
+  test('G2: a UTF-8 BOM does not make a conversation vanish', async () => {
+    // gray-matter strips a BOM, so a BOM page is a first-class conversation
+    // to gbrain; refusing to see its frontmatter dropped the whole
+    // conversation into the anonymous "without frontmatter" count.
+    const result = await exportPages({
+      'a.md': '﻿' + recordedPage({ id: 'c-bom', record: RECORD_2, body: BODY_2 }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    expect(result.envelope.conversations[0].id).toBe('c-bom');
+  });
+
+  test('G3: trailing YAML comments are stripped, and a comment can never become an id', async () => {
+    // js-yaml strips comments on read. Keeping them read `type: conversation
+    // # imported` as a different type (conversation dropped), `id: m1 # first`
+    // as a different id, and `id: # placeholder` - a null id under YAML - as
+    // the invented string "# placeholder", bypassing the null-id gate.
+    const commented = [
+      '---',
+      'type: conversation # imported',
+      'title: "Commented" # the title',
+      'date: "2026-02-01"',
+      'source: "chatgpt"',
+      'memvelope_conversation_id: "c-comment"',
+      'messages:',
+      '  - id: m1 # first',
+      '    ts: "2026-02-01T09:00:00.000Z"',
+      '---',
+      '# Commented',
+      '',
+      '**Me** (2026-02-01 09:00):',
+      '',
+      'a turn',
+      '',
+    ].join('\n');
+    const nullIdComment = recordedPage({
+      id: 'c-nullcomment',
+      record: ['messages:', '  - id: # placeholder', '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({ 'a.md': commented, 'b.md': nullIdComment });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 1 });
+    expect(result.envelope.conversations[0].id).toBe('c-comment');
+    expect(result.envelope.conversations[0].messages[0].id).toBe('m1');
+    // The null id was refused, not read as "# placeholder".
+    expect(result.stderr).toContain('messages[0] records null');
+    expect(JSON.stringify(result.envelope)).not.toContain('placeholder');
+  });
+
+  test('G4: js-yaml 3.14 int forms - sexagesimal and binary - are refused as non-string ids', async () => {
+    // `190:20:30` is the integer 685230 and `0b1010` is 10 to gbrain's own
+    // YAML reader; exporting them as strings would emit ids the record does
+    // not hold.
+    const page = (name: string, idLine: string) => recordedPage({
+      id: name,
+      record: ['messages:', `  - id: ${idLine}`, '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({
+      'a.md': page('c-sexa', '190:20:30'),
+      'b.md': page('c-bin', '0b1010'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(0);
+    expect(result.stderr).toContain('"190:20:30"');
+    expect(result.stderr).toContain('"0b1010"');
+  });
+
+  test('G5: a balanced fence keeps a quoted next-clock header as sample text', async () => {
+    // The first cut demoted a fence the instant the next expected clock
+    // appeared inside it, with no look at whether the fence closes in its own
+    // turn - so a pasted transcript quoting the conversation's own next turn
+    // stole the boundary from the real header below. Balanced fences now win:
+    // demotion is considered only when the body anchors fewer turns than the
+    // record holds.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-balanced',
+        record: RECORD_2,
+        body: [
+          '**Me** (2026-02-01 09:00):',
+          '',
+          'look at this transcript:',
+          '',
+          FENCE,
+          '**Assistant** (2026-02-01 09:05):',
+          'quoted reply',
+          FENCE,
+          '',
+          'end of quote',
+          '',
+          '**Assistant** (2026-02-01 09:05):',
+          '',
+          'real reply',
+        ].join('\n'),
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    const out = result.envelope.conversations[0].messages as Array<{ role: string; text: string }>;
+    expect(out[0].text).toContain('quoted reply');
+    expect(out[0].text).toContain('end of quote');
+    expect(out[1].text).toBe('real reply');
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(result.stderr).toContain('read as sample text');
+    expect(result.stderr).not.toContain('is still open at the turn header');
+  });
+
+  test('G6: a timeline cut is named per page with its body line', async () => {
+    // The aggregate note alone could not tell an operator WHICH page was cut;
+    // every other loss event names its file, and now this one does too.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-cutnamed',
+        record: ['messages:', '  - id: "m1"', '    ts: "2026-02-01T09:00:00.000Z"'],
+        body: '**Me** (2026-02-01 09:00):\n\nkept\n\n<!-- timeline -->\n\n- an entry',
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].messages[0].text).toBe('kept');
+    expect(result.stderr).toContain('a.md');
+    expect(result.stderr).toContain('cut at the timeline sentinel on body line');
+  });
+
+  test('G7: conversation ids differing only by surrounding whitespace stay distinct', async () => {
+    // The importer records ids verbatim precisely so these stay two
+    // conversations; the exporter trimming them re-collapsed the identities
+    // on the way out.
+    const page = (name: string, id: string) => recordedPage({
+      title: name,
+      id,
+      record: ['messages:', '  - id: "m1"', '    ts: "2026-02-01T09:00:00.000Z"'],
+      body: '**Me** (2026-02-01 09:00):\n\na turn',
+    });
+    const result = await exportPages({
+      'a.md': page('A', 'abc'),
+      'b.md': page('B', ' abc '),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 2 });
+    expect((result.envelope.conversations as Array<{ id: string }>).map((c) => c.id).sort()).toEqual([' abc ', 'abc']);
+    // Distinct ids - no duplicate-id warning belongs here.
+    expect(result.stderr).not.toContain('already used by another page');
+  });
+
+  test('G8: a messages record with items at column 0 still reads', async () => {
+    // Valid YAML (the noArrayIndent style); js-yaml reads it, so refusing it
+    // with "the record is empty" was a false diagnosis.
+    const result = await exportPages({
+      'a.md': [
+        '---',
+        'type: conversation',
+        'title: "Column zero"',
+        'date: "2026-02-01"',
+        'source: "chatgpt"',
+        'memvelope_conversation_id: "c-col0"',
+        'messages:',
+        '- id: "m1"',
+        '  ts: "2026-02-01T09:00:00.000Z"',
+        '- id: "m2"',
+        '  ts: "2026-02-01T09:05:00.000Z"',
+        '---',
+        '# Column zero',
+        '',
+        BODY_2,
+        '',
+      ].join('\n'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
+    expect(result.envelope.conversations[0].messages.map((m: { id: string }) => m.id)).toEqual(['m1', 'm2']);
+  });
+
+  test('G9: non-blank body content before the first turn header is reported', async () => {
+    // Documented loss, but it was the one loss class with no stderr trace.
+    const result = await exportPages({
+      'a.md': recordedPage({
+        id: 'c-preamble',
+        record: ['messages:', '  - id: "m1"', '    ts: "2026-02-01T09:00:00.000Z"'],
+        body: 'a preamble line the export drops\n\n**Me** (2026-02-01 09:00):\n\nhello',
+      }),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations[0].messages[0].text).toBe('hello');
+    expect(result.stderr).toContain('before the first turn header were not exported');
+  });
+
+  test('G10: ids survive gbrain\'s own serializer byte-for-byte, whitespace shapes included', async () => {
+    // The block-scalar reader once collapsed whitespace-only content lines
+    // and miscounted keep-chomping breaks, so ids like "a\n \nb" came back
+    // corrupted with zero stderr. This drives gbrain's actual serializer
+    // (gray-matter = js-yaml, the engine of serializeMarkdown) over a battery
+    // of whitespace-hostile ids and requires every one back verbatim.
+    const matter = (await import('gray-matter')).default;
+    const HOSTILE = ['a\n \nb', ' \na', '\n', '\n\n', 'a\n', 'a\n\n', '\na', 'a \n', 'x'.repeat(90), 'm-plain'];
+    const ts = (i: number) => `2026-02-01T09:${String(i).padStart(2, '0')}:00.000Z`;
+    const front = {
+      type: 'conversation',
+      title: 'Rewritten',
+      date: '2026-02-01',
+      source: 'chatgpt',
+      memvelope_conversation_id: 'c-rewritten',
+      messages: HOSTILE.map((id, i) => ({ id, ts: ts(i) })),
+    };
+    const body = HOSTILE.map((_, i) => `**Me** (2026-02-01 09:${String(i).padStart(2, '0')}):\n\nturn ${i + 1}`).join('\n\n');
+    const page = matter.stringify(`\n# Rewritten\n\n${body}\n`, front);
+    const result = await exportPages({ 'a.md': page });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: HOSTILE.length });
+    expect(result.envelope.conversations[0].messages.map((m: { id: string }) => m.id)).toEqual(HOSTILE);
+  });
+
+  test('G11: the checker accepts year-0000 leap dates the published schema accepts', async () => {
+    // Date.UTC maps year 0 to 1900 (the two-digit-year rule), so the checker
+    // falsely rejected 0000-02-29 - a real date in the proleptic Gregorian
+    // calendar, accepted by ajv-formats - turning the suite red against a
+    // conforming document. Only ever a false-red, never a false-green.
+    expect(isRfc3339DateTime('0000-02-29T12:34:56Z')).toBe(true);
+    expect(isRfc3339DateTime('0000-02-30T12:34:56Z')).toBe(false);
+    expect(isRfc3339Date('0000-02-29')).toBe(true);
+    expect(isRfc3339Date('0000-02-30')).toBe(false);
+    // The 1900-mapping would also have accepted 1900's non-leap February.
+    expect(isRfc3339DateTime('1900-02-29T00:00:00Z')).toBe(false);
   });
 
   test('a missing directory argument or unreadable path exits 1', async () => {

--- a/test/gbrain-to-envelope.test.ts
+++ b/test/gbrain-to-envelope.test.ts
@@ -5,6 +5,7 @@
  * by running the importer on its own fixture, so the round trip is the test.
  */
 import { afterAll, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -12,6 +13,19 @@ import { join } from 'node:path';
 const IMPORTER_PATH = join(import.meta.dir, '..', 'scripts', 'envelope-to-gbrain.mjs');
 const EXPORTER_PATH = join(import.meta.dir, '..', 'scripts', 'gbrain-to-envelope.mjs');
 const FIXTURE_PATH = join(import.meta.dir, 'fixtures', 'memvelope', 'sample.mve.json');
+/**
+ * envelope-v0 as published, vendored byte-for-byte. Fetched 2026-08-02 from
+ * memvelope.com/schema/envelope-v0.schema.json and checked identical, by sha256,
+ * to raw.githubusercontent.com/memvelope/memvelope/main/public/schema/envelope-v0.schema.json
+ * and to the copy in the memvelope package - all three
+ * 423813d563de394cde2798848e90fdadc85ba52458f5c18b1da897e6c8ae52b9. The checker
+ * below reads these bytes, so a constraint is enforced because the schema states
+ * it and not because someone transcribed it.
+ */
+const SCHEMA_PATH = join(import.meta.dir, 'fixtures', 'memvelope', 'envelope-v0.schema.json');
+const SCHEMA_BYTES = readFileSync(SCHEMA_PATH);
+const SCHEMA_SHA256 = '423813d563de394cde2798848e90fdadc85ba52458f5c18b1da897e6c8ae52b9';
+const ENVELOPE_V0_SCHEMA = JSON.parse(SCHEMA_BYTES.toString('utf8')) as Record<string, unknown>;
 const TEMP_DIRS: string[] = [];
 
 afterAll(() => {
@@ -70,57 +84,239 @@ async function exportPages(pages: Record<string, string>) {
 }
 
 /**
- * Structural conformance against envelope-v0 as published (JSON Schema draft-07
- * at memvelope.com/schema/envelope-v0.schema.json). Every constraint the schema
- * states is asserted here rather than paraphrased: required keys, types, the
- * role enum, `minItems: 1` on messages, `minLength: 1` on text, and the integer
- * minimums on the meta counts. Written out longhand so the test needs no
- * validator dependency, matching the scripts' own zero-dependency posture.
+ * The draft-07 keywords the checker below implements, split into the ones that
+ * constrain a document and the ones that only annotate it. Anything else in the
+ * vendored schema is a constraint this checker would silently ignore, so
+ * `assertSchemaFullyImplemented` fails on it rather than letting it through -
+ * which is the whole point of validating against the bytes instead of a
+ * transcription.
  */
-function assertEnvelopeV0(doc: unknown): void {
-  expect(doc).toBeObject();
-  const env = doc as Record<string, unknown>;
-  expect(env.memvelope).toBe('envelope-v0');
+const ANNOTATION_KEYWORDS = new Set(['$schema', '$id', 'title', 'description', 'examples', 'default']);
+const CONSTRAINT_KEYWORDS = new Set([
+  'type', 'const', 'enum', 'required', 'properties', 'additionalProperties',
+  'items', 'minItems', 'minLength', 'minimum', 'anyOf', 'format',
+]);
+const IMPLEMENTED_FORMATS = new Set(['date', 'date-time']);
 
-  expect(env.meta).toBeObject();
-  const meta = env.meta as Record<string, unknown>;
-  expect(typeof meta.source_provider).toBe('string');
-  expect(Number.isInteger(meta.conversation_count)).toBe(true);
-  expect(meta.conversation_count as number).toBeGreaterThanOrEqual(0);
-  expect(Number.isInteger(meta.message_count)).toBe(true);
-  expect(meta.message_count as number).toBeGreaterThanOrEqual(0);
-  // Optional, and the spec says omitted rather than null when unknown.
-  if ('source_export_date' in meta) expect(typeof meta.source_export_date).toBe('string');
-
-  expect(Array.isArray(env.conversations)).toBe(true);
-  const conversations = env.conversations as Array<Record<string, unknown>>;
-  for (const c of conversations) {
-    for (const key of ['id', 'title', 'created_at', 'updated_at', 'messages']) {
-      expect(c).toHaveProperty(key);
-    }
-    expect(c.id === null || typeof c.id === 'string').toBe(true);
-    expect(typeof c.title).toBe('string');
-    expect(c.created_at === null || typeof c.created_at === 'string').toBe(true);
-    expect(c.updated_at === null || typeof c.updated_at === 'string').toBe(true);
-    expect(Array.isArray(c.messages)).toBe(true);
-    const messages = c.messages as Array<Record<string, unknown>>;
-    expect(messages.length).toBeGreaterThanOrEqual(1);
-    for (const m of messages) {
-      for (const key of ['id', 'role', 'ts', 'text']) {
-        expect(m).toHaveProperty(key);
-      }
-      expect(typeof m.id).toBe('string');
-      expect(['user', 'assistant']).toContain(m.role as string);
-      expect(m.ts === null || typeof m.ts === 'string').toBe(true);
-      expect(typeof m.text).toBe('string');
-      expect((m.text as string).length).toBeGreaterThanOrEqual(1);
+/** Recursively asserts the vendored schema states nothing the checker cannot enforce. */
+function assertSchemaFullyImplemented(schema: unknown, path = '#'): void {
+  expect(schema).toBeObject();
+  const node = schema as Record<string, unknown>;
+  for (const key of Object.keys(node)) {
+    if (ANNOTATION_KEYWORDS.has(key) || CONSTRAINT_KEYWORDS.has(key)) continue;
+    throw new Error(`${SCHEMA_PATH} states \`${key}\` at ${path}, which this checker does not implement`);
+  }
+  if (typeof node.format === 'string' && !IMPLEMENTED_FORMATS.has(node.format)) {
+    throw new Error(`${SCHEMA_PATH} names format \`${node.format}\` at ${path}, which this checker does not implement`);
+  }
+  // `additionalProperties: true` is the only form here; a subschema there would
+  // need walking too, so anything else is refused.
+  if ('additionalProperties' in node && node.additionalProperties !== true) {
+    throw new Error(`${SCHEMA_PATH} sets a non-\`true\` additionalProperties at ${path}, which this checker does not implement`);
+  }
+  if (node.properties) {
+    for (const [name, sub] of Object.entries(node.properties as Record<string, unknown>)) {
+      assertSchemaFullyImplemented(sub, `${path}/properties/${name}`);
     }
   }
-  // The counts are part of the document, so they get checked against it.
-  expect(meta.conversation_count).toBe(conversations.length);
-  expect(meta.message_count).toBe(
-    conversations.reduce((n, c) => n + (c.messages as unknown[]).length, 0),
+  if (node.items) assertSchemaFullyImplemented(node.items, `${path}/items`);
+  if (node.anyOf) {
+    for (const [i, sub] of (node.anyOf as unknown[]).entries()) {
+      assertSchemaFullyImplemented(sub, `${path}/anyOf/${i}`);
+    }
+  }
+}
+
+function jsonTypeMatches(type: string, value: unknown): boolean {
+  switch (type) {
+    case 'object': return typeof value === 'object' && value !== null && !Array.isArray(value);
+    case 'array': return Array.isArray(value);
+    case 'string': return typeof value === 'string';
+    case 'integer': return Number.isInteger(value);
+    case 'number': return typeof value === 'number';
+    case 'boolean': return typeof value === 'boolean';
+    case 'null': return value === null;
+    default: throw new Error(`unsupported JSON Schema type \`${type}\``);
+  }
+}
+
+/** Collects every way `value` violates `schema`, as human-readable paths. */
+function schemaErrors(schema: Record<string, unknown>, value: unknown, path: string, errors: string[]): void {
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? (schema.type as string[]) : [schema.type as string];
+    if (!types.some((t) => jsonTypeMatches(t, value))) {
+      errors.push(`${path}: expected type ${types.join('|')}`);
+      return;
+    }
+  }
+  if ('const' in schema && value !== schema.const) {
+    errors.push(`${path}: expected const ${JSON.stringify(schema.const)}`);
+  }
+  if (schema.enum && !(schema.enum as unknown[]).includes(value)) {
+    errors.push(`${path}: expected one of ${JSON.stringify(schema.enum)}`);
+  }
+  if (typeof schema.format === 'string' && typeof value === 'string') {
+    const ok = schema.format === 'date' ? isRfc3339Date(value) : isRfc3339DateTime(value);
+    if (!ok) errors.push(`${path}: ${JSON.stringify(value)} is not a ${schema.format}`);
+  }
+  if (typeof schema.minLength === 'number' && typeof value === 'string' && value.length < schema.minLength) {
+    errors.push(`${path}: shorter than minLength ${schema.minLength}`);
+  }
+  if (typeof schema.minimum === 'number' && typeof value === 'number' && value < schema.minimum) {
+    errors.push(`${path}: below minimum ${schema.minimum}`);
+  }
+  if (schema.anyOf) {
+    const branches = schema.anyOf as Array<Record<string, unknown>>;
+    if (!branches.some((sub) => {
+      const local: string[] = [];
+      schemaErrors(sub, value, path, local);
+      return local.length === 0;
+    })) {
+      errors.push(`${path}: matched none of the anyOf branches`);
+    }
+  }
+  if (Array.isArray(value)) {
+    if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+      errors.push(`${path}: fewer than minItems ${schema.minItems}`);
+    }
+    if (schema.items) {
+      for (const [i, item] of value.entries()) {
+        schemaErrors(schema.items as Record<string, unknown>, item, `${path}[${i}]`, errors);
+      }
+    }
+  }
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    for (const key of (schema.required as string[] | undefined) ?? []) {
+      if (!(key in obj)) errors.push(`${path}: missing required \`${key}\``);
+    }
+    for (const [name, sub] of Object.entries((schema.properties as Record<string, unknown> | undefined) ?? {})) {
+      // Absent optional properties are the `source_export_date` case: omitted,
+      // not null, is what the spec asks for, so absence is never an error here.
+      if (name in obj) schemaErrors(sub as Record<string, unknown>, obj[name], `${path}/${name}`, errors);
+    }
+  }
+}
+
+/**
+ * Structural conformance against envelope-v0 as published, by validating the
+ * document against the vendored schema bytes rather than against a list of
+ * constraints someone read off it. The walker above implements the draft-07
+ * subset the schema uses and refuses to run against any keyword it does not,
+ * so a constraint added upstream turns this suite red instead of going
+ * unchecked. Zero dependencies, matching the scripts' own posture.
+ *
+ * Nothing is asserted about extra keys, because envelope-v0 sets
+ * `additionalProperties: true` at every level.
+ *
+ * `expected` carries what the caller knows about the INPUT, independently of
+ * the document in hand. The meta counts are not a schema constraint - the
+ * schema only says they are non-negative integers - so they are cross-checked
+ * here: against the arrays they were computed from, and, when the caller passes
+ * it, against a number from outside the document. Without that second number
+ * the count check is self-consistency only, which an envelope that quietly lost
+ * half its turns satisfies perfectly.
+ */
+function assertEnvelopeV0(
+  doc: unknown,
+  expected?: { conversations: number; messages: number },
+): void {
+  const errors: string[] = [];
+  schemaErrors(ENVELOPE_V0_SCHEMA, doc, 'envelope', errors);
+  expect(errors).toEqual([]);
+
+  const env = doc as Record<string, unknown>;
+  const meta = env.meta as Record<string, unknown>;
+  const conversations = env.conversations as Array<Record<string, unknown>>;
+  const totalMessages = conversations.reduce(
+    (n, c) => n + (c.messages as unknown[]).length,
+    0,
   );
+  // The counts are part of the document, so they get checked against it...
+  expect(meta.conversation_count).toBe(conversations.length);
+  expect(meta.message_count).toBe(totalMessages);
+  // ...and, when the caller knows the input, against a number from outside it.
+  if (expected) {
+    expect(conversations.length).toBe(expected.conversations);
+    expect(meta.conversation_count).toBe(expected.conversations);
+    expect(totalMessages).toBe(expected.messages);
+    expect(meta.message_count).toBe(expected.messages);
+  }
+}
+
+/**
+ * The checker's public shape. assertEnvelopeV0 takes the second argument now,
+ * so this alias is a plain rename, kept for readability at the call sites that
+ * pass counts the test knows from its own input.
+ */
+type EnvelopeChecker = (
+  doc: unknown,
+  expected?: { conversations: number; messages: number },
+) => void;
+const checkEnvelope: EnvelopeChecker = assertEnvelopeV0;
+
+/**
+ * Strict RFC 3339 `date-time`, the profile JSON Schema's `format: date-time`
+ * names. Regex for shape, then real calendar and clock bounds - a loose
+ * `\d{4}-\d{2}-\d{2}T...` regex would accept 2026-02-30T25:61:00Z.
+ *
+ * Second 60 is a leap second, and a leap second is inserted at midnight UTC, so
+ * the local clock may read anything that names that instant - RFC 3339's own
+ * examples include `1990-12-31T15:59:60-08:00`. The offset is normalized away
+ * and the UTC time-of-day has to be 23:59. This matches ajv 8.20.0 +
+ * ajv-formats 3.0.1 in strict/full mode value for value, including
+ * `2026-02-01T09:00:60Z` and `2026-12-31T23:59:60+01:00`, which both fail.
+ */
+function isRfc3339DateTime(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|([+-])(\d{2}):(\d{2}))$/.exec(value);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  if (month < 1 || month > 12) return false;
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (day < 1 || day > daysInMonth) return false;
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  const second = Number(m[6]);
+  if (hour > 23 || minute > 59 || second > 60) return false;
+  let offsetMinutes = 0;
+  if (m[8] !== 'Z' && m[8] !== 'z') {
+    const offsetHour = Number(m[10]);
+    const offsetMinute = Number(m[11]);
+    if (offsetHour > 23 || offsetMinute > 59) return false;
+    offsetMinutes = (m[9] === '-' ? -1 : 1) * (offsetHour * 60 + offsetMinute);
+  }
+  if (second === 60) {
+    const utcMinuteOfDay = (((hour * 60 + minute - offsetMinutes) % 1440) + 1440) % 1440;
+    if (utcMinuteOfDay !== 23 * 60 + 59) return false;
+  }
+  return true;
+}
+
+/** Strict RFC 3339 full-date, the `format: date` half of meta.source_export_date's anyOf. */
+function isRfc3339Date(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return false;
+  const month = Number(m[2]);
+  if (month < 1 || month > 12) return false;
+  const day = Number(m[3]);
+  return day >= 1 && day <= new Date(Date.UTC(Number(m[1]), month, 0)).getUTCDate();
+}
+
+/** Every timestamp the document emits, labelled by where it came from. */
+function timestampsIn(doc: any): Array<{ where: string; value: unknown }> {
+  const found: Array<{ where: string; value: unknown }> = [];
+  for (const [i, c] of (doc.conversations as any[]).entries()) {
+    found.push({ where: `conversations[${i}].created_at`, value: c.created_at });
+    found.push({ where: `conversations[${i}].updated_at`, value: c.updated_at });
+    for (const [j, m] of (c.messages as any[]).entries()) {
+      found.push({ where: `conversations[${i}].messages[${j}].ts`, value: m.ts });
+    }
+  }
+  return found;
 }
 
 /** The page shape gbrain itself writes: js-yaml frontmatter, unquoted scalars. */
@@ -147,7 +343,7 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.imported.exitCode).toBe(0);
     expect(result.exported.exitCode).toBe(0);
     expect(result.exported.stdout).toContain('wrote 1 conversation(s), 4 message(s)');
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 4 });
   });
 
   test('round trip preserves ids, titles, roles, text, timestamps and provider', async () => {
@@ -198,7 +394,7 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
     expect(result.envelope.meta.source_provider).toBe('chatgpt');
     expect(result.envelope.conversations[0].id).toBe('c-nested');
     expect(result.envelope.conversations[0].title).toBe('Rollout notes');
@@ -230,7 +426,7 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 1 });
     expect(result.envelope.conversations[0].messages[0].ts).toBeNull();
     expect(result.envelope.conversations[0].created_at).toBeNull();
   });
@@ -246,7 +442,7 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
     expect(result.envelope.conversations[0].id).toBeNull();
     expect(JSON.stringify(result.envelope)).not.toContain('conv-1');
   });
@@ -304,7 +500,7 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 1 });
     expect(result.envelope.conversations[0].messages).toHaveLength(1);
     expect(result.envelope.meta.message_count).toBe(1);
     expect(result.stderr).toContain('has no text; dropped');
@@ -387,7 +583,7 @@ describe('gbrain-to-envelope exporter', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 2 });
     expect(result.envelope.conversations[0].id).toBe('c-crlf');
     expect(result.envelope.conversations[0].messages).toHaveLength(2);
     expect(JSON.stringify(result.envelope)).not.toContain('\\r');
@@ -405,7 +601,7 @@ describe('gbrain-to-envelope exporter', () => {
     const result = await exportPages({ 'a.md': page('First'), 'b.md': page('Second') });
 
     expect(result.exitCode).toBe(0);
-    assertEnvelopeV0(result.envelope);
+    assertEnvelopeV0(result.envelope, { conversations: 2, messages: 4 });
     expect(result.envelope.conversations).toHaveLength(2);
     expect(result.stderr).toContain('already used by another page');
   });
@@ -427,6 +623,518 @@ describe('gbrain-to-envelope exporter', () => {
     expect(result.envelope.meta.source_provider).toBe('chatgpt');
     expect(result.stderr).toContain('source providers');
     expect(result.envelope.conversations).toHaveLength(2);
+  });
+
+  // --- Regression tests for six verified defects. -------------------------
+  // Each was reproduced against the script before the fix, and each guards the
+  // fixed behavior here.
+
+  test('D1: a message that quotes the timeline sentinel does not destroy the turns after it', async () => {
+    // Guards the rule that only a sentinel with no speaker turn after it is a
+    // timeline boundary. Cutting at the FIRST literal `<!-- timeline -->`
+    // instead, without asking whether that occurrence is gbrain's delimiter or
+    // ordinary prose, truncated a conversation ABOUT gbrain's page format -
+    // exactly the kind this brain holds - mid-sentence and lost every later
+    // turn, at exit 0 with an empty stderr and a meta.message_count that agreed
+    // with the reduced array. The loss was invisible from the output alone,
+    // which is why the assertion below is on the ids and not on the count.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Sentinel in prose', 'source: chatgpt', 'memvelope_conversation_id: c-sentinel'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'How does gbrain mark the timeline section inside a page?',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'It writes the literal comment <!-- timeline --> on its own line, then the entries below it.',
+          '',
+          '---',
+          '',
+          '**Me** (2026-02-01T09:10:00.000Z · m3):',
+          '',
+          'So anything after that marker is timeline rather than prose.',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:15:00.000Z · m4):',
+          '',
+          'Right, and a message that merely quotes the marker must not be cut short.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(1);
+    const messages = result.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    expect(messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(messages[1].text).toContain('then the entries below it');
+    expect(messages[3].text).toContain('must not be cut short');
+    expect(result.envelope.meta.message_count).toBe(4);
+  });
+
+  test('D2: a turn header quoted inside a fenced block yields no non-conforming timestamp', async () => {
+    // Guards the fence mask over TURN_HEADER. With a line-anchored but not
+    // block-aware match, a header-shaped line inside a fenced sample split the
+    // message in two and the split half's timestamp was lifted straight out of
+    // prose, so conforming input produced output that violated
+    // `format: date-time`. The fence here opens and closes inside one turn,
+    // which is the case where a fence legitimately hides a header - the R1
+    // tests below pin the case where it must not.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Quoted transcript', 'source: chatgpt', 'memvelope_conversation_id: c-quoted'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'The export I am pasting has header lines shaped like this:',
+          '',
+          FENCE,
+          '**Assistant** (yesterday afternoon · m-quoted):',
+          '',
+          'sample data inside a fenced block, not a real turn',
+          FENCE,
+          '',
+          'Can you parse that shape?',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    // The schema violation first: every emitted timestamp is null or a strict
+    // RFC 3339 date-time, with no exceptions.
+    const nonConforming = timestampsIn(result.envelope).filter(
+      (t) => t.value !== null && !isRfc3339DateTime(t.value),
+    );
+    expect(nonConforming).toEqual([]);
+    // And the fenced sample line is sample text, not a second turn.
+    expect(result.envelope.conversations[0].messages).toHaveLength(1);
+    expect(result.envelope.conversations[0].messages[0].text).toContain('Can you parse that shape?');
+  });
+
+  test('D3: a folded frontmatter title and id survive the documented gbrain export path', async () => {
+    // Guards block-scalar frontmatter. This is byte-for-byte what gbrain's own
+    // serializeMarkdown produces (matter.stringify -> js-yaml at the default
+    // lineWidth of 80): any string of 80+ characters becomes a folded block
+    // scalar. A parseFrontmatter that dropped `>-` outright turned the title
+    // silently into 'Untitled conversation' and an 80+ character id silently
+    // into null - on the input path the script header advertises. The
+    // untruncated title is also one line below in the body's H1, which gbrain's
+    // own parser falls back to (inferTitleFromBody), so both routes are pinned.
+    const FOLDED_TITLE =
+      'Onboarding checklist for the acme-example widget-co rollout and the fund-a reporting questions';
+    const FOLDED_ID =
+      'c-3f9a2b-onboarding-checklist-acme-example-widget-co-rollout-fund-a-reporting-question';
+    const result = await exportPages({
+      'conversations/2026-02-01-folded.md': [
+        '---',
+        'type: conversation',
+        'title: >-',
+        '  Onboarding checklist for the acme-example widget-co rollout and the fund-a',
+        '  reporting questions',
+        "date: '2026-02-01'",
+        'source: chatgpt',
+        'memvelope_conversation_id: >-',
+        `  ${FOLDED_ID}`,
+        'origin: memvelope/envelope-v0',
+        '---',
+        '',
+        `# ${FOLDED_TITLE}`,
+        '',
+        TURNS,
+        '',
+      ].join('\n'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(1);
+    expect(result.envelope.conversations[0].title).toBe(FOLDED_TITLE);
+    expect(result.envelope.conversations[0].id).toBe(FOLDED_ID);
+  });
+
+  test('D4: the envelope checker rejects every document the published schema rejects', async () => {
+    // Guards the checker itself. It once paraphrased the schema and left
+    // `format: date-time` and the source_export_date anyOf out entirely, which
+    // is how D2 stayed green through seventeen tests; it now walks the vendored
+    // schema bytes (see R4). A checker is only worth as much as the documents it
+    // refuses, so each constraint the exporter could plausibly break gets a
+    // document that breaks it.
+    const conforming = () => ({
+      memvelope: 'envelope-v0',
+      meta: { source_provider: 'chatgpt', conversation_count: 1, message_count: 1 },
+      conversations: [
+        {
+          id: 'c-1',
+          title: 'Conforming',
+          created_at: '2026-02-01T09:00:00.000Z',
+          updated_at: '2026-02-01T09:00:00.000Z',
+          messages: [{ id: 'm1', role: 'user', ts: '2026-02-01T09:00:00.000Z', text: 'hi' }],
+        },
+      ],
+    });
+    // Guard against a checker that rejects everything.
+    expect(() => assertEnvelopeV0(conforming())).not.toThrow();
+    // Sanity on the checkers this test leans on, so a bug there cannot be
+    // mistaken for a bug in the exporter.
+    expect(isRfc3339DateTime('2026-02-30T09:00:00Z')).toBe(false);
+    expect(isRfc3339DateTime('2026-02-01T25:00:00Z')).toBe(false);
+    expect(isRfc3339DateTime('2026-02-01')).toBe(false);
+    expect(isRfc3339DateTime('2026-02-01T09:00:00+05:30')).toBe(true);
+    expect(isRfc3339Date('2026-02-01')).toBe(true);
+    expect(isRfc3339Date('2026-13-01')).toBe(false);
+
+    const cases: Array<{ label: string; mutate: (d: any) => void }> = [
+      { label: 'conversation.created_at lifted from prose', mutate: (d) => { d.conversations[0].created_at = 'yesterday afternoon'; } },
+      { label: 'conversation.created_at is a date, not a date-time', mutate: (d) => { d.conversations[0].created_at = '2026-02-01'; } },
+      { label: 'conversation.updated_at lifted from prose', mutate: (d) => { d.conversations[0].updated_at = 'no timestamp'; } },
+      { label: 'conversation.updated_at names a day that does not exist', mutate: (d) => { d.conversations[0].updated_at = '2026-02-30T09:00:00.000Z'; } },
+      { label: 'message.ts lifted from prose', mutate: (d) => { d.conversations[0].messages[0].ts = 'no timestamp'; } },
+      { label: 'meta.source_export_date is neither a date nor a date-time', mutate: (d) => { d.meta.source_export_date = 'sometime last week'; } },
+      { label: 'conversations[] item is not an object', mutate: (d) => { d.conversations[0] = 'c-1'; } },
+      { label: 'messages[] item is not an object', mutate: (d) => { d.conversations[0].messages[0] = 'm1'; } },
+      { label: 'memvelope const is wrong', mutate: (d) => { d.memvelope = 'envelope-v1'; } },
+      { label: 'meta is missing', mutate: (d) => { delete d.meta; } },
+      { label: 'meta.source_provider is missing', mutate: (d) => { delete d.meta.source_provider; } },
+      { label: 'meta.message_count is negative', mutate: (d) => { d.meta.message_count = -1; } },
+      { label: 'meta.conversation_count is not an integer', mutate: (d) => { d.meta.conversation_count = 1.5; } },
+      { label: 'conversation.id is neither a string nor null', mutate: (d) => { d.conversations[0].id = 7; } },
+      { label: 'conversation.title is missing', mutate: (d) => { delete d.conversations[0].title; } },
+      { label: 'conversation.messages is empty', mutate: (d) => { d.conversations[0].messages = []; d.meta.message_count = 0; } },
+      { label: 'message.role is outside the enum', mutate: (d) => { d.conversations[0].messages[0].role = 'system'; } },
+      { label: 'message.ts key is absent rather than null', mutate: (d) => { delete d.conversations[0].messages[0].ts; } },
+      { label: 'message.text is empty', mutate: (d) => { d.conversations[0].messages[0].text = ''; } },
+      { label: 'message.id is null', mutate: (d) => { d.conversations[0].messages[0].id = null; } },
+      { label: 'conversations is not an array', mutate: (d) => { d.conversations = {}; } },
+    ];
+    const wronglyAccepted = cases
+      .filter(({ mutate }) => {
+        const doc = conforming();
+        mutate(doc);
+        try {
+          assertEnvelopeV0(doc);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .map((c) => c.label);
+    expect(wronglyAccepted).toEqual([]);
+  });
+
+  test('D5: a page set with no source frontmatter reports the provider token it invents', async () => {
+    // meta.source_provider is REQUIRED by the published schema and its
+    // description names a registry ("chatgpt", "claude"); 'unknown' is not a
+    // registered token. It cannot be omitted, so minting it silently is the
+    // wrong trade - the guess has to be reported the way every other lossy edge
+    // in this script is.
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: No provider', 'memvelope_conversation_id: c-noprov'].join('\n'),
+        TURNS,
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.envelope.conversations).toHaveLength(1);
+    expect(result.stderr).toContain('source_provider');
+    // Whatever token it settles on, the warning has to name it so the operator
+    // can find it in the output.
+    expect(result.stderr).toContain(result.envelope.meta.source_provider);
+  });
+
+  test('D6: the checker verifies meta counts against independently known numbers', async () => {
+    // Guards the count check against collapsing back into a tautology.
+    // meta.conversation_count against conversations.length is one object
+    // agreeing with itself, and an envelope that lost half its turns satisfies
+    // it perfectly - which is how D1 stayed invisible. The counts have to be
+    // checked against a number the test knows from its own input as well.
+    const result = await roundTrip();
+    expect(result.exported.exitCode).toBe(0);
+
+    // The fixture states 1 conversation and 4 messages, and holds 4 messages.
+    expect(() => checkEnvelope(result.envelope, { conversations: 1, messages: 4 })).not.toThrow();
+    expect(() => checkEnvelope(result.envelope, { conversations: 1, messages: 2 })).toThrow();
+    expect(() => checkEnvelope(result.envelope, { conversations: 2, messages: 4 })).toThrow();
+  });
+
+  test('R4: the checker runs against the vendored schema bytes, and implements all of them', async () => {
+    // The checker used to be a hand transcription of the published schema, with
+    // the gap that let D2 through. It now reads
+    // test/fixtures/memvelope/envelope-v0.schema.json, which is the published
+    // file byte-for-byte: fetched 2026-08-02 from memvelope.com and confirmed
+    // identical, by sha256, to the raw.githubusercontent.com copy on
+    // memvelope/memvelope@main and to the copy shipped in the memvelope
+    // package. Pinning the digest here is what makes "vendored, not
+    // transcribed" checkable rather than asserted.
+    expect(createHash('sha256').update(SCHEMA_BYTES).digest('hex')).toBe(SCHEMA_SHA256);
+    expect(ENVELOPE_V0_SCHEMA.$id).toBe('https://memvelope.com/schema/envelope-v0.schema.json');
+    expect(ENVELOPE_V0_SCHEMA.$schema).toBe('http://json-schema.org/draft-07/schema#');
+
+    // And the checker enforces every keyword the file states. A constraint
+    // added upstream lands in these bytes and fails here, instead of sitting
+    // unchecked until someone notices it needs transcribing.
+    expect(() => assertSchemaFullyImplemented(ENVELOPE_V0_SCHEMA)).not.toThrow();
+    // The guard is real: a keyword the walker does not implement is refused.
+    expect(() => assertSchemaFullyImplemented({ type: 'string', pattern: '^x$' })).toThrow('pattern');
+    expect(() => assertSchemaFullyImplemented({ type: 'string', format: 'uri' })).toThrow('uri');
+    expect(() =>
+      assertSchemaFullyImplemented({ type: 'object', properties: { a: { maxLength: 3 } } }),
+    ).toThrow('maxLength');
+  });
+
+  // --- Regression tests for the round-3 defects. --------------------------
+  // R1 guards the rule that a code fence never reaches past the turn it opened
+  // in. The round-2 fence fix masked lines between an opening fence and its
+  // close across the WHOLE body, with no notion of turn boundaries, and the
+  // header scan then skipped masked lines - so a fence that opened in one turn
+  // and closed in a later one hid every turn header in between. Those turns'
+  // ids, roles and timestamps were destroyed and their text swallowed into the
+  // preceding message, at exit 0, with zero stderr, and with meta.message_count
+  // agreeing with the reduced array: nothing in the output showed a message had
+  // ever existed. Each case below was measured against the pre-fix script, and
+  // the measured pre-fix result is recorded on each so the test cannot be
+  // weakened into passing by accident.
+  //
+  // The trigger was a turn holding an ODD number of fence lines. Balanced
+  // nesting was never affected and D2 pins that a fence opening and closing
+  // inside one turn still hides a header; these three cases are the odd-count
+  // shapes an ordinary conversation produces.
+
+  test('R1: a fence that opens in one turn and closes in a later turn loses no turn', async () => {
+    // Pre-fix: 4 turns in, ids ["m1","m4"] out, stderr empty - m2 and m3
+    // annihilated and their text swallowed into m1.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Half a paste', 'source: chatgpt', 'memvelope_conversation_id: c-spanning'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'I pasted half a block by mistake:',
+          '',
+          `${FENCE}js`,
+          "const widget = 'acme-example';",
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'The block is still open - nothing closed it.',
+          '',
+          '---',
+          '',
+          '**Me** (2026-02-01T09:10:00.000Z · m3):',
+          '',
+          'Here is the rest of what I meant to paste:',
+          '',
+          FENCE,
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:15:00.000Z · m4):',
+          '',
+          'Now the block is balanced again.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 4 });
+    const messages = result.envelope.conversations[0].messages as Array<{ id: string; role: string; ts: string | null; text: string }>;
+    expect(messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+    // The destroyed turns' own timestamps, which vanish with their headers.
+    expect(messages[1].ts).toBe('2026-02-01T09:05:00.000Z');
+    expect(messages[2].ts).toBe('2026-02-01T09:10:00.000Z');
+    // ...and their text belongs to them, not to the turn above.
+    expect(messages[1].text).toContain('nothing closed it');
+    expect(messages[0].text).not.toContain('nothing closed it');
+    expect(messages[0].text).not.toContain('**Assistant**');
+    // The fence lost, and the operator is told which one and where, because the
+    // script read something as prose that its author may have meant as code.
+    expect(result.stderr).toContain('is still open at the turn header');
+  });
+
+  test('R1: a fence opened inside a bullet does not swallow the turns after it', async () => {
+    // The same annihilation, reached the way a conversation about markdown
+    // reaches it: a bullet whose continuation line is a bare fence, indented two
+    // spaces, which the fence scanner still treats as a fence (it allows up to
+    // three). One fence line in m1, one in m3. Pre-fix: ids ["m1","m4"], stderr
+    // empty - nothing between them survived.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Fence in a bullet', 'source: chatgpt', 'memvelope_conversation_id: c-bullet'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'Two things about the page format:',
+          '',
+          '- a code block starts with a line like',
+          `  ${FENCE}`,
+          '- and it runs until the same characters appear again',
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'That is right for gbrain pages too.',
+          '',
+          '---',
+          '',
+          '**Me** (2026-02-01T09:10:00.000Z · m3):',
+          '',
+          'So the closing line is also:',
+          '',
+          '- the same three characters, like',
+          `  ${FENCE}`,
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:15:00.000Z · m4):',
+          '',
+          'Exactly.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 4 });
+    const messages = result.envelope.conversations[0].messages as Array<{ id: string; text: string }>;
+    expect(messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(messages[1].text).toContain('right for gbrain pages too');
+    expect(messages[2].text).toContain('the closing line is also');
+    expect(messages[0].text).not.toContain('right for gbrain pages too');
+    expect(result.stderr).toContain('is still open at the turn header');
+  });
+
+  test('R1: a turn asking how to close a fence does not annihilate the reply', async () => {
+    // The plainest trigger there is, and one this brain will actually hold: a
+    // user asks how to close a triple-backtick block, writing the opening line
+    // on its own; the assistant answers by writing the same line. Two turns,
+    // one fence line each, and the reply's header sits between them. Pre-fix:
+    // ids ["m1","m3"] - the assistant's whole turn gone, at exit 0 with an
+    // empty stderr.
+    const FENCE = '```';
+    const result = await exportPages({
+      'a.md': gbrainPage(
+        ['type: conversation', 'title: Closing a fence', 'source: chatgpt', 'memvelope_conversation_id: c-howto'].join('\n'),
+        [
+          '**Me** (2026-02-01T09:00:00.000Z · m1):',
+          '',
+          'How do I close a block that starts with this line?',
+          '',
+          FENCE,
+          '',
+          '---',
+          '',
+          '**Assistant** (2026-02-01T09:05:00.000Z · m2):',
+          '',
+          'You end it with the same three characters on their own line:',
+          '',
+          FENCE,
+          '',
+          '---',
+          '',
+          '**Me** (2026-02-01T09:10:00.000Z · m3):',
+          '',
+          'Thanks, that is clear.',
+        ].join('\n'),
+      ),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 1, messages: 3 });
+    const messages = result.envelope.conversations[0].messages as Array<{ id: string; role: string; text: string }>;
+    expect(messages.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+    // The only assistant turn in the page. Losing it turns a Q-and-A into a
+    // monologue, which no count in the document contradicts.
+    expect(messages.filter((m) => m.role === 'assistant')).toHaveLength(1);
+    expect(messages[1].text).toContain('on their own line');
+    expect(messages[0].text).not.toContain('on their own line');
+    expect(result.stderr).toContain('is still open at the turn header');
+  });
+
+  test('R2: second 60 is accepted only at 23:59:60 UTC, the one leap second RFC 3339 allows', async () => {
+    // Guards the leap-second bound. An unconditional `second > 60` let ANY
+    // `:60` timestamp through; RFC 3339 permits second 60 only at the instant a
+    // leap second is inserted, midnight UTC, so the offset has to be normalized
+    // away before the hour and minute are judged. Measured against ajv 8.20.0 +
+    // ajv-formats 3.0.1 in strict/full mode, which is what a consumer
+    // validating the published schema runs:
+    //   2026-02-01T09:00:60.000Z   -> rejected (UTC 09:00, not 23:59)
+    //   2026-12-31T23:59:60Z       -> accepted
+    //   2026-12-31T23:59:60+00:00  -> accepted
+    //   2026-12-31T23:59:60+01:00  -> rejected (UTC 22:59, not 23:59)
+    //   1990-12-31T15:59:60-08:00  -> accepted (UTC 23:59; RFC 3339's own example)
+    // A non-conforming value takes the route every other unparseable timestamp
+    // takes - null, and a warning - rather than shipping a document that fails
+    // validation. A conforming one is kept, offset and all.
+    const turn = (ts: string) => `**Me** (${ts} · m1):\n\nA turn stamped ${ts}.`;
+    const page = (title: string, id: string, ts: string) =>
+      gbrainPage(
+        ['type: conversation', `title: ${title}`, 'source: chatgpt', `memvelope_conversation_id: ${id}`].join('\n'),
+        turn(ts),
+      );
+    const result = await exportPages({
+      'a-not-leap.md': page('Not a leap second', 'c-notleap', '2026-02-01T09:00:60.000Z'),
+      'b-leap-z.md': page('Leap second Z', 'c-leapz', '2026-12-31T23:59:60Z'),
+      'c-leap-offset.md': page('Leap second +00:00', 'c-leapoffset', '2026-12-31T23:59:60+00:00'),
+      'd-leap-nonutc.md': page('Second 60 at +01:00', 'c-nonutc', '2026-12-31T23:59:60+01:00'),
+      'e-leap-pacific.md': page('Leap second at -08:00', 'c-pacific', '1990-12-31T15:59:60-08:00'),
+    });
+
+    expect(result.exitCode).toBe(0);
+    assertEnvelopeV0(result.envelope, { conversations: 5, messages: 5 });
+    const byId = Object.fromEntries(
+      (result.envelope.conversations as Array<{ id: string; created_at: string | null; messages: Array<{ ts: string | null }> }>)
+        .map((c) => [c.id, c]),
+    );
+
+    // Rejected: emitted as null, and said out loud, exactly as a turn header
+    // carrying prose where a timestamp goes already is.
+    expect(byId['c-notleap'].messages[0].ts).toBeNull();
+    expect(byId['c-notleap'].created_at).toBeNull();
+    expect(byId['c-nonutc'].messages[0].ts).toBeNull();
+    expect(result.stderr).toContain('2026-02-01T09:00:60.000Z');
+    expect(result.stderr).toContain('2026-12-31T23:59:60+01:00');
+    expect(result.stderr).toContain('not an RFC 3339 date-time');
+
+    // Accepted: a genuine leap second is a valid date-time and must not be
+    // thrown away by a fix that simply bans `:60`.
+    expect(byId['c-leapz'].messages[0].ts).toBe('2026-12-31T23:59:60Z');
+    expect(byId['c-leapoffset'].messages[0].ts).toBe('2026-12-31T23:59:60+00:00');
+    // The same instant on a Pacific clock. Banning `:60` outside hour 23 would
+    // throw this away, and it is RFC 3339's own worked example.
+    expect(byId['c-pacific'].messages[0].ts).toBe('1990-12-31T15:59:60-08:00');
+
+    // Nothing non-conforming reached the document by any route.
+    const nonConforming = timestampsIn(result.envelope).filter(
+      (t) => t.value !== null && !isRfc3339DateTime(t.value),
+    );
+    expect(nonConforming).toEqual([]);
+
+    // The checker carried the same unconditional `> 60` bound, so it would have
+    // waved the bad document through and the assertion above would have proved
+    // nothing. D4 claims this checker rejects everything the published schema
+    // rejects; that claim covers this too.
+    expect(isRfc3339DateTime('2026-02-01T09:00:60.000Z')).toBe(false);
+    expect(isRfc3339DateTime('2026-12-31T23:59:60+01:00')).toBe(false);
+    expect(isRfc3339DateTime('2026-12-31T23:59:60Z')).toBe(true);
+    expect(isRfc3339DateTime('2026-12-31T23:59:60+00:00')).toBe(true);
+    // Every value the ajv probe covered, so the two implementations agree on
+    // the whole boundary and not only on the four the exporter emitted above.
+    expect(isRfc3339DateTime('1990-12-31T15:59:60-08:00')).toBe(true);
+    expect(isRfc3339DateTime('2026-12-31T00:29:60+00:30')).toBe(true);
+    expect(isRfc3339DateTime('2026-01-01T05:29:60+05:30')).toBe(true);
+    expect(isRfc3339DateTime('2026-06-30T23:59:60Z')).toBe(true);
+    expect(isRfc3339DateTime('2026-12-31T23:58:60Z')).toBe(false);
+    expect(isRfc3339DateTime('2026-12-31T22:59:60Z')).toBe(false);
+    expect(isRfc3339DateTime('2026-12-31T23:59:60+05:30')).toBe(false);
   });
 
   test('a missing directory argument or unreadable path exits 1', async () => {


### PR DESCRIPTION
I wrote the envelope-v0 importer that merged as #3549 - scripts/envelope-to-gbrain.mjs - to facilitate bringing outside chat history/context into gbrain. Today, we are unable to export the history built using gbrain out using the same format. gbrain can read envelope-v0 but nothing writes it. Once a brain is seeded from an envelope file, that file is the only copy of that shape that exists. If I lose it I can't regenerate it from the brain it built.

This PR completes the circle - scripts/gbrain-to-envelope.mjs. It is built with the same specs as the importer: standalone, zero dependencies, deterministic, no network, and doesn't call gbrain. The exporter reads conversation pages and writes envelope-v0 back out so a brain that was seeded from a file can produce that file again. In this case, the cohesiveness of the record is important as users compound context over time and take their brain to other model, tools, platforms, and so on.

## What changes

The export half of the round trip: `scripts/gbrain-to-envelope.mjs`, a standalone script that reads gbrain conversation pages back into an envelope-v0 file. It is the counterpart of `scripts/envelope-to-gbrain.mjs` (#3549, made parser-legible in #3788) — that script reads the format, this one writes it. Zero dependencies, deterministic, no network, never calls gbrain; point it at a `gbrain export --dir` tree, a brain repo, or the importer's output.

**1. Identity from the frontmatter record, not from prose.** On pages the importer writes since #3788, per-message identity — the id and the full RFC 3339 timestamp — lives in a frontmatter `messages:` array, and body turn headers carry only a speaker and a minute-resolution clock. The exporter reads it back the same way: `messages[i]` belongs to the i-th body turn, and a header-shaped line is a turn boundary only when it carries the clock derived from the next recorded `ts` (the importer's own derivation, kept in lockstep). So message text cannot split a message by looking like a header, an id cannot break the line that carries it, and one trailing space no longer silently absorbs a turn. Pages without the key keep the exact legacy read. A recorded page that cannot be read honestly is refused loudly — unreadable record, non-string id, empty record, or a body anchoring a different number of turns than the record holds — skipped with both numbers on stderr, never joined wrong. Fenced code blocks are never scanned for headers or sentinels, with a staged demotion so a fence can never swallow the turns after it.

**2. One envelope per provider — a mixed directory no longer falsifies `source:`.** An envelope names ONE `meta.source_provider`. The previous revision collapsed a mixed-provider page set to the first provider in sorted path order (warned once), and re-importing that envelope stamped the winner onto every losing page: the identity check matched the conversation ids, read a legitimate refresh, and overwrote `source:` at exit 0 — with nothing on disk retaining the truth, since envelope-v0 has no per-conversation provider field. Merging several vendors' history into one directory is the format's mainstream case, so this fired on the pitch, not on an edge.

Now the set fans out — one conforming envelope per provider, named for it (`out.chatgpt.mve.json`, `out.claude.mve.json`), each listed on stdout with its own counts:

| | before | after |
|---|---|---|
| mixed chatgpt+claude directory | 1 envelope, one provider chosen for everyone | 2 envelopes, each true |
| the circle back into the same directory | claude pages come back `source: "chatgpt"`, exit 0, silent | every id-carrying page byte-identical |

A single-provider directory is unchanged: one file, the same name and words as before. Pages with no `source:` key are their own group under the documented `unknown` placeholder, never folded into a neighbouring provider — that fold would be the same falsification arriving through absence — and the filename token is sanitized to `[A-Za-z0-9._-]` and deduplicated case-insensitively, so a hostile `source:` cannot steer the write and case-only twins survive a case-insensitive filesystem. One honest residue, measured and documented in the header: a native gbrain page has no `memvelope_conversation_id`, so its conversation travels as `id: null`, and re-importing the `unknown` envelope writes a new positional page rather than refreshing the original (the importer's standing null-id behavior). A duplicate page, never a falsified one.

**3. Every timeline-sentinel spelling gbrain accepts.** gbrain's `findTimelineSplitIndex` (src/core/markdown.ts) accepts four sentinel forms; the exporter recognized three exact strings, so the case/space-tolerant `--- TIMELINE ---` variants and the bare `---` above a `## Timeline`/`## History` heading exported a page's timeline into the last message's text at exit 0. All four forms now cut, under one discipline: candidates are fence-masked, only a sentinel past the last accepted turn cuts (where gbrain's own parser cuts at the FIRST hit and truncates every turn below a quoted sentinel — the one deliberate divergence), and both the cut and the refusal to cut are reported per page. The bare-rule form is safe against the legacy turn separator through its heading lookahead, pinned by negative tests (`---` above prose, and `## Timelines`, both keep their bytes).

**4. A header whose claims are measurements.** The script's header states what survives the round trip and what does not, each item measured on a probe built to carry it — including the residues this PR could have been quieter about: the id-less duplicate above, the form-4 cut of a final message that legitimately ends in `---` + `## Timeline` (gbrain's parser reads that page the same way), and the fields a page cannot carry (`created_at`/`updated_at` come back as the first/last message timestamps).

## How it was tested

`test/gbrain-to-envelope.test.ts`: **67 pass, 0 fail**, `tsc --noEmit` clean, and the repo's own `bun run verify` gate green (34/34) — identical to the untouched base. The importer's suite is untouched and stays **120 pass, 0 fail**.

New tests were written red-first, and the two behavior changes are pinned by mutation, not by a green suite alone:

- Sentinel forms: 60 pass / 3 fail against the previous script (form-3 variants, form 4, and the mid-page warn discipline). Four mutants — drop the decorated-form regex, kill the bare-rule branch, drop `history` from the heading pattern, cut without the heading lookahead — each fails exactly the test named for it.
- Provider fan-out: 63 pass / 4 fail against the previous script. Six mutants, including restoring the flatten itself (every conversation into the first group), dropping or stamping the sourceless group, removing the filename sanitizer, and removing the case-insensitive dedupe — every one killed; restoring the flatten reproduces the full red-first set.

Round trip against the real producer, on the importer as merged: the repo's sample fixture comes back deep-equal with zero stderr. A mixed directory — chatgpt and claude envelopes imported into ONE directory plus a native source-less page — fans out into three conforming envelopes; re-importing all three into the same directory leaves both id-carrying pages byte-identical and the native page untouched, plus the one documented positional duplicate a null id mints. Earlier rounds (2026-08-02, gbrain v0.42.72.1) drove the long path through a throwaway brain — envelope → importer → `gbrain import` → `gbrain export --dir` → exporter — so the reader is proven against the frontmatter shapes gbrain's own js-yaml serializer really emits (block-scalar and folded ids, single-quoted timestamps, reordered keys); a 17-message probe with hostile ids, offset/microsecond/null timestamps, same-minute collisions, quoted sentinels and fences spanning turns came back verbatim. gbrain's serializer emits only `<!-- timeline -->`, so the closed sentinel forms arrive on hand-edited or legacy pages — which is where they were losing content.

Conformance is enforced in CI against the published envelope-v0 schema, vendored byte-for-byte (sha256-pinned, identical across memvelope.com, the GitHub raw, and the npm package) and walked by a checker that refuses any keyword it does not implement — a constraint added upstream turns the suite red instead of passing unchecked. Both round-trip outputs also validate under ajv + ajv-formats in full mode out of tree.

## Scope

`scripts/gbrain-to-envelope.mjs`, `test/gbrain-to-envelope.test.ts`, and the vendored schema fixture — 3 files, +4149, nothing else touched. Nothing in `src/`. No new dependencies: the script imports only `node:fs` and `node:path`. Builds on the importer exactly as merged in #3788; the round-trip tests shell it in-tree.

Happy to adjust naming or placement to repo conventions, and to maintain this going forward.