### PR TITLE
fix(sources): removeSource cascades source-scoped OAuth clients

### DIFF
--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -662,6 +662,9 @@ export async function listSources(
 export interface RemoveResult {
   id: string;
   pages_deleted: number;
+  /** Source-scoped OAuth clients removed to satisfy the ON DELETE RESTRICT FK
+   *  (oauth_clients.source_id, migrate v64) before the source row is deleted. */
+  clients_deleted: number;
   clone_removed: boolean;
   clone_path: string | null;
   dryRun: boolean;
@@ -697,11 +700,23 @@ export async function removeSource(
   }
 
   const pageCount = await countAllPages(engine, opts.id);
+  // Source-scoped OAuth clients (provision_source registers one per tenant brain).
+  // Their FK is ON DELETE RESTRICT (migrate v64), so `DELETE FROM sources` below
+  // fails outright unless we drop them first — the "revoke the clients first" path
+  // v64's comment describes.
+  const clientCount =
+    (
+      await engine.executeRaw<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM oauth_clients WHERE source_id = $1`,
+        [opts.id],
+      )
+    )[0]?.n ?? 0;
 
   if (opts.dryRun) {
     return {
       id: opts.id,
       pages_deleted: pageCount,
+      clients_deleted: clientCount,
       clone_removed: false,
       clone_path: src.local_path,
       dryRun: true,
@@ -709,11 +724,13 @@ export async function removeSource(
   }
 
   // Confirmation gate (caller should usually have already shown the impact
-  // preview from destructive-guard.ts).
-  if (pageCount > 0 && !opts.confirmDestructive && !opts.yes) {
+  // preview from destructive-guard.ts). Clients count as destructive too — a
+  // clear "needs confirm" message beats the raw FK violation the RESTRICT FK
+  // would otherwise throw.
+  if ((pageCount > 0 || clientCount > 0) && !opts.confirmDestructive && !opts.yes) {
     throw new SourceOpError(
       'protected_id', // closest existing code; caller can frame as "needs confirm"
-      `Refusing to remove source "${opts.id}" with ${pageCount} pages without --confirm-destructive or --yes.`,
+      `Refusing to remove source "${opts.id}" with ${pageCount} pages and ${clientCount} OAuth clients without --confirm-destructive or --yes.`,
     );
   }
 
@@ -750,11 +767,19 @@ export async function removeSource(
     }
   }
 
+  // Drop the source-scoped OAuth clients first (their oauth_tokens cascade via
+  // oauth_tokens.client_id ON DELETE CASCADE), so the ON DELETE RESTRICT FK on
+  // oauth_clients.source_id doesn't block the source delete below.
+  if (clientCount > 0) {
+    await engine.executeRaw(`DELETE FROM oauth_clients WHERE source_id = $1`, [opts.id]);
+  }
+
   await engine.executeRaw(`DELETE FROM sources WHERE id = $1`, [opts.id]);
 
   return {
     id: opts.id,
     pages_deleted: pageCount,
+    clients_deleted: clientCount,
     clone_removed: cloneRemoved,
     clone_path: src.local_path,
     dryRun: false,

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -17,6 +17,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { GBrainOAuthProvider } from '../src/core/oauth-provider.ts';
+import { sqlQueryForEngine } from '../src/core/sql-query.ts';
 import {
   addSource,
   listSources,
@@ -449,6 +451,68 @@ describe('removeSource — clone-cleanup', () => {
         expect(e).toBeInstanceOf(SourceOpError);
         expect((e as SourceOpError).code).toBe('protected_id');
       }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeSource — OAuth client cascade (PEU-528)
+// ---------------------------------------------------------------------------
+
+describe('removeSource — OAuth client cascade', () => {
+  // Register a source-scoped client the same way provision_source does.
+  async function provisionClient(source: string): Promise<void> {
+    await addSource(engine, { id: source, localPath: `/tmp/${source}-fixture` });
+    const provider = new GBrainOAuthProvider({ sql: sqlQueryForEngine(engine) });
+    await provider.registerClientManual(
+      source,
+      ['client_credentials'],
+      'read write',
+      [],
+      source, // sourceId
+      [source], // federatedRead allowlist = own source
+      'client_secret_post',
+    );
+  }
+
+  const clientCount = async (source: string): Promise<number> =>
+    (
+      await engine.executeRaw<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM oauth_clients WHERE source_id = $1`,
+        [source],
+      )
+    )[0]?.n ?? 0;
+
+  test('confirmDestructive cascades the source-scoped OAuth client(s)', async () => {
+    await withEnv2(async () => {
+      await provisionClient('with-client');
+      expect(await clientCount('with-client')).toBe(1);
+
+      const res = await removeSource(engine, { id: 'with-client', confirmDestructive: true });
+      expect(res.clients_deleted).toBe(1);
+
+      // Source row gone AND no orphaned client — the whole point (PEU-528).
+      expect((await listSources(engine)).find((s) => s.id === 'with-client')).toBeUndefined();
+      expect(await clientCount('with-client')).toBe(0);
+    });
+  });
+
+  test('without confirm: refuses with a clear message, leaves the client intact', async () => {
+    await withEnv2(async () => {
+      await provisionClient('needs-confirm');
+
+      try {
+        await removeSource(engine, { id: 'needs-confirm' });
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SourceOpError);
+        // Names the client count, not a raw FK violation from ON DELETE RESTRICT.
+        expect((e as SourceOpError).message).toContain('1 OAuth clients');
+      }
+
+      // Nothing removed on the refusal path.
+      expect(await clientCount('needs-confirm')).toBe(1);
+      expect((await listSources(engine)).find((s) => s.id === 'needs-confirm')).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Problem

`oauth_clients.source_id` has an `ON DELETE RESTRICT` FK (migrate **v64**, `src/schema.sql:654` / `src/core/pglite-schema.ts`). So `removeSource`'s final `DELETE FROM sources WHERE id = $1` (`src/core/sources-ops.ts`) throws a raw FK violation for **any source that has a source-scoped OAuth client** — the source can't be removed at all, and the caller just sees a Postgres error, not an actionable message.

v64's comment says the operator path is "revoke or re-scope the clients first," but there's no reusable revoke helper and `removeSource` never does it — so in practice a client-bearing source is undeletable via `sources remove` / the `sources_remove` MCP op.

## Fix

`removeSource` now:
- counts the source's `oauth_clients`,
- includes them in the confirm-destructive gate (a clear `"…N OAuth clients without --confirm-destructive"` message instead of a raw FK violation),
- and, when confirmed, `DELETE`s them (their `oauth_tokens` cascade via the existing `oauth_tokens.client_id ON DELETE CASCADE`) immediately before the source row.

The `RESTRICT` FK stays intact — we satisfy it by revoking first, which is exactly the path the v64 comment prescribes. Adds `clients_deleted` to `RemoveResult`.

## Tests

Two PGLite cases in `test/sources-ops.test.ts` (`describe('removeSource — OAuth client cascade')`): registers a source-scoped client via `registerClientManual` (as an operator would), then asserts (1) `confirm_destructive` removes the source **and** its client (`clients_deleted === 1`), and (2) without confirm it refuses with the clear message and leaves the client intact.

`bun test test/sources-ops.test.ts` → 53 pass / 0 fail; `tsc --noEmit` clean. Also verified end-to-end against a running `serve --http` instance on real Postgres: `provision_source` → `sources_remove {confirm_destructive:true}` now returns `clients_deleted` and succeeds (previously FK-errored).