### PR TITLE
fix(cli): global help advertises `list -n N`, a flag list does not accept

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2803,7 +2803,8 @@ PAGES
   get <slug>                         Read a page
   put <slug> [< file.md]             Write/update a page
   delete <slug>                      Delete a page
-  list [--type T] [--tag T] [-n N]   List pages
+  list [--type T] [--tag T] [--limit N]
+                                     List pages
 
 SEARCH
   search <query>                     Keyword search (tsvector)


### PR DESCRIPTION
## Problem

`gbrain --help` documents:

```
  list [--type T] [--tag T] [-n N]   List pages
```

`list` does not read `-n`. The limit flag is `--limit`, which `gbrain list --help` already
documents. Nothing in the tree parses `-n` for this command — the only `-n` in `src/` is
`integrations.ts`'s alias for `--dry-run`.

Measured on a fresh PGLite brain with 60 imported pages, v0.42.76.0:

| invocation | rows |
|---|---|
| `list -n 5` | 50 (the default) |
| `list -n 300` | 50 |
| `list --limit 5` | 5 |
| `list --limit 300` | 60 |

**Not silent, but not usable either.** The run does print `output truncated at 50 rows
(default 50). Pass an explicit limit` — and a reader who reached for `-n` because the summary
line said so has already done exactly what that message asks. The remedy points back at the
thing they think they did.

Found while reading `gbrain --help` to page through a freshly imported corpus.

## What changed

The summary line only. `--limit N` replaces `-n N`, and the description wraps to the
continuation column the surrounding block uses. `bun run build:flag-registry` regenerates with
no diff.

## Scope note

An earlier version of this change also rewrote the `orphans` and `salience` summary lines, on
the theory that `--count` and `--kind` were stale because `operations.ts` declares neither.
**That was wrong and is not in this PR.** Those commands parse their own flags in their CLI
handlers — `orphans.ts` reads `--count`, and `salience.ts` accepts `--kind` as an alias for
`--slug-prefix` — so the operation contract is the MCP surface, not the full CLI surface, and
removing them would have deleted documentation of flags that work. Only `list -n` is a real
mismatch, and it is verified behaviourally above rather than from the contract.

That also rules out the obvious guard: a test comparing help lines against `operations.ts`
params would flag those two working flags, and comparing against `CLI_FLAG_REGISTRY` is
circular because the registry is generated from sources that include the help text. A sound
guard for this class needs a different oracle than either, so this PR does not add one.

## Verification (on 130d321d / v0.42.76.0)

- `bun test test/cli.test.ts test/cli-flag-validation.test.ts` → **48 pass / 0 fail**
- `bun run typecheck` → clean
- `bun run verify` → 34/34 green
- `git diff --check` → clean
