### PR TITLE
fix(think): extend the 16K output headroom to OpenAI reasoning models

### DIFF
--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -171,8 +171,19 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 4000;
 // keeps 4000.
 const THINKING_DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const THINKING_BY_DEFAULT_MODEL_RE = /^anthropic[:/]claude-[a-z0-9]+-5(?:[.-]|$)/i;
+// OpenAI reasoning models spend output budget on internal reasoning tokens
+// the same way — reasoning tokens are billed as output and count against
+// `max_tokens` — so they get the same headroom. Deliberately scoped to the
+// gpt-5 family and the numbered o-series only; anything else (gpt-4o, the
+// non-reasoning `*-chat` snapshots like gpt-5-chat-latest, other providers'
+// reasoning models routed through their own recipes) keeps the conservative
+// 4000 default.
+const OPENAI_REASONING_MODEL_RE = /^openai[:/](?:gpt-5|o[0-9]+)(?:[.-]|$)/i;
+const OPENAI_CHAT_SNAPSHOT_RE = /-chat(?:-|$)/i; // gpt-5-chat-latest, gpt-5.2-chat-latest
 export function maxOutputTokensFor(modelStr: string): number {
-  return THINKING_BY_DEFAULT_MODEL_RE.test(modelStr)
+  const openaiReasoning =
+    OPENAI_REASONING_MODEL_RE.test(modelStr) && !OPENAI_CHAT_SNAPSHOT_RE.test(modelStr);
+  return THINKING_BY_DEFAULT_MODEL_RE.test(modelStr) || openaiReasoning
     ? THINKING_DEFAULT_MAX_OUTPUT_TOKENS
     : DEFAULT_MAX_OUTPUT_TOKENS;
 }

--- a/test/think-max-output-tokens.test.ts
+++ b/test/think-max-output-tokens.test.ts
@@ -1,9 +1,10 @@
 /**
  * Pins `maxOutputTokensFor` — the per-model output-token budget `runThink`
  * passes to `client.create`. Thinking-by-default Claude 5 models
- * (`anthropic:claude-*-5`) spend a large share of the budget on internal
- * reasoning before emitting an answer, so the 4000 default left `think` with
- * empty/truncated text. They now get 16000; everything else stays 4000.
+ * (`anthropic:claude-*-5`) and OpenAI reasoning models (gpt-5 family,
+ * o-series) spend a large share of the budget on internal reasoning before
+ * emitting an answer, so the 4000 default left `think` with empty/truncated
+ * text. They get 16000; everything else stays 4000.
  */
 import { describe, test, expect } from 'bun:test';
 import { maxOutputTokensFor } from '../src/core/think/index.ts';
@@ -17,12 +18,42 @@ describe('maxOutputTokensFor — thinking-default headroom', () => {
     expect(maxOutputTokensFor('anthropic/claude-sonnet-5')).toBe(16000); // slash form
   });
 
-  test('non-Claude-5 and non-Anthropic keep 4000', () => {
+  test('OpenAI reasoning models (gpt-5 family, o-series) get 16000', () => {
+    expect(maxOutputTokensFor('openai:gpt-5')).toBe(16000);
+    expect(maxOutputTokensFor('openai:gpt-5.2')).toBe(16000);
+    expect(maxOutputTokensFor('openai:gpt-5.5')).toBe(16000);
+    expect(maxOutputTokensFor('openai:gpt-5-mini')).toBe(16000);
+    expect(maxOutputTokensFor('openai:o1')).toBe(16000);
+    expect(maxOutputTokensFor('openai:o3')).toBe(16000);
+    expect(maxOutputTokensFor('openai:o4-mini')).toBe(16000);
+    expect(maxOutputTokensFor('openai/gpt-5.2')).toBe(16000); // slash form
+  });
+
+  test('non-Claude-5 and non-reasoning models keep 4000', () => {
     expect(maxOutputTokensFor('anthropic:claude-opus-4-8')).toBe(4000);
     expect(maxOutputTokensFor('anthropic:claude-haiku-4-5')).toBe(4000);
     expect(maxOutputTokensFor('anthropic:claude-sonnet-4-6')).toBe(4000);
     expect(maxOutputTokensFor('anthropic:claude-3-haiku')).toBe(4000);
     expect(maxOutputTokensFor('openai:gpt-4o')).toBe(4000);
+    expect(maxOutputTokensFor('openai:gpt-4o-mini')).toBe(4000);
+    expect(maxOutputTokensFor('openai:gpt-4.1')).toBe(4000);
+    // Non-reasoning ChatGPT snapshots of the gpt-5 family stay at 4000.
+    expect(maxOutputTokensFor('openai:gpt-5-chat-latest')).toBe(4000);
+    expect(maxOutputTokensFor('openai:gpt-5.2-chat-latest')).toBe(4000);
+    // Scope is the gpt-5 family + numbered o-series only — other OpenAI
+    // reasoning-capable ids (e.g. codex-mini-latest) keep the conservative
+    // default until deliberately added.
+    expect(maxOutputTokensFor('openai:codex-mini-latest')).toBe(4000);
+    // Version/name boundaries: `gpt-50` and `o3foo` are not gpt-5 / o3.
+    expect(maxOutputTokensFor('openai:gpt-50')).toBe(4000);
+    expect(maxOutputTokensFor('openai:o3foo')).toBe(4000);
+    // Other providers' reasoning models are out of scope here — the routed
+    // provider recipe, not this budget, is what changes for them.
     expect(maxOutputTokensFor('deepseek:deepseek-reasoner')).toBe(4000);
+    // Prefix must be the openai provider — a bare model name or another
+    // provider's gpt-5 spelling doesn't match.
+    expect(maxOutputTokensFor('o3')).toBe(4000);
+    expect(maxOutputTokensFor('gpt-5.2')).toBe(4000);
+    expect(maxOutputTokensFor('openrouter:openai/gpt-5.2')).toBe(4000);
   });
 });


### PR DESCRIPTION
**Why I'm opening this (from the reporter, verbatim):**

> when i was running "gbrain think" with a reasoning model by OpenAI such as gpt5.6, i figured out that the token window was wider only with Anthropic Claude-5 family. And i believe that it should be available with other new models. Therefore, i've created this PR.

## What

`gbrain think` clamps output at 4,000 tokens unless the model matches the Anthropic Claude-5 thinking regex, which gets a 16,000 headroom (`src/core/think/index.ts:165-178`). That headroom exists because thinking-by-default models spend part of the output budget on reasoning before the visible answer.

OpenAI reasoning models (the gpt-5 family and the numbered o-series) are in exactly the same situation — reasoning tokens draw from the same `max_tokens` budget — but they fall through to the 4,000 default, so a think run routed at them starves its visible synthesis.

## Fix

A second, deliberately narrow regex: `/^openai[:/](?:gpt-5|o[0-9]+)(?:[.-]|$)/i`, with `-chat` snapshots (non-reasoning) excluded. The 4,000/16,000 defaults are unchanged and no config knob is added.

A recipe-level "reasoning" capability declaration doesn't exist today (grepped `recipes/openai.ts` and `types.ts` — the only hit is a DeepSeek `reasoning_content` comment), so this follows the existing model-regex precedent in the same function rather than inventing new schema surface.

## Scope

- `gpt-5-chat-latest` and other `-chat` snapshots intentionally stay at 4K (pinned by test).
- `codex-mini-latest` and other non gpt-5/o-series ids intentionally stay at 4K (pinned by test).
- openrouter-nested ids don't match (boundary-tested), and boundary look-alikes (`gpt-50`, `o3foo`, bare ids) are covered.

## Tests

- Discriminating test — OpenAI reasoning ids get 16,000 — fails on pre-fix code (revert-check executed: 2 pass / 1 fail pre-fix, 3 pass post-fix).
- Anthropic Claude-5 control (16,000, unchanged) and non-reasoning control (4,000, unchanged).
- 3 tests / 29 asserts in the file; `bun run typecheck` clean.

