### PR TITLE
fix(cli): fail closed on unavailable ambient sources

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -996,8 +996,8 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
   // params.source is set when a CLI flag was parsed for the op (rare; most
   // CLI ops don't take --source). Falls through to env/dotfile/path-match.
   const explicit = (params.source as string | undefined) ?? null;
+  const { resolveSourceWithTier, localFederatedSourceIds, SourceTargetError } = await import('./core/source-resolver.ts');
   try {
-    const { resolveSourceWithTier, localFederatedSourceIds } = await import('./core/source-resolver.ts');
     const resolved = await resolveSourceWithTier(engine, explicit);
     sourceId = resolved.source_id;
     localFederated = await localFederatedSourceIds(engine, resolved.source_id, resolved.tier);
@@ -1006,7 +1006,10 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
     // source that doesn't exist) must error loudly — the blanket swallow
     // turned `--source __all__` and typos into a silent `default` scope,
     // which is how three bug reports became debugging sessions.
-    if (explicit) throw err;
+    // Ambient user-selected targets (GBRAIN_SOURCE / .gbrain-source /
+    // sources.default) are just as authoritative as --source. Only structural
+    // pre-init failures retain the legacy default fallback.
+    if (explicit || err instanceof SourceTargetError) throw err;
     // Ambient resolution failed (e.g. sources table doesn't exist on a fresh
     // pre-init brain). Leave sourceId unset; engine read methods fall through
     // to the cross-source view (D16 back-compat path).

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -24,6 +24,14 @@ import { isTrustedDotfile, realpathOrResolve } from './path-confine.ts';
 // either module (#1712).
 export { ALL_SOURCES };
 
+/** A caller-selected source id is invalid, missing, or archived. */
+export class SourceTargetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SourceTargetError';
+  }
+}
+
 const DOTFILE = '.gbrain-source';
 // Canonical SOURCE_ID_RE imported from `source-id.ts` (single source of truth).
 // Re-exported below as `__testing.SOURCE_ID_RE` for legacy test imports.
@@ -93,7 +101,7 @@ export async function resolveSourceId(
   if (explicit) {
     if (explicit === ALL_SOURCES) return ALL_SOURCES;
     if (!SOURCE_ID_RE.test(explicit)) {
-      throw new Error(`Invalid --source value "${explicit}". Must match [a-z0-9-]{1,32}.`);
+      throw new SourceTargetError(`Invalid --source value "${explicit}". Must match [a-z0-9-]{1,32}.`);
     }
     await assertSourceExists(engine, explicit);
     return explicit;
@@ -104,7 +112,7 @@ export async function resolveSourceId(
   if (env && env.length > 0) {
     if (env === ALL_SOURCES) return ALL_SOURCES;
     if (!SOURCE_ID_RE.test(env)) {
-      throw new Error(`Invalid GBRAIN_SOURCE value "${env}". Must match [a-z0-9-]{1,32}.`);
+      throw new SourceTargetError(`Invalid GBRAIN_SOURCE value "${env}". Must match [a-z0-9-]{1,32}.`);
     }
     await assertSourceExists(engine, env);
     return env;
@@ -138,7 +146,13 @@ export async function resolveSourceId(
       }
     }
   }
-  if (best) return best.id;
+  if (best) {
+    // A local_path registration can outlive source archival. Treat landing in
+    // that tree as an explicit unavailable target, never as permission to
+    // continue writing through an archived source id.
+    await assertSourceExists(engine, best.id);
+    return best.id;
+  }
 
   // 5. Brain-level default.
   // Silent-fallback tier per codex P1-F: an invalid `sources.default` config
@@ -249,14 +263,14 @@ export function formatSoleNonDefaultNudge(sourceId: string): string | null {
 
 async function assertSourceExists(engine: BrainEngine, id: string): Promise<void> {
   const rows = await engine.executeRaw<{ id: string }>(
-    `SELECT id FROM sources WHERE id = $1`,
+    `SELECT id FROM sources WHERE id = $1 AND archived = false`,
     [id],
   );
   if (rows.length === 0) {
-    throw new Error(
-      `Source "${id}" not found. Available sources: ` +
+    throw new SourceTargetError(
+      `Source "${id}" not found or is archived. Available active sources: ` +
       `run \`gbrain sources list\` to see registered sources, ` +
-      `or \`gbrain sources add ${id}\` to create it.`,
+      `or create/restore "${id}" before retrying.`,
     );
   }
 }
@@ -337,7 +351,7 @@ export async function resolveSourceWithTier(
       return { source_id: ALL_SOURCES, tier: 'flag', detail: `--source ${ALL_SOURCES} (spans all sources)` };
     }
     if (!SOURCE_ID_RE.test(explicit)) {
-      throw new Error(`Invalid --source value "${explicit}". Must match [a-z0-9-]{1,32}.`);
+      throw new SourceTargetError(`Invalid --source value "${explicit}". Must match [a-z0-9-]{1,32}.`);
     }
     await assertSourceExists(engine, explicit);
     return { source_id: explicit, tier: 'flag', detail: `--source ${explicit}` };
@@ -350,7 +364,7 @@ export async function resolveSourceWithTier(
       return { source_id: ALL_SOURCES, tier: 'env', detail: `GBRAIN_SOURCE=${ALL_SOURCES} (spans all sources)` };
     }
     if (!SOURCE_ID_RE.test(env)) {
-      throw new Error(`Invalid GBRAIN_SOURCE value "${env}". Must match [a-z0-9-]{1,32}.`);
+      throw new SourceTargetError(`Invalid GBRAIN_SOURCE value "${env}". Must match [a-z0-9-]{1,32}.`);
     }
     await assertSourceExists(engine, env);
     return { source_id: env, tier: 'env', detail: `GBRAIN_SOURCE=${env}` };
@@ -378,7 +392,10 @@ export async function resolveSourceWithTier(
       }
     }
   }
-  if (best) return { source_id: best.id, tier: 'local_path', detail: best.path };
+  if (best) {
+    await assertSourceExists(engine, best.id);
+    return { source_id: best.id, tier: 'local_path', detail: best.path };
+  }
 
   // 5. Brain-level default. Silent-fallback (P1-F) like tier 5 in resolveSourceId.
   const globalDefault = await engine.getConfig('sources.default');

--- a/test/cli-ambient-source-fail-closed.test.ts
+++ b/test/cli-ambient-source-fail-closed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression: an ambient source target must never be swallowed into `default`.
+ *
+ * The write is deliberately driven through makeContext(), the CLI seam that
+ * used to catch resolver errors, then through the resolved ctx.sourceId. This
+ * proves both sides of the guard: unavailable targets stop before a write and
+ * an active registered target still writes successfully.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeContext } from '../src/cli.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resolveSourceWithTier } from '../src/core/source-resolver.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, archived)
+     VALUES ('active-target', 'active-target', false),
+            ('archived-target', 'archived-target', true)`,
+  );
+});
+
+describe('CLI ambient source routing fails closed', () => {
+  test('RED negative: nonexistent GBRAIN_SOURCE errors and writes zero rows to default', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'does-not-exist' }, async () => {
+      await expect(makeContext(engine, {})).rejects.toThrow(/not found|archived/i);
+    });
+
+    const rows = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM pages WHERE slug = 'receipts/negative-control'`,
+    );
+    expect(rows[0]?.n ?? 0).toBe(0);
+  });
+
+  test('RED negative: archived GBRAIN_SOURCE errors and writes zero rows to default', async () => {
+    await withEnv({ GBRAIN_SOURCE: 'archived-target' }, async () => {
+      await expect(makeContext(engine, {})).rejects.toThrow(/not found|archived/i);
+    });
+
+    const rows = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM pages WHERE slug = 'receipts/archived-control'`,
+    );
+    expect(rows[0]?.n ?? 0).toBe(0);
+  });
+
+  test('RED negative: entering an archived source local_path errors instead of falling to default', async () => {
+    const sourceDir = mkdtempSync(join(tmpdir(), 'gbrain-archived-target-'));
+    try {
+      await engine.executeRaw(
+        `UPDATE sources SET local_path = $1 WHERE id = 'archived-target'`,
+        [sourceDir],
+      );
+      await withEnv({ GBRAIN_SOURCE: undefined }, async () => {
+        await expect(resolveSourceWithTier(engine, null, sourceDir)).rejects.toThrow(/archived/i);
+      });
+    } finally {
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test('GREEN positive: active GBRAIN_SOURCE resolves and the in-scope write succeeds', async () => {
+    const ctx = await withEnv({ GBRAIN_SOURCE: 'active-target' }, () => makeContext(engine, {}));
+    expect(ctx.sourceId).toBe('active-target');
+
+    await engine.putPage('receipts/positive-control', {
+      type: 'note',
+      title: 'Positive control',
+      compiled_truth: 'An active source remains writable.',
+    }, { sourceId: ctx.sourceId });
+
+    const rows = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM pages WHERE slug = 'receipts/positive-control'`,
+    );
+    expect(rows).toEqual([{ source_id: 'active-target' }]);
+  });
+});


### PR DESCRIPTION
## Problem

`makeContext()` catches every `resolveSourceWithTier()` failure but rethrows only when `params.source` came from an explicit flag. A missing source selected through `GBRAIN_SOURCE`, `.gbrain-source`, or `sources.default` therefore leaves `sourceId` unset and the return path silently substitutes `default`. Archived source rows are also accepted by the resolver existence check. A write intended for an unavailable source can consequently land in the shared default source.

## Minimal fix

- Add a narrow `SourceTargetError` for invalid, missing, or archived caller-selected targets.
- Require the selected source row to be active, including the local-path tier.
- Make `makeContext()` rethrow only this typed target error (plus its existing explicit-flag failures), retaining the legacy fallback for structural pre-init errors such as a missing sources table.
- Do not change tier precedence, federated widening, or the `__all__` sentinel.

## Regression proof

`bun test test/cli-ambient-source-fail-closed.test.ts test/all-sources-sentinel.test.ts test/source-resolver-with-tier.test.ts test/source-resolver-silent-fallback.test.ts test/source-resolver.test.ts`

Result: 59 pass, 0 fail. The new seeded controls prove:

- nonexistent `GBRAIN_SOURCE` errors and writes zero rows to `default`;
- archived `GBRAIN_SOURCE` errors and writes zero rows to `default`;
- entering an archived source local path errors;
- an active registered source still accepts the in-scope write.

## Drift cost

Runtime change is confined to `src/cli.ts` and `src/core/source-resolver.ts`; the third file is one focused regression test. No source-resolution redesign or schema change.