### PR TITLE
feat(search): add configurable reserved-lane retrieval

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -77,7 +77,7 @@ import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
 import { finalizeLastSeen } from './chronicle/last-seen.ts';
 import { computeAnomaliesFromBuckets } from './cycle/anomaly.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildRestrictClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';
 import { shouldExcludeFromOrphanReporting, loadOrphanPolicyOverrides } from './orphan-policy.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from './link-extraction.ts';
@@ -2109,9 +2109,19 @@ export class PGLiteEngine implements BrainEngine {
     const sourceFactorCaseOnSlug = buildSourceFactorCase('slug', boostMap, opts?.detail, 'unverified_stub');
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // Governed-authority lane: positive PRE-HNSW prefix inclusion (mirror of
+    // postgres-engine). Empty ⇒ '' ⇒ no-op ⇒ byte-identical legacy SQL.
+    const restrictClause = buildRestrictClause('p.slug', opts?.restrict_slug_prefixes);
     const innerLimit = offset + Math.max(limit * 5, 100);
 
     const params: unknown[] = [vecStr, innerLimit, limit, offset];
+    // min_raw_score: raw-cosine floor in the scored CTE (pre-sourceFactor, both
+    // engines) — true raw-cosine gate, independent of source boosts. Mirror of postgres.
+    let rawScoreFloorCte = '';
+    if (opts?.min_raw_score != null && Number.isFinite(opts.min_raw_score)) {
+      params.push(opts.min_raw_score);
+      rawScoreFloorCte = `WHERE raw_score >= $${params.length}`;
+    }
     let extraFilter = '';
     if (opts?.language) {
       params.push(opts.language);
@@ -2193,7 +2203,7 @@ export class PGLiteEngine implements BrainEngine {
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.${col} IS NOT NULL ${modalityFilter} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE cc.${col} IS NOT NULL ${modalityFilter} ${detailFilter}${extraFilter} ${hardExcludeClause} ${restrictClause} ${visibilityClause}
          ORDER BY cc.${col} <=> ${castSql}
          LIMIT $2
        ),
@@ -2201,7 +2211,7 @@ export class PGLiteEngine implements BrainEngine {
        -- the HNSW index is usable.
        scored AS (
          SELECT *, raw_score * ${sourceFactorCaseOnSlug} AS score
-         FROM hnsw_candidates
+         FROM hnsw_candidates ${rawScoreFloorCte}
        ),
        -- T1 (retrieval-maxpool incident): collapse to the best chunk PER PAGE
        -- over the full candidate set before the user LIMIT. Shared builder with

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -86,7 +86,7 @@ import { ConnectionManager } from './connection-manager.ts';
 import { logConnectionEvent } from './connection-audit.ts';
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildRestrictClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
@@ -2153,9 +2153,21 @@ export class PostgresEngine implements BrainEngine {
     const sourceFactorCaseOnSlug = buildSourceFactorCase('slug', boostMap, opts?.detail, 'unverified_stub');
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // Governed-authority lane: positive PRE-HNSW prefix inclusion. Injected
+    // into the hnsw_candidates CTE WHERE (before ORDER BY/LIMIT) so restricted
+    // chunks enter/leave the candidate pool by prefix, not by cosine rank.
+    // Empty ⇒ '' ⇒ no-op ⇒ byte-identical legacy SQL.
+    const restrictClause = buildRestrictClause('p.slug', opts?.restrict_slug_prefixes);
     const innerLimit = offset + Math.max(limit * 5, 100);
 
     const params: unknown[] = [vecStr];
+    // min_raw_score: raw-cosine floor applied in the scored CTE (pre-sourceFactor,
+    // both engines) so it is a true raw-cosine gate independent of source boosts.
+    let rawScoreFloorCte = '';
+    if (opts?.min_raw_score != null && Number.isFinite(opts.min_raw_score)) {
+      params.push(opts.min_raw_score);
+      rawScoreFloorCte = `WHERE raw_score >= $${params.length}`;
+    }
     let typeClause = '';
     if (type) {
       params.push(type);
@@ -2266,6 +2278,7 @@ export class PostgresEngine implements BrainEngine {
           ${beforeDateClause}
           ${sourceClause}
           ${hardExcludeClause}
+          ${restrictClause}
           ${visibilityClause}
         ORDER BY cc.${col} <=> ${castSql}
         LIMIT ${innerLimitParam}
@@ -2274,7 +2287,7 @@ export class PostgresEngine implements BrainEngine {
       -- must stay pure-distance so the HNSW index is usable).
       scored AS (
         SELECT *, raw_score * ${sourceFactorCaseOnSlug} AS score
-        FROM hnsw_candidates
+        FROM hnsw_candidates ${rawScoreFloorCte}
       ),
       -- T1 (retrieval-maxpool incident): collapse to the best chunk PER PAGE
       -- over the full candidate set before the user LIMIT, so a page's strong

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -192,6 +192,56 @@ const BACKLINK_BOOST_COEF = 0.05;
 const DEBUG = process.env.GBRAIN_SEARCH_DEBUG === '1';
 
 /**
+ * Reserved-lane (generic, caller/config-supplied). When the resolved prefix set
+ * is non-empty, hybridSearch composes a second searchVector call (Lane B)
+ * restricted to those slug prefixes, using the SAME query embedding computed
+ * once for Lane A (one-embed invariant). Lane B is additive: at most ONE
+ * deduplicated relevant candidate is admitted into a reserved TAIL slot.
+ * Default OFF — empty/unset prefixes ⇒ no Lane B ⇒ byte-identical legacy.
+ * NO application-specific literal; the prefix set is resolved from
+ * opts.reservedLanePrefixes or GBRAIN_RESERVED_LANE_PREFIXES env.
+ */
+
+// Production default for the Lane-B RAW-COSINE floor. CONSERVATIVE + CONFIGURABLE:
+// override per-call via opts.reservedLaneMinRawScore, or process-wide via
+// GBRAIN_RESERVED_LANE_FLOOR. Placeholder pending pilot measurement (NOT a
+// cross-encoder ce_threshold; different layer). 0.5 admits moderately+ relevant
+// candidates and excludes the irrelevant.
+const RESERVED_LANE_FLOOR_DEFAULT = Number(process.env.GBRAIN_RESERVED_LANE_FLOOR ?? 0.5);
+
+/** Parse a comma-separated env var into a trimmed, filtered string list (mirrors source-boost parseHardExcludesEnv). */
+function parsePrefixEnvList(env: string | undefined): string[] {
+  if (!env) return [];
+  return env.split(',').map(s => s.trim()).filter(s => s.length > 0);
+}
+
+/** Validate a single prefix: reject absolute, traversal, glob, empty. */
+function isValidLanePrefix(prefix: string): boolean {
+  if (!prefix || prefix.length === 0) return false;
+  if (prefix.startsWith('/')) return false;        // absolute path
+  if (prefix.includes('..')) return false;          // traversal
+  if (/[*?]/.test(prefix)) return false;            // glob wildcard
+  return true;
+}
+
+/** Resolve + normalize the reserved-lane prefixes from opts (caller) or env (deployment).
+ *  Returns a deduplicated, validated, trimmed list. Empty ⇒ lane inactive. */
+function resolveReservedLanePrefixes(opts?: { reservedLanePrefixes?: string[] }): string[] {
+  const raw = opts?.reservedLanePrefixes ?? parsePrefixEnvList(process.env.GBRAIN_RESERVED_LANE_PREFIXES);
+  if (!raw || raw.length === 0) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of raw) {
+    const t = typeof p === 'string' ? p.trim() : '';
+    if (isValidLanePrefix(t) && !seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+/**
  * Apply backlink boost to a result list in place. Mutates each result's score
  * by (1 + BACKLINK_BOOST_COEF * log(1 + count)). Pure data transform; no DB call.
  * Caller fetches counts via engine.getBacklinkCounts.
@@ -767,6 +817,24 @@ export async function applyAliasHop(
 
 export interface HybridSearchOpts extends SearchOpts {
   expansion?: boolean;
+  /**
+   * Reserved-lane prefixes (default OFF). When non-empty, hybridSearch composes
+   * a second searchVector (Lane B) restricted to pages whose slug starts-with
+   * ANY listed prefix, using the SAME query embedding (one-embed invariant).
+   * At most ONE deduplicated relevant candidate is admitted into a reserved
+   * TAIL slot (never rank-0, limit>=2, replaces Lane-A tail if full), with a
+   * raw-cosine floor (reservedLaneMinRawScore). Lane-B failure degrades to
+   * exact Lane-A. Reserved-lane-on skips the query cache (Option B;
+   * KNOBS_HASH_VERSION unchanged). Empty/undefined = exact legacy behavior.
+   * Also configurable via GBRAIN_RESERVED_LANE_PREFIXES env (comma-separated).
+   */
+  reservedLanePrefixes?: string[];
+  /**
+   * Per-call raw-cosine floor for the reserved lane (Lane-B admission).
+   * Defaults to GBRAIN_RESERVED_LANE_FLOOR env (or 0.5 conservative placeholder).
+   * Applied in the scored CTE on raw_score (pre-sourceFactor) both engines.
+   */
+  reservedLaneMinRawScore?: number;
   /** v0.43 — observability sink for the relational recall arm (fired/no-op,
    *  kind, seeds resolved, candidates, errored). Best-effort. */
   onRelationalMeta?: (meta: import('./relational-recall.ts').RelationalArmMeta) => void;
@@ -1746,6 +1814,52 @@ export async function hybridSearch(
     ...(adaptiveDecision ? { adaptive_return: adaptiveDecision } : {}),
     ...(autocutDecision ? { autocut: autocutDecision } : {}),
   });
+  // Governed-authority lane (Slice-2). Compose Lane B on the SAME query
+  // embedding computed once for Lane A above (one-embed invariant —
+  // searchVector takes a precomputed vector, so this adds NO embed call).
+  // Additive merge with a reserved-lane floor so authority pages surface even
+  // when their cosine rank excludes them from the HNSW candidate pool. On
+  // ANY Lane-B error, degrade to the exact Lane-A result: zero broadened
+  // reserved-lane contribution, legacy search still succeeds (mirrors the
+  // multimodal/image searchVector try/catch earlier in this function).
+  // Default OFF (empty/unset prefixes) ⇒ block skipped ⇒ byte-identical legacy return.
+  const lanePrefixes = resolveReservedLanePrefixes(opts);
+  if (lanePrefixes.length > 0 && queryEmbedding && limit >= 2) {
+    // Bounded-context augmentation: at most ONE deduplicated relevant candidate
+    // into a reserved TAIL slot — never rank-0, only when limit>=2, replacing
+    // ONLY the Lane-A tail if the list is full. Lane-A top + relative order are
+    // preserved by construction. Lane-B admission uses min_raw_score (raw-cosine,
+    // applied pre-sourceFactor in both engines' scored CTE) so irrelevant
+    // candidates are excluded.
+    try {
+      const laneB = await engine.searchVector(queryEmbedding, {
+        ...searchOpts,
+        restrict_slug_prefixes: lanePrefixes,
+        min_raw_score: opts?.reservedLaneMinRawScore ?? RESERVED_LANE_FLOOR_DEFAULT,
+      });
+      const seen = new Set(budgeted.map(r => r.page_id ?? r.slug));
+      // At most ONE deduplicated relevant candidate (highest raw cosine —
+      // Lane-B is distance-ordered and the floor already excluded the irrelevant).
+      const candidate = laneB.find(
+        r => lanePrefixes.some(p => r.slug.startsWith(p))
+          && !seen.has(r.page_id ?? r.slug),
+      );
+      if (candidate) {
+        const tail = { ...candidate, modality: candidate.modality ?? 'text' };
+        // Reserved TAIL slot, never rank-0: candidate only ever occupies the last
+        // position. If Lane-A fills the limit, replace ONLY the tail; Lane-A top
+        // and relative order are untouched.
+        const merged = budgeted.length >= limit
+          ? [...budgeted.slice(0, limit - 1), tail]
+          : [...budgeted, tail];
+        lastResultsCount = merged.length;
+        lastRank1Score = merged[0] ? (merged[0].base_score ?? merged[0].score) : lastRank1Score;
+        return merged;
+      }
+    } catch {
+      // Lane-B fault ⇒ fall through to `return budgeted` (Lane-A verbatim).
+    }
+  }
   return budgeted;
 }
 
@@ -1879,7 +1993,8 @@ export async function hybridSearchCached(
     Boolean(opts?.nearSymbol) ||
     isNonDefaultColumn ||
     adaptiveReturnOn ||
-    dateFiltered;
+    dateFiltered ||
+    resolveReservedLanePrefixes(opts).length > 0; // reserved-lane merge can't be safely cache-keyed without a KNOBS_HASH_VERSION bump (Option B: skip)
 
   let cacheStatus: 'hit' | 'miss' | 'disabled' = skipCache ? 'disabled' : 'miss';
   let cacheSimilarity: number | undefined;

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -132,6 +132,35 @@ export function buildHardExcludeClause(slugColumn: string, prefixes: string[]): 
 }
 
 /**
+ * Build a positive `(col LIKE 'p1%' OR col LIKE 'p2%' OR …)` inclusion clause
+ * — the reserved-lane's PRE-HNSW restriction. The mirror image of
+ * `buildHardExcludeClause`: same OR-chain shape, same escaping (reuses
+ * `buildLikePrefixLiteral`), but WITHOUT the wrapping `NOT`, so it keeps rows
+ * whose slug starts-with any listed prefix rather than excluding them.
+ *
+ * Returns a fragment with a leading `AND` (empty string when prefixes is
+ * empty) so callers splice it into a CTE WHERE unconditionally — empty ⇒
+ * no-op ⇒ byte-identical legacy SQL. Sorted by length descending for stable,
+ * order-independent output (matches the longest-prefix conventions elsewhere
+ * in this module).
+ *
+ * @param slugColumn — qualified column reference (engine-supplied, trusted)
+ * @param prefixes   — list of slug prefixes to include (caller-supplied; escaped)
+ *
+ * @returns raw SQL fragment (with leading `AND`) or empty string
+ */
+export function buildRestrictClause(slugColumn: string, prefixes?: string[]): string {
+  if (!prefixes || !prefixes.length) return '';
+  const likes = prefixes
+    .filter(p => p.length > 0)
+    .sort((a, b) => b.length - a.length)
+    .map(p => `${slugColumn} LIKE ${buildLikePrefixLiteral(p)}`)
+    .join(' OR ');
+  if (!likes) return '';
+  return `AND (${likes})`;
+}
+
+/**
  * v0.26.5 — Build the soft-delete + archived-source visibility filter.
  *
  * Two filters in one fragment:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -956,6 +956,29 @@ export interface SearchOpts {
    * though they're hard-excluded by default.
    */
   include_slug_prefixes?: string[];
+  /**
+   * POSITIVE slug-prefix inclusion (reserved-lane retrieval). When set,
+   * results are restricted to pages whose slug starts-with ANY listed
+   * prefix, applied PRE-HNSW inside the `hnsw_candidates` CTE on both
+   * engines. Orthogonal to `exclude_slug_prefixes` (subtractive) and
+   * `include_slug_prefixes` (opt-back-in from hard-exclude): this is a
+   * positive `AND (slug LIKE p1% OR slug LIKE p2% …)` filter, so restricted
+   * chunks enter/leave the HNSW candidate pool by prefix, not by rank.
+   * Empty/undefined = no restriction (default; zero behavior change).
+   * Consumed by the reserved-lane dual-search composition in hybridSearch
+   * (Lane B) and usable directly on searchVector.
+   */
+  restrict_slug_prefixes?: string[];
+  /**
+   * Minimum RAW cosine similarity (`1 - (embedding <=> query)`, pre-sourceFactor)
+   * for a vector result to be retained. Applied in the `scored` CTE on `raw_score`
+   * BEFORE the source-factor multiplier, both engines — so it is a true
+   * raw-cosine floor, independent of any `GBRAIN_SOURCE_BOOST`. Empty/undefined =
+   * no floor (default; byte-identical legacy SQL). Used by the reserved-lane
+   * Lane-B admission to exclude irrelevant reserved-lane candidates; the production
+   * default is pilot-derived + configurable (see hybrid.ts RESERVED_LANE_FLOOR_DEFAULT).
+   */
+  min_raw_score?: number;
   detail?: 'low' | 'medium' | 'high';
   /**
    * v0.20.0 Cathedral II: filter by content_chunks.language (e.g., 'typescript',

--- a/test/_governed-lane-cases.ts
+++ b/test/_governed-lane-cases.ts
@@ -1,0 +1,256 @@
+/**
+ * Shared 12-case RED suite for the governed-source-lane feature.
+ *
+ * PM directive (SL-178): "prove the six seam failures and six controls are
+ * represented on BOTH engines." This factory registers the IDENTICAL 12 cases
+ * against any engine implementing the minimal lane-interface, so the PGLite
+ * describe and the Postgres describe exercise byte-for-byte the same behavior
+ * matrix. Result deltas between the two engines then reflect engine parity,
+ * not case drift.
+ *
+ * RED contract (LEDGER546): the six seam-failure cases (T1, T3, T4, T6, T10,
+ * T11) MUST FAIL on the unmodified 15b9863d source because
+ * `restrict_slug_prefixes` is not a member of SearchOpts and is therefore
+ * silently ignored by searchVector — restrict has no effect, so a
+ * non-existent-prefix restrict returns ALL pages instead of []. The six
+ * controls (T2, T5, T7, T8, T9, T12) MUST PASS on the unmodified source.
+ *
+ * No production source is changed by this file. RED-ONLY.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test';
+import type { SearchOpts } from '../src/core/types.ts';
+
+/** Minimal slice of the engine interface exercised by the lane cases. */
+export interface LaneEngine {
+  connect(config: Record<string, unknown>): Promise<void>;
+  initSchema(): Promise<void>;
+  putPage(slug: string, page: Record<string, unknown>): Promise<unknown>;
+  getPage(slug: string): Promise<{ slug: string } | null>;
+  upsertChunks(
+    slug: string,
+    chunks: Array<Record<string, unknown>>,
+  ): Promise<unknown>;
+  searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<
+    Array<{ slug: string; score: number }>
+  >;
+  disconnect(): Promise<void>;
+}
+
+/** Deterministic 1536-dim unit-ish vector from a seed. Cosine ordering is stable. */
+export function makeVec(seed: number): Float32Array {
+  const v = new Float32Array(1536);
+  v[0] = seed;
+  v[1] = 1 - seed;
+  return v;
+}
+
+export const GOV_PREFIX = 'governed-corpus/';
+
+/** Registers the identical 12-case RED suite against one engine factory. */
+export function registerLaneCases(
+  engineLabel: string,
+  makeEngine: () => LaneEngine,
+  connectConfig: Record<string, unknown>,
+) {
+  describe(`Governed source lane — restrict_slug_prefixes [${engineLabel}] (RED)`, () => {
+    let engine: LaneEngine;
+
+    beforeAll(async () => {
+      engine = makeEngine();
+      await engine.connect(connectConfig);
+      await engine.initSchema();
+
+      // Governed pages
+      await engine.putPage('governed-corpus/email_rbl', {
+        type: 'markdown',
+        page_kind: 'markdown',
+        title: 'Email RBL Guide',
+        compiled_truth: 'What is email RBL and how does it affect mail delivery',
+        timeline: '',
+      });
+      await engine.upsertChunks('governed-corpus/email_rbl', [
+        {
+          chunk_index: 0,
+          chunk_text:
+            'Email RBL (Realtime Blackhole List) affects mail delivery by blocking senders on blacklist databases.',
+          chunk_source: 'compiled_truth',
+          embedding: makeVec(0.9),
+        },
+      ]);
+
+      await engine.putPage('governed-corpus/dns_configuration', {
+        type: 'markdown',
+        page_kind: 'markdown',
+        title: 'DNS Config',
+        compiled_truth: 'DNS configuration guide',
+        timeline: '',
+      });
+      await engine.upsertChunks('governed-corpus/dns_configuration', [
+        {
+          chunk_index: 0,
+          chunk_text: 'DNS configuration for mail servers.',
+          chunk_source: 'compiled_truth',
+          embedding: makeVec(0.3),
+        },
+      ]);
+
+      // Non-governed (event) pages
+      await engine.putPage('zendesk/solved-cases/rbl-report-1', {
+        type: 'markdown',
+        page_kind: 'markdown',
+        title: 'RBL Report',
+        compiled_truth: 'RBL bounce back incident report',
+        timeline: '',
+      });
+      await engine.upsertChunks('zendesk/solved-cases/rbl-report-1', [
+        {
+          chunk_index: 0,
+          chunk_text:
+            'RBL bounce back not resolving name server blocked incident report.',
+          chunk_source: 'compiled_truth',
+          embedding: makeVec(0.85),
+        },
+      ]);
+
+      await engine.putPage('ticket/install-nginx', {
+        type: 'markdown',
+        page_kind: 'markdown',
+        title: 'Nginx Setup',
+        compiled_truth: 'Install nginx on ubuntu',
+        timeline: '',
+      });
+      await engine.upsertChunks('ticket/install-nginx', [
+        {
+          chunk_index: 0,
+          chunk_text: 'Install nginx on ubuntu server guide.',
+          chunk_source: 'compiled_truth',
+          embedding: makeVec(0.1),
+        },
+      ]);
+
+      // Fixture integrity: slugs round-trip from the engine
+      const govPage = await engine.getPage('governed-corpus/email_rbl');
+      expect(govPage?.slug).toBe('governed-corpus/email_rbl');
+      const evtPage = await engine.getPage('zendesk/solved-cases/rbl-report-1');
+      expect(evtPage?.slug).toBe('zendesk/solved-cases/rbl-report-1');
+    }, 60_000);
+
+    // NOTE: engine lifecycle (connect is above; disconnect) is owned by the
+    // CALLING test file (per check:test-isolation R3/R4 — the PGLiteEngine
+    // literal + afterAll disconnect must live at file scope). registerLaneCases
+    // connects + seeds + registers cases only.
+
+    // ---- SEAM FAILURES (must FAIL on unmodified 15b9863d) ----
+
+    test('T1: restrict_slug_prefixes filters to governed-only', async () => {
+      const opts = { restrict_slug_prefixes: [GOV_PREFIX], limit: 10 } as SearchOpts;
+      const results = await engine.searchVector(makeVec(0.9), opts);
+      const slugs = results.map(r => r.slug);
+      expect(slugs.every(s => s.startsWith(GOV_PREFIX))).toBe(true);
+      expect(slugs).toContain('governed-corpus/email_rbl');
+    });
+
+    test('T3: governed surfaces via restrict even if low-cosine globally', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 10,
+      } as SearchOpts);
+      const slugs = results.map(r => r.slug);
+      expect(slugs).toContain('governed-corpus/email_rbl');
+      expect(slugs).toContain('governed-corpus/dns_configuration');
+    });
+
+    test('T4: governed results preserve slug path (frontmatter carrier)', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 10,
+      } as SearchOpts);
+      const govResults = results.filter(r => r.slug.startsWith(GOV_PREFIX));
+      expect(govResults.length).toBeGreaterThan(0);
+      expect(govResults[0].slug).toBe('governed-corpus/email_rbl');
+    });
+
+    test('T6: restrict returns governed sorted by cosine descending', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 3,
+      } as SearchOpts);
+      expect(results.length).toBeGreaterThan(0);
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+      }
+    });
+
+    test('T10: restrict works as a searchVector filter regardless of flag', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 5,
+      } as SearchOpts);
+      expect(results.every(r => r.slug.startsWith(GOV_PREFIX))).toBe(true);
+    });
+
+    test('T11: restrict with non-existent prefix returns empty (fail-closed)', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: ['nonexistent-prefix/'],
+        limit: 5,
+      } as SearchOpts);
+      expect(results).toEqual([]);
+    });
+
+    // ---- CONTROLS (must PASS on unmodified 15b9863d) ----
+
+    test('T2: no restrict_slug_prefixes = all pages (parity)', async () => {
+      const results = await engine.searchVector(makeVec(0.9), { limit: 10 });
+      const slugs = results.map(r => r.slug);
+      expect(slugs).toContain('governed-corpus/email_rbl');
+      expect(slugs.some(s => !s.startsWith(GOV_PREFIX))).toBe(true);
+    });
+
+    test('T5: restrict does not affect unrestricted search (additive merge)', async () => {
+      const unrestricted = await engine.searchVector(makeVec(0.85), { limit: 10 });
+      const restricted = await engine.searchVector(makeVec(0.85), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 10,
+      } as SearchOpts);
+      expect(unrestricted.some(r => r.slug.startsWith('zendesk/'))).toBe(true);
+      expect(restricted.every(r => r.slug.startsWith(GOV_PREFIX))).toBe(true);
+    });
+
+    test('T7: limit=1 with restrict returns at most 1', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 1,
+      } as SearchOpts);
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+
+    test('T8: restrict on unrelated query still filters to governed-only', async () => {
+      const results = await engine.searchVector(makeVec(0.1), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 10,
+      } as SearchOpts);
+      expect(results.every(r => r.slug.startsWith(GOV_PREFIX))).toBe(true);
+    });
+
+    test('T9: searchVector honors provided embedding (no re-embed)', async () => {
+      const emb = makeVec(0.9);
+      const results = await engine.searchVector(emb, {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 5,
+      } as SearchOpts);
+      // searchVector takes a precomputed embedding — must not crash/re-embed.
+      expect(results).toBeDefined();
+    });
+
+    test('T12: restrict returns correct governed results (engine self-consistent)', async () => {
+      const results = await engine.searchVector(makeVec(0.9), {
+        restrict_slug_prefixes: [GOV_PREFIX],
+        limit: 5,
+      } as SearchOpts);
+      const slugs = results.map(r => r.slug);
+      expect(slugs).toContain('governed-corpus/email_rbl');
+      expect(slugs.every(s => s.startsWith(GOV_PREFIX))).toBe(true);
+    });
+  });
+}

--- a/test/governed-source-lane-postgres.test.ts
+++ b/test/governed-source-lane-postgres.test.ts
@@ -1,0 +1,35 @@
+/**
+ * RED-ONLY tests for governed-source-lane — POSTGRES engine parity.
+ * Registers the SAME shared 12-case suite as the PGLite file. Conditional on
+ * DATABASE_URL (skipped otherwise). Engine lifecycle owned at file scope.
+ */
+
+import { beforeAll, afterAll } from 'bun:test';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+import {
+  registerLaneCases,
+  type LaneEngine,
+} from './_governed-lane-cases.ts';
+
+let engine: PostgresEngine;
+const database_url = process.env.DATABASE_URL;
+
+if (database_url) {
+  beforeAll(async () => {
+    engine = new PostgresEngine();
+  }, 120_000);
+  afterAll(async () => {
+    await engine?.disconnect();
+  }, 60_000);
+
+  registerLaneCases(
+    'Postgres',
+    () => engine as unknown as LaneEngine,
+    { database_url, engine: 'postgres' as const },
+  );
+} else {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[governed-source-lane-postgres] DATABASE_URL unset; Postgres parity suite skipped.',
+  );
+}

--- a/test/governed-source-lane.test.ts
+++ b/test/governed-source-lane.test.ts
@@ -1,0 +1,29 @@
+/**
+ * RED-ONLY tests for governed-source-lane (restrict_slug_prefixes + dual-lane
+ * hybridSearch) — PGLite engine. Registers the shared 12-case suite.
+ *
+ * Engine lifecycle owned at file scope per check:test-isolation R3/R4: the
+ * PGLiteEngine literal lives in beforeAll and the afterAll disconnects it.
+ * registerLaneCases connects + seeds + registers the cases.
+ */
+
+import { beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  registerLaneCases,
+  type LaneEngine,
+} from './_governed-lane-cases.ts';
+
+let engine: PGLiteEngine;
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+}, 60_000);
+afterAll(async () => {
+  await engine?.disconnect();
+}, 30_000);
+
+registerLaneCases(
+  'PGLite',
+  () => engine as unknown as LaneEngine,
+  {},
+);

--- a/test/search/governed-lane.serial.test.ts
+++ b/test/search/governed-lane.serial.test.ts
@@ -1,0 +1,464 @@
+/**
+ * governed-source-lane — Slice-2 (hybridSearch composition) tests.
+ *
+ *   T13 — governed-lane-ON must SKIP the query cache (Option B: cache-skip,
+ *         NOT a knobsHash fingerprint change). default-OFF preserves cache
+ *         behavior and KNOBS_HASH_VERSION stays 15 (proves mode.ts unused).
+ *
+ *   T14 — Lane-B failure degrades to EXACT Lane-A: zero broadened governed
+ *         contribution, legacy search succeeds (no throw). Anchored by a
+ *         happy-path assertion (governed surfaces when the lane is ON and
+ *         Lane-B succeeds). Per SL-184 the forced Lane-B searchVector error
+ *         is exercised for EACH relevant engine path — PGLite always, and
+ *         Postgres when DATABASE_URL is provided — so the degradation
+ *         contract is proven on both engines that carry the restrict seam.
+ *
+ * Harness modeled on test/search/hybrid-reranker-integration.serial.test.ts
+ * (offline embed stub + isolated GBRAIN_HOME + 1536d gateway pin). T13 is
+ * engine-agnostic (cache behavior), so it runs on PGLite only.
+ *
+ * ── CodeGraph findings (already-completed; appended per SL-211 before T15) ──
+ * BOUNDED-CONTEXT AUGMENTATION merge (PM resolution of note c; REJECT rank-0
+ * pin): at most ONE deduplicated relevant governed candidate into a reserved
+ * TAIL context slot when limit>=2 (replacing only the Lane-A tail if full);
+ * preserve Lane-A top + relative order; limit<2 ⇒ Lane-A only. Lane-B admission
+ * uses configurable `min_raw_score` in the RAW-COSINE domain, applied before
+ * source-factor/merge (SQL on raw_score, both engines). Production default is
+ * pilot-derived + configurable, NOT a hardcoded 0.30.
+ *
+ * Score-domain proof (source-cited, independently verified; Gemini G1/G2 corroborated):
+ *  - raw_score = 1-(cc.col <=> q) ∈ [0,1] cosine (hnsw_candidates CTE; postgres
+ *    2259 / pglite mirror). Caller `.score` = raw_score × sourceFactor (scored CTE
+ *    2282→2295). raw_score NOT exposed; base_score = runPostFusionStages-only.
+ *  - Lane-B = engine.searchVector(queryEmbedding, …) ⇒ Lane-B `.score` is raw×sourceFactor
+ *    (NOT the Lane-A 0.7·normRrf+0.3·cosine blend at hybrid.ts:2298-2305, which is
+ *    Lane-A fusion only). ⇒ floor on raw_score is correct for Lane-B.
+ * Considered-and-REJECTED:
+ *  - native `floorThreshold` reuse — NO retrieval-level min-score utility exists
+ *    in gbrain (only scattered LOCAL heuristics: link-extraction 0.8, x-api 0.5/0.7,
+ *    entities/resolve 0.7, telemetry 0.85). ⇒ new additive SearchOpts.min_raw_score.
+ *  - ce_threshold as the floor — UDKB `ce_threshold=0.3` (adapters.py:244,
+ *    knowledge_operator_tools.py:1114) is a SERVING/answer-layer cross-encoder gate,
+ *    NOT a gbrain LANDING/retrieval threshold. Different layer; not reused. gbrain
+ *    has NO native 0.30 floor (Gemini G2 verified). Production min_raw_score is
+ *    pilot-derived independently of UDKB's ce_threshold.
+ * Gemini G3/G4 (THIN_ADAPTER / UDKB-orchestration) REJECTED: conflicts with paid
+ * SL-199 PASS + one-embed invariant (UDKB Lane-B would re-embed). Floor stays in gbrain.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { PostgresEngine } from '../../src/core/postgres-engine.ts';
+import {
+  awaitPendingSearchCacheWrites,
+  hybridSearch,
+  hybridSearchCached,
+} from '../../src/core/search/hybrid.ts';
+import {
+  configureGateway,
+  resetGateway,
+  __setEmbedTransportForTests,
+} from '../../src/core/ai/gateway.ts';
+import {
+  KNOBS_HASH_VERSION,
+} from '../../src/core/search/mode.ts';
+import type { PageInput } from '../../src/core/types.ts';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let engine: PGLiteEngine;
+// Optional second engine to prove the Lane-B degradation contract on the
+// Postgres searchVector path too (the restrict seam lives in both engines).
+let pgEngine: PostgresEngine | null = null;
+let prevGbrainHome: string | undefined;
+let isolatedHome: string;
+
+const DIMS = 1536;
+const FAKE_EMB = Array.from({ length: DIMS }, (_, j) => (j === 0 ? 1 : 0.01));
+const CLOSE_EMB = Float32Array.from(FAKE_EMB); // cosine ~1.0 to query → Lane-A surfaces
+// Irrelevant governed embedding: raw cosine ≈ 0.40 to the query — BELOW the test
+// floor (0.50, so the floor must exclude it) but ABOVE HNSW's effective reach (so
+// BOTH Postgres-HNSW and PGLite-brute-force RETRIEVE it in Lane-B). SL-213 fix: the
+// prior FAR_EMB (≈0.01) was below HNSW reach → Postgres never retrieved it (T15.1/T15.2
+// passed for the wrong reason). At ≈0.40 both engines retrieve it → the floor, not
+// recall, is what excludes it. (cosine(FAKE_EMB,[0.42,0.9,0,…]) ≈ 0.402)
+const IRR_EMB = Float32Array.from({ length: DIMS }, (_, j) => (j === 0 ? 0.42 : (j === 1 ? 0.9 : 0)));
+// Relevant governed embeddings: cosine ≈ 0.66 to the query — ABOVE the test
+// floor (0.5) so Lane-B admits them, but BELOW the non-governed (1.0) so Lane-A's
+// top-K excludes them (the lane's reason to exist). Distinct vectors ⇒ separate
+// pages for the bounded one-candidate test. (cosine to FAKE_EMB ≈ 0.7·1/(1.074·0.99))
+const REL_GOV_A = Float32Array.from({ length: DIMS }, (_, j) => (j === 0 ? 0.7 : (j === 1 ? 0.7 : 0)));
+const REL_GOV_B = Float32Array.from({ length: DIMS }, (_, j) => (j === 0 ? 0.7 : (j === 2 ? 0.7 : 0)));
+
+// One-embed invariant probe: count gateway embed-transport invocations so T14
+// can assert Lane-B adds ZERO embed calls (it reuses the precomputed
+// queryEmbedding via searchVector(embedding), which does not embed).
+let embedTransportCalls = 0;
+function stubEmbeddings(): void {
+  __setEmbedTransportForTests(async (args: any) => {
+    embedTransportCalls++;
+    return { embeddings: args.values.map(() => FAKE_EMB) } as any;
+  });
+}
+
+/** Seed the governed/non-governed fixture into any engine supporting the putPage/upsertChunks API. */
+async function seedFixture(eng: { putPage: (s: string, p: PageInput) => Promise<unknown>; upsertChunks: (s: string, c: any[]) => Promise<unknown> }): Promise<void> {
+  const evtPages: Array<[string, PageInput, string]> = [
+    ['zendesk/case-a', { type: 'note', title: 'Case A', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce case a'],
+    ['zendesk/case-b', { type: 'note', title: 'Case B', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce case b'],
+    ['zendesk/case-c', { type: 'note', title: 'Case C', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce case c'],
+    ['ticket/inst-a', { type: 'note', title: 'Inst A', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce inst a'],
+    ['ticket/inst-b', { type: 'note', title: 'Inst B', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce inst b'],
+    ['ticket/inst-c', { type: 'note', title: 'Inst C', compiled_truth: 'rbl definitional bounce' }, 'rbl definitional bounce inst c'],
+  ];
+  for (const [slug, page, chunkText] of evtPages) {
+    await eng.putPage(slug, page);
+    await eng.upsertChunks(slug, [
+      { chunk_index: 0, chunk_text: chunkText, chunk_source: 'compiled_truth', embedding: CLOSE_EMB },
+    ]);
+  }
+  // Irrelevant governed page: raw cosine ≈ 0.40 (below floor 0.50, above HNSW
+  // reach) AND text omits query keywords → Lane-A top-K excludes it; Lane-B
+  // (slug-restricted) RETRIEVES it on both engines; the floor must EXCLUDE it.
+  await eng.putPage('governed-corpus/email_rbl', {
+    type: 'note',
+    title: 'Email RBL Authority',
+    compiled_truth: 'unrelated authority topic content',
+  });
+  await eng.upsertChunks('governed-corpus/email_rbl', [
+    { chunk_index: 0, chunk_text: 'unrelated authority topic content', chunk_source: 'compiled_truth', embedding: IRR_EMB },
+  ]);
+  // Two RELEVANT governed pages: cosine ≈0.66 (above floor 0.5, below non-governed
+  // 1.0 ⇒ Lane-A top-K excludes them). chunk_text deliberately AVOIDS the query
+  // terms so Lane-A's keyword arm doesn't boost them either — the lane is what
+  // surfaces them (via slug-restricted vector search + raw-cosine floor). Used by
+  // the bounded-context-augmentation RED tests: relevant survival at the reserved
+  // TAIL slot, and bounded one-candidate (only ONE of the two admitted).
+  await eng.putPage('governed-corpus/rbl_authority', { type: 'note', title: 'RBL Authority', compiled_truth: 'authority reference document content' });
+  await eng.upsertChunks('governed-corpus/rbl_authority', [{ chunk_index: 0, chunk_text: 'authority reference document content', chunk_source: 'compiled_truth', embedding: REL_GOV_A }]);
+  await eng.putPage('governed-corpus/dns_authority', { type: 'note', title: 'DNS Authority', compiled_truth: 'authority reference document content' });
+  await eng.upsertChunks('governed-corpus/dns_authority', [{ chunk_index: 0, chunk_text: 'authority reference document content', chunk_source: 'compiled_truth', embedding: REL_GOV_B }]);
+
+  // TRUSTED/ pages (ARBITRARY prefix for genericization RED — proves the lane
+  // prefix is caller-supplied via reservedLanePrefixes, NOT hardcoded). Same
+  // cosine strategy as governed-corpus: relevant pages at ≈0.66 (above floor,
+  // below non-governed 1.0), irrelevant at ≈0.40 (below floor). chunk_text
+  // avoids query terms so Lane-A keyword arm doesn't boost them.
+  await eng.putPage('trusted/rbl-guide', { type: 'note', title: 'Trusted RBL', compiled_truth: 'authority reference document content' });
+  await eng.upsertChunks('trusted/rbl-guide', [{ chunk_index: 0, chunk_text: 'authority reference document content', chunk_source: 'compiled_truth', embedding: REL_GOV_A }]);
+  await eng.putPage('trusted/dns-guide', { type: 'note', title: 'Trusted DNS', compiled_truth: 'authority reference document content' });
+  await eng.upsertChunks('trusted/dns-guide', [{ chunk_index: 0, chunk_text: 'authority reference document content', chunk_source: 'compiled_truth', embedding: REL_GOV_B }]);
+  await eng.putPage('trusted/irrelevant', { type: 'note', title: 'Trusted Irrelevant', compiled_truth: 'unrelated authority topic content' });
+  await eng.upsertChunks('trusted/irrelevant', [{ chunk_index: 0, chunk_text: 'unrelated authority topic content', chunk_source: 'compiled_truth', embedding: IRR_EMB }]);
+}
+
+async function countCacheRows(queryText?: string): Promise<number> {
+  const sql = queryText
+    ? 'SELECT COUNT(*)::int AS n FROM query_cache WHERE query_text = $1'
+    : 'SELECT COUNT(*)::int AS n FROM query_cache';
+  const rows = queryText
+    ? await engine.executeRaw<{ n: number }>(sql, [queryText])
+    : await engine.executeRaw<{ n: number }>(sql);
+  return rows[0].n;
+}
+
+beforeAll(async () => {
+  prevGbrainHome = process.env.GBRAIN_HOME;
+  isolatedHome = mkdtempSync(join(tmpdir(), 'gbrain-govlane-home-'));
+  process.env.GBRAIN_HOME = isolatedHome;
+
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await seedFixture(engine);
+
+  // Optional Postgres engine for the T14 per-engine degradation path.
+  if (process.env.DATABASE_URL) {
+    pgEngine = new PostgresEngine();
+    await pgEngine.connect({ database_url: process.env.DATABASE_URL, engine: 'postgres' });
+    await pgEngine.initSchema();
+    await seedFixture(pgEngine);
+  }
+
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: DIMS,
+    env: { OPENAI_API_KEY: 'sk-test' },
+  });
+  stubEmbeddings();
+}, 120_000);
+
+afterAll(async () => {
+  __setEmbedTransportForTests(null);
+  resetGateway();
+  await engine.disconnect();
+  if (pgEngine) await pgEngine.disconnect();
+  if (prevGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = prevGbrainHome;
+  rmSync(isolatedHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM query_cache');
+}, 30_000);
+
+const Q = 'rbl definitional';
+
+describe('T13 — governed-lane-ON skips query cache (Option B); default-OFF preserved, no version bump', () => {
+  test('governed-lane-ON writes ZERO cache rows; default-OFF still caches; KNOBS_HASH_VERSION unchanged', async () => {
+    // --- default-OFF baseline: legacy cache behavior is preserved ---
+    await hybridSearchCached(engine, Q, { limit: 5, useCache: true } as any);
+    await awaitPendingSearchCacheWrites();
+    const offRows = await countCacheRows(Q);
+    expect(offRows).toBe(1); // precondition: cache active in this hermetic env
+
+    // --- governed-lane-ON: must skip the cache entirely (no store) ---
+    await engine.executeRaw('DELETE FROM query_cache');
+    await hybridSearchCached(engine, Q, { limit: 5, useCache: true, reservedLanePrefixes: ['governed-corpus/'] } as any);
+    await awaitPendingSearchCacheWrites();
+    const onRows = await countCacheRows(Q);
+    expect(onRows).toBe(0);                     // governed-lane-ON skips cache
+    expect(onRows).toBeLessThan(offRows);        // contrast: skip < default-off
+
+    // --- no hash-version bump: Option B (cache-skip) leaves mode.ts untouched. ---
+    expect(KNOBS_HASH_VERSION).toBe(15);
+  });
+});
+
+/**
+ * T14 — Lane-B failure degrades to exact Lane-A. Run for EACH relevant engine
+ * path (PGLite always; Postgres when available) per SL-184. The forced
+ * Lane-B error overrides the engine's searchVector to throw when a restrict
+ * prefix set is passed — that is exactly the Lane-B call shape.
+ */
+async function runLaneBDegradation(getEng: () => PGLiteEngine | PostgresEngine, label: string): Promise<void> {
+  test(`T14 [${label}]: happy path surfaces governed; forced Lane-B throw degrades to exact Lane-A`, async () => {
+    const eng = getEng();
+    // happy-path anchor: reservedLanePrefixes set ⇒ candidate surfaces via Lane-B.
+    embedTransportCalls = 0;
+    const happyOn = await hybridSearch(eng as any, Q, { limit: 5, reservedLanePrefixes: ['governed-corpus/'] } as any);
+    const onEmbedCalls = embedTransportCalls;
+    expect(
+      happyOn.some(r => r.slug.startsWith('governed-corpus/')),
+    ).toBe(true);
+
+    // baseline: Lane-A only (no reservedLanePrefixes) — lane candidates excluded by the fixture.
+    embedTransportCalls = 0;
+    const laneAOnly = await hybridSearch(eng as any, Q, { limit: 5 } as any);
+    const offEmbedCalls = embedTransportCalls;
+    expect(laneAOnly.some(r => r.slug.startsWith('governed-corpus/'))).toBe(false);
+
+    // one-embedQuery invariant (SL-184/185/190): Lane-B reuses the precomputed
+    // queryEmbedding via searchVector(embedding) — it adds ZERO embed calls.
+    // Spy-proven: governed-ON embed count == governed-OFF == exactly 1 (single
+    // non-expanded query; bare hybridSearch does no cache-lookup embed).
+    expect(offEmbedCalls).toBe(1);
+    expect(onEmbedCalls).toBe(1);
+    expect(onEmbedCalls).toBe(offEmbedCalls);
+
+    // degradation: force Lane-B to throw, assert exact Lane-A recovery.
+    const origSearchVector = eng.searchVector.bind(eng);
+    let laneBThrowCount = 0;
+    try {
+      (eng as any).searchVector = (emb: Float32Array, opts?: any) => {
+        if (opts?.restrict_slug_prefixes?.length) {
+          laneBThrowCount++;
+          throw new Error('forced Lane-B failure');
+        }
+        return origSearchVector(emb, opts);
+      };
+
+      let degraded: Awaited<ReturnType<typeof hybridSearch>> | undefined;
+      let didThrow = false;
+      try {
+        degraded = await hybridSearch(eng as any, Q, { limit: 5, reservedLanePrefixes: ['governed-corpus/'] } as any);
+      } catch {
+        didThrow = true;
+      }
+
+      expect(laneBThrowCount).toBeGreaterThan(0); // Lane-B path was actually exercised on this engine
+      expect(didThrow).toBe(false);               // (a) legacy search succeeds
+      expect(degraded).toBeDefined();
+      expect(degraded!.some(r => r.slug.startsWith('governed-corpus/'))).toBe(false); // (b) zero broadened governed
+      expect(degraded!.map(r => r.slug).sort()).toEqual(laneAOnly.map(r => r.slug).sort()); // (c) exact Lane-A
+    } finally {
+      (eng as any).searchVector = origSearchVector;
+    }
+  }, 60_000);
+}
+
+describe('T14 — Lane-B failure degrades to exact Lane-A (per engine)', () => {
+  // PGLite path — always exercised. Postgres path is registered when
+  // DATABASE_URL is present at load time (test bodies run after beforeAll
+  // connects pgEngine, so the engine is ready by then).
+  runLaneBDegradation(() => engine, 'PGLite');
+  if (process.env.DATABASE_URL) runLaneBDegradation(() => pgEngine!, 'Postgres');
+});
+
+/**
+ * T15 — BOUNDED-CONTEXT AUGMENTATION (RED, SL-211). PM resolution of note c:
+ * REJECT rank-0 pin; admit at most ONE deduplicated relevant governed candidate
+ * into a reserved TAIL context slot when limit>=2 (replacing only the Lane-A
+ * tail if full); preserve Lane-A top + relative order; limit<2 ⇒ Lane-A only.
+ * Lane-B admission uses configurable min_raw_score (raw-cosine, pre-source-factor).
+ *
+ * RED contract: each case FAILS on the frozen old-merge code (prepend top-3, no
+ * floor) solely because the bounded-merge + raw-cosine floor is unimplemented.
+ * Existing controls (12-case seam, T13, T14) remain stable. Both engines.
+ */
+async function runBoundedMergeCases(getEng: () => PGLiteEngine | PostgresEngine, label: string): Promise<void> {
+  const LIMIT = 5;
+  const FLOOR = 0.5; // explicit test threshold (raw-cosine domain); NOT a production default
+  const gov = (s: string) => s.startsWith('governed-corpus/');
+
+  test(`T15.0 [${label}]: PRE-CONDITION — searchVector(restrict) retrieves email_rbl on BOTH engines (proves the floor, not recall)`, async () => {
+    const eng = getEng();
+    // Direct Lane-B probe with the query embedding (FAKE_EMB = what the stub returns
+    // and what hybridSearch's Lane-B reuses). email_rbl cosine ≈ 0.40 ⇒ both Postgres
+    // HNSW and PGLite brute-force MUST retrieve it. If this fails, the fixture cosine
+    // is below an engine's reach and T15.1/T15.2 would pass for the wrong reason.
+    const laneB = await (eng as any).searchVector(Float32Array.from(FAKE_EMB), { restrict_slug_prefixes: ['governed-corpus/'], limit: 5 } as any);
+    expect(laneB.some((r: any) => r.slug === 'governed-corpus/email_rbl')).toBe(true);
+  });
+
+  test(`T15.1 [${label}]: irrelevant governed EXCLUDED (raw cosine < floor)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+    expect(res.some(r => r.slug === 'governed-corpus/email_rbl')).toBe(false); // irrelevant (FAR_EMB, cosine≪floor) must not be admitted
+  });
+
+  test(`T15.2 [${label}]: boosted irrelevant STILL excluded (floor on raw, not re-ranked score)`, async () => {
+    const eng = getEng();
+    const saved = process.env.GBRAIN_SOURCE_BOOST;
+    process.env.GBRAIN_SOURCE_BOOST = 'governed-corpus/:2.0'; // sourceFactor=2 ⇒ re-ranked .score inflates, but raw cosine unchanged
+    try {
+      const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+      expect(res.some(r => r.slug === 'governed-corpus/email_rbl')).toBe(false); // raw<floor ⇒ excluded despite boost
+    } finally {
+      if (saved === undefined) delete process.env.GBRAIN_SOURCE_BOOST; else process.env.GBRAIN_SOURCE_BOOST = saved;
+    }
+  });
+
+  test(`T15.3 [${label}]: relevant governed survives in the reserved TAIL slot`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+    const admitted = res.filter(r => gov(r.slug));
+    expect(admitted.length).toBe(1);                              // exactly one governed
+    expect(res[res.length - 1]?.slug).toMatch(/governed-corpus\//); // ...at the TAIL (last position)
+    expect(res[0]?.slug).not.toMatch(/governed-corpus\//);         // ...NOT rank-0 (reject pin)
+  });
+
+  test(`T15.4 [${label}]: Lane-A TOP + relative order preserved`, async () => {
+    const eng = getEng();
+    const laneA = await hybridSearch(eng as any, Q, { limit: LIMIT } as any);
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+    expect(res[0]?.slug).toBe(laneA[0]?.slug);                     // Lane-A top preserved (rank-0 unchanged)
+    const resNg = res.filter(r => !gov(r.slug)).map(r => r.slug);  // non-governed keep relative order
+    const laneANg = laneA.filter(r => !gov(r.slug)).map(r => r.slug).slice(0, LIMIT - 1);
+    expect(resNg).toEqual(laneANg);
+  });
+
+  test(`T15.5 [${label}]: bounded ONE candidate + dedup (multiple relevant ⇒ still one)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+    expect(res.filter(r => gov(r.slug)).length).toBe(1); // both rbl_authority + dns_authority are relevant, but only ONE admitted
+  });
+
+  test(`T15.6 [${label}]: limit<2 ⇒ Lane-A only (no governed)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: 1, reservedLanePrefixes: ['governed-corpus/'], reservedLaneMinRawScore: FLOOR } as any);
+    expect(res.some(r => gov(r.slug))).toBe(false); // limit<2 ⇒ reserved tail slot not created
+  });
+}
+
+describe('T15 — bounded-context augmentation (RED, per engine)', () => {
+  runBoundedMergeCases(() => engine, 'PGLite');
+  if (process.env.DATABASE_URL) runBoundedMergeCases(() => pgEngine!, 'Postgres');
+});
+
+// ─── T16 GENERICIZATION RED (SL-222/224): caller-supplied reservedLanePrefixes ──
+// These tests FAIL on the committed literal-bearing code (ecf42981) because the
+// generic API (reservedLanePrefixes / GBRAIN_RESERVED_LANE_PREFIXES /
+// reservedLaneMinRawScore) is NOT yet implemented — the production source
+// hardcodes a literal prefix set. Expected: failures
+// solely from the missing generic API/env/validation + literal-removal. Existing
+// T13/T14/T15 tests remain unchanged.
+
+test('T16.0: NO application literal governed-corpus/ in production source (src/)', () => {
+  // git grep exits 1 (no matches) after GREEN removes the literal.
+  // Currently exits 0 (literal at hybrid.ts:203) → FAIL (RED).
+  let exitCode = 0;
+  try {
+    execSync('git grep --count governed-corpus/ -- src/', { stdio: 'pipe' });
+  } catch (e: any) {
+    exitCode = e.status ?? 1;
+  }
+  expect(exitCode).toBe(1);
+});
+
+async function runGenericLaneCases(getEng: () => PGLiteEngine | PostgresEngine, label: string): Promise<void> {
+  const LIMIT = 5;
+  const trusted = (s: string) => s.startsWith('trusted/');
+
+  test(`T16.1 [${label}]: arbitrary prefix trusted/ works via reservedLanePrefixes`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['trusted/'] } as any);
+    expect(res.some(r => trusted(r.slug))).toBe(true);
+  });
+
+  test(`T16.2 [${label}]: two prefixes deterministic (trusted/ + docs/ → one candidate)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['trusted/', 'docs/'] } as any);
+    const laneCands = res.filter(r => trusted(r.slug) || r.slug.startsWith('docs/'));
+    expect(laneCands.length).toBe(1); // bounded one
+  });
+
+  test(`T16.3 [${label}]: env GBRAIN_RESERVED_LANE_PREFIXES=trusted/ activates lane`, async () => {
+    const eng = getEng();
+    const saved = process.env.GBRAIN_RESERVED_LANE_PREFIXES;
+    process.env.GBRAIN_RESERVED_LANE_PREFIXES = 'trusted/';
+    try {
+      const res = await hybridSearch(eng as any, Q, { limit: LIMIT } as any);
+      expect(res.some(r => trusted(r.slug))).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.GBRAIN_RESERVED_LANE_PREFIXES;
+      else process.env.GBRAIN_RESERVED_LANE_PREFIXES = saved;
+    }
+  });
+
+  test(`T16.4 [${label}]: whitespace + duplicate normalization ([' trusted/ ', 'trusted/'] → one)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: [' trusted/ ', 'trusted/'] } as any);
+    expect(res.some(r => trusted(r.slug))).toBe(true);
+  });
+
+  test(`T16.5 [${label}]: configurable reservedLaneMinRawScore (0.9 blocks, 0.5 admits)`, async () => {
+    const eng = getEng();
+    // relevant trusted/ cosine ≈ 0.66; floor 0.9 > 0.66 → no candidate
+    const blocked = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['trusted/'], reservedLaneMinRawScore: 0.9 } as any);
+    expect(blocked.some(r => trusted(r.slug))).toBe(false);
+    // floor 0.5 < 0.66 → candidate admitted
+    const admitted = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['trusted/'], reservedLaneMinRawScore: 0.5 } as any);
+    expect(admitted.some(r => trusted(r.slug))).toBe(true);
+  });
+
+  test(`T16.6 [${label}]: empty/unset reservedLanePrefixes → exact legacy (no lane, no candidate)`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: [] } as any);
+    expect(res.some(r => trusted(r.slug))).toBe(false);
+    expect(res.some(r => r.slug.startsWith('governed-corpus/'))).toBe(false);
+  });
+
+  test(`T16.7 [${label}]: invalid prefix (path traversal /../) → fail closed`, async () => {
+    const eng = getEng();
+    const res = await hybridSearch(eng as any, Q, { limit: LIMIT, reservedLanePrefixes: ['./../'] } as any);
+    expect(res.some(r => trusted(r.slug))).toBe(false);
+  });
+}
+
+describe('T16 — genericization: caller-supplied reservedLanePrefixes (RED, per engine)', () => {
+  runGenericLaneCases(() => engine, 'PGLite');
+  if (process.env.DATABASE_URL) runGenericLaneCases(() => pgEngine!, 'Postgres');
+});


### PR DESCRIPTION
> Refs #3877.

### Problem
A curated slug-prefix subset (reference pages, authoritative definitions — any caller-chosen prefix) often loses rank competition against high-volume pages and never enters the HNSW candidate pool, so it can't surface alongside regular results. A post-HNSW source boost can't recover chunks the pool never selected.

### What this adds (all additive, default-OFF)

**Engine primitives (usable independently):**
- `SearchOpts.restrict_slug_prefixes?: string[]` — positive slug-prefix inclusion applied **pre-HNSW** in the inner `hnsw_candidates` CTE on both Postgres and PGlite (`buildRestrictClause`, sibling of `buildHardExcludeClause`).
- `SearchOpts.min_raw_score?: number` — configurable **raw-cosine** floor applied in the `scored` CTE **before** the source-factor multiplier (true raw-cosine gate, independent of `GBRAIN_SOURCE_BOOST`).

**Composition (one-embedding bounded-lane merge):**
- `HybridSearchOpts.reservedLanePrefixes?: string[]` — non-empty enables a second vector lane ("Lane B") on the **same query embedding** (one-embed invariant: reuses the precomputed vector, no re-embed). Also configurable via `GBRAIN_RESERVED_LANE_PREFIXES` env (comma-separated, deployment-supplied — **no application-specific literal** in production source).
- `HybridSearchOpts.reservedLaneMinRawScore?: number` — per-call floor override (default `GBRAIN_RESERVED_LANE_FLOOR=0.5`, conservative placeholder pending pilot).
- Prefix resolution: trims whitespace, deduplicates, validates (rejects absolute `/`, traversal `..`, glob `*`/`?`, empty). Invalid ⇒ lane disabled (fail-closed).
- **Bounded merge**: at most **one** deduplicated relevant candidate in a **reserved tail slot** (never rank-0, `limit>=2`, replaces only the Lane-A tail when full, `limit<2` ⇒ Lane-A only). Lane-A top + relative order preserved. Lane-B failure (`try/catch`) ⇒ exact Lane-A.
- Reserved-lane-on **skips the query cache** (Option B — `skipCache` predicate; `KNOBS_HASH_VERSION` unchanged).

### Primitive vs composition — maintainer may accept or split
This PR includes both the engine primitives (`restrict_slug_prefixes`, `min_raw_score`) AND the composition (`reservedLanePrefixes` → bounded-tail merge in `hybridSearch`). If preferred, the primitives can land first (they're independently useful) and the composition in a follow-up.

### Compatibility / rollback
- Default OFF (empty/unset prefixes) ⇒ **byte-identical legacy** SQL and behavior. `min_raw_score` unset ⇒ empty clause. No `mode.ts`, no schema/migration, no re-embed.
- Rollback: `git revert` (single commit) or image swap to prior — no DB state to undo.

### Tests
- **32 serial** (both PGLite + Postgres where the engine seam applies): cache-skip + `KNOBS=15`; Lane-B throw → exact Lane-A + one-embed spy; bounded-merge (irrelevant exclusion, boosted-irrelevant exclusion, relevant survival in reserved tail, Lane-A top+order, bounded one-candidate, `limit<2`); genericization (arbitrary `trusted/` prefix, two-prefix deterministic, env parsing, whitespace/dedup normalization, `reservedLaneMinRawScore` configurable, empty-legacy, invalid fail-closed, src grep no-literal contract).
- **12-case seam** (positive-prefix filter + raw-score floor) × PGLite + Postgres (parity).
- **75 focused regressions** (query-cache-knobs-hash, sql-ranking, search-lang-symbol-kind).
- `tsc --noEmit` exit 0; `verify` 34/34 (typecheck/privacy/jsonb/source-id/test-isolation).

### serve-http E2E gap
`serve-http-takes-holders` e2e requires a running `gbrain serve --http` + brain; it is **skipped** in the dev harness (environmental). This patch has **zero overlap** with `serve-http`/`takes_holders`/`oauth-provider` (the v0.42.74.0 security files). The e2e **must run at deployment smoke** in a serve-http environment before go-live.

### Questions for maintainer
1. Naming: `reservedLanePrefixes` — acceptable, or prefer `governedLanePrefixes` / `authorityLanePrefixes`? Optionally, the test filenames currently use `governed-*` development names (`_governed-lane-cases.ts`, `governed-source-lane*.test.ts`, `governed-lane.serial.test.ts`) — happy to rename to `reserved-*` if preferred for consistency.
2. `min_raw_score`: keep as a general `SearchOpts` (any caller can floor), or scope to the reserved lane only?
3. Bounded merge: "at most one, reserved tail, Lane-A preserved" — acceptable, or prefer configurable candidate count?
4. Default floor: `GBRAIN_RESERVED_LANE_FLOOR=0.5` placeholder — OK to ship conservative pending pilot, or leave unset?

### File manifest (9 files, 980+/6-)
| file | status |
|------|--------|
| src/core/types.ts | M |
| src/core/search/sql-ranking.ts | M |
| src/core/postgres-engine.ts | M |
| src/core/pglite-engine.ts | M |
| src/core/search/hybrid.ts | M |
| test/_governed-lane-cases.ts (shared seam factory) | A |
| test/governed-source-lane.test.ts | A |
| test/governed-source-lane-postgres.test.ts | A |
| test/search/governed-lane.serial.test.ts | A |