### PR TITLE
fix: include tags in contentHash to prevent infinite re-embed loop

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -37,7 +37,7 @@ import {
 } from './embedding-context.ts';
 import { loadSearchModeConfig, resolveSearchMode } from './search/mode.ts';
 import { normalizeAliasList } from './search/alias-normalize.ts';
-import { isUndefinedTableError, warnOncePerProcess, validateSlug } from './utils.ts';
+import { isUndefinedTableError, warnOncePerProcess, validateSlug, contentHashLegacy } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
@@ -693,6 +693,16 @@ export async function importFromContent(
 
   if (existing?.content_hash === hash && !opts.forceRechunk) {
     return { slug, status: 'skipped', chunks: 0, parsedPage, ...(typeWarning ? { type_warning: typeWarning } : {}) };
+  }
+
+  // v0.42.68 backward-compat: old hash formula (without tags). If the DB
+  // still holds the legacy hash we skip the page — it will be rehashed
+  // on the next full reindex, avoiding an unnecessary re-embed cycle.
+  if (existing?.content_hash && !opts.forceRechunk) {
+    const legacyHash = contentHashLegacy(parsedPage);
+    if (existing.content_hash === legacyHash) {
+      return { slug, status: 'skipped', chunks: 0, parsedPage };
+    }
   }
 
   // v0.41.13 (#1309) — identity-based cross-slug dedup pre-check.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -86,10 +86,12 @@ import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
   EnrichCandidatesOpts, EnrichCandidate,
 } from './types.ts';
-import { validateSlug, contentHash, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { validateSlug, contentHash, contentHashLegacy, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
+import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb, type SqlValue } from './sql-query.ts';
-import { sanitizeForJsonb, buildLinkRows, buildTimelineRows } from './batch-rows.ts';
-import { PAGE_SORT_SQL, MIN_ENTITY_PAGES_FOR_COVERAGE } from './types.ts';
+import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
+import { GBrainError, PAGE_SORT_SQL, MIN_ENTITY_PAGES_FOR_COVERAGE, ENRICH_ORDER_SQL } from './types.ts';
 import { finalizeLastSeen } from './chronicle/last-seen.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -79,7 +79,7 @@ import * as db from './db.ts';
 import { ConnectionManager, DEFAULT_DIRECT_POOL_SIZE } from './connection-manager.ts';
 import { logConnectionEvent } from './connection-audit.ts';
 import { drainBackgroundWorkBeforeDisconnect } from './background-work.ts';
-import { validateSlug, contentHash, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { validateSlug, contentHash, contentHashLegacy, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -216,6 +216,11 @@ export interface PageInput {
   frontmatter?: Record<string, unknown>;
   content_hash?: string;
   /**
+   * v0.42.67: tags are now included in content_hash computation.
+   * When omitted, defaults to [] for backward compatibility.
+   */
+  tags?: string[];
+  /**
    * v0.19.0: distinguishes markdown vs code pages at the DB level. Defaults
    * to 'markdown' when omitted so existing callers work unchanged. Set to
    * 'code' by importCodeFile; drives orphans filter, auto-link bypass, and

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -64,6 +64,24 @@ export function contentHash(page: PageInput): string {
       compiled_truth: page.compiled_truth,
       timeline: page.timeline || '',
       frontmatter: page.frontmatter || {},
+      tags: (page.tags || []).sort(),
+    }))
+    .digest('hex');
+}
+
+/**
+ * Backward-compatible content hash that omits `tags`. Used during a
+ * transition window so pages written by the old formula (without tags)
+ * are still recognised as unchanged while the DB is being rehashed.
+ */
+export function contentHashLegacy(page: PageInput): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      title: page.title,
+      type: page.type,
+      compiled_truth: page.compiled_truth,
+      timeline: page.timeline || '',
+      frontmatter: page.frontmatter || {},
     }))
     .digest('hex');
 }


### PR DESCRIPTION
Fixes #3694

## Problem

The importer computed its SHA-256 hash with tags, but contentHash() in utils.ts (used by putPage via postgres-engine.ts) did not include tags. This mismatch caused every gbrain import run to detect a changed hash and re-embed pages whose tags had not actually changed, creating an infinite re-embed cycle.

## Root cause

- contentHash (utils.ts) hashed: title, type, compiled_truth, timeline, frontmatter — NO tags
- importer (import-file.ts) hashed: title, type, compiled_truth, timeline, frontmatter, tags — WITH tags

When gbrain put (or MCP) called putPage without an explicit content_hash, the fallback contentHash(page) produced a hash without tags. On the next gbrain import, the importer computed a hash with tags, found a mismatch, and re-embedded every single time.

## Fix

1. PageInput gets tags optional field — backward-compatible, defaults to empty array
2. contentHash() now includes sorted tags — matches the importer formula
3. contentHashLegacy() added — computes the old hash (without tags) for backward comparison
4. Importer skip logic — if the DB hash matches the legacy formula, skip the page (avoids unnecessary re-embeds during the transition window; gbrain reindex will update hashes on full reindex)

### Files changed
- src/core/utils.ts — contentHash includes tags, new contentHashLegacy
- src/core/types.ts — PageInput.tags field
- src/core/postgres-engine.ts — import contentHashLegacy
- src/core/pglite-engine.ts — import contentHashLegacy
- src/core/import-file.ts — import contentHashLegacy, legacy hash skip
