### PR TITLE
fix(pages): purge-deleted dry-run shares the delete predicate — the listPages cap under-counts

### DIFF
--- a/src/commands/pages.ts
+++ b/src/commands/pages.ts
@@ -30,19 +30,17 @@ async function runPurgeDeleted(engine: BrainEngine, args: string[]): Promise<voi
   const json = args.includes('--json');
 
   if (dryRun) {
-    // Use listPages with includeDeleted to enumerate the recoverable set, then
-    // count how many would be purged given the cutoff. Stays read-only.
-    const candidates = await engine.listPages({ includeDeleted: true, limit: 10000 });
-    const cutoff = Date.now() - olderThanHours * 60 * 60 * 1000;
-    const wouldPurge = candidates.filter(
-      (p) => p.deleted_at && p.deleted_at instanceof Date && p.deleted_at.getTime() < cutoff,
-    );
+    // Same engine method, same WHERE predicate, same DB now() clock as the
+    // real purge — only the verb differs (SELECT, stays read-only). The old
+    // listPages enumeration capped at 10000 rows (live pages included), so
+    // brains past the cap under-reported the purge set.
+    const preview = await engine.purgeDeletedPages(olderThanHours, { dryRun: true });
     if (json) {
-      console.log(JSON.stringify({ dry_run: true, older_than_hours: olderThanHours, count: wouldPurge.length, slugs: wouldPurge.map((p) => p.slug) }, null, 2));
+      console.log(JSON.stringify({ dry_run: true, older_than_hours: olderThanHours, count: preview.count, slugs: preview.slugs }, null, 2));
       return;
     }
-    console.log(`(dry-run) Would purge ${wouldPurge.length} page(s) soft-deleted more than ${olderThanHours}h ago.`);
-    for (const p of wouldPurge) console.log(`  ${p.slug}  deleted_at=${p.deleted_at?.toISOString()}`);
+    console.log(`(dry-run) Would purge ${preview.count} page(s) soft-deleted more than ${olderThanHours}h ago.`);
+    for (const p of preview.pages ?? []) console.log(`  ${p.slug}  deleted_at=${p.deleted_at.toISOString()}`);
     return;
   }
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -819,8 +819,18 @@ export interface BrainEngine {
    * v0.26.5 — hard-delete pages whose `deleted_at` is older than the cutoff.
    * Called by the autopilot purge phase and by the `gbrain pages purge-deleted`
    * CLI escape hatch. Cascades through existing FKs.
+   *
+   * `opts.dryRun: true` runs a SELECT with the SAME WHERE predicate (same
+   * cutoff arithmetic, same DB `now()` clock source) instead of the DELETE,
+   * so the preview and a subsequent real run agree up to whatever crosses
+   * the cutoff (or is soft-deleted/restored) between the two statements.
+   * Dry-run responses additionally carry `pages` (slug + deleted_at) for
+   * display; the destructive path leaves `pages` undefined.
    */
-  purgeDeletedPages(olderThanHours: number): Promise<{ slugs: string[]; count: number }>;
+  purgeDeletedPages(
+    olderThanHours: number,
+    opts?: { dryRun?: boolean },
+  ): Promise<{ slugs: string[]; count: number; pages?: { slug: string; deleted_at: Date }[] }>;
   /**
    * v0.26.5: by default `listPages` excludes soft-deleted rows. Set
    * `filters.includeDeleted: true` to surface them.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1405,10 +1405,30 @@ export class PGLiteEngine implements BrainEngine {
     return rows.length > 0;
   }
 
-  async purgeDeletedPages(olderThanHours: number): Promise<{ slugs: string[]; count: number }> {
+  async purgeDeletedPages(
+    olderThanHours: number,
+    opts?: { dryRun?: boolean },
+  ): Promise<{ slugs: string[]; count: number; pages?: { slug: string; deleted_at: Date }[] }> {
     // Clamp to non-negative integer; cascade through FKs (content_chunks,
     // page_links, chunk_relations) on DELETE.
     const hours = Math.max(0, Math.floor(olderThanHours));
+    if (opts?.dryRun) {
+      // SAME WHERE predicate as the DELETE below (same cutoff arithmetic,
+      // same DB now() clock source) — only the verb differs, so preview and
+      // purge agree modulo rows crossing the cutoff between statements.
+      const { rows } = await this.db.query(
+        `SELECT slug, deleted_at FROM pages
+         WHERE deleted_at IS NOT NULL
+           AND deleted_at < now() - ($1 || ' hours')::interval
+         ORDER BY deleted_at ASC, slug ASC`,
+        [hours]
+      );
+      const pages = (rows as { slug: string; deleted_at: Date | string }[]).map((r) => ({
+        slug: r.slug,
+        deleted_at: r.deleted_at instanceof Date ? r.deleted_at : new Date(r.deleted_at),
+      }));
+      return { slugs: pages.map((p) => p.slug), count: pages.length, pages };
+    }
     const { rows } = await this.db.query(
       `DELETE FROM pages
        WHERE deleted_at IS NOT NULL

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1266,11 +1266,30 @@ export class PostgresEngine implements BrainEngine {
     return rows.length > 0;
   }
 
-  async purgeDeletedPages(olderThanHours: number): Promise<{ slugs: string[]; count: number }> {
+  async purgeDeletedPages(
+    olderThanHours: number,
+    opts?: { dryRun?: boolean },
+  ): Promise<{ slugs: string[]; count: number; pages?: { slug: string; deleted_at: Date }[] }> {
     const sql = this.sql;
     // Clamp to non-negative integer; runaway purge protection. The DELETE
     // cascades through content_chunks, page_links, chunk_relations via FKs.
     const hours = Math.max(0, Math.floor(olderThanHours));
+    if (opts?.dryRun) {
+      // SAME WHERE predicate as the DELETE below (same cutoff arithmetic,
+      // same DB now() clock source) — only the verb differs, so preview and
+      // purge agree modulo rows crossing the cutoff between statements.
+      const rows = await sql`
+        SELECT slug, deleted_at FROM pages
+        WHERE deleted_at IS NOT NULL
+          AND deleted_at < now() - (${hours} || ' hours')::interval
+        ORDER BY deleted_at ASC, slug ASC
+      `;
+      const pages = rows.map((r) => ({
+        slug: r.slug as string,
+        deleted_at: r.deleted_at instanceof Date ? (r.deleted_at as Date) : new Date(r.deleted_at as string),
+      }));
+      return { slugs: pages.map((p) => p.slug), count: pages.length, pages };
+    }
     const rows = await sql`
       DELETE FROM pages
       WHERE deleted_at IS NOT NULL

--- a/test/e2e/purge-deleted-dryrun-postgres.test.ts
+++ b/test/e2e/purge-deleted-dryrun-postgres.test.ts
@@ -1,0 +1,73 @@
+/**
+ * purgeDeletedPages dry-run parity, LIVE Postgres engine.
+ *
+ * Engine-parity counterpart of the PGLite coverage in
+ * test/pages-soft-delete.test.ts ("purgeDeletedPages dry-run"): the dry-run
+ * SELECT and the destructive DELETE share one WHERE predicate (same cutoff
+ * arithmetic, same DB now() clock source), so absent concurrent writes the
+ * previewed set equals the set a subsequent real run deletes (as here, where
+ * the test is the only writer), and dry-run never mutates rows.
+ *
+ * Uses the canonical e2e harness (setupDB/teardownDB); gated by DATABASE_URL
+ * via hasDatabase() and skips cleanly when unset, per the repo E2E lifecycle.
+ *
+ *   Run: DATABASE_URL=... bun test test/e2e/purge-deleted-dryrun-postgres.test.ts
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import type { PostgresEngine } from '../../src/core/postgres-engine.ts';
+import { hasDatabase, setupDB, teardownDB } from './helpers.ts';
+
+const RUN = hasDatabase();
+const d = RUN ? describe : describe.skip;
+
+let engine: PostgresEngine;
+
+async function insertPage(slug: string, deletedAtSql: string | null): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO pages (source_id, slug, type, title, deleted_at)
+     VALUES ('default', $1, 'note', $1, ${deletedAtSql ?? 'NULL'})`,
+    [slug],
+  );
+}
+
+async function pageCount(): Promise<number> {
+  const rows = await engine.executeRaw<{ n: number }>(`SELECT COUNT(*)::int AS n FROM pages`);
+  return rows[0].n;
+}
+
+d('purgeDeletedPages dry-run parity (live Postgres)', () => {
+  beforeAll(async () => {
+    engine = await setupDB();
+    await insertPage('purge-dryrun/old-a', `now() - INTERVAL '73 hours'`);
+    await insertPage('purge-dryrun/old-b', `now() - INTERVAL '73 hours'`);
+    await insertPage('purge-dryrun/recent', `now()`);
+    await insertPage('purge-dryrun/live', null);
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownDB();
+  });
+
+  test('dry-run mutates nothing, previews exactly the set the real run deletes, and skips live rows', async () => {
+    const before = await pageCount();
+
+    const preview = await engine.purgeDeletedPages(72, { dryRun: true });
+    expect(await pageCount()).toBe(before); // read-only
+    expect([...preview.slugs].sort()).toEqual(['purge-dryrun/old-a', 'purge-dryrun/old-b']);
+    expect(preview.count).toBe(2);
+    // deleted_at is surfaced as a Date for CLI display.
+    for (const p of preview.pages ?? []) expect(p.deleted_at).toBeInstanceOf(Date);
+    expect(preview.pages?.length).toBe(2);
+
+    const purged = await engine.purgeDeletedPages(72);
+    expect([...purged.slugs].sort()).toEqual([...preview.slugs].sort());
+    expect(purged.count).toBe(preview.count);
+
+    // Live + inside-window rows survive the real run.
+    const rows = await engine.executeRaw<{ slug: string }>(
+      `SELECT slug FROM pages WHERE slug LIKE 'purge-dryrun/%'`,
+    );
+    const remaining = rows.map((r) => r.slug).sort();
+    expect(remaining).toEqual(['purge-dryrun/live', 'purge-dryrun/recent']);
+  });
+});

--- a/test/pages-soft-delete.test.ts
+++ b/test/pages-soft-delete.test.ts
@@ -193,6 +193,123 @@ describe('purgeDeletedPages (TTL boundary)', () => {
   });
 });
 
+describe('purgeDeletedPages dry-run (shares the delete predicate)', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = await setupBrain();
+  }, 30000);
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  async function pageCount(): Promise<number> {
+    const rows = await engine.executeRaw<{ n: number }>(`SELECT COUNT(*)::int AS n FROM pages`);
+    return rows[0].n;
+  }
+
+  test('dryRun: true deletes nothing (row count unchanged)', async () => {
+    await seedPage(engine, 'dryrun/keeps-rows');
+    await engine.softDeletePage('dryrun/keeps-rows');
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() - INTERVAL '73 hours' WHERE slug = $1`,
+      ['dryrun/keeps-rows'],
+    );
+    const before = await pageCount();
+    const preview = await engine.purgeDeletedPages(72, { dryRun: true });
+    expect(preview.count).toBeGreaterThanOrEqual(1);
+    expect(preview.slugs).toContain('dryrun/keeps-rows');
+    expect(await pageCount()).toBe(before);
+  });
+
+  test('dryRun set === set actually deleted by the subsequent real run; live pages in neither', async () => {
+    await seedPage(engine, 'dryrun/old-a');
+    await seedPage(engine, 'dryrun/old-b');
+    await seedPage(engine, 'dryrun/recent');
+    await seedPage(engine, 'dryrun/live');
+    await engine.softDeletePage('dryrun/old-a');
+    await engine.softDeletePage('dryrun/old-b');
+    await engine.softDeletePage('dryrun/recent');
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() - INTERVAL '73 hours' WHERE slug IN ($1, $2)`,
+      ['dryrun/old-a', 'dryrun/old-b'],
+    );
+
+    const preview = await engine.purgeDeletedPages(72, { dryRun: true });
+    const purged = await engine.purgeDeletedPages(72);
+
+    expect([...preview.slugs].sort()).toEqual([...purged.slugs].sort());
+    expect(preview.count).toBe(purged.count);
+    // Live and inside-window pages are in neither set.
+    expect(preview.slugs).not.toContain('dryrun/live');
+    expect(preview.slugs).not.toContain('dryrun/recent');
+    expect(purged.slugs).not.toContain('dryrun/live');
+    expect(purged.slugs).not.toContain('dryrun/recent');
+    // The real run actually removed the previewed rows.
+    const rows = await engine.executeRaw<{ slug: string }>(`SELECT slug FROM pages`);
+    const remaining = rows.map((r) => r.slug);
+    expect(remaining).not.toContain('dryrun/old-a');
+    expect(remaining).not.toContain('dryrun/old-b');
+    expect(remaining).toContain('dryrun/live');
+    expect(remaining).toContain('dryrun/recent');
+  });
+
+  test('dry-run pages carry deleted_at as a Date (for CLI display)', async () => {
+    await seedPage(engine, 'dryrun/dated');
+    await engine.softDeletePage('dryrun/dated');
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() - INTERVAL '73 hours' WHERE slug = $1`,
+      ['dryrun/dated'],
+    );
+    const preview = await engine.purgeDeletedPages(72, { dryRun: true });
+    const entry = preview.pages?.find((p) => p.slug === 'dryrun/dated');
+    expect(entry).toBeDefined();
+    expect(entry!.deleted_at).toBeInstanceOf(Date);
+    // Clean up so later tests in this describe see a stable baseline.
+    await engine.purgeDeletedPages(72);
+  });
+
+  test('red contrast: the old listPages enumeration under-counts once live pages consume the cap', async () => {
+    // The pre-fix dry-run enumerated listPages({ includeDeleted: true,
+    // limit: 10000 }) and filtered in JS against Date.now(). Live pages
+    // consume the cap, so a soft-deleted row past the cap is silently
+    // missed. Reproduce the class at small scale: 3 recently-updated live
+    // pages + 1 old soft-deleted page, enumeration capped at 3.
+    for (const slug of ['cap/live-1', 'cap/live-2', 'cap/live-3', 'cap/victim']) {
+      await seedPage(engine, slug);
+    }
+    await engine.softDeletePage('cap/victim');
+    // Old deleted_at (past the 72h cutoff) AND old updated_at so the victim
+    // sorts LAST under listPages' default updated_desc — exactly the row
+    // shape that fell off the capped enumeration.
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() - INTERVAL '73 hours', updated_at = now() - INTERVAL '100 hours' WHERE slug = $1`,
+      ['cap/victim'],
+    );
+
+    // Old predicate, verbatim (src/commands/pages.ts pre-fix), cap = 3.
+    const candidates = await engine.listPages({ includeDeleted: true, limit: 3 });
+    const cutoff = Date.now() - 72 * 60 * 60 * 1000;
+    const oldStyle = candidates.filter(
+      (p) => p.deleted_at && p.deleted_at instanceof Date && p.deleted_at.getTime() < cutoff,
+    );
+    expect(oldStyle.map((p) => p.slug)).not.toContain('cap/victim'); // the bug
+
+    // The predicate-sharing dry-run finds it, and the real run deletes it.
+    const preview = await engine.purgeDeletedPages(72, { dryRun: true });
+    expect(preview.slugs).toContain('cap/victim');
+    const purged = await engine.purgeDeletedPages(72);
+    expect(purged.slugs).toContain('cap/victim');
+  });
+
+  test('dry-run clamps negative hours (no crash, finite count)', async () => {
+    const preview = await engine.purgeDeletedPages(-72, { dryRun: true });
+    expect(Number.isFinite(preview.count)).toBe(true);
+    expect(preview.count).toBeGreaterThanOrEqual(0);
+  });
+});
+
 describe('getPage / listPages includeDeleted contract (Q3 IRON RULE)', () => {
   let engine: PGLiteEngine;
 


### PR DESCRIPTION
## Problem

`gbrain pages purge-deleted --dry-run` and the real purge use two different predicates, so the dry-run count is not a guarantee of what the destructive run will do.

- **Dry-run** (`src/commands/pages.ts`, pre-fix): enumerates `engine.listPages({ includeDeleted: true, limit: 10000 })` and filters in JS against `Date.now()`:

  ```ts
  const candidates = await engine.listPages({ includeDeleted: true, limit: 10000 });
  const cutoff = Date.now() - olderThanHours * 60 * 60 * 1000;
  const wouldPurge = candidates.filter(
    (p) => p.deleted_at && p.deleted_at instanceof Date && p.deleted_at.getTime() < cutoff,
  );
  ```

- **Real run** (`purgeDeletedPages` in both engines): an unbounded DELETE on the DB clock:

  ```sql
  DELETE FROM pages
  WHERE deleted_at IS NOT NULL
    AND deleted_at < now() - ($1 || ' hours')::interval
  RETURNING slug
  ```

The 10000-row cap is consumed by **live** pages too (`includeDeleted: true` returns everything, default sort `updated_desc`). On a brain past 10000 pages, any soft-deleted row that sorts beyond the first 10000 `updated_desc` results falls off the enumeration, and the dry-run under-reports — in the extreme, dry-run says 0 while the real run deletes N. The two paths also read different clocks (JS `Date.now()` vs DB `now()`).

Same broader dry-run honesty/safety class as previously merged fixes: #3594 ("Dry-run is unsafe in at least 3 commands"), #3955 (dry-run progress told the wrong scale), #3956 (dry-run flag unwired, actually mutated), #1575 (destructive default contradicting its doc).

## Fix

Route the dry-run through the engine method: `purgeDeletedPages(olderThanHours, { dryRun: true })` runs a SELECT with the **identical WHERE clause** (same cutoff arithmetic, same DB `now()` clock source) in both engines. The predicate text is kept adjacent to the DELETE in each engine rather than extracted to a helper, and the new parity tests pin that the two branches select the same rows. It returns `{ slugs, count, pages }`, where the optional `pages` field carries `slug + deleted_at` so the CLI keeps its `deleted_at=` display line. The destructive path is byte-for-byte unchanged; existing callers (`cycle.ts`, `jobs.ts`, `operations.ts`) are unaffected (optional second parameter, optional response field).

The CLI dry-run branch in `src/commands/pages.ts` now calls this instead of the capped enumeration.

## Tests

`test/pages-soft-delete.test.ts` (PGLite, always runs) — new describe:
- dry-run mutates nothing (row count unchanged before/after)
- dry-run slug set == the set a subsequent real run actually deletes; live and inside-window pages in neither
- dry-run `pages` carry `deleted_at` as a `Date` (CLI display contract)
- **red contrast**: reproduces the pre-fix predicate verbatim at small scale (3 recently-updated live pages + 1 old soft-deleted page, enumeration capped at 3) — the old filter misses the victim; the predicate-sharing dry-run and the real DELETE both catch it
- dry-run clamps negative hours (no crash, finite count)

`test/e2e/purge-deleted-dryrun-postgres.test.ts` (new, DATABASE_URL-gated) — same parity assertions on the live Postgres engine, per the engine-parity invariant.

Red-green verified: with `src/` reverted to master and the new tests kept, 4/5 fail (the reverted dry-run actually deletes rows); with the fix, 20/20 pass. `bun run typecheck` clean.

## Scope / open question

This PR aligns the dry-run with the destructive run and deliberately adds no new feature surface; the dry-run's own behavior does change (uncapped enumeration, DB clock, previously missed candidates now listed) — that change is the fix. One thing I noticed but left out: `purge-deleted` has no way to scope by source (the DELETE spans all sources). Whether that should exist feels like a product call, so I'm flagging it here rather than implementing it.
