### PR TITLE
fix(embed): dry-run announced one page of progress regardless of the stale count

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1057,7 +1057,11 @@ async function embedAllStale(
   if (dryRun) {
     result.would_embed += staleCount;
     result.total_chunks += staleCount;
-    if (onProgress) onProgress(1, 1, 0);
+    // No progress event: a dry run reads a count and processes zero pages, so
+    // there is no page total to report. The previous synthetic onProgress(1,1,0)
+    // made `embed.pages` claim total:1 next to a summary naming a much larger
+    // stale count. docs/progress-events.md allows omitting `total` when it is
+    // not known up front; it does not allow asserting a wrong one.
     if (!staleOpts?.quiet) slog(`[dry-run] Would embed ${staleCount} stale chunks`);
     return;
   }

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -280,6 +280,38 @@ describe('runEmbedCore --dry-run never calls the embedding model', () => {
     expect(result.pages_processed).toBe(0);
   });
 
+  test('dry-run --stale emits no page progress, since it processes no pages', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const stale = [
+      { slug: 'a', chunk_index: 0, chunk_text: 'a', chunk_source: 'compiled_truth' as const, model: null, token_count: 1, source_id: 'default', page_id: 1 },
+      { slug: 'b', chunk_index: 0, chunk_text: 'b', chunk_source: 'compiled_truth' as const, model: null, token_count: 1, source_id: 'default', page_id: 2 },
+      { slug: 'c', chunk_index: 0, chunk_text: 'c', chunk_source: 'compiled_truth' as const, model: null, token_count: 1, source_id: 'default', page_id: 3 },
+    ];
+    const engine = mockEngine({
+      countStaleChunks: async () => stale.length,
+      listStaleChunks: async () => stale,
+      listPages: async () => [{ slug: 'a' }, { slug: 'b' }, { slug: 'c' }],
+      getChunks: async () => [],
+    });
+
+    const calls: Array<[number, number]> = [];
+    const result = await runEmbedCore(engine, {
+      stale: true,
+      dryRun: true,
+      onProgress: (done, total) => { calls.push([done, total]); },
+    });
+
+    // The CLI latches its `embed.pages` total from the first callback, so a
+    // synthetic (1, 1) here made the progress stream announce one page while
+    // the summary named every stale chunk. Consistent with pages_processed
+    // above: a dry run enumerates no pages, so it reports no page progress.
+    // docs/progress-events.md permits omitting a total that is not known up
+    // front; it does not permit asserting a wrong one.
+    expect(calls).toEqual([]);
+    expect(result.pages_processed).toBe(0);
+    expect(result.would_embed).toBe(3);
+  });
+
   test('dry-run --stale correctly identifies stale chunks (SQL-side path)', async () => {
     const { runEmbedCore } = await import('../src/commands/embed.ts');
     // SQL-side stale: only the 3 chunks where embedding IS NULL come back,


### PR DESCRIPTION
## Problem

`gbrain embed --stale --dry-run` emitted a synthetic `onProgress(1, 1, 0)`. The CLI latches its
`embed.pages` total from the first callback, so the progress stream announced a single page next
to a summary naming every stale chunk:

```
{"event":"start","phase":"embed.pages","total":1}
{"event":"tick","phase":"embed.pages","done":1,"total":1,"pct":100,"eta_ms":0}
[dry-run] Would embed 60 stale chunks
{"event":"finish","phase":"embed.pages","done":1,"total":1}
```

Measured on a fresh PGLite brain with 60 unembedded pages, v0.42.76.0. A preview exists to tell
you the size of the thing you are about to do; `total: 1` is the one number it must not get wrong.

`docs/progress-events.md` defines `total` as *"the total item count if known at start"* and says it
is omitted when the work has no total up front. **Omission is provided for; asserting a wrong value
is not.**

It is also inconsistent with this path's own result. The existing test asserts
`pages_processed === 0` for a dry run, with the comment *"we don't enumerate pages in dry-run
(cheaper pre-flight)"* — so the same code says zero pages in its result and one page in its
progress.

## What changed

The synthetic call is dropped. A dry run now emits no `embed.pages` phase, matching the zero pages
it processes.

No consumer requires the phase to appear: `progress-tail.ts` names it only as an example, and the
minion path (`jobs.ts:1553`) passes its own callback from the real embed loop. The CLI reporter is
started lazily on the first callback and `finish()` is guarded by that same flag, so never starting
leaves nothing half-open.

## Related, and deliberately not fixed here

#1459 reports the denominator of a **real** `--stale` run being latched from the first callback
while pages keep arriving, so the numerator climbs past it. Same phase, different cause. This
change does not touch that path.

## Verification (on 130d321d / v0.42.76.0)

- `bun test test/embed.serial.test.ts` → **35 pass / 0 fail**
- Red check: with `upstream/master`'s `embed.ts` → **34 pass / 1 fail**
- Live: `embed --stale --dry-run --progress-json` on the 60-page brain now prints the summary only
- `bun run typecheck` → clean
- `bun run verify` → 34/34 green
