### PR TITLE
fix(budget): price non-Anthropic canonical models; audit the no-pricing refusal

### DIFF
--- a/src/core/anthropic-pricing.ts
+++ b/src/core/anthropic-pricing.ts
@@ -49,16 +49,47 @@ export const ANTHROPIC_PRICING: Record<string, ModelPricing> = Object.fromEntrie
  * `:`-only split missed slash form → BudgetTracker no_pricing hard-fail with
  * `--max-cost N` (closes #1540).
  */
+/**
+ * Resolve a chat model id to its canonical pricing entry.
+ *
+ * Looks at the FULL canonical table, not just the bare-keyed Anthropic view.
+ * Previously this resolved against `ANTHROPIC_PRICING` alone, which is
+ * `CANONICAL_PRICING` filtered to `anthropic:` keys — so every non-Anthropic
+ * model priced a `null` even though canonical carried its rate (14 of the 25
+ * canonical entries were unreachable). Because `BudgetTracker.reserve()`
+ * hard-throws `BudgetExhausted{reason:'no_pricing'}` when a cap is set and
+ * pricing is missing, that made every cost-capped path — `gbrain enrich`,
+ * `cycle.enrich_thin`, `extract_atoms`, skillopt — fail outright on OpenAI,
+ * Gemini, and DeepSeek models. See garrytan/gbrain#2504.
+ *
+ * Resolution order, most-specific first:
+ *   1. bare Anthropic id (`claude-haiku-4-5`) — the form most callers pass
+ *   2. fully-qualified canonical id (`openai:gpt-5.2`)
+ *   3. bare id behind any provider prefix (`bedrock:claude-haiku-4-5`)
+ *
+ * Routing-provider ids (`openrouter:openai/gpt-5.2`) deliberately stay
+ * unpriced. A router bills its OWN rates, so resolving it to the vendor's
+ * direct price would under-estimate real spend — a silently wrong cap is worse
+ * than a refused one under the TX2 contract. Pricing routers needs their rate
+ * table, which is out of scope here (existing TODO #2, pinned by the
+ * "OpenRouter nested form returns null" test).
+ */
+function resolveChatPricing(modelId: string): ModelPricing | undefined {
+  const direct = ANTHROPIC_PRICING[modelId] ?? CANONICAL_PRICING[modelId];
+  if (direct) return direct;
+
+  const { model: tail } = splitProviderModelId(modelId);
+  if (!tail) return undefined;
+
+  return ANTHROPIC_PRICING[tail] ?? CANONICAL_PRICING[tail];
+}
+
 export function estimateMaxCostUsd(
   modelId: string,
   estimatedInputTokens: number,
   maxOutputTokens: number,
 ): number | null {
-  let p: ModelPricing | undefined = ANTHROPIC_PRICING[modelId];
-  if (!p) {
-    const { model: tail } = splitProviderModelId(modelId);
-    if (tail) p = ANTHROPIC_PRICING[tail];
-  }
+  const p = resolveChatPricing(modelId);
   if (!p) return null;
   return (
     (estimatedInputTokens / 1_000_000) * p.input +

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -332,7 +332,24 @@ export class BudgetTracker {
         // pricing we can't enforce the cap, and silently ignoring it would
         // void the contract.
         const msg = `${this.opts.label}: no pricing entry for model "${estimate.modelId}" (kind=${estimate.kind}). ` +
-          `Add it to src/core/${estimate.kind === 'embed' ? 'embedding-pricing.ts' : 'anthropic-pricing.ts'} or drop --max-cost.`;
+          `Add it to src/core/${estimate.kind === 'embed' ? 'embedding-pricing.ts' : 'model-pricing.ts'} or drop --max-cost.`;
+        // Audit the refusal. The `reserve_denied` path below writes a line, but
+        // this one did not — so a run that aborted here left an audit log
+        // containing ONLY successful reserve/record pairs, which reads as
+        // "the budget was fine" while the command reports budget_exhausted.
+        // That combination is actively misleading during diagnosis.
+        appendAuditLine(this.auditPath, {
+          schema_version: 1,
+          ts: new Date().toISOString(),
+          event: 'reserve_no_pricing',
+          label: this.opts.label,
+          kind: estimate.kind,
+          model: estimate.modelId,
+          sub_label: estimate.label,
+          estimated_input_tokens: estimate.estimatedInputTokens,
+          max_output_tokens: estimate.maxOutputTokens,
+          max_cost_usd: this.opts.maxCostUsd,
+        });
         this.fireExhausted();
         throw new BudgetExhausted(msg, {
           reason: 'no_pricing',

--- a/test/anthropic-pricing.test.ts
+++ b/test/anthropic-pricing.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { ANTHROPIC_PRICING, estimateMaxCostUsd } from '../src/core/anthropic-pricing.ts';
+import { CANONICAL_PRICING } from '../src/core/model-pricing.ts';
 
 describe('estimateMaxCostUsd', () => {
   // Sonnet 4.6 = $3 input / $15 output per MTok.
@@ -71,5 +72,46 @@ describe('estimateMaxCostUsd', () => {
       expect(estimateMaxCostUsd(`anthropic:${key}`, 1_000_000, 0)).not.toBeNull();
       expect(estimateMaxCostUsd(`anthropic/${key}`, 1_000_000, 0)).not.toBeNull();
     }
+  });
+});
+
+/**
+ * garrytan/gbrain#2504 — non-Anthropic canonical models must be priceable.
+ *
+ * `ANTHROPIC_PRICING` is `CANONICAL_PRICING` filtered to `anthropic:` keys, and
+ * `estimateMaxCostUsd` used to resolve against that view alone — so every
+ * non-Anthropic model returned null despite canonical carrying its rate.
+ * `BudgetTracker.reserve()` hard-throws on a null estimate when a cap is set,
+ * which took out every cost-capped path (enrich, enrich_thin, extract_atoms,
+ * skillopt) on OpenAI / Gemini / DeepSeek models.
+ */
+describe('estimateMaxCostUsd — canonical (non-Anthropic) coverage (#2504)', () => {
+  test.each([
+    ['openai:gpt-5.2'],
+    ['openai:gpt-4o'],
+    ['deepseek:deepseek-chat'],
+    ['deepseek:deepseek-v4-flash'],
+    ['google:gemini-2.0-flash'],
+  ])('%s prices from canonical instead of null', (modelId) => {
+    const cost = estimateMaxCostUsd(modelId, 1_000_000, 0);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  test('every canonical entry is priceable by its fully-qualified id', () => {
+    for (const key of Object.keys(CANONICAL_PRICING)) {
+      expect(estimateMaxCostUsd(key, 1_000, 1_000)).not.toBeNull();
+    }
+  });
+
+  test('genuinely unknown models still return null (TX2 contract intact)', () => {
+    expect(estimateMaxCostUsd('acme:not-a-real-model', 1_000, 1_000)).toBeNull();
+  });
+
+  test('routing-provider ids stay unpriced — a router bills its own rates', () => {
+    // Resolving these to the vendor's direct price would UNDER-estimate spend.
+    // Refusing is the correct posture until a router rate table exists (TODO #2).
+    expect(estimateMaxCostUsd('openrouter:openai/gpt-5.2', 1_000, 1_000)).toBeNull();
+    expect(estimateMaxCostUsd('openrouter:acme/nope', 1_000, 1_000)).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes the root cause behind #2504.

## The bug

`estimateMaxCostUsd` resolved against `ANTHROPIC_PRICING` — which is `CANONICAL_PRICING` filtered to `anthropic:` keys (`anthropic-pricing.ts:30-34`). Since `BudgetTracker.reserve()` calls it for **every** provider, non-Anthropic models were unpriced *by construction*, even where canonical carried their rate:

```
deepseek keys in CANONICAL_PRICING: ["deepseek:deepseek-chat","deepseek:deepseek-v4-flash","deepseek:deepseek-v4-pro"]
deepseek keys in ANTHROPIC_PRICING: []

estimateMaxCostUsd("openai:gpt-5.2")             = null   (in CANONICAL_PRICING: true)
estimateMaxCostUsd("deepseek:deepseek-chat")     = null   (in CANONICAL_PRICING: true)
estimateMaxCostUsd("google:gemini-2.0-flash")    = null   (in CANONICAL_PRICING: true)
estimateMaxCostUsd("anthropic:claude-haiku-4-5") = 0.0015

CANONICAL total keys: 25 | ANTHROPIC view keys: 11
```

14 of 25 priced models were unreachable. `reserve()` hard-throws `BudgetExhausted{reason:'no_pricing'}` when a cap is set and pricing is missing (the TX2 contract), so every cost-capped path — `gbrain enrich`, `cycle.enrich_thin`, `extract_atoms`, skillopt — failed outright on OpenAI, Gemini, and DeepSeek.

Worth flagging for #2504 specifically: the fix proposed there (add DeepSeek entries to `anthropic-pricing.ts`) could not have worked. That map is recomputed from canonical on every load, so the `anthropic:` filter would drop the new entries again.

## The fix

`resolveChatPricing()` consults the full canonical table, preserving the existing bare-key and provider-tail fallbacks so callers passing `claude-haiku-4-5` are unaffected.

**Routing providers stay unpriced, deliberately.** My first draft resolved `openrouter:openai/gpt-5.2` → `openai:gpt-5.2`, and the existing `OpenRouter nested form returns null` test caught it. That test is right: a router bills its own marked-up rates, so pricing one at the vendor's direct rate would *under*-estimate real spend — and a silently wrong cap is worse than a refused one. Pricing routers needs their own rate table (the existing TODO #2). That test still passes unmodified.

The same reasoning applies to `lookupEmbeddingPrice`, which has the same exact-key limitation for `openrouter:openai/text-embedding-3-small`. I've left it alone here for the same correctness reason — it wants a router rate table, not a vendor-price alias. Noting it because it's a real second instance: `enrich` embeds a query in `retrieveEvidence()`, so a brain embedding through a router still hits the no-pricing hard-fail on every capped run even after this PR.

## Observability

The `reserve_denied` path writes an audit line; the `no_pricing` throw did not. An aborted run therefore left `~/.gbrain/audit/budget-*.jsonl` containing only *successful* reserve/record pairs:

```
reserve  enrich:default  anthropic:claude-haiku-4-5  projected=$0.0108  cap=$2
record   enrich:default  anthropic:claude-haiku-4-5  actual=$0.0011  cum=$0.0011  cap=$2
```

…while the command reported `budget_exhausted: true`. Reading the audit literally says the budget was fine, which cost me a long time diagnosing. This adds a `reserve_no_pricing` event, and repoints the error text at `model-pricing.ts` (where rates live) instead of the derived `anthropic-pricing.ts`.

## Tests

Added to `test/anthropic-pricing.test.ts`:
- each of `openai:gpt-5.2`, `openai:gpt-4o`, `deepseek:deepseek-chat`, `deepseek:deepseek-v4-flash`, `google:gemini-2.0-flash` prices non-null
- **every** `CANONICAL_PRICING` key is priceable by its fully-qualified id (regression guard against the view/canonical split reopening)
- unknown models still return `null` (TX2 intact)
- routing-provider ids still return `null`, with the rationale in the test name

`bun test test/anthropic-pricing.test.ts test/embedding-pricing.test.ts test/model-pricing.test.ts` → **49 pass, 0 fail**. Across all budget/pricing suites: 95 pass, 3 fail — all 3 pre-existing environmental hook timeouts in `cycle-patterns-deadline-budget.test.ts`, identical on the base commit with these changes stashed.

Not addressed here, but adjacent if you want it in scope: `cycle.enrich_thin.max_cost_usd` runs through `parseFloatOrDefault`, so `off`/`unlimited` parse as `NaN` and silently fall back to the `$1.00` default — unlike the sync cost gate, which accepts `off`. That leaves no way to opt out of the cap when a model genuinely can't be priced.
