### PR TITLE
v0.44.0.0 fix(takes): emit JSON for page extraction (#3962)

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -619,12 +619,13 @@ async function cmdExtract(engine: BrainEngine, rest: string[]): Promise<void> {
   const sub = rest[0];
   if (sub !== '--from-pages') {
     process.stderr.write(
-      'Usage: gbrain takes extract --from-pages [--yes] [--dry-run] [--source-id <id>] [--max-pages N (clamped to 1000)] [--include-covered] [--holder <name>]\n' +
+      'Usage: gbrain takes extract --from-pages [--yes] [--dry-run] [--json] [--source-id <id>] [--max-pages N (clamped to 1000)] [--include-covered] [--holder <name>]\n' +
       'Runs progress: pages that already hold takes are skipped, so repeat runs sweep a large corpus in slices. --include-covered rescans everything (refresh).\n',
     );
     process.exit(1);
   }
   const dryRun = rest.includes('--dry-run');
+  const json = rest.includes('--json');
   const skipConfirm = rest.includes('--yes');
   const sourceIdx = rest.indexOf('--source-id');
   const sourceIdFilter = sourceIdx >= 0 ? rest[sourceIdx + 1] : undefined;
@@ -662,8 +663,16 @@ async function cmdExtract(engine: BrainEngine, rest: string[]): Promise<void> {
     holder,
   });
   if (result.llm_unavailable) {
-    process.stderr.write(`[takes extract] chat gateway unavailable (no API key configured).\n`);
+    if (json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      process.stderr.write(`[takes extract] chat gateway unavailable (no API key configured).\n`);
+    }
     process.exit(2);
+  }
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
   }
   process.stdout.write(
     `takes extract --from-pages: ${result.claims_extracted} claim(s) from ${result.pages_scanned} page(s)` +

--- a/test/takes-extract-json.test.ts
+++ b/test/takes-extract-json.test.ts
@@ -1,0 +1,56 @@
+/**
+ * #3962 — `takes extract --from-pages --json` must emit the structured
+ * extraction result instead of the human summary line.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { runTakes } from '../src/commands/takes.ts';
+import {
+  configureGateway,
+  resetGateway,
+} from '../src/core/ai/gateway.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+const engine = {
+  getConfig: async (key: string) => key === 'takes.bootstrap_enabled' ? 'true' : null,
+  executeRaw: async () => [],
+} as unknown as BrainEngine;
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return chunks.join('');
+}
+
+beforeAll(() => {
+  configureGateway({
+    chat_model: 'openai:gpt-test',
+    env: { OPENAI_API_KEY: 'sk-test-takes-json' },
+  });
+});
+
+afterAll(() => {
+  resetGateway();
+});
+
+describe('gbrain takes extract --from-pages --json (#3962)', () => {
+  test('emits the extraction result as parseable JSON', async () => {
+    const stdout = await captureStdout(() =>
+      runTakes(engine, ['extract', '--from-pages', '--dry-run', '--json']));
+
+    expect(JSON.parse(stdout)).toEqual({
+      pages_scanned: 0,
+      claims_extracted: 0,
+      consent_gate_blocked: false,
+      llm_unavailable: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3962.

`gbrain takes extract --from-pages --json` now writes the complete
`ExtractTakesFromPagesResult` as JSON instead of printing the human summary.
The same structured result is emitted before exit code 2 when the chat gateway
is unavailable.

## Root cause

The command registry accepted `--json`, but `cmdExtract` never inspected it.
After extraction it always wrote:

```text
takes extract --from-pages: <n> claim(s) from <n> page(s)
```

That made successful output impossible for scripts to parse.

## Changes

- Render the existing extraction result object for `--json` callers.
- Preserve the current human summary and stderr error for non-JSON callers.
- Document `--json` in the subcommand usage line.
- Add a behavior-level regression test through the real `runTakes` dispatcher.

## Verification

Red control on the pre-fix implementation:

```text
bun test test/takes-extract-json.test.ts
0 pass, 1 fail
SyntaxError: JSON Parse error: Unexpected identifier "takes"
```

Post-fix:

```text
bun test test/takes-extract-json.test.ts \
  test/extract-takes-from-pages-progression.test.ts \
  test/takes-list-subcommand.test.ts \
  test/extract-takes-model-resolution.test.ts
10 pass, 0 fail

bun run verify
34 checks passed, 0 failed
```

The full unit run completed with 15,656 passing, 20 skipped, and 3 failures:

- `page-search-vector-overflow.test.ts` timed out under the full run and passed
  when rerun alone.
- `retrieval-reflex.test.ts` and `worker-registry.serial.test.ts` also fail when
  rerun alone. This branch has no diff from `origin/master` in either test or
  their related modules.

`bun run ci:local:diff` was not available because Docker is not installed in
the local environment.

## Scope

No extraction, consent, persistence, or model-selection semantics changed.
Only output formatting for the already accepted `--json` flag is affected.
