### PR TITLE
fix(config): read the config table once instead of once per key

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -52,6 +52,7 @@ import {
   openrouterRequiresExplicitPromptCache,
 } from './recipes/openrouter.ts';
 import { resolveModel, TIER_DEFAULTS } from '../model-config.ts';
+import { snapshotConfigReader } from '../config-snapshot.ts';
 import { parseLlmJson } from '../llm-json.ts';
 import type { BrainEngine } from '../engine.ts';
 import { dimsProviderOptions } from './dims.ts';
@@ -551,15 +552,24 @@ export function configureGateway(config: AIGatewayConfig): void {
  */
 export async function reconfigureGatewayWithEngine(engine: BrainEngine): Promise<AIGatewayConfig> {
   const cfg = requireConfig();
+
+  // Six resolutions follow, each walking a 5-tier precedence chain that reads
+  // up to 4 config keys, plus alias expansion. Against the engine that is ~40
+  // sequential round trips before the CLI does any work — 3.1s of `gbrain
+  // stats`'s wall clock on a hosted brain, for reads the server answered in
+  // microseconds. Take one snapshot of the config table and resolve every
+  // model against it. Same keys, same precedence, one round trip.
+  const reader = await snapshotConfigReader(engine);
+
   // Resolve expansion (utility tier) and chat (reasoning tier). Embedding is
   // intentionally NOT re-resolved here — switching embedding models invalidates
   // the vector index. Out of scope per v0.31.12 plan ("Embedding tier knob").
-  const newExpansion = await resolveModel(engine, {
+  const newExpansion = await resolveModel(reader, {
     configKey: 'models.expansion',
     tier: 'utility',
     fallback: cfg.expansion_model ?? DEFAULT_EXPANSION_MODEL,
   });
-  const newChat = await resolveModel(engine, {
+  const newChat = await resolveModel(reader, {
     configKey: 'models.chat',
     tier: 'reasoning',
     fallback: cfg.chat_model ?? DEFAULT_CHAT_MODEL,
@@ -583,7 +593,7 @@ export async function reconfigureGatewayWithEngine(engine: BrainEngine): Promise
   // the resolveModel chain).
   const tierModels: string[] = [];
   for (const tier of ['utility', 'reasoning', 'deep', 'subagent'] as const) {
-    tierModels.push(await resolveModel(engine, { tier, fallback: TIER_DEFAULTS[tier] }));
+    tierModels.push(await resolveModel(reader, { tier, fallback: TIER_DEFAULTS[tier] }));
   }
 
   _config = { ...cfg, expansion_model: expansionFull, chat_model: chatFull };

--- a/src/core/config-snapshot.ts
+++ b/src/core/config-snapshot.ts
@@ -1,0 +1,65 @@
+/**
+ * One-round-trip config reads.
+ *
+ * Two startup paths need dozens of config keys before the CLI does any work:
+ * `loadConfigWithEngine()` merges the DB plane over file/env, and
+ * `reconfigureGatewayWithEngine()` resolves six models through a precedence
+ * chain that reads up to four keys each. Read one key at a time and that is
+ * one network round trip per key.
+ *
+ * On PGLite each read costs microseconds, so the pattern stayed invisible for
+ * a long time. On a hosted Postgres it is the wall clock: `gbrain stats`
+ * against a Supabase brain spent over 3 seconds on config reads that
+ * pg_stat_statements showed the server answering in under 3ms total.
+ *
+ * The config table is a handful of rows, so read it once and answer every key
+ * from memory. The snapshot lives for one resolution pass, not for the life of
+ * the process, so a `gbrain config set` from another process is picked up by
+ * the next command exactly as before.
+ */
+
+/** The only thing config resolution needs from an engine. */
+export interface ConfigReader {
+  getConfig(key: string): Promise<string | null | undefined>;
+}
+
+/** An engine that can read its whole config table in one query. */
+export interface BulkConfigReader extends ConfigReader {
+  getAllConfig?(): Promise<Record<string, string>>;
+}
+
+/**
+ * Read the whole config table as a key -> value map.
+ *
+ * Returns null when the bulk read is unavailable or fails — a brain
+ * mid-migration has no config table, and an engine implemented outside this
+ * repo may not have `getAllConfig`. Callers fall back to per-key reads, at the
+ * old cost but with the old behavior.
+ */
+export async function loadConfigSnapshot(
+  engine: BulkConfigReader | null | undefined,
+): Promise<Record<string, string> | null> {
+  if (!engine || typeof engine.getAllConfig !== 'function') return null;
+  try {
+    return await engine.getAllConfig();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return a reader that answers every key from a single snapshot, or the engine
+ * itself when the snapshot is unavailable.
+ */
+export async function snapshotConfigReader(
+  engine: BulkConfigReader | null | undefined,
+): Promise<ConfigReader | null> {
+  if (!engine) return null;
+  const rows = await loadConfigSnapshot(engine);
+  if (!rows) return engine;
+  return {
+    async getConfig(key: string): Promise<string | null> {
+      return rows[key] ?? null;
+    },
+  };
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'f
 import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
 import type { EngineConfig, EmbeddingColumnConfig } from './types.ts';
+import { loadConfigSnapshot } from './config-snapshot.ts';
 
 /**
  * Where is the active DB URL coming from? Pure introspection, no connection
@@ -694,6 +695,7 @@ export async function loadConfigWithEngine(
   engine: {
     getConfig(key: string): Promise<string | null | undefined>;
     listConfigKeys?(prefix: string): Promise<string[]>;
+    getAllConfig?(): Promise<Record<string, string>>;
   },
   base?: GBrainConfig | null,
 ): Promise<GBrainConfig | null> {
@@ -710,12 +712,22 @@ export async function loadConfigWithEngine(
     (base !== undefined ? base : loadConfig()) ??
     ({ engine: 'postgres' } as GBrainConfig);
 
-  // DB-plane reads. Quiet failures — if the config table doesn't exist yet
-  // (pre-v36 brain mid-migration), treat as null and let file/env defaults
-  // win. The migration runner reads file/env directly anyway.
+  // This function reads two dozen config keys. One key per round trip is free
+  // on PGLite and is most of the wall clock on a hosted Postgres, so read the
+  // whole table once and answer every key from that. See config-snapshot.ts.
+  //
+  // Quiet failure below is deliberate and unchanged: when the snapshot is
+  // unavailable (a pre-v36 brain mid-migration, or an engine from outside this
+  // repo) every read falls back to a per-key getConfig(), same as before.
+  const snapshot = await loadConfigSnapshot(engine);
+
+  function dbRaw(key: string): Promise<string | null | undefined> {
+    if (snapshot) return Promise.resolve(snapshot[key]);
+    return Promise.resolve(engine.getConfig(key));
+  }
   async function dbBool(key: string): Promise<boolean | undefined> {
     try {
-      const v = await engine.getConfig(key);
+      const v = await dbRaw(key);
       if (v === undefined || v === null || v === '') return undefined;
       return v === 'true';
     } catch {
@@ -724,7 +736,7 @@ export async function loadConfigWithEngine(
   }
   async function dbStr(key: string): Promise<string | undefined> {
     try {
-      const v = await engine.getConfig(key);
+      const v = await dbRaw(key);
       if (v === undefined || v === null || v === '') return undefined;
       return v;
     } catch {
@@ -732,11 +744,16 @@ export async function loadConfigWithEngine(
     }
   }
   async function dbPrefixMap(prefix: string): Promise<Record<string, string> | undefined> {
-    if (typeof engine.listConfigKeys !== 'function') return undefined;
     let keys: string[];
-    try {
-      keys = await engine.listConfigKeys(prefix);
-    } catch {
+    if (snapshot) {
+      keys = Object.keys(snapshot);
+    } else if (typeof engine.listConfigKeys === 'function') {
+      try {
+        keys = await engine.listConfigKeys(prefix);
+      } catch {
+        return undefined;
+      }
+    } else {
       return undefined;
     }
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -2104,6 +2104,20 @@ export interface BrainEngine {
    * Does NOT support glob/regex on purpose — the caller knows the prefix.
    */
   listConfigKeys(prefix: string): Promise<string[]>;
+  /**
+   * Read the whole config table in one round trip, as a key -> value map.
+   *
+   * `loadConfigWithEngine()` needs ~44 config keys on every connect. Read one
+   * key at a time that is 44 round trips, which costs nothing on PGLite and
+   * dominates the wall clock on a hosted Postgres: `gbrain stats` against a
+   * Supabase brain spent seconds on reads the server answered in under 3ms
+   * total. The config table is a handful of rows, so fetching all of it is
+   * cheaper than fetching any meaningful subset of it.
+   *
+   * Callers that need a single key still use getConfig(). This is for the
+   * bulk-read path only.
+   */
+  getAllConfig(): Promise<Record<string, string>>;
 
   // Migration support
   runMigration(version: number, sql: string): Promise<void>;

--- a/src/core/model-config.ts
+++ b/src/core/model-config.ts
@@ -20,7 +20,7 @@
  * AND lose to new-key config when both are set.
  */
 
-import type { BrainEngine } from './engine.ts';
+import type { ConfigReader } from './config-snapshot.ts';
 import { splitProviderModelId } from './model-id.ts';
 
 export type ModelTier = 'utility' | 'reasoning' | 'deep' | 'subagent';
@@ -131,7 +131,7 @@ function emitDeprecationWarning(oldKey: string, newKey: string, ignored: boolean
  * have an engine (rare; usually CLI bootstrap before connect).
  */
 export async function resolveModel(
-  engine: BrainEngine | null,
+  engine: ConfigReader | null,
   opts: ResolveModelOpts,
 ): Promise<string> {
   const envVar = opts.envVar ?? 'GBRAIN_MODEL';
@@ -303,7 +303,7 @@ void enforceSubagentAnthropic;
  * to `super-opus` which aliases to `opus`, we return `super-opus` and stop.
  */
 export async function resolveAlias(
-  engine: BrainEngine | null,
+  engine: ConfigReader | null,
   name: string,
   depth = 0,
 ): Promise<string> {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5908,6 +5908,13 @@ export class PGLiteEngine implements BrainEngine {
     return (rows as { key: string }[]).map(r => r.key);
   }
 
+  async getAllConfig(): Promise<Record<string, string>> {
+    const { rows } = await this.db.query('SELECT key, value FROM config');
+    const out: Record<string, string> = {};
+    for (const row of rows as { key: string; value: string }[]) out[row.key] = row.value;
+    return out;
+  }
+
   // Migration support
   async runMigration(_version: number, sql: string): Promise<void> {
     await this.db.exec(sql);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5871,6 +5871,17 @@ export class PostgresEngine implements BrainEngine {
     });
   }
 
+  async getAllConfig(): Promise<Record<string, string>> {
+    return this.connRetry(async () => {
+      const rows = await this.sql<{ key: string; value: string }[]>`
+        SELECT key, value FROM config
+      `;
+      const out: Record<string, string> = {};
+      for (const row of rows) out[row.key] = row.value;
+      return out;
+    });
+  }
+
   // Migration support
   async runMigration(_version: number, sqlStr: string): Promise<void> {
     const conn = this.sql;

--- a/test/config-db-plane-round-trips.test.ts
+++ b/test/config-db-plane-round-trips.test.ts
@@ -1,0 +1,172 @@
+// Regression: loadConfigWithEngine() read every DB-plane key one at a time.
+//
+// SYMPTOM. On a Supabase-hosted brain, `gbrain stats` took 7.7s wall clock.
+// pg_stat_statements showed 54 queries totalling 2.3ms of server time — 44 of
+// them `SELECT value FROM config WHERE key = $1`. The database did no work;
+// the CLI paid one ~70ms round trip per config key. The same command against a
+// local PGLite brain took 0.26s, which is why the pattern survived so long: on
+// an embedded database each read costs microseconds and is invisible.
+//
+// The config table is a handful of rows, so it is now read once via
+// getAllConfig() and every key is answered from that snapshot. These tests pin
+// the round-trip count, not the wall clock: a timing assertion would be flaky
+// in CI, while a call counter is deterministic.
+//
+// Against the pre-fix code the first two cases report 18+ per-key reads.
+
+import { describe, expect, test } from 'bun:test';
+import { loadConfigWithEngine, type GBrainConfig } from '../src/core/config.ts';
+
+/** Engine double that counts how many times each config read is issued. */
+function makeCountingEngine(values: Record<string, string> = {}) {
+  const stats = { getConfig: 0, getAllConfig: 0, listConfigKeys: 0 };
+
+  return {
+    stats,
+    async getConfig(key: string): Promise<string | null> {
+      stats.getConfig++;
+      return key in values ? values[key] : null;
+    },
+    async getAllConfig(): Promise<Record<string, string>> {
+      stats.getAllConfig++;
+      return { ...values };
+    },
+    async listConfigKeys(prefix: string): Promise<string[]> {
+      stats.listConfigKeys++;
+      return Object.keys(values).filter((k) => k.startsWith(prefix));
+    },
+  };
+}
+
+/** Engine without the bulk read — an older or third-party implementation. */
+function makeLegacyEngine(values: Record<string, string> = {}) {
+  const stats = { getConfig: 0 };
+  return {
+    stats,
+    async getConfig(key: string): Promise<string | null> {
+      stats.getConfig++;
+      return key in values ? values[key] : null;
+    },
+    async listConfigKeys(prefix: string): Promise<string[]> {
+      return Object.keys(values).filter((k) => k.startsWith(prefix));
+    },
+  };
+}
+
+const BASE: GBrainConfig = { engine: 'postgres' } as GBrainConfig;
+
+describe('loadConfigWithEngine DB-plane round trips', () => {
+  test('reads the config table once, not once per key', async () => {
+    const engine = makeCountingEngine();
+
+    await loadConfigWithEngine(engine, BASE);
+
+    expect(engine.stats.getAllConfig).toBe(1);
+    expect(engine.stats.getConfig).toBe(0);
+    expect(engine.stats.listConfigKeys).toBe(0);
+  });
+
+  test('resolves a key prefix map from the same snapshot', async () => {
+    // dbPrefixMap used to list keys, then read one value per matched key, so
+    // its cost scaled with how many keys the prefix matched.
+    const engine = makeCountingEngine({
+      'provider_base_urls.openai': 'https://a.example',
+      'provider_base_urls.anthropic': 'https://b.example',
+      'provider_base_urls.voyage': 'https://c.example',
+    });
+
+    const merged = await loadConfigWithEngine(engine, BASE);
+
+    expect(merged?.provider_base_urls).toEqual({
+      openai: 'https://a.example',
+      anthropic: 'https://b.example',
+      voyage: 'https://c.example',
+    });
+    expect(engine.stats.getAllConfig).toBe(1);
+    expect(engine.stats.getConfig).toBe(0);
+  });
+
+  test('the snapshot does not change which values win', async () => {
+    const engine = makeCountingEngine({
+      embedding_multimodal: 'true',
+      embedding_multimodal_model: 'voyage:voyage-multimodal-3',
+      'content_sanity.bytes_warn': '1024',
+      'dream.synthesize.verdict_model': 'anthropic:claude-haiku-4-5',
+    });
+
+    const merged = await loadConfigWithEngine(engine, BASE);
+
+    expect(merged?.embedding_multimodal).toBe(true);
+    expect(merged?.embedding_multimodal_model).toBe('voyage:voyage-multimodal-3');
+    expect(merged?.content_sanity?.bytes_warn).toBe(1024);
+    expect(merged?.dream?.synthesize?.verdict_model).toBe('anthropic:claude-haiku-4-5');
+  });
+
+  test('file/env config still beats the DB plane', async () => {
+    // Precedence is the reason each key is resolved separately in the first
+    // place; the snapshot must not disturb it.
+    const engine = makeCountingEngine({ embedding_multimodal_model: 'db:model' });
+    const base = { ...BASE, embedding_multimodal_model: 'file:model' } as GBrainConfig;
+
+    const merged = await loadConfigWithEngine(engine, base);
+
+    expect(merged?.embedding_multimodal_model).toBe('file:model');
+  });
+
+  test('an engine without getAllConfig still resolves every key', async () => {
+    // Fallback path: a pre-v43 or third-party engine keeps the per-key reads.
+    const engine = makeLegacyEngine({
+      embedding_multimodal: 'true',
+      'provider_base_urls.openai': 'https://a.example',
+    });
+
+    const merged = await loadConfigWithEngine(engine, BASE);
+
+    expect(merged?.embedding_multimodal).toBe(true);
+    expect(merged?.provider_base_urls).toEqual({ openai: 'https://a.example' });
+    expect(engine.stats.getConfig).toBeGreaterThan(10);
+  });
+
+  test('a failing bulk read degrades to per-key reads', async () => {
+    // A brain mid-migration has no config table. getAllConfig throwing must
+    // not abort the load, and must not skip the DB plane on a brain where the
+    // per-key path would have worked.
+    const stats = { getConfig: 0 };
+    const engine = {
+      async getAllConfig(): Promise<Record<string, string>> {
+        throw new Error('relation "config" does not exist');
+      },
+      async getConfig(key: string): Promise<string | null> {
+        stats.getConfig++;
+        return key === 'embedding_multimodal' ? 'true' : null;
+      },
+      async listConfigKeys(): Promise<string[]> {
+        return [];
+      },
+    };
+
+    const merged = await loadConfigWithEngine(engine, BASE);
+
+    expect(merged?.embedding_multimodal).toBe(true);
+    expect(stats.getConfig).toBeGreaterThan(10);
+  });
+
+  test('a brain with no config table at all still loads', async () => {
+    const engine = {
+      async getAllConfig(): Promise<Record<string, string>> {
+        throw new Error('relation "config" does not exist');
+      },
+      async getConfig(): Promise<string | null> {
+        throw new Error('relation "config" does not exist');
+      },
+      async listConfigKeys(): Promise<string[]> {
+        throw new Error('relation "config" does not exist');
+      },
+    };
+
+    const merged = await loadConfigWithEngine(engine, BASE);
+
+    expect(merged).toBeTruthy();
+    expect(merged?.embedding_multimodal).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The problem

`gbrain stats` against a Supabase-hosted brain took **7.7s**. `pg_stat_statements` for that single run:

- 54 queries
- **2.3ms** of total server time
- 44 of them `SELECT value FROM config WHERE key = $1`

The database does no work. The CLI pays one network round trip per config key, sequentially, before the command starts.

The same command against a local PGLite brain takes 0.26s. That is why this survived: on an embedded database each read costs microseconds and the pattern is invisible. It only appears once the brain is a network hop away.

## Where the reads come from

Two startup paths, both on every command:

| Path | Reads | Cost on a hosted brain |
|---|---|---|
| `loadConfigWithEngine()` | ~24 keys, DB plane merged over file/env | ~1.5s |
| `reconfigureGatewayWithEngine()` | 6 models x a precedence chain of up to 4 keys, plus alias expansion | **3.1s** |

The gateway path was the bigger half and the less obvious one — `resolveModel` looks cheap at the callsite, and it is called six times in a loop.

## The fix

The config table is a handful of rows, so read it once and answer every key from memory.

- `engine.getAllConfig()` — one `SELECT key, value FROM config`, implemented on both engines (parity).
- `src/core/config-snapshot.ts` — wraps it as either a raw map (`loadConfigSnapshot`) or a `ConfigReader` (`snapshotConfigReader`).
- `resolveModel` / `resolveAlias` now take a `ConfigReader` instead of a `BrainEngine`. `getConfig` is the only method they ever called, so this is a widening, not a break.

## What does not change

- Same keys, same precedence (env > file > DB > defaults), same per-key quiet failure.
- The snapshot lives for **one resolution pass**, not for the process. A `gbrain config set` from another process is picked up by the next command, exactly as before.
- When the bulk read is unavailable — a brain mid-migration with no config table, or an engine implemented outside this repo — every read falls back to the old per-key path.

## Result

Measured against a Supabase brain (transaction pooler, us-east), median of 3:

```
gbrain stats   7.7s  ->  1.9s
```

Remaining time is connect (~0.5s), the migration probe (~0.15s), CLI boot (~0.5s), and the actual work.

## Tests

`test/config-db-plane-round-trips.test.ts` pins the **round-trip count**, not the wall clock — a timing assertion would be flaky in CI, while a call counter is deterministic. Seven cases: one bulk read instead of per-key; prefix maps resolved from the same snapshot; precedence unchanged; file/env still beats the DB plane; an engine without `getAllConfig` still resolves every key; a throwing bulk read degrades to per-key; a brain with no config table at all still loads.

- `bun run verify` — 34/34 green
- `bun run typecheck` — clean
- Config, gateway, and model-resolution suites pass

## Note for reviewers

I went at this with `Promise.all` batching first. It did help (7.7s -> 5.5s), but it was the wrong lever: postgres.js opens a connection per concurrent query up to the pool cap, so 18 parallel reads opened 9 physical connections, each paying TLS + auth + a full `pg_type` catalog load. Reading once removes the round trips *and* the connection pressure. Mentioning it in case the batching approach looks tempting later.