### PR TITLE
doctor: add source_durability_hardening check

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -58,6 +58,8 @@ import {
   DERIVE_PHASE_DB_ONLY_DEFAULTS,
   findDbOnlyCollisions,
 } from '../core/storage-config.ts';
+import { validateRepoState } from '../core/git-remote.ts';
+import { isDurabilityHardened } from '../core/brain-repo-durability.ts';
 import { slugifyPath } from '../core/sync.ts';
 // issue #1777: hidden_by_search_policy — count chunked pages withheld from
 // default search by the hard-exclude prefix policy. Reuses the canonical
@@ -3834,6 +3836,51 @@ export async function checkUndeclaredDbOnlyPages(engine: BrainEngine): Promise<C
     };
   } catch (e) {
     return { name, status: 'warn', message: `Could not check undeclared db-only pages: ${(e as Error).message}` };
+  }
+}
+
+/**
+ * source_durability_hardening — a source with a pushable git remote that
+ * write-through writes into but that was never hardened via `gbrain sources
+ * harden` has no way for those writes to reach git: `isDurabilityHardened`
+ * gates write-through's best-effort commit (write-through.ts), so on an
+ * un-hardened repo the `.md` artifact lands on disk and stays there —
+ * uncommitted, unpushed, invisible on a fresh clone. The DB row becomes the
+ * only durable copy even though `put_page` reported success.
+ *
+ * Only sources with a configured `origin` remote are in scope
+ * (`validateRepoState(...) === 'healthy'`) — a local-only working tree with
+ * no remote has nothing for hardening to push to, so it's not a gap.
+ */
+export async function checkSourceDurabilityHardening(engine: BrainEngine): Promise<Check> {
+  const name = 'source_durability_hardening';
+  try {
+    const sources = await engine.executeRaw<{ id: string; local_path: string | null }>(
+      `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL`,
+    );
+    const withRemote = sources.filter(
+      s => s.local_path && existsSync(s.local_path) && validateRepoState(s.local_path) === 'healthy',
+    );
+    if (withRemote.length === 0) {
+      return { name, status: 'ok', message: 'Not applicable (no sources with a pushable git remote on this host)' };
+    }
+    const unhardened = withRemote.filter(s => !isDurabilityHardened(s.local_path!));
+    if (unhardened.length === 0) {
+      return {
+        name,
+        status: 'ok',
+        message: `All ${withRemote.length} source(s) with a git remote are durability-hardened`,
+      };
+    }
+    const ids = unhardened.map(s => s.id);
+    return {
+      name,
+      status: 'warn',
+      message: `${unhardened.length}/${withRemote.length} source(s) accept writes but are not durability-hardened — write-through content lands on disk but is never committed/pushed, so the DB row is the only durable copy. Fix: gbrain sources harden --source <id> for: ${ids.join(', ')}`,
+      details: { unhardened: ids },
+    };
+  } catch (e) {
+    return { name, status: 'warn', message: `Could not check source durability hardening: ${(e as Error).message}` };
   }
 }
 
@@ -8035,6 +8082,11 @@ export async function buildChecks(
     checks.push(await checkUndeclaredDbOnlyPages(engine));
     progress.heartbeat('db_only_collector_collision');
     checks.push(await checkDbOnlyCollectorCollision(engine));
+    // Write-path durability: sources with a pushable remote that were never
+    // hardened via `gbrain sources harden` (write-through commits are gated
+    // on isDurabilityHardened — see checkSourceDurabilityHardening).
+    progress.heartbeat('source_durability_hardening');
+    checks.push(await checkSourceDurabilityHardening(engine));
   }
 
   // v0.32.3 search-lite — mode + eval_drift surfaces. Status stays 'ok' per

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -164,6 +164,7 @@ export const OPS_CHECK_NAMES: ReadonlySet<string> = new Set([
   'search_mode',
   'pool_reap_health',
   'self_upgrade_health',
+  'source_durability_hardening',
   'stale_locks',
   'subagent_capability',
   'subagent_health',

--- a/test/doctor-source-durability-hardening.test.ts
+++ b/test/doctor-source-durability-hardening.test.ts
@@ -1,0 +1,136 @@
+/**
+ * source_durability_hardening doctor check.
+ *
+ * Gap: write-through (`put_page`, capture, enrichment) writes a source's
+ * `.md` artifact to disk and reports success regardless of whether the repo
+ * is durability-hardened. On an un-hardened repo the file sits uncommitted
+ * forever — never pushed, invisible to `git status` on a fresh clone — so the
+ * DB row becomes the only durable copy. `isDurabilityHardened` (used today
+ * only to gate write-through's best-effort commit) had no doctor-facing
+ * check surfacing which sources with a pushable remote never opted in via
+ * `gbrain sources harden`.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { checkSourceDurabilityHardening } from '../src/commands/doctor.ts';
+
+let engine: PGLiteEngine;
+const tempDirs: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', ['-C', cwd, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8',
+  }).trim();
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-doctor-durability-'));
+  tempDirs.push(dir);
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.email', 't@t.t');
+  git(dir, 'config', 'user.name', 'tester');
+  return dir;
+}
+
+function addOriginRemote(repoPath: string): void {
+  // Any URL works — the check only reads config (`git remote get-url`), it
+  // never fetches or pushes.
+  git(repoPath, 'remote', 'add', 'origin', 'https://example.invalid/brain.git');
+}
+
+/** Install a hook file carrying the gbrain durability banner (the detection
+ *  key `isDurabilityHardened` looks for) — same fake used by
+ *  write-through-commit.serial.test.ts, so no real push machinery needed. */
+function installFakeDurabilityHook(repoPath: string): void {
+  const hooksDir = join(repoPath, '.git', 'hooks');
+  mkdirSync(hooksDir, { recursive: true });
+  const hookPath = join(hooksDir, 'post-commit');
+  writeFileSync(hookPath, [
+    '#!/usr/bin/env bash',
+    '# gbrain brain-durability post-commit hook (v0.42.44+)',
+    'exit 0',
+    '',
+  ].join('\n'));
+  chmodSync(hookPath, 0o755);
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function addSource(id: string, localPath: string | null): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ($1, $1, $2, '{}'::jsonb)
+     ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+    [id, localPath],
+  );
+}
+
+describe('source_durability_hardening', () => {
+  test('no sources with local_path → ok (not applicable)', async () => {
+    const c = await checkSourceDurabilityHardening(engine);
+    expect(c.status).toBe('ok');
+    expect(c.message).toContain('Not applicable');
+  });
+
+  test('source with no git remote → ok (not applicable, hardening does not apply)', async () => {
+    const repo = makeRepo();
+    await addSource('src-a', repo);
+    const c = await checkSourceDurabilityHardening(engine);
+    expect(c.status).toBe('ok');
+    expect(c.message).toContain('Not applicable');
+  });
+
+  test('hardened source with a remote → ok', async () => {
+    const repo = makeRepo();
+    addOriginRemote(repo);
+    installFakeDurabilityHook(repo);
+    await addSource('src-a', repo);
+    const c = await checkSourceDurabilityHardening(engine);
+    expect(c.status).toBe('ok');
+  });
+
+  test('un-hardened source with a remote → warn naming the source', async () => {
+    const repo = makeRepo();
+    addOriginRemote(repo);
+    await addSource('src-a', repo);
+    const c = await checkSourceDurabilityHardening(engine);
+    expect(c.status).toBe('warn');
+    expect(c.message).toContain('src-a');
+    expect(c.message).toContain('gbrain sources harden');
+    expect((c.details as any).unhardened).toEqual(['src-a']);
+  });
+
+  test('mixed hardened + un-hardened sources → warn counts only the un-hardened one', async () => {
+    const hardened = makeRepo();
+    addOriginRemote(hardened);
+    installFakeDurabilityHook(hardened);
+    await addSource('src-hard', hardened);
+
+    const bare = makeRepo();
+    addOriginRemote(bare);
+    await addSource('src-soft', bare);
+
+    const c = await checkSourceDurabilityHardening(engine);
+    expect(c.status).toBe('warn');
+    expect((c.details as any).unhardened).toEqual(['src-soft']);
+    expect(c.message).not.toContain('src-hard');
+  });
+});


### PR DESCRIPTION
## doctor: add `source_durability_hardening` check

Adds a doctor check for one piece of the write-path durability gap described
in the companion issue: a source that accepts writes but was never
durability-hardened.

`isDurabilityHardened()` (`src/core/brain-repo-durability.ts`) gates whether
`writePageThrough` (`src/core/write-through.ts`) best-effort commits its
`.md` artifact. On a repo that never ran `gbrain sources harden`, the file
lands on disk and nothing ever commits it — no doctor check surfaced that
gap even though the primitive to detect it (`isDurabilityHardened`) already
existed and is a single cheap file read.

### What the check does

`checkSourceDurabilityHardening` (`src/commands/doctor.ts`):

1. Reads every source with a `local_path`.
2. Filters to the ones whose repo has a configured `origin` remote
   (`validateRepoState(local_path) === 'healthy'`) — a local-only working
   tree with nothing to push to isn't in scope for hardening.
3. Calls `isDurabilityHardened(local_path)` on each.
4. `ok` (not applicable) when no source has a remote; `ok` when every
   source with a remote is hardened; `warn` naming the un-hardened source
   ids and pointing at `gbrain sources harden --source <id>` otherwise.

Wired into the existing check pipeline right next to the other
silent-write-failure checks (`undeclared_db_only_pages`,
`db_only_collector_collision`) since it's the same class of problem, and
categorized under `ops` in `src/core/doctor-categories.ts` (same bucket as
`stale_locks` / `self_upgrade_health` — "is the machinery actually
running").

### Testing

New test file `test/doctor-source-durability-hardening.test.ts`, following
the existing `doctor-silent-death-checks.test.ts` idiom (hermetic PGLite +
temp dirs standing in for source repos) plus the fake-hook helper from
`write-through-commit.serial.test.ts` (a `post-commit` hook file carrying
the detection banner, so no real push machinery is needed to exercise
`isDurabilityHardened`'s true/false branches). Covers:

- no sources with `local_path` → ok (not applicable)
- a source with a local repo but no git remote → ok (not applicable)
- a hardened source with a remote → ok
- an un-hardened source with a remote → warn, names the source, points at
  the fix command
- mixed hardened + un-hardened sources → warn counts only the un-hardened
  one

`bun test test/doctor-source-durability-hardening.test.ts` — 5 pass.
`bun test test/doctor-categories.test.ts` (drift-guard for the new category
name) — 10 pass. `tsc --noEmit` clean.

Part of #3932 — closes the unhardened-source gap; the two git-state checks remain proposed there