### PR TITLE
v0.42.74.1 fix(extract): summarize wrapped inline citations by paragraph (#3664)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -39,6 +39,7 @@ import {
   extractFrontmatterLinks, isGlobalBasenameEnabled, LINK_EXTRACTOR_VERSION_TS,
   WIKILINK_BASENAME_LINK_TYPE,
   buildBasenameIndex, queryBasenameIndex, stripCodeBlocks,
+  parseInlineCitationTimelineEntries,
   type UnresolvedFrontmatterRef, type LinkCandidate,
 } from '../core/link-extraction.ts';
 import { createProgress } from '../core/progress.ts';
@@ -566,23 +567,11 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
   // carries its own [Source: ...] citation, and re-extracting it would file
   // a duplicate entry under a different (source, summary) shape that the
   // DB-level uniqueness cannot collapse.
-  const citationPattern = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
   const bulletLinePattern = /^-\s+\*\*\d{4}-\d{2}-\d{2}\*\*\s*\|/;
-  for (const line of content.split(/\r?\n/)) {
-    if (bulletLinePattern.test(line)) continue;
-    const lineMatches = [...line.matchAll(citationPattern)];
-    if (lineMatches.length === 0) continue;
-    // Strip every citation marker from the line to leave the annotated text.
-    const summary = line
-      .replace(/\[Source:[^\]]*\]/g, '')
-      .replace(/^[-*>#\s]+/, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 300);
-    if (!summary) continue; // a bare citation with no surrounding text is not an event
-    for (const m of lineMatches) {
-      entries.push({ slug, date: m[2], source: m[1].trim().slice(0, 200), summary });
-    }
+  for (const entry of parseInlineCitationTimelineEntries(content, {
+    skipLine: (line) => bulletLinePattern.test(line),
+  })) {
+    entries.push({ slug, date: entry.date, source: entry.source, summary: entry.summary });
   }
 
   return entries;

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -14,7 +14,12 @@
 import type { BrainEngine } from './engine.ts';
 import type { PageType, EffectiveDateSource } from './types.ts';
 import { ensureWellFormed } from './text-safe.ts';
+import { stripCodeBlocks } from './markdown-code.ts';
+import { parseInlineCitationTimelineEntries } from './timeline-citations.ts';
 import { slugifyPath } from './sync.ts';
+
+export { stripCodeBlocks } from './markdown-code.ts';
+export { parseInlineCitationTimelineEntries, type InlineCitationTimelineCandidate } from './timeline-citations.ts';
 
 /**
  * v0.42.7 — link-extraction version stamp. Bump this ISO timestamp whenever the
@@ -205,42 +210,6 @@ const WIKILINK_GENERIC_RE = /\[\[([^|\]#\n[]+?)(?:#[^|\]]*?)?(?:\|([^\]]+?))?\]\
  * span out of the 2c scan so a wikilink inside a markdown label is inert.
  */
 const MARKDOWN_LABEL_WIKILINK_RE = /\[[^\]\n]*\[\[[^\]\n]+\]\][^\]\n]*\]\([^)\n]+\)/g;
-
-/**
- * Strip fenced code blocks (```...```) and inline code (`...`) from markdown,
- * replacing them with whitespace of equivalent length. Preserves byte offsets
- * for any caller that cares about positions; for our extractors this is just
- * defense-in-depth — slugs inside code are not real entity references.
- */
-export function stripCodeBlocks(content: string): string {
-  let out = '';
-  let i = 0;
-  while (i < content.length) {
-    // Fenced block: ``` (optional language) ... ```
-    if (content.startsWith('```', i)) {
-      const end = content.indexOf('```', i + 3);
-      if (end === -1) { out += ' '.repeat(content.length - i); break; }
-      out += ' '.repeat(end + 3 - i);
-      i = end + 3;
-      continue;
-    }
-    // Inline code: `...` (single backtick, no newline inside)
-    if (content[i] === '`') {
-      const end = content.indexOf('`', i + 1);
-      if (end === -1 || content.slice(i + 1, end).includes('\n')) {
-        out += content[i];
-        i++;
-        continue;
-      }
-      out += ' '.repeat(end + 1 - i);
-      i = end + 1;
-      continue;
-    }
-    out += content[i];
-    i++;
-  }
-  return out;
-}
 
 /**
  * A code-reference found in markdown prose. Created by extractCodeRefs and
@@ -1310,82 +1279,6 @@ const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*
 // 年/月 markers so plain ASCII `- 2020-01-02 - text` does NOT match — non-bold
 // ASCII dates were never timeline entries and must stay that way.
 const TIMELINE_LINE_RE_CN = /^\s*-?\s*(?:\*\*)?(\d{4})年(\d{1,2})月(\d{1,2})日?(?:\*\*)?\s*[|\-–—]+\s*(.+?)\s*$/;
-const CITATION_TIMELINE_RE = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
-
-export interface InlineCitationTimelineCandidate {
-  date: string;
-  source: string;
-  summary: string;
-}
-
-interface CitationParagraph {
-  lines: string[];
-  text: string;
-}
-
-function startsMarkdownBlock(line: string): boolean {
-  return /^#{1,6}\s/.test(line) || /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
-}
-
-function citationParagraphs(
-  content: string,
-  opts: { skipLine?: (line: string) => boolean } = {},
-): CitationParagraph[] {
-  const paragraphs: CitationParagraph[] = [];
-  let lines: string[] = [];
-
-  const flush = () => {
-    if (lines.length === 0) return;
-    paragraphs.push({
-      lines,
-      text: lines.map((line) => line.trim()).join(' '),
-    });
-    lines = [];
-  };
-
-  for (const line of stripCodeBlocks(content).split(/\r?\n/)) {
-    if (line.trim().length === 0) {
-      flush();
-      continue;
-    }
-    if (opts.skipLine?.(line)) {
-      flush();
-      continue;
-    }
-    if (lines.length > 0 && startsMarkdownBlock(line)) flush();
-    lines.push(line);
-  }
-  flush();
-
-  return paragraphs;
-}
-
-export function parseInlineCitationTimelineEntries(
-  content: string,
-  opts: { skipLine?: (line: string) => boolean } = {},
-): InlineCitationTimelineCandidate[] {
-  const result: InlineCitationTimelineCandidate[] = [];
-  for (const paragraph of citationParagraphs(content, opts)) {
-    const matches = [...paragraph.text.matchAll(CITATION_TIMELINE_RE)];
-    if (matches.length === 0) continue;
-    const summary = paragraph.text
-      .replace(/\[Source:[^\]]*\]/g, '')
-      .replace(/^[-*>#\s]+/, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 300);
-    if (!summary) continue;
-    for (const m of matches) {
-      if (!isValidDate(m[2])) continue;
-      result.push({
-        date: m[2],
-        source: m[1].trim().slice(0, 200),
-        summary,
-      });
-    }
-  }
-  return result;
-}
 
 /**
  * Parse timeline entries from content. Looks at:

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1327,7 +1327,10 @@ function startsMarkdownBlock(line: string): boolean {
   return /^#{1,6}\s/.test(line) || /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
 }
 
-function citationParagraphs(content: string): CitationParagraph[] {
+function citationParagraphs(
+  content: string,
+  opts: { skipLine?: (line: string) => boolean } = {},
+): CitationParagraph[] {
   const paragraphs: CitationParagraph[] = [];
   let lines: string[] = [];
 
@@ -1340,8 +1343,12 @@ function citationParagraphs(content: string): CitationParagraph[] {
     lines = [];
   };
 
-  for (const line of content.split(/\r?\n/)) {
+  for (const line of stripCodeBlocks(content).split(/\r?\n/)) {
     if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    if (opts.skipLine?.(line)) {
       flush();
       continue;
     }
@@ -1358,8 +1365,7 @@ export function parseInlineCitationTimelineEntries(
   opts: { skipLine?: (line: string) => boolean } = {},
 ): InlineCitationTimelineCandidate[] {
   const result: InlineCitationTimelineCandidate[] = [];
-  for (const paragraph of citationParagraphs(content)) {
-    if (opts.skipLine && paragraph.lines.some(opts.skipLine)) continue;
+  for (const paragraph of citationParagraphs(content, opts)) {
     const matches = [...paragraph.text.matchAll(CITATION_TIMELINE_RE)];
     if (matches.length === 0) continue;
     const summary = paragraph.text

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1310,6 +1310,76 @@ const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*
 // 年/月 markers so plain ASCII `- 2020-01-02 - text` does NOT match — non-bold
 // ASCII dates were never timeline entries and must stay that way.
 const TIMELINE_LINE_RE_CN = /^\s*-?\s*(?:\*\*)?(\d{4})年(\d{1,2})月(\d{1,2})日?(?:\*\*)?\s*[|\-–—]+\s*(.+?)\s*$/;
+const CITATION_TIMELINE_RE = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
+
+export interface InlineCitationTimelineCandidate {
+  date: string;
+  source: string;
+  summary: string;
+}
+
+interface CitationParagraph {
+  lines: string[];
+  text: string;
+}
+
+function startsMarkdownBlock(line: string): boolean {
+  return /^#{1,6}\s/.test(line) || /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+}
+
+function citationParagraphs(content: string): CitationParagraph[] {
+  const paragraphs: CitationParagraph[] = [];
+  let lines: string[] = [];
+
+  const flush = () => {
+    if (lines.length === 0) return;
+    paragraphs.push({
+      lines,
+      text: lines.map((line) => line.trim()).join(' '),
+    });
+    lines = [];
+  };
+
+  for (const line of content.split(/\r?\n/)) {
+    if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    if (lines.length > 0 && startsMarkdownBlock(line)) flush();
+    lines.push(line);
+  }
+  flush();
+
+  return paragraphs;
+}
+
+export function parseInlineCitationTimelineEntries(
+  content: string,
+  opts: { skipLine?: (line: string) => boolean } = {},
+): InlineCitationTimelineCandidate[] {
+  const result: InlineCitationTimelineCandidate[] = [];
+  for (const paragraph of citationParagraphs(content)) {
+    if (opts.skipLine && paragraph.lines.some(opts.skipLine)) continue;
+    const matches = [...paragraph.text.matchAll(CITATION_TIMELINE_RE)];
+    if (matches.length === 0) continue;
+    const summary = paragraph.text
+      .replace(/\[Source:[^\]]*\]/g, '')
+      .replace(/^[-*>#\s]+/, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 300);
+    if (!summary) continue;
+    for (const m of matches) {
+      if (!isValidDate(m[2])) continue;
+      result.push({
+        date: m[2],
+        source: m[1].trim().slice(0, 200),
+        summary,
+      });
+    }
+  }
+  return result;
+}
 
 /**
  * Parse timeline entries from content. Looks at:
@@ -1372,24 +1442,12 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
   // until now this parser (the db-source extract + ingest path) could not
   // see it, so a page whose dates all live in citations scored zero
   // timeline coverage. Kept in sync with extractTimelineFromContent's
-  // Format 3 (the fs-source path). Lines already captured by the timeline
+  // Format 3 (the fs-source path). Blocks already captured by the timeline
   // bullet pass are skipped (a bullet often carries its own citation).
-  const citationRe = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
-  for (const line of lines) {
-    if (TIMELINE_LINE_RE.test(line)) continue;
-    const matches = [...line.matchAll(citationRe)];
-    if (matches.length === 0) continue;
-    const summary = line
-      .replace(/\[Source:[^\]]*\]/g, '')
-      .replace(/^[-*>#\s]+/, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 300);
-    if (!summary) continue;
-    for (const m of matches) {
-      if (!isValidDate(m[2])) continue;
-      result.push({ date: m[2], summary, detail: `Source: ${m[1].trim().slice(0, 200)}` });
-    }
+  for (const entry of parseInlineCitationTimelineEntries(content, {
+    skipLine: (line) => TIMELINE_LINE_RE.test(line) || TIMELINE_LINE_RE_CN.test(line),
+  })) {
+    result.push({ date: entry.date, summary: entry.summary, detail: `Source: ${entry.source}` });
   }
   return result;
 }

--- a/src/core/markdown-code.ts
+++ b/src/core/markdown-code.ts
@@ -1,0 +1,32 @@
+/**
+ * Strip fenced code blocks (```...```) and inline code (`...`) from markdown,
+ * replacing them with whitespace of equivalent length. Preserves byte offsets
+ * for callers that care about positions.
+ */
+export function stripCodeBlocks(content: string): string {
+  let out = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content.startsWith('```', i)) {
+      const end = content.indexOf('```', i + 3);
+      if (end === -1) { out += ' '.repeat(content.length - i); break; }
+      out += ' '.repeat(end + 3 - i);
+      i = end + 3;
+      continue;
+    }
+    if (content[i] === '`') {
+      const end = content.indexOf('`', i + 1);
+      if (end === -1 || content.slice(i + 1, end).includes('\n')) {
+        out += content[i];
+        i++;
+        continue;
+      }
+      out += ' '.repeat(end + 1 - i);
+      i = end + 1;
+      continue;
+    }
+    out += content[i];
+    i++;
+  }
+  return out;
+}

--- a/src/core/timeline-citations.ts
+++ b/src/core/timeline-citations.ts
@@ -1,0 +1,83 @@
+import { stripCodeBlocks } from './markdown-code.ts';
+
+const CITATION_TIMELINE_RE = /\[Source:\s*([^\]]+?),\s*(\d{4}-\d{2}-\d{2})\s*\]/g;
+
+export interface InlineCitationTimelineCandidate {
+  date: string;
+  source: string;
+  summary: string;
+}
+
+interface CitationParagraph {
+  text: string;
+}
+
+function startsMarkdownBlock(line: string): boolean {
+  return /^#{1,6}\s/.test(line) || /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+}
+
+function citationParagraphs(
+  content: string,
+  opts: { skipLine?: (line: string) => boolean } = {},
+): CitationParagraph[] {
+  const paragraphs: CitationParagraph[] = [];
+  let lines: string[] = [];
+
+  const flush = () => {
+    if (lines.length === 0) return;
+    paragraphs.push({ text: lines.map((line) => line.trim()).join(' ') });
+    lines = [];
+  };
+
+  for (const line of stripCodeBlocks(content).split(/\r?\n/)) {
+    if (line.trim().length === 0) {
+      flush();
+      continue;
+    }
+    if (opts.skipLine?.(line)) {
+      flush();
+      continue;
+    }
+    if (lines.length > 0 && startsMarkdownBlock(line)) flush();
+    lines.push(line);
+  }
+  flush();
+
+  return paragraphs;
+}
+
+export function parseInlineCitationTimelineEntries(
+  content: string,
+  opts: { skipLine?: (line: string) => boolean } = {},
+): InlineCitationTimelineCandidate[] {
+  const result: InlineCitationTimelineCandidate[] = [];
+  for (const paragraph of citationParagraphs(content, opts)) {
+    const matches = [...paragraph.text.matchAll(CITATION_TIMELINE_RE)];
+    if (matches.length === 0) continue;
+    const summary = paragraph.text
+      .replace(/\[Source:[^\]]*\]/g, '')
+      .replace(/^[-*>#\s]+/, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 300);
+    if (!summary) continue;
+    for (const m of matches) {
+      if (!isValidDate(m[2])) continue;
+      result.push({
+        date: m[2],
+        source: m[1].trim().slice(0, 200),
+        summary,
+      });
+    }
+  }
+  return result;
+}
+
+function isValidDate(s: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const [y, mo, d] = s.split('-').map(Number);
+  if (mo < 1 || mo > 12) return false;
+  if (d < 1 || d > 31) return false;
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === mo - 1 && dt.getUTCDate() === d;
+}

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -237,6 +237,28 @@ after the prototype demo. [Source: user interview, 2026-07-30]`;
     expect(entries[0].source).toBe('Meeting');
   });
 
+  it('keeps a prose citation directly under a timeline bullet', () => {
+    const content = `- **2025-03-18** | Meeting notes
+Follow-up decision recorded. [Source: memo, 2025-03-20]`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2025-03-20');
+    expect(entries[0].source).toBe('memo');
+    expect(entries[0].summary).toBe('Follow-up decision recorded.');
+  });
+
+  it('ignores dated citations inside fenced code blocks', () => {
+    const content = `\`\`\`
+Fake claim. [Source: generated fixture, 2025-01-01]
+\`\`\`
+Real claim. [Source: memo, 2025-01-02]`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2025-01-02');
+    expect(entries[0].source).toBe('memo');
+    expect(entries[0].summary).toBe('Real claim.');
+  });
+
   it('skips a bare citation with no surrounding text', () => {
     const content = `[Source: import batch, 2025-07-01]`;
     expect(extractTimelineFromContent(content, 'test')).toHaveLength(0);

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -241,10 +241,13 @@ after the prototype demo. [Source: user interview, 2026-07-30]`;
     const content = `- **2025-03-18** | Meeting notes
 Follow-up decision recorded. [Source: memo, 2025-03-20]`;
     const entries = extractTimelineFromContent(content, 'test');
-    expect(entries).toHaveLength(1);
-    expect(entries[0].date).toBe('2025-03-20');
-    expect(entries[0].source).toBe('memo');
-    expect(entries[0].summary).toBe('Follow-up decision recorded.');
+    expect(entries).toHaveLength(2);
+    expect(entries[0].date).toBe('2025-03-18');
+    expect(entries[0].source).toBe('markdown');
+    expect(entries[0].summary).toBe('Meeting notes');
+    expect(entries[1].date).toBe('2025-03-20');
+    expect(entries[1].source).toBe('memo');
+    expect(entries[1].summary).toBe('Follow-up decision recorded.');
   });
 
   it('ignores dated citations inside fenced code blocks', () => {

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -210,6 +210,17 @@ describe('extractTimelineFromContent', () => {
     expect(entries[0].source).toBe('email from alice-example re: offer, signed');
   });
 
+  it('uses the full paragraph for a wrapped inline citation summary', () => {
+    const content = `The imported app showed product fit for commercial use
+after the prototype demo. [Source: user interview, 2026-07-30]`;
+    const entries = extractTimelineFromContent(content, 'projects/imported-app');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-07-30');
+    expect(entries[0].summary).toBe(
+      'The imported app showed product fit for commercial use after the prototype demo.',
+    );
+  });
+
   it('extracts one entry per citation when a line carries several', () => {
     const content = `Both sides confirmed the partnership. [Source: call with widget-co, 2025-06-01] [Source: follow-up email, 2025-06-03]`;
     const entries = extractTimelineFromContent(content, 'companies/widget-co');

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -1599,6 +1599,31 @@ after the prototype demo. [Source: user interview, 2026-07-30]`);
     expect(entries).toHaveLength(1); // bullet pass only
   });
 
+  test('keeps a prose citation directly under a timeline bullet', () => {
+    const entries = parseTimelineEntries(`- **2025-03-18** | Meeting notes
+Follow-up decision recorded. [Source: memo, 2025-03-20]`);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].date).toBe('2025-03-18');
+    expect(entries[1]).toEqual({
+      date: '2025-03-20',
+      summary: 'Follow-up decision recorded.',
+      detail: 'Source: memo',
+    });
+  });
+
+  test('ignores dated citations inside fenced code blocks', () => {
+    const entries = parseTimelineEntries(`\`\`\`
+Fake claim. [Source: generated fixture, 2025-01-01]
+\`\`\`
+Real claim. [Source: memo, 2025-01-02]`);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      date: '2025-01-02',
+      summary: 'Real claim.',
+      detail: 'Source: memo',
+    });
+  });
+
   test('skips invalid calendar dates and bare citations', () => {
     expect(parseTimelineEntries('Claim. [Source: memo, 2026-13-45]')).toHaveLength(0);
     expect(parseTimelineEntries('[Source: import batch, 2025-07-01]')).toHaveLength(0);

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -1583,6 +1583,17 @@ describe('parseTimelineEntries — Format 3: inline [Source: ..., YYYY-MM-DD] ci
     expect(entries[0].detail).toBe('Source: email re: offer, signed');
   });
 
+  test('uses the full paragraph for a wrapped inline citation summary', () => {
+    const entries = parseTimelineEntries(`The imported app showed product fit for commercial use
+after the prototype demo. [Source: user interview, 2026-07-30]`);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-07-30');
+    expect(entries[0].summary).toBe(
+      'The imported app showed product fit for commercial use after the prototype demo.',
+    );
+    expect(entries[0].detail).toBe('Source: user interview');
+  });
+
   test('does not double-extract a timeline bullet carrying its own citation', () => {
     const entries = parseTimelineEntries('- **2025-03-18** | Meeting notes [Source: notes, 2025-03-18]');
     expect(entries).toHaveLength(1); // bullet pass only


### PR DESCRIPTION
## Summary

Fixes #3664 by making inline citation timeline extraction summarize the surrounding paragraph instead of only the physical line containing `[Source: ..., YYYY-MM-DD]`.

Previously, a wrapped sentence could create a timeline row whose summary was just the second half of the sentence. That made normal citation-following pages produce misleading dated fragments.

## Changes

- Adds a shared inline-citation timeline parser that groups markdown paragraph blocks before stripping citation markers.
- Keeps the existing skip behavior for timeline bullets that already produce a Format 1 entry, so a bullet with its own citation is not double-filed.
- Reuses the shared parser from the filesystem extraction path so db-source and fs-source citation extraction stay aligned.
- Adds focused regression coverage for wrapped citation paragraphs in both extraction surfaces.

## Tests

- Extends `test/link-extraction.test.ts` for the db-source/ingest parser.
- Extends `test/extract.test.ts` for `extractTimelineFromContent`.

## Verification

- `bun test test/extract.test.ts test/link-extraction.test.ts` - 203 pass, 0 fail, 471 expect calls.
- `bash scripts/gbrain-gate.sh <worktree> test/extract.test.ts test/link-extraction.test.ts` - `RESULT: GREEN`; verify green; focused unit tests green; diff-mapped E2E green with 19 pass, 0 fail.
