### PR TITLE
fix: source-scope get_recent_salience and find_anomalies

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3837,11 +3837,18 @@ const get_recent_salience: Operation = {
   },
   handler: async (ctx, p) => {
     const recencyBias = p.recency_bias === 'on' ? 'on' : 'flat';
+    // Scope by the caller's source (canonical sourceScopeOpts ladder: federated
+    // array > scalar > nothing), matching find_orphans/find_experts. Pre-fix
+    // this op returned brain-wide salience regardless of a source-bound OAuth
+    // client's grant — a read leak in the v0.34.1 (#861) source-isolation class
+    // that the v0.29 salience/anomaly batch missed. Trusted local callers
+    // (ctx.remote === false) still get the empty scope = full brain.
     return ctx.engine.getRecentSalience({
       days: typeof p.days === 'number' ? p.days : undefined,
       limit: typeof p.limit === 'number' ? p.limit : undefined,
       slugPrefix: typeof p.slugPrefix === 'string' ? p.slugPrefix : undefined,
       recency_bias: recencyBias,
+      ...sourceScopeOpts(ctx),
     });
   },
   cliHints: { name: 'salience' },
@@ -3959,10 +3966,16 @@ const find_anomalies: Operation = {
     },
   },
   handler: async (ctx, p) => {
+    // Scope by the caller's source (same v0.34.1 #861 source-isolation class as
+    // get_recent_salience above — the v0.29 batch missed both). Applied to the
+    // baseline AND today windows inside the engine so the anomaly math stays
+    // self-consistent. Trusted local callers (ctx.remote === false) get the
+    // empty scope = full brain.
     return ctx.engine.findAnomalies({
       since: typeof p.since === 'string' ? p.since : undefined,
       lookback_days: typeof p.lookback_days === 'number' ? p.lookback_days : undefined,
       sigma: typeof p.sigma === 'number' ? p.sigma : undefined,
+      ...sourceScopeOpts(ctx),
     });
   },
   cliHints: { name: 'anomalies' },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -6072,6 +6072,16 @@ export class PGLiteEngine implements BrainEngine {
     const excludeBriefings = !(slugPrefix && slugPrefix.startsWith('briefings'))
       ? `AND p.slug NOT LIKE 'briefings/%'`
       : '';
+    // Source scope: array wins over scalar (canonical precedence). Parity with
+    // postgres-engine.getRecentSalience() and listEnrichCandidates().
+    let sourceCondition = '';
+    if (opts.sourceIds && opts.sourceIds.length > 0) {
+      params.push(opts.sourceIds);
+      sourceCondition = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts.sourceId) {
+      params.push(opts.sourceId);
+      sourceCondition = `AND p.source_id = $${params.length}`;
+    }
     params.push(limit);
     const limitParam = `$${params.length}`;
 
@@ -6107,6 +6117,7 @@ export class PGLiteEngine implements BrainEngine {
         WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= $1::timestamptz
           ${prefixCondition}
           ${excludeBriefings}
+          ${sourceCondition}
         GROUP BY p.id
         ORDER BY score DESC
         LIMIT ${limitParam}`,
@@ -6208,6 +6219,23 @@ export class PGLiteEngine implements BrainEngine {
     const sinceEnd = new Date(sinceDate.getTime() + 86400000);
     const baselineStart = new Date(sinceDate.getTime() - lookbackDays * 86400000);
 
+    // Source scope (array wins over scalar). Bound as $3 in EVERY cohort query
+    // below so today's counts and the baseline share one scope — otherwise the
+    // anomaly math would compare a scoped today against an unscoped baseline.
+    // Every query's params are [$1 date, $2 date, ...sourceParam].
+    const sourceClause =
+      opts.sourceIds && opts.sourceIds.length > 0
+        ? `AND p.source_id = ANY($3::text[])`
+        : opts.sourceId
+          ? `AND p.source_id = $3`
+          : '';
+    const sourceParam: unknown[] =
+      opts.sourceIds && opts.sourceIds.length > 0
+        ? [opts.sourceIds]
+        : opts.sourceId
+          ? [opts.sourceId]
+          : [];
+
     const tagBaselineRes = await this.db.query(
       `WITH days AS (
          SELECT day::date FROM generate_series(
@@ -6216,20 +6244,20 @@ export class PGLiteEngine implements BrainEngine {
        ),
        cohort_keys AS (
          SELECT DISTINCT t.tag FROM tags t JOIN pages p ON p.id = t.page_id
-          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
        ),
        touched AS (
          SELECT t.tag,
                 date_trunc('day', p.updated_at)::date AS day,
                 COUNT(DISTINCT p.id) AS cnt
            FROM tags t JOIN pages p ON p.id = t.page_id
-          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
           GROUP BY 1, 2
        )
        SELECT cd.tag AS cohort_value, d.day::text AS day, COALESCE(t.cnt, 0)::int AS count
          FROM cohort_keys cd CROSS JOIN days d
          LEFT JOIN touched t ON t.tag = cd.tag AND t.day = d.day`,
-      [baselineStart.toISOString(), sinceDate.toISOString()]
+      [baselineStart.toISOString(), sinceDate.toISOString(), ...sourceParam]
     );
 
     const typeBaselineRes = await this.db.query(
@@ -6240,20 +6268,20 @@ export class PGLiteEngine implements BrainEngine {
        ),
        cohort_keys AS (
          SELECT DISTINCT p.type FROM pages p
-          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
        ),
        touched AS (
          SELECT p.type,
                 date_trunc('day', p.updated_at)::date AS day,
                 COUNT(DISTINCT p.id) AS cnt
            FROM pages p
-          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+          WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
           GROUP BY 1, 2
        )
        SELECT cd.type AS cohort_value, d.day::text AS day, COALESCE(t.cnt, 0)::int AS count
          FROM cohort_keys cd CROSS JOIN days d
          LEFT JOIN touched t ON t.type = cd.type AND t.day = d.day`,
-      [baselineStart.toISOString(), sinceDate.toISOString()]
+      [baselineStart.toISOString(), sinceDate.toISOString(), ...sourceParam]
     );
 
     const tagTodayRes = await this.db.query(
@@ -6261,9 +6289,9 @@ export class PGLiteEngine implements BrainEngine {
               COUNT(DISTINCT p.id)::int AS count,
               array_agg(DISTINCT p.slug) AS slugs
          FROM tags t JOIN pages p ON p.id = t.page_id
-        WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+        WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
         GROUP BY 1`,
-      [sinceIso, sinceEnd.toISOString()]
+      [sinceIso, sinceEnd.toISOString(), ...sourceParam]
     );
 
     const typeTodayRes = await this.db.query(
@@ -6271,9 +6299,9 @@ export class PGLiteEngine implements BrainEngine {
               COUNT(DISTINCT p.id)::int AS count,
               array_agg(DISTINCT p.slug) AS slugs
          FROM pages p
-        WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz
+        WHERE p.updated_at >= $1::timestamptz AND p.updated_at < $2::timestamptz ${sourceClause}
         GROUP BY 1`,
-      [sinceIso, sinceEnd.toISOString()]
+      [sinceIso, sinceEnd.toISOString(), ...sourceParam]
     );
 
     const baseline = [

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -6373,6 +6373,13 @@ export class PostgresEngine implements BrainEngine {
     const excludeBriefings = !(slugPrefix && slugPrefix.startsWith('briefings'))
       ? sql`AND p.slug NOT LIKE 'briefings/%'`
       : sql``;
+    // Source scope: array wins over scalar (canonical precedence). Parity with
+    // pglite-engine.getRecentSalience() and listEnrichCandidates().
+    const sourceCondition = opts.sourceIds && opts.sourceIds.length > 0
+      ? sql`AND p.source_id = ANY(${opts.sourceIds}::text[])`
+      : opts.sourceId
+        ? sql`AND p.source_id = ${opts.sourceId}`
+        : sql``;
     // v0.29.1: third score term via buildRecencyComponentSql. Default
     // 'flat' = v0.29.0 behavior (1 / (1 + days_old)). 'on' opts into the
     // per-prefix decay map (concepts/ evergreen, daily/ aggressive, etc.).
@@ -6406,6 +6413,7 @@ export class PostgresEngine implements BrainEngine {
        WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= ${boundaryIso}::timestamptz
          ${prefixCondition}
          ${excludeBriefings}
+         ${sourceCondition}
        GROUP BY p.id
        ORDER BY score DESC
        LIMIT ${limit}
@@ -6501,6 +6509,15 @@ export class PostgresEngine implements BrainEngine {
     const sinceEnd = new Date(sinceDate.getTime() + 86400000);
     const baselineStart = new Date(sinceDate.getTime() - lookbackDays * 86400000);
 
+    // Source scope (array wins over scalar). Applied to the baseline AND today
+    // windows so the anomaly math stays self-consistent. Parity with
+    // pglite-engine.findAnomalies().
+    const sourceCondition = opts.sourceIds && opts.sourceIds.length > 0
+      ? sql`AND p.source_id = ANY(${opts.sourceIds}::text[])`
+      : opts.sourceId
+        ? sql`AND p.source_id = ${opts.sourceId}`
+        : sql``;
+
     // Tag cohort baseline with day densification + zero-fill (codex C4#6).
     const tagBaseline = await sql`
       WITH days AS (
@@ -6514,6 +6531,7 @@ export class PostgresEngine implements BrainEngine {
         SELECT DISTINCT t.tag FROM tags t JOIN pages p ON p.id = t.page_id
          WHERE p.updated_at >= ${baselineStart.toISOString()}::timestamptz
            AND p.updated_at <  ${sinceDate.toISOString()}::timestamptz
+           ${sourceCondition}
       ),
       touched AS (
         SELECT t.tag,
@@ -6522,6 +6540,7 @@ export class PostgresEngine implements BrainEngine {
           FROM tags t JOIN pages p ON p.id = t.page_id
          WHERE p.updated_at >= ${baselineStart.toISOString()}::timestamptz
            AND p.updated_at <  ${sinceDate.toISOString()}::timestamptz
+           ${sourceCondition}
          GROUP BY 1, 2
       )
       SELECT cd.tag AS cohort_value, d.day::text AS day, COALESCE(t.cnt, 0)::int AS count
@@ -6541,6 +6560,7 @@ export class PostgresEngine implements BrainEngine {
         SELECT DISTINCT p.type FROM pages p
          WHERE p.updated_at >= ${baselineStart.toISOString()}::timestamptz
            AND p.updated_at <  ${sinceDate.toISOString()}::timestamptz
+           ${sourceCondition}
       ),
       touched AS (
         SELECT p.type,
@@ -6549,6 +6569,7 @@ export class PostgresEngine implements BrainEngine {
           FROM pages p
          WHERE p.updated_at >= ${baselineStart.toISOString()}::timestamptz
            AND p.updated_at <  ${sinceDate.toISOString()}::timestamptz
+           ${sourceCondition}
          GROUP BY 1, 2
       )
       SELECT cd.type AS cohort_value, d.day::text AS day, COALESCE(t.cnt, 0)::int AS count
@@ -6564,6 +6585,7 @@ export class PostgresEngine implements BrainEngine {
         FROM tags t JOIN pages p ON p.id = t.page_id
        WHERE p.updated_at >= ${sinceIso}::timestamptz
          AND p.updated_at <  ${sinceEnd.toISOString()}::timestamptz
+         ${sourceCondition}
        GROUP BY 1
     `;
     const typeToday = await sql`
@@ -6573,6 +6595,7 @@ export class PostgresEngine implements BrainEngine {
         FROM pages p
        WHERE p.updated_at >= ${sinceIso}::timestamptz
          AND p.updated_at <  ${sinceEnd.toISOString()}::timestamptz
+         ${sourceCondition}
        GROUP BY 1
     `;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -429,6 +429,10 @@ export interface SalienceOpts {
    * Default preserves v0.29.0 ranking; 'on' is opt-in.
    */
   recency_bias?: 'flat' | 'on';
+  /** Source scope (canonical precedence: array wins over scalar). Undefined =
+   *  unscoped (trusted local callers). */
+  sourceId?: string;
+  sourceIds?: string[];
 }
 
 export interface SalienceResult {
@@ -520,6 +524,11 @@ export interface AnomaliesOpts {
   lookback_days?: number;
   /** Sigma threshold. Default 3.0. */
   sigma?: number;
+  /** Source scope (canonical precedence: array wins over scalar). Applied to
+   *  BOTH the baseline and today windows so the anomaly math stays consistent.
+   *  Undefined = unscoped (trusted local callers). */
+  sourceId?: string;
+  sourceIds?: string[];
 }
 
 export interface AnomalyResult {

--- a/test/e2e/salience-anomalies-source-isolation-pglite.test.ts
+++ b/test/e2e/salience-anomalies-source-isolation-pglite.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Source-isolation regression for the v0.29 read ops the #861 (v0.34.1) sweep
+ * missed: get_recent_salience and find_anomalies. Both are scope:'read' and
+ * reachable over MCP, yet pre-fix ignored the caller's source scope entirely —
+ * a source-bound OAuth client could read salient pages and anomaly cohorts from
+ * every source in the brain. (get_recent_transcripts is NOT covered: it is
+ * localOnly + remote-gated, so it's fail-closed to remote callers by design.)
+ *
+ * Runs against PGLite in-memory (exercises both engines' parity surface).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+
+let engine: PGLiteEngine;
+
+// A minimal remote ctx for driving op handlers directly (matches the
+// source-isolation-pglite regression's dispatcher simulation).
+function ctxFor(scope: { sourceId?: string; allowedSources?: string[] }) {
+  return {
+    engine,
+    config: { engine: 'pglite' as const },
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: true,
+    sourceId: scope.sourceId,
+    ...(scope.allowedSources
+      ? { auth: { token: 't', clientId: 't', scopes: ['read'], allowedSources: scope.allowedSources } }
+      : {}),
+  } as never;
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  // 'default' is seeded by initSchema; add src-b.
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, config) VALUES ('src-b', 'src-b', '{}'::jsonb) ON CONFLICT DO NOTHING`,
+  );
+
+  // Same slug in both sources — proves filtering is on source_id, not slug.
+  await engine.putPage('people/alice', { type: 'person', title: 'Alice A', compiled_truth: 'A' }, { sourceId: 'default' });
+  await engine.putPage('people/alice', { type: 'person', title: 'Alice B', compiled_truth: 'B' }, { sourceId: 'src-b' });
+
+  // 3 default pages tagged `spikea`, 3 src-b pages tagged `spikeb`, all touched
+  // today. Empty baseline (no history in the lookback window) + count > 1 makes
+  // each tag cohort fire the zero-baseline anomaly branch, scoped to its source.
+  for (let i = 0; i < 3; i++) {
+    await engine.putPage(`notes/a-${i}`, { type: 'note', title: `A note ${i}`, compiled_truth: 'x' }, { sourceId: 'default' });
+    await engine.addTag(`notes/a-${i}`, 'spikea', { sourceId: 'default' });
+    await engine.putPage(`notes/b-${i}`, { type: 'note', title: `B note ${i}`, compiled_truth: 'y' }, { sourceId: 'src-b' });
+    await engine.addTag(`notes/b-${i}`, 'spikeb', { sourceId: 'src-b' });
+  }
+}, 30_000); // PGLite initSchema + seeding exceeds the default 5s hook timeout
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+});
+
+describe('get_recent_salience source isolation', () => {
+  test('sourceId=default excludes src-b rows (incl. the shared slug)', async () => {
+    const rows = await engine.getRecentSalience({ days: 30, limit: 100, sourceId: 'default' });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) expect(r.source_id).toBe('default');
+    // The shared slug resolves to the default page, never src-b's.
+    expect(rows.find((r) => r.title === 'Alice B')).toBeUndefined();
+  });
+
+  test('sourceId=src-b excludes default rows', async () => {
+    const rows = await engine.getRecentSalience({ days: 30, limit: 100, sourceId: 'src-b' });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) expect(r.source_id).toBe('src-b');
+  });
+
+  test('sourceIds=[default,src-b] returns the union', async () => {
+    const rows = await engine.getRecentSalience({ days: 30, limit: 100, sourceIds: ['default', 'src-b'] });
+    const sources = new Set(rows.map((r) => r.source_id));
+    expect(sources.has('default')).toBe(true);
+    expect(sources.has('src-b')).toBe(true);
+  });
+
+  test('no source scope returns all sources (trusted local unchanged)', async () => {
+    const rows = await engine.getRecentSalience({ days: 30, limit: 100 });
+    expect(new Set(rows.map((r) => r.source_id)).size).toBeGreaterThanOrEqual(2);
+  });
+
+  test('op handler threads ctx.sourceId through sourceScopeOpts', async () => {
+    const { operations } = await import('../../src/core/operations.ts');
+    const op = operations.find((o) => o.name === 'get_recent_salience')!;
+    const rows = (await op.handler(ctxFor({ sourceId: 'src-b' }), { days: 30, limit: 100 })) as Array<{ source_id: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) expect(r.source_id).toBe('src-b');
+  });
+});
+
+describe('find_anomalies source isolation', () => {
+  const slugsOf = (rows: Array<{ page_slugs: string[] }>) => rows.flatMap((r) => r.page_slugs);
+
+  test('sourceId=default surfaces only default cohorts/slugs', async () => {
+    const rows = await engine.findAnomalies({ sourceId: 'default' });
+    expect(rows.find((r) => r.cohort_value === 'spikea')).toBeDefined();
+    expect(rows.find((r) => r.cohort_value === 'spikeb')).toBeUndefined();
+    for (const s of slugsOf(rows)) expect(s.startsWith('notes/b-')).toBe(false);
+  });
+
+  test('sourceId=src-b surfaces only src-b cohorts/slugs', async () => {
+    const rows = await engine.findAnomalies({ sourceId: 'src-b' });
+    expect(rows.find((r) => r.cohort_value === 'spikeb')).toBeDefined();
+    expect(rows.find((r) => r.cohort_value === 'spikea')).toBeUndefined();
+    for (const s of slugsOf(rows)) expect(s.startsWith('notes/a-')).toBe(false);
+  });
+
+  test('sourceIds=[default,src-b] surfaces both cohorts', async () => {
+    const rows = await engine.findAnomalies({ sourceIds: ['default', 'src-b'] });
+    expect(rows.find((r) => r.cohort_value === 'spikea')).toBeDefined();
+    expect(rows.find((r) => r.cohort_value === 'spikeb')).toBeDefined();
+  });
+
+  test('op handler threads ctx.sourceId through sourceScopeOpts', async () => {
+    const { operations } = await import('../../src/core/operations.ts');
+    const op = operations.find((o) => o.name === 'find_anomalies')!;
+    const rows = (await op.handler(ctxFor({ sourceId: 'src-b' }), {})) as Array<{ cohort_value: string; page_slugs: string[] }>;
+    expect(rows.find((r) => r.cohort_value === 'spikea')).toBeUndefined();
+    for (const s of rows.flatMap((r) => r.page_slugs)) expect(s.startsWith('notes/a-')).toBe(false);
+  });
+});


### PR DESCRIPTION
`get_recent_salience` and `find_anomalies` are the two v0.29 read ops that don't thread the caller's source scope into the engine, unlike the other read ops (`list_pages`, `search`, `traverse_graph`, `find_experts`, `find_orphans`), which all resolve `sourceScopeOpts(ctx)`. This brings the two in line so a source-bound caller sees only its granted sources.

## Change
- Add `sourceId` / `sourceIds` to `SalienceOpts` and `AnomaliesOpts` (canonical precedence: federated array wins over scalar).
- Thread `sourceScopeOpts(ctx)` through both op handlers.
- Add the source-filter clause to both engines' SQL. For `findAnomalies` the same filter is applied to all four cohort queries (tag/type × baseline/today) so the baseline and today windows share one scope and the anomaly math stays self-consistent.
- Trusted local callers (`ctx.remote === false`, empty scope) are unchanged: full-brain results as before.
- `get_recent_transcripts` is intentionally left alone — it is `localOnly` + remote-gated, so it never serves remote callers.

## Test
`test/e2e/salience-anomalies-source-isolation-pglite.test.ts` (PGLite, no `DATABASE_URL` needed): seeds two sources and asserts scalar scoping excludes the other source, the federated array returns the union, an unscoped call still spans both, and both op handlers thread `ctx.sourceId` end-to-end.
