### PR TITLE
fix(cycle): price synthesize_concepts estimates from the canonical table

### DIFF
--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -30,8 +30,20 @@ import { chat as gatewayChat, isAvailable } from '../ai/gateway.ts';
 // source-boost's 1.3× 'concepts/' weighting can actually reach them.
 import { importFromContent } from '../import-file.ts';
 import { serializeMarkdown } from '../markdown.ts';
+import { canonicalLookup, type ModelPricing } from '../model-pricing.ts';
 
 const DEFAULT_BUDGET_USD = 1.5;
+// Canonical-miss policy — mirrors skillopt/preflight.ts's lookupPrice:
+// assume Sonnet-tier pricing for models absent from CANONICAL_PRICING.
+// Conservative and non-throwing; keeps the budget gate effective (and
+// matches this file's pre-canonical behavior) instead of letting an
+// unpriced model run unmetered. The rates are DERIVED from the canonical
+// table (never hand-copied — CLAUDE.md invariant); the literal pair only
+// fires if the Sonnet key itself ever leaves the table.
+const FALLBACK_PRICING: ModelPricing = canonicalLookup('anthropic:claude-sonnet-4-6') ?? {
+  input: 3.0,
+  output: 15.0,
+};
 const TIER_T1_MIN = 10;
 const TIER_T2_MIN = 5;
 const TIER_T3_MIN = 2;
@@ -204,9 +216,14 @@ export async function runPhaseSynthesizeConcepts(
           // codex flagged. Throttle inside maybeYield bounds the actual
           // refresh rate.
           await maybeYield();
-          // Sonnet at ~$3/M input + $15/M output
+          // Price from the model that actually answered, through the one
+          // canonical chat-pricing table (CLAUDE.md invariant). Canonical
+          // miss → Sonnet-tier FALLBACK_PRICING (see constant above).
+          const pricing = canonicalLookup(result.model) ?? FALLBACK_PRICING;
           estimatedSpendUsd +=
-            (result.usage.input_tokens * 3.0 + result.usage.output_tokens * 15.0) / 1_000_000;
+            (result.usage.input_tokens * pricing.input +
+              result.usage.output_tokens * pricing.output) /
+            1_000_000;
           narrative = result.text.trim() || deterministicNarrative(group);
         } catch (err) {
           failures.push({

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -17,6 +17,7 @@ import { runPhaseExtractAtoms, parseAtomsResponse } from '../../src/core/cycle/e
 import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-concepts.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
+import { canonicalLookup } from '../../src/core/model-pricing.ts';
 
 let engine: PGLiteEngine;
 
@@ -368,6 +369,93 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
     );
     expect(page[0].type).toBe('concept');
     expect((page[0].fm as Record<string, unknown>).tier).toBe('T1');
+  });
+});
+
+// Canonical pricing: synthesize_concepts' estimated_spend_usd must derive
+// from the model that actually answered (ChatResult.model) through
+// canonicalLookup — not hardcoded Sonnet rates. A wrong per-model rate both
+// trips the $1.50 budget gate early (deterministic-template fallback for
+// work that had budget left) and persists an inflated cost into
+// receipts/rollups. Canonical-miss models keep Sonnet-tier pricing (the
+// same conservative fallback as skillopt/preflight's lookupPrice).
+describe('synthesize_concepts: cost estimate uses canonical per-model pricing', () => {
+  // 6 atoms on one concept → single T2 group → exactly one LLM call.
+  const t2Atoms = Array.from({ length: 6 }, (_, i) => ({
+    slug: `priced-${i}`,
+    title: `Priced ${i}`,
+    body: `Priced body ${i}.`,
+    concept_refs: ['priced-concept'],
+  }));
+
+  // 1M input + 1M output tokens → estimated_spend_usd equals
+  // (input_rate + output_rate) in dollars, read straight off the table.
+  function pricedChat(model: string): (o: ChatOpts) => Promise<ChatResult> {
+    return async (_o: ChatOpts) => ({
+      text: 'Priced narrative.',
+      blocks: [{ type: 'text', text: 'Priced narrative.' }],
+      stopReason: 'end',
+      usage: {
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+      model,
+      providerId: model.split(':')[0] ?? 'anthropic',
+    });
+  }
+
+  // Expected values derive from the canonical table (never hand-copied
+  // dollar literals — the same invariant the fix enforces), so these tests
+  // survive future price refreshes in model-pricing.ts.
+  const sonnetRate = canonicalLookup('anthropic:claude-sonnet-4-6')!;
+  const gpt52Rate = canonicalLookup('openai:gpt-5.2')!;
+
+  test('non-Sonnet canonical model is priced at its own rates (openai:gpt-5.2)', async () => {
+    const result = await runPhaseSynthesizeConcepts(engine, {
+      _atoms: t2Atoms,
+      _chat: pricedChat('openai:gpt-5.2') as typeof import('../../src/core/ai/gateway.ts').chat,
+      dryRun: true,
+    });
+    // gpt-5.2's own canonical rates — NOT Sonnet's (the pre-fix hardcode).
+    // Guard the guard: the two rate cards must actually differ, or this
+    // test can't discriminate.
+    expect(gpt52Rate.input + gpt52Rate.output).not.toBeCloseTo(
+      sonnetRate.input + sonnetRate.output,
+      6,
+    );
+    expect(result.details?.estimated_spend_usd).toBeCloseTo(
+      gpt52Rate.input + gpt52Rate.output,
+      6,
+    );
+  });
+
+  test('canonical-miss model falls back to Sonnet-tier pricing', async () => {
+    const result = await runPhaseSynthesizeConcepts(engine, {
+      _atoms: t2Atoms,
+      _chat: pricedChat('acme:unpriced-model-x') as typeof import('../../src/core/ai/gateway.ts').chat,
+      dryRun: true,
+    });
+    // Not in CANONICAL_PRICING → conservative Sonnet-tier fallback.
+    expect(result.details?.estimated_spend_usd).toBeCloseTo(
+      sonnetRate.input + sonnetRate.output,
+      6,
+    );
+  });
+
+  test('control: Sonnet model estimate is unchanged by canonical routing', async () => {
+    const result = await runPhaseSynthesizeConcepts(engine, {
+      _atoms: t2Atoms,
+      _chat: pricedChat('anthropic:claude-sonnet-4-6') as typeof import('../../src/core/ai/gateway.ts').chat,
+      dryRun: true,
+    });
+    // Same Sonnet-tier rates the pre-canonical hardcode used ($3/$15 at
+    // the time of writing) → identical estimate before and after the fix.
+    expect(result.details?.estimated_spend_usd).toBeCloseTo(
+      sonnetRate.input + sonnetRate.output,
+      6,
+    );
   });
 });
 


### PR DESCRIPTION
**Why I'm opening this (from the reporter, verbatim):**

> the price table seems fixed for Sonnet even thou we can run with a cheaper model such as gpt-5.2. therefore, i've modified the price mapping so that the price estimation would work correctly.

## What

`synthesize_concepts`' T1/T2 cost estimates hardcode Sonnet rates (`* 3.0` / `* 15.0` with a "Sonnet at ~$3/M input + $15/M output" comment — `src/core/cycle/synthesize-concepts.ts:207-209`), which violates the repo invariant that all paid-cloud chat prices live once in `CANONICAL_PRICING` and everything else derives from it.

On a non-Sonnet model the estimate diverges from reality: with `openai:gpt-5.2` ($1.25/$10 vs Sonnet's $3/$15) it runs 1.5×–2.4× high depending on the input/output token mix, so the `$1.50` budget gate can fire early and drop concept generation to the deterministic template, and the inflated figure is then persisted into receipts (`:268`) and extract rollups (`:282`) as if it were real spend.

## Fix

- Price from `canonicalLookup(result.model)` — the model that actually answered (`ChatResult.model` carries `provider:modelId`).
- Canonical miss falls back to Sonnet-tier rates **derived from** `canonicalLookup('anthropic:claude-sonnet-4-6')` (non-throwing), following the `skillopt/preflight.ts` `lookupPrice` precedent. This preserves the pre-fix behavior exactly for unknown models and keeps the budget gate armed. The BudgetMeter warn-and-bypass shape was considered and not used here: it would newly allow unmetered runs and $0 receipts for unknown models.
- The `$1.50` gate threshold, concept generation, and model resolution are untouched.

## Relationship to #3718

Complementary, not overlapping. #3718 fixes *which model is called* (honour `models.dream.synthesize`); this PR fixes *what the call is priced at*. The hunks don't intersect — both patches were verified to apply cleanly together. Once #3718 lands, non-Sonnet models actually flow through this path, which makes this fix more load-bearing.

## Tests

- Discriminating test — "non-Sonnet canonical model is priced at its own rates (openai:gpt-5.2)" — fails on pre-fix code, passes post-fix (revert-check executed, 29 pass / 1 fail pre-fix).
- Miss-policy test + Sonnet control test. Expectations are derived from the canonical table so future price updates don't break them, with a guard asserting that gpt-5.2 and Sonnet rates actually differ (the discriminating test cannot silently degenerate).
- `bun test test/cycle/extract-atoms-synthesize-concepts.test.ts` 30 pass / 0 fail; adjacent suites (synthesize-concepts-progress, model-pricing) 22 pass; `bun run typecheck` clean.


