### PR TITLE
fix(cycle): route atom extraction through utility model config

### DIFF
--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -50,6 +50,7 @@ const PER_TASK_KEYS: PerTaskModelRoute[] = [
   { key: 'models.dream.synthesize',         tier: 'reasoning', description: 'Dream synthesis (conversation → brain pages)' },
   { key: 'models.dream.synthesize_verdict', tier: 'utility',   description: 'Dream synthesis verdict (Haiku judge)' },
   { key: 'models.dream.patterns',           tier: 'reasoning', description: 'Pattern discovery (cross-take themes)' },
+  { key: 'models.cycle.extract_atoms',      tier: 'utility',   description: 'Cycle extract_atoms atom extraction' },
   { key: 'models.drift',                    tier: 'reasoning', description: 'Drift LLM judge (v0.29 scaffold)' },
   { key: 'models.auto_think',               tier: 'deep',      description: 'Auto-think question answering' },
   { key: 'models.think',                    tier: 'deep',      description: '`gbrain think` synthesis op' },

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -57,6 +57,7 @@ import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
 import { slugifySegment } from '../sync.ts';
+import { resolveModel } from '../model-config.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 const DEFAULT_EXTRACT_ATOMS_MODEL = 'anthropic:claude-haiku-4-5';
@@ -419,6 +420,11 @@ export async function runPhaseExtractAtoms(
 ): Promise<PhaseResult> {
   const sourceId = opts.sourceId ?? 'default';
   const chat = opts._chat ?? gatewayChat;
+  const extractionModel = await resolveModel(engine, {
+    configKey: 'models.cycle.extract_atoms',
+    tier: 'utility',
+    fallback: DEFAULT_EXTRACT_ATOMS_MODEL,
+  });
 
   // 1a. Get transcripts (test seam OR production discovery).
   //     v0.41.2.1: config loader switched to loadConfigWithEngine() so the
@@ -564,18 +570,15 @@ export async function runPhaseExtractAtoms(
   const failures: Array<{ source: string; error: string }> = [];
   let estimatedSpendUsd = 0;
   let budgetExhausted = false;
-  let extractModel = DEFAULT_EXTRACT_ATOMS_MODEL;
   let budgetCap = DEFAULT_BUDGET_USD;
   try {
-    const configuredModel = await engine.getConfig('models.dream.extract_atoms');
-    if (configuredModel) extractModel = configuredModel;
     const configuredBudget = await engine.getConfig('cycle.extract_atoms.budget_usd');
     if (configuredBudget) {
       const n = Number(configuredBudget);
       if (Number.isFinite(n) && n > 0) budgetCap = n;
     }
   } catch {
-    // Keep safe defaults: Haiku + $0.30.
+    // Keep safe default budget.
   }
   // A cost cap is only meaningful for a model the tracker can price.
   // BudgetTracker.reserve() hard-fails with BudgetExhausted(reason:'no_pricing')
@@ -583,10 +586,10 @@ export async function runPhaseExtractAtoms(
   // it warns once and proceeds. Because this phase always set a cap, every
   // non-Anthropic model tripped that hard-fail on the first item, latched
   // `budgetExhausted`, and skipped the entire workload while reporting ok.
-  const priceable = isModelPriceable(extractModel, 'chat');
+  const priceable = isModelPriceable(extractionModel, 'chat');
   if (!priceable) {
     console.error(
-      `[extract_atoms] model "${extractModel}" is not in the pricing maps; ` +
+      `[extract_atoms] model "${extractionModel}" is not in the pricing maps; ` +
         `running without a cost gate (a cap cannot be enforced on an unpriced model).`,
     );
   }
@@ -630,7 +633,7 @@ export async function runPhaseExtractAtoms(
     const originLabel = item.kind === 'transcript' ? item.filePath : item.slug;
     try {
       const result = await chat({
-        model: extractModel,
+        model: extractionModel,
         system: EXTRACT_PROMPT,
         messages: [
           {
@@ -798,7 +801,7 @@ export async function runPhaseExtractAtoms(
       failures,
       estimated_spend_usd: estimatedSpendUsd,
       budget_usd: budgetCap,
-      model: extractModel,
+      model: extractionModel,
       budget_exhausted: budgetExhausted,
       source_id: sourceId,
       dry_run: opts.dryRun ?? false,

--- a/test/extract-atoms-page-discovery.test.ts
+++ b/test/extract-atoms-page-discovery.test.ts
@@ -246,6 +246,31 @@ describe('v0.41.2.1: discoverExtractablePages SQL contract', () => {
 });
 
 describe('v0.41.2.1: runPhaseExtractAtoms — dual-source merge + idempotency', () => {
+  test('uses the Haiku utility tier for extraction by default', async () => {
+    let seenModel: string | undefined;
+    const chat = async (o: ChatOpts): Promise<ChatResult> => {
+      seenModel = o.model;
+      const text = `[{"title":"x","atom_type":"insight","body":"b"}]`;
+      return {
+        text,
+        blocks: [{ type: 'text', text }],
+        stopReason: 'end',
+        usage: { input_tokens: 100, output_tokens: 50, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: o.model ?? 'anthropic:claude-haiku-4-5-20251001',
+        providerId: 'anthropic',
+      };
+    };
+
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/T.txt', content: 'tc', contentHash: 'tchash1234567890ab' }],
+      _pages: [],
+      _chat: chat,
+    });
+
+    expect(seenModel).toBe('anthropic:claude-haiku-4-5-20251001');
+    expect(result.details?.model).toBe('anthropic:claude-haiku-4-5-20251001');
+  });
+
   test('dual-source merge: transcripts win on contentHash collision', async () => {
     const chat = stubChat(`[{"title":"x","atom_type":"insight","body":"b"}]`);
     const result = await runPhaseExtractAtoms(engine, {


### PR DESCRIPTION
## Summary
- route `extract_atoms` through `models.cycle.extract_atoms` on the utility tier
- surface the resolved extraction model in phase details
- add regression coverage for default Haiku utility routing

## Verification
- `bun test test/extract-atoms-page-discovery.test.ts`
- `bun run typecheck`