### PR TITLE
fix(sync): unquote git C-style-quoted paths in buildSyncManifest (#3897)

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -102,6 +102,54 @@ const CODE_EXTENSIONS = new Set<string>([
  *   D       path/to/deleted-file.md
  *   R100    old/path.md     new/path.md
  */
+/**
+ * Undo git's C-style path quoting.
+ *
+ * git quotes any path containing `"`, `\` or a control character, and it does
+ * so unconditionally: `core.quotepath=false` (buildGitInvocation in
+ * commands/sync.ts, #119) only suppresses octal-escaping of NON-ASCII bytes.
+ * A path like `people/Jason "Jay" Strand.md` therefore reaches
+ * buildSyncManifest as `"people/Jason \"Jay\" Strand.md"` — surrounding quotes
+ * included — so it ends `.md"`, fails isMarkdownFilePath(), and is dropped from
+ * the manifest with no error and no counter.
+ *
+ * Octal escapes are decoded as BYTES and utf-8 decoded once at the end: a
+ * single codepoint can span several \NNN escapes, so per-escape decoding
+ * produces mojibake.
+ *
+ * An unquoted path is returned unchanged, so this is a no-op for the common
+ * case.
+ */
+export function unquoteGitPath(raw: string): string {
+  if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) return raw;
+  const body = raw.slice(1, -1);
+  const simple: Record<string, number> = {
+    n: 10, t: 9, r: 13, '"': 34, '\\': 92, a: 7, b: 8, f: 12, v: 11,
+  };
+  const bytes: number[] = [];
+  let i = 0;
+  while (i < body.length) {
+    const c = body[i];
+    if (c === '\\' && i + 1 < body.length) {
+      const nxt = body[i + 1];
+      if (nxt in simple) {
+        bytes.push(simple[nxt]);
+        i += 2;
+        continue;
+      }
+      const trio = body.slice(i + 1, i + 4);
+      if (trio.length === 3 && /^[0-7]{3}$/.test(trio)) {
+        bytes.push(parseInt(trio, 8));
+        i += 4;
+        continue;
+      }
+    }
+    for (const b of new TextEncoder().encode(c)) bytes.push(b);
+    i += 1;
+  }
+  return new TextDecoder('utf-8').decode(new Uint8Array(bytes));
+}
+
 export function buildSyncManifest(gitDiffOutput: string): SyncManifest {
   const manifest: SyncManifest = {
     added: [],
@@ -120,18 +168,21 @@ export function buildSyncManifest(gitDiffOutput: string): SyncManifest {
     if (parts.length < 2) continue;
 
     const action = parts[0];
-    const path = parts[parts.length === 3 ? 2 : 1]; // For renames, new path is 3rd column
+    // Unquote at the single point every path enters the manifest, so the
+    // extension filter and every downstream consumer (slug resolution, file
+    // reads) all see the real name.
+    const path = unquoteGitPath(parts[parts.length === 3 ? 2 : 1]); // For renames, new path is 3rd column
 
     if (action === 'A') {
       manifest.added.push(path);
     } else if (action === 'M') {
       manifest.modified.push(path);
     } else if (action === 'D') {
-      manifest.deleted.push(parts[1]);
+      manifest.deleted.push(unquoteGitPath(parts[1]));
     } else if (action.startsWith('R')) {
       // Rename: R100\told-path\tnew-path
-      const oldPath = parts[1];
-      const newPath = parts[2];
+      const oldPath = unquoteGitPath(parts[1]);
+      const newPath = unquoteGitPath(parts[2]);
       if (oldPath && newPath) {
         manifest.renamed.push({ from: oldPath, to: newPath });
       }

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
-import { buildSyncManifest, isSyncable, pathToSlug, pruneDir, isCodeFilePath } from '../src/core/sync.ts';
+import { buildSyncManifest, isSyncable, pathToSlug, pruneDir, isCodeFilePath, unquoteGitPath } from '../src/core/sync.ts';
 import { buildAutoEmbedArgs, buildGitInvocation } from '../src/commands/sync.ts';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
@@ -278,6 +278,100 @@ describe('buildSyncManifest edge cases', () => {
     expect(manifest.modified).toEqual([]);
     expect(manifest.deleted).toEqual([]);
     expect(manifest.renamed).toEqual([]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────
+// C-style-quoted paths. git quotes any path containing `"`, `\` or a
+// control character, unconditionally — core.quotepath=false (#119) only
+// governs octal-escaping of NON-ASCII bytes. Before unquoteGitPath, such
+// an entry ended `.md"`, failed isSyncable(), and was dropped from the
+// manifest silently: no error, no warning, no counter.
+// ────────────────────────────────────────────────────────────────
+
+describe('unquoteGitPath', () => {
+  test('leaves an unquoted path untouched', () => {
+    expect(unquoteGitPath('people/plain-name.md')).toBe('people/plain-name.md');
+    expect(unquoteGitPath('people/Ольга Петрова.md')).toBe('people/Ольга Петрова.md');
+    expect(unquoteGitPath('')).toBe('');
+  });
+
+  test('strips the wrapping quotes and unescapes embedded ones', () => {
+    expect(unquoteGitPath('"people/Jason \\"Jay\\" Strand.md"'))
+      .toBe('people/Jason "Jay" Strand.md');
+  });
+
+  test('unescapes a literal backslash', () => {
+    expect(unquoteGitPath('"people/a\\\\b.md"')).toBe('people/a\\b.md');
+  });
+
+  test('decodes single-character escapes', () => {
+    expect(unquoteGitPath('"people/a\\tb\\nc.md"')).toBe('people/a\tb\nc.md');
+  });
+
+  test('decodes octal escapes as bytes, utf-8 decoding once at the end', () => {
+    // "ы" is U+044B = 0xD1 0x8B — one codepoint, two \NNN escapes. Decoding
+    // per-escape instead of per-byte yields mojibake here.
+    expect(unquoteGitPath('"people/\\321\\213.md"')).toBe('people/ы.md');
+  });
+
+  test('resulting path passes the extension filter', () => {
+    expect(isSyncable(unquoteGitPath('"people/Jason \\"Jay\\" Strand.md"'))).toBe(true);
+  });
+});
+
+describe('buildSyncManifest — C-style-quoted paths', () => {
+  test('unquotes add, modify and delete entries', () => {
+    const output = [
+      'A\t"people/Marcus \\"Esports\\" Howard.md"',
+      'M\t"companies/ПАО \\"Ростелеком\\".md"',
+      'D\t"people/Jason \\"Jay\\" Strand.md"',
+    ].join('\n');
+    const manifest = buildSyncManifest(output);
+    expect(manifest.added).toEqual(['people/Marcus "Esports" Howard.md']);
+    expect(manifest.modified).toEqual(['companies/ПАО "Ростелеком".md']);
+    expect(manifest.deleted).toEqual(['people/Jason "Jay" Strand.md']);
+  });
+
+  test('unquotes both sides of a rename', () => {
+    const output = 'R100\t"people/old \\"nick\\".md"\t"people/new \\"nick\\".md"';
+    const manifest = buildSyncManifest(output);
+    expect(manifest.renamed).toEqual([
+      { from: 'people/old "nick".md', to: 'people/new "nick".md' },
+    ]);
+  });
+
+  test('quoted entries survive the syncable filter', () => {
+    const output = 'M\t"people/Christian \\"Raz\\" Kippelt.md"';
+    const manifest = buildSyncManifest(output);
+    expect(manifest.modified.filter(p => isSyncable(p))).toHaveLength(1);
+  });
+
+  test('real git output for a quoted filename reaches the manifest', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-quoted-path-'));
+    try {
+      const name = 'people/Marcus "Esports" Howard.md';
+      execSync('git init -q .', { cwd: repo });
+      execSync('git config user.email t@t.t && git config user.name t', { cwd: repo, shell: '/bin/bash' });
+      mkdirSync(join(repo, 'people'));
+      writeFileSync(join(repo, name), 'x\n');
+      execSync('git add -A && git commit -q -m one', { cwd: repo, shell: '/bin/bash' });
+      writeFileSync(join(repo, name), 'x\ny\n');
+      execSync('git add -A && git commit -q -m two', { cwd: repo, shell: '/bin/bash' });
+
+      // gbrain's own invocation, quotepath and all.
+      const argv = buildGitInvocation(repo, ['diff', '--name-status', '-M', 'HEAD~1..HEAD']);
+      const out = execSync(`git ${argv.map(a => JSON.stringify(a)).join(' ')}`, { encoding: 'utf-8' });
+
+      // git really does quote it, whatever core.quotepath says.
+      expect(out.trim()).toBe('M\t"people/Marcus \\"Esports\\" Howard.md"');
+
+      const manifest = buildSyncManifest(out);
+      expect(manifest.modified).toEqual([name]);
+      expect(manifest.modified.filter(p => isSyncable(p))).toHaveLength(1);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #3897.

## The bug

`buildSyncManifest` takes git's path column verbatim. git C-style-quotes any
path containing `"`, `\` or a control character, so such a path arrives as
`"people/Jason \"Jay\" Strand.md"` — surrounding quotes included — ends `.md"`,
fails `isMarkdownFilePath()`, and is dropped from the manifest with no error, no
warning and no counter. The sync output is byte-identical to a clean run.

`core.quotepath=false` (#119) does not prevent this: it governs octal-escaping
of non-ASCII bytes only. Quoting of `"`, `\` and control characters is
unconditional in git — no config disables it. That is why the bug hides: a vault
full of accented and CJK names syncs perfectly, and only a name with a literal
quote is lost.

Observed in production on a 14.7k-page vault (2026-08-08): 41 tracked files
carry such a name; a pass that deleted 45 pages had `sync_brain` report
`deleted: 44`, and `people/Jason "Jay" Strand.md` stayed live in the brain with
`deleted_at: null` after its file was gone. It was caught only because that pass
happened to know the exact expected count.

## The fix

`unquoteGitPath()` — unquote at the single point every path enters the manifest,
so the extension filter and every downstream consumer (slug resolution, file
reads) see the real name. Four call sites in `buildSyncManifest`: add/modify,
delete, and both sides of a rename.

Octal escapes are decoded as **bytes** and utf-8 decoded once at the end — one
codepoint can span several `\NNN` escapes, so per-escape decoding produces
mojibake. An unquoted path is returned unchanged, so this is a no-op for the
common case and nothing about existing behaviour changes.

## Tests

9 new tests in `test/sync.test.ts`: `unquoteGitPath` unit coverage (passthrough,
quote/backslash/control escapes, multi-byte octal), manifest coverage for
add/modify/delete/rename, and one test that builds a real git repo with a quoted
filename, runs gbrain's own `buildGitInvocation`, asserts the exact quoted bytes
git emits, and pushes them through `buildSyncManifest`.

**Discrimination result** (per CONTRIBUTING / #3665) — with `unquoteGitPath`
stubbed to `return raw`, the 9 new tests fail and the 73 pre-existing ones in
that file pass:

```
(fail) unquoteGitPath > strips the wrapping quotes and unescapes embedded ones
(fail) unquoteGitPath > unescapes a literal backslash
(fail) unquoteGitPath > decodes single-character escapes
(fail) unquoteGitPath > decodes octal escapes as bytes, utf-8 decoding once at the end
(fail) unquoteGitPath > resulting path passes the extension filter
(fail) buildSyncManifest — C-style-quoted paths > unquotes add, modify and delete entries
(fail) buildSyncManifest — C-style-quoted paths > unquotes both sides of a rename
(fail) buildSyncManifest — C-style-quoted paths > quoted entries survive the syncable filter
(fail) buildSyncManifest — C-style-quoted paths > real git output for a quoted filename reaches the manifest
 73 pass
 9 fail
```

With the fix in place: `82 pass, 0 fail` in `test/sync.test.ts`, and
`bun run verify` is `pass=34 fail=0`.

The same change has been running against the live 14.7k-page vault since
2026-08-08: an edit to a quoted-filename page that previously synced as
`up_to_date, modified: 0` now reports the edit and updates the page, and the
commit range that previously lost one deletion now reports all 45. Entry counts
reconcile exactly — git reports 93 `.md` entries for the range, gbrain processes
93.

## Not included

The issue's second suggestion — warning when a manifest entry is dropped, rather
than dropping it silently — is deliberately left out of this PR. It changes
output on paths this one doesn't touch, and is worth its own change.

## Test-suite note

`bun run test` on this machine also reports 4 pre-existing failures in
`test/search/autocut-integration.serial.test.ts` and
`test/worker-registry.serial.test.ts`. They reproduce identically on unmodified
`master` @ `0b47afbf402a`, so they are not from this change.
