### PR TITLE
feat(claude-cli): list the Claude 5 models the CLI already serves

### DIFF
--- a/src/core/ai/recipes/claude-cli.ts
+++ b/src/core/ai/recipes/claude-cli.ts
@@ -35,7 +35,11 @@ export const claudeCli: Recipe = {
     // No embedding or expansion touchpoints — chat-only.
     chat: {
       models: [
+        'claude-fable-5',
+        'claude-opus-5',
+        'claude-opus-4-8',
         'claude-opus-4-7',
+        'claude-sonnet-5',
         'claude-sonnet-4-6',
         'claude-haiku-4-5-20251001',
       ],


### PR DESCRIPTION
## Problem

The `claude-cli` recipe describes itself as the subscription-billed twin of the `anthropic` recipe:

> users pick per call: `anthropic:claude-sonnet-4-6` (API key + per-token billing) vs `claude-cli:claude-sonnet-4-6` (OAuth subscription, no API key)

The two model lists have drifted. `anthropic.ts` chat already lists `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8` and `claude-sonnet-5`. `claude-cli.ts` lists none of them.

The practical effect: `gbrain think --model claude-cli:claude-opus-5` is rejected with `unknown_model`, and a Max subscriber falls back to the API path — paying per token for a model their subscription already covers. That is the exact case #334 set out to solve.

## Change

Add the four Claude 5 ids to `claude-cli` chat, mirroring `anthropic`. Existing entries are untouched, so nothing that works today stops working.

## Verification

Each added id exercised end to end against a live CLI:

```
gbrain providers test --touchpoint chat --model claude-cli:<id>
```

| model | result |
|---|---|
| `claude-fable-5` | ok |
| `claude-opus-5` | ok |
| `claude-opus-4-8` | ok |
| `claude-sonnet-5` | ok |

`claude-haiku-5` does not exist — the newest Haiku is 4.5, already listed. It is deliberately not added.

`test/claude-cli-recipe.test.ts`: 20 pass, 0 fail.