### PR TITLE
feat(ai): add Novita AI embedding recipe (bge-m3)

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -1,6 +1,6 @@
 # Embedding providers
 
-GBrain ships with 16 embedding-provider recipes covering OpenAI, ZeroEntropy, Voyage, OpenRouter (single key, many hosted models), the major hosted alternatives, three local options, and a universal escape hatch (LiteLLM proxy). Run `gbrain providers list` to see the live registry; `gbrain providers explain --json` emits a machine-readable matrix for agents.
+GBrain ships with 17 embedding-provider recipes covering OpenAI, ZeroEntropy, Voyage, OpenRouter (single key, many hosted models), the major hosted alternatives, three local options, and a universal escape hatch (LiteLLM proxy). Run `gbrain providers list` to see the live registry; `gbrain providers explain --json` emits a machine-readable matrix for agents.
 
 This page is the human-readable counterpart: capability per provider, env-var setup, dimensions, cost, and known constraints.
 
@@ -36,6 +36,7 @@ The resolved provider + dimensions get persisted to `~/.gbrain/config.json` atom
 | `llama-server` | (none — runs locally) | user-set | 0 | yes | no |
 | `litellm` | `LITELLM_API_KEY` (optional) | user-set | varies | yes (proxy) | yes (backend permitting) |
 | `together` | `TOGETHER_API_KEY` | 768 | varies | no | no |
+| `novita` | `NOVITA_API_KEY` | 1024 (fixed, `baai/bge-m3`) | 0.01 | no | no |
 | `anthropic` | (no embedding model — chat only) | — | — | — | — |
 | `deepseek` | (no embedding model — chat only) | — | — | — | — |
 | `groq` | (no embedding model — chat only) | — | — | — | — |

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -29,6 +29,7 @@ import { moonshot } from './moonshot.ts';
 import { mistral } from './mistral.ts';
 import { nvidia } from './nvidia.ts';
 import { perplexity } from './perplexity.ts';
+import { novita } from './novita.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -54,6 +55,7 @@ const ALL: Recipe[] = [
   mistral,
   nvidia,
   perplexity,
+  novita,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/novita.ts
+++ b/src/core/ai/recipes/novita.ts
@@ -1,0 +1,41 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Novita AI's OpenAI-compatible /openai/v1/embeddings endpoint.
+ *
+ * Reference: https://novita.ai/docs/api-reference/model-apis-llm-create-embeddings
+ *
+ * The `model` field is documented as an exhaustive enum with a single value
+ * (`baai/bge-m3`) — no other embedding model is exposed on this endpoint as
+ * of 2026-07-28, even though Novita's model console separately lists
+ * qwen3-embedding-{0.6b,8b} under chat-completions pricing. Only the
+ * documented embeddings-endpoint model is declared here.
+ *
+ * BGE-M3 (BAAI) is a fixed 1024-dim, 8192-token-context multilingual model
+ * (https://huggingface.co/BAAI/bge-m3) — no Matryoshka truncation, so no
+ * `dims_options`/dimensions passthrough is wired for it.
+ */
+export const novita: Recipe = {
+  id: 'novita',
+  name: 'Novita AI',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://api.novita.ai/openai/v1',
+  auth_env: {
+    required: ['NOVITA_API_KEY'],
+    setup_url: 'https://novita.ai/settings/key-management',
+  },
+  touchpoints: {
+    embedding: {
+      models: ['baai/bge-m3'],
+      default_dims: 1024,
+      cost_per_1m_tokens_usd: 0.01,
+      price_last_verified: '2026-08-03',
+      // Docs cap array inputs at 2048 items; no published token-budget cap
+      // beyond the model's own 8192-token context. Conservative batch cap
+      // so the gateway pre-splits before hitting the item ceiling.
+      max_batch_items: 2048,
+    },
+  },
+  setup_hint: 'Get an API key at https://novita.ai/settings/key-management, then `export NOVITA_API_KEY=...`',
+};

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -58,6 +58,8 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   // Perplexity (https://docs.perplexity.ai/getting-started/pricing, verified 2026-07-28)
   'perplexity:pplx-embed-v1-0.6b': { pricePerMTok: 0.004 },
   'perplexity:pplx-embed-v1-4b':   { pricePerMTok: 0.03 },
+  // Novita AI (https://novita.ai/models-console/model-detail/baai-bge-m3, verified 2026-08-03)
+  'novita:baai/bge-m3':            { pricePerMTok: 0.01 },
 };
 
 export type PriceLookupResult =

--- a/test/ai/recipe-novita.test.ts
+++ b/test/ai/recipe-novita.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Novita AI recipe smoke.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+import { lookupEmbeddingPrice } from '../../src/core/embedding-pricing.ts';
+
+describe('recipe: novita', () => {
+  test('registered with expected OpenAI-compatible shape', () => {
+    const r = getRecipe('novita');
+    expect(r).toBeDefined();
+    expect(r!.id).toBe('novita');
+    expect(r!.tier).toBe('openai-compat');
+    expect(r!.implementation).toBe('openai-compatible');
+    expect(r!.base_url_default).toBe('https://api.novita.ai/openai/v1');
+    expect(r!.auth_env?.required).toEqual(['NOVITA_API_KEY']);
+  });
+
+  test('embedding touchpoint declares the documented bge-m3 model + fixed dims', () => {
+    const e = getRecipe('novita')!.touchpoints.embedding;
+    expect(e).toBeDefined();
+    expect(e!.models).toEqual(['baai/bge-m3']);
+    expect(e!.default_dims).toBe(1024);
+    // BGE-M3 is fixed-dim (no Matryoshka truncation); no dims_options declared.
+    expect(e!.dims_options).toBeUndefined();
+  });
+
+  test('embedding model resolves to a known price', () => {
+    expect(lookupEmbeddingPrice('novita:baai/bge-m3').kind).toBe('known');
+  });
+
+  test('default auth: NOVITA_API_KEY set -> Bearer token', () => {
+    const r = getRecipe('novita')!;
+    const auth = defaultResolveAuth(r, { NOVITA_API_KEY: 'fake-novita-key' }, 'embedding');
+    expect(auth.headerName).toBe('Authorization');
+    expect(auth.token).toBe('Bearer fake-novita-key');
+  });
+
+  test('default auth: missing NOVITA_API_KEY -> AIConfigError', () => {
+    const r = getRecipe('novita')!;
+    expect(() => defaultResolveAuth(r, {}, 'embedding')).toThrow(AIConfigError);
+  });
+});


### PR DESCRIPTION

## Summary

Adds Novita AI as a 17th embedding-provider recipe, following the existing `openai-compatible` recipe pattern (mirrors `voyage.ts`).

## Changes

- `src/core/ai/recipes/novita.ts`: new recipe for Novita's OpenAI-compatible `/openai/v1/embeddings` endpoint. Registers the single documented model (`baai/bge-m3`, fixed 1024 dims, no Matryoshka truncation) with a batch cap and setup hint.
- `src/core/ai/recipes/index.ts`: register the recipe.
- `src/core/embedding-pricing.ts`: add `novita:baai/bge-m3` pricing ($0.01/1M tokens, per Novita's pricing console, verified 2026-08-03).
- `docs/integrations/embedding-providers.md`: add Novita to the provider matrix, bump the recipe count 16 → 17.
- `test/ai/recipe-novita.test.ts`: smoke test mirroring the existing mistral/nvidia recipe tests.

## Verification

- `bun install` — 283 packages.
- `bun test test/ai/recipe-novita.test.ts` — 5 pass / 0 fail.
- `bun test test/ai/` — 492 pass / 1 fail (the pre-existing `header-transport.serial.test.ts:219` flaky, unrelated to this change).
- `GET https://api.novita.ai/openai/v1/models` — HTTP 200.
- `POST https://api.novita.ai/openai/v1/embeddings` against the recipe's configured base URL/model — HTTP 200, `baai/bge-m3`, 1024-dim embedding returned with usage.
