### PR TITLE
fix(ai): match hyphenated Qwen3-Embedding ids for dimensions passthrough

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -309,9 +309,12 @@ export function dimsProviderOptions(
       // provider serving it) supports Matryoshka truncation via `dimensions`.
       // Native sizes: 0.6B=1024, 4B=2560, 8B=4096. Without `dimensions`,
       // Ollama returns the native size and brains configured for narrower
-      // widths hard-fail with a dim-mismatch error. Pattern match the bare
-      // model name + any `:tag` (e.g. `qwen3-embedding:4b`, `qwen3-embedding:0.6b`).
-      if (modelId === 'qwen3-embedding' || modelId.startsWith('qwen3-embedding:')) {
+      // widths hard-fail with a dim-mismatch error. Two naming schemes reach
+      // this path: Ollama's colon-tag form (`qwen3-embedding:4b`) and the
+      // hyphenated hub form used by OpenRouter/HF-style routers
+      // (`qwen/qwen3-embedding-8b` — org prefix stripped to
+      // `qwen3-embedding-8b` above). Match both.
+      if (bareModelId === 'qwen3-embedding' || bareModelId.startsWith('qwen3-embedding:') || bareModelId.startsWith('qwen3-embedding-')) {
         // Only send `dimensions` when it actually differs from the model's
         // native width. Fixed-dim OpenAI-compatible backends serving this
         // family (e.g. vLLM) reject the parameter outright with HTTP 400
@@ -323,8 +326,11 @@ export function dimsProviderOptions(
           'qwen3-embedding:0.6b': 1024,
           'qwen3-embedding:4b': 2560,
           'qwen3-embedding:8b': 4096,
+          'qwen3-embedding-0.6b': 1024,
+          'qwen3-embedding-4b': 2560,
+          'qwen3-embedding-8b': 4096,
         };
-        if (QWEN3_EMBEDDING_NATIVE_DIMS[modelId] === dims) return undefined;
+        if (QWEN3_EMBEDDING_NATIVE_DIMS[bareModelId] === dims) return undefined;
         return { openaiCompatible: { dimensions: dims } };
       }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric

--- a/test/ai/dims-qwen3-native.test.ts
+++ b/test/ai/dims-qwen3-native.test.ts
@@ -38,3 +38,28 @@ describe('qwen3-embedding native-width suppression', () => {
       .toEqual({ openaiCompatible: { dimensions: 1024 } });
   });
 });
+
+describe('qwen3-embedding hyphenated hub-form ids (OpenRouter et al.)', () => {
+  test('org-prefixed hub id requests Matryoshka truncation at non-native dim', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen/qwen3-embedding-8b', 1536))
+      .toEqual({ openaiCompatible: { dimensions: 1536 } });
+    expect(dimsProviderOptions('openai-compatible', 'qwen/qwen3-embedding-4b', 1024))
+      .toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('hub id at native width emits no dimensions param', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen/qwen3-embedding-8b', 4096)).toBeUndefined();
+    expect(dimsProviderOptions('openai-compatible', 'qwen/qwen3-embedding-4b', 2560)).toBeUndefined();
+    expect(dimsProviderOptions('openai-compatible', 'qwen/qwen3-embedding-0.6b', 1024)).toBeUndefined();
+  });
+
+  test('bare hyphenated id (no org prefix) also matches', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding-8b', 2000))
+      .toEqual({ openaiCompatible: { dimensions: 2000 } });
+  });
+
+  test('unknown hyphenated variant falls through to sending the configured dim', () => {
+    expect(dimsProviderOptions('openai-compatible', 'qwen3-embedding-32b', 1024))
+      .toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+});


### PR DESCRIPTION
## Problem

The Qwen3-Embedding matryoshka `dimensions` passthrough in `dimsProviderOptions` only matches Ollama's colon-tag naming (`qwen3-embedding:8b`). OpenRouter and other HF-style routers serve the same family as `qwen/qwen3-embedding-8b` — org prefix plus hyphenated size.

Result today: with `embedding_model: openrouter:qwen/qwen3-embedding-8b` and a narrower configured width (e.g. 1536), the `dimensions` parameter is silently never sent, the provider returns the model's native width (4096 for 8B), and the brain hard-fails with a dim mismatch at first embed — even though both the model and the engine fully support the truncation.

## Fix

Match the bare hyphenated form alongside the colon-tag form, reusing the `bareModelId` org-prefix strip already used by the `text-embedding-3` branch a few lines up. Native-width suppression (the vLLM HTTP-400 guard) extended to both spellings.

Verified live against OpenRouter: `qwen/qwen3-embedding-8b` honors `dimensions` at 1536/2000/1024 exactly, and a full 8.7k-chunk brain migration via `gbrain migrate embeddings` completes with the patch applied.

## Tests

`test/ai/dims-qwen3-native.test.ts` extended: hub-form truncation, hub-form native-width suppression, bare hyphenated form, unknown hyphenated variant fall-through. Full `test/ai/` suite green on this branch (492 pass).

Related: #3584 (query-side Instruct template) composes with this — that PR covers the asymmetric-query gap, this one covers reaching the family through hub-form routers at all.
