### PR TITLE
v0.42.73.3 fix(progress): preserve Ctrl-C termination for shared reporter (#3614)

### DIFF
--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -50,9 +50,10 @@ export interface ProgressReporter {
 // every live reporter. Per-instance handlers would leak listeners and interfere
 // with command-level handlers (e.g. shell-handler abort in jobs.ts).
 //
-// We never call process.exit() or swallow the signal — we just emit abort
-// events for live phases, then remove ourselves so the user's own handlers
-// (or the default Node behavior) run as usual.
+// We never call process.exit() — we just emit abort events for live phases.
+// Installing a SIGINT listener suppresses the runtime's default terminate
+// behavior, so when no command-level handler remains we re-raise SIGINT after
+// the abort event has had a tick to flush.
 
 interface LivePhase {
   reporter: PhaseState;
@@ -75,6 +76,11 @@ function installSignalHandler(): void {
       } catch {
         /* best-effort */
       }
+    }
+    if (reason === 'SIGINT' && process.listenerCount('SIGINT') === 0) {
+      setTimeout(() => {
+        process.kill(process.pid, 'SIGINT');
+      }, 0);
     }
   };
 

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -62,10 +62,15 @@ interface LivePhase {
 
 const liveReporters = new Set<LivePhase>();
 let signalHandlerInstalled = false;
+let hadSigintHandlersAtInstall = false;
 
 function installSignalHandler(): void {
   if (signalHandlerInstalled) return;
   signalHandlerInstalled = true;
+  // Capture command-level SIGINT ownership before our once-wrapper can be
+  // consumed by the same signal emission. A preceding once('SIGINT') listener
+  // is already gone by the time our handler runs.
+  hadSigintHandlersAtInstall = process.listenerCount('SIGINT') > 0;
 
   const onSignal = (reason: 'SIGINT' | 'SIGTERM') => {
     // Copy to array so abort() can mutate liveReporters during iteration.
@@ -77,7 +82,7 @@ function installSignalHandler(): void {
         /* best-effort */
       }
     }
-    if (reason === 'SIGINT' && process.listenerCount('SIGINT') === 0) {
+    if (reason === 'SIGINT' && !hadSigintHandlersAtInstall && process.listenerCount('SIGINT') === 0) {
       setTimeout(() => {
         process.kill(process.pid, 'SIGINT');
       }, 0);

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -1,6 +1,11 @@
 import { describe, test, expect } from 'bun:test';
-import { PassThrough } from 'node:stream';
+import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import { join } from 'node:path';
+import { PassThrough, type Readable } from 'node:stream';
 import { createProgress, startHeartbeat, __liveReporterCountForTest, __signalHandlerInstalledForTest } from '../src/core/progress.ts';
+
+const REPO = join(import.meta.dir, '..');
+type SigintHarnessProcess = ChildProcessByStdio<null, Readable, Readable>;
 
 /** Collect everything a reporter writes into a string. */
 function sink(isTTY = false): { stream: PassThrough & { isTTY?: boolean }; read: () => string } {
@@ -16,6 +21,84 @@ function parseJsonl(raw: string): Record<string, unknown>[] {
     .split('\n')
     .filter((l) => l.length > 0)
     .map((l) => JSON.parse(l));
+}
+
+function waitForStdoutMarker(proc: SigintHarnessProcess, marker: string, readStdout: () => string, timeoutMs = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      proc.stdout.off('data', onData);
+      proc.off('exit', onExit);
+      proc.off('error', onError);
+    };
+    const onData = () => {
+      if (!readStdout().includes(marker)) return;
+      cleanup();
+      resolve();
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`child exited before ${marker}: code=${code} signal=${signal}`));
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for ${marker}; stdout=${JSON.stringify(readStdout())}`));
+    }, timeoutMs);
+
+    proc.stdout.on('data', onData);
+    proc.once('exit', onExit);
+    proc.once('error', onError);
+    onData();
+  });
+}
+
+function waitForExit(proc: SigintHarnessProcess, timeoutMs = 1500): Promise<{ exited: boolean; code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      proc.off('exit', onExit);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ exited: true, code, signal });
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve({ exited: false, code: null, signal: null });
+    }, timeoutMs);
+    proc.once('exit', onExit);
+  });
+}
+
+async function runSigintHarness(script: string): Promise<{
+  exited: boolean;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const proc = spawn(process.execPath, ['-e', script], {
+    cwd: REPO,
+    env: { ...process.env, FORCE_COLOR: '0' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  proc.stdout.on('data', (chunk) => { stdout += chunk.toString('utf8'); });
+  proc.stderr.on('data', (chunk) => { stderr += chunk.toString('utf8'); });
+
+  await waitForStdoutMarker(proc, 'READY\n', () => stdout);
+  proc.kill('SIGINT');
+  const result = await waitForExit(proc);
+  if (!result.exited) {
+    proc.kill('SIGKILL');
+    await waitForExit(proc);
+  }
+  return { ...result, stdout, stderr };
 }
 
 describe('progress reporter', () => {
@@ -233,6 +316,40 @@ describe('progress reporter', () => {
     // After 50 reporter lifecycles, still exactly one handler and no new live entries.
     expect(__signalHandlerInstalledForTest()).toBe(installedBefore || true);
     expect(__liveReporterCountForTest()).toBe(liveBefore);
+  });
+
+  test('SIGINT exits a child process when the progress reporter is the only handler', async () => {
+    const result = await runSigintHarness(`
+      const { createProgress } = await import('./src/core/progress.ts');
+      const progress = createProgress({ mode: 'json' });
+      progress.start('sigint_repro', 1);
+      process.stdout.write('READY\\n');
+      setInterval(() => {}, 1000);
+    `);
+
+    expect(result.exited).toBe(true);
+    expect(result.signal === 'SIGINT' || result.code === 130).toBe(true);
+    expect(result.stderr).toContain('"event":"abort"');
+    expect(result.stderr).toContain('"reason":"SIGINT"');
+  });
+
+  test('SIGINT still defers to another process handler when one is installed', async () => {
+    const result = await runSigintHarness(`
+      const { createProgress } = await import('./src/core/progress.ts');
+      const progress = createProgress({ mode: 'quiet' });
+      progress.start('sigint_repro', 1);
+      process.once('SIGINT', () => {
+        process.stdout.write('HANDLED\\n');
+        process.exit(0);
+      });
+      process.stdout.write('READY\\n');
+      setInterval(() => {}, 1000);
+    `);
+
+    expect(result.exited).toBe(true);
+    expect(result.code).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toContain('HANDLED');
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -336,12 +336,12 @@ describe('progress reporter', () => {
   test('SIGINT still defers to another process handler when one is installed', async () => {
     const result = await runSigintHarness(`
       const { createProgress } = await import('./src/core/progress.ts');
-      const progress = createProgress({ mode: 'quiet' });
-      progress.start('sigint_repro', 1);
       process.once('SIGINT', () => {
         process.stdout.write('HANDLED\\n');
-        process.exit(0);
+        setTimeout(() => process.exit(0), 50);
       });
+      const progress = createProgress({ mode: 'json' });
+      progress.start('sigint_repro', 1);
       process.stdout.write('READY\\n');
       setInterval(() => {}, 1000);
     `);
@@ -350,6 +350,8 @@ describe('progress reporter', () => {
     expect(result.code).toBe(0);
     expect(result.signal).toBeNull();
     expect(result.stdout).toContain('HANDLED');
+    expect(result.stderr).toContain('"event":"abort"');
+    expect(result.stderr).toContain('"reason":"SIGINT"');
   });
 
   test('startHeartbeat() fires heartbeats and stop() clears', async () => {


### PR DESCRIPTION
## Summary

Fixes #3614 by preserving normal Ctrl-C termination for commands whose only SIGINT listener is the shared progress reporter.

The reporter already emitted abort events for live phases, but installing the listener suppressed the runtime's default SIGINT behavior. For bulk commands without their own shutdown handler, the first Ctrl-C aborted the reporter and then left the process running.

## Changes

- After emitting progress abort events, the shared SIGINT handler now checks whether any other SIGINT listener remains.
- If no command-level handler is present, it re-raises SIGINT on the next tick so the process exits normally while giving the abort event a chance to flush.
- SIGTERM behavior is unchanged, and commands with their own SIGINT handler still own their shutdown path.

## Tests

- Added spawn-level coverage in `test/progress.test.ts` proving a child process with only the progress reporter exits on SIGINT.
- Added a companion spawn-level test proving a command-level SIGINT handler still runs and exits cleanly.

## Verification

- Reproduced red before the fix: `bun test test/progress.test.ts` failed because the progress-only child stayed alive after SIGINT.
- `bun test test/progress.test.ts` - 19 pass, 0 fail, 50 expect calls.
- `bun run typecheck` - pass.
- `bash scripts/gbrain-gate.sh <worktree> test/progress.test.ts` - `RESULT: GREEN`; verify green; focused unit test green; unrelated E2E skipped by the diff selector.
