### PR TITLE
fix(enrich): keep entity-name candidates on a single line

### DIFF
--- a/src/core/enrichment-service.ts
+++ b/src/core/enrichment-service.ts
@@ -286,11 +286,12 @@ export function extractEntities(text: string): Array<{ name: string; type: 'pers
   // Match capitalized multi-word names (likely people or companies)
   // Pattern: 2-4 capitalized words in sequence, scoped to a single line so a
   // paragraph break (or any line break) can't splice unrelated capitalized
-  // words from adjacent sentences into one bogus candidate. `[^\S\r\n\u2028\u2029]+`
-  // matches same-line whitespace (spaces, tabs, NBSP, other Unicode space
-  // separators) but excludes `\n`/`\r` and the Unicode line/paragraph
-  // separators (U+2028/U+2029), unlike a plain `[ \t]+`.
-  const namePattern = /\b([A-Z][a-z]+(?:[^\S\r\n\u2028\u2029]+[A-Z][a-z]+){1,3})\b/g;
+  // words from adjacent sentences into one bogus candidate. The pattern
+  // excludes all vertical whitespace -- CR, LF, VT (U+000B), FF (U+000C),
+  // and the Unicode line/paragraph separators (U+2028/U+2029) -- while
+  // retaining horizontal whitespace (spaces, tabs, NBSP, other Unicode
+  // space separators), unlike a plain `[ \t]+`.
+  const namePattern = /\b([A-Z][a-z]+(?:[^\S\r\n\v\f\u2028\u2029]+[A-Z][a-z]+){1,3})\b/g;
   let match;
   while ((match = namePattern.exec(text)) !== null) {
     const name = match[1];

--- a/src/core/enrichment-service.ts
+++ b/src/core/enrichment-service.ts
@@ -284,8 +284,13 @@ export function extractEntities(text: string): Array<{ name: string; type: 'pers
   const seen = new Set<string>();
 
   // Match capitalized multi-word names (likely people or companies)
-  // Pattern: 2-4 capitalized words in sequence
-  const namePattern = /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b/g;
+  // Pattern: 2-4 capitalized words in sequence, scoped to a single line so a
+  // paragraph break (or any line break) can't splice unrelated capitalized
+  // words from adjacent sentences into one bogus candidate. `[^\S\r\n\u2028\u2029]+`
+  // matches same-line whitespace (spaces, tabs, NBSP, other Unicode space
+  // separators) but excludes `\n`/`\r` and the Unicode line/paragraph
+  // separators (U+2028/U+2029), unlike a plain `[ \t]+`.
+  const namePattern = /\b([A-Z][a-z]+(?:[^\S\r\n\u2028\u2029]+[A-Z][a-z]+){1,3})\b/g;
   let match;
   while ((match = namePattern.exec(text)) !== null) {
     const name = match[1];

--- a/test/enrichment-service.test.ts
+++ b/test/enrichment-service.test.ts
@@ -109,6 +109,16 @@ describe('enrichment-service', () => {
       const entities = extractEntities('Winters\u2029Reyes discussed the proof.');
       expect(entities.some(e => e.name.includes('\u2029'))).toBe(false);
     });
+
+    test('does not merge capitalized words across a vertical tab (U+000B)', () => {
+      const entities = extractEntities('Winters\vReyes discussed the proof.');
+      expect(entities.some(e => e.name.includes('\v'))).toBe(false);
+    });
+
+    test('does not merge capitalized words across a form feed (U+000C)', () => {
+      const entities = extractEntities('Winters\fReyes discussed the proof.');
+      expect(entities.some(e => e.name.includes('\f'))).toBe(false);
+    });
   });
 
   describe('enrichEntity (mock)', () => {

--- a/test/enrichment-service.test.ts
+++ b/test/enrichment-service.test.ts
@@ -78,6 +78,37 @@ describe('enrichment-service', () => {
       const entities = extractEntities('Mary Jane Watson Parker joined the team.');
       expect(entities.some(e => e.name.split(' ').length >= 3)).toBe(true);
     });
+
+    test('does not merge capitalized words across a paragraph break', () => {
+      const entities = extractEntities('We spoke with Winters\n\nReyes continued the analysis.');
+      expect(entities.some(e => e.name.includes('\n'))).toBe(false);
+      expect(entities.some(e => e.name.replace(/\s+/g, ' ') === 'Winters Reyes')).toBe(false);
+    });
+
+    test('does not merge capitalized words across a single line break', () => {
+      const entities = extractEntities('Winters\nReyes discussed the proof.');
+      expect(entities.some(e => e.name.includes('\n'))).toBe(false);
+    });
+
+    test('still matches same-line multi-word capitalized names', () => {
+      const entities = extractEntities('Casey Morgan visited the lab.');
+      expect(entities.some(e => e.name === 'Casey Morgan')).toBe(true);
+    });
+
+    test('still matches names separated by a non-breaking space on the same line', () => {
+      const entities = extractEntities('Jordan Blake requested access.');
+      expect(entities.some(e => e.name === 'Jordan Blake')).toBe(true);
+    });
+
+    test('does not merge capitalized words across a Unicode line separator (U+2028)', () => {
+      const entities = extractEntities('Winters\u2028Reyes discussed the proof.');
+      expect(entities.some(e => e.name.includes('\u2028'))).toBe(false);
+    });
+
+    test('does not merge capitalized words across a Unicode paragraph separator (U+2029)', () => {
+      const entities = extractEntities('Winters\u2029Reyes discussed the proof.');
+      expect(entities.some(e => e.name.includes('\u2029'))).toBe(false);
+    });
   });
 
   describe('enrichEntity (mock)', () => {


### PR DESCRIPTION
## Symptom

`extractEntities()` in `src/core/enrichment-service.ts` uses a regex to pull
capitalized multi-word name candidates (people/companies) out of free text:

```ts
// src/core/enrichment-service.ts:288
const namePattern = /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b/g;
```

`\s+` matches any whitespace, including newlines. When a capitalized word
ends one paragraph and another capitalized word starts the next, the regex
happily splices them together into a single bogus entity candidate whose
name contains the paragraph break, e.g.:

```
"...discussed the outcome with Winters\n\nReyes continued the analysis..."
```

produces one candidate named `"Winters\n\nReyes"` instead of correctly
treating `Winters` and `Reyes` as unrelated single words (which don't
qualify as multi-word name candidates on their own).

This surfaced during single-user dogfooding on a ~100-page install
(v0.44.0.0): `extractEntities` produced roughly 1,620 raw candidates, and
these paragraph-spanning splices were the largest single source of noise
in that set -- two capitalized words from adjacent, unrelated sentences
merged into one fake "name."

## Fix

The pattern now excludes all vertical whitespace -- CR, LF, VT (U+000B),
FF (U+000C), and the Unicode line/paragraph separators (U+2028, U+2029) --
while retaining horizontal whitespace, including NBSP (U+00A0) and other
Unicode space separators (common in HTML-derived text), between
same-line words:

```ts
const namePattern = /\b([A-Z][a-z]+(?:[^\S\r\n\v\f\u2028\u2029]+[A-Z][a-z]+){1,3})\b/g;
```

A capitalized word can now only combine with another capitalized word
that's on the *same line*: any vertical-whitespace code point between
them stops the match, same as it already does for punctuation. This is a
deliberate behavior change: a two-word name that happens to be
hard-wrapped across a single line break will also no longer match. Given
the false-positive volume from paragraph splicing, trading that narrow
edge case for eliminating cross-paragraph noise is the right call.

This went through two review passes after the initial `\s+` -> horizontal-
only fix: the first landed `[^\S\r\n]+` but missed the Unicode line/
paragraph separators (U+2028/U+2029), which `\s` treats as whitespace but
`\r`/`\n` alone don't cover; the second added those two code points but
still missed VT (U+000B) and FF (U+000C), which are also `\s`-matching
vertical whitespace outside `\r`/`\n`. The final pattern above excludes
the full vertical-whitespace set.

Out of scope: `enrichEntity`'s direct `putPage` call (candidates aren't
chunked) is a separate, pre-existing issue and isn't touched here.

## Testing

Added to `test/enrichment-service.test.ts` (`extractEntities` describe
block), using generic placeholder names per this repo's privacy
convention:

- Regression: text with a capitalized word at the end of one paragraph and
  another at the start of the next no longer merges into one candidate
  (and no candidate name contains a literal newline).
- Same, for a single line break (not just a blank-line paragraph break).
- Same, for the Unicode line separator (U+2028) and paragraph separator
  (U+2029) individually.
- Same, for vertical tab (U+000B) and form feed (U+000C) individually.
- Control: a same-line multi-word name still matches, confirming the fix
  doesn't regress the common case.
- Control: a same-line name separated by a non-breaking space (U+00A0)
  still matches, confirming the fix only excludes vertical whitespace and
  not horizontal Unicode whitespace generally.

`bun test test/enrichment-service.test.ts` -- 26 pass / 0 fail. `bun run
typecheck` clean.
