### PR TITLE
feat(write-through): add sync.write_through opt-out flag for DB-only brains

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -963,6 +963,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'sync',
   'sync.repo_path',
   'sync.last_commit',
+  // Opt-out for the put_page/capture disk write-through (write-through.ts):
+  // 'false' makes every page write DB-only. For brains whose host repo is a
+  // shared working tree where stray root-level .md artifacts are unwanted.
+  'sync.write_through',
   // Gateway-native subagent loop toggle (routes subagent jobs through the
   // provider-agnostic gateway.toolLoop for non-Anthropic providers). The
   // subagent handler's error message tells users to `config set` this, so it

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -46,6 +46,10 @@ export interface WriteThroughResult {
   committed?: boolean;
   /**
    * Non-error reasons the file was not written:
+   *   - disabled_by_config: `sync.write_through` is set to 'false' — the brain
+   *     is DB-only by operator choice (e.g. the host repo is a shared working
+   *     tree where stray root-level `.md` artifacts are unwanted). Checked
+   *     before any FS or DB work.
    *   - no_repo_configured: the resolved target (source `local_path` or, for a
    *     sole-source brain, `sync.repo_path`) is unset (DB-only by design).
    *   - repo_not_found: target set but missing / not a directory.
@@ -61,7 +65,7 @@ export interface WriteThroughResult {
    *     differently-cased entry that the FS folds onto this page's file, so
    *     writing would silently clobber the OTHER slug's file (#2831) — refused.
    */
-  skipped?: 'no_repo_configured' | 'repo_not_found' | 'source_repo_belongs_to_other_source' | 'page_not_found_after_write' | 'path_escapes_source_root' | 'case_insensitive_collision';
+  skipped?: 'disabled_by_config' | 'no_repo_configured' | 'repo_not_found' | 'source_repo_belongs_to_other_source' | 'page_not_found_after_write' | 'path_escapes_source_root' | 'case_insensitive_collision';
   /** Set when the render/write/rename itself threw (EACCES, ENOTDIR, disk full). */
   error?: string;
 }
@@ -86,6 +90,14 @@ export async function writePageThrough(
 ): Promise<WriteThroughResult> {
   const sourceId = opts.sourceId ?? 'default';
   try {
+    // Opt-out flag: `sync.write_through=false` makes every page write DB-only,
+    // for brains whose host repo is a shared working tree where per-page `.md`
+    // artifacts are unwanted. Mirrors the `=== 'true'` opt-in convention used
+    // elsewhere (search.mcp_keyword_only, autopilot.*): only the explicit
+    // string 'false' disables; unset or any other value keeps the default.
+    if ((await engine.getConfig('sync.write_through')) === 'false') {
+      return { written: false, skipped: 'disabled_by_config' };
+    }
     // #2018: pick the disk target so a page is NEVER written into a different
     // source's working tree. Two legitimate topologies, plus the leak guard:
     //   1. The assigned source has its OWN `local_path` (a separate working

--- a/test/write-through.test.ts
+++ b/test/write-through.test.ts
@@ -120,6 +120,57 @@ describe('writePageThrough', () => {
     expect(res).toEqual({ written: false, skipped: 'page_not_found_after_write' });
   });
 
+  test('sync.write_through=false → skipped disabled_by_config, nothing touches disk', async () => {
+    // Everything else is configured for a successful write — the flag alone
+    // must stop it, proving the gate runs before any FS work.
+    await engine.setConfig('sync.repo_path', brainDir);
+    await engine.setConfig('sync.write_through', 'false');
+    const slug = 'wiki/ideas/db-only-note';
+    await seedPage(slug);
+
+    const res = await writePageThrough(engine, slug, { sourceId: 'default' });
+
+    expect(res).toEqual({ written: false, skipped: 'disabled_by_config' });
+    expect(walkFiles(brainDir).some((f) => f.endsWith('.md'))).toBe(false);
+    // The DB row stays the durable sink.
+    expect(await engine.getPage(slug, { sourceId: 'default' })).not.toBeNull();
+  });
+
+  test('sync.write_through=false also gates the per-source local_path branch', async () => {
+    const alphaDir = path.join(tmpRoot, 'alpha-flag-repo');
+    fs.mkdirSync(alphaDir, { recursive: true });
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config) VALUES ('alpha', 'Alpha', $1, '{}'::jsonb)`,
+      [alphaDir],
+    );
+    await engine.setConfig('sync.write_through', 'false');
+
+    const slug = 'notes/alpha-db-only';
+    await importFromContent(engine, slug, `---\ntitle: T\ntype: note\n---\n\n# Body\n`, {
+      noEmbed: true,
+      sourceId: 'alpha',
+      sourcePath: `${slug}.md`,
+    });
+
+    const res = await writePageThrough(engine, slug, { sourceId: 'alpha' });
+
+    expect(res).toEqual({ written: false, skipped: 'disabled_by_config' });
+    expect(walkFiles(alphaDir).some((f) => f.endsWith('.md'))).toBe(false);
+  });
+
+  test('sync.write_through unset or any non-"false" value keeps the default write-through behavior', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    // Explicit 'true' — same as unset (the flag is an opt-out).
+    await engine.setConfig('sync.write_through', 'true');
+    const slug = 'wiki/ideas/still-written';
+    await seedPage(slug);
+
+    const res = await writePageThrough(engine, slug, { sourceId: 'default' });
+
+    expect(res.written).toBe(true);
+    expect(fs.existsSync(res.path!)).toBe(true);
+  });
+
   test('[REGRESSION #2018] default page (null local_path) in a multi-source brain → skipped, no leak into a sibling source repo', async () => {
     // A sibling federated source with its OWN working tree.
     const siblingDir = path.join(tmpRoot, 'housefax');


### PR DESCRIPTION
## What

Adds a `sync.write_through` config flag (opt-out, default unchanged) checked at the top of `writePageThrough` before any FS or DB work:

```bash
gbrain config set sync.write_through false   # every page write is DB-only
gbrain config set sync.write_through true    # (or unset) today's behavior
```

Skips surface as a new `skipped: 'disabled_by_config'` variant so callers (`put_page` MCP result, capture, brainstorm/lsd --save) report *why* no file appeared instead of silently not writing.

## Why

When the brain's `default` source is a **shared working tree** — a team's actual code repository indexed for code-aware recall — every `put_page` drops a rendered `.md` at the repo root. Each agent session journaling to the brain leaves stray root-level files that pollute `git status` for every collaborator and every CI diff.

Today there is no supported way out: unsetting the source's `local_path` kills sync entirely, and the #2018 leak-guard only covers the *cross-source* topology. We hit this running gbrain against a live monorepo (the exact setup INSTALL_FOR_AGENTS.md encourages): 3 stray root files in one day across parallel agent sessions.

Only the explicit string `'false'` disables — mirroring the existing string-compare convention (`search.mcp_keyword_only`, `autopilot.*`). The DB row remains the durable sink; `gbrain sync` reconciliation is unaffected.

## Tests

TDD (red first): three new cases in `test/write-through.test.ts` —
- flag off gates the `sync.repo_path` branch: `disabled_by_config`, nothing on disk, DB row intact;
- flag off gates the per-source `local_path` branch too (the check runs before target resolution);
- explicit `'true'` / unset keeps the default write-through behavior.

`bun test test/write-through.test.ts test/ingestion/put-page-write-through.test.ts` → **22 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)