### PR TITLE
sources: list shows unset federation distinctly from explicit isolated

### DIFF
--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -55,6 +55,7 @@ import {
   parseSourceConfig,
   normalizeSourceConfig,
   isSourceFederated,
+  sourceFederationState,
   type SourceRow as LoadedSourceRow,
 } from '../core/sources-load.ts';
 
@@ -348,8 +349,14 @@ async function runList(engine: BrainEngine, args: string[]): Promise<void> {
   // Human-readable table.
   console.log('SOURCES');
   console.log('───────');
-  for (const e of entries) {
-    const fedMark = e.federated ? 'federated' : (e as any).archived ? '⚠ archived' : 'isolated';
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    // Explicit `federated: false` (`sources unfederate`) fully isolates a
+    // source's reads in both directions; an absent key ('unset') only keeps
+    // it out of OTHER anchors' reads — its own unqualified reads still widen
+    // outward (see sourceFederationState). Collapsing both to "isolated"
+    // overstates what an unset flag does.
+    const fedMark = (e as any).archived ? '⚠ archived' : sourceFederationState(rows[i].config);
     const pathStr = e.local_path ?? '(no local path)';
     const sync = e.last_sync_at ? `last sync ${e.last_sync_at}` : 'never synced';
     console.log(`  ${e.id.padEnd(20)}  ${fedMark.padEnd(12)}  ${String(e.page_count).padStart(6)} pages  ${sync}`);

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -161,6 +161,28 @@ export function isSourceFederated(config: unknown): boolean {
 }
 
 /**
+ * Three-way federation state for display (CLI `sources list`, etc.).
+ *
+ * `isSourceFederated` collapses to a boolean for the inclusion check (does
+ * this source show up in OTHER anchors' unqualified reads?), which is
+ * correctly strict — 'unset' behaves like 'isolated' there. But 'unset' and
+ * 'isolated' are NOT interchangeable for display: only an explicit
+ * `federated: false` (`sources unfederate` / `--no-federated`) opts a source
+ * out of cross-source read mixing in both directions. A source that has
+ * simply never set the flag still widens its OWN unqualified reads to
+ * include the federated set (the #1434 sole-source convenience, pinned
+ * behavior — see test/local-federated-search-scope.test.ts and
+ * test/unfederate-read-scope-2928.test.ts). Labeling it "isolated" overstates
+ * what the flag actually does.
+ */
+export function sourceFederationState(config: unknown): 'federated' | 'isolated' | 'unset' {
+  const raw = parseSourceConfig(config).federated;
+  if (raw === true) return 'federated';
+  if (raw === false) return 'isolated';
+  return 'unset';
+}
+
+/**
  * Enumerate every source. Order: 'default' first, then alphabetical by id.
  *
  * Caller filters in-process when the predicate is cheap (federatedOnly,

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -6,7 +6,7 @@
  * shape, validation, and flag parsing.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -229,6 +229,37 @@ describe('sources list', () => {
 
     const count = calls.find(c => c.sql.includes('COUNT(*)::int AS n FROM pages'));
     expect(count?.sql).toContain('deleted_at IS NULL');
+  });
+
+  test('distinguishes explicit false / absent key / explicit true in the human-readable label', async () => {
+    const { engine } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [
+        { id: 'wiki', name: 'wiki', local_path: '/tmp/wiki', last_commit: null, last_sync_at: null, config: '{"federated":true}', created_at: new Date() },
+        { id: 'yc-media', name: 'yc-media', local_path: '/tmp/yc', last_commit: null, last_sync_at: null, config: '{"federated":false}', created_at: new Date() },
+        { id: 'gstack', name: 'gstack', local_path: '/tmp/gstack', last_commit: null, last_sync_at: null, config: '{}', created_at: new Date() },
+      ],
+      'COUNT(*)::int AS n FROM pages': [{ n: 0 }],
+    });
+    const lines: string[] = [];
+    const logSpy = spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+    try {
+      await runSources(engine, ['list']);
+    } finally {
+      logSpy.mockRestore();
+    }
+    const wikiLine = lines.find(l => l.includes('wiki'))!;
+    const ycLine = lines.find(l => l.includes('yc-media'))!;
+    const gstackLine = lines.find(l => l.includes('gstack'))!;
+    // Explicit `federated: true` — unchanged.
+    expect(wikiLine).toContain('federated');
+    // Explicit `federated: false` (`sources unfederate`) — fully isolated.
+    expect(ycLine).toContain('isolated');
+    // Absent key (bare `sources add`, config={}) is NOT the same as explicit
+    // false: it doesn't appear in others' federated reads, but its own
+    // unqualified reads still widen outward (#1434/#2561/#2928). The label
+    // must say something other than "isolated", which overstates it.
+    expect(gstackLine).not.toContain('isolated');
+    expect(gstackLine).toContain('unset');
   });
 });
 


### PR DESCRIPTION
## `sources list` no longer calls an unset `federated` key "isolated"

### What

`sources list`'s human-readable table collapsed any non-`true` `config.federated` value to `isolated`, whether the source had never set the flag or had been explicitly run through `sources unfederate`. Those aren't the same thing: only an explicit `federated: false` fully isolates a source's reads in both directions (per the `#2928` guard in `source-resolver.ts`); a source that simply never set the flag still widens its own unqualified reads to include the federated set (the pinned `#1434`/`#2561` sole-source convenience — see `test/local-federated-search-scope.test.ts` and `test/unfederate-read-scope-2928.test.ts`).

This PR adds a `sourceFederationState()` helper (`src/core/sources-load.ts`) that returns the three real states — `'federated' | 'isolated' | 'unset'` — and wires it into `sources list`'s table instead of the boolean collapse:

```
SOURCES
───────
  default               federated          3 pages  ...
  yc-media               isolated           12 pages  ...   # sources unfederate yc-media
  gstack                 unset              0 pages  ...    # bare `sources add`, no flag
```

### What this does NOT change

- No change to `localFederatedSourceIds`, `federatedSearchScope`, or any read-scope resolution — the underlying widen/isolate behavior is untouched.
- `sources list --json`'s `federated: boolean` field is untouched. It's a strict `=== true` check, which is already accurate for both `false` and unset (both correctly report `false`) — the mismatch is purely in the three-way *text* label, not in the boolean.
- `sources add`'s own confirmation line (`federated: false — only searched when explicitly named via --source`) is untouched; this PR is scoped to `sources list` only.

### Testing

New test in `test/sources.test.ts` (`'distinguishes explicit false / absent key / explicit true in the human-readable label'`) captures `sources list`'s stdout for three sources — `federated: true`, `federated: false`, and `{}` — and asserts each gets a distinct label. Failing before the fix (an unset-config source's line contained `isolated`), passing after.

Ran the full `sources`/federation-adjacent suite locally: `sources.test.ts`, `sources-archive-idempotent.test.ts`, `all-sources-sentinel.test.ts`, `e2e/multi-source.test.ts`, `local-federated-search-scope.test.ts`, `unfederate-read-scope-2928.test.ts`, `cli.test.ts` — 88 pass, 0 fail. `tsc --noEmit` clean.

### Related

Opened a companion issue asking whether the underlying asymmetry (unset widens outward, explicit-false isolates both ways) should be spelled out in `docs/guides/multi-source-brains.md`'s federation table — no behavior change requested there, just documentation. This PR doesn't wait on that answer since it only touches display wording that's honest regardless of how that question resolves.

Refs #3934 — the label half; the documentation question stays open there