### PR TITLE
fix(search): tokenize multi-word CJK queries instead of matching the whole string

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1874,18 +1874,48 @@ export class PGLiteEngine implements BrainEngine {
     },
   ): Promise<SearchResult[]> {
     const { limit, offset, innerLimit, sourceFactorCase, hardExcludeClause, visibilityClause, detailFilter, opts, dedup } = ctx;
-    const qRaw = query;
-    if (qRaw.length === 0) return [];
-    const qLike = escapeLikePattern(qRaw);
+    // Whitespace tokenization. The original matched the ENTIRE query as one
+    // indivisible ILIKE substring, so any multi-token query containing CJK
+    // returned empty unless the corpus held that exact string verbatim —
+    // spaces included. "记忆 系统" demanded a literal "记忆 系统"; Chinese
+    // prose writes "记忆系统". The failure was silent: an empty array reads
+    // as "nothing in the brain", not "the tokenizer can't express this".
+    //
+    // Mixed queries route here too (hasCJK is true for "cron 定时"), so the
+    // ASCII half was collateral damage on the same code path.
+    //
+    // Each token becomes its own ILIKE conjunct; scores sum across tokens.
+    // Single-token queries produce arithmetic identical to pre-fix.
+    const tokens = query.split(/\s+/).filter(t => t.length > 0);
+    if (tokens.length === 0) return [];
 
-    // $1 = qLike (escaped for ILIKE)
-    // $2 = qRaw  (raw for position()/replace() ranking arithmetic)
-    // $3 = inner limit (dedup path) OR final limit (chunk-grain path)
-    // $4 = final limit (dedup path only) — see callers
-    // $5 = offset (dedup path)  /  $4 = offset (chunk-grain path)
-    const params: unknown[] = dedup
-      ? [qLike, qRaw, innerLimit, limit, offset]
-      : [qLike, qRaw, limit, offset];
+    // Two bindings per token: LIKE-escaped for the ILIKE conjunct, raw for the
+    // position()/replace() ranking arithmetic. Escaped chars would corrupt the
+    // occurrence count, so they cannot be shared (codex C8).
+    const params: unknown[] = [];
+    const likeIdx: number[] = [];
+    const rawIdx: number[] = [];
+    for (const t of tokens) {
+      params.push(escapeLikePattern(t));
+      likeIdx.push(params.length);
+      params.push(t);
+      rawIdx.push(params.length);
+    }
+    let pInner = 0;
+    if (dedup) {
+      params.push(innerLimit);
+      pInner = params.length;
+    }
+    params.push(limit);
+    const pLimit = params.length;
+    params.push(offset);
+    const pOffset = params.length;
+
+    // All tokens must be present. OR would make a two-token query strictly
+    // noisier than each token alone, which is the wrong direction.
+    const ilikeClause = likeIdx
+      .map(i => `cc.chunk_text ILIKE '%' || $${i} || '%' ESCAPE '\\'`)
+      .join(' AND ');
 
     let extraFilter = '';
     if (opts?.language) {
@@ -1913,13 +1943,17 @@ export class PGLiteEngine implements BrainEngine {
       extraFilter += ` AND p.source_id = $${params.length}`;
     }
 
-    // Bigram-frequency count: count occurrences of $qRaw in chunk_text via
-    // (length(chunk) - length(replace(chunk, q, ''))) / length(q). Acts as
+    // Bigram-frequency count per token: occurrences via
+    // (length(chunk) - length(replace(chunk, tok, ''))) / length(tok). Acts as
     // a ts_rank substitute. position()-tiebreaker so earlier-in-chunk hits
-    // outrank later ones at the same occurrence count.
+    // outrank later ones at the same occurrence count. Summed across tokens so
+    // a chunk matching both tokens densely outranks one that barely matches.
+    const perTokenScore = rawIdx
+      .map(i => `((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $${i}, ''))) / NULLIF(LENGTH($${i}), 0)::real
+        + 1.0 / NULLIF(POSITION($${i} IN cc.chunk_text), 0)::real)`)
+      .join(' + ');
     const scoreExpr = `
-      ((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $2, ''))) / NULLIF(LENGTH($2), 0)::real
-        + 1.0 / NULLIF(POSITION($2 IN cc.chunk_text), 0)::real)
+      (${perTokenScore})
       * ${sourceFactorCase}
     `;
 
@@ -1941,15 +1975,15 @@ export class PGLiteEngine implements BrainEngine {
            FROM content_chunks cc
            JOIN pages p ON p.id = cc.page_id
            JOIN sources s ON s.id = p.source_id
-           WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\' ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+           WHERE ${ilikeClause} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
              AND cc.modality = 'text'
            ORDER BY score DESC
-           LIMIT $3
+           LIMIT $${pInner}
          ),
          ${buildBestPerPagePoolCte('ranked')}
          SELECT * FROM best_per_page
          ORDER BY score DESC, page_id ASC, chunk_id ASC
-         LIMIT $4 OFFSET $5`,
+         LIMIT $${pLimit} OFFSET $${pOffset}`,
         params,
       );
       return (rows as Record<string, unknown>[]).map(rowToSearchResult);
@@ -1970,9 +2004,9 @@ export class PGLiteEngine implements BrainEngine {
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\' ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE ${ilikeClause} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
          ORDER BY score DESC
-         LIMIT $3 OFFSET $4`,
+         LIMIT $${pLimit} OFFSET $${pOffset}`,
         params,
       );
       return (rows as Record<string, unknown>[]).map(rowToSearchResult);

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -503,6 +503,100 @@ describe('PGLiteEngine: CJK keyword fallback (v0.32.7)', () => {
     // to the ASCII FTS path which also returns nothing for empty.
     expect(results).toEqual([]);
   });
+
+  // ── Multi-token CJK tokenization ──────────────────────────────────────
+  // Pre-fix the CJK branch matched the WHOLE query as one ILIKE substring, so
+  // "记忆 系统" demanded a literal "记忆 系统" (space included) in the corpus.
+  // Chinese prose writes "记忆系统". Every multi-token query containing CJK
+  // returned [] — silently, which reads as "nothing in the brain" rather than
+  // "the tokenizer cannot express this query".
+
+  test('FIX: multi-token CJK query matches spaceless prose', async () => {
+    await engine.putPage('originals/memory-gc', {
+      type: 'concept', title: 'Memory GC',
+      compiled_truth: '记忆系统需要定期回收，否则索引会持续膨胀',
+    });
+    await engine.upsertChunks('originals/memory-gc', [
+      { chunk_index: 0, chunk_text: '记忆系统需要定期回收，否则索引会持续膨胀', chunk_source: 'compiled_truth' },
+    ]);
+    const results = await engine.searchKeyword('记忆 系统');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].slug).toBe('originals/memory-gc');
+  });
+
+  test('FIX: mixed CJK+ASCII query tokenizes both halves', async () => {
+    // hasCJK is true for "cron 定时", so mixed queries route here too — the
+    // ASCII half was collateral damage on the same code path.
+    await engine.putPage('originals/cron-doc', {
+      type: 'concept', title: 'Cron doc',
+      compiled_truth: '定时任务用 cron 表达式配置，daemon 每 30 秒轮询一次',
+    });
+    await engine.upsertChunks('originals/cron-doc', [
+      { chunk_index: 0, chunk_text: '定时任务用 cron 表达式配置，daemon 每 30 秒轮询一次', chunk_source: 'compiled_truth' },
+    ]);
+    const results = await engine.searchKeyword('cron 定时');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].slug).toBe('originals/cron-doc');
+  });
+
+  test('AND semantics: a chunk matching only one token is excluded', async () => {
+    await engine.putPage('originals/both-tokens', {
+      type: 'concept', title: 'Both',
+      compiled_truth: '记忆系统的清理策略',
+    });
+    await engine.upsertChunks('originals/both-tokens', [
+      { chunk_index: 0, chunk_text: '记忆系统的清理策略', chunk_source: 'compiled_truth' },
+    ]);
+    await engine.putPage('originals/one-token', {
+      type: 'concept', title: 'One',
+      compiled_truth: '记忆的容量限制',
+    });
+    await engine.upsertChunks('originals/one-token', [
+      { chunk_index: 0, chunk_text: '记忆的容量限制', chunk_source: 'compiled_truth' },
+    ]);
+    const results = await engine.searchKeyword('记忆 系统');
+    const slugs = results.map(r => r.slug);
+    expect(slugs).toContain('originals/both-tokens');
+    expect(slugs).not.toContain('originals/one-token');
+  });
+
+  test('multi-token scores sum: denser match outranks sparser', async () => {
+    await engine.putPage('originals/dense', {
+      type: 'concept', title: 'Dense',
+      compiled_truth: '记忆系统 记忆系统 记忆系统 三次重复',
+    });
+    await engine.upsertChunks('originals/dense', [
+      { chunk_index: 0, chunk_text: '记忆系统 记忆系统 记忆系统 三次重复', chunk_source: 'compiled_truth' },
+    ]);
+    await engine.putPage('originals/sparse', {
+      type: 'concept', title: 'Sparse',
+      compiled_truth: '这里只提到记忆和系统各一次而已',
+    });
+    await engine.upsertChunks('originals/sparse', [
+      { chunk_index: 0, chunk_text: '这里只提到记忆和系统各一次而已', chunk_source: 'compiled_truth' },
+    ]);
+    const results = await engine.searchKeyword('记忆 系统');
+    const idxDense = results.findIndex(r => r.slug === 'originals/dense');
+    const idxSparse = results.findIndex(r => r.slug === 'originals/sparse');
+    expect(idxDense).toBeGreaterThanOrEqual(0);
+    expect(idxSparse).toBeGreaterThanOrEqual(0);
+    expect(idxDense).toBeLessThan(idxSparse);
+  });
+
+  test('three-token CJK query binds params correctly', async () => {
+    // Guards the dynamic $N numbering: token count drives how many params
+    // precede limit/offset, so an off-by-one here throws or mis-binds.
+    await engine.putPage('originals/three-tok', {
+      type: 'concept', title: 'Three',
+      compiled_truth: '定时任务的记忆系统需要轮询守护进程',
+    });
+    await engine.upsertChunks('originals/three-tok', [
+      { chunk_index: 0, chunk_text: '定时任务的记忆系统需要轮询守护进程', chunk_source: 'compiled_truth' },
+    ]);
+    const results = await engine.searchKeyword('定时 记忆 轮询');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].slug).toBe('originals/three-tok');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

`PGLiteEngine._searchKeywordCJK` binds the ENTIRE query as one indivisible
`ILIKE` substring. Any multi-token query containing CJK returns zero rows
unless the corpus holds that exact string verbatim, spaces included.

```
query "记忆 系统"   ->  ILIKE '%记忆 系统%'   ->  0 rows
```

Chinese prose writes `记忆系统` with no space, so nothing matches. On a brain
with ~350 pages of Chinese content, every two-word query came back empty.

Single tokens work (`记忆` alone is a valid substring), which is why this went
unnoticed: it only bites once a user types two words, and it surfaces as an
empty array. Empty reads as "nothing in the brain", not as "the tokenizer
cannot express this query". There is no error, no warning, no log line.

Mixed queries route here too, since `hasCJK("cron 定时")` is true, so the
ASCII half is collateral damage on the same path.

Reproduction on a brain containing the text `记忆系统需要定期回收`:

| query | before | after |
|---|---|---|
| `记忆` | hit | hit |
| `记忆 系统` | **0 rows** | hit |
| `cron 定时` | **0 rows** | hit |
| `memory system` (ASCII, FTS path) | hit | hit |

## The fix

Each whitespace-separated token becomes its own `ILIKE` conjunct, and the
per-token bigram-frequency scores sum.

AND rather than OR: with OR a two-token query would be strictly noisier than
either token alone, which is the wrong direction for a query the user made
*more* specific.

Single-token queries produce byte-identical arithmetic to before, so existing
CJK behavior is untouched. Both bindings per token are preserved from the
original codex C8 fix (LIKE-escaped for the conjunct, raw for the
`position()`/`replace()` ranking), and `ESCAPE '\'` still applies per conjunct.
Parameter numbering is now derived from token count, so `limit`/`offset` and
the `extraFilter` pushes downstream stay correctly indexed.

Postgres engine is untouched. It goes through `websearch_to_tsquery`, which is
a separate problem (needs pgroonga / zhparser) and out of scope here.

## Tests

Five cases added to `test/pglite-engine.test.ts`, all failing before this change:

- multi-token CJK against spaceless prose
- mixed CJK+ASCII (`cron 定时`)
- AND semantics (a chunk matching only one token is excluded)
- score summation (denser match outranks sparser)
- three-token query, which guards the dynamic `$N` numbering

Verified by mutation rather than by a green check:

- reverting the tokenizer (splitting on `\x00` instead of `\s+`) turns exactly
  those five red, 100 pass / 5 fail
- flipping `AND` to `OR` turns the AND-semantics case red **and** the
  pre-existing `LIKE-meta-char escape` case red, 103 pass / 2 fail

`114 pass / 0 fail` in `test/pglite-engine.test.ts` with the fix in place.
`bun run typecheck` clean.