### PR TITLE
fix(features): treat heartbeat-backed integrations as configured

### DIFF
--- a/src/commands/features.ts
+++ b/src/commands/features.ts
@@ -72,6 +72,32 @@ function saveOffers(offers: FeatureOffersFile) {
   } catch { /* best-effort */ }
 }
 
+// Real-world check: did this integration actually get set up?
+// Heartbeat files are written by Hermes during install (and by other hosts),
+// so they are the source of truth for "is this wired up" — not just whether
+// a secret env var happens to be exported in this shell.
+function integrationHeartbeatExists(recipeId: string): boolean {
+  try {
+    const dir = join(process.env.HOME || '', '.gbrain', 'integrations', recipeId);
+    const heartbeat = join(dir, 'heartbeat.jsonl');
+    if (!existsSync(heartbeat)) return false;
+    const lines = readFileSync(heartbeat, 'utf-8')
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean);
+    return lines.some(line => {
+      try {
+        const evt = JSON.parse(line);
+        return evt?.event === 'setup_complete';
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
+}
+
 function shouldPitch(rec: FeatureRecommendation, offers: FeatureOffersFile, currentVersion: string): boolean {
   if (rec.priority === 1) return true; // always pitch data quality
   const majorMinor = currentVersion.split('.').slice(0, 2).join('.');
@@ -146,9 +172,15 @@ async function scanFeatures(engine: BrainEngine): Promise<FeatureScanResult> {
     }
 
     // Unconfigured integrations
-    const unconfigured = RECIPE_META.filter(r =>
-      !r.secrets.every(s => process.env[s])
-    );
+    // A recipe counts as configured if EITHER its secrets are present in the
+    // environment OR a real setup heartbeat file exists on disk (wired up via
+    // Hermes/another host). Env-only checks produced false "not configured"
+    // reports for integrations that were actually installed.
+    const unconfigured = RECIPE_META.filter(r => {
+      const envOk = r.secrets.every(s => !!process.env[s]);
+      if (envOk) return false;
+      return !integrationHeartbeatExists(r.id);
+    });
     if (unconfigured.length > 0) {
       recommendations.push({
         id: 'no-integrations', priority: 2,


### PR DESCRIPTION
## Problem
The \`gbrain features\` command's 'Set Up Integrations' recommendation decided whether an integration was configured by checking ONLY if its secret env vars were exported in the current shell:

\`\`\`ts
const unconfigured = RECIPE_META.filter(r => !r.secrets.every(s => process.env[s]));
\`\`\`

Integrations installed through Hermes (and other hosts) persist a \`setup_complete\` event to \`~/.gbrain/integrations/<id>/heartbeat.jsonl\` rather than exporting secrets into the shell. Result: a fully-installed integration with a real heartbeat was falsely reported as 'not configured'. On one real deployment this reported 7/7 recipes as unconfigured when 4 were actually live.

## Fix
A recipe is now considered configured if EITHER its secrets are present in the environment OR a real \`setup_complete\` heartbeat exists on disk. Added \`integrationHeartbeatExists(id)\` which reads the heartbeat jsonl and confirms a successful setup event.

## Verification
- Typecheck passes (\`bun build --no-bundle\`).
- Ran the actual command against a live brain: previously reported 7 unconfigured, now correctly reports only the 3 recipes with no heartbeat file (Voice to Brain, Meeting Sync, Ngrok Tunnel).

This is a non-destructive, strictly-more-accurate check — it can only reduce false 'not configured' reports.