### PR TITLE
v0.42.75.1 fix(import): reject malformed YAML frontmatter (#3708)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -224,7 +224,7 @@ export interface ImportResult {
    * Parsed page content. Present for status='imported' AND status='skipped'
    * (skip happens when content is identical to existing page; auto-link still
    * needs to run for reconciliation in case links table drifted from page text).
-   * Absent only on status='error' (early payload-size rejection).
+   * Absent on early rejection before a page can be parsed.
    */
   parsedPage?: ParsedPage;
   /** Content-quality gate (issue #1699): true when the page landed with a
@@ -238,6 +238,13 @@ export interface ImportResult {
 }
 
 const MAX_FILE_SIZE = 5_000_000; // 5MB
+
+function invalidYamlFrontmatterError(parsed: ReturnType<typeof parseMarkdown>): string | null {
+  const yamlError = parsed.errors?.find((error) => error.code === 'YAML_PARSE');
+  if (!yamlError) return null;
+  const detail = yamlError.message.replace(/^YAML parse failed:\s*/, '').trim();
+  return `Invalid YAML frontmatter: ${detail}. Quote scalar values that contain ": " or fix the frontmatter block.`;
+}
 
 /**
  * Import content from a string. Core pipeline:
@@ -343,7 +350,14 @@ export async function importFromContent(
     };
   }
 
-  const parsed = parseMarkdown(content, slug + '.md', { activePack: opts.activePack });
+  const parsed = parseMarkdown(content, slug + '.md', {
+    validate: true,
+    ...(opts.activePack ? { activePack: opts.activePack } : {}),
+  });
+  const frontmatterError = invalidYamlFrontmatterError(parsed);
+  if (frontmatterError) {
+    return { slug, status: 'error', chunks: 0, error: frontmatterError };
+  }
 
   // v0.42 (#1699 trust boundary): strip gate-owned markers from UNTRUSTED
   // input. parseMarkdown preserves every frontmatter key except type/title/
@@ -1092,6 +1106,17 @@ export async function importFromFile(
     });
   }
 
+  const preInferenceParsed = parseMarkdown(content, relativePath, { validate: true });
+  const preInferenceFrontmatterError = invalidYamlFrontmatterError(preInferenceParsed);
+  if (preInferenceFrontmatterError) {
+    return {
+      slug: slugifyPath(relativePath),
+      status: 'skipped',
+      chunks: 0,
+      error: preInferenceFrontmatterError,
+    };
+  }
+
   // v0.22.8 — Frontmatter inference: if the file has no frontmatter and
   // inference is enabled, synthesize it from the filesystem path + content.
   // This turns bare markdown files into fully-typed, dated, tagged pages
@@ -1106,7 +1131,11 @@ export async function importFromFile(
     }
   }
 
-  const parsed = parseMarkdown(content, relativePath, { activePack: opts.activePack });
+  const parsed = parseMarkdown(content, relativePath, {
+    validate: true,
+    ...(opts.activePack ? { activePack: opts.activePack } : {}),
+  });
+  const frontmatterError = invalidYamlFrontmatterError(parsed);
 
   // Enforce path-authoritative slug. parseMarkdown prefers frontmatter.slug over
   // the path-derived slug, so a mismatch here means the frontmatter is trying
@@ -1118,6 +1147,15 @@ export async function importFromFile(
   const expectedSlug = slugifyPath(relativePath);
   let resolvedSlug = expectedSlug;
   let usedFrontmatterFallback = false;
+
+  if (frontmatterError) {
+    return {
+      slug: expectedSlug,
+      status: 'skipped',
+      chunks: 0,
+      error: frontmatterError,
+    };
+  }
 
   if (expectedSlug === '') {
     if (parsed.slug && parsed.slug.length > 0) {

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -315,11 +315,22 @@ function collectValidationErrors(
     }
   }
 
-  // 6. YAML_PARSE — gray-matter threw.
-  if (ctx.yamlParseError) {
+  // 6. YAML_PARSE — validate the fenced YAML directly. gray-matter normally
+  // throws for malformed frontmatter, but it can also return the whole file as
+  // body with empty data, so the validation surface must not depend only on
+  // gray-matter's parse path.
+  let detectedYamlParseError = ctx.yamlParseError;
+  if (!detectedYamlParseError && fmBody.length > 0) {
+    try {
+      yamlSafeLoad(fmBody);
+    } catch (e) {
+      detectedYamlParseError = e as Error;
+    }
+  }
+  if (detectedYamlParseError) {
     errors.push({
       code: 'YAML_PARSE',
-      message: `YAML parse failed: ${ctx.yamlParseError.message}`,
+      message: `YAML parse failed: ${detectedYamlParseError.message}`,
       line: firstNonEmpty + 1,
     });
   }

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -315,12 +315,15 @@ function collectValidationErrors(
     }
   }
 
+  const looksLikeFrontmatter = hasFrontmatterFieldSyntax(fmBody);
+
   // 6. YAML_PARSE — validate the fenced YAML directly. gray-matter normally
   // throws for malformed frontmatter, but it can also return the whole file as
   // body with empty data, so the validation surface must not depend only on
-  // gray-matter's parse path.
-  let detectedYamlParseError = ctx.yamlParseError;
-  if (!detectedYamlParseError && fmBody.length > 0) {
+  // gray-matter's parse path. Gate this on frontmatter-shaped fields so a
+  // leading Markdown thematic break / epigraph is preserved as body content.
+  let detectedYamlParseError = looksLikeFrontmatter ? ctx.yamlParseError : null;
+  if (!detectedYamlParseError && looksLikeFrontmatter) {
     try {
       yamlSafeLoad(fmBody);
     } catch (e) {
@@ -360,6 +363,17 @@ function collectValidationErrors(
       });
     }
   }
+}
+
+function hasFrontmatterFieldSyntax(fmBody: string): boolean {
+  for (const line of fmBody.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) continue;
+    if (/^(?:['"][^'"]+['"]|[A-Za-z_][\w.-]*)\s*:/.test(trimmed)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/test/commands/capture.test.ts
+++ b/test/commands/capture.test.ts
@@ -16,12 +16,19 @@ import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import matter from 'gray-matter';
 import { runCapture, __testing } from '../../src/commands/capture.ts';
+import { configureGateway, resetGateway } from '../../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 let tmpRoot: string;
 let brainDir: string;
 
 beforeAll(async () => {
+  // Keep capture's put_page integration hermetic under CI's fake provider keys.
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: {},
+  });
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
@@ -29,6 +36,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await engine.disconnect();
+  resetGateway();
 });
 
 beforeEach(async () => {

--- a/test/import-yaml-frontmatter.test.ts
+++ b/test/import-yaml-frontmatter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { importFile, importFromContent } from '../src/core/import-file.ts';
+
+function mockEngine(): BrainEngine {
+  const calls: { method: string; args: any[] }[] = [];
+  const pages = new Map<string, { slug: string; content_hash: string; title: string; type: string; frontmatter: Record<string, unknown> }>();
+
+  const engine = new Proxy({} as any, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (prop === 'getTags') return () => Promise.resolve([]);
+      if (prop === 'getPage') {
+        return (slug: string) => Promise.resolve(pages.get(slug) ?? null);
+      }
+      if (prop === 'putPage') {
+        return async (slug: string, page: { content_hash?: string; title?: string; type?: string; frontmatter?: Record<string, unknown> }) => {
+          calls.push({ method: 'putPage', args: [slug, page] });
+          pages.set(slug, {
+            slug,
+            content_hash: page.content_hash ?? '',
+            title: page.title ?? '',
+            type: page.type ?? '',
+            frontmatter: page.frontmatter ?? {},
+          });
+        };
+      }
+      if (prop === 'transaction') return async (fn: (tx: BrainEngine) => Promise<any>) => fn(engine);
+      return (...args: any[]) => {
+        calls.push({ method: String(prop), args });
+        return Promise.resolve(null);
+      };
+    },
+  });
+
+  return engine as BrainEngine;
+}
+
+describe('import YAML frontmatter validation', () => {
+  test('importFromContent rejects invalid YAML frontmatter instead of importing it as body', async () => {
+    const content = `---
+type: note
+title: Re: October booking
+---
+
+Body text.
+`;
+
+    const engine = mockEngine();
+    const result = await importFromContent(engine, 'emails/reply-october-booking', content, { noEmbed: true });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Invalid YAML frontmatter');
+    expect(result.error).toContain('title: Re: October booking');
+    expect((engine as any)._calls).toEqual([]);
+  });
+
+  test('importFile rejects invalid YAML before frontmatter inference can wrap it', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-invalid-yaml-'));
+    try {
+      const filePath = join(dir, 'reply.md');
+      writeFileSync(filePath, `---
+type: note
+title: Re: October booking
+---
+
+Body text.
+`);
+
+      const engine = mockEngine();
+      const result = await importFile(engine, filePath, 'emails/reply-october-booking.md', { noEmbed: true });
+
+      expect(result.status).toBe('skipped');
+      expect(result.error).toContain('Invalid YAML frontmatter');
+      expect(result.error).toContain('title: Re: October booking');
+      expect((engine as any)._calls).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('quoted frontmatter values with colon-space still import', async () => {
+    const content = `---
+type: note
+title: "Re: October booking"
+---
+
+Body text.
+`;
+
+    const engine = mockEngine();
+    const result = await importFromContent(engine, 'emails/reply-october-booking', content, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    const putCall = (engine as any)._calls.find((call: any) => call.method === 'putPage');
+    expect(putCall.args[1].title).toBe('Re: October booking');
+    expect(putCall.args[1].compiled_truth).toBe('Body text.');
+  });
+});

--- a/test/import-yaml-frontmatter.test.ts
+++ b/test/import-yaml-frontmatter.test.ts
@@ -99,4 +99,31 @@ Body text.
     expect(putCall.args[1].title).toBe('Re: October booking');
     expect(putCall.args[1].compiled_truth).toBe('Body text.');
   });
+
+  test('importFile preserves leading thematic-break epigraphs as body content', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-thematic-epigraph-'));
+    try {
+      const filePath = join(dir, 'epigraph.md');
+      writeFileSync(filePath, `---
+> Re: quoted epigraph, not YAML frontmatter
+---
+
+# Epigraph Note
+
+Body text.
+`);
+
+      const engine = mockEngine();
+      const result = await importFile(engine, filePath, 'notes/epigraph.md', { noEmbed: true });
+
+      expect(result.status).toBe('imported');
+      expect(result.error).toBeUndefined();
+      const putCall = (engine as any)._calls.find((call: any) => call.method === 'putPage');
+      expect(putCall.args[1].title).toBe('Epigraph Note');
+      expect(putCall.args[1].compiled_truth).toContain('> Re: quoted epigraph, not YAML frontmatter');
+      expect(putCall.args[1].compiled_truth).toContain('# Epigraph Note');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #3708 by making malformed YAML frontmatter fail closed during Markdown import instead of being treated as page body.

Previously, an unquoted scalar containing `: ` could make frontmatter parsing fall back to empty metadata. `put_page` and file import could then accept the write, infer a generic title/type, and store the original frontmatter fence inside `compiled_truth`.

## Changes

- Validates fenced YAML directly when `parseMarkdown(..., { validate: true })` is used, so validation does not depend only on `gray-matter` throwing.
- Makes `importFromContent` return `status: "error"` before DB work when the leading frontmatter fence has invalid YAML.
- Makes `importFile` reject invalid YAML before frontmatter inference can wrap the bad fence in synthesized metadata.
- Adds focused regression coverage for invalid unquoted `: ` frontmatter and the quoted-value success path.

## Tests

- `bun test test/import-yaml-frontmatter.test.ts`
- `bun test test/markdown.test.ts test/import-yaml-frontmatter.test.ts`
- `bun test test/import-file.test.ts`
- `bash scripts/gbrain-gate.sh <worktree> test/markdown.test.ts test/import-file.test.ts test/import-yaml-frontmatter.test.ts` - `RESULT: GREEN`; verify green; focused unit tests green with 77 pass, 0 fail, 189 expect calls; diff-mapped E2E skipped as unrelated.
