### PR TITLE
docs(search): telemetry comments promised an exit flush the code deliberately removed

### DIFF
--- a/src/core/search/telemetry.ts
+++ b/src/core/search/telemetry.ts
@@ -4,11 +4,12 @@
  * Architecture decision (D2 in the plan, [CDX-19]): per-process in-memory
  * bucket, flushed periodically (60s OR 100 calls, whichever first). There is
  * deliberately NO flush on process exit — `ensureExitHook` below documents why
- * the beforeExit/SIGINT/SIGTERM drain was removed. Consequence: a process that
- * exits holding fewer than FLUSH_THRESHOLD_CALLS buffered calls, less than
- * FLUSH_INTERVAL_MS after its last flush, loses them. Long-running processes
- * (HTTP MCP server, autopilot, jobs work) are covered by the timer; a
- * short-lived CLI invocation typically is not.
+ * the beforeExit/SIGINT/SIGTERM drain was removed. Consequence: anything still
+ * buffered when the process exits is lost, and so is a snapshot handed to an
+ * in-flight `flush()` that has not committed yet (`flush` clears `buckets`
+ * before awaiting the write). Long-running processes (HTTP MCP server,
+ * autopilot, jobs work) are covered by the timer; a short-lived CLI invocation
+ * usually exits before either trigger fires, so its calls are simply dropped.
  * The search hot path NEVER waits on this write — `record()` is sync and
  * the flush is fire-and-forget.
  *
@@ -24,8 +25,10 @@
  * Per-process bucketing means stdio MCP, HTTP MCP, and CLI processes each
  * maintain their own buffers. Stats are directional, not exact — acceptable
  * because the consumer is the operator (or an agent running `gbrain search
- * tune`), not a financial ledger. The "lose last bucket on hard crash"
- * downside is documented in the methodology doc.
+ * tune`), not a financial ledger. Note the loss is not limited to hard
+ * crashes: with no exit drain, an ordinary exit loses whatever has not been
+ * committed. Weigh that when reading counts from a process class that exits
+ * often.
  */
 
 import type { BrainEngine } from '../engine.ts';
@@ -59,9 +62,9 @@ const FLUSH_THRESHOLD_CALLS = 100;
 
 /**
  * Per-process telemetry singleton. Each gbrain process (CLI, stdio MCP,
- * HTTP MCP) gets one instance. The flush timer and exit hooks are
- * installed lazily on the first `record()` call so importing this module
- * has no side effects.
+ * HTTP MCP) gets one instance. The flush timer is installed lazily on the
+ * first `record()` call so importing this module has no side effects. No
+ * exit hooks are installed — see `ensureExitHook`.
  */
 class TelemetryWriter {
   private buckets = new Map<string, Bucket>();
@@ -191,7 +194,7 @@ class TelemetryWriter {
     return this.flushInFlight;
   }
 
-  /** Stop the timer and uninstall exit hooks. Called from tests / shutdown. */
+  /** Stop the timer and drop the buffer. Called from tests / shutdown. */
   stop(): void {
     if (this.timer) {
       clearInterval(this.timer);

--- a/src/core/search/telemetry.ts
+++ b/src/core/search/telemetry.ts
@@ -65,9 +65,10 @@ const FLUSH_THRESHOLD_CALLS = 100;
 
 /**
  * Per-process telemetry singleton. Each gbrain process (CLI, stdio MCP,
- * HTTP MCP) gets one instance. The flush timer is installed lazily on the
- * first `record()` call so importing this module has no side effects. No
- * exit hooks are installed — see `ensureExitHook`.
+ * HTTP MCP) gets one instance. The flush timer is installed lazily by the
+ * first `setEngine()` call, not by `record()`, so importing this module has
+ * no side effects and a caller can wire an engine without recording. No exit
+ * hooks are installed — see `ensureExitHook`.
  */
 class TelemetryWriter {
   private buckets = new Map<string, Bucket>();

--- a/src/core/search/telemetry.ts
+++ b/src/core/search/telemetry.ts
@@ -2,7 +2,10 @@
  * v0.32.3 search-lite telemetry rollup writer.
  *
  * Architecture decision (D2 in the plan, [CDX-19]): per-process in-memory
- * bucket, flushed periodically (60s OR 100 calls, whichever first). There is
+ * bucket, flushed on a best-effort basis (60s timer, or FLUSH_THRESHOLD_CALLS
+ * records — the latter is a trigger, not a guarantee: a threshold-crossing
+ * record that arrives while a flush is in flight coalesces onto it and does
+ * not drain the new bucket, so a buffer can exceed the threshold). There is
  * deliberately NO flush on process exit — `ensureExitHook` below documents why
  * the beforeExit/SIGINT/SIGTERM drain was removed. Consequence: anything still
  * buffered when the process exits is lost, and so is a snapshot handed to an
@@ -140,9 +143,12 @@ class TelemetryWriter {
 
   /**
    * Drain the bucket map to the database. Idempotent; concurrent flushes
-   * are coalesced via flushInFlight. The bucket map is swapped atomically
-   * before the SQL write so new `record()` calls during flush land in a
-   * fresh map.
+   * are coalesced via flushInFlight — a caller arriving mid-flush awaits the
+   * running write and does NOT get its own drain, so whatever it buffered
+   * waits for the next trigger. The bucket map is swapped atomically before
+   * the SQL write so new `record()` calls during flush land in a fresh map;
+   * that swap is also why an uncommitted snapshot is unrecoverable if the
+   * process exits mid-write.
    */
   async flush(): Promise<void> {
     if (this.flushInFlight) return this.flushInFlight;
@@ -194,7 +200,11 @@ class TelemetryWriter {
     return this.flushInFlight;
   }
 
-  /** Stop the timer and drop the buffer. Called from tests / shutdown. */
+  /**
+   * Stop the timer and drop the buffer. Test-only in practice: the sole
+   * caller is `_resetTelemetryWriterForTest`. Nothing in production shuts
+   * the writer down — processes exit and the buffer goes with them.
+   */
   stop(): void {
     if (this.timer) {
       clearInterval(this.timer);
@@ -248,9 +258,9 @@ class TelemetryWriter {
     // exit immediately, not block on a DB write that may never complete.
   }
 
-  // Test-only: previously inspected by tests. Retained as a no-op so the
-  // test harness's _resetTelemetryWriterForTest doesn't need to know about
-  // the exit-hook decision.
+  // Test-only, and currently unreferenced: no test calls it and
+  // `_resetTelemetryWriterForTest` uses `stop()`. Despite the name it is not
+  // a no-op and is not wired to any exit path — it just forces a flush.
   flushOnExitForTest(): Promise<void> {
     return this.flush().catch(() => { /* swallow */ });
   }

--- a/src/core/search/telemetry.ts
+++ b/src/core/search/telemetry.ts
@@ -2,8 +2,13 @@
  * v0.32.3 search-lite telemetry rollup writer.
  *
  * Architecture decision (D2 in the plan, [CDX-19]): per-process in-memory
- * bucket, flushed periodically (60s OR 100 calls, whichever first) AND on
- * process exit via beforeExit/SIGINT/SIGTERM with a 2-second timeout cap.
+ * bucket, flushed periodically (60s OR 100 calls, whichever first). There is
+ * deliberately NO flush on process exit — `ensureExitHook` below documents why
+ * the beforeExit/SIGINT/SIGTERM drain was removed. Consequence: a process that
+ * exits holding fewer than FLUSH_THRESHOLD_CALLS buffered calls, less than
+ * FLUSH_INTERVAL_MS after its last flush, loses them. Long-running processes
+ * (HTTP MCP server, autopilot, jobs work) are covered by the timer; a
+ * short-lived CLI invocation typically is not.
  * The search hot path NEVER waits on this write — `record()` is sync and
  * the flush is fire-and-forget.
  *


### PR DESCRIPTION
## Problem

`src/core/search/telemetry.ts` documents an exit flush it does not perform. The module header
said the buffer is:

> flushed periodically (60s OR 100 calls, whichever first) AND on process exit via
> beforeExit/SIGINT/SIGTERM with a 2-second timeout cap.

`ensureExitHook`, ~200 lines below in the same file, says the opposite and is the current
behaviour: *"Lossy by design: skip the buffered drain entirely on process exit"*, with the signal
handlers dropped too. That removal was correct — the old `beforeExit` drain kept short-lived CLI
processes alive waiting on a DB write and hung `test/e2e/claw-test.test.ts`. The header just never
followed.

A reader who stops at the header concludes every recorded search reaches `search_telemetry`.

**Measured on v0.42.76.0, Postgres engine:** `gbrain search stats` reported `Total searches: 106`,
then three consecutive CLI searches (`gbrain search` ×2, `gbrain query` ×1), then `search stats`
again: still `106`. Not "lost one call" — for a CLI-primary operator the recorded sample is
structurally empty, so `search stats` and `search tune` describe MCP traffic only. That is
consistent with the design decision as written; the header is what made it surprising.

## What changed

Comment-only. Every lifecycle claim this file makes is now checked against the code:

1. **Header** — states there is no exit drain, and that anything not yet committed is lost on
   exit, including a snapshot already handed to an in-flight `flush()` (which clears `buckets`
   before awaiting the write).
2. **Header** — the call threshold is a trigger, not a guarantee. `flush()` returns the in-flight
   promise at its first line, before the bucket swap, so a threshold-crossing record arriving
   mid-write coalesces onto the running flush and never drains the new bucket. The buffer can
   therefore exceed the threshold.
3. **`flush()` docstring** — spells out that coalesced callers get no drain of their own, and that
   the pre-write swap is why an uncommitted snapshot is unrecoverable.
4. **Per-process note** — attributed the loss to a *"hard crash"* and pointed at the methodology
   doc. Checked: `docs/eval/SEARCH_MODE_METHODOLOGY.md` carries no such explanation, and with no
   exit drain an ordinary exit loses data too.
5. **`TelemetryWriter` docblock** — said the timer "and exit hooks" install on the first
   `record()`. `ensureTimer()` has one call site and it is inside `setEngine()`; no exit hooks
   exist.
6. **`stop()`** — said "Called from tests / shutdown". Its only caller in `src/` and `test/` is
   `_resetTelemetryWriterForTest`.
7. **`flushOnExitForTest()`** — said it is "retained as a no-op"; it calls `flush()`. It is also
   unreferenced: the only occurrence in the tree is its own definition. Comment corrected, helper
   left in place — deleting an exported test helper is beyond a comment fix.

Items 2–7 came out of adversarial review after the first commit; fixing only the header would have
left the file contradicting itself in five more places.

## Verification (on 130d321d / v0.42.76.0)

- `bun test test/search-telemetry.test.ts test/search-telemetry-cache-wiring.serial.test.ts` → **20 pass / 0 fail**
- `bun run typecheck` → clean
- `bun run verify` → 34/34 green
- `grep` for `uninstall` and `exit hook` in the file → only the line that now states none are installed

## One question, not implemented here

Should `gbrain search stats` say what its sample covers? Right now it prints `Total searches: N`
with no qualifier, and `search tune` derives recommendations from it, so a CLI-primary operator
tunes on a sample that excludes their own traffic. I have deliberately not added output surface —
that is your call, and I would rather ask than ship it. Happy to send it if you want the shape.
