### PR TITLE
fix(import): call clearFailures() for paths that succeed this run

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -289,6 +289,11 @@ export async function runImport(
   const importedSlugs: string[] = [];
   const errorCounts: Record<string, number> = {};
   const failures: Array<{ path: string; error: string }> = []; // Bug 9
+  // #3839: paths that succeeded (imported OR unchanged) this run, keyed the
+  // same way as `failures` above (importRelPath) so a path that failed on a
+  // prior run and now succeeds clears its ledger row instead of staying
+  // `open` forever.
+  const succeededPaths: string[] = [];
   const startTime = Date.now();
 
   // Progress on stderr so stdout stays clean for the final summary / --json payload.
@@ -328,6 +333,7 @@ export async function runImport(
         importedSlugs.push(result.slug);
         // v0.33.2: path-based checkpoint — record only on success.
         completed.add(relativePath);
+        succeededPaths.push(importRelPath); // #3839
       } else {
         skipped++;
         if (result.error && result.error !== 'unchanged') {
@@ -340,6 +346,7 @@ export async function runImport(
           // 'unchanged' or no-error skip: content_hash matched a prior
           // successful import, so this file IS done for checkpoint purposes.
           completed.add(relativePath);
+          succeededPaths.push(importRelPath); // #3839
         }
       }
     } catch (e: unknown) {
@@ -567,6 +574,17 @@ export async function runImport(
     if (failures.length > 0) {
       const { recordFailures } = await import('../core/sync.ts');
       recordFailures(opts.sourceId ?? 'default', failures, gitHead);
+    }
+    // #3839: a path that failed on a prior run and succeeded (imported or
+    // unchanged) this run must clear its ledger row — pre-fix, clearFailures
+    // existed but had no caller anywhere, so `open` rows never healed short
+    // of a manual `gbrain sync --skip-failed`. Runs on every non-empty
+    // success list regardless of whether this SAME run also had failures,
+    // so a stale row from an earlier run gets cleared even if today's run
+    // is only partially clean.
+    if (succeededPaths.length > 0) {
+      const { clearFailures } = await import('../core/sync.ts');
+      clearFailures(opts.sourceId ?? 'default', succeededPaths);
     }
     if (failures.length === 0) {
       await engine.setConfig('sync.last_commit', gitHead);

--- a/test/import-clear-failures-on-success.test.ts
+++ b/test/import-clear-failures-on-success.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #3839 — `clearFailures()` (src/core/sync-failure-ledger.ts) existed and
+ * was unit-tested, but no command path ever called it. A path recorded as
+ * `open` in the sync-failures ledger stayed `open` forever, even after the
+ * exact same file imported cleanly on a later run — the ledger never
+ * self-healed short of a manual `gbrain sync --skip-failed`.
+ *
+ * Two-run scenario: a poison file fails run 1 (recorded), gets fixed, then
+ * succeeds run 2 (must clear).
+ *
+ * Hermetic PGLite in-memory. Sandboxes the failure ledger under a temp
+ * GBRAIN_HOME via `withEnv` so this test never touches the real
+ * ~/.gbrain/sync-failures.jsonl on the machine running it (see #2121).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runImport } from '../src/commands/import.ts';
+import { withEnv } from './helpers/with-env.ts';
+import { loadSyncFailures } from '../src/core/sync-failure-ledger.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('a path that fails then succeeds clears its ledger row (#3839)', () => {
+  test('poison.md: open after run 1, gone after run 2', async () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-clear-failures-'));
+    execSync('git init', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.email "t@t.t"', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+    writeFileSync(join(repo, 'seed.md'), '---\ntype: note\n---\n# Seed\n\nbody\n');
+    execSync('git add seed.md', { cwd: repo, stdio: 'pipe' });
+    execSync('git commit -m seed', { cwd: repo, stdio: 'pipe' });
+
+    // Run 1: poison.md is oversized (deterministic soft-failure, same
+    // MAX_FILE_SIZE trigger as the #3838 test — no thrown exception needed).
+    const poisonPath = join(repo, 'poison.md');
+    writeFileSync(poisonPath, '---\ntype: note\n---\n' + 'x'.repeat(5_000_001));
+
+    const gbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-home-'));
+
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      await runImport(engine, [repo, '--fresh', '--no-embed', '--json']);
+
+      const afterRun1 = loadSyncFailures().filter((f) => f.path === 'poison.md');
+      expect(afterRun1.length).toBe(1);
+      expect(afterRun1[0].state).toBe('open');
+    });
+
+    // Fix poison.md: small enough to import cleanly. Different content, so
+    // this is a real re-import, not a content_hash 'unchanged' skip.
+    writeFileSync(poisonPath, '---\ntype: note\n---\n# Poison, fixed\n\nnow well under the limit.\n');
+
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      await runImport(engine, [repo, '--fresh', '--no-embed', '--json']);
+
+      const afterRun2 = loadSyncFailures().filter((f) => f.path === 'poison.md');
+      expect(afterRun2.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3839.

## What

`src/core/sync-failure-ledger.ts` exports `clearFailures(sourceId, paths)`
specifically so a previously-failed path can heal once it imports cleanly
again — the module's own header docstring describes this as part of the
intended `open -> (clearFailures, file imports OK) -> removed` state
machine, and it's covered by unit tests
(`test/sync-failure-ledger.serial.test.ts`).

But no command path anywhere ever called it. A repo-wide search for the
literal call pattern `clearFailures(` returns exactly two hits: the
function's own definition, and its test. `runImport` only ever *adds* to
the ledger via `recordFailures` (on failure); the incremental path in
`src/core/sync.ts` doesn't call it either. Once a path landed in
`~/.gbrain/sync-failures.jsonl` as `open`, it stayed there forever — even
after the exact same file imported without error on a later run — short of
a manual `gbrain sync --skip-failed` (which acknowledges the row rather
than confirming/clearing it based on the new success).

## Fix

`runImport` now tracks every path that succeeded this run (imported OR
unchanged — the same `importRelPath` keying `failures` already uses in
`succeededPaths`) and calls `clearFailures(sourceId, succeededPaths)`
alongside the existing `recordFailures` call, gated by the same
`gitHead && !opts.managedBookmark` condition those already use. It fires
whenever there's a non-empty success list, independent of whether this
same run also had failures — so a stale row from an earlier run clears
even on a run that's only partially clean today.

Scope note: I didn't route `gbrain import`'s bare-CLI path through the
shared `applySyncFailureGate` (the orchestrator `performFullSync`/`sync`
already use, which would give clearing "for free" plus threshold/auto-skip
handling). That's a much larger behavioral change — `runImport` doesn't
currently read `--skip-failed` at all, and adopting the gate would also
change bookmark-advance semantics on `block`/`hard_block`. Wiring
`clearFailures` directly is the minimal fix for what #3839 reports; happy
to discuss the bigger unification separately if that's preferred.

## Testing

New test `test/import-clear-failures-on-success.test.ts` (PGLite,
hermetic, sandboxes the ledger under a temp `GBRAIN_HOME` via the existing
`withEnv` helper — never touches a real `~/.gbrain/sync-failures.jsonl`,
see #2121): a poison file (oversized content, same deterministic
soft-failure trigger as #3838's test) fails run 1 and is recorded `open`;
fixed content then succeeds on run 2 and the row is gone. Confirmed via
`git stash` that the test fails against the pre-fix code (the row would
incorrectly still be present after run 2) before confirming it passes
fixed.

- `bun run typecheck` — clean.
- Targeted run of this test + `import-checkpoint.test.ts` +
  `sync-failure-ledger.serial.test.ts` together — 48/48 pass.
- No schema/query changes, so I didn't spin up the E2E Postgres stack
  locally; happy to if CI wants it.

## Note

Branched independently from `master` (not stacked on #3841/#3842) so this
can be reviewed/merged on its own.
