### PR TITLE
fix(frontmatter): drop the shipped rule binding a personal folder to a sensitive category

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -40,7 +40,7 @@ import { MinionQueue } from '../minions/queue.ts';
 import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.ts';
 import { makeSubagentHandler } from '../minions/handlers/subagent.ts';
 import type { MinionJobInput, MinionJobContext, MinionHandler, SubagentHandlerData } from '../minions/types.ts';
-import { discoverTranscripts, type DiscoveredTranscript } from './transcript-discovery.ts';
+import { discoverTranscripts, DEFAULT_EXCLUDE_PATTERNS, type DiscoveredTranscript } from './transcript-discovery.ts';
 import { serializeMarkdown, serializePageToMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
 import { validateSourceId } from '../utils.ts';
@@ -836,7 +836,7 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     DEFAULT_SUBAGENT_WAIT_TIMEOUT_MS,
   );
 
-  let excludePatterns: string[] = ['medical', 'therapy'];
+  let excludePatterns: string[] = [...DEFAULT_EXCLUDE_PATTERNS];
   if (excludeStr) {
     try {
       const parsed = JSON.parse(excludeStr);

--- a/src/core/cycle/transcript-discovery.ts
+++ b/src/core/cycle/transcript-discovery.ts
@@ -120,6 +120,14 @@ export function isDreamOutput(content: string, bypass = false): boolean {
 }
 
 /**
+ * Sensitivity categories dream excludes from transcript ingestion by default.
+ * The single source for this vocabulary: `dream.synthesize.exclude_patterns`
+ * overrides it at runtime, and test/frontmatter-inference.test.ts asserts no
+ * shipped DIRECTORY_RULE binds a path to one of these.
+ */
+export const DEFAULT_EXCLUDE_PATTERNS: readonly string[] = ['medical', 'therapy'];
+
+/**
  * Auto-wrap bare-word patterns in `\b<word>\b`. Power users can pass full
  * regex (e.g. `^therapy:`) which we honor verbatim. Heuristic: any input
  * that's purely alphanumeric+hyphen+underscore is treated as a bare word.

--- a/src/core/frontmatter-inference.ts
+++ b/src/core/frontmatter-inference.ts
@@ -112,14 +112,6 @@ export const DIRECTORY_RULES: DirectoryRule[] = [
     datePattern: 'filename',
     titleStrategy: 'filename',
   },
-  {
-    pathPrefix: 'apple notes/jan bowman notes/',
-    type: 'apple-note',
-    source: 'apple-notes',
-    tags: ['therapy', 'jan-bowman'],
-    datePattern: 'filename',
-    titleStrategy: 'filename',
-  },
   // Catch-all for Apple Notes not in a subfolder
   {
     pathPrefix: 'apple notes/',

--- a/test/frontmatter-inference.test.ts
+++ b/test/frontmatter-inference.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
+  compileExcludePatterns,
+  DEFAULT_EXCLUDE_PATTERNS,
+} from '../src/core/cycle/transcript-discovery.ts';
+import {
   inferFrontmatter,
   extractDateFromFilename,
   extractTitleFromFilename,
@@ -336,18 +340,21 @@ describe('DIRECTORY_RULES', () => {
     return sameFields && [...(r.tags ?? [])].sort().join(',') === derived;
   };
 
-  // The sensitivity vocabulary gbrain applies to its own corpus: transcripts
-  // matching these are excluded before any LLM call (see the excludePatterns
-  // default in src/core/cycle/synthesize.ts). A shipped DIRECTORY_RULE that
-  // maps a specific person's folder onto one of these categories encodes a
-  // private fact about a real individual into every install, which the Privacy
-  // rule in CLAUDE.md forbids for checked-in code. Personal mappings like that
-  // belong in the operator's own notes, not in the default rule table.
-  const SENSITIVE_CATEGORIES = ['medical', 'therapy'];
-
+  // Transcripts matching gbrain's sensitivity vocabulary are dropped before any
+  // LLM call. A shipped DIRECTORY_RULE that maps a specific person's folder
+  // onto one of those categories encodes a private fact about a real individual
+  // into every install, which the Privacy rule in CLAUDE.md forbids for
+  // checked-in code. Personal mappings belong in the operator's own notes.
+  //
+  // Matched with the production compiler, not a local `includes`: bare words
+  // compile to \b<word>\b, so `therapy-notes` and `medical records` are caught
+  // the same way discoverTranscripts catches them. An exact-equality check
+  // would let those spellings recreate the association with CI green.
   test('no shipped rule binds a path to a sensitive category', () => {
+    const res = compileExcludePatterns([...DEFAULT_EXCLUDE_PATTERNS]);
+    expect(res.length).toBe(DEFAULT_EXCLUDE_PATTERNS.length); // no silent drop
     const offenders = DIRECTORY_RULES.filter(r =>
-      (r.tags ?? []).some(t => SENSITIVE_CATEGORIES.includes(t.toLowerCase())),
+      (r.tags ?? []).some(t => res.some(re => re.test(t))),
     );
     // Report indices, not prefixes: an offending prefix is by definition the
     // kind of string this test exists to keep out of public artifacts, and a

--- a/test/frontmatter-inference.test.ts
+++ b/test/frontmatter-inference.test.ts
@@ -336,6 +336,25 @@ describe('DIRECTORY_RULES', () => {
     return sameFields && [...(r.tags ?? [])].sort().join(',') === derived;
   };
 
+  // The sensitivity vocabulary gbrain applies to its own corpus: transcripts
+  // matching these are excluded before any LLM call (see the excludePatterns
+  // default in src/core/cycle/synthesize.ts). A shipped DIRECTORY_RULE that
+  // maps a specific person's folder onto one of these categories encodes a
+  // private fact about a real individual into every install, which the Privacy
+  // rule in CLAUDE.md forbids for checked-in code. Personal mappings like that
+  // belong in the operator's own notes, not in the default rule table.
+  const SENSITIVE_CATEGORIES = ['medical', 'therapy'];
+
+  test('no shipped rule binds a path to a sensitive category', () => {
+    const offenders = DIRECTORY_RULES.filter(r =>
+      (r.tags ?? []).some(t => SENSITIVE_CATEGORIES.includes(t.toLowerCase())),
+    );
+    // Report indices, not prefixes: an offending prefix is by definition the
+    // kind of string this test exists to keep out of public artifacts, and a
+    // failing assertion is printed into CI logs.
+    expect(offenders.map(r => DIRECTORY_RULES.indexOf(r))).toEqual([]);
+  });
+
   test('Apple Notes rules are more specific than the catch-all', () => {
     const appleRules = DIRECTORY_RULES.filter(isAppleRule);
     expect(appleRules.length).toBeGreaterThan(1); // subfolder rules + catch-all


### PR DESCRIPTION
## Problem

`DIRECTORY_RULES` in `src/core/frontmatter-inference.ts` ships one Apple Notes entry whose
`pathPrefix` is a single real individual's folder and whose `tags` assign a category that gbrain
itself treats as protected — `discoverTranscripts` drops transcripts matching that vocabulary
before any LLM call, and `src/core/types.ts` lists a corresponding page type.

The Privacy rule in `CLAUDE.md` says public artifacts must not reference real people, and names
comments in checked-in code as public artifacts. A shipped default rule is stronger than a
comment: it is data every install evaluates, and here it encodes a private fact about a named
person. That rule ships to everyone who installs gbrain, not only to the brain it was written for.

I hit this while reading `DIRECTORY_RULES` to work out the filename convention for importing my
own Apple Notes corpus — the rule table is the documentation for that convention, so operators do
read it.

## What changed

**Remove the rule.** This is close to behaviour-neutral for the operator whose folder it
describes. The generic `apple notes/` rule already assigns type, source and date, and derives a
tag from the first-level folder name, so title/date/type/source are unchanged and a
folder-derived tag remains. What is lost is one hardcoded semantic tag, which belongs in that
operator's own notes rather than in the default table.

Verified rather than assumed: `inferFrontmatter` on a path under that prefix returns the same
`type` / `source` / `date` / `title` before and after, and a grep for the folder segment and its
tag slug across the whole tree returns 0 remaining references.

**Add a guard so the shape cannot return.** No `DIRECTORY_RULES` entry may carry a tag in the
project's own sensitivity vocabulary. Two details worth flagging for review:

- It matches with `compileExcludePatterns`, the production compiler, not a local equality check.
  Bare words compile to `\b<word>\b`, so hyphenated and multi-word spellings are caught the same
  way the runtime catches them. An exact-equality guard let those spellings through with CI green
  (raised in review before this landed). Boundary semantics are production-identical and no
  wider — `psychotherapy` is not caught, exactly as the runtime filter treats it.
- It reports rule **indices**, not prefixes. An offending prefix is by definition the kind of
  string this test exists to keep out of public artifacts, and a failing assertion is printed into
  CI logs.

To make that matching possible without hand-copying the vocabulary, the inline default in
`synthesize.ts` moves to an exported `DEFAULT_EXCLUDE_PATTERNS` beside the compiler it feeds.
Runtime behaviour is unchanged: same two entries, and `dream.synthesize.exclude_patterns` still
overrides it.

## Verification (on 130d321d / v0.42.76.0)

- `bun test test/frontmatter-inference.test.ts test/page-type-exhaustive.test.ts test/cycle-synthesize.test.ts` → **85 pass / 0 fail**
- Red check: restoring the rule from `upstream/master` → **38 pass / 1 fail**. (My first red check was
  void — it stashed against this branch's own commit, so the rule was never actually restored. Redone
  against master.)
- Guard boundary behaviour, measured: `therapy` / `therapy-notes` / `medical records` / `Therapy`
  caught; `psychotherapy` / `gstack` / `yc` / `pitch-notes` not caught.
- `bun run typecheck` → clean
- `bun run verify` → 34/34 green
- `bun run build:flag-registry` → no diff (the new import introduces no flag literals)

## Not included

There are also five Apple Notes rules whose output is byte-identical to what the generic rule
already produces — dead entries. Deliberately left out so this PR stays about the one thing;
happy to send that cleanup separately if useful.
