### PR TITLE
fix(doctor): honor the recorded pid_file in supervisor_singleton check

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5435,10 +5435,9 @@ export async function buildChecks(
       const effectiveMaxRss = typeof lastStarted.max_rss_mb === 'number' ? lastStarted.max_rss_mb : null;
       // The 'started' event already records the pid-file path actually in use
       // (this.opts.pidFile, which reflects a custom --pid-file). Prefer that
-      // over the HOME-derived DEFAULT_PID_FILE so a launchd/custom --pid-file
+      // over re-deriving DEFAULT_PID_FILE locally so a custom --pid-file
       // deployment doesn't false-positive a singleton mismatch against itself.
-      // Falls back to DEFAULT_PID_FILE when the event predates this field or
-      // wasn't recorded.
+      // Falls back to DEFAULT_PID_FILE when the event carries no usable value.
       const pidFilePath = typeof lastStarted.pid_file === 'string' && lastStarted.pid_file.length > 0
         ? lastStarted.pid_file
         : DEFAULT_PID_FILE;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5433,7 +5433,16 @@ export async function buildChecks(
     if (lastStarted && engine) {
       const queue = typeof lastStarted.queue === 'string' ? lastStarted.queue : 'default';
       const effectiveMaxRss = typeof lastStarted.max_rss_mb === 'number' ? lastStarted.max_rss_mb : null;
-      const localPid = readSupervisorPid(DEFAULT_PID_FILE).pid;
+      // The 'started' event already records the pid-file path actually in use
+      // (this.opts.pidFile, which reflects a custom --pid-file). Prefer that
+      // over the HOME-derived DEFAULT_PID_FILE so a launchd/custom --pid-file
+      // deployment doesn't false-positive a singleton mismatch against itself.
+      // Falls back to DEFAULT_PID_FILE when the event predates this field or
+      // wasn't recorded.
+      const pidFilePath = typeof lastStarted.pid_file === 'string' && lastStarted.pid_file.length > 0
+        ? lastStarted.pid_file
+        : DEFAULT_PID_FILE;
+      const localPid = readSupervisorPid(pidFilePath).pid;
       const localHost = hostname();
 
       // Read the DB singleton lock holder for this queue.

--- a/src/core/minions/supervisor.ts
+++ b/src/core/minions/supervisor.ts
@@ -42,7 +42,7 @@ import {
   unlinkSync,
   writeSync,
 } from 'fs';
-import { dirname } from 'path';
+import { dirname, resolve } from 'path';
 import type { BrainEngine } from '../engine.ts';
 import { tryAcquireDbLock, type DbLockHandle } from '../db-lock.ts';
 import { currentBrainId } from './worker-registry.ts';
@@ -574,7 +574,13 @@ export class MinionSupervisor {
     // 5. Announce start.
     this.emit('started', {
       supervisor_pid: process.pid,
-      pid_file: this.opts.pidFile,
+      // Resolved to absolute at emit time (relative to THIS process's cwd,
+      // the only context in which a relative --pid-file was meaningful) so a
+      // later reader (e.g. `gbrain doctor`, possibly running from a
+      // different cwd) doesn't misresolve it. `this.opts.pidFile` itself
+      // stays as-given for this process's own reads/writes below, which are
+      // already correctly relative to this same cwd.
+      pid_file: resolve(this.opts.pidFile),
       concurrency: this.opts.concurrency,
       queue: this.opts.queue,
       max_crashes: this.opts.maxCrashes,

--- a/test/doctor-supervisor-singleton-pidfile.test.ts
+++ b/test/doctor-supervisor-singleton-pidfile.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression test: `gbrain doctor`'s `supervisor_singleton` check should read
+ * the pid-file path that was used at supervisor start (recorded on the
+ * 'started' audit event as `pid_file` — `this.opts.pidFile` in
+ * `MinionSupervisor.start()`), not blindly re-derive the HOME-derived
+ * `DEFAULT_PID_FILE`.
+ *
+ * Pre-fix, `doctor.ts` read `readSupervisorPid(DEFAULT_PID_FILE).pid` even
+ * though the 'started' event already carried the real path. A supervisor
+ * launched with a custom `--pid-file` (the common launchd/systemd deployment
+ * pattern) could then produce a false "singleton mismatch" warn against its
+ * own live DB lock, because the pidfile doctor.ts checked was never the one
+ * the supervisor actually wrote.
+ *
+ * #1849 established the queue-scoped DB lock as the real singleton
+ * authority — `supervisor_singleton` is a diagnostic display derived from
+ * that lock, not a second enforcement mechanism. This fix only corrects
+ * which pidfile the display reads; it does not touch the DB lock itself.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { withEnv } from './helpers/with-env.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+import { supervisorLockId } from '../src/core/minions/supervisor.ts';
+import { computeSupervisorAuditFilename } from '../src/core/minions/handlers/supervisor-audit.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+let auditDir: string;
+let pidFileDir: string;
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.executeRaw(`DELETE FROM gbrain_cycle_locks`);
+  auditDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-supervisor-singleton-audit-'));
+  pidFileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-supervisor-singleton-pidfile-'));
+});
+
+afterEach(() => {
+  try { fs.rmSync(auditDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  try { fs.rmSync(pidFileDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+function writeStartedEvent(fields: Record<string, unknown>): void {
+  const file = path.join(auditDir, computeSupervisorAuditFilename());
+  const row = { event: 'started', ts: new Date().toISOString(), supervisor_pid: process.pid, ...fields };
+  fs.writeFileSync(file, `${JSON.stringify(row)}\n`, 'utf8');
+}
+
+async function holdLiveLock(queue: string, holderPid: number, holderHost: string): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
+     VALUES ($1, $2, $3, now(), now() + interval '30 minutes', now())`,
+    [supervisorLockId(queue), holderPid, holderHost],
+  );
+}
+
+async function findSingletonCheck() {
+  const checks = await buildChecks(engine, []);
+  return checks.find((c) => c.name === 'supervisor_singleton');
+}
+
+describe('doctor supervisor_singleton — honors the recorded pid_file (custom --pid-file)', () => {
+  test('custom --pid-file matching the live DB lock holder → single, not mismatch', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      // A pid-file at a path OTHER than DEFAULT_PID_FILE, holding the pid of
+      // this very test process (guaranteed alive via process.kill(pid, 0)).
+      const customPidFile = path.join(pidFileDir, 'custom-supervisor.pid');
+      fs.writeFileSync(customPidFile, String(process.pid), 'utf8');
+
+      // The 'started' event records that custom path, matching what
+      // MinionSupervisor.start() actually emits (this.opts.pidFile).
+      writeStartedEvent({ pid_file: customPidFile, queue: 'default', max_rss_mb: 512 });
+
+      // The DB lock (the real singleton authority per #1849) is held by
+      // this same (host, pid) — a single, healthy supervisor.
+      await holdLiveLock('default', process.pid, os.hostname());
+
+      const check = await findSingletonCheck();
+      expect(check).toBeDefined();
+      expect(check?.status).toBe('ok');
+      expect(check?.message).toContain('Single supervisor');
+      // Pre-fix this would have read DEFAULT_PID_FILE (which this test never
+      // writes to), gotten pid=null, and warned 'mismatch' instead.
+      expect(check?.message).not.toContain('mismatch');
+    });
+  });
+
+  test('pid_file that does not resolve to the lock holder → mismatch (an absent/wrong local pidfile still warns)', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      // pid_file recorded, but nothing is written at that path — readSupervisorPid
+      // resolves to pid=null, so the DB lock holder can't be locally confirmed.
+      const customPidFile = path.join(pidFileDir, 'never-written-supervisor.pid');
+      writeStartedEvent({ pid_file: customPidFile, queue: 'default', max_rss_mb: 512 });
+
+      await holdLiveLock('default', process.pid, os.hostname());
+
+      const check = await findSingletonCheck();
+      expect(check).toBeDefined();
+      expect(check?.status).toBe('warn');
+      expect(check?.message).toContain('singleton lock is held by');
+    });
+  });
+});
+
+// Compatibility fallback: a 'started' event from before this fix (or any
+// caller that never recorded `pid_file`) has no such field. doctor.ts falls
+// back to DEFAULT_PID_FILE for those — behavior-preserving relative to
+// pre-fix. Pinned as a source-grep (rather than a behavioral run against the
+// real DEFAULT_PID_FILE) because DEFAULT_PID_FILE is a module-load-time
+// constant derived from $HOME; asserting against it directly would make the
+// test's outcome depend on whatever real supervisor state happens to exist
+// on the machine running the suite.
+describe('doctor supervisor_singleton — pid_file fallback (source-grep)', () => {
+  test('falls back to DEFAULT_PID_FILE when the started event has no pid_file', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    expect(source).toMatch(
+      /typeof lastStarted\.pid_file === 'string' && lastStarted\.pid_file\.length > 0\s*\n\s*\? lastStarted\.pid_file\s*\n\s*: DEFAULT_PID_FILE/,
+    );
+    expect(source).toContain('readSupervisorPid(pidFilePath)');
+  });
+});

--- a/test/doctor-supervisor-singleton-pidfile.test.ts
+++ b/test/doctor-supervisor-singleton-pidfile.test.ts
@@ -2,13 +2,13 @@
  * Regression test: `gbrain doctor`'s `supervisor_singleton` check should read
  * the pid-file path that was used at supervisor start (recorded on the
  * 'started' audit event as `pid_file` — `this.opts.pidFile` in
- * `MinionSupervisor.start()`), not blindly re-derive the HOME-derived
- * `DEFAULT_PID_FILE`.
+ * `MinionSupervisor.start()`), not blindly re-derive `DEFAULT_PID_FILE`
+ * locally.
  *
  * Pre-fix, `doctor.ts` read `readSupervisorPid(DEFAULT_PID_FILE).pid` even
  * though the 'started' event already carried the real path. A supervisor
- * launched with a custom `--pid-file` (the common launchd/systemd deployment
- * pattern) could then produce a false "singleton mismatch" warn against its
+ * launched with a custom `--pid-file` (e.g. a launchd/systemd unit passing an
+ * explicit pidfile path) could then produce a false "singleton mismatch" warn against its
  * own live DB lock, because the pidfile doctor.ts checked was never the one
  * the supervisor actually wrote.
  *


### PR DESCRIPTION
## Summary

`gbrain doctor`'s `supervisor_singleton` check (introduced under #1849) compares the local
pidfile holder against the queue-scoped DB lock holder to surface a rogue second supervisor.
It read `readSupervisorPid(DEFAULT_PID_FILE)` unconditionally — even though the supervisor's
own `'started'` audit event already records the pid-file path actually in use
(`this.opts.pidFile`). A supervisor launched with a custom `--pid-file` (e.g. a
launchd/systemd unit passing an explicit pidfile path) would get a false `"singleton mismatch"` warning against
its own healthy, single instance, because the pidfile doctor read was never the one the
supervisor actually wrote.

**Relationship to #1849:** this does not change #1849's design. The queue-scoped DB lock
(`gbrain_cycle_locks`) remains the sole singleton *authority* — `supervisor_singleton` is (and
stays) a read-only diagnostic *display* derived from that lock, not a second enforcement
mechanism. `classifySupervisorSingleton`, lock acquisition/refresh/release, and the DB query are
all untouched. This PR only corrects which pidfile path the display reads for the local side of
the comparison.

## Changes

- `src/commands/doctor.ts`: prefer the `pid_file` recorded on the last `'started'` audit event
  when it's a non-empty string, falling back to `DEFAULT_PID_FILE` when the event carries no
  usable value.
- `src/core/minions/supervisor.ts`: resolve `pid_file` to an absolute path (`path.resolve`) at
  emit time, since that's the only cwd context in which a relative `--pid-file` argument is
  meaningful — a later reader (doctor, possibly running from a different cwd) can't otherwise
  resolve a relative path correctly. The supervisor's own internal pidfile guard/read/write
  paths (which stay correctly relative to its own process lifetime) are untouched.
- `test/doctor-supervisor-singleton-pidfile.test.ts` (new): drives the real `buildChecks`
  seam against a real PGLite engine + a real `gbrain_cycle_locks` row + a synthetic `'started'`
  audit event, covering:
  - a custom `--pid-file` path that matches the live DB lock holder → `ok` ("Single supervisor"),
    not a false `mismatch`
  - an absent local pidfile still correctly warns `mismatch` when a live DB lock holder
    exists (the pre-existing fallback for a missing local pidfile is unchanged; dead-PID
    edge cases are outside this PR's scope and keep upstream behavior)
  - a source-grep pin for the `DEFAULT_PID_FILE` compatibility fallback (kept as source-grep
    rather than behavioral, since `DEFAULT_PID_FILE` is a module-load-time constant derived from
    the environment (`GBRAIN_SUPERVISOR_PID_FILE` override, else a brain-scoped default under
    `$HOME`) — asserting against it behaviorally would make the test depend on whatever real
    supervisor state exists on the machine running the suite)

## Test plan

- [x] `bun test --timeout=60000 test/doctor-supervisor-singleton-pidfile.test.ts test/supervisor-db-lock.test.ts` — 20 pass, 0 fail (new tests + the existing `#1849` `classifySupervisorSingleton`/DB-lock suite, confirming no regression there)
- [x] `bun run typecheck` — clean
- [x] `scripts/check-test-isolation.sh` — clean (1123 files scanned)
- [x] `scripts/check-jsonb-pattern.sh` / `scripts/check-jsonb-params.mjs` / `scripts/check-engine-dynamic-import.sh` — clean


