### PR TITLE
links: percent-decode markdown link targets before resolution

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -233,8 +233,14 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
   const mdPattern = /\[([^\]]+)\]\(([^)]+\.md)\)/g;
   let match;
   while ((match = mdPattern.exec(content)) !== null) {
-    const target = match[2];
+    let target = match[2];
     if (target.includes('://')) continue;
+    // Obsidian's useMarkdownLinks mode percent-encodes link targets
+    // (`[Alice](People/Alice%20Chen.md)`). Decode before resolution; a
+    // malformed escape keeps the raw text rather than throwing.
+    if (target.includes('%')) {
+      try { target = decodeURIComponent(target); } catch { /* keep raw */ }
+    }
     results.push({ name: match[1], relTarget: target });
   }
 

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -345,7 +345,13 @@ export function extractEntityRefs(content: string): EntityRef[] {
   const mdPattern = new RegExp(ENTITY_REF_RE.source, ENTITY_REF_RE.flags);
   while ((match = mdPattern.exec(stripped)) !== null) {
     const name = match[1];
-    const fullPath = match[2];
+    let fullPath = match[2];
+    // Obsidian's useMarkdownLinks mode percent-encodes link targets
+    // (`[Alice](people/alice%20chen)`). Decode before resolution; a
+    // malformed escape keeps the raw text rather than throwing.
+    if (fullPath.includes('%')) {
+      try { fullPath = decodeURIComponent(fullPath); } catch { /* keep raw */ }
+    }
     const slug = fullPath;
     const dir = fullPath.split('/')[0];
     refs.push({ name, slug, dir });

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -30,6 +30,19 @@ describe('extractMarkdownLinks', () => {
     const content = '[A](a.md) and [B](b.md)';
     expect(extractMarkdownLinks(content)).toHaveLength(2);
   });
+
+  it('percent-decodes targets from Obsidian useMarkdownLinks mode', () => {
+    const content = '[Alice](People/Alice%20Chen.md)';
+    const links = extractMarkdownLinks(content);
+    expect(links).toHaveLength(1);
+    expect(links[0].relTarget).toBe('People/Alice Chen.md');
+  });
+
+  it('keeps a malformed percent-escape raw instead of throwing', () => {
+    const content = '[Bad](People/Alice%ZZ.md)';
+    expect(() => extractMarkdownLinks(content)).not.toThrow();
+    expect(extractMarkdownLinks(content)[0].relTarget).toBe('People/Alice%ZZ.md');
+  });
 });
 
 describe('extractLinksFromFile', () => {
@@ -47,6 +60,20 @@ describe('extractLinksFromFile', () => {
     const allSlugs = new Set(['deals/test']);
     const links = await extractLinksFromFile(content, 'deals/test.md', allSlugs);
     expect(links).toHaveLength(0);
+  });
+
+  it('resolves a percent-encoded Obsidian markdown-link target to its slugified page', async () => {
+    const content = 'See [Alice](People/Alice%20Chen.md).';
+    const allSlugs = new Set(['deals/test', 'people/alice-chen']);
+    const links = await extractLinksFromFile(content, 'deals/test.md', allSlugs);
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0].to_slug).toBe('people/alice-chen');
+  });
+
+  it('does not throw and produces no edge for a malformed percent-escape', async () => {
+    const content = 'See [Alice](People/Alice%ZZ.md).';
+    const allSlugs = new Set(['deals/test', 'people/alice-chen']);
+    await expect(extractLinksFromFile(content, 'deals/test.md', allSlugs)).resolves.toHaveLength(0);
   });
 
   it('extracts frontmatter company links (v0.13, includeFrontmatter opt-in)', async () => {

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -118,6 +118,23 @@ describe('extractEntityRefs', () => {
     expect(refs[0].dir).toBe('meetings');
   });
 
+  test('percent-decodes a markdown-link target before resolution', () => {
+    // ANY_DIR_SEGMENT requires a lowercase leading directory segment, so
+    // this producer's realistic percent-encoded input keeps the dir
+    // lowercase and encodes a character in the basename — here `%2D` for
+    // `-`, decoding to the exact page slug `people/alice-chen`.
+    const refs = extractEntityRefs('Met with [Alice Chen](people/alice%2Dchen) at the office.');
+    expect(refs.length).toBe(1);
+    expect(refs[0].slug).toBe('people/alice-chen');
+  });
+
+  test('keeps a malformed percent-escape raw instead of throwing', () => {
+    expect(() => extractEntityRefs('[Alice](people/alice%zzchen)')).not.toThrow();
+    const refs = extractEntityRefs('[Alice](people/alice%zzchen)');
+    expect(refs.length).toBe(1);
+    expect(refs[0].slug).toBe('people/alice%zzchen');
+  });
+
   // ─── issue #972: generic `[[bare-name]]` wikilinks (pass 2c) ─────────────
 
   test('tags bare wikilinks with needsResolution flag', () => {


### PR DESCRIPTION
# Percent-decode markdown-link targets before resolution (Obsidian `useMarkdownLinks` mode)

Fixes the issue filed alongside this PR: Obsidian's `useMarkdownLinks` mode writes markdown-link targets percent-encoded (`[Alice](People/Alice%20Chen.md)`), and neither markdown-link extractor ever decoded them, so every such link produced zero graph edges — silently, with no error. #1964 already fixed the sibling case (a written path with a literal, unencoded space folding through `slugifyPath`); this closes the remaining gap for what Obsidian's UI actually writes to disk in that mode.

## What changed

**`src/commands/extract.ts`** (`extractMarkdownLinks`, the scanner `gbrain sync`'s filesystem-source path uses)
- After the existing `://` external-link check, percent-decode `target` if it contains a `%`, fail-open (`try/catch`, keep the raw string on a malformed escape). The decoded target then flows into `resolveSlug` unchanged, which already folds it (`slugifyPath`) to match real page slugs — no changes needed there.

**`src/core/link-extraction.ts`** (`extractEntityRefs`'s markdown-link pass, used by the DB-source / conversation extraction path)
- Same fail-open percent-decode, applied to `fullPath` before it becomes the candidate's `slug`.

Both sites use the identical pattern:
```ts
if (target.includes('%')) {
  try { target = decodeURIComponent(target); } catch { /* keep raw */ }
}
```
The `%`-presence check is just a cheap skip for the common case (most links have nothing to decode); the `try/catch` is what actually matters — a link containing a literal `%` that isn't a valid escape sequence (`%ZZ`) must not throw and abort extraction, it should fall through with the raw text unchanged, exactly like a link that never had a `%` in it.

## Why not touch wikilink extraction

Obsidian never percent-encodes wikilink targets (`[[Alice Chen]]`) — only markdown-link targets, and only in `useMarkdownLinks` mode. Decoding wikilink text would be solving a problem that doesn't occur in practice and risks corrupting a wikilink that legitimately contains a literal `%`. Scoped to the two markdown-link (`[text](target)`) sites only.

## Tests

TDD: both new tests written first and confirmed RED against the old (non-decoding) behavior, then GREEN against this change.

`test/extract.test.ts` (`extractMarkdownLinks` / `extractLinksFromFile`):
- `[Alice](People/Alice%20Chen.md)` → `relTarget` decodes to `People/Alice Chen.md`.
- End-to-end through `extractLinksFromFile`: the same encoded link, with `people/alice-chen` in `allSlugs`, now resolves to a `to_slug: 'people/alice-chen'` edge (previously 0 edges).
- A malformed escape (`People/Alice%ZZ.md`) doesn't throw, and correctly produces no edge (there's no real page for it) rather than a bogus one.

`test/link-extraction.test.ts` (`extractEntityRefs`):
- A percent-encoded markdown-link target decodes before becoming the ref's `slug` (using `%2D` for a hyphen, since this extractor's directory-segment pattern requires a lowercase leading segment — the encoded-space repro from the issue applies to the filesystem-source scanner above, which has no such restriction).
- A malformed escape doesn't throw and keeps the raw text as the slug.

Ran the full extractor suite to confirm no regressions:
```
bun test test/extract.test.ts test/link-extraction.test.ts \
  test/link-extraction-code-refs.test.ts test/link-extraction-dir-whitelist-2576.test.ts
# 227 pass, 0 fail, 619 expect() calls

bun test test/extract-fs.test.ts test/extract-db.test.ts test/extract-incremental.test.ts \
  test/extract-source-aware.test.ts test/extract-fs-source-id.test.ts test/extract-stale.test.ts
# 75 pass, 0 fail, 166 expect() calls
```

`tsc --noEmit` is clean.

## Before / after

Before:
```
Note content: [Alice](People/Alice%20Chen.md)
Graph edges from this note: 0
```

After:
```
Note content: [Alice](People/Alice%20Chen.md)
Graph edges from this note: 1  →  people/alice-chen
```

Closes #3933