### PR TITLE
fix(gateway): propagate finish_reason=length through toolLoop as a non-clean stop

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -3645,7 +3645,7 @@ export interface ToolLoopOpts {
   onHeartbeat?: (event: string, data: Record<string, unknown>) => void;
 }
 
-export type ToolLoopStopReason = 'end' | 'max_turns' | 'refusal' | 'content_filter' | 'aborted' | 'unrecoverable';
+export type ToolLoopStopReason = 'end' | 'length' | 'max_turns' | 'refusal' | 'content_filter' | 'aborted' | 'unrecoverable';
 
 export interface ToolLoopResult {
   finalText: string;
@@ -3750,7 +3750,11 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
     );
 
     if (toolCalls.length === 0) {
-      stopReason = 'end';
+      // An output-cap stop (finish_reason=length / max-tokens) is NOT a clean
+      // end — the text is truncated. Propagate it so the caller can record a
+      // non-clean stop_reason instead of a silent success (the gateway-loop
+      // analog of the legacy path's #2778 handling).
+      stopReason = chatResult.stopReason === 'length' ? 'length' : 'end';
       finalText = chatResult.text;
       break;
     }

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -51,7 +51,7 @@ import { resolveModel, isAnthropicProvider, TIER_DEFAULTS } from '../../model-co
 import { resolveAnthropicKey } from '../../ai/anthropic-key.ts';
 import { buildSystemPrompt, DEFAULT_SUBAGENT_SYSTEM } from '../system-prompt.ts';
 import { toolLoop as gatewayToolLoop } from '../../ai/gateway.ts';
-import type { ChatToolDef, ChatMessage, ChatBlock, ChatResult, ToolHandler } from '../../ai/gateway.ts';
+import type { ChatToolDef, ChatMessage, ChatBlock, ChatResult, ToolHandler, ToolLoopStopReason } from '../../ai/gateway.ts';
 import { classifyCapabilities } from '../../ai/capabilities.ts';
 import { randomUUIDv7 } from 'bun';
 
@@ -1072,19 +1072,21 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     onHeartbeat: heartbeat,
   });
 
-  // Map gateway stop reason to SubagentStopReason. SubagentStopReason has
-  // {end_turn, max_turns, refusal, error}; aborted maps to error.
-  const stopReason: SubagentStopReason = result.stopReason === 'end'
-    ? 'end_turn'
-    : result.stopReason === 'max_turns'
-      ? 'max_turns'
-      : result.stopReason === 'refusal'
-        ? 'refusal'
-        : result.stopReason === 'content_filter'
-          ? 'refusal'
-          : result.stopReason === 'aborted'
-            ? 'error'
-            : 'end_turn';
+  // Map gateway stop reason to SubagentStopReason. length maps to max_tokens
+  // (same truncation marker the legacy path emits per #2778 — the result text
+  // is NOT a clean end_turn); aborted/unrecoverable map to error. The Record
+  // is exhaustive over ToolLoopStopReason so a future gateway stop reason
+  // fails typecheck here instead of silently mapping to a clean end_turn.
+  const stopReasonMap: Record<ToolLoopStopReason, SubagentStopReason> = {
+    end: 'end_turn',
+    length: 'max_tokens',
+    max_turns: 'max_turns',
+    refusal: 'refusal',
+    content_filter: 'refusal',
+    aborted: 'error',
+    unrecoverable: 'error',
+  };
+  const stopReason: SubagentStopReason = stopReasonMap[result.stopReason];
 
   return {
     result: result.finalText,

--- a/src/core/skillopt/types.ts
+++ b/src/core/skillopt/types.ts
@@ -13,6 +13,7 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
+import type { ToolLoopStopReason } from '../ai/gateway.ts';
 
 // ─── Benchmarks + judges ──────────────────────────────────────────────────
 
@@ -103,8 +104,8 @@ export interface Trajectory {
   };
   /** Number of agent turns the loop took. */
   turns: number;
-  /** End reason from gateway.toolLoop. */
-  stop_reason: 'end' | 'max_turns' | 'refusal' | 'content_filter' | 'aborted' | 'unrecoverable';
+  /** End reason from gateway.toolLoop (kept in lockstep by referencing the source type). */
+  stop_reason: ToolLoopStopReason;
   /** Wall-clock duration in ms. */
   duration_ms: number;
 }

--- a/test/ai/gateway-tool-loop.test.ts
+++ b/test/ai/gateway-tool-loop.test.ts
@@ -318,6 +318,67 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
     expect(result.totalTurns).toBeGreaterThanOrEqual(3);
   });
 
+  it('propagates length stop reason when the final turn is truncated (no tool calls)', async () => {
+    __setChatTransportForTests(async () => ({
+      text: 'this answer was cut off mid-sen',
+      blocks: [{ type: 'text', text: 'this answer was cut off mid-sen' }] as ChatBlock[],
+      stopReason: 'length',
+      usage: { input_tokens: 5, output_tokens: 4096, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'anthropic:claude-sonnet-4-6',
+      providerId: 'anthropic',
+    }));
+
+    const result = await toolLoop({
+      initialMessages: [{ role: 'user', content: 'write a long essay' }],
+      tools: [],
+      toolHandlers: new Map(),
+    });
+
+    // A truncated final turn must NOT surface as a clean 'end'.
+    expect(result.stopReason).toBe('length');
+    expect(result.finalText).toBe('this answer was cut off mid-sen');
+  });
+
+  it('control: length stop with tool calls still dispatches and continues (unchanged path)', async () => {
+    let turn = 0;
+    __setChatTransportForTests(async () => {
+      turn++;
+      if (turn === 1) {
+        // Provider reports length but still emitted a complete tool call —
+        // the loop's tool-continuation path is unchanged by length handling.
+        return {
+          text: '',
+          blocks: [
+            { type: 'tool-call', toolCallId: 'tc-len', toolName: 'search', input: { q: 'x' } },
+          ] as ChatBlock[],
+          stopReason: 'length',
+          usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'anthropic:claude-sonnet-4-6',
+          providerId: 'anthropic',
+        };
+      }
+      return {
+        text: 'recovered fine',
+        blocks: [{ type: 'text', text: 'recovered fine' }] as ChatBlock[],
+        stopReason: 'end',
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'anthropic:claude-sonnet-4-6',
+        providerId: 'anthropic',
+      };
+    });
+
+    let toolWasCalled = false;
+    const result = await toolLoop({
+      initialMessages: [{ role: 'user', content: 'go' }],
+      tools: [{ name: 'search', description: 's', inputSchema: { type: 'object' } }],
+      toolHandlers: new Map([['search', { idempotent: true, async execute() { toolWasCalled = true; return { hits: 1 }; } }]]),
+    });
+
+    expect(toolWasCalled).toBe(true);
+    expect(result.stopReason).toBe('end');
+    expect(result.finalText).toBe('recovered fine');
+  });
+
   it('returns refusal reason without dispatching tools when stopReason=refusal', async () => {
     __setChatTransportForTests(async () => ({
       text: 'I cannot help with that',

--- a/test/e2e/subagent-gateway-path.test.ts
+++ b/test/e2e/subagent-gateway-path.test.ts
@@ -350,6 +350,28 @@ describe('runSubagentViaGateway (v0.38 Slice 1 — full handler path through gat
     expect(result.result).toBe('I cannot help with that');
   });
 
+  it('length stop reason: handler maps length → SubagentStopReason max_tokens (truncated, not clean)', async () => {
+    // finish_reason=length (e.g. an openai-compat model hitting its output
+    // cap) must NOT be recorded as a clean end_turn — the result text is
+    // truncated. Same marker as the legacy path's #2778 handling.
+    __setChatTransportForTests(async () => ({
+      text: 'a very long answer that got cut',
+      blocks: [{ type: 'text', text: 'a very long answer that got cut' }] as ChatBlock[],
+      stopReason: 'length',
+      usage: { input_tokens: 5, output_tokens: 4096, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'openai:gpt-5.2',
+      providerId: 'openai',
+    } satisfies ChatResult));
+
+    const tools = makeStubTools([]);
+    const handler = buildHandler(tools);
+    const { ctx } = await makeFakeJob({ prompt: 'write everything', model: 'openai:gpt-5.2' });
+
+    const result = await handler(ctx);
+    expect(result.stop_reason).toBe('max_tokens');
+    expect(result.result).toBe('a very long answer that got cut');
+  });
+
   it('non-Anthropic model routes through gateway path (the load-bearing v0.38 unlock)', async () => {
     // This is the headline scenario: openai:gpt-5.2 (no caching) works.
     // Pre-v0.38, this would have refused at queue.ts. With the gateway path


### PR DESCRIPTION
**Why I'm opening this (from the reporter, verbatim):**

> when i was running toolLoop by OpenAI models on GBrain subagents, GBrain always recognizes normal result even thou the actual result was "finish_reason=length". Therefore, i would like to fix this issue to let it show the actual ones.

## What

When a gateway-routed subagent turn ends with the provider's `finish_reason=length` (output truncated), `toolLoop` reports it as a clean end: the zero-tool-calls exit path sets `stopReason = 'end'` unconditionally and never consults `chatResult.stopReason` — and the `ToolLoopStopReason` union has no `'length'` member, so the truncation is structurally impossible to propagate. Downstream, the subagent handler maps `'end'` to `stop_reason='end_turn'`, so a truncated run is recorded as a clean success.

`mapStopReason` itself already maps the provider's length signal correctly; it is only the loop's exit classification that drops it.

## Fix

- Add `'length'` to `ToolLoopStopReason`; the zero-tool-calls exit returns it when `chatResult.stopReason === 'length'`. All other exit paths unchanged.
- The subagent handler maps `'length'` to the **existing** `'max_tokens'` stop reason (the #2778 "result text is TRUNCATED" marker) — record-only, the job is not failed. This is deliberately the same policy the legacy Anthropic-direct path already applies to a zero-tool-use `max_tokens` stop, so the two paths now agree instead of one of them silently reporting success.
- The handler's stop-reason mapping is now an exhaustive `Record<ToolLoopStopReason, SubagentStopReason>` (a future stop-reason addition fails typecheck instead of silently falling through to a success value).
- `skillopt`'s `Trajectory.stop_reason` was a hand-written copy of the gateway union; it now imports the type from the source (no consumer branches on it).

## Relationship to the synthesize completion stamp

This PR makes truncation *visible* to every consumer of `stop_reason`. Whether synthesize should still stamp completion over non-clean children is a separate question tracked elsewhere; nothing here changes completion semantics.

## Tests

- Red-first: "toolLoop propagates length stop reason" and "handler maps length → max_tokens" both fail on pre-fix code (revert-check executed: 17 pass / 2 fail pre-fix, 19 pass / 0 fail post-fix).
- Controls pin that a length stop with tool calls still continues the loop, and that clean ends stay `end_turn`.
- Adjacent suites (skillopt, subagent-handler, crash-replay, resume-reconciliation, gateway-chat): 290 pass. `bun run typecheck` clean.

Related to #2778 (the `max_tokens` truncation marker this reuses).

