### PR TITLE
fix(embed): retry 502 Bad Gateway during embed --stale backfill (#3966)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1352,12 +1352,14 @@ async function embedAllStale(
 
 /**
  * v0.33.3: rate-limit-aware embedBatch wrapper.
+ * #3966: also retries transient gateway errors (502/503/504) that NIM and
+ * similar providers emit under sustained bulk load.
  *
  * The OpenAI SDK has built-in retry with exponential backoff, but its
  * backoff window (max ~4s) is too short for TPM (tokens-per-minute)
  * rate limits on large pages (~90K tokens).  This wrapper catches
- * 429-shaped errors, parses the retry delay from the error message
- * (e.g. "Please try again in 248ms"), and sleeps before retrying.
+ * 429-shaped and gateway-overload errors, parses the retry delay from
+ * the error message (e.g. "Please try again in 248ms"), and sleeps before retrying.
  *
  * v0.33.4 hardening (codex + re-review findings):
  *   - D4: detect 429 via the wrapped error's `cause.status` (the gateway's
@@ -1399,6 +1401,26 @@ export function detect429FromCause(e: unknown): boolean {
   for (let depth = 0; depth < 5 && cur !== undefined && cur !== null; depth++) {
     const obj = cur as { status?: unknown; statusCode?: unknown; cause?: unknown };
     if (obj.status === 429 || obj.statusCode === 429) return true;
+    cur = obj.cause;
+  }
+  return false;
+}
+
+/** Gateway overload statuses retried with the same backoff as 429 (#3966). */
+const RETRIABLE_GATEWAY_STATUSES = new Set([502, 503, 504]);
+
+/**
+ * Walk the cause chain looking for 502/503/504. Same depth bound as
+ * detect429FromCause — one normalizeAIError wrap is typical.
+ *
+ * @internal exported for unit tests.
+ */
+export function detectGatewayErrorFromCause(e: unknown): boolean {
+  let cur: unknown = e;
+  for (let depth = 0; depth < 5 && cur !== undefined && cur !== null; depth++) {
+    const obj = cur as { status?: unknown; statusCode?: unknown; cause?: unknown };
+    const status = obj.status ?? obj.statusCode;
+    if (typeof status === 'number' && RETRIABLE_GATEWAY_STATUSES.has(status)) return true;
     cur = obj.cause;
   }
   return false;
@@ -1465,10 +1487,11 @@ export async function embedBatchWithBackoff(
       // If the budget fired we may have been aborted mid-fetch; bubble out.
       if (signal?.aborted) throw e;
       const msg = e instanceof Error ? e.message : String(e);
-      if (!isRateLimitError(e) || attempt === MAX_RATE_LIMIT_RETRIES) throw e;
+      if (!isEmbedRetriableError(e) || attempt === MAX_RATE_LIMIT_RETRIES) throw e;
 
       const delayMs = parseRetryDelayMs(msg);
-      serr(`  [rate-limit] attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES}, waiting ${delayMs}ms...`);
+      // One label for every retriable class — 429 and gateway blips share the loop.
+      serr(`  [embed-retry] attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES}, waiting ${delayMs}ms...`);
       await abortableSleep(delayMs, signal);
     }
   }
@@ -1477,14 +1500,20 @@ export async function embedBatchWithBackoff(
 }
 
 /**
- * 429 judgment shared by embedBatchWithBackoff (retry decision) and
+ * Retriable embed errors: 429 rate limits plus transient gateway overload
+ * (502/503/504). Shared by embedBatchWithBackoff (retry decision) and
  * embedPageTexts (fan-out decision). D4: structured detection first
  * (gateway-wrapped errors via cause chain); message-match as fallback for
  * providers whose wrappers strip `cause.status`.
  */
-function isRateLimitError(e: unknown): boolean {
+function isEmbedRetriableError(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e);
-  return detect429FromCause(e) || /rate.?limit|429/i.test(msg);
+  return (
+    detect429FromCause(e) ||
+    detectGatewayErrorFromCause(e) ||
+    /rate.?limit|429/i.test(msg) ||
+    /bad gateway|502|503|504|service unavailable|gateway timeout/i.test(msg)
+  );
 }
 
 /** Walk the cause chain (like detect429FromCause) for the first HTTP status. */
@@ -1535,7 +1564,7 @@ async function embedPageTexts(
   } catch (e: unknown) {
     if (opts.abortSignal?.aborted) throw e; // shutdown, not a chunk problem
     if (texts.length <= 1) throw e; // nothing to isolate
-    if (isRateLimitError(e) || e instanceof AITransientError) throw e;
+    if (isEmbedRetriableError(e) || e instanceof AITransientError) throw e;
     const status = statusFromCause(e);
     if (status === 401 || status === 403) throw e;
 

--- a/test/embed-partial-failure-3037.serial.test.ts
+++ b/test/embed-partial-failure-3037.serial.test.ts
@@ -242,8 +242,12 @@ describe('#3037 — cost bounding: no per-chunk fan-out on transient failures', 
     expect(result.failures).toBe(3);
   }, 30_000);
 
-  test('AITransientError (outage/network) does not fan out', async () => {
-    embedBatchBehavior = async () => { throw new AITransientError('upstream 502', { status: 502 }); };
+  test('sustained 502 retries batch but does not fan out per-chunk (#3966)', async () => {
+    embedBatchBehavior = async () => {
+      const err = new Error('Bad Gateway — try again in 0ms.');
+      (err as any).cause = { status: 502 };
+      throw err;
+    };
     const stale = THREE_CHUNKS.map(c => ({
       slug: 'outage-page', chunk_index: c.chunk_index, chunk_text: c.chunk_text,
       chunk_source: c.chunk_source, model: null, token_count: 1, source_id: 'default', page_id: 1,
@@ -257,10 +261,10 @@ describe('#3037 — cost bounding: no per-chunk fan-out on transient failures', 
 
     const result = await runEmbedCore(engine, { stale: true });
 
-    // Non-429 → no backoff retries; transient → no isolation. Exactly 1 call.
-    expect(embedCalls).toHaveLength(1);
-    expect(embedCalls[0]).toHaveLength(3);
+    // 502 → embedBatchWithBackoff retries the full batch; never 1-text isolation.
+    expect(embedCalls.length).toBeGreaterThan(1);
+    for (const call of embedCalls) expect(call).toHaveLength(3);
     expect(result.embedded).toBe(0);
     expect(result.failures).toBe(3);
-  });
+  }, 30_000);
 });

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -599,7 +599,7 @@ describe('embedBatchWithBackoff (D2/D4/D4a/D8)', () => {
     }
   });
 
-  test('case 4: non-rate-limit error rethrows immediately without retry', async () => {
+  test('case 4: non-retriable error rethrows immediately without retry', async () => {
     const { embedBatchWithBackoff } = await import('../src/commands/embed.ts');
     let calls = 0;
     embedBatchBehavior = async () => {
@@ -607,8 +607,31 @@ describe('embedBatchWithBackoff (D2/D4/D4a/D8)', () => {
       throw new Error('500 internal server error');
     };
     await expect(embedBatchWithBackoff(['x'])).rejects.toThrow('500 internal server error');
-    // Single attempt — no retries on non-429.
+    // Single attempt — no retries on non-gateway 5xx (#3966 keeps 500 fatal).
     expect(calls).toBe(1);
+  });
+
+  test('case 4b: 502 Bad Gateway retries then succeeds (#3966)', async () => {
+    const { embedBatchWithBackoff, detectGatewayErrorFromCause } = await import('../src/commands/embed.ts');
+    expect(detectGatewayErrorFromCause({ cause: { status: 502 } })).toBe(true);
+    expect(detectGatewayErrorFromCause({ cause: { status: 503 } })).toBe(true);
+    expect(detectGatewayErrorFromCause({ cause: { status: 504 } })).toBe(true);
+    expect(detectGatewayErrorFromCause({ cause: { status: 500 } })).toBe(false);
+
+    let calls = 0;
+    embedBatchBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        // NIM-style wrap: status on cause; parseable delay keeps the test fast.
+        const err = new Error('[embed(nvidia:nvidia/nv-embed-v1)] Bad Gateway — try again in 10ms');
+        (err as any).cause = { status: 502 };
+        throw err;
+      }
+      return [new Float32Array(1536)];
+    };
+    const result = await embedBatchWithBackoff(['x']);
+    expect(calls).toBe(2);
+    expect(result).toHaveLength(1);
   });
 
   test('case 5: jitter range — same parsed delay produces non-identical sleeps across runs', async () => {
@@ -647,7 +670,7 @@ describe('embedBatchWithBackoff (D2/D4/D4a/D8)', () => {
   });
 
   test('case 7: AITransientError-shaped wrap with 429 cause triggers retry; 500 cause does not', async () => {
-    const { embedBatchWithBackoff, detect429FromCause } = await import('../src/commands/embed.ts');
+    const { embedBatchWithBackoff, detect429FromCause, detectGatewayErrorFromCause } = await import('../src/commands/embed.ts');
 
     // Pure helper checks first.
     expect(detect429FromCause({ cause: { status: 429 } })).toBe(true);
@@ -656,6 +679,7 @@ describe('embedBatchWithBackoff (D2/D4/D4a/D8)', () => {
     expect(detect429FromCause({ status: 500 })).toBe(false);
     expect(detect429FromCause(undefined)).toBe(false);
     expect(detect429FromCause(null)).toBe(false);
+    expect(detectGatewayErrorFromCause({ cause: { cause: { status: 502 } } })).toBe(true);
     // Deep wrap (defensive — current normalizeAIError wraps once).
     expect(detect429FromCause({ cause: { cause: { status: 429 } } })).toBe(true);
 


### PR DESCRIPTION
## Summary
- Extend `embedBatchWithBackoff` to retry transient HTTP 502/503/504 gateway errors with the same backoff loop already used for 429 rate limits
- Prevents bulk `gbrain embed --stale --catch-up` runs from permanently failing chunks on intermittent NVIDIA NIM outages

Fixes #3966

## Test plan
- [x] `bun test test/embed.serial.test.ts` — new 502 retry case passes
- [x] `bun test test/embed-partial-failure-3037.serial.test.ts` — sustained 502 retries batch but does not fan out per-chunk
- [x] `bun run verify` — full pre-push gate green

Made with [Cursor](https://cursor.com)