### PR TITLE
put_page: fail the operation when write-through cannot produce the file

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1253,8 +1253,8 @@ const put_page: Operation = {
     // v0.38 put_page write-through (ingestion cathedral):
     // After importFromContent succeeds, if `sync.repo_path` resolves to a
     // real directory, persist the markdown file to disk alongside the DB
-    // row. Failures non-fatal — DB write is durable; subsequent sync
-    // reconciles drift.
+    // row. A failure here is fatal to the call (see the check right below)
+    // except for the one deliberate DB-only configuration.
     //
     // Trust gating:
     //   - Subagent sandbox (viaSubagent without allowedSlugPrefixes) → DB-only.
@@ -1281,6 +1281,38 @@ const put_page: Operation = {
       writeThrough = { written: false, skipped: 'subagent_sandbox' };
     } else if (ctx.dryRun) {
       writeThrough = { written: false, skipped: 'dry_run' };
+    }
+
+    // The markdown file is the system of record (docs/architecture/
+    // system-of-record.md); the DB row is a derived cache. `no_repo_configured`
+    // is the one deliberate, by-design DB-only outcome (no `sync.repo_path`
+    // set at all). Every other non-written outcome — a thrown write error, or
+    // a guard that REFUSED to write into an existing repo (missing dir,
+    // sibling-source collision, escaped path, case-fold clash, unreadable
+    // row) — means a file was supposed to exist and doesn't, so put_page must
+    // not report success.
+    if (writeThrough && !writeThrough.written
+      && writeThrough.skipped !== 'no_repo_configured'
+      && writeThrough.skipped !== 'subagent_sandbox') {
+      // Roll back rather than leave an index-only orphan, but only when this
+      // call is what created the row: created_at === updated_at is set by
+      // the SAME insert statement (the ON CONFLICT UPDATE branch never
+      // touches created_at), so equality here means "brand new, this call."
+      // An update (or a dedup hit resolved to a pre-existing page) is left
+      // alone — the prior file on disk still matches the prior DB content.
+      try {
+        const row = await ctx.engine.getPage(result.slug, { sourceId: ctx.sourceId ?? 'default' });
+        if (row && row.created_at.getTime() === row.updated_at.getTime()) {
+          await ctx.engine.deletePage(result.slug, { sourceId: ctx.sourceId ?? 'default' });
+        }
+      } catch {
+        // best-effort; the error thrown below still surfaces the failure
+      }
+      throw new OperationError(
+        'storage_error',
+        `put_page: the page content could not be written to disk (${writeThrough.skipped ?? writeThrough.error}).`,
+        'Check that the configured repo path exists and is writable, then retry.',
+      );
     }
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/test/brain-allowlist.serial.test.ts
+++ b/test/brain-allowlist.serial.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import * as fs from 'node:fs';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { operations, OperationError } from '../src/core/operations.ts';
 import {
@@ -151,6 +152,9 @@ describe('buildBrainTools', () => {
   // put_page → importFromContent, so subagent writes land in the cycle's
   // resolved source instead of the hardcoded 'default'.
   test('execute() on put_page writes to the configured sourceId (#1586)', async () => {
+    // Write-through needs a real directory for this source's local_path —
+    // put_page now rejects a write whose file can't be written to disk.
+    fs.mkdirSync('/tmp/mybrain', { recursive: true });
     await engine.executeRaw(
       `INSERT INTO sources (id, name, local_path, config, archived, created_at)
        VALUES ('mybrain', 'My Brain', '/tmp/mybrain', '{}'::jsonb, false, now())

--- a/test/ingestion/put-page-write-through.test.ts
+++ b/test/ingestion/put-page-write-through.test.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
-import { operations } from '../../src/core/operations.ts';
+import { operations, OperationError } from '../../src/core/operations.ts';
 import type { OperationContext } from '../../src/core/operations.ts';
 import { resetGateway } from '../../src/core/ai/gateway.ts';
 
@@ -184,14 +184,16 @@ describe('put_page write-through — config edge cases', () => {
     expect(result.write_through?.skipped).toBe('no_repo_configured');
   });
 
-  test('repo path points at a missing directory → skipped repo_not_found', async () => {
+  test('repo path points at a missing directory → put_page rejects, no orphan row', async () => {
     await engine.setConfig('sync.repo_path', path.join(tmpRoot, 'does-not-exist'));
     const ctx = makeCtx();
-    const result = (await putPage.handler(ctx, {
-      slug: 'inbox/missing-repo',
-      content: '---\ntitle: M\n---\n\nbody',
-    })) as { write_through?: { skipped?: string } };
-    expect(result.write_through?.skipped).toBe('repo_not_found');
+    await expect(
+      putPage.handler(ctx, {
+        slug: 'inbox/missing-repo',
+        content: '---\ntitle: M\n---\n\nbody',
+      }),
+    ).rejects.toBeInstanceOf(OperationError);
+    expect(await ctx.engine.getPage('inbox/missing-repo', { sourceId: 'default' })).toBeNull();
   });
 });
 
@@ -214,7 +216,7 @@ describe('put_page write-through — multi-source filing', () => {
 });
 
 describe('put_page write-through — failure isolation', () => {
-  test('disk-write failure does not roll back DB', async () => {
+  test('disk-write failure rejects the call and rolls back the new page (no index-only orphan)', async () => {
     // Point the config at a path that exists but isn't writable so the
     // write fails. Best portable trick: a regular file (writeFileSync to
     // a path inside a regular file fails with ENOTDIR).
@@ -223,18 +225,17 @@ describe('put_page write-through — failure isolation', () => {
     await engine.setConfig('sync.repo_path', blockFile);
 
     const ctx = makeCtx();
-    const result = (await putPage.handler(ctx, {
-      slug: 'inbox/fail-isolated',
-      content: '---\ntitle: F\n---\n\nbody',
-    })) as { write_through?: { skipped?: string; error?: string } };
-    // Either skipped (existsSync sees a file, not a dir) or error during write.
-    expect(
-      result.write_through?.skipped === 'repo_not_found' ||
-        typeof result.write_through?.error === 'string',
-    ).toBe(true);
+    await expect(
+      putPage.handler(ctx, {
+        slug: 'inbox/fail-isolated',
+        content: '---\ntitle: F\n---\n\nbody',
+      }),
+    ).rejects.toBeInstanceOf(OperationError);
 
-    // DB write succeeded.
+    // The markdown file is the system of record; a page that only exists
+    // as a DB row is an orphan the caller can't see or fix. Since this was
+    // a brand-new slug, the failed write is rolled back entirely.
     const page = await engine.getPage('inbox/fail-isolated');
-    expect(page).not.toBeNull();
+    expect(page).toBeNull();
   });
 });

--- a/test/put-page-write-through-failure.test.ts
+++ b/test/put-page-write-through-failure.test.ts
@@ -1,0 +1,111 @@
+/**
+ * put_page must not report success when the disk write-through fails.
+ *
+ * The DB row is a derived cache; the markdown file under a source's working
+ * tree is the system of record (docs/architecture/system-of-record.md). If
+ * `writePageThrough` can't produce that file — the write throws, or a guard
+ * refuses it for a reason that isn't the deliberate "no repo configured at
+ * all" case — `put_page` must reject the call instead of returning
+ * `created_or_updated`, and a brand-new page's DB row must not survive as an
+ * index-only orphan.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { operations, OperationError } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/operations.ts';
+import { resetGateway } from '../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+let tmpRoot: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  resetGateway();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  resetGateway();
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-put-page-wt-'));
+});
+
+function makeCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine,
+    config: { engine: 'pglite' as const },
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+    ...overrides,
+  };
+}
+
+const putPage = operations.find((o) => o.name === 'put_page')!;
+const PAGE_CONTENT = '---\ntitle: T\ntype: note\n---\n\n# Body\n\nSome content.';
+
+async function expectRejected(ctx: OperationContext, params: Record<string, unknown>): Promise<OperationError> {
+  try {
+    await putPage.handler(ctx, params);
+  } catch (e) {
+    expect(e).toBeInstanceOf(OperationError);
+    return e as OperationError;
+  }
+  throw new Error('expected put_page to reject when write-through failed, but it reported success');
+}
+
+describe('put_page — write-through failure must not report success', () => {
+  test('write-through throws (blocked parent dir) → put_page rejects and rolls back the new page', async () => {
+    const sourceDir = path.join(tmpRoot, 'wt-fail-source');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config) VALUES ('wt-fail', 'WT Fail', $1, '{}'::jsonb)`,
+      [sourceDir],
+    );
+    // `notes` is a FILE, not a directory, so mkdir -p `notes/x` throws ENOTDIR
+    // inside writePageThrough — the write-through-write-fails repro.
+    fs.writeFileSync(path.join(sourceDir, 'notes'), 'blocker');
+
+    const slug = 'notes/x';
+    const err = await expectRejected(makeCtx({ sourceId: 'wt-fail' }), { slug, content: PAGE_CONTENT });
+    expect(err.code).toBe('storage_error');
+
+    // No orphan: the brand-new page must not survive with no markdown file.
+    expect(await engine.getPage(slug, { sourceId: 'wt-fail' })).toBeNull();
+    expect(fs.existsSync(path.join(sourceDir, 'notes.md'))).toBe(false);
+  });
+
+  test('write-through skip that is a refusal, not deliberate config (repo_not_found) → put_page rejects', async () => {
+    const fileAsRepo = path.join(tmpRoot, 'not-a-dir');
+    fs.writeFileSync(fileAsRepo, 'x');
+    await engine.setConfig('sync.repo_path', fileAsRepo);
+
+    const slug = 'inbox/repo-missing';
+    const err = await expectRejected(makeCtx(), { slug, content: PAGE_CONTENT });
+    expect(err.code).toBe('storage_error');
+    expect(await engine.getPage(slug, { sourceId: 'default' })).toBeNull();
+  });
+
+  test('no sync.repo_path configured at all (DB-only by design) still succeeds', async () => {
+    await engine.setConfig('sync.repo_path', '');
+    const slug = 'inbox/db-only';
+    const result = (await putPage.handler(makeCtx(), { slug, content: PAGE_CONTENT })) as {
+      status: string;
+      write_through?: { skipped?: string };
+    };
+    expect(result.status).toBe('created_or_updated');
+    expect(result.write_through?.skipped).toBe('no_repo_configured');
+    expect(await engine.getPage(slug, { sourceId: 'default' })).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

`put_page` now fails the call when the disk write-through can't produce a markdown file, instead of silently reporting success with an index-only page. `no_repo_configured` (no `sync.repo_path` set at all) is unchanged — that's a deliberate, DB-only configuration, not a failure.

`src/core/operations.ts`:
- After `writePageThrough` runs, if the result is `written: false` and the reason isn't `no_repo_configured` (deliberate config) or `subagent_sandbox` (existing trust-gating skip, unrelated to disk state), the handler now throws an `OperationError` with code `storage_error` instead of returning `created_or_updated`.
- When the failed write-through was for a page this same call just created (`pages.created_at === pages.updated_at`, which only holds immediately after an insert — the `ON CONFLICT ... DO UPDATE` path never touches `created_at`), the row is deleted before the error is thrown, so a failed `put_page` never leaves an index-only orphan. An update to a page that already existed (or a dedup hit that resolved to a different, pre-existing page) is left alone, since its prior file on disk is untouched and still matches its prior content.
- Updated the stale doc comment above the write-through call site that said failures were "non-fatal."

No changes to `src/core/write-through.ts` itself — its contract (never throw; report outcome via `skipped`/`error`) is correct and shared by `gbrain brainstorm/lsd --save` and `sync`, which are out of scope here. This PR only changes how the `put_page` MCP/CLI operation *interprets* that result.

## Behavior before / after

| `write_through` outcome | Before | After |
|---|---|---|
| `written: true` | success | success (unchanged) |
| `skipped: 'no_repo_configured'` (no `sync.repo_path` set — DB-only by design) | success | success (unchanged) |
| `skipped: 'subagent_sandbox'` (trust gating, not a disk-state outcome) | success | success (unchanged) |
| `skipped: 'repo_not_found'` (configured path missing / not a directory) | success, orphan row on a new page | rejected (`storage_error`); new-page row rolled back |
| `skipped: 'source_repo_belongs_to_other_source'` (write refused to avoid polluting a sibling source's tree) | success, orphan row on a new page | rejected; new-page row rolled back |
| `skipped: 'path_escapes_source_root'` (resolved path escaped the source's tree) | success, orphan row on a new page | rejected; new-page row rolled back |
| `skipped: 'case_insensitive_collision'` (case-folded filename clash) | success, orphan row on a new page | rejected; new-page row rolled back |
| `skipped: 'page_not_found_after_write'` (row unreadable immediately after the DB write) | success, orphan row on a new page | rejected; new-page row rolled back |
| `error: '<message>'` (write threw — EACCES, ENOTDIR, disk full, …) | success, orphan row on a new page | rejected; new-page row rolled back |

An update to a pre-existing page behaves the same as a new page in the "rejected" column, minus the rollback: the call still throws, but the existing DB row (and its still-intact file on disk) is left as-is rather than deleted.

## Tests

New: `test/put-page-write-through-failure.test.ts` — three cases:
1. Write-through throws (parent path blocked by a file, forcing `ENOTDIR`) → `put_page` rejects with `storage_error`, and the new page's DB row does not survive.
2. Write-through skips with `repo_not_found` (configured `sync.repo_path` isn't a directory) → same rejection + rollback.
3. Write-through skips with `no_repo_configured` → still succeeds, unchanged.

Updated two pre-existing tests whose assertions directly encoded the bug being fixed here:
- `test/ingestion/put-page-write-through.test.ts`: "repo path points at a missing directory" now expects rejection instead of a `skipped` field on a successful response; "failure isolation" (`disk-write failure does not roll back DB`) now asserts the opposite — the call rejects and the new page's row is rolled back — since "isolating" a write failure into a silently-successful DB-only page is exactly what this PR removes.
- `test/brain-allowlist.serial.test.ts`: the `#1586` sourceId-threading test used a `local_path` (`/tmp/mybrain`) that was never actually created on disk; it happened to work before because write-through failures didn't block anything. Added the one-line `mkdirSync` the test's own fixture needed.

Full results (bug-finding lint + every test file that exercises `put_page`, run individually to avoid cross-file PGLite resource contention in one process): `bun test` — 0 failures. `tsc --noEmit` — clean.

## Note for maintainers

Widening the failure classification from just thrown errors to also cover the `skipped` guard reasons (`repo_not_found` etc.) touched two test files outside the immediate write-through suite that had, until now, relied on "a missing/misconfigured repo path doesn't block a write" as an incidental assumption. That's consistent with `docs/architecture/system-of-record.md`, but I want to flag it explicitly in case there's a reason a *misconfigured-but-present* `sync.repo_path` was meant to degrade gracefully rather than fail loudly — happy to narrow the classification (e.g. treat only a thrown `error` as fatal, leave the `skipped` guards as-is) if that's the preferred contract.

Closes #3929