### PR TITLE
feat(list): surface PageFilters.slugPrefix as list_pages slug_prefix

### DIFF
--- a/src/core/operations-descriptions.ts
+++ b/src/core/operations-descriptions.ts
@@ -59,6 +59,9 @@ export const LIST_PAGES_DESCRIPTION =
   "List pages with optional filters. " +
   "For 'what's recent / what did I touch this week' questions, use list_pages " +
   "with sort=updated_desc instead of semantic search. " +
+  "To enumerate a slug-path-organized collection (e.g. everything under " +
+  "sources/youtube/), filter with slug_prefix — slugs are not searchable text, " +
+  "so search/query never reach pages whose bodies don't mention the path. " +
   "Default 50 rows; remote callers are capped at 100 (local CLI callers' explicit " +
   "limits are honored). A result with exactly `limit` rows may be truncated. " +
   "For exhaustive listing, page with sort=updated_asc + " +

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1746,6 +1746,18 @@ const list_pages: Operation = {
       type: 'string',
       description: 'ISO date (YYYY-MM-DD) or full timestamp. Returns pages with updated_at > value.',
     },
+    // Surface PageFilters.slugPrefix the same way — engines have implemented
+    // it all along (LIKE range scan on the (source_id, slug) btree, meta-
+    // characters escaped), but the op never passed it, so slug-path-organized
+    // collections (sources/youtube/<channel>/…) could not be enumerated over
+    // MCP: slugs are not searchable text, and no other list filter reaches them.
+    slug_prefix: {
+      type: 'string',
+      description:
+        "Filter to slugs starting with this literal prefix (e.g. 'sources/youtube/'). " +
+        "Plain string-prefix semantics — include the trailing '/' to stay inside a " +
+        "path segment ('media/x' also matches 'media/xerox').",
+    },
     sort: {
       type: 'string',
       enum: [...LIST_PAGES_SORT_VALUES],
@@ -1807,6 +1819,7 @@ const list_pages: Operation = {
       offset,
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
+      slugPrefix: typeof p.slug_prefix === 'string' && p.slug_prefix.length > 0 ? p.slug_prefix : undefined,
       sort,
       ...scope,
     });
@@ -1824,7 +1837,7 @@ const list_pages: Operation = {
       console.error(
         `[list_pages] output truncated at ${limit} rows (default 50). ` +
         `Pass an explicit limit, page through with sort=updated_asc + ` +
-        `updated_after=<last row's updated_at>, or narrow with type/tag.`,
+        `updated_after=<last row's updated_at>, or narrow with type/tag/slug_prefix.`,
       );
     }
     return pages.map(pg => ({

--- a/test/list-pages-slug-prefix.test.ts
+++ b/test/list-pages-slug-prefix.test.ts
@@ -1,0 +1,103 @@
+/**
+ * list_pages slug_prefix — op-level coverage.
+ *
+ * Pins (upstream draft "list_pages cannot enumerate slug-path collections"):
+ *   - `slug_prefix` threads from the op params to PageFilters.slugPrefix,
+ *     which both engines have implemented all along (the op layer never
+ *     passed it — same shape as the v0.29 `updated_after` surfacing and the
+ *     `offset` threading fix).
+ *   - Plain string-prefix semantics are the engine contract: 'media/x'
+ *     (no trailing '/') also matches 'media/xerox'.
+ *   - LIKE metacharacters in the prefix stay literal through the op
+ *     boundary: 'media/_' must not wildcard-match 'media/x/…'.
+ *   - Composes with the existing `type` filter; omitted/empty/non-string
+ *     `slug_prefix` leaves pre-existing behavior untouched.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { operationsByName } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/operations.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+afterAll(async () => { await engine.disconnect(); });
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  // 5-page corpus: two path collections, a path-segment trap sharing the
+  // 'media/x' character prefix, a LIKE-metacharacter slug, and an outsider.
+  const body = { type: 'note', title: 'Page', compiled_truth: 'body' };
+  await engine.putPage('media/x/tweet-001', body);
+  await engine.putPage('media/x/tweet-002', body);
+  await engine.putPage('media/xerox/doc-001', { ...body, type: 'concept' });
+  await engine.putPage('media/_docs/readme', body);
+  await engine.putPage('people/alice', body);
+});
+
+function mkCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine,
+    config: {} as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} } as any,
+    dryRun: false,
+    remote: false,
+    ...overrides,
+  } as OperationContext;
+}
+
+const op = () => operationsByName['list_pages'];
+const slugsOf = (rows: unknown) => (rows as Array<{ slug: string }>).map((r) => r.slug).sort();
+
+describe('list_pages — slug_prefix threads through to the engine filter', () => {
+  test('trailing-/ prefix returns exactly the collection', async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 'media/x/' });
+    expect(slugsOf(rows)).toEqual(['media/x/tweet-001', 'media/x/tweet-002']);
+  });
+
+  test("plain string-prefix semantics: 'media/x' also matches 'media/xerox' (engine contract)", async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 'media/x' });
+    expect(slugsOf(rows)).toEqual([
+      'media/x/tweet-001',
+      'media/x/tweet-002',
+      'media/xerox/doc-001',
+    ]);
+  });
+
+  test("LIKE metacharacters stay literal: 'media/_' must not match 'media/x/…'", async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 'media/_' });
+    expect(slugsOf(rows)).toEqual(['media/_docs/readme']);
+  });
+
+  test('composes with the type filter', async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 'media/', type: 'concept' });
+    expect(slugsOf(rows)).toEqual(['media/xerox/doc-001']);
+  });
+
+  test('no match returns an empty list, not an error', async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 'nothing/here/' });
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('list_pages — omitted or invalid slug_prefix leaves behavior unchanged', () => {
+  test('omitted: full corpus (pre-existing shape)', async () => {
+    const rows = await op().handler(mkCtx(), {});
+    expect(slugsOf(rows).length).toBe(5);
+  });
+
+  test('empty string: treated as unset', async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: '' });
+    expect(slugsOf(rows).length).toBe(5);
+  });
+
+  test('non-string: ignored, no throw', async () => {
+    const rows = await op().handler(mkCtx(), { slug_prefix: 42 as unknown as string });
+    expect(slugsOf(rows).length).toBe(5);
+  });
+});


### PR DESCRIPTION
## Problem

Slug paths are the one organizational axis `list_pages` cannot reach. Both engines have implemented `PageFilters.slugPrefix` all along — a LIKE range scan on the `(source_id, slug)` btree with metacharacters escaped, in `postgres-engine.ts` and `pglite-engine.ts` alike — but the op layer never passes it, and no other route substitutes:

- slugs are not searchable text: `search`/`query` never reach a page whose body doesn't happen to mention the path;
- `type`/`tag` only help when every page in the collection carries a dedicated type or tag;
- remote MCP callers have no SQL fallback.

So a brain organized around path collections (`media/x/…`, `sources/youtube/<channel>/…`) cannot enumerate one collection over MCP at all.

**Repro** (upstream master `15b9863d`, seeded `media/x/tweet-001`, `media/x/tweet-002`, `media/xerox/doc-001`, `people/alice`):

```
$ gbrain list --slug-prefix media/x/
people/alice        person  2026-08-05  Alice
media/xerox/doc-001 media   2026-08-05  Doc 001
media/x/tweet-002   media   2026-08-05  Tweet 002
media/x/tweet-001   media   2026-08-05  Tweet 001
```

The flag is accepted and silently ignored — the generic kebab→snake CLI mapping produces a `slug_prefix` param that `list_pages` never declared, so it is dropped without a warning.

## Fix

Same surfacing shape as the v0.29 `updated_after` param and the `offset` threading fix (both already annotated inside this op): declare `slug_prefix` on `list_pages` and thread it to the engine as `PageFilters.slugPrefix`. Engines untouched.

- Plain string-prefix semantics, documented on the param: `'media/x'` also matches `'media/xerox'`; include the trailing `/` to stay inside a path segment. This matches the engine contract already pinned in `test/pglite-engine.test.ts` (“listPages with slugPrefix filter (Issue #13)”).
- CLI `gbrain list --slug-prefix …` works through the existing generic flag mapping — no `cli.ts` change.
- The local truncation hint now names `slug_prefix` as a narrowing option alongside `type`/`tag`.
- Guard: empty or non-string values are treated as unset (behavior identical to before this PR).

**After** (same corpus):

```
$ gbrain list --slug-prefix media/x/
media/x/tweet-002   media   2026-08-05  Tweet 002
media/x/tweet-001   media   2026-08-05  Tweet 001
```

## Tests

New `test/list-pages-slug-prefix.test.ts` — op-level coverage against the canonical PGLite block (R1–R4 clean), 8 tests:

- trailing-`/` prefix returns exactly the collection;
- literal-prefix segment trap (`'media/x'` also matches `'media/xerox'`) pinned as the documented contract;
- LIKE metacharacters stay literal through the op boundary — `'media/_'` must **not** wildcard-match `'media/x/…'`;
- composes with the existing `type` filter;
- no match → empty list, not an error;
- omitted / empty-string / non-string `slug_prefix` leave pre-existing behavior untouched (back-compat shape, mirroring `test/e2e/list-pages-regression.test.ts`).

The filter implementation itself was already covered at the engine layer (`test/pglite-engine.test.ts`: slugPrefix filtering + LIKE escape); this PR adds only the op passthrough, so no engine code changes and no new engine-level surface.

## Verification

- `bun run verify` — 34/34 green
- unit suite (`scripts/run-unit-parallel.sh`) — 7,873 pass / 20 skip / 7 fail. The same 7 tests fail identically on pristine upstream master `15b9863d` in this environment (re-ran the five affected files on an untouched checkout: 61 pass / 7 fail) — all are host-environment-dependent (`delete process.env.OPENAI_API_KEY` fixtures neutralized by local provider config; repo-hardening / worker-registry expecting a clean host), none touch `list_pages`.
- e2e not run locally (no `DATABASE_URL`); the script's documented fallback path was taken
- eval replay not attached: `list_pages` is not a retrieval path — no changes under `src/core/search/`, `embedding.ts`, or the query/search op handlers; ranking cannot change.
