### PR TITLE
docs(brainstorm): correct estimateCost's cost figures to match its own formula

### DIFF
--- a/src/core/brainstorm/orchestrator.ts
+++ b/src/core/brainstorm/orchestrator.ts
@@ -252,9 +252,11 @@ export interface BrainstormResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Per-profile cost estimate. brainstorm: ~$0.05-0.15. lsd: ~$0.20-0.40.
- * Real numbers depend on configured model; we anchor on Sonnet pricing.
- * The estimate is informational — operators see actuals printed at run-end.
+ * Per-profile cost estimate. At Sonnet pricing ($3/M in, $15/M out — the
+ * gateway fallback), this formula yields brainstorm ~$0.8 and lsd ~$1.0;
+ * it scales linearly with the configured chat model's pricing (a Haiku 4.5
+ * chat_model at $1/$5 lands exactly 3x lower). The estimate is
+ * informational — operators see actuals printed at run-end.
  */
 export function estimateCost(profile: BrainstormProfile, model: string): number {
   const crosses = profile.k_close * profile.m_far;


### PR DESCRIPTION
## What

Comment-only correction of the `estimateCost` doc comment in `src/core/brainstorm/orchestrator.ts`. No behavior change.

## Why

The comment claims the figures anchor on Sonnet pricing, but plugging the function's own token budgets into Sonnet's canonical rates gives numbers ~3-5x above the stated ranges:

| profile | crosses × ideas | input tokens (gen + judge) | output tokens (gen + judge) | at $3/$15 | comment said |
|---|---|---|---|---|---|
| brainstorm (4×6, 3/cross) | 24 × 3 = 72 ideas | 72,000 + 25,200 | 18,000 + 14,400 | **~$0.78** | ~$0.05-0.15 |
| lsd (2×12, 4/cross) | 24 × 4 = 96 ideas | 72,000 + 33,600 | 24,000 + 19,200 | **~$0.96** | ~$0.20-0.40 |

Two supporting facts:

- The anchor is right for default installs: `resolveBrainstormChatModel` falls back to `anthropic:claude-sonnet-4-6` ($3/$15 in `model-pricing.ts`), so Sonnet pricing is what a fresh install's preview actually uses.
- No single model in the canonical pricing table makes **both** stated ranges true (Haiku 4.5 at $1/$5 puts lsd at $0.32 — inside its range — but brainstorm at $0.26, outside its $0.05-0.15 range).

`git log -L` shows the comment, the formula's token budgets, and the profile constants all landed in the same commit (`613da940`), so this is an arithmetic slip in the original comment rather than drift from later constant changes.

The new text states the formula-derived values at the fallback anchor and notes the exact 3x relationship for a Haiku 4.5 `chat_model`, so the comment stays truthful under model switching instead of pinning to numbers that rot.

## Scope

- Formula, profile constants, and the preview mechanism are untouched.
- The runtime preview already prints the real per-run number via `canonicalLookup`; this only stops the doc comment from contradicting it.
