### PR TITLE
fix(security): fail-closed facts visibility — omitted remote flag reads world-only

### DIFF
--- a/src/commands/eval-trajectory.ts
+++ b/src/commands/eval-trajectory.ts
@@ -139,6 +139,8 @@ export async function runEvalTrajectory(engine: BrainEngine, args: string[]): Pr
       since: parsed.since,
       until: parsed.until,
       limit: parsed.limit,
+      // Fail-closed trust: local CLI must say so explicitly.
+      remote: false,
     });
     const { regressions, drift_score } = computeTrajectoryStats(points);
     result = {

--- a/src/commands/founder-scorecard.ts
+++ b/src/commands/founder-scorecard.ts
@@ -305,6 +305,8 @@ export async function runFounder(engine: BrainEngine, args: string[]): Promise<v
       kind: 'metric',
       since: windowSince,
       until: windowUntil,
+      // Fail-closed trust: local CLI must say so explicitly.
+      remote: false,
     });
     let takes: Take[] = [];
     try {

--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -133,6 +133,9 @@ prints what would have been the input (exit 0).
     try {
       result = await runThink(engine, {
         question, anchor, rounds, save, take, model, since, until,
+        // Fail-closed trust: local CLI must say so explicitly, or trajectory
+        // injection degrades to visibility='world' rows.
+        remote: false,
         // #1698: explicit --model → hard error on an unresolvable model (no silent
         // degrade to the no-LLM stub). Omitting --model keeps the graceful default path.
         modelExplicit: !!model,

--- a/src/core/cycle/auto-think.ts
+++ b/src/core/cycle/auto-think.ts
@@ -163,6 +163,9 @@ export async function runPhaseAutoThink(
         save: config.autoCommit,
         client: opts.client,
         model: modelId,
+        // Fail-closed trust: the local dream cycle must say so explicitly, or
+        // trajectory injection degrades to visibility='world' rows.
+        remote: false,
       });
       // #1698: an empty synthesis (no LLM available / malformed output / empty-JSON answer)
       // must NOT count as complete or advance the cooldown — that is the same silent-success

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -589,7 +589,11 @@ export interface TrajectoryOpts {
   sourceId?: string;
   /** Federated array scope (mutually exclusive with sourceId; the array wins when set). */
   sourceIds?: string[];
-  /** When true, filters to visibility='world' only. Set by MCP layer from ctx.remote. */
+  /**
+   * Filters to visibility='world' unless strictly `false`. FAIL-CLOSED: an
+   * omitted flag means world-only, so trusted local callers must pass
+   * `remote: false` explicitly.
+   */
   remote?: boolean;
   /** Metric filter. When set, only facts with this canonical metric label participate. */
   metric?: string;

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2298,7 +2298,8 @@ const think: Operation = {
       until: p.until ? String(p.until) : undefined,
       takesHoldersAllowList: ctx.takesHoldersAllowList,
       ...thinkScope,
-      remote: ctx.remote === true,
+      // Fail-closed: only a context that explicitly says local gets local.
+      remote: ctx.remote !== false,
     });
 
     // Persist if --save was passed locally
@@ -4135,7 +4136,8 @@ const find_trajectory: Operation = {
     const points = await ctx.engine.findTrajectory({
       entitySlug: p.entity_slug,
       ...scope,
-      remote: ctx.remote === true,
+      // Fail-closed: only a context that explicitly says local gets local.
+      remote: ctx.remote !== false,
       metric,
       kind,
       since,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4509,7 +4509,10 @@ export class PGLiteEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    // Fail-closed (CV6 / v0.26.9 F7b posture): anything not strictly local
+    // is remote. An omitted flag (cast-bypassed context, caller that forgot
+    // to thread it) degrades to world-only reads, never to a private-fact leak.
+    const remoteFilter = opts.remote !== false;
 
     // Build SQL dynamically. PGLite uses $N positional params; we
     // assemble the WHERE clauses + params array in tandem to keep them

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4704,7 +4704,10 @@ export class PostgresEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    // Fail-closed (CV6 / v0.26.9 F7b posture): anything not strictly local
+    // is remote. An omitted flag (cast-bypassed context, caller that forgot
+    // to thread it) degrades to world-only reads, never to a private-fact leak.
+    const remoteFilter = opts.remote !== false;
 
     // Source-scope predicate: array path (federated) wins over scalar.
     // Engine.ts contract: returns chronological points; regressions +

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -107,9 +107,11 @@ export interface RunThinkOpts {
    */
   allowedSources?: string[];
   /**
-   * v0.40.2.0 — scalar projection of `OperationContext.remote`. When
-   * true, trajectory queries apply `visibility='world'` filter (mirrors
-   * the recall posture for untrusted callers). CLI defaults to false.
+   * v0.40.2.0 — scalar projection of `OperationContext.remote`. Trajectory
+   * queries apply the `visibility='world'` filter unless this is strictly
+   * `false` (FAIL-CLOSED). Every trusted caller (CLI, dream cycle) passes
+   * `remote: false` explicitly; omitting it degrades trajectory injection
+   * to world-only rows.
    */
   remote?: boolean;
 }

--- a/test/e2e/think-trajectory-pglite.test.ts
+++ b/test/e2e/think-trajectory-pglite.test.ts
@@ -140,6 +140,7 @@ describe('e2e/think-trajectory: temporal intent end-to-end', () => {
     const { client, captured } = captureClient();
 
     const result = await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -164,6 +165,7 @@ describe('e2e/think-trajectory: temporal intent end-to-end', () => {
     const { client, captured } = captureClient();
 
     await runThink(engine, {
+      remote: false,
       question: 'What is the current role for marco?',
       client,
     });
@@ -182,6 +184,7 @@ describe('e2e/think-trajectory: other intent short-circuits', () => {
     const { client, captured } = captureClient();
 
     await runThink(engine, {
+      remote: false,
       question: 'Summarize the company',
       client,
     });
@@ -201,6 +204,7 @@ describe('e2e/think-trajectory: kill switch via think.trajectory_enabled', () =>
 
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -218,6 +222,7 @@ describe('e2e/think-trajectory: empty brain (no facts) graceful no-op', () => {
     const { client, captured } = captureClient();
 
     const result = await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -235,6 +240,7 @@ describe('e2e/think-trajectory: multi-entity ordering deterministic', () => {
 
     // Question references both Marco and Acme — both have facts.
     await runThink(engine, {
+      remote: false,
       question: 'when did marco at acme last change roles',
       client,
     });
@@ -273,6 +279,7 @@ describe('e2e/think-trajectory: prompt sanitization end-to-end', () => {
 
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did I meet eve?',
       client,
     });

--- a/test/engine-find-trajectory.test.ts
+++ b/test/engine-find-trajectory.test.ts
@@ -108,7 +108,7 @@ describe('findTrajectory — chronological ordering (R3)', () => {
     const idJan = await insertTyped({ entity_slug: 'traj-order', metric: 'mrr', value: 50000,  valid_from: new Date('2026-01-15') });
     const idApr = await insertTyped({ entity_slug: 'traj-order', metric: 'mrr', value: 200000, valid_from: new Date('2026-04-12') });
 
-    const points = await engine.findTrajectory({ entitySlug: 'traj-order' });
+    const points = await engine.findTrajectory({ entitySlug: 'traj-order', remote: false });
     expect(points.map(p => p.fact_id)).toEqual([idJan, idApr, idJul]);
     expect(points[0].valid_from.toISOString().slice(0, 10)).toBe('2026-01-15');
     expect(points[2].valid_from.toISOString().slice(0, 10)).toBe('2026-07-08');
@@ -120,11 +120,11 @@ describe('findTrajectory — source scoping (D-CDX-6)', () => {
     await insertTyped({ source_id: 'traj-src-A', entity_slug: 'traj-srcscope', metric: 'mrr', value: 50000, valid_from: new Date('2026-01-15') });
     await insertTyped({ source_id: 'traj-src-B', entity_slug: 'traj-srcscope', metric: 'mrr', value: 99999, valid_from: new Date('2026-01-15') });
 
-    const pointsA = await engine.findTrajectory({ entitySlug: 'traj-srcscope', sourceId: 'traj-src-A' });
+    const pointsA = await engine.findTrajectory({ entitySlug: 'traj-srcscope', sourceId: 'traj-src-A', remote: false });
     expect(pointsA.length).toBe(1);
     expect(pointsA[0].value).toBe(50000);
 
-    const pointsB = await engine.findTrajectory({ entitySlug: 'traj-srcscope', sourceId: 'traj-src-B' });
+    const pointsB = await engine.findTrajectory({ entitySlug: 'traj-srcscope', sourceId: 'traj-src-B', remote: false });
     expect(pointsB.length).toBe(1);
     expect(pointsB[0].value).toBe(99999);
   });
@@ -137,6 +137,7 @@ describe('findTrajectory — source scoping (D-CDX-6)', () => {
     const points = await engine.findTrajectory({
       entitySlug: 'traj-fed',
       sourceIds: ['traj-src-A', 'traj-src-B'],
+      remote: false,
     });
     // Two of three sources visible, in chronological order.
     expect(points.length).toBe(2);
@@ -157,13 +158,16 @@ describe('findTrajectory — visibility filter (D-CDX-1 / R6)', () => {
     expect(remote[0].value).toBe(99999);
   });
 
-  test('remote default (undefined) is treated as trusted — sees both', async () => {
+  test('FAIL-CLOSED: remote default (undefined) is world-only — private rows hidden', async () => {
     await insertTyped({ entity_slug: 'traj-vis-default', metric: 'mrr', value: 50000, visibility: 'private', valid_from: new Date('2026-01-15') });
     await insertTyped({ entity_slug: 'traj-vis-default', metric: 'mrr', value: 99999, visibility: 'world',   valid_from: new Date('2026-04-12') });
 
-    // No `remote` field — engine default must be trusted.
-    const all = await engine.findTrajectory({ entitySlug: 'traj-vis-default' });
-    expect(all.length).toBe(2);
+    // No `remote` field — fail-closed: an omitted flag (cast-bypassed
+    // context, forgotten threading) must degrade to world-only, never leak
+    // private rows.
+    const worldOnly = await engine.findTrajectory({ entitySlug: 'traj-vis-default' });
+    expect(worldOnly.length).toBe(1);
+    expect(worldOnly[0].value).toBe(99999);
   });
 });
 
@@ -172,7 +176,7 @@ describe('findTrajectory — metric + since + until filters', () => {
     await insertTyped({ entity_slug: 'traj-m', metric: 'mrr', value: 50000, valid_from: new Date('2026-01-15') });
     await insertTyped({ entity_slug: 'traj-m', metric: 'arr', value: 600000, valid_from: new Date('2026-01-15') });
 
-    const mrrOnly = await engine.findTrajectory({ entitySlug: 'traj-m', metric: 'mrr' });
+    const mrrOnly = await engine.findTrajectory({ entitySlug: 'traj-m', metric: 'mrr', remote: false });
     expect(mrrOnly.length).toBe(1);
     expect(mrrOnly[0].metric).toBe('mrr');
   });
@@ -186,6 +190,7 @@ describe('findTrajectory — metric + since + until filters', () => {
       entitySlug: 'traj-w',
       since: '2026-02-01',
       until: '2026-05-01',
+      remote: false,
     });
     expect(inWindow.length).toBe(1);
     expect(inWindow[0].value).toBe(99999);

--- a/test/engine-parity-event-type.test.ts
+++ b/test/engine-parity-event-type.test.ts
@@ -51,7 +51,7 @@ describe('PGLite — facts.event_type round-trip', () => {
     `);
 
     // kind: 'all' (default) returns all three
-    const all = await engine.findTrajectory({ entitySlug: 'people/alice' });
+    const all = await engine.findTrajectory({ entitySlug: 'people/alice', remote: false });
     expect(all.length).toBe(3);
 
     // Find the event row and assert event_type round-trips
@@ -78,6 +78,7 @@ describe('PGLite — facts.event_type round-trip', () => {
     const points = await engine.findTrajectory({
       entitySlug: 'people/alice',
       kind: 'metric',
+      remote: false,
     });
     expect(points.length).toBe(1);
     expect(points[0].metric).toBe('mrr');
@@ -88,6 +89,7 @@ describe('PGLite — facts.event_type round-trip', () => {
     const points = await engine.findTrajectory({
       entitySlug: 'people/alice',
       kind: 'event',
+      remote: false,
     });
     expect(points.length).toBe(1);
     expect(points[0].metric).toBeNull();
@@ -98,14 +100,15 @@ describe('PGLite — facts.event_type round-trip', () => {
     const explicit = await engine.findTrajectory({
       entitySlug: 'people/alice',
       kind: 'all',
+      remote: false,
     });
-    const implicit = await engine.findTrajectory({ entitySlug: 'people/alice' });
+    const implicit = await engine.findTrajectory({ entitySlug: 'people/alice', remote: false });
     expect(explicit.length).toBe(implicit.length);
     expect(explicit.length).toBe(3);
   });
 
   test('chronological ordering preserved when mixed metric + event rows', async () => {
-    const points = await engine.findTrajectory({ entitySlug: 'people/alice' });
+    const points = await engine.findTrajectory({ entitySlug: 'people/alice', remote: false });
     expect(points.length).toBe(3);
     // 2026-01-01 → 2026-02-15 → 2026-03-01
     expect(points[0].valid_from.toISOString().slice(0, 10)).toBe('2026-01-01');
@@ -119,6 +122,7 @@ describe('PGLite — facts.event_type round-trip', () => {
     const points = await engine.findTrajectory({
       entitySlug: 'people/alice',
       metric: 'mrr',
+      remote: false,
     });
     expect(points.length).toBe(1);
     expect(points[0].metric).toBe('mrr');

--- a/test/operations-find-trajectory.test.ts
+++ b/test/operations-find-trajectory.test.ts
@@ -147,6 +147,23 @@ describe('find_trajectory MCP op — visibility filter (R6 / D-CDX-1)', () => {
     expect(remote.points.length).toBe(1);
     expect(remote.points[0].value).toBe(99999);
   });
+
+  test('FAIL-CLOSED cast bypass: a context missing `remote` is world-only (F7b)', async () => {
+    await insertTyped({ entity_slug: 'optraj-vis-bypass', metric: 'mrr', value: 50000, visibility: 'private', valid_from: new Date('2026-01-15') });
+    await insertTyped({ entity_slug: 'optraj-vis-bypass', metric: 'mrr', value: 99999, visibility: 'world',   valid_from: new Date('2026-04-12') });
+
+    const op = operationsByName['find_trajectory'];
+    // Simulate the type bypass this fix closes: a widened context (Partial<>
+    // cast) whose `remote` was never threaded. If the ops-layer coercion ever
+    // regresses to `ctx.remote === true`, this context becomes an explicit
+    // remote: false and reads the private row — the exact leak class F7b
+    // closed for whoami. It must degrade to world-only instead.
+    const ctx = mkCtx();
+    delete (ctx as any).remote;
+    const result = await op.handler(ctx, { entity_slug: 'optraj-vis-bypass' }) as any;
+    expect(result.points.length).toBe(1);
+    expect(result.points[0].value).toBe(99999);
+  });
 });
 
 describe('find_trajectory MCP op — source scoping (D-CDX-6)', () => {

--- a/test/regressions/v0_40_2_0-trajectory-backcompat.test.ts
+++ b/test/regressions/v0_40_2_0-trajectory-backcompat.test.ts
@@ -60,6 +60,7 @@ describe('v0.40.2.0 back-compat — event rows ignored by metric callers', () =>
     // Pull all points (kind:'all' default) — includes the event row.
     const allPoints = await engine.findTrajectory({
       entitySlug: 'companies/acme-test',
+      remote: false,
     });
     expect(allPoints.length).toBe(4);
     expect(allPoints.some(p => p.event_type === 'meeting')).toBe(true);
@@ -68,6 +69,7 @@ describe('v0.40.2.0 back-compat — event rows ignored by metric callers', () =>
     const metricPoints = await engine.findTrajectory({
       entitySlug: 'companies/acme-test',
       kind: 'metric',
+      remote: false,
     });
     expect(metricPoints.length).toBe(3);
     expect(metricPoints.every(p => p.event_type === null)).toBe(true);
@@ -85,6 +87,7 @@ describe('v0.40.2.0 back-compat — event rows ignored by metric callers', () =>
   test('computeFounderScorecard ignores event rows in per-metric math', async () => {
     const allPoints = await engine.findTrajectory({
       entitySlug: 'companies/acme-test',
+      remote: false,
     });
 
     const withEventRows = computeFounderScorecard({
@@ -113,6 +116,7 @@ describe('v0.40.2.0 back-compat — event rows ignored by metric callers', () =>
   test('founder-scorecard math does not throw NaN on mixed input', async () => {
     const allPoints = await engine.findTrajectory({
       entitySlug: 'companies/acme-test',
+      remote: false,
     });
     const scorecard = computeFounderScorecard({
       entitySlug: 'companies/acme-test',
@@ -129,6 +133,7 @@ describe('v0.40.2.0 back-compat — event rows ignored by metric callers', () =>
   test('kind: "all" returns event row in chronological position', async () => {
     const points = await engine.findTrajectory({
       entitySlug: 'companies/acme-test',
+      remote: false,
     });
     // Chronological order: 2026-01-01, 2026-04-01, 2026-05-15 (event), 2026-07-01
     expect(points.map(p => p.valid_from.toISOString().slice(0, 10))).toEqual([

--- a/test/think-trajectory-injection.test.ts
+++ b/test/think-trajectory-injection.test.ts
@@ -87,6 +87,7 @@ describe('runThink — trajectory injection happy path', () => {
   test('temporal intent → trajectory block appears in user message', async () => {
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -99,6 +100,7 @@ describe('runThink — trajectory injection happy path', () => {
   test('"other" intent → no trajectory block', async () => {
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'Summarize the deal pipeline',
       client,
     });
@@ -112,6 +114,7 @@ describe('runThink — kill switches', () => {
   test('withTrajectory: false bypasses injection even for temporal intent', async () => {
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
       withTrajectory: false,
@@ -126,6 +129,7 @@ describe('runThink — kill switches', () => {
     );
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -145,6 +149,7 @@ describe('runThink — empty trajectory short-circuits', () => {
     });
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did empty last visit?',
       client,
     });
@@ -168,6 +173,7 @@ describe('runThink — graceful degradation', () => {
     try {
       const { client, captured } = captureClient();
       const result = await runThink(engine, {
+        remote: false,
         question: 'When did Marco last switch jobs?',
         client,
       });
@@ -189,6 +195,7 @@ describe('runThink — trajectory points count exposed via warnings', () => {
   test('successful injection records TRAJECTORY_INJECTED_*_POINTS warning', async () => {
     const { client } = captureClient();
     const result = await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
     });
@@ -218,6 +225,7 @@ describe('runThink — calibration-mode trajectory placement', () => {
   test('default mode: trajectory block lands AFTER retrieved blocks, BEFORE instruction', async () => {
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
       // No withCalibration → default-mode prompt assembly.
@@ -266,6 +274,7 @@ describe('runThink — calibration-mode trajectory placement', () => {
 
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did Marco last switch jobs?',
       client,
       withCalibration: true,
@@ -303,6 +312,7 @@ describe('runThink — calibration-mode trajectory placement', () => {
     // shape is unchanged from the v0.36 baseline.
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'Summarize the deal pipeline',
       client,
       withCalibration: true,
@@ -351,6 +361,7 @@ describe('runThink — resolution_source != fallback_slugify gate', () => {
 
     const { client, captured } = captureClient();
     await runThink(engine, {
+      remote: false,
       question: 'When did I last meet zelda?',
       client,
     });


### PR DESCRIPTION
## Problem

`findTrajectory`'s visibility filter keys on `opts.remote === true` (both engines), and the `think` / `find_trajectory` op handlers thread it as `remote: ctx.remote === true`. That polarity is fail-open: a context that loses its `remote` flag (a widening cast, a caller that forgets to thread it) reads `visibility='private'` fact rows.

This contradicts the repo's own stated trust posture. `put_page`'s coercion a few hundred lines up says it directly: *"Fail-closed — anything not strictly local is remote (matches CV6 / v0.26.9 F7b posture)"* — and F7b closed exactly this cast-bypass class for whoami. The facts read path is the one surface still keying trust on strict-true.

## Fix

- Both engines: `remoteFilter = opts.remote !== false`
- Ops layer: `remote: ctx.remote !== false` in the `think` and `find_trajectory` handlers
- Every trusted local caller now says so explicitly (`remote: false`): CLI `think`, the auto-think dream cycle, `founder-scorecard`, `eval-trajectory` (`eval-longmemeval` already did)
- `TrajectoryOpts.remote` / `ThinkOpts.remote` docs state the fail-closed contract
- The facts meta-hook (`meta-hook.ts`) was already fail-closed and is untouched

Behavior is unchanged for every caller that threads the flag: `remote: true` still filters to world, `remote: false` still sees all rows. Only the ambiguous-context default moves — from private-leak to world-only.

## Tests

- `engine-find-trajectory.test.ts`: the `remote default (undefined) is treated as trusted` pin is inverted to pin fail-closed (undefined → world-only, private rows hidden)
- Trajectory/think test callers gain explicit `remote: false` so each test keeps its original intent
- 71 tests across the 8 affected files pass; `tsc --noEmit` clean

## Noted, deliberately out of scope

`operations.ts` has one more strict-true trust site in the same class: the fence-strip trigger `const isUntrustedReader = ctx.remote === true` (v0.32.2). An ambiguous context skips fence stripping there. Left out to keep this PR's surface reviewable; happy to follow up.