### PR TITLE
fix: support targeted embedding reindex

### DIFF
--- a/src/commands/reindex.ts
+++ b/src/commands/reindex.ts
@@ -35,6 +35,10 @@ import { runSlidingPool } from '../core/worker-pool.ts';
 import { resolveWorkersWithClamp } from '../core/sync-concurrency.ts';
 
 interface ReindexOpts {
+  /** Force-reindex only these exact slugs. Repeat --slug for multiple pages. */
+  slugs?: string[];
+  /** Tighter per-chunk cap, allowed only with explicit exact-slug targets. */
+  maxChars?: number;
   /** Cap total pages reindexed. Useful for triage runs on huge brains. */
   limit?: number;
   /** Report would-do count; don't actually reindex. */
@@ -75,6 +79,14 @@ function parseArgs(args: string[]): ReindexOpts {
     if (a === '--dry-run') out.dryRun = true;
     else if (a === '--json') out.json = true;
     else if (a === '--no-embed') out.noEmbed = true;
+    else if (a === '--slug') {
+      const slug = (args[++i] ?? '').trim();
+      if (slug) (out.slugs ??= []).push(slug);
+    }
+    else if (a === '--max-chars') {
+      const value = Number.parseInt(args[++i] ?? '', 10);
+      if (Number.isFinite(value) && value >= 256 && value <= 6000) out.maxChars = value;
+    }
     else if (a === '--limit') {
       const v = parseInt(args[++i] ?? '', 10);
       if (Number.isFinite(v) && v > 0) out.limit = v;
@@ -110,7 +122,18 @@ function parseArgs(args: string[]): ReindexOpts {
  * hook for post-v81 brains. The simple `chunker_version OR mode IS NULL`
  * predicate covers the headline upgrade case the wave is shipping.
  */
-async function countPending(engine: BrainEngine): Promise<number> {
+async function countPending(engine: BrainEngine, slugs: string[] = []): Promise<number> {
+  if (slugs.length > 0) {
+    const rows = await engine.executeRaw<{ count: string | number }>(
+      `SELECT COUNT(*)::bigint AS count
+         FROM pages
+        WHERE page_kind = 'markdown'
+          AND deleted_at IS NULL
+          AND slug = ANY($1::text[])`,
+      [slugs],
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
   const rows = await engine.executeRaw<{ count: string | number }>(
     `SELECT COUNT(*)::bigint AS count
        FROM pages
@@ -127,7 +150,19 @@ async function countPending(engine: BrainEngine): Promise<number> {
  * partial completion pick up where they left off without re-doing pages
  * whose chunker_version was already bumped.
  */
-async function readBatch(engine: BrainEngine, batchSize: number): Promise<Array<{ slug: string; source_path: string | null; compiled_truth: string; source_id: string }>> {
+async function readBatch(engine: BrainEngine, batchSize: number, slugs: string[] = []): Promise<Array<{ slug: string; source_path: string | null; compiled_truth: string; source_id: string }>> {
+  if (slugs.length > 0) {
+    return engine.executeRaw(
+      `SELECT slug, source_path, compiled_truth, source_id
+         FROM pages
+        WHERE page_kind = 'markdown'
+          AND deleted_at IS NULL
+          AND slug = ANY($1::text[])
+        ORDER BY id ASC
+        LIMIT $2`,
+      [slugs, batchSize],
+    );
+  }
   return engine.executeRaw(
     `SELECT slug, source_path, compiled_truth, source_id
        FROM pages
@@ -143,19 +178,23 @@ async function readBatch(engine: BrainEngine, batchSize: number): Promise<Array<
 export async function runReindex(engine: BrainEngine, args: string[]): Promise<ReindexResult> {
   const opts = parseArgs(args);
 
+  if (opts.maxChars !== undefined && !opts.slugs?.length) {
+    throw new Error('gbrain reindex --max-chars requires at least one exact --slug target');
+  }
+
   // Require `--markdown` explicitly. Future modes (e.g. --code) get their
   // own routing here.
   if (!args.includes('--markdown')) {
     if (opts.json) {
       process.stdout.write(JSON.stringify({ error: 'gbrain reindex requires a target flag, e.g. --markdown' }) + '\n');
     } else {
-      process.stderr.write('Usage: gbrain reindex --markdown [--limit N] [--dry-run] [--json] [--repo PATH]\n');
+      process.stderr.write('Usage: gbrain reindex --markdown [--slug SLUG ...] [--limit N] [--dry-run] [--json] [--repo PATH]\n');
     }
     setCliExitVerdict(2);
     return { pending: 0, reindexed: 0, skipped: 0, failed: 0, dryRun: !!opts.dryRun, chunkerVersion: MARKDOWN_CHUNKER_VERSION };
   }
 
-  const pending = await countPending(engine);
+  const pending = await countPending(engine, opts.slugs);
 
   if (opts.json && pending === 0) {
     process.stdout.write(JSON.stringify({ pending: 0, reindexed: 0, skipped: 0, failed: 0, chunker_version: MARKDOWN_CHUNKER_VERSION }) + '\n');
@@ -190,7 +229,7 @@ export async function runReindex(engine: BrainEngine, args: string[]): Promise<R
   while (reindexed + skipped + failed < target) {
     const remaining = target - (reindexed + skipped + failed);
     const batchSize = Math.min(BATCH, remaining);
-    const batch = await readBatch(engine, batchSize);
+    const batch = await readBatch(engine, batchSize, opts.slugs);
     if (batch.length === 0) break;
 
     // v0.41.15.0 (T10, D9): per-batch sliding pool. Counters are JS-
@@ -217,6 +256,7 @@ export async function runReindex(engine: BrainEngine, args: string[]): Promise<R
                 sourceId: row.source_id,
                 inferFrontmatter: false,
                 forceRechunk: true,
+                chunkMaxChars: opts.maxChars,
               });
               reindexed++;
               return;
@@ -243,6 +283,7 @@ export async function runReindex(engine: BrainEngine, args: string[]): Promise<R
             sourceId: row.source_id,
             noEmbed: !!opts.noEmbed,
             forceRechunk: true,
+            chunkMaxChars: opts.maxChars,
           });
           reindexed++;
         } catch (err) {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -281,6 +281,8 @@ export async function importFromContent(
      * the version bump.
      */
     forceRechunk?: boolean;
+    /** Operator-only tighter chunk cap for exact-slug embedding repair. */
+    chunkMaxChars?: number;
     /**
      * v0.39.0.0 T1.5: active schema pack for type inference. When set, parseMarkdown
      * uses the pack's path_prefixes instead of the hardcoded gbrain-base table.
@@ -713,12 +715,12 @@ export async function importFromContent(
   const embedSkipped = isEmbedSkipped(parsed.frontmatter) || isQuarantined(parsed.frontmatter);
   if (!embedSkipped) {
     if (parsed.compiled_truth.trim()) {
-      for (const c of chunkText(parsed.compiled_truth)) {
+      for (const c of chunkText(parsed.compiled_truth, { maxChars: opts.chunkMaxChars })) {
         chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
       }
     }
     if (parsed.timeline?.trim()) {
-      for (const c of chunkText(parsed.timeline)) {
+      for (const c of chunkText(parsed.timeline, { maxChars: opts.chunkMaxChars })) {
         chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'timeline' });
       }
     }
@@ -1063,6 +1065,7 @@ export async function importFromFile(
     inferFrontmatter?: boolean;
     sourceId?: string;
     forceRechunk?: boolean;
+    chunkMaxChars?: number;
     /**
      * v0.39 T1.5: active schema pack threaded through to importFromContent so
      * `parseMarkdown` uses pack-driven type inference. Load ONCE per command;

--- a/test/reindex.test.ts
+++ b/test/reindex.test.ts
@@ -99,6 +99,53 @@ describe('gbrain reindex --markdown (v0.32.7)', () => {
     expect(Number(remaining[0].count)).toBe(3);
   });
 
+  test('--slug force-reindexes only the exact selected page', async () => {
+    for (const slug of ['target-page', 'untouched-page']) {
+      await engine.executeRaw(
+        `INSERT INTO pages (slug, type, title, compiled_truth, page_kind, chunker_version, contextual_retrieval_mode)
+         VALUES ($1, 'note', $1, $2, 'markdown', $3, 'title')`,
+        [slug, `${slug} body`, MARKDOWN_CHUNKER_VERSION],
+      );
+    }
+
+    const result = await runReindex(engine, [
+      '--markdown', '--no-embed', '--slug', 'target-page',
+    ]);
+    expect(result).toMatchObject({ pending: 1, reindexed: 1, failed: 0 });
+
+    const rows = await engine.executeRaw<{ slug: string; chunks: string | number }>(
+      `SELECT p.slug, COUNT(c.id)::bigint AS chunks
+         FROM pages p LEFT JOIN content_chunks c ON c.page_id = p.id
+        GROUP BY p.slug ORDER BY p.slug`,
+    );
+    expect(rows).toHaveLength(2);
+    expect(Number(rows.find((row) => row.slug === 'target-page')?.chunks)).toBeGreaterThan(0);
+    expect(Number(rows.find((row) => row.slug === 'untouched-page')?.chunks)).toBe(0);
+  });
+
+  test('--max-chars is exact-slug-only and tightens repaired chunks', async () => {
+    await engine.executeRaw(
+      `INSERT INTO pages (slug, type, title, compiled_truth, page_kind, chunker_version, contextual_retrieval_mode)
+       VALUES ('dense-page', 'note', 'dense-page', $1, 'markdown', $2, 'title')`,
+      ['密'.repeat(900), MARKDOWN_CHUNKER_VERSION],
+    );
+
+    await expect(runReindex(engine, ['--markdown', '--no-embed', '--max-chars', '256']))
+      .rejects.toThrow('--max-chars requires at least one exact --slug');
+
+    const result = await runReindex(engine, [
+      '--markdown', '--no-embed', '--slug', 'dense-page', '--max-chars', '256',
+    ]);
+    expect(result.reindexed).toBe(1);
+    const chunks = await engine.executeRaw<{ max_chars: string | number; count: string | number }>(
+      `SELECT MAX(LENGTH(c.chunk_text))::bigint AS max_chars, COUNT(*)::bigint AS count
+         FROM content_chunks c JOIN pages p ON p.id = c.page_id
+        WHERE p.slug = 'dense-page'`,
+    );
+    expect(Number(chunks[0].max_chars)).toBeLessThanOrEqual(256);
+    expect(Number(chunks[0].count)).toBeGreaterThan(1);
+  });
+
   test('REGRESSION: forceRechunk bypasses content_hash short-circuit (codex F1)', async () => {
     // The bug: importFromContent skips pages whose content_hash matches even
     // when the chunker version is stale. The fix: reindex passes


### PR DESCRIPTION
## What changed

- adds repeatable exact `--slug` targeting to `gbrain reindex --markdown`
- adds an operator-only `--max-chars` repair cap gated behind explicit slug targets
- threads the cap through file/content import chunking
- adds exact-target, safety-gate, and chunk-size tests

## Why

Three oversized pages could not be embedded with the normal chunk size, while a corpus-wide reindex would be unnecessarily expensive and risky.

## Impact

Operators can repair known pages deterministically without reprocessing unrelated corpus content or globally changing chunking behavior.

## Validation

- `bun test test/reindex.test.ts` (8 passed)
- live targeted repair completed with zero missing or stale embeddings
