### PR TITLE
fix(mcp): make explicit __all__ match unqualified stdio reads (#3644)

### DIFF
--- a/src/core/ops/context.ts
+++ b/src/core/ops/context.ts
@@ -533,11 +533,15 @@ export function resolveRequestedScope(
  * were invisible to get_page/search/list_pages while resolve_slugs leaked them).
  *
  * The expansion NEVER applies when:
- *   - a per-call `source_id` was passed (explicit wins, including `__all__`);
+ *   - a concrete per-call `source_id` was passed (explicit wins);
  *   - the resolver already produced a federated array (OAuth grant governs);
  *   - the transport didn't populate `localFederatedSourceIds` (see that
- *     field's doc: it is only set for callers with NO explicit source scope,
- *     and never from caller-controlled params — so trust stays fail-closed).
+ *     field's doc: it is transport-computed and never derived from
+ *     caller-controlled params — so trust stays fail-closed).
+ *
+ * The read-only `__all__` sentinel is equivalent to an unqualified read when
+ * it resolves to the caller's scalar floor. It may therefore use the same
+ * transport-computed federated set, but never widens an OAuth grant.
  *
  * Deliberately NOT inside `sourceScopeOpts`: code-intel ops collapse a
  * multi-element scope to an error (`resolveCodeIntelScope`), and the remaining
@@ -549,7 +553,8 @@ export function federatedSearchScope(
 ): { sourceId?: string; sourceIds?: string[] } {
   const scope = resolveRequestedScope(ctx, sourceIdParam);
   if (
-    sourceIdParam === undefined &&
+    (sourceIdParam === undefined || sourceIdParam === ALL_SOURCES) &&
+    ctx.auth?.allowedSources === undefined &&
     scope.sourceId !== undefined &&
     scope.sourceIds === undefined &&
     ctx.localFederatedSourceIds !== undefined &&

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -184,7 +184,7 @@ const query: Operation = {
     source_id: {
       type: 'string',
       description:
-        "v0.34: scope search to a single source. Defaults to OperationContext.sourceId (set from CLI --source / GBRAIN_SOURCE / .gbrain-source dotfile). Pass '__all__' to span every source for trusted local callers; for remote callers '__all__' spans only your granted sources.",
+        "v0.34: scope search to a single source. Defaults to OperationContext.sourceId (set from CLI --source / GBRAIN_SOURCE / .gbrain-source dotfile). Pass '__all__' to span every source for trusted local callers. For remote callers, '__all__' uses the same scope as omission: an OAuth grant when present, otherwise the transport-computed federated sources for grantless local stdio.",
     },
     cross_modal: {
       type: 'string',

--- a/test/all-sources-sentinel.test.ts
+++ b/test/all-sources-sentinel.test.ts
@@ -142,6 +142,51 @@ describe('__all__ is never narrower than an unqualified read', () => {
     // …and __all__ must be a superset of that: the whole brain ({}).
     const all = ctxOf({ remote: false, sourceId: '__all__' });
     expect(federatedSearchScope(all)).toEqual({});
+
+    // An explicit sentinel keeps trusted-local whole-brain semantics too.
+    expect(federatedSearchScope(unqualified, '__all__')).toEqual({});
+  });
+
+  test('grantless stdio treats explicit __all__ like an omitted source', () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      localFederatedSourceIds: ['default', 'src-a', 'src-b'],
+    });
+
+    expect(federatedSearchScope(ctx)).toEqual({
+      sourceIds: ['default', 'src-a', 'src-b'],
+    });
+    expect(federatedSearchScope(ctx, '__all__')).toEqual({
+      sourceIds: ['default', 'src-a', 'src-b'],
+    });
+    expect(federatedSearchScope(ctx, 'src-a')).toEqual({ sourceId: 'src-a' });
+  });
+
+  test('remote scalar scope stays pinned when no transport federation exists', () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'src-b' });
+    expect(federatedSearchScope(ctx, '__all__')).toEqual({ sourceId: 'src-b' });
+  });
+
+  test('OAuth grants, including empty grants, stay authoritative over local federation', () => {
+    const localFederatedSourceIds = ['default', 'src-a', 'src-b'];
+    const granted = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      localFederatedSourceIds,
+      auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['tenant-a', 'tenant-b'] } as any,
+    });
+    expect(federatedSearchScope(granted, '__all__')).toEqual({
+      sourceIds: ['tenant-a', 'tenant-b'],
+    });
+
+    const emptyGrant = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      localFederatedSourceIds,
+      auth: { token: 't', clientId: 'c', scopes: [], allowedSources: [] } as any,
+    });
+    expect(federatedSearchScope(emptyGrant, '__all__')).toEqual({ sourceId: 'default' });
   });
 });
 

--- a/test/e2e/serve-stdio-roundtrip.test.ts
+++ b/test/e2e/serve-stdio-roundtrip.test.ts
@@ -36,11 +36,17 @@ import { VERB_NAMES } from '../../src/core/verbs.ts';
 
 // Distinctive token so keyword search can't accidentally match anything else.
 const MARKER = 'qantani-marker-9f3z';
+const FEDERATED_MARKER = 'umbriel-federated-marker-71c4';
 
 function textOf(result: unknown): string {
   const content = (result as { content?: Array<{ type?: string; text?: string }> })?.content;
   if (!Array.isArray(content)) return '';
   return content.map((c) => (typeof c?.text === 'string' ? c.text : '')).join('\n');
+}
+
+function resultSourceIds(text: string): string[] {
+  const result = JSON.parse(text) as Array<{ source_id?: unknown }>;
+  return result.flatMap((row) => (typeof row.source_id === 'string' ? [row.source_id] : []));
 }
 
 describe('serve stdio round-trip E2E (local PGLite → real MCP tool calls)', () => {
@@ -62,6 +68,7 @@ describe('serve stdio round-trip E2E (local PGLite → real MCP tool calls)', ()
     env.GBRAIN_HOME = home;
     delete env.DATABASE_URL;
     delete env.GBRAIN_DATABASE_URL;
+    delete env.GBRAIN_SOURCE;
 
     // 1. Init a local PGLite brain (the "from nothing" step).
     execFileSync('bun', ['run', 'src/cli.ts', 'init', '--pglite', '--no-embedding', '--non-interactive'], {
@@ -80,6 +87,26 @@ describe('serve stdio round-trip E2E (local PGLite → real MCP tool calls)', ()
     execFileSync('bun', ['run', 'src/cli.ts', 'import', notes, '--no-embed'], {
       cwd: process.cwd(), env, stdio: 'ignore',
     });
+
+    // Seed a second source that participates in unqualified federated reads.
+    // Import through the CLI so this uses the ordinary source registration
+    // and page-routing path.
+    const federatedNotes = join(home, 'federated-notes');
+    mkdirSync(federatedNotes, { recursive: true });
+    writeFileSync(
+      join(federatedNotes, 'marker.md'),
+      `---\ntitle: ${FEDERATED_MARKER} note\n---\n\n# ${FEDERATED_MARKER}\n\nThis page exists only in the federated source.\n`,
+    );
+    execFileSync(
+      'bun',
+      ['run', 'src/cli.ts', 'sources', 'add', 'federated-source', '--path', federatedNotes, '--federated', '--force'],
+      { cwd: process.cwd(), env, stdio: 'ignore' },
+    );
+    execFileSync(
+      'bun',
+      ['run', 'src/cli.ts', 'import', federatedNotes, '--no-embed', '--source-id', 'federated-source'],
+      { cwd: process.cwd(), env, stdio: 'ignore' },
+    );
 
     // 3. Let the MCP SDK spawn `gbrain serve` (stdio) and run the initialize
     //    handshake — exactly what `claude mcp add gbrain -- gbrain serve` does.
@@ -130,6 +157,28 @@ describe('serve stdio round-trip E2E (local PGLite → real MCP tool calls)', ()
     const text = textOf(res);
     // The result payload (slug / title / snippet) must mention the marker.
     expect(text).toContain(MARKER);
+  }, 30_000);
+
+  test('query treats an explicit __all__ like an omitted source in federated stdio', async () => {
+    expect(connected).toBe(true);
+    const args = { query: FEDERATED_MARKER, expand: false, limit: 5 };
+
+    const omitted = textOf(await client!.callTool({ name: 'query', arguments: args }));
+    const explicitAll = textOf(await client!.callTool({
+      name: 'query',
+      arguments: { ...args, source_id: '__all__' },
+    }));
+    const explicitDefault = textOf(await client!.callTool({
+      name: 'query',
+      arguments: { ...args, source_id: 'default' },
+    }));
+
+    expect(omitted).toContain(FEDERATED_MARKER);
+    expect(explicitAll).toContain(FEDERATED_MARKER);
+    expect(explicitDefault).not.toContain(FEDERATED_MARKER);
+    expect(resultSourceIds(omitted)).toContain('federated-source');
+    expect(resultSourceIds(explicitAll)).toContain('federated-source');
+    expect(resultSourceIds(explicitDefault)).not.toContain('federated-source');
   }, 30_000);
 });
 


### PR DESCRIPTION
## Problem

Fixes #3644.

For grantless stdio callers, the transport computes the local federated source set and stores it in `OperationContext.localFederatedSourceIds`. An omitted `source_id` expands to that set, but `federatedSearchScope()` rejected every explicit per-call value from the same expansion path, including the read-only `__all__` sentinel.

As a result, `query({ source_id: "__all__" })` could fall back to the scalar `default` source and return no matches even though the otherwise-identical unqualified query found content in a federated source.

## Fix

- Treat explicit `__all__` like omission only when the transport supplied a local federation set and no OAuth `allowedSources` grant is present.
- Keep concrete source IDs pinned, preserve non-empty and empty OAuth grants, and leave trusted-local whole-brain behavior unchanged.
- Update the MCP tool description and add a raw stdio SDK round-trip regression that seeds a second federated source through the real CLI path.

## Tests

- Focused federation, sentinel, unfederate, and raw stdio suite: 50 passed, 0 failed.
- Raw stdio suite with ambient `GBRAIN_SOURCE=default`: 4 passed, 0 failed.
- `bun run verify`: 34 checks passed, 0 failed.
- `git diff --check`: clean.
