### PR TITLE
fix(serve-http): default-deny OAuth CORS preflight on /token, /revoke, /register (#3845)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -12,7 +12,7 @@
 
 import express from 'express';
 import type { Socket } from 'net';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
@@ -406,7 +406,11 @@ export function parseCorsAllowlistOAuth(): Set<string> | null {
 /**
  * Build a `cors.CorsOptions['origin']` value from the allowlist. The cors
  * package accepts:
- *   - `false` → reject everything (no Allow-Origin header sent)
+ *   - `false` → NOT an Allow-Origin header of "none"; cors@2.8.x treats a
+ *     falsy `origin` option as "no CORS gate" and simply calls `next()`
+ *     without setting or short-circuiting anything (see the mismatch note on
+ *     `mountOAuthCorsGate` below). We keep `false` for the null-allowlist case
+ *     because the gate is enforced by `mountOAuthCorsGate`, not by cors.
  *   - `(origin, cb) => cb(null, boolean)` → dynamic per-request check
  * We use the function form when an allowlist is set so the value of the
  * Allow-Origin header echoes the request Origin (RFC 6454) instead of a
@@ -422,6 +426,45 @@ export function resolveCorsOrigin(allowlist: Set<string> | null): cors.CorsOptio
   return (origin: string | undefined, cb: (err: Error | null, allow?: boolean) => void) => {
     if (!origin) return cb(null, true);
     cb(null, allowlist.has(origin));
+  };
+}
+
+/**
+ * Wrap the OAuth `cors()` middleware so it OWNS the preflight response and a
+ * denied/default-deny origin can never fall through to a downstream handler
+ * that answers OPTIONS with `Access-Control-Allow-Origin: *`.
+ *
+ * Why this is necessary (#3845): the MCP SDK's `mcpAuthRouter` mounts a bare
+ * `cors()` (origin `*`) as the FIRST middleware on `/token`, `/revoke`, and
+ * `/register` (see @modelcontextprotocol/sdk auth/handlers/{token,revoke,
+ * register}). Our gate at `app.use('/token', cors(oauthOptions))` runs first,
+ * but when the origin is denied — either the allowlist is unset (origin
+ * `false`) or the request Origin is not on the allowlist — cors@2.8.x does NOT
+ * emit a header and does NOT short-circuit; it just calls `next()`. Control
+ * then reaches the SDK's bare `cors()`, which answers the OPTIONS preflight
+ * with `*`, leaking the endpoint surface + methods to any web origin and
+ * contradicting the documented default-deny posture.
+ *
+ * The wrapper closes that gap: cors() only reaches our callback when it did
+ * NOT short-circuit the preflight itself (i.e. the origin was denied or the
+ * request is a real, non-OPTIONS request). For a denied OPTIONS we terminate
+ * with a header-free 204 so the SDK's cors never runs; real requests fall
+ * through unchanged. Allowed origins are still short-circuited by cors() with
+ * the reflected Origin, exactly as before.
+ */
+export function mountOAuthCorsGate(options: cors.CorsOptions): RequestHandler {
+  const corsMiddleware = cors(options);
+  return (req: Request, res: Response, next: NextFunction) => {
+    corsMiddleware(req, res, (err?: unknown) => {
+      if (err) return next(err as Error);
+      if (req.method === 'OPTIONS') {
+        // Default-deny preflight: no Allow-Origin header, no fall-through.
+        res.statusCode = 204;
+        res.setHeader('Content-Length', '0');
+        return res.end();
+      }
+      return next();
+    });
   };
 }
 
@@ -807,10 +850,15 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],
   };
   app.use('/mcp', cors(corsOAuthOptions));
-  app.use('/token', cors(corsOAuthOptions));
   app.use('/authorize', cors(corsOAuthOptions));
-  app.use('/register', cors(corsOAuthOptions));
-  app.use('/revoke', cors(corsOAuthOptions));
+  // /token, /revoke and /register are shadowed by the MCP SDK's own bare
+  // `cors()` (origin `*`) mounted inside mcpAuthRouter. A denied preflight must
+  // be terminated here — a plain `cors(corsOAuthOptions)` would fall through to
+  // the SDK's `*` (#3845). /mcp and /authorize are not shadowed (no downstream
+  // cors), so they keep the plain gate.
+  app.use('/token', mountOAuthCorsGate(corsOAuthOptions));
+  app.use('/register', mountOAuthCorsGate(corsOAuthOptions));
+  app.use('/revoke', mountOAuthCorsGate(corsOAuthOptions));
 
   // ---------------------------------------------------------------------------
   // Custom client_credentials handler (before mcpAuthRouter)

--- a/test/serve-http-cors.test.ts
+++ b/test/serve-http-cors.test.ts
@@ -14,7 +14,10 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { parseCorsAllowlistOAuth, resolveCorsOrigin } from '../src/commands/serve-http.ts';
+import express from 'express';
+import cors from 'cors';
+import type { Server } from 'http';
+import { parseCorsAllowlistOAuth, resolveCorsOrigin, mountOAuthCorsGate } from '../src/commands/serve-http.ts';
 import { withEnv } from './helpers/with-env.ts';
 
 describe('parseCorsAllowlistOAuth', () => {
@@ -114,5 +117,112 @@ describe('resolveCorsOrigin', () => {
     const calls: Array<boolean | undefined> = [];
     (fn as Function)('https://Claude.AI', (_err: unknown, allow?: boolean) => calls.push(allow));
     expect(calls[0]).toBe(false);
+  });
+});
+
+/**
+ * Integration coverage for #3845.
+ *
+ * The MCP SDK's mcpAuthRouter mounts a bare `cors()` (origin `*`) as the first
+ * middleware on /token, /revoke, and /register. gbrain's own gate runs first,
+ * but with a denied/default-deny origin cors@2.8.x neither sets a header nor
+ * short-circuits — it calls next() — so the SDK's `*` answered the preflight,
+ * leaking the endpoint surface to any web origin.
+ *
+ * These tests wire the REAL exported `mountOAuthCorsGate` in front of a
+ * bare-cors "SDK" router (same ordering as serve-http.ts) and assert the
+ * preflight is default-deny. A plain `cors(oauthOptions)` mount fails every
+ * "no allow-origin" assertion below (that is the pre-fix regression).
+ */
+describe('mountOAuthCorsGate — OAuth preflight is default-deny (#3845)', () => {
+  function buildApp(allowlist: Set<string> | null): express.Express {
+    const oauthOptions: cors.CorsOptions = {
+      origin: resolveCorsOrigin(allowlist),
+      credentials: false,
+      methods: ['GET', 'POST', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],
+    };
+    const app = express();
+    // gbrain gate (runs first) — mirrors serve-http.ts.
+    app.use('/token', mountOAuthCorsGate(oauthOptions));
+    app.use('/revoke', mountOAuthCorsGate(oauthOptions));
+    // Downstream SDK-style router: bare cors() then the POST handler.
+    const sdk = express.Router();
+    sdk.use('/token', cors());
+    sdk.post('/token', (_req, res) => res.json({ ok: true }));
+    sdk.use('/revoke', cors());
+    sdk.post('/revoke', (_req, res) => res.json({ ok: true }));
+    app.use(sdk);
+    return app;
+  }
+
+  async function withServer<T>(
+    allowlist: Set<string> | null,
+    fn: (base: string) => Promise<T>,
+  ): Promise<T> {
+    const server: Server = buildApp(allowlist).listen(0);
+    await new Promise<void>(resolve => server.once('listening', () => resolve()));
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    try {
+      return await fn(`http://127.0.0.1:${port}`);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  }
+
+  function preflight(base: string, path: string, origin: string) {
+    return fetch(`${base}${path}`, {
+      method: 'OPTIONS',
+      headers: { Origin: origin, 'Access-Control-Request-Method': 'POST' },
+    });
+  }
+
+  test('allowlist unset → OPTIONS /token carries no Allow-Origin (was: *)', async () => {
+    await withEnv({ GBRAIN_HTTP_CORS_ORIGIN: undefined }, async () => {
+      await withServer(null, async base => {
+        const res = await preflight(base, '/token', 'https://evil.example');
+        expect(res.headers.get('access-control-allow-origin')).toBeNull();
+        expect(res.status).toBe(204);
+      });
+    });
+  });
+
+  test('allowlist unset → OPTIONS /revoke carries no Allow-Origin (was: *)', async () => {
+    await withServer(null, async base => {
+      const res = await preflight(base, '/revoke', 'https://evil.example');
+      expect(res.headers.get('access-control-allow-origin')).toBeNull();
+      expect(res.status).toBe(204);
+    });
+  });
+
+  test('allowlist set → non-listed Origin preflight is denied (no Allow-Origin)', async () => {
+    await withServer(new Set(['https://claude.ai']), async base => {
+      const res = await preflight(base, '/token', 'https://evil.example');
+      expect(res.headers.get('access-control-allow-origin')).toBeNull();
+      expect(res.status).toBe(204);
+    });
+  });
+
+  test('allowlist set → listed Origin preflight reflects that Origin', async () => {
+    await withServer(new Set(['https://claude.ai']), async base => {
+      const res = await preflight(base, '/token', 'https://claude.ai');
+      expect(res.headers.get('access-control-allow-origin')).toBe('https://claude.ai');
+      expect(res.status).toBe(204);
+    });
+  });
+
+  test('actual POST still reaches the downstream handler (gate only guards preflight)', async () => {
+    await withServer(null, async base => {
+      const res = await fetch(`${base}/token`, {
+        method: 'POST',
+        headers: { Origin: 'https://evil.example', 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      // The gate never touches non-OPTIONS requests — they fall straight
+      // through to the token handler untouched.
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
   });
 });


### PR DESCRIPTION
Fixes #3845.

## Bug

With `GBRAIN_HTTP_CORS_ORIGIN` unset, `gbrain serve --http` intends default-deny CORS on every OAuth endpoint (v0.41.3 T7). The actual-request path is default-deny, but the **OPTIONS preflight on `/token` and `/revoke` returns `Access-Control-Allow-Origin: *`**, leaking the endpoint surface + methods to any web origin and contradicting the documented posture.

```
$ curl -sS -D - -o /dev/null -X OPTIONS http://127.0.0.1:3131/token \
    -H 'Origin: https://evil.example' -H 'Access-Control-Request-Method: POST'
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
```

## Root cause (deeper than the issue's suggested one-liner)

The gate `app.use('/token', cors(corsOAuthOptions))` runs first, but for a denied / default-deny origin **cors@2.8.x does not emit a header and does not short-circuit the preflight — it calls `next()`**. In `cors/lib/index.js`, a falsy `origin` option (our `resolveCorsOrigin(null) === false`) makes `originCallback` null, so the middleware just `next()`s; the allowlist function form does the same via `cb(null, false)` for a denied origin.

Control then reaches the MCP SDK's `mcpAuthRouter`, whose token/revoke/register handlers each mount a **bare `cors()` (origin `*`) as their first middleware**:

```
# @modelcontextprotocol/sdk 1.29.0 — auth/handlers/token.ts, revoke.ts, register.ts
router.use(cors());
router.use(allowedMethods(['POST']));
```

That downstream `cors()` answers the OPTIONS preflight with `*`. `/mcp` and `/authorize` are **not** shadowed (no downstream `cors`; `/authorize` runs `allowedMethods` first → 405), which matches the issue's observations exactly.

I verified that the issue's suggested `resolveCorsOrigin` change (callback form for the null case) **does not fix it** — gbrain's gate still `next()`s for a denied origin, so the SDK's `*` still wins the preflight. Reproduced with an isolated express app mirroring the mount order:

| variant | evil OPTIONS `/token` | claude OPTIONS `/token` |
|---|---|---|
| current / suggested one-liner | `204` + `aco: *` | `204` + `aco: *` |
| **this PR** (allowlist unset) | `204` + `aco: none` | `204` + `aco: none` |
| **this PR** (allowlist=`claude.ai`) | `204` + `aco: none` | `204` + `aco: https://claude.ai` |

## Fix

`mountOAuthCorsGate` wraps `cors()` so the gate **owns** the preflight: `cors()` only reaches the wrapper's callback when it did not short-circuit itself (i.e. the origin was denied, or it is a real non-OPTIONS request). A denied `OPTIONS` is terminated here with a header-free `204`, so the SDK's `cors()` never runs. Allowed origins are still short-circuited by `cors()` with the reflected `Origin`, and real requests fall through unchanged. Applied to the three SDK-shadowed endpoints (`/token`, `/revoke`, `/register`); `/mcp` and `/authorize` keep the plain gate.

## Tests

Extended `test/serve-http-cors.test.ts` with integration coverage that mounts the **real** exported gate in front of a bare-cors SDK stub (same ordering as `serve-http.ts`) and asserts:

- allowlist unset → `OPTIONS /token` and `OPTIONS /revoke` carry **no** `Access-Control-Allow-Origin` (the regression)
- allowlist set → non-listed Origin preflight is denied (no `Allow-Origin`)
- allowlist set → listed Origin preflight reflects that Origin
- real `POST` still reaches the downstream handler

```
$ bun test test/serve-http-cors.test.ts
 18 pass  0 fail  34 expect() calls
```

`tsc --noEmit` is clean; the neighboring `serve-http-*` unit suites (58 tests) pass. No behavior change for same-origin requests, allowed origins, or actual (non-OPTIONS) requests.