### PR TITLE
feat(budget): price OpenRouter models from their published catalogue

### DIFF
--- a/src/core/anthropic-pricing.ts
+++ b/src/core/anthropic-pricing.ts
@@ -18,6 +18,7 @@
 
 import { CANONICAL_PRICING, type ModelPricing } from './model-pricing.ts';
 import { splitProviderModelId } from './model-id.ts';
+import { lookupOpenRouterChatPrice, routerTail } from './openrouter-rates.ts';
 
 export type { ModelPricing };
 
@@ -33,22 +34,6 @@ export const ANTHROPIC_PRICING: Record<string, ModelPricing> = Object.fromEntrie
     .map(([key, pricing]) => [key.slice('anthropic:'.length), pricing]),
 );
 
-/**
- * Estimate the upper-bound USD cost of a single submit.
- * Uses (estimatedInputTokens × inputRate) + (maxOutputTokens × outputRate).
- * The maxOutputTokens upper-bounds the output cost — actual completions
- * usually return less.
- *
- * Returns null when the model isn't in the pricing map. Callers warn-once
- * and treat as zero-cost (the cycle runs unbounded for that submit).
- *
- * Accepts bare (`claude-opus-4-7`), colon-prefixed (`anthropic:claude-opus-4-7`),
- * and slash-prefixed (`anthropic/claude-opus-4-7`) ids. Routes through
- * `splitProviderModelId` so the slash-form (which arrives via CLI `--judge-model`
- * and OpenRouter recipe lists) hits the pricing table. Pre-v0.41.21.0 the inline
- * `:`-only split missed slash form → BudgetTracker no_pricing hard-fail with
- * `--max-cost N` (closes #1540).
- */
 /**
  * Resolve a chat model id to its canonical pricing entry.
  *
@@ -67,16 +52,29 @@ export const ANTHROPIC_PRICING: Record<string, ModelPricing> = Object.fromEntrie
  *   2. fully-qualified canonical id (`openai:gpt-5.2`)
  *   3. bare id behind any provider prefix (`bedrock:claude-haiku-4-5`)
  *
- * Routing-provider ids (`openrouter:openai/gpt-5.2`) deliberately stay
- * unpriced. A router bills its OWN rates, so resolving it to the vendor's
- * direct price would under-estimate real spend — a silently wrong cap is worse
- * than a refused one under the TX2 contract. Pricing routers needs their rate
- * table, which is out of scope here (existing TODO #2, pinned by the
- * "OpenRouter nested form returns null" test).
+ * Routing-provider ids (`openrouter:openai/gpt-5.2`) resolve ONLY from
+ * OpenRouter's own published catalogue, cached on disk by
+ * `openrouter-rates.ts`. They are never aliased to the vendor's direct price:
+ * a router bills its OWN rates, so an alias would under-estimate real spend and
+ * hand back a silently wrong cap — worse than a refused one under the TX2
+ * contract. With no cached rate the id stays unpriced and that refusal stands,
+ * exactly as it did before this lookup existed.
  */
 function resolveChatPricing(modelId: string): ModelPricing | undefined {
   const direct = ANTHROPIC_PRICING[modelId] ?? CANONICAL_PRICING[modelId];
   if (direct) return direct;
+
+  // Checked BEFORE the tail fallback below: the tail of
+  // `openrouter:anthropic/claude-sonnet-4-6` must never be allowed to match a
+  // bare canonical key and quietly price at Anthropic's direct rate.
+  const routed = lookupOpenRouterChatPrice(modelId);
+  if (routed) return routed;
+
+  // A router id whose rate is not cached must stay unpriced. Falling through
+  // to the tail fallback would let `openrouter:anthropic/claude-sonnet-4-6`
+  // match a bare canonical key and price at Anthropic's DIRECT rate — the
+  // vendor-alias mistake this whole path exists to avoid.
+  if (routerTail(modelId) !== null) return undefined;
 
   const { model: tail } = splitProviderModelId(modelId);
   if (!tail) return undefined;
@@ -84,6 +82,22 @@ function resolveChatPricing(modelId: string): ModelPricing | undefined {
   return ANTHROPIC_PRICING[tail] ?? CANONICAL_PRICING[tail];
 }
 
+/**
+ * Estimate the upper-bound USD cost of a single submit.
+ * Uses (estimatedInputTokens × inputRate) + (maxOutputTokens × outputRate).
+ * The maxOutputTokens upper-bounds the output cost — actual completions
+ * usually return less.
+ *
+ * Returns null when the model isn't in the pricing map. Callers warn-once
+ * and treat as zero-cost (the cycle runs unbounded for that submit).
+ *
+ * Accepts bare (`claude-opus-4-7`), colon-prefixed (`anthropic:claude-opus-4-7`),
+ * and slash-prefixed (`anthropic/claude-opus-4-7`) ids. Routes through
+ * `splitProviderModelId` so the slash-form (which arrives via CLI `--judge-model`
+ * and OpenRouter recipe lists) hits the pricing table. Pre-v0.41.21.0 the inline
+ * `:`-only split missed slash form → BudgetTracker no_pricing hard-fail with
+ * `--max-cost N` (closes #1540).
+ */
 export function estimateMaxCostUsd(
   modelId: string,
   estimatedInputTokens: number,

--- a/src/core/anthropic-pricing.ts
+++ b/src/core/anthropic-pricing.ts
@@ -49,16 +49,47 @@ export const ANTHROPIC_PRICING: Record<string, ModelPricing> = Object.fromEntrie
  * `:`-only split missed slash form → BudgetTracker no_pricing hard-fail with
  * `--max-cost N` (closes #1540).
  */
+/**
+ * Resolve a chat model id to its canonical pricing entry.
+ *
+ * Looks at the FULL canonical table, not just the bare-keyed Anthropic view.
+ * Previously this resolved against `ANTHROPIC_PRICING` alone, which is
+ * `CANONICAL_PRICING` filtered to `anthropic:` keys — so every non-Anthropic
+ * model priced a `null` even though canonical carried its rate (14 of the 25
+ * canonical entries were unreachable). Because `BudgetTracker.reserve()`
+ * hard-throws `BudgetExhausted{reason:'no_pricing'}` when a cap is set and
+ * pricing is missing, that made every cost-capped path — `gbrain enrich`,
+ * `cycle.enrich_thin`, `extract_atoms`, skillopt — fail outright on OpenAI,
+ * Gemini, and DeepSeek models. See garrytan/gbrain#2504.
+ *
+ * Resolution order, most-specific first:
+ *   1. bare Anthropic id (`claude-haiku-4-5`) — the form most callers pass
+ *   2. fully-qualified canonical id (`openai:gpt-5.2`)
+ *   3. bare id behind any provider prefix (`bedrock:claude-haiku-4-5`)
+ *
+ * Routing-provider ids (`openrouter:openai/gpt-5.2`) deliberately stay
+ * unpriced. A router bills its OWN rates, so resolving it to the vendor's
+ * direct price would under-estimate real spend — a silently wrong cap is worse
+ * than a refused one under the TX2 contract. Pricing routers needs their rate
+ * table, which is out of scope here (existing TODO #2, pinned by the
+ * "OpenRouter nested form returns null" test).
+ */
+function resolveChatPricing(modelId: string): ModelPricing | undefined {
+  const direct = ANTHROPIC_PRICING[modelId] ?? CANONICAL_PRICING[modelId];
+  if (direct) return direct;
+
+  const { model: tail } = splitProviderModelId(modelId);
+  if (!tail) return undefined;
+
+  return ANTHROPIC_PRICING[tail] ?? CANONICAL_PRICING[tail];
+}
+
 export function estimateMaxCostUsd(
   modelId: string,
   estimatedInputTokens: number,
   maxOutputTokens: number,
 ): number | null {
-  let p: ModelPricing | undefined = ANTHROPIC_PRICING[modelId];
-  if (!p) {
-    const { model: tail } = splitProviderModelId(modelId);
-    if (tail) p = ANTHROPIC_PRICING[tail];
-  }
+  const p = resolveChatPricing(modelId);
   if (!p) return null;
   return (
     (estimatedInputTokens / 1_000_000) * p.input +

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -35,6 +35,7 @@ import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
 import { canonicalLookup } from '../model-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
+import { lookupOpenRouterChatPrice, routerTail } from '../openrouter-rates.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
 
 export type BudgetKind = 'chat' | 'embed' | 'rerank';
@@ -234,6 +235,21 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   // their own provider-specific pricing surfaces.
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
+  }
+  // Router-prefixed ids price from OpenRouter's own cached catalogue. Checked
+  // BEFORE canonicalLookup so a router id can never resolve to the vendor's
+  // direct rate: a router bills its own spread, and under-estimating spend
+  // hands back a silently wrong cap. Returns null when uncached, preserving
+  // the TX2 refusal.
+  //
+  // Note this is a SEPARATE resolution path from anthropic-pricing.ts's
+  // estimateMaxCostUsd — that one serves budget-meter / batch-projection /
+  // skillopt preflight, this one gates BudgetTracker. Wiring only the former
+  // leaves capped runs failing here, which is exactly what happened.
+  if (kind === 'chat' || kind === 'rerank') {
+    const routed = lookupOpenRouterChatPrice(modelId);
+    if (routed) return routed;
+    if (routerTail(modelId) !== null) return null;
   }
   // Fall back to the full canonical pricing table so non-Anthropic chat
   // models with a known price (openai:*, google:*, deepseek:*) resolve under

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -332,7 +332,24 @@ export class BudgetTracker {
         // pricing we can't enforce the cap, and silently ignoring it would
         // void the contract.
         const msg = `${this.opts.label}: no pricing entry for model "${estimate.modelId}" (kind=${estimate.kind}). ` +
-          `Add it to src/core/${estimate.kind === 'embed' ? 'embedding-pricing.ts' : 'anthropic-pricing.ts'} or drop --max-cost.`;
+          `Add it to src/core/${estimate.kind === 'embed' ? 'embedding-pricing.ts' : 'model-pricing.ts'} or drop --max-cost.`;
+        // Audit the refusal. The `reserve_denied` path below writes a line, but
+        // this one did not — so a run that aborted here left an audit log
+        // containing ONLY successful reserve/record pairs, which reads as
+        // "the budget was fine" while the command reports budget_exhausted.
+        // That combination is actively misleading during diagnosis.
+        appendAuditLine(this.auditPath, {
+          schema_version: 1,
+          ts: new Date().toISOString(),
+          event: 'reserve_no_pricing',
+          label: this.opts.label,
+          kind: estimate.kind,
+          model: estimate.modelId,
+          sub_label: estimate.label,
+          estimated_input_tokens: estimate.estimatedInputTokens,
+          max_output_tokens: estimate.maxOutputTokens,
+          max_cost_usd: this.opts.maxCostUsd,
+        });
         this.fireExhausted();
         throw new BudgetExhausted(msg, {
           reason: 'no_pricing',

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1427,6 +1427,13 @@ async function purgeOrphanClones(staleHours: number): Promise<{ count: number; b
   return { count: removed.length, bytes, names: removed };
 }
 
+/**
+ * Age at which the cached OpenRouter rate table is refreshed by the purge
+ * sweep. Published rates move on the order of months, so a weekly refresh is
+ * ample; the cache is never invalidated by age, only refreshed opportunistically.
+ */
+const RATES_MAX_AGE_DAYS = 7;
+
 async function runPhasePurge(engine: BrainEngine, dryRun: boolean): Promise<PhaseResult> {
   try {
     if (dryRun) {
@@ -1483,6 +1490,23 @@ async function runPhasePurge(engine: BrainEngine, dryRun: boolean): Promise<Phas
     } catch {
       // Non-fatal.
     }
+    // Refresh the cached OpenRouter rate table when it goes stale. Lives here,
+    // in the housekeeping sweep, because pricing lookups are SYNCHRONOUS and
+    // sit on the budget hot path — `BudgetTracker.reserve()` can never await a
+    // fetch. Out-of-band refresh keeps every lookup a local read.
+    //
+    // Best-effort in the strongest sense: a failed refresh keeps serving the
+    // previous cache and is not reported as a cycle failure. Refusing to spend
+    // because a rate fetch timed out is exactly the bug class this removes.
+    let ratesRefreshed = false;
+    try {
+      const { ratesNeedRefresh, refreshOpenRouterRates } = await import('./openrouter-rates.ts');
+      if (ratesNeedRefresh(RATES_MAX_AGE_DAYS)) {
+        ratesRefreshed = (await refreshOpenRouterRates()).ok;
+      }
+    } catch {
+      // Non-fatal.
+    }
     return {
       phase: 'purge',
       status: 'ok',
@@ -1492,7 +1516,8 @@ async function runPhasePurge(engine: BrainEngine, dryRun: boolean): Promise<Phas
         `${purgedClones.count} orphan clone temp dir(s), ${purgedCheckpoints} stale op_checkpoint(s), ` +
         `${purgedBrainstormCheckpoints} stale brainstorm checkpoint(s), ` +
         `${purgedBatchRetryAuditFiles} stale batch-retry audit file(s), ` +
-        `and ${purgedVolunteerEvents} stale volunteer event(s)`,
+        `and ${purgedVolunteerEvents} stale volunteer event(s)` +
+        (ratesRefreshed ? '; refreshed OpenRouter rates' : ''),
       details: {
         purged_sources_count: purgedSources.length,
         purged_pages_count: purgedPages.count,

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -19,6 +19,8 @@
  * fabricate numbers.
  */
 
+import { lookupOpenRouterEmbeddingPrice } from './openrouter-rates.ts';
+
 export interface EmbeddingPricing {
   /** USD per 1M tokens (embedding cost; embeddings have no separate output rate). */
   pricePerMTok: number;
@@ -75,6 +77,13 @@ export function lookupEmbeddingPrice(modelString: string): PriceLookupResult {
   const provider = providerRaw.trim().toLowerCase();
   const model = (modelRaw ?? '').trim();
   const key = `${provider}:${model}`;
+
+  // OpenRouter's own published rate wins over the bundled constant below: it is
+  // authoritative and current, whereas the constant is a snapshot. Only ever
+  // consulted for `openrouter:` ids — never to alias a router to vendor rates.
+  const routed = lookupOpenRouterEmbeddingPrice(modelString);
+  if (routed !== undefined) return { kind: 'known', pricePerMTok: routed, key };
+
   const hit = EMBEDDING_PRICING[key];
   if (hit) return { kind: 'known', pricePerMTok: hit.pricePerMTok, key };
   return { kind: 'unknown', provider, model };

--- a/src/core/openrouter-rates.ts
+++ b/src/core/openrouter-rates.ts
@@ -1,0 +1,262 @@
+/**
+ * openrouter-rates.ts — cached OpenRouter rate table.
+ *
+ * OpenRouter resells other vendors' models and can charge its own spread, so a
+ * router-prefixed id (`openrouter:openai/gpt-5.2`) must NOT be priced by
+ * aliasing it to the vendor's direct rate — that under-estimates spend and
+ * hands back a cap that is quietly wrong. Historically such ids simply priced
+ * `null`, which under the TX2 contract (BudgetTracker hard-fails when a cap is
+ * set and pricing is missing) took out every cost-capped path for anyone
+ * routing through OpenRouter. See garrytan/gbrain#2504.
+ *
+ * OpenRouter publishes both halves machine-readably, on two SEPARATE endpoints:
+ *
+ *   GET /api/v1/models             chat/completion only — no embedding entries
+ *   GET /api/v1/embeddings/models  embedding models, with pricing
+ *
+ * Both report `pricing.prompt` / `pricing.completion` as USD **per token** as
+ * decimal strings; this module normalizes to USD per 1M tokens to match
+ * `model-pricing.ts` and `embedding-pricing.ts`.
+ *
+ * ── Resolution order (deliberate) ────────────────────────────────────────────
+ *   1. in-memory (this process)
+ *   2. disk cache — last successful fetch, used REGARDLESS OF AGE
+ *   3. caller's bundled table (the hardcoded constants) as the floor
+ *   4. undefined → caller decides (null estimate → TX2 refusal)
+ *
+ * A failed or absent fetch is a NON-EVENT: it logs nothing to the hot path,
+ * keeps serving the last good cache, and never causes a refusal on its own.
+ * That is the whole point — refusing to spend because a network call timed out
+ * would recreate the class of bug this exists to fix. Rates move on the order
+ * of months (gbrain's own bundled table was still cent-accurate 11 days after
+ * its verification stamp), so a stale cache is overwhelmingly better than none.
+ *
+ * Reads are SYNCHRONOUS by necessity: `BudgetTracker.reserve()` prices inline,
+ * so a lookup can never await. Refresh is async and runs OUT OF BAND (cycle /
+ * doctor), never at reserve time.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, statSync } from 'fs';
+import { dirname } from 'path';
+import { gbrainPath } from './config.ts';
+import { splitProviderModelId } from './model-id.ts';
+import type { ModelPricing } from './model-pricing.ts';
+
+export const OPENROUTER_CHAT_URL = 'https://openrouter.ai/api/v1/models';
+export const OPENROUTER_EMBEDDING_URL = 'https://openrouter.ai/api/v1/embeddings/models';
+
+/** Cache schema. Bump `schema_version` on any shape change; readers reject mismatches. */
+export const RATES_SCHEMA_VERSION = 1;
+
+export interface OpenRouterRatesCache {
+  schema_version: number;
+  /** ISO timestamp of the last SUCCESSFUL fetch. */
+  fetched_at: string;
+  /** `openai/gpt-5.2` → USD per 1M tokens. */
+  chat: Record<string, ModelPricing>;
+  /** `openai/text-embedding-3-small` → USD per 1M tokens. */
+  embedding: Record<string, number>;
+}
+
+export function ratesCachePath(): string {
+  return gbrainPath('openrouter-rates.json');
+}
+
+// ── read path (sync, hot) ───────────────────────────────────────────────────
+
+let _memo: OpenRouterRatesCache | null | undefined;
+
+/** Reset the in-process memo. Tests only. */
+export function _resetRatesMemo(): void {
+  _memo = undefined;
+}
+
+/**
+ * Last known rates, or null when there is no usable cache. Never throws — a
+ * missing, unreadable, malformed, or schema-mismatched cache is indistinguishable
+ * from "no cache yet" and must degrade to the caller's bundled table.
+ */
+export function readCachedRates(): OpenRouterRatesCache | null {
+  if (_memo !== undefined) return _memo;
+  try {
+    const raw = readFileSync(ratesCachePath(), 'utf8');
+    const parsed = JSON.parse(raw) as OpenRouterRatesCache;
+    if (
+      !parsed ||
+      parsed.schema_version !== RATES_SCHEMA_VERSION ||
+      typeof parsed.chat !== 'object' ||
+      typeof parsed.embedding !== 'object'
+    ) {
+      _memo = null;
+      return null;
+    }
+    _memo = parsed;
+    return parsed;
+  } catch {
+    _memo = null;
+    return null;
+  }
+}
+
+/**
+ * Strip a leading `openrouter` provider segment, returning the catalogue id
+ * (`openai/gpt-5.2`). Null for anything that is not a router id.
+ *
+ * Delegates to `splitProviderModelId` rather than hand-splitting on ':' so it
+ * inherits slash-form support — `openrouter/openai/gpt-5.2` arrives from CLI
+ * flags and recipe lists exactly as the colon form does (see #1540/#1698), and
+ * a colon-only check would silently miss it.
+ */
+export function routerTail(modelId: string): string | null {
+  const { provider, model } = splitProviderModelId(modelId);
+  if (!provider || provider.trim().toLowerCase() !== 'openrouter') return null;
+  const tail = (model ?? '').trim();
+  return tail.length > 0 ? tail : null;
+}
+
+/** Chat rate for an `openrouter:`-prefixed id, or undefined when unknown. */
+export function lookupOpenRouterChatPrice(modelId: string): ModelPricing | undefined {
+  const tail = routerTail(modelId);
+  if (!tail) return undefined;
+  return readCachedRates()?.chat[tail];
+}
+
+/** Embedding rate (USD per 1M tokens) for an `openrouter:`-prefixed id. */
+export function lookupOpenRouterEmbeddingPrice(modelId: string): number | undefined {
+  const tail = routerTail(modelId);
+  if (!tail) return undefined;
+  return readCachedRates()?.embedding[tail];
+}
+
+/** Age of the cache in days, or null when there is none. Surfaced by doctor. */
+export function ratesAgeDays(): number | null {
+  const cached = readCachedRates();
+  if (!cached?.fetched_at) return null;
+  const ms = Date.now() - Date.parse(cached.fetched_at);
+  return Number.isFinite(ms) ? ms / 86_400_000 : null;
+}
+
+// ── refresh path (async, out-of-band) ───────────────────────────────────────
+
+interface RawModel {
+  id?: unknown;
+  pricing?: { prompt?: unknown; completion?: unknown };
+}
+
+/** Decimal-string USD/token → USD/1M-tokens. Returns null for junk. */
+function perMTok(v: unknown): number | null {
+  if (typeof v !== 'string' && typeof v !== 'number') return null;
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n * 1_000_000;
+}
+
+async function fetchJson(url: string, timeoutMs: number): Promise<{ data?: RawModel[] } | null> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as { data?: RawModel[] };
+  } catch {
+    return null;
+  }
+}
+
+export interface RefreshResult {
+  ok: boolean;
+  chatCount: number;
+  embeddingCount: number;
+  /** Populated when ok=false; the previous cache is left untouched. */
+  error?: string;
+}
+
+/**
+ * Fetch both catalogues and replace the cache. On any failure the previous
+ * cache is left exactly as it was — a bad refresh must never be worse than no
+ * refresh. Run from maintenance paths only, never from a pricing lookup.
+ */
+export async function refreshOpenRouterRates(
+  opts: { timeoutMs?: number } = {},
+): Promise<RefreshResult> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const [chatRes, embedRes] = await Promise.all([
+    fetchJson(OPENROUTER_CHAT_URL, timeoutMs),
+    fetchJson(OPENROUTER_EMBEDDING_URL, timeoutMs),
+  ]);
+
+  if (!chatRes && !embedRes) {
+    return { ok: false, chatCount: 0, embeddingCount: 0, error: 'both catalogue fetches failed' };
+  }
+
+  const chat: Record<string, ModelPricing> = {};
+  for (const m of chatRes?.data ?? []) {
+    if (typeof m?.id !== 'string') continue;
+    const input = perMTok(m.pricing?.prompt);
+    const output = perMTok(m.pricing?.completion);
+    // Free models legitimately price 0; only a missing/unparseable rate is a skip.
+    if (input === null || output === null) continue;
+    chat[m.id] = { input, output };
+  }
+
+  const embedding: Record<string, number> = {};
+  for (const m of embedRes?.data ?? []) {
+    if (typeof m?.id !== 'string') continue;
+    const rate = perMTok(m.pricing?.prompt);
+    if (rate === null) continue;
+    embedding[m.id] = rate;
+  }
+
+  // Refuse to overwrite a good cache with an empty one — a 200 carrying no
+  // usable rows is a upstream-shape change, not a reason to lose what we have.
+  if (Object.keys(chat).length === 0 && Object.keys(embedding).length === 0) {
+    return { ok: false, chatCount: 0, embeddingCount: 0, error: 'catalogues returned no priceable models' };
+  }
+
+  const previous = readCachedRates();
+  const next: OpenRouterRatesCache = {
+    schema_version: RATES_SCHEMA_VERSION,
+    fetched_at: new Date().toISOString(),
+    // A half-failure keeps the other half from the previous cache rather than
+    // dropping it: losing embedding rates because the chat endpoint blipped
+    // would re-break capped enrich runs.
+    chat: Object.keys(chat).length > 0 ? chat : (previous?.chat ?? {}),
+    embedding: Object.keys(embedding).length > 0 ? embedding : (previous?.embedding ?? {}),
+  };
+
+  try {
+    const path = ratesCachePath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(next, null, 2) + '\n', 'utf8');
+  } catch (err) {
+    return {
+      ok: false,
+      chatCount: 0,
+      embeddingCount: 0,
+      error: `cache write failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  _memo = next;
+  return {
+    ok: true,
+    chatCount: Object.keys(next.chat).length,
+    embeddingCount: Object.keys(next.embedding).length,
+  };
+}
+
+/** True when the cache is missing or older than `maxAgeDays`. */
+export function ratesNeedRefresh(maxAgeDays = 7): boolean {
+  const age = ratesAgeDays();
+  return age === null || age > maxAgeDays;
+}
+
+/** mtime of the cache file, for diagnostics that want it without a parse. */
+export function ratesCacheMtime(): Date | null {
+  try {
+    return statSync(ratesCachePath()).mtime;
+  } catch {
+    return null;
+  }
+}

--- a/test/anthropic-pricing.test.ts
+++ b/test/anthropic-pricing.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { ANTHROPIC_PRICING, estimateMaxCostUsd } from '../src/core/anthropic-pricing.ts';
+import { CANONICAL_PRICING } from '../src/core/model-pricing.ts';
 
 describe('estimateMaxCostUsd', () => {
   // Sonnet 4.6 = $3 input / $15 output per MTok.
@@ -71,5 +72,46 @@ describe('estimateMaxCostUsd', () => {
       expect(estimateMaxCostUsd(`anthropic:${key}`, 1_000_000, 0)).not.toBeNull();
       expect(estimateMaxCostUsd(`anthropic/${key}`, 1_000_000, 0)).not.toBeNull();
     }
+  });
+});
+
+/**
+ * garrytan/gbrain#2504 — non-Anthropic canonical models must be priceable.
+ *
+ * `ANTHROPIC_PRICING` is `CANONICAL_PRICING` filtered to `anthropic:` keys, and
+ * `estimateMaxCostUsd` used to resolve against that view alone — so every
+ * non-Anthropic model returned null despite canonical carrying its rate.
+ * `BudgetTracker.reserve()` hard-throws on a null estimate when a cap is set,
+ * which took out every cost-capped path (enrich, enrich_thin, extract_atoms,
+ * skillopt) on OpenAI / Gemini / DeepSeek models.
+ */
+describe('estimateMaxCostUsd — canonical (non-Anthropic) coverage (#2504)', () => {
+  test.each([
+    ['openai:gpt-5.2'],
+    ['openai:gpt-4o'],
+    ['deepseek:deepseek-chat'],
+    ['deepseek:deepseek-v4-flash'],
+    ['google:gemini-2.0-flash'],
+  ])('%s prices from canonical instead of null', (modelId) => {
+    const cost = estimateMaxCostUsd(modelId, 1_000_000, 0);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  test('every canonical entry is priceable by its fully-qualified id', () => {
+    for (const key of Object.keys(CANONICAL_PRICING)) {
+      expect(estimateMaxCostUsd(key, 1_000, 1_000)).not.toBeNull();
+    }
+  });
+
+  test('genuinely unknown models still return null (TX2 contract intact)', () => {
+    expect(estimateMaxCostUsd('acme:not-a-real-model', 1_000, 1_000)).toBeNull();
+  });
+
+  test('routing-provider ids stay unpriced — a router bills its own rates', () => {
+    // Resolving these to the vendor's direct price would UNDER-estimate spend.
+    // Refusing is the correct posture until a router rate table exists (TODO #2).
+    expect(estimateMaxCostUsd('openrouter:openai/gpt-5.2', 1_000, 1_000)).toBeNull();
+    expect(estimateMaxCostUsd('openrouter:acme/nope', 1_000, 1_000)).toBeNull();
   });
 });

--- a/test/anthropic-pricing.test.ts
+++ b/test/anthropic-pricing.test.ts
@@ -8,7 +8,29 @@
  * drop slash-form support.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { _resetRatesMemo } from '../src/core/openrouter-rates.ts';
+
+// Router ids now resolve through the on-disk OpenRouter rate cache
+// (openrouter-rates.ts). Without this isolation these assertions would depend
+// on whether the machine running them happens to have a populated
+// ~/.gbrain/openrouter-rates.json — green on CI, red on a dev box that had
+// refreshed rates. Pin an empty GBRAIN_HOME so "no cached router rate" is a
+// stated precondition rather than an accident of the environment.
+let _ratesHome: string;
+beforeEach(() => {
+  _ratesHome = mkdtempSync(join(tmpdir(), 'gbrain-pricing-'));
+  process.env.GBRAIN_HOME = _ratesHome;
+  _resetRatesMemo();
+});
+afterEach(() => {
+  delete process.env.GBRAIN_HOME;
+  rmSync(_ratesHome, { recursive: true, force: true });
+  _resetRatesMemo();
+});
 import { ANTHROPIC_PRICING, estimateMaxCostUsd } from '../src/core/anthropic-pricing.ts';
 import { CANONICAL_PRICING } from '../src/core/model-pricing.ts';
 
@@ -56,10 +78,11 @@ describe('estimateMaxCostUsd', () => {
   });
 
   test('OpenRouter nested form returns null — tail is `anthropic/claude-...` which is not a pricing key', () => {
-    // Per D2 architecture: parseModelId returns {provider:'openrouter',
-    // model:'anthropic/claude-sonnet-4-6'}; lookup on the tail
-    // 'anthropic/claude-sonnet-4-6' misses (table has bare 'claude-sonnet-4-6').
-    // OpenRouter pricing is intentionally out of scope (TODO #2).
+    // Routers are priced ONLY from OpenRouter's own catalogue (cached by
+    // openrouter-rates.ts); with no cached rate the id stays unpriced and the
+    // TX2 refusal stands. Critically it must NOT fall through to the tail
+    // fallback and price at Anthropic's DIRECT rate — a router bills its own
+    // rates, so that alias would under-estimate spend.
     expect(estimateMaxCostUsd('openrouter:anthropic/claude-sonnet-4-6', 1_000, 1_000)).toBeNull();
   });
 

--- a/test/openrouter-rates.test.ts
+++ b/test/openrouter-rates.test.ts
@@ -1,0 +1,252 @@
+/**
+ * openrouter-rates: cache-backed router pricing (garrytan/gbrain#2504).
+ *
+ * The load-bearing property is that a failed fetch is a NON-EVENT — a stale
+ * cache must keep serving, because refusing to spend on a network blip is the
+ * exact failure class this module exists to remove.
+ *
+ * No network: `fetch` is stubbed per-test and GBRAIN_HOME points at a tmpdir so
+ * the cache never touches a real ~/.gbrain.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  readCachedRates,
+  refreshOpenRouterRates,
+  lookupOpenRouterChatPrice,
+  lookupOpenRouterEmbeddingPrice,
+  ratesAgeDays,
+  ratesNeedRefresh,
+  ratesCachePath,
+  routerTail,
+  RATES_SCHEMA_VERSION,
+  _resetRatesMemo,
+} from '../src/core/openrouter-rates.ts';
+import { estimateMaxCostUsd } from '../src/core/anthropic-pricing.ts';
+import { lookupEmbeddingPrice } from '../src/core/embedding-pricing.ts';
+
+let home: string;
+const realFetch = globalThis.fetch;
+
+function seedCache(cache: unknown): void {
+  const p = ratesCachePath();
+  mkdirSync(join(home, '.gbrain'), { recursive: true });
+  writeFileSync(p, JSON.stringify(cache), 'utf8');
+  _resetRatesMemo();
+}
+
+/** Stub both catalogue endpoints. `null` for either simulates a failed fetch. */
+function stubFetch(chat: unknown | null, embed: unknown | null): void {
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const u = String(url);
+    const body = u.includes('/embeddings/models') ? embed : chat;
+    if (body === null) throw new Error('network down');
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-rates-'));
+  process.env.GBRAIN_HOME = home;
+  _resetRatesMemo();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.GBRAIN_HOME;
+  rmSync(home, { recursive: true, force: true });
+  _resetRatesMemo();
+});
+
+describe('routerTail', () => {
+  test.each([
+    ['openrouter:openai/gpt-5.2', 'openai/gpt-5.2'],
+    ['openrouter/openai/gpt-5.2', 'openai/gpt-5.2'],   // slash form (#1540/#1698)
+    ['OpenRouter:openai/gpt-5.2', 'openai/gpt-5.2'],   // case-insensitive
+  ])('%s → %s', (input, expected) => {
+    expect(routerTail(input)).toBe(expected);
+  });
+
+  test.each([
+    ['openai:gpt-5.2'],
+    ['claude-haiku-4-5'],        // bare id: provider is null, must not throw
+    ['anthropic:claude-haiku-4-5'],
+    ['openrouter:'],             // empty tail
+  ])('%s is not a router id', (input) => {
+    expect(routerTail(input)).toBeNull();
+  });
+});
+
+describe('cache read', () => {
+  test('missing cache reads null and never throws', () => {
+    expect(readCachedRates()).toBeNull();
+    expect(ratesAgeDays()).toBeNull();
+    expect(ratesNeedRefresh()).toBe(true);
+  });
+
+  test('malformed JSON degrades to null rather than throwing', () => {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(ratesCachePath(), '{not json', 'utf8');
+    _resetRatesMemo();
+    expect(readCachedRates()).toBeNull();
+  });
+
+  test('schema mismatch is treated as no cache', () => {
+    seedCache({ schema_version: RATES_SCHEMA_VERSION + 99, fetched_at: new Date().toISOString(), chat: {}, embedding: {} });
+    expect(readCachedRates()).toBeNull();
+  });
+
+  test('a stale cache is still served — age never invalidates', () => {
+    const old = new Date(Date.now() - 400 * 86_400_000).toISOString();
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: old,
+      chat: { 'openai/gpt-5.2': { input: 1.75, output: 14 } },
+      embedding: {},
+    });
+    expect(lookupOpenRouterChatPrice('openrouter:openai/gpt-5.2')).toEqual({ input: 1.75, output: 14 });
+    expect(ratesAgeDays()!).toBeGreaterThan(365);
+    expect(ratesNeedRefresh(7)).toBe(true); // flagged as stale…
+  });
+});
+
+describe('refresh', () => {
+  test('populates the cache from both catalogues, normalizing per-token → per-MTok', async () => {
+    stubFetch(
+      { data: [{ id: 'openai/gpt-5.2', pricing: { prompt: '0.00000175', completion: '0.000014' } }] },
+      { data: [{ id: 'openai/text-embedding-3-small', pricing: { prompt: '0.00000002', completion: '0' } }] },
+    );
+    const r = await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(r.ok).toBe(true);
+    expect(r.chatCount).toBe(1);
+    expect(r.embeddingCount).toBe(1);
+
+    expect(lookupOpenRouterChatPrice('openrouter:openai/gpt-5.2')).toEqual({ input: 1.75, output: 14 });
+    expect(lookupOpenRouterEmbeddingPrice('openrouter:openai/text-embedding-3-small')).toBeCloseTo(0.02, 10);
+  });
+
+  test('total fetch failure leaves an existing cache untouched', async () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'openai/gpt-5.2': { input: 1.75, output: 14 } },
+      embedding: { 'openai/text-embedding-3-small': 0.02 },
+    });
+    stubFetch(null, null);
+
+    const r = await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(r.ok).toBe(false);
+
+    _resetRatesMemo();
+    expect(lookupOpenRouterChatPrice('openrouter:openai/gpt-5.2')).toEqual({ input: 1.75, output: 14 });
+    expect(lookupOpenRouterEmbeddingPrice('openrouter:openai/text-embedding-3-small')).toBe(0.02);
+  });
+
+  test('half failure keeps the other half from the previous cache', async () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'openai/gpt-5.2': { input: 1.75, output: 14 } },
+      embedding: { 'openai/text-embedding-3-small': 0.02 },
+    });
+    // chat OK, embeddings down — embedding rates must survive, or capped
+    // enrich runs re-break on the very id this was built for.
+    stubFetch({ data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }] }, null);
+
+    const r = await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(r.ok).toBe(true);
+    expect(lookupOpenRouterChatPrice('openrouter:openai/gpt-4o')).toEqual({ input: 2.5, output: 10 });
+    expect(lookupOpenRouterEmbeddingPrice('openrouter:openai/text-embedding-3-small')).toBe(0.02);
+  });
+
+  test('an empty-but-200 catalogue does not clobber a good cache', async () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'openai/gpt-5.2': { input: 1.75, output: 14 } },
+      embedding: {},
+    });
+    stubFetch({ data: [] }, { data: [] });
+
+    const r = await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(r.ok).toBe(false);
+    _resetRatesMemo();
+    expect(lookupOpenRouterChatPrice('openrouter:openai/gpt-5.2')).toEqual({ input: 1.75, output: 14 });
+  });
+
+  test('free models (rate 0) are kept, not skipped as falsy', async () => {
+    stubFetch(
+      { data: [{ id: 'nvidia/nemotron:free', pricing: { prompt: '0', completion: '0' } }] },
+      { data: [] },
+    );
+    await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(lookupOpenRouterChatPrice('openrouter:nvidia/nemotron:free')).toEqual({ input: 0, output: 0 });
+  });
+
+  test('cache file is written with the declared schema version', async () => {
+    stubFetch(
+      { data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }] },
+      { data: [] },
+    );
+    await refreshOpenRouterRates({ timeoutMs: 500 });
+    expect(existsSync(ratesCachePath())).toBe(true);
+    const onDisk = JSON.parse(readFileSync(ratesCachePath(), 'utf8'));
+    expect(onDisk.schema_version).toBe(RATES_SCHEMA_VERSION);
+    expect(typeof onDisk.fetched_at).toBe('string');
+  });
+});
+
+describe('integration with the pricing lookups', () => {
+  test('router chat id prices from cache, and is NOT aliased to the vendor rate', () => {
+    // Cached router rate is deliberately different from Anthropic's direct rate
+    // so an alias bug would be visible rather than coincidentally correct.
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'anthropic/claude-sonnet-4-6': { input: 9, output: 45 } },
+      embedding: {},
+    });
+    // 1M input at $9/MTok = $9.00 (direct Anthropic rate would give $3.00).
+    expect(estimateMaxCostUsd('openrouter:anthropic/claude-sonnet-4-6', 1_000_000, 0)).toBeCloseTo(9, 6);
+  });
+
+  test('uncached router id stays null — TX2 refusal preserved', () => {
+    expect(estimateMaxCostUsd('openrouter:anthropic/claude-sonnet-4-6', 1_000, 1_000)).toBeNull();
+    expect(estimateMaxCostUsd('openrouter:openai/gpt-5.2', 1_000, 1_000)).toBeNull();
+  });
+
+  test('direct (non-router) ids are unaffected by the cache', () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'anthropic/claude-sonnet-4-6': { input: 9, output: 45 } },
+      embedding: {},
+    });
+    // Sonnet 4.6 direct = $3/MTok input; the router entry must not leak here.
+    expect(estimateMaxCostUsd('claude-sonnet-4-6', 1_000_000, 0)).toBeCloseTo(3, 6);
+  });
+
+  test('router embedding id prices from cache, overriding the bundled constant', () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: {},
+      embedding: { 'openai/text-embedding-3-small': 0.05 }, // deliberately ≠ bundled 0.02
+    });
+    const r = lookupEmbeddingPrice('openrouter:openai/text-embedding-3-small');
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.05);
+  });
+
+  test('bundled embedding constants still resolve with no cache present', () => {
+    const r = lookupEmbeddingPrice('openai:text-embedding-3-small');
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.02);
+  });
+});

--- a/test/openrouter-rates.test.ts
+++ b/test/openrouter-rates.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../src/core/openrouter-rates.ts';
 import { estimateMaxCostUsd } from '../src/core/anthropic-pricing.ts';
 import { lookupEmbeddingPrice } from '../src/core/embedding-pricing.ts';
+import { isModelPriceable, BudgetTracker } from '../src/core/budget/budget-tracker.ts';
 
 let home: string;
 const realFetch = globalThis.fetch;
@@ -248,5 +249,60 @@ describe('integration with the pricing lookups', () => {
     const r = lookupEmbeddingPrice('openai:text-embedding-3-small');
     expect(r.kind).toBe('known');
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.02);
+  });
+});
+
+/**
+ * BudgetTracker resolves chat pricing through its OWN `lookupPricing`, not
+ * through `estimateMaxCostUsd`. Wiring only the latter left capped runs still
+ * failing on router ids — the embedding half worked purely because
+ * `lookupPricing` delegates to `lookupEmbeddingPrice`. These pin the gate
+ * itself so the two paths can't drift apart again.
+ */
+describe('budget gate (isModelPriceable) — the path that actually gates spend', () => {
+  test('router chat id is priceable once cached', () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'deepseek/deepseek-v4-flash-0731': { input: 0.09, output: 0.18 } },
+      embedding: {},
+    });
+    expect(isModelPriceable('openrouter:deepseek/deepseek-v4-flash-0731', 'chat')).toBe(true);
+  });
+
+  test('uncached router chat id is NOT priceable — TX2 refusal preserved', () => {
+    expect(isModelPriceable('openrouter:deepseek/deepseek-v4-flash-0731', 'chat')).toBe(false);
+  });
+
+  test('a cached router id never resolves to the vendor rate', () => {
+    seedCache({
+      schema_version: RATES_SCHEMA_VERSION,
+      fetched_at: new Date().toISOString(),
+      chat: { 'anthropic/claude-sonnet-4-6': { input: 9, output: 45 } },
+      embedding: {},
+    });
+    // Direct Sonnet is $3/MTok; the router entry is $9. Anything but 9 means
+    // the id leaked into a vendor-priced path.
+    const tracker = new BudgetTracker({ maxCostUsd: 100, label: 'test' });
+    tracker.reserve({
+      modelId: 'openrouter:anthropic/claude-sonnet-4-6',
+      estimatedInputTokens: 1_000_000,
+      maxOutputTokens: 0,
+      kind: 'chat',
+    });
+    tracker.record({
+      modelId: 'openrouter:anthropic/claude-sonnet-4-6',
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+    }, 'chat');
+    expect(tracker.totalSpent).toBeCloseTo(9, 6);
+  });
+
+  test('non-Anthropic canonical ids were already priceable (regression guard)', () => {
+    // These resolve via canonicalLookup inside lookupPricing and must keep
+    // working with no cache present.
+    for (const id of ['openai:gpt-5.2', 'deepseek:deepseek-chat', 'google:gemini-2.0-flash']) {
+      expect(isModelPriceable(id, 'chat')).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #3833 (**stacked on it** — please review that one first; the diff here is only the second commit). Closes the router half of #2504 and picks up TODO #2.

## Why

Router-prefixed ids had no pricing, so under the TX2 contract every cost-capped path broke for anyone routing through OpenRouter — `enrich`, `cycle.enrich_thin`, `extract_atoms`, skillopt. Aliasing them to the vendor's direct rate isn't an option: a router bills its own spread, and a silently wrong cap is worse than a refused one. That's why #3833 deliberately leaves them `null`.

The data turns out to be published machine-readably, on two **separate** endpoints — which is easy to miss, since the obvious one carries no embeddings at all:

```
GET /api/v1/models             chat only — zero embedding entries
GET /api/v1/embeddings/models  31 embedding models, with pricing
```

## Design

`openrouter-rates.ts` caches both to `~/.gbrain/openrouter-rates.json`, normalized USD/token → USD/MTok. Resolution is **memory → disk cache → the caller's bundled constants → undefined**.

The properties that matter, all pinned by tests:

- **The cache is never invalidated by age.** A failed or absent fetch is a non-event: it keeps serving the last good cache and never causes a refusal on its own. Refusing to spend because a rate fetch timed out would recreate the exact bug class this removes. Rates move on the order of months — every OpenRouter embedding rate currently matches `embedding-pricing.ts` to the cent, 11 days after that table's verification stamp.
- **Reads are synchronous.** `BudgetTracker.reserve()` prices inline and can never await, so lookups are local reads. Refresh is async and runs out-of-band from the `purge` sweep at a 7-day TTL — best-effort, non-fatal, never a cycle failure. No new phase, config key, or ordering surface.
- **A bad refresh is never worse than no refresh.** Total failure leaves the cache untouched; a half failure keeps the other half from the previous cache (losing embedding rates to a chat-endpoint blip would re-break capped enrich); an empty-but-200 response refuses to clobber a good cache.
- **TX2 is preserved.** An uncached router id still prices `null`, and is explicitly stopped from falling through to the bare-key tail fallback — otherwise `openrouter:anthropic/claude-sonnet-4-6` would have matched a bare canonical key and priced at Anthropic's *direct* rate, the vendor-alias mistake this exists to avoid. There's a test asserting a cached router rate deliberately different from the vendor's, so an alias bug can't pass silently.
- Router detection goes through `splitProviderModelId`, so slash form (`openrouter/openai/gpt-5.2`, #1540/#1698) is covered.
- Free models (rate `0`) are kept, not dropped as falsy.

## Test-isolation change worth flagging

`test/anthropic-pricing.test.ts` now pins `GBRAIN_HOME` to an empty tmpdir. Without it, those assertions depend on whether the machine running them happens to have a populated cache — green on CI, red on a dev box that had refreshed rates. I confirmed the failure before fixing it. The `OpenRouter nested form returns null` test keeps its assertion; only its rationale comment is updated, since the reason is now "no cached router rate" rather than "the tail isn't a pricing key".

## Verification

22 new tests, all offline (`fetch` stubbed, `GBRAIN_HOME` tmpdir'd). `bun run typecheck` clean. Across all budget/pricing suites: 117 pass, 3 fail — the same 3 pre-existing hook timeouts in `cycle-patterns-deadline-budget.test.ts`, identical on the base commit with these changes stashed.

Against the live endpoints: **394 chat + 31 embedding models** cached (35KB), `openrouter:openai/gpt-5.2` → $1.75/$14.00, slash form resolving identically, `openrouter:openai/text-embedding-3-small` → $0.02/MTok.

## One thing this surfaced

`openrouter:openai/gpt-5.2` prices $1.75/$14.00 while canonical `openai:gpt-5.2` carries $1.25/$10.00 — but `openai/gpt-4o` and `anthropic/claude-haiku-4.5` both match canonical to the cent. Two exact matches beside one 40% gap reads like **canonical drift on the gpt-5.2 entry** rather than an OpenRouter spread. `model-pricing.test.ts`'s drift guard pins the derived views against canonical, but nothing pins canonical against reality. Out of scope here — flagging it because this PR is what made it visible.
