### PR TITLE
fix(engine): NUL-sanitize pages body columns + chunk_text (both engines)

### DIFF
--- a/src/core/batch-rows.ts
+++ b/src/core/batch-rows.ts
@@ -87,6 +87,18 @@ export const stripNul = (s: string): string => (s.includes('\0') ? s.replace(/\0
  */
 export const sanitizeForJsonb = (s: string): string => ensureWellFormed(stripNul(s));
 
+/**
+ * Null-safe free-prose sanitizer for plain TEXT / TEXT[] columns (title,
+ * compiled_truth, timeline, chunk_text). Same NUL + lone-surrogate cleanup as
+ * `sanitizeForJsonb` — a raw 0x00 in a page body otherwise aborts the INSERT
+ * with `invalid byte sequence for encoding "UTF8": 0x00` (Postgres text cannot
+ * store NUL), and a lone surrogate is likewise rejected. Passes null/undefined
+ * through unchanged so nullable columns keep their semantics. Same policy as
+ * sanitizeForJsonb: free-prose body only, NEVER identity/security fields.
+ */
+export const sanitizeText = <T extends string | null | undefined>(s: T): T =>
+  (typeof s === 'string' ? (sanitizeForJsonb(s) as T) : s);
+
 /** One links row, keys === the jsonb_to_recordset column list. */
 export interface LinkRow {
   from_slug: string;

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -49,7 +49,7 @@ import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowTo
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
-import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
+import { sanitizeForJsonb, sanitizeText, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
 import { finalizeLastSeen } from './chronicle/last-seen.ts';
 import { computeAnomaliesFromBuckets } from './cycle/anomaly.ts';
@@ -1039,7 +1039,7 @@ export class PGLiteEngine implements BrainEngine {
          ingested_via          = COALESCE(EXCLUDED.ingested_via,          pages.ingested_via),
          ingested_at           = COALESCE(EXCLUDED.ingested_at,           pages.ingested_at)
        RETURNING id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, effective_date, effective_date_source, import_filename, source_kind, source_uri, ingested_via, ingested_at`,
-      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash, effectiveDate, effectiveDateSource, importFilename, chunkerVersion, sourcePath, sourceKind, sourceUri, ingestedVia, ingestedAt]
+      [sourceId, slug, page.type, pageKind, sanitizeText(page.title), sanitizeText(page.compiled_truth), sanitizeText(page.timeline || ''), JSON.stringify(frontmatter), hash, effectiveDate, effectiveDateSource, importFilename, chunkerVersion, sourcePath, sourceKind, sourceUri, ingestedVia, ingestedAt]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }
@@ -2152,7 +2152,7 @@ export class PGLiteEngine implements BrainEngine {
       if (embeddingStr) params.push(embeddingStr);
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
-        pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
+        pageId, chunk.chunk_index, sanitizeText(chunk.chunk_text), chunk.chunk_source,
         chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -22,7 +22,7 @@ import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
-import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
+import { sanitizeForJsonb, sanitizeText, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
@@ -1006,7 +1006,7 @@ export class PostgresEngine implements BrainEngine {
     const ingestedAt = (sourceKind || sourceUri || ingestedVia) ? new Date() : null;
     const rows = await sql`
       INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at, effective_date, effective_date_source, import_filename, chunker_version, source_path, source_kind, source_uri, ingested_via, ingested_at)
-      VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now(), ${effectiveDate}, ${effectiveDateSource}, ${importFilename}, COALESCE(${chunkerVersion}::smallint, 1), ${sourcePath}, ${sourceKind}, ${sourceUri}, ${ingestedVia}, ${ingestedAt})
+      VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${sanitizeText(page.title)}, ${sanitizeText(page.compiled_truth)}, ${sanitizeText(page.timeline || '')}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now(), ${effectiveDate}, ${effectiveDateSource}, ${importFilename}, COALESCE(${chunkerVersion}::smallint, 1), ${sourcePath}, ${sourceKind}, ${sourceUri}, ${ingestedVia}, ${ingestedAt})
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,
@@ -2173,7 +2173,7 @@ export class PostgresEngine implements BrainEngine {
       if (embeddingStr) params.push(embeddingStr);
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
-        pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
+        pageId, chunk.chunk_index, sanitizeText(chunk.chunk_text), chunk.chunk_source,
         chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,


### PR DESCRIPTION
## Problem

`putPage` binds `title` / `compiled_truth` / `timeline` raw, and `upsertChunks` binds `chunk_text` raw, in **both** `postgres-engine.ts` and `pglite-engine.ts`. A raw NUL byte (`0x00`) anywhere in a page body aborts the INSERT with:

```
ERROR: invalid byte sequence for encoding "UTF8": 0x00
```

Postgres `text` (and PGLite, which is Postgres under the hood) cannot store `0x00`, so a single bad byte silently drops the **entire** document — the page never persists. This is common in large ingests of real-world content (transcripts, scraped pages, exported chat logs); in one deployment it dropped ~240 documents before the cause was traced.

## Root cause

#2011 added NUL + lone-surrogate sanitization (`sanitizeForJsonb`) for the free-text of **links, timeline entries, and takes** — but the same treatment was never applied to the `pages` table's own body columns (`title`, `compiled_truth`, `timeline`) or to `content_chunks.chunk_text`. Those four fields still reach the driver raw, so the NUL/lone-surrogate class that #2011 fixed everywhere else still aborts a page write.

## Fix

Adds a small null-safe helper beside the existing sanitizers in `batch-rows.ts`:

```ts
export const sanitizeText = <T extends string | null | undefined>(s: T): T =>
  (typeof s === 'string' ? (sanitizeForJsonb(s) as T) : s);
```

and wraps the four body fields with it in both engines. Same free-prose-body policy as `sanitizeForJsonb` (strip NUL + well-form lone surrogates; never applied to identity/security fields). `null` / `undefined` pass through unchanged so nullable columns keep their semantics.

## Verification

- Current build **rejects** a document containing a `0x00` with the exact error above.
- Patched build **ingests** it (NUL stripped) and it persists — confirmed via `get_page` and a direct DB row check, on real Postgres.
- `tsc --noEmit` clean. 18 insertions across 3 files; no behavior change for content that was already valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
