### PR TITLE
fix(import): thread the resolved sourceId into recordFailures + logIngest

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -535,10 +535,15 @@ export async function runImport(
     }
   }
 
-  // Log the ingest
+  // Log the ingest. `sourceId ?? 'default'` mirrors the fallback `processFile`
+  // itself uses when calling importFile/importImageFile below — this must
+  // report the source the pages actually landed in, not the unresolved CLI
+  // arg (see #3838: pre-fix this field always read 'default' regardless of
+  // where resolveSourceWithTier actually routed the run).
   await engine.logIngest({
     source_type: 'directory',
     source_ref: dir,
+    source_id: sourceId ?? 'default',
     pages_updated: importedSlugs,
     summary: `Imported ${imported} pages, ${skipped} skipped, ${chunksCreated} chunks`,
   });
@@ -566,7 +571,13 @@ export async function runImport(
     // state as last time" from "new broken state." Source-scoped (#1939 #2).
     if (failures.length > 0) {
       const { recordFailures } = await import('../core/sync.ts');
-      recordFailures(opts.sourceId ?? 'default', failures, gitHead);
+      // #3838: `opts.sourceId` is the caller-supplied value, which stays
+      // undefined for a bare CLI invocation unless the resolver's
+      // sole_non_default tier explicitly adopted it (see the comment above
+      // this function's sourceId resolution). Use the resolved `sourceId`
+      // — the same value every importFile/importImageFile call in this run
+      // actually wrote to — so the ledger is keyed by the true source.
+      recordFailures(sourceId ?? 'default', failures, gitHead);
     }
     if (failures.length === 0) {
       await engine.setConfig('sync.last_commit', gitHead);

--- a/test/import-source-id-bookkeeping.test.ts
+++ b/test/import-source-id-bookkeeping.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #3838 — the sync-failures ledger and ingest_log both hard-coded
+ * `source_id: 'default'` for a bare `gbrain import <dir>` run, even when
+ * the resolver's `sole_non_default` tier (5.5) routed the run to a
+ * different source. `recordFailures` was called with
+ * `opts.sourceId ?? 'default'` — the unresolved CLI parameter, which stays
+ * undefined for a bare invocation — instead of the `sourceId` local
+ * variable every `importFile` call in the same run actually used.
+ * `engine.logIngest(...)` never passed `source_id` at all.
+ *
+ * Hermetic PGLite in-memory. Sandboxes the failure ledger under a temp
+ * GBRAIN_HOME via `withEnv` so this test never touches the real
+ * ~/.gbrain/sync-failures.jsonl on the machine running it (see #2121).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runImport } from '../src/commands/import.ts';
+import { withEnv } from './helpers/with-env.ts';
+import { loadSyncFailures } from '../src/core/sync-failure-ledger.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  // Registering the ONLY non-default source with a local_path is what
+  // fires resolveSourceWithTier's sole_non_default tier (5.5) — the tier
+  // import.ts actually adopts into its local `sourceId` variable for a
+  // bare CLI call. (Setting `sources.default`/tier 5 does NOT reach this
+  // code path: import.ts's own resolution block only ever adopts
+  // `resolved.source_id` when `resolved.tier === 'sole_non_default'`, by
+  // design — every other tier falls through and `sourceId` stays
+  // undefined, defaulting the actual writes to 'default' regardless of
+  // what the resolver reports. The path doesn't need to exist on disk;
+  // pickSoleNonDefaultSource only checks the column is non-null.)
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path) VALUES ('dept-x', 'dept-x', '/nonexistent/dept-x') ON CONFLICT DO NOTHING`,
+  );
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('import bookkeeping records the resolved source (#3838)', () => {
+  test('failure ledger and ingest_log both say dept-x, not default', async () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-source-bookkeeping-'));
+    execSync('git init', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.email "t@t.t"', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+    writeFileSync(join(repo, 'seed.md'), '---\ntype: note\n---\n# Seed\n\nbody\n');
+    execSync('git add seed.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m seed', { cwd: repo, stdio: 'pipe' });
+
+    // Deterministic soft-failure: import-file.ts rejects any file over
+    // MAX_FILE_SIZE (5_000_000 bytes) with a real `result.error`, which
+    // runImport pushes into `failures[]` without needing a thrown
+    // exception — the exact code path recordFailures reads from.
+    writeFileSync(join(repo, 'oversized.md'), '---\ntype: note\n---\n' + 'x'.repeat(5_000_001));
+
+    const gbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-home-'));
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      // No --source-id: the resolver must reach tier 5 on its own.
+      await runImport(engine, [repo, '--no-embed', '--json']);
+
+      const failures = loadSyncFailures().filter((f) => f.path === 'oversized.md');
+      expect(failures.length).toBe(1);
+      expect(failures[0].source_id).toBe('dept-x');
+    });
+
+    // Not filtering by source_ref: runImport resolves `dir` to its real,
+    // symlink-free path (macOS: /tmp -> /private/tmp) before logging it,
+    // so it won't byte-match the pre-realpath `repo` string here. This is
+    // the only import in the test, so the latest row is unambiguous.
+    const ingestRows = await engine.executeRaw<{ source_id: string; source_ref: string }>(
+      `SELECT source_id, source_ref FROM ingest_log ORDER BY id DESC LIMIT 1`,
+    );
+    expect(ingestRows.length).toBe(1);
+    expect(ingestRows[0].source_ref).toContain('gbrain-source-bookkeeping-');
+    expect(ingestRows[0].source_id).toBe('dept-x');
+  });
+});


### PR DESCRIPTION
Fixes #3838.

## What

Two separate bookkeeping writes in `runImport` (`src/commands/import.ts`)
used the wrong `source_id` whenever a bare `gbrain import <dir>` call (no
`--source-id`) got routed away from `'default'` by the resolver's
`sole_non_default` tier (5.5):

- `recordFailures(opts.sourceId ?? 'default', failures, gitHead)` used
  `opts.sourceId` — the caller-supplied CLI/programmatic parameter, which
  stays `undefined` unless the caller passed `--source-id` explicitly. The
  *actually-resolved* `sourceId` local variable (the one threaded into
  every `importFile`/`importImageFile` call in the same run) never made it
  into this call, so every ledger row in `~/.gbrain/sync-failures.jsonl`
  landed with `source_id: 'default'` regardless of where the pages really
  went.
- `engine.logIngest(...)` never passed `source_id` at all — the field
  already exists on `IngestLogInput`, it just wasn't populated here — so
  the column always fell back to its schema default `'default'`.

## Fix

Both call sites now use the resolved `sourceId ?? 'default'` local
variable instead of the unresolved CLI parameter / schema default.

## Testing

New test `test/import-source-id-bookkeeping.test.ts` (PGLite, hermetic,
sandboxes the ledger under a temp `GBRAIN_HOME` via the existing `withEnv`
helper so it never touches a real `~/.gbrain/sync-failures.jsonl`):
registers a sole non-default source with a `local_path` so
`resolveSourceWithTier`'s tier 5.5 fires on a bare call, causes one file to
soft-fail (over `MAX_FILE_SIZE`), and asserts both the ledger row and the
`ingest_log` row report the real source. Confirmed via `git stash` that the
test fails against the pre-fix code before confirming it passes fixed.

- `bun run typecheck` — clean.
- Targeted run of this test + `import-source-id.test.ts` +
  `import-checkpoint.test.ts` + `import-error-summary.test.ts` (from #3841)
  together — 28/28 pass.
- No schema/query changes beyond the two existing call sites, so I didn't
  spin up the E2E Postgres stack locally; happy to if CI wants it.

## Note

Branched independently from `master` (not stacked on #3841) so this can be
reviewed/merged on its own.
