### PR TITLE
fix(recall): SQL-side grep + bare-token entity resolution for hosts/projects dirs

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -552,6 +552,15 @@ export interface FactListOpts {
    * are returned. Remote (untrusted) callers must supply ['world'].
    */
   visibility?: FactVisibility[];
+  /**
+   * Case-insensitive substring filter on fact text, applied IN SQL (before
+   * limit). A client-side post-limit grep silently returns nothing for
+   * high-cardinality entities — the match may sit outside the newest-N
+   * window (found by the 2026-08-06 memory eval on an entity with hundreds
+   * of facts). LIKE wildcards in the needle are escaped; plain substring
+   * semantics only.
+   */
+  grep?: string;
 }
 
 /** Per-source operational health snapshot consumed by `gbrain doctor`. */

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -111,7 +111,13 @@ function isBareName(raw: string): boolean {
   return true;
 }
 
-const PREFIX_EXPANSION_DIRS = ['people', 'companies'] as const;
+// hosts/projects joined people/companies after the 2026-08-06 memory eval: a
+// bare infra token ("hive") fell through to slugify and recall returned
+// nothing while the canonical hosts/<token> page + its facts sat one prefix
+// away. `infra/` is deliberately NOT here — it is a mixed namespace of
+// analysis/runbook documents (`infra/hive-dependency-audit-…`), and any such
+// doc would trip the ambiguity gate and re-break bare-token resolution.
+const PREFIX_EXPANSION_DIRS = ['people', 'companies', 'hosts', 'projects'] as const;
 
 /**
  * v0.40.2.0 — resolution-source-tagged variant for trajectory routing.
@@ -311,10 +317,13 @@ async function tryPrefixExpansion(
          FROM pages p
          WHERE p.source_id = $1
            AND p.deleted_at IS NULL
-           AND p.slug LIKE $2
+           AND (p.slug LIKE $2 OR p.slug = $3)
          ORDER BY connection_count DESC, p.slug ASC
          LIMIT 5`,
-        [source_id, pattern],
+        // $3 covers the BARE child (hosts/hive) — the suffixed-only pattern
+        // missed it, so a bare token with an exact canonical page still fell
+        // through to slugify (2026-08-06 memory eval).
+        [source_id, pattern, `${dir}/${token}`],
       );
       if (rows.length === 0) continue;
       // Single unambiguous match: return it.

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4497,7 +4497,7 @@ const recall: Operation = {
     include_expired: { type: 'boolean', description: 'When true, include expired_at IS NOT NULL rows. Default false.' },
     supersessions: { type: 'boolean', description: 'When true, return only the supersession audit log (expired_at + superseded_by both set).' },
     limit: { type: 'number', description: 'Max rows to return. Default 50, cap 100.' },
-    grep: { type: 'string', description: 'Substring filter on fact text (case-insensitive). Applied client-side after recall.' },
+    grep: { type: 'string', description: 'Substring filter on fact text (case-insensitive). Applied in SQL before the limit, so matches on high-cardinality entities are found even outside the newest-N window.' },
     include_pending: { type: 'boolean', description: 'v0.32: when true, response includes pending_consolidation_count (facts not yet promoted to takes by the dream-cycle consolidate phase). One round trip; backward-compatible (field omitted when false).' },
   },
   scope: 'read',
@@ -4527,12 +4527,14 @@ const recall: Operation = {
         activeOnly: !includeExpired,
         limit,
         visibility,
+        grep: grep ?? undefined,
       });
     } else if (typeof p.session_id === 'string' && p.session_id.length > 0) {
       rows = await ctx.engine.listFactsBySession(sourceId, p.session_id, {
         activeOnly: !includeExpired,
         limit,
         visibility,
+        grep: grep ?? undefined,
       });
     } else if (p.since !== undefined) {
       const since = parseSinceParam(p.since);
@@ -4541,6 +4543,7 @@ const recall: Operation = {
           activeOnly: !includeExpired,
           limit,
           visibility,
+          grep: grep ?? undefined,
         });
       }
     } else {
@@ -4549,10 +4552,15 @@ const recall: Operation = {
         activeOnly: !includeExpired,
         limit,
         visibility,
+        grep: grep ?? undefined,
       });
     }
 
-    if (grep) rows = rows.filter(r => r.fact.toLowerCase().includes(grep));
+    // Engines apply grep in SQL (pre-limit). This client-side pass stays only
+    // as the filter for the supersessions branch, which bypasses FactListOpts.
+    if (grep && p.supersessions === true) {
+      rows = rows.filter(r => r.fact.toLowerCase().includes(grep));
+    }
 
     // v0.32: optional pending-consolidation count piggy-backed on the recall
     // response. Single round trip on thin-client; omitted when not requested

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4674,6 +4674,13 @@ export class PGLiteEngine implements BrainEngine {
       whereParts.push(`visibility = ANY($visibility)`);
       params.visibility = opts.visibility;
     }
+    if (opts.grep && opts.grep.trim()) {
+      // SQL-side substring filter (before limit) — a client-side post-limit
+      // grep silently misses matches outside the newest-N window on
+      // high-cardinality entities. Parity with the postgres engine.
+      whereParts.push(`fact ILIKE $grepPat ESCAPE '\\'`);
+      params.grepPat = '%' + escapeLikePattern(opts.grep.trim()) + '%';
+    }
     for (const c of opts.whereClauses ?? []) whereParts.push(c);
     Object.assign(params, opts.whereParams ?? {});
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -93,6 +93,7 @@ import { DELETE_BATCH_SIZE } from './engine-constants.ts';
 import { SOURCE_CONFIG_OBJECT_SQL } from './source-config-sql.ts';
 import { shouldExcludeFromOrphanReporting, loadOrphanPolicyOverrides } from './orphan-policy.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from './link-extraction.ts';
+import { escapeLikePattern } from './cjk.ts';
 
 function escapeSqlStringLiteral(value: string): string {
   return value.replace(/'/g, "''");
@@ -4564,6 +4565,7 @@ export class PostgresEngine implements BrainEngine {
     const activeOnly = opts?.activeOnly !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
+    const grepPat = (opts?.grep && opts.grep.trim()) ? '%' + escapeLikePattern(opts.grep.trim()) + '%' : null;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
@@ -4571,6 +4573,7 @@ export class PostgresEngine implements BrainEngine {
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${grepPat ? sql`AND fact ILIKE ${grepPat} ESCAPE '\\'` : sql``}
       ORDER BY valid_from DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -4588,6 +4591,7 @@ export class PostgresEngine implements BrainEngine {
     const activeOnly = opts?.activeOnly !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
+    const grepPat = (opts?.grep && opts.grep.trim()) ? '%' + escapeLikePattern(opts.grep.trim()) + '%' : null;
     const entitySlug = opts?.entitySlug ?? null;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
@@ -4597,6 +4601,7 @@ export class PostgresEngine implements BrainEngine {
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${grepPat ? sql`AND fact ILIKE ${grepPat} ESCAPE '\\'` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -4614,6 +4619,7 @@ export class PostgresEngine implements BrainEngine {
     const activeOnly = opts?.activeOnly !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
+    const grepPat = (opts?.grep && opts.grep.trim()) ? '%' + escapeLikePattern(opts.grep.trim()) + '%' : null;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
@@ -4621,6 +4627,7 @@ export class PostgresEngine implements BrainEngine {
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${grepPat ? sql`AND fact ILIKE ${grepPat} ESCAPE '\\'` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;


### PR DESCRIPTION
## What

Two `recall` retrieval defects found by a live memory eval (retrieval-QA probes over a brain with ~20k extracted conversation facts):

**1. `grep` filtered client-side AFTER the limit.** On a high-cardinality entity (hundreds of facts), the matching fact sits outside the newest-N window, so `recall --entity X --grep needle` returns empty while the fact exists — indistinguishable from "not in memory". The filter now lands in SQL (`fact ILIKE`, wildcards escaped via the existing `escapeLikePattern`) in all three fact-list methods of **both engines** (parity preserved); `FactListOpts.grep` documents the contract. The handler's client-side pass survives only for the supersessions branch, which bypasses `FactListOpts`.

**2. Bare tokens with a canonical `hosts/<token>` page fell through to slugify.** Prefix expansion only tried `people/` and `companies/`, and its LIKE pattern matched *suffixed* children only (`<dir>/<token>-%`), so an exact bare-child page (`hosts/boxname`) was invisible. `hosts/` and `projects/` joined `PREFIX_EXPANSION_DIRS`, and the expansion SQL now also matches `<dir>/<token>` exactly. A docs-heavy namespace (`infra/`) was tried and deliberately excluded — its analysis pages (`infra/<token>-audit-…`) trip the ambiguity gate and re-break resolution; the comment in the code pins that reasoning.

## Verification

- Typecheck clean on top of upstream master (0 errors).
- `entity-resolve-slug-fallback` / `recall-extensions` / `facts-engine` suites green (35 tests).
- Verified live over MCP on a production brain: both previously-empty probes (`grep` on a hundreds-of-facts entity; bare host token) now return the facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)