### PR TITLE
engine: deterministic federated get_page — anchor source first, then lexical

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1209,9 +1209,16 @@ export class PGLiteEngine implements BrainEngine {
     const params: unknown[] = [slug];
     // #1393: federated grant (sourceIds[]) wins over scalar sourceId so the
     // exact-match read honors allowedSources, not just one source.
+    let orderBy = '';
     if (sourceIds && sourceIds.length > 0) {
       params.push(sourceIds);
       where.push(`source_id = ANY($${params.length}::text[])`);
+      // Same slug in more than one federated source: order deterministically
+      // instead of leaving the winner to scan order (see postgres-engine.ts
+      // getPage for the full rationale). The caller's own/anchor source
+      // (sourceIds[0]) wins when present; otherwise lexical by source_id.
+      params.push(sourceIds[0]);
+      orderBy = ` ORDER BY (source_id = $${params.length}) DESC, source_id ASC`;
     } else if (sourceId) {
       params.push(sourceId);
       where.push(`source_id = $${params.length}`);
@@ -1224,7 +1231,7 @@ export class PGLiteEngine implements BrainEngine {
               effective_date, effective_date_source,
               source_kind, source_uri, ingested_via, ingested_at,
               contextual_retrieval_mode
-       FROM pages WHERE ${where.join(' AND ')} LIMIT 1`,
+       FROM pages WHERE ${where.join(' AND ')}${orderBy} LIMIT 1`,
       params
     );
     if (rows.length === 0) return null;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1085,6 +1085,18 @@ export class PostgresEngine implements BrainEngine {
             ? tx`AND source_id = ${sourceId}`
             : tx``;
       const deletedCondition = includeDeleted ? tx`` : tx`AND deleted_at IS NULL`;
+      // When the same slug exists in more than one source inside a federated
+      // grant, `LIMIT 1` with no ORDER BY leaves the winner to whatever order
+      // Postgres happens to scan rows in — unspecified, and free to change
+      // between identical queries or after a reindex/VACUUM. Deterministic
+      // precedence: the caller's own/anchor source (sourceIds[0] — threaded
+      // first by federatedSearchScope's "resolved source first" contract)
+      // wins when it has a matching row; otherwise the remaining candidates
+      // sort lexically by source_id.
+      const orderCondition =
+        sourceIds && sourceIds.length > 0
+          ? tx`ORDER BY (source_id = ${sourceIds[0]}) DESC, source_id ASC`
+          : tx``;
       const rows = await tx`
         SELECT id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at,
                effective_date, effective_date_source,
@@ -1092,6 +1104,7 @@ export class PostgresEngine implements BrainEngine {
                contextual_retrieval_mode
         FROM pages
         WHERE slug = ${slug} ${sourceCondition} ${deletedCondition}
+        ${orderCondition}
         LIMIT 1
       `;
       if (rows.length === 0) return null;

--- a/test/get-page-federated-scope.test.ts
+++ b/test/get-page-federated-scope.test.ts
@@ -122,6 +122,17 @@ beforeEach(async () => {
     type: 'note', title: 'Dup beta', compiled_truth: 'b', frontmatter: {},
   }, { sourceId: 'beta' });
   await engine.addTag('shared/dup', 'beta-only', { sourceId: 'beta' });
+
+  // Slug-shadowing fixture: a THIRD source ('gamma') also carries the same
+  // slug, plus a registered 'zeta' source that does NOT — used to prove
+  // engine.getPage's federated-array winner follows the documented
+  // precedence (caller's own/anchor source, then lexical) rather than
+  // whatever order Postgres happens to scan rows in.
+  await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('gamma', 'gamma', '/tmp/gamma') ON CONFLICT (id) DO NOTHING`);
+  await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('zeta', 'zeta', '/tmp/zeta') ON CONFLICT (id) DO NOTHING`);
+  await engine.putPage('shared/dup', {
+    type: 'note', title: 'Dup gamma', compiled_truth: 'g', frontmatter: {},
+  }, { sourceId: 'gamma' });
 });
 
 function remoteCtx(allowedSources: string[]): OperationContext {
@@ -144,6 +155,35 @@ describe('engine.getPage honors sourceIds[] (federated grant)', () => {
     // scalar says alpha, array says beta-only — array wins, page found.
     const page = await engine.getPage('secret/beta-doc', { sourceId: 'alpha', sourceIds: ['beta'] });
     expect(page?.title).toBe('Beta secret');
+  });
+});
+
+describe('engine.getPage same-slug shadowing across federated sources is deterministic', () => {
+  test('the caller\'s own/anchor source (sourceIds[0]) wins even when it sorts after the others lexically', async () => {
+    // 'beta' is NOT alphabetically first among [beta, alpha, gamma] — if the
+    // winner were picked by lexical order (or arbitrary scan order) this
+    // would not reliably return the beta row.
+    const page = await engine.getPage('shared/dup', { sourceIds: ['beta', 'alpha', 'gamma'] });
+    expect(page?.title).toBe('Dup beta');
+  });
+
+  test('anchor reselected: the SAME slug + SAME source set returns the source placed first', async () => {
+    const page = await engine.getPage('shared/dup', { sourceIds: ['gamma', 'beta', 'alpha'] });
+    expect(page?.title).toBe('Dup gamma');
+  });
+
+  test('anchor has no matching page: falls back to lexical order among the remaining matches', async () => {
+    // 'zeta' is a real granted source but has no 'shared/dup' page, so the
+    // anchor itself is not a candidate — tie-break among {gamma, alpha}
+    // must be deterministic (lexically: 'alpha' < 'gamma').
+    const page = await engine.getPage('shared/dup', { sourceIds: ['zeta', 'gamma', 'alpha'] });
+    expect(page?.title).toBe('Dup alpha');
+  });
+
+  test('resolution is stable across repeated calls with the same scope', async () => {
+    const first = await engine.getPage('shared/dup', { sourceIds: ['beta', 'alpha', 'gamma'] });
+    const second = await engine.getPage('shared/dup', { sourceIds: ['beta', 'alpha', 'gamma'] });
+    expect(first?.title).toBe(second?.title);
   });
 });
 

--- a/test/get-page-shadowing-engine-parity.test.ts
+++ b/test/get-page-shadowing-engine-parity.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Engine parity for getPage's federated slug-shadowing precedence. PGLite-half
+ * always runs (hermetic). Postgres-half runs only when `DATABASE_URL` is set —
+ * same gate as the other engine-parity tests (see
+ * phantom-redirect-engine-parity.test.ts).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let pglite: PGLiteEngine;
+let pg: PostgresEngine | null = null;
+
+beforeAll(async () => {
+  pglite = new PGLiteEngine();
+  await pglite.connect({});
+  await pglite.initSchema();
+
+  if (process.env.DATABASE_URL) {
+    pg = new PostgresEngine();
+    await pg.connect({ database_url: process.env.DATABASE_URL });
+    await pg.initSchema();
+  }
+});
+
+afterAll(async () => {
+  await pglite.disconnect();
+  if (pg) await pg.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(pglite);
+  if (pg) {
+    await pg.executeRaw('DELETE FROM pages');
+    await pg.executeRaw(`DELETE FROM sources WHERE id IN ('alpha','beta','gamma','zeta')`);
+  }
+  for (const engine of [pglite, pg].filter(Boolean) as BrainEngine[]) {
+    await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('alpha','alpha','/tmp/alpha') ON CONFLICT (id) DO NOTHING`);
+    await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('beta','beta','/tmp/beta') ON CONFLICT (id) DO NOTHING`);
+    await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('gamma','gamma','/tmp/gamma') ON CONFLICT (id) DO NOTHING`);
+    await engine.executeRaw(`INSERT INTO sources (id, name, local_path) VALUES ('zeta','zeta','/tmp/zeta') ON CONFLICT (id) DO NOTHING`);
+    await engine.putPage('shared/dup', { type: 'note', title: 'Dup alpha', compiled_truth: 'a', frontmatter: {} }, { sourceId: 'alpha' });
+    await engine.putPage('shared/dup', { type: 'note', title: 'Dup beta', compiled_truth: 'b', frontmatter: {} }, { sourceId: 'beta' });
+    await engine.putPage('shared/dup', { type: 'note', title: 'Dup gamma', compiled_truth: 'g', frontmatter: {} }, { sourceId: 'gamma' });
+  }
+});
+
+describe('getPage same-slug shadowing (parity)', () => {
+  test('anchor (sourceIds[0]) wins even when not lexically first', async () => {
+    for (const engine of [pglite, pg].filter(Boolean) as BrainEngine[]) {
+      const page = await engine.getPage('shared/dup', { sourceIds: ['beta', 'alpha', 'gamma'] });
+      expect(page?.title).toBe('Dup beta');
+    }
+  });
+
+  test('anchor has no matching page: falls back to lexical order', async () => {
+    for (const engine of [pglite, pg].filter(Boolean) as BrainEngine[]) {
+      const page = await engine.getPage('shared/dup', { sourceIds: ['zeta', 'gamma', 'alpha'] });
+      expect(page?.title).toBe('Dup alpha');
+    }
+  });
+});


### PR DESCRIPTION
# Make `get_page` deterministic when a slug is shadowed across federated sources

Fixes the nondeterministic-row-selection bug described in the linked issue.

## Problem

`getPage(slug, { sourceIds: [...] })` — the read path used by federated grants (multiple sources visible to one caller) — resolved a slug that exists in more than one of those sources with:

```sql
WHERE slug = $1 AND source_id = ANY($2::text[]) ...
LIMIT 1
```

No `ORDER BY`. Which row wins is unspecified by Postgres semantics, so it can differ between two otherwise-identical calls, or after a reindex/VACUUM changes the physical scan order. Confirmed by a new test where requesting `sourceIds: ['beta', 'alpha', 'gamma']` for a slug that exists under all three sources returned `'alpha'`'s page (physical/insertion-order winner) instead of the caller-preferred `'beta'`.

## Fix

Add a deterministic `ORDER BY` to both engines' `getPage`:

```sql
ORDER BY (source_id = <anchor>) DESC, source_id ASC
```

Where `<anchor>` is `sourceIds[0]`. This follows the precedence already documented on `federatedSearchScope` (operations.ts): for an unqualified local CLI call, `localFederatedSourceIds` threads the caller's own resolved source in first — `[resolvedSource, ...otherFederatedSourceIds]`. Reusing that same "position 0 is the anchor" convention means:

- If the caller's own source has a matching page, they get it — deterministically.
- Otherwise (e.g. a remote OAuth client's flat `allowedSources` grant, where there's no meaningful "anchor"), the remaining candidates break ties lexically by `source_id` — still deterministic, just not caller-preference-driven.

Applied identically to `PostgresEngine.getPage` (`src/core/postgres-engine.ts`) and `PGLiteEngine.getPage` (`src/core/pglite-engine.ts`) so the two engines stay in lockstep.

## Before / after

```ts
// same slug exists in both 'alpha' and 'beta' sources
await engine.getPage('shared/dup', { sourceIds: ['beta', 'alpha', 'gamma'] });

// before: "Dup alpha"  (whatever Postgres scanned first — ignores the array)
// after:  "Dup beta"   (sourceIds[0] is the anchor and has a matching row)

await engine.getPage('shared/dup', { sourceIds: ['zeta', 'gamma', 'alpha'] });
// 'zeta' has no 'shared/dup' page, so the anchor isn't a candidate.
// before: "Dup alpha"  (still just whatever scanned first — same as above, coincidentally)
// after:  "Dup alpha"  (now *because* 'alpha' < 'gamma' lexically, not by accident)
```

## Scope

`get_tags` / `get_links` / `get_backlinks` / `get_timeline`'s federated branches were also inspected for the same class of bug. They deliberately `UNION` across every matching page in the grant rather than picking one — that's intentional (see the `D3A`/`D4A` tests) and out of scope here. `getPage`'s `LIMIT 1` was the only by-slug read that silently discarded information instead of surfacing it.

## Testing

- New test: `test/get-page-federated-scope.test.ts` — `engine.getPage same-slug shadowing across federated sources is deterministic` (4 cases: anchor wins even when it's not lexically first, re-anchoring flips the winner, anchor-absent falls back to lexical order, repeated calls with the same scope are stable). Confirmed RED against the pre-fix code, GREEN after.
- New parity test: `test/get-page-shadowing-engine-parity.test.ts` ran the same scenario against a real Postgres 16 + pgvector instance (not just PGLite) — failed pre-fix and passed post-fix on both engines.
- Full existing suite for this file, plus the engine-parity and multi-source federation suites, pass unchanged: `get-page-federated-scope.test.ts`, `get-page-shadowing-engine-parity.test.ts`, `phantom-redirect-engine-parity.test.ts`, `engine-parity-event-type.test.ts`, `multi-source-integration.test.ts`, `multi-source-drift.test.ts`, `operations-fuzzy-source-scope.test.ts`, `local-federated-search-scope.test.ts`, `legacy-token-federated-scope.test.ts`, `unfederate-read-scope-2928.test.ts` — 129 tests, 0 failures.
- `tsc --noEmit` clean.

Closes #3931