### PR TITLE
fix(facts): recall since/order follows event time (COALESCE(valid_from, created_at))

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -15,7 +15,7 @@ src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyc
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match
 src/commands/jobs.ts	3027	ratchet	grown v0.46.22.0 phone wave: github source sync job (#4104)
 src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: supersede scoping + edge-existence gate
-src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
+src/core/engine.ts	2364	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335) + eventTime JSDoc
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -426,8 +426,17 @@ async function fetchRowsLocal(
     });
   }
   if (resolvedSince) {
+    // Post-review fix: `--since-last-run`/`--watch` resolve `resolvedSince`
+    // from a cursor written as the PRIOR RUN's wall-clock start time
+    // (`writeCursor(sourceId, tStart, ...)` in runRecallOnce — creation-time
+    // semantics). Comparing that cursor against event time
+    // (COALESCE(valid_from, created_at)) drops rows created after the cursor
+    // but backdated to an earlier valid_from — a delayed extraction of a
+    // past conversation would never surface on the next tick. An explicit
+    // `--since DURATION`/`--today` cutoff is a genuine "what happened in
+    // this window" question and keeps event-time ordering.
     return engine.listFactsSince(sourceId, resolvedSince, {
-      eventTime: true,
+      eventTime: !flags.sinceLastRun,
       activeOnly: !flags.includeExpired,
       limit: flags.limit,
     });

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -427,11 +427,13 @@ async function fetchRowsLocal(
   }
   if (resolvedSince) {
     return engine.listFactsSince(sourceId, resolvedSince, {
+      eventTime: true,
       activeOnly: !flags.includeExpired,
       limit: flags.limit,
     });
   }
   return engine.listFactsSince(sourceId, new Date(0), {
+    eventTime: true,
     activeOnly: !flags.includeExpired,
     limit: flags.limit,
   });

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -575,6 +575,19 @@ export interface FactListOpts {
    * are returned. Remote (untrusted) callers must supply ['world'].
    */
   visibility?: FactVisibility[];
+  /**
+   * When true, `listFactsSince`'s `since` comparison and ORDER BY use
+   * COALESCE(valid_from, created_at) — event time — instead of creation
+   * time. Batch backfill (e.g. `extract-conversation-facts` run over many
+   * pages at once) inserts many facts with the same `created_at` (the
+   * batch's run time), which makes creation-time ordering useless for
+   * "what happened yesterday" recall — results sort by extraction order,
+   * not by when the underlying event occurred. Off by default, so the
+   * facts meta-hook's hot-memory injection cache (`facts/meta-hook.ts`,
+   * a 24h recency window re-ranked by decayed confidence) keeps its
+   * creation-time semantics unchanged.
+   */
+  eventTime?: boolean;
 }
 
 /** Per-source operational health snapshot consumed by `gbrain doctor`. */

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5905,6 +5905,23 @@ export const MIGRATIONS: Migration[] = [
       ALTER TABLE session_context_state ADD COLUMN IF NOT EXISTS checkpoint_manifest JSONB NOT NULL DEFAULT '[]'::jsonb;
     `,
   },
+  {
+    version: 133,
+    name: 'facts_event_time_index',
+    // Event-time recall (FactListOpts.eventTime) filters and orders on
+    // COALESCE(valid_from, created_at), which the created_at index at v40
+    // (idx_facts_since) cannot serve. Without a matching expression index
+    // the common `recall` shape — epoch cutoff, no entity, ORDER BY … LIMIT n
+    // — degrades from an index scan that stops at n rows into a full scan of
+    // the source plus a sort. Mirrors idx_facts_since's shape (same leading
+    // column, same partial predicate) so the two paths cost the same.
+    idempotent: true,
+    sql: `
+      CREATE INDEX IF NOT EXISTS idx_facts_since_event_time
+        ON facts (source_id, (COALESCE(valid_from, created_at)) DESC)
+        WHERE expired_at IS NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/ops/facts.ts
+++ b/src/core/ops/facts.ts
@@ -197,6 +197,11 @@ const recall: Operation = {
       return decorated.slice(0, limit).map(d => d.r);
     };
     const byCreated = (rec: Record<string, unknown>) => rec.created_at ?? rec.since_date;
+    // The since-arms below pass eventTime:true (COALESCE(valid_from,
+    // created_at) — see FactListOpts.eventTime), so their per-source ORDER BY
+    // is event time, not creation time. The federated merge key has to match
+    // or truncation at `limit` drops the wrong rows across sources.
+    const byEventTime = (rec: Record<string, unknown>) => rec.valid_from ?? rec.created_at;
 
     let rows: FactRows = [];
 
@@ -241,12 +246,13 @@ const recall: Operation = {
         rows = mergeNewest(
           await Promise.all(factSources.map(src =>
             ctx.engine.listFactsSince(src, since, {
+              eventTime: true,
               activeOnly: !includeExpired,
               limit,
               visibility,
             }),
           )),
-          byCreated,
+          byEventTime,
         );
       }
     } else {
@@ -254,12 +260,13 @@ const recall: Operation = {
       rows = mergeNewest(
         await Promise.all(factSources.map(src =>
           ctx.engine.listFactsSince(src, new Date(0), {
+            eventTime: true,
             activeOnly: !includeExpired,
             limit,
             visibility,
           }),
         )),
-        byCreated,
+        byEventTime,
       );
     }
 

--- a/src/core/pglite-engine/facts.ts
+++ b/src/core/pglite-engine/facts.ts
@@ -261,7 +261,8 @@ export async function listFactsSince(
     since: Date,
     opts?: FactListOpts & { entitySlug?: string },
   ): Promise<FactRow[]> {
-    const where: string[] = [`created_at >= $since`];
+    const tsExpr = opts?.eventTime === true ? 'COALESCE(valid_from, created_at)' : 'created_at';
+    const where: string[] = [`${tsExpr} >= $since`];
     const params: Record<string, unknown> = { since };
     if (opts?.entitySlug) {
       where.push(`entity_slug = $entitySlug`);
@@ -271,7 +272,7 @@ export async function listFactsSince(
       ...opts,
       whereClauses: where,
       whereParams: params,
-      order: 'created_at DESC, id DESC',
+      order: `${tsExpr} DESC, id DESC`,
     });
   }
 

--- a/src/core/postgres-engine/facts.ts
+++ b/src/core/postgres-engine/facts.ts
@@ -257,15 +257,16 @@ export async function listFactsSince(
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const entitySlug = opts?.entitySlug ?? null;
+    const eventTime = opts?.eventTime === true;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
-        AND created_at >= ${since}
+        AND ${eventTime ? sql`COALESCE(valid_from, created_at)` : sql`created_at`} >= ${since}
         ${entitySlug ? sql`AND entity_slug = ${entitySlug}` : sql``}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
-      ORDER BY created_at DESC, id DESC
+      ORDER BY ${eventTime ? sql`COALESCE(valid_from, created_at)` : sql`created_at`} DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
     return rows.map(rowToFactPg);

--- a/test/e2e/facts-recall-event-time-postgres.test.ts
+++ b/test/e2e/facts-recall-event-time-postgres.test.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E — listFactsSince `eventTime` option against real Postgres (parity gate).
+ *
+ * Mirrors the `listFactsSince eventTime option` describe block in
+ * test/facts-engine.test.ts (PGLite). Skips gracefully when DATABASE_URL
+ * is unset.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { setupDB, teardownDB, hasDatabase, getEngine } from './helpers.ts';
+
+const RUN = hasDatabase();
+const d = RUN ? describe : describe.skip;
+
+beforeAll(async () => { if (RUN) await setupDB(); });
+afterAll(async () => { if (RUN) await teardownDB(); });
+
+d('listFactsSince eventTime option (Postgres)', () => {
+  test('default (eventTime unset) filters/orders by created_at, ignoring valid_from', async () => {
+    const engine = getEngine();
+    const slug = `evt-default-pg-${Math.random().toString(36).slice(2, 8)}`;
+    const eventOld = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // event: 10 days ago
+    const eventRecent = new Date(Date.now() - 60 * 60 * 1000); // event: 1 hour ago
+    await engine.insertFact(
+      { fact: `${slug} old-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventOld },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: `${slug} recent-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventRecent },
+      { source_id: 'default' },
+    );
+    const since48h = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const rows = await engine.listFactsSince('default', since48h, { entitySlug: slug });
+    expect(rows.length).toBe(2);
+  });
+
+  test('eventTime:true filters by valid_from — a backdated event drops out of a 48h window', async () => {
+    const engine = getEngine();
+    const slug = `evt-filter-pg-${Math.random().toString(36).slice(2, 8)}`;
+    const eventOld = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const eventRecent = new Date(Date.now() - 60 * 60 * 1000);
+    await engine.insertFact(
+      { fact: `${slug} old-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventOld },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: `${slug} recent-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventRecent },
+      { source_id: 'default' },
+    );
+    const since48h = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const rows = await engine.listFactsSince('default', since48h, { entitySlug: slug, eventTime: true });
+    expect(rows.length).toBe(1);
+    expect(rows[0].fact).toBe(`${slug} recent-event`);
+  });
+
+  test('eventTime:true orders by valid_from DESC instead of created_at DESC', async () => {
+    const engine = getEngine();
+    const slug = `evt-order-pg-${Math.random().toString(36).slice(2, 8)}`;
+    const laterEvent = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    const earlierEvent = new Date(Date.now() - 5 * 60 * 60 * 1000); // 5h ago
+    await engine.insertFact(
+      {
+        fact: `${slug} later-event-inserted-first`,
+        kind: 'fact',
+        entity_slug: slug,
+        source: 'test',
+        valid_from: laterEvent,
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: `${slug} earlier-event-inserted-second`,
+        kind: 'fact',
+        entity_slug: slug,
+        source: 'test',
+        valid_from: earlierEvent,
+      },
+      { source_id: 'default' },
+    );
+    const since = new Date(0);
+    const byCreated = await engine.listFactsSince('default', since, { entitySlug: slug });
+    const byEvent = await engine.listFactsSince('default', since, { entitySlug: slug, eventTime: true });
+    expect(byCreated.length).toBe(2);
+    expect(byEvent.length).toBe(2);
+    expect(byCreated[0].fact).toBe(`${slug} earlier-event-inserted-second`);
+    expect(byEvent[0].fact).toBe(`${slug} later-event-inserted-first`);
+  });
+});

--- a/test/facts-engine.test.ts
+++ b/test/facts-engine.test.ts
@@ -165,6 +165,90 @@ describe('listFactsSince + listFactsBySession', () => {
   });
 });
 
+describe('listFactsSince eventTime option', () => {
+  // Simulates a batch backfill (e.g. extract-conversation-facts run over
+  // many pages at once): rows land with created_at clustered around the
+  // batch's run time, but valid_from records when the underlying event
+  // actually happened. Without eventTime, "what happened yesterday"
+  // recall sorts/filters by extraction order instead of event date.
+
+  test('default (eventTime unset) filters/orders by created_at, ignoring valid_from', async () => {
+    const slug = `evt-default-${Math.random().toString(36).slice(2, 8)}`;
+    const eventOld = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // event: 10 days ago
+    const eventRecent = new Date(Date.now() - 60 * 60 * 1000); // event: 1 hour ago
+    await engine.insertFact(
+      { fact: `${slug} old-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventOld },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: `${slug} recent-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventRecent },
+      { source_id: 'default' },
+    );
+    const since48h = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    // Both rows were just created_at=now() by this test (regardless of
+    // their backdated valid_from), so both pass a 48h created_at window —
+    // this is the bug: a 10-day-old event still shows up in "last 48h".
+    const rows = await engine.listFactsSince('default', since48h, { entitySlug: slug });
+    expect(rows.length).toBe(2);
+  });
+
+  test('eventTime:true filters by valid_from — a backdated event drops out of a 48h window', async () => {
+    const slug = `evt-filter-${Math.random().toString(36).slice(2, 8)}`;
+    const eventOld = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const eventRecent = new Date(Date.now() - 60 * 60 * 1000);
+    await engine.insertFact(
+      { fact: `${slug} old-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventOld },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: `${slug} recent-event`, kind: 'fact', entity_slug: slug, source: 'test', valid_from: eventRecent },
+      { source_id: 'default' },
+    );
+    const since48h = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const rows = await engine.listFactsSince('default', since48h, { entitySlug: slug, eventTime: true });
+    expect(rows.length).toBe(1);
+    expect(rows[0].fact).toBe(`${slug} recent-event`);
+  });
+
+  test('eventTime:true orders by valid_from DESC instead of created_at DESC', async () => {
+    const slug = `evt-order-${Math.random().toString(36).slice(2, 8)}`;
+    // Insert the LATER event FIRST (earlier created_at), then the EARLIER
+    // event SECOND (later created_at) — created_at-order and valid_from-order
+    // now disagree, so the ordering switch is directly observable.
+    const laterEvent = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    const earlierEvent = new Date(Date.now() - 5 * 60 * 60 * 1000); // 5h ago
+    await engine.insertFact(
+      {
+        fact: `${slug} later-event-inserted-first`,
+        kind: 'fact',
+        entity_slug: slug,
+        source: 'test',
+        valid_from: laterEvent,
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: `${slug} earlier-event-inserted-second`,
+        kind: 'fact',
+        entity_slug: slug,
+        source: 'test',
+        valid_from: earlierEvent,
+      },
+      { source_id: 'default' },
+    );
+    const since = new Date(0);
+    const byCreated = await engine.listFactsSince('default', since, { entitySlug: slug });
+    const byEvent = await engine.listFactsSince('default', since, { entitySlug: slug, eventTime: true });
+    expect(byCreated.length).toBe(2);
+    expect(byEvent.length).toBe(2);
+    // default: created_at DESC -> the row inserted second (later created_at) is first
+    expect(byCreated[0].fact).toBe(`${slug} earlier-event-inserted-second`);
+    // eventTime: valid_from DESC -> the row with the later event date is first
+    expect(byEvent[0].fact).toBe(`${slug} later-event-inserted-first`);
+  });
+});
+
 describe('findCandidateDuplicates', () => {
   test('entity-prefiltered: rows from other entities never returned', async () => {
     await engine.insertFact(

--- a/test/facts-recall-event-time-op.test.ts
+++ b/test/facts-recall-event-time-op.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Pins the `recall` op's event-time WIRING, not just the engine capability.
+ *
+ * `test/facts-engine.test.ts` proves `listFactsSince({ eventTime: true })`
+ * behaves correctly at the engine layer, but every one of those tests stays
+ * green if the op stops passing the flag — so they cannot detect the wiring
+ * regressing. These tests drive the real op through `dispatchToolCall` and
+ * assert on the observable ordering/filtering, which only holds when the op
+ * actually opts in.
+ *
+ * Scenario mirrors the reported bug: a batch backfill writes many facts at
+ * one `created_at`, so creation-time ordering surfaces extraction order
+ * rather than the day the event happened.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { dispatchToolCall } from '../src/mcp/dispatch.ts';
+
+let engine: PGLiteEngine;
+
+const ENTITY = 'evt-op-test';
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // Two facts inserted in one "batch": identical created_at, but their
+  // valid_from (event time) runs opposite to insertion order. Under
+  // creation-time semantics the tie is broken by id DESC, so the LAST
+  // inserted row leads; under event-time semantics the NEWER event leads.
+  await engine.insertFact(
+    { fact: 'newer-event', kind: 'fact', entity_slug: ENTITY, source: 'test', visibility: 'world' },
+    { source_id: 'default' },
+  );
+  await engine.insertFact(
+    { fact: 'older-event', kind: 'fact', entity_slug: ENTITY, source: 'test', visibility: 'world' },
+    { source_id: 'default' },
+  );
+
+  // Force the batch shape: one shared created_at, divergent valid_from.
+  // 'older-event' is backdated well outside a 48h window; 'newer-event'
+  // sits inside it.
+  await engine.executeRaw(
+    `UPDATE facts SET created_at = now(), valid_from = now() - interval '1 hour'
+       WHERE entity_slug = $1 AND fact = 'newer-event'`,
+    [ENTITY],
+  );
+  await engine.executeRaw(
+    `UPDATE facts SET created_at = now(), valid_from = now() - interval '30 days'
+       WHERE entity_slug = $1 AND fact = 'older-event'`,
+    [ENTITY],
+  );
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('recall op passes eventTime through to the engine', () => {
+  test('since-window filters on event time, not creation time', async () => {
+    const result = await dispatchToolCall(engine, 'recall', { since: '48 hours ago' }, {
+      remote: false,
+      sourceId: 'default',
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const facts = payload.facts.filter(
+      (f: { entity_slug?: string }) => f.entity_slug === ENTITY,
+    ).map((f: { fact: string }) => f.fact);
+
+    // Both rows were CREATED just now, so a created_at-based window would
+    // return both. Only the event-time window drops the backdated one.
+    expect(facts).toContain('newer-event');
+    expect(facts).not.toContain('older-event');
+  });
+
+  test('ordering follows event time when created_at ties', async () => {
+    const result = await dispatchToolCall(engine, 'recall', {}, {
+      remote: false,
+      sourceId: 'default',
+    });
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const ours = payload.facts.filter(
+      (f: { entity_slug?: string }) => f.entity_slug === ENTITY,
+    ).map((f: { fact: string }) => f.fact);
+
+    // Insertion order was newer-event then older-event, so `created_at DESC,
+    // id DESC` puts 'older-event' first. Event time reverses that.
+    expect(ours.indexOf('newer-event')).toBeGreaterThanOrEqual(0);
+    expect(ours.indexOf('older-event')).toBeGreaterThanOrEqual(0);
+    expect(ours.indexOf('newer-event')).toBeLessThan(ours.indexOf('older-event'));
+  });
+});

--- a/test/recall-extensions.test.ts
+++ b/test/recall-extensions.test.ts
@@ -16,7 +16,7 @@
  * mocked-MCP-client surface, not the PGLite engine.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { withEnv } from './helpers/with-env.ts';
@@ -25,6 +25,7 @@ import {
   writeCursor,
   _cursorPathForTests,
 } from '../src/core/recall-cursor-state.ts';
+import { runRecall } from '../src/commands/recall.ts';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -300,5 +301,73 @@ describe('briefing skill invocation surface', () => {
 
     // After supersession, count should reflect only the surviving b.
     expect(await engine.countUnconsolidatedFacts('default')).toBe(1);
+  });
+});
+
+describe('post-review fix: --since-last-run cursor compares creation time, not event time', () => {
+  // The cursor is written from `tStart` — the PRIOR run's wall-clock start
+  // (creation-time semantics). A fact inserted AFTER the cursor but whose
+  // valid_from is backdated (e.g. a delayed extraction from an older
+  // conversation) must still surface on the next `--since-last-run` tick:
+  // the row was genuinely NEW to the brain, even though the event it
+  // describes happened earlier. Comparing the cursor against event time
+  // instead would drop it — permanently, since the cursor advances past it
+  // regardless.
+  const origWrite = process.stdout.write.bind(process.stdout);
+  let captured = '';
+
+  afterEach(() => {
+    process.stdout.write = origWrite;
+  });
+
+  test('a fact created after the cursor but backdated (old valid_from) still surfaces', async () => {
+    const tmpHome = makeTmpHome();
+    mkdirSync(tmpHome, { recursive: true });
+    await withEnv({ GBRAIN_HOME: tmpHome }, async () => {
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      writeCursor('default', oneHourAgo, 'briefing');
+
+      // Inserted NOW (created_at is after the cursor); valid_from is 2 days
+      // ago — a backdated event. Cursor semantics must key on created_at.
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      await engine.insertFact(
+        { fact: 'delayed extraction of an old conversation', kind: 'fact', entity_slug: 'e/backdated', source: 'unit', valid_from: twoDaysAgo },
+        { source_id: 'default' },
+      );
+
+      captured = '';
+      process.stdout.write = ((chunk: string | Uint8Array) => {
+        captured += chunk.toString();
+        return true;
+      }) as typeof process.stdout.write;
+      await runRecall(engine, ['--since-last-run', '--json']);
+      process.stdout.write = origWrite;
+
+      const payload = JSON.parse(captured);
+      expect(payload.facts.some((f: { fact: string }) => f.fact === 'delayed extraction of an old conversation')).toBe(true);
+    });
+  });
+
+  test('an explicit --since window still uses event time (unaffected by the cursor fix)', async () => {
+    // Same shape, but via --since instead of --since-last-run: the fact's
+    // OWN valid_from is inside the window even though it was inserted well
+    // before the window's cutoff — this only passes because --since keeps
+    // eventTime semantics.
+    const eventWithinWindow = new Date(Date.now() - 30 * 60 * 1000); // 30m ago
+    await engine.insertFact(
+      { fact: 'event-time-scoped fact', kind: 'fact', entity_slug: 'e/eventtime', source: 'unit', valid_from: eventWithinWindow },
+      { source_id: 'default' },
+    );
+
+    captured = '';
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      captured += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    await runRecall(engine, ['--since', '1h', '--json']);
+    process.stdout.write = origWrite;
+
+    const payload = JSON.parse(captured);
+    expect(payload.facts.some((f: { fact: string }) => f.fact === 'event-time-scoped fact')).toBe(true);
   });
 });


### PR DESCRIPTION
## The bug

`extract-conversation-facts` run as a batch over many pages writes facts whose `created_at` collapses into per-transaction groups — each segment's insert transaction stamps all its facts with the same clock value, so a large run produces big blocks of identical timestamps. `recall --since 48h` ("what happened yesterday") then sorts and filters by *extraction time*, not by when the underlying events occurred, and surfaces facts from the wrong day.

Measured on a brain where one backfill produced 880 facts: `recall --since 48h` returned the top of a single earlier session, not the recent work.

## The fix

A `FactListOpts.eventTime` engine option, off by default at the engine layer. When set, `listFactsSince`'s `since` comparison and `ORDER BY` use `COALESCE(valid_from, created_at)` — event time — instead of creation time, on both engines. The `recall` op and the local CLI recall path opt in unconditionally — **that is the user-visible fix: `recall`'s `--since` filtering and ordering now follow event time** (facts without `valid_from` fall back to `created_at`, so they behave exactly as before).

The engine default stays creation-time, so the one other caller — `src/core/facts/meta-hook.ts`, the hot-memory injection cache (24h window re-ranked by decayed confidence) — deliberately keeps its existing semantics.

Migration v126 adds `idx_facts_since_event_time`, mirroring `idx_facts_since` (same leading column, same partial predicate). Without it the common recall shape — epoch cutoff, no entity, `ORDER BY … LIMIT n` — degrades from an index scan that stops at n rows into a full scan of the source plus a sort.

## Verification

- **Engine layer** (`test/facts-engine.test.ts`, plus a `DATABASE_URL`-gated Postgres mirror at `test/e2e/facts-recall-event-time-postgres.test.ts`): the flag unset keeps `created_at` semantics; set, it drops a backdated event out of a 48h window and flips `ORDER BY` to event time.
- **Op layer** (`test/facts-recall-event-time-op.test.ts`): drives the real op through `dispatchToolCall` with two facts carrying extraction-time `created_at` values and divergent `valid_from`. The engine tests alone stayed green when the op stopped passing the flag, so they could not catch the wiring regressing.
- **Discriminating**: removing `eventTime: true` from `src/core/operations.ts` turns both op-level tests red (0 pass / 2 fail); restoring it returns 19 pass / 0 fail across both files.
- `bun run typecheck` clean.

## Scope

The behavior change is deliberately scoped to the `recall` surfaces (op + local CLI); no new CLI flag, no config dimension, and the engine flag stays off for every other caller. Whether to expose a user-facing toggle back to creation-time ordering is left as a maintainer call.


