### PR TITLE
fix(facts,search): exclude extraction audit checkpoint rows from recall

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -15,7 +15,7 @@ src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyc
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match
 src/commands/jobs.ts	3027	ratchet	grown v0.46.22.0 phone wave: github source sync job (#4104)
 src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: supersede scoping + edge-existence gate
-src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
+src/core/engine.ts	2365	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335) + #4008 recall-exclude-audit-rows fix
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -94,6 +94,7 @@ import { assertFactsEmbeddingDimMatchesConfig } from '../core/embedding-dim-chec
 import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
 import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../core/facts/audit-sources.ts';
 
 // Re-exported verbatim so existing importers (this file's own helpers below
 // and this file's tests) keep working unchanged; doctor.ts, jobs.ts,
@@ -103,6 +104,12 @@ import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-type
 // own CLI flag surface.
 export { ALLOWED_TYPES };
 export type { AllowedType };
+
+// Re-exported for existing importers (test/extract-conversation-facts.test.ts,
+// test/doctor-conversation-facts-backlog.test.ts, src/eval/brainbench/metrics/write-back.ts).
+// The values themselves now live in ../core/facts/audit-sources.ts — see that
+// leaf module's docstring for why (engine-live static-import requirement).
+export { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE };
 
 // ---------------------------------------------------------------------------
 // Tunables (exported for tests).
@@ -220,21 +227,13 @@ export const CHECKPOINT_OP = 'extract-conversation-facts';
  */
 export const PER_SEGMENT_SOURCE_PREFIX = 'cli:extract-conversation-facts';
 
-/**
- * Source string written on the page-level terminal audit row (Eng-v2 C7).
- * Doctor's backlog query matches THIS source + source_session, not
- * the per-segment source. Partial extraction = no terminal row = page
- * stays in backlog.
- */
-export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2';
-
-/**
- * Durable outcome for a successfully scanned page that contains no eligible
- * multi-message segment. Kept distinct from successful extraction so operator
- * surfaces can report the truth without rescanning the page forever.
- */
-export const NON_EXTRACTABLE_AUDIT_SOURCE =
-  'cli:extract-conversation-facts:non-extractable:v2';
+// TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE: defined in
+// ../core/facts/audit-sources.ts, imported + re-exported above. (Doctor's
+// backlog query matches TERMINAL_AUDIT_SOURCE + source_session, not the
+// per-segment source; partial extraction = no terminal row = page stays in
+// backlog. NON_EXTRACTABLE_AUDIT_SOURCE is kept distinct from successful
+// extraction so operator surfaces can report the truth without rescanning
+// the page forever.)
 
 // ---------------------------------------------------------------------------
 // Public types.

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -417,23 +417,27 @@ async function fetchRowsLocal(
     return engine.listFactsByEntity(sourceId, slug, {
       activeOnly: !flags.includeExpired,
       limit: flags.limit,
+      excludeAuditRows: true,
     });
   }
   if (flags.sessionId) {
     return engine.listFactsBySession(sourceId, flags.sessionId, {
       activeOnly: !flags.includeExpired,
       limit: flags.limit,
+      excludeAuditRows: true,
     });
   }
   if (resolvedSince) {
     return engine.listFactsSince(sourceId, resolvedSince, {
       activeOnly: !flags.includeExpired,
       limit: flags.limit,
+      excludeAuditRows: true,
     });
   }
   return engine.listFactsSince(sourceId, new Date(0), {
     activeOnly: !flags.includeExpired,
     limit: flags.limit,
+    excludeAuditRows: true,
   });
 }
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -575,6 +575,20 @@ export interface FactListOpts {
    * are returned. Remote (untrusted) callers must supply ['world'].
    */
   visibility?: FactVisibility[];
+  /**
+   * When true, exclude the durable audit checkpoint rows that
+   * extract-conversation-facts writes into the facts table
+   * (`EXTRACTION_COMPLETE` / `EXTRACTION_NOT_APPLICABLE`). These are
+   * batch-run checkpoints, not user facts; their `created_at` is always
+   * the most recent write, so for trusted callers (no visibility filter)
+   * they dominate the newest-N fetch window right after a batch run and
+   * starve `recall` of real facts. Honored consistently by
+   * `listFactsByEntity` / `listFactsBySession` / `listFactsSince` on both
+   * engines. Off by default so existing callers that intentionally want
+   * the full row set (e.g. `gbrain doctor` checkpoint audits) are
+   * unaffected.
+   */
+  excludeAuditRows?: boolean;
 }
 
 /** Per-source operational health snapshot consumed by `gbrain doctor`. */

--- a/src/core/facts/audit-sources.ts
+++ b/src/core/facts/audit-sources.ts
@@ -1,0 +1,32 @@
+/**
+ * Source-string constants for the durable audit checkpoint rows that
+ * extract-conversation-facts writes into the facts table to mark
+ * batch-run progress:
+ *   - `TERMINAL_AUDIT_SOURCE` — page-level "extraction complete" checkpoint
+ *     (Eng-v2 C7). Doctor's backlog query matches this source +
+ *     source_session, not the per-segment fact source.
+ *   - `NON_EXTRACTABLE_AUDIT_SOURCE` — durable outcome for a successfully
+ *     scanned page that contains no eligible multi-message segment, kept
+ *     distinct from successful extraction so operator surfaces can report
+ *     the truth without rescanning the page forever.
+ *
+ * These are checkpoints, not user facts. Recall-side callers filter rows
+ * whose `source` is one of these out of the newest-N fetch window (see
+ * `FactListOpts.excludeAuditRows` in `../engine.ts`).
+ *
+ * Pulled into a leaf module (no other imports) so `pglite-engine.ts` and
+ * `postgres-engine.ts` — engine-live paths where runtime dynamic `import()`
+ * is forbidden (`scripts/check-engine-dynamic-import.sh`) — can reference
+ * these values via a static top-level import instead of reaching into the
+ * much heavier `commands/extract-conversation-facts.ts` command module.
+ * `extract-conversation-facts.ts` re-exports both names unchanged so its
+ * existing importers are unaffected.
+ */
+
+export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2';
+
+export const NON_EXTRACTABLE_AUDIT_SOURCE =
+  'cli:extract-conversation-facts:non-extractable:v2';
+
+/** Both audit-row source values, for callers that want a single IN-list. */
+export const AUDIT_ROW_SOURCES = [TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE] as const;

--- a/src/core/facts/audit-sources.ts
+++ b/src/core/facts/audit-sources.ts
@@ -9,6 +9,13 @@
  *     scanned page that contains no eligible multi-message segment, kept
  *     distinct from successful extraction so operator surfaces can report
  *     the truth without rescanning the page forever.
+ *   - `LEGACY_TERMINAL_AUDIT_SOURCE` — the pre-`:v2` spelling of
+ *     TERMINAL_AUDIT_SOURCE. `src/core/migrate.ts`'s doctor-backlog-index
+ *     comment and `test/extract-conversation-facts.test.ts` ("legacy
+ *     terminal rows do not suppress strict v2 replay") both reference this
+ *     exact string, so brains upgraded through the pre-v2 checkpoint scheme
+ *     can still carry rows under it. Excluded from recall the same as the
+ *     current spelling — a legacy checkpoint is not a user fact either.
  *
  * These are checkpoints, not user facts. Recall-side callers filter rows
  * whose `source` is one of these out of the newest-N fetch window (see
@@ -19,8 +26,8 @@
  * is forbidden (`scripts/check-engine-dynamic-import.sh`) — can reference
  * these values via a static top-level import instead of reaching into the
  * much heavier `commands/extract-conversation-facts.ts` command module.
- * `extract-conversation-facts.ts` re-exports both names unchanged so its
- * existing importers are unaffected.
+ * `extract-conversation-facts.ts` re-exports both current names unchanged
+ * so its existing importers are unaffected.
  */
 
 export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2';
@@ -28,5 +35,11 @@ export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2
 export const NON_EXTRACTABLE_AUDIT_SOURCE =
   'cli:extract-conversation-facts:non-extractable:v2';
 
-/** Both audit-row source values, for callers that want a single IN-list. */
-export const AUDIT_ROW_SOURCES = [TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE] as const;
+export const LEGACY_TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal';
+
+/** All audit-row source values (current + legacy), for callers that want a single IN-list. */
+export const AUDIT_ROW_SOURCES = [
+  TERMINAL_AUDIT_SOURCE,
+  NON_EXTRACTABLE_AUDIT_SOURCE,
+  LEGACY_TERMINAL_AUDIT_SOURCE,
+] as const;

--- a/src/core/ops/facts.ts
+++ b/src/core/ops/facts.ts
@@ -22,6 +22,7 @@ import { packToBudget, estimateTokens, resultTokens } from '../search/token-budg
 import { isAvailable } from '../ai/gateway.ts';
 import { MEMORY_VERBS_VERSION } from '../verbs.ts';
 import type { SearchResult } from '../types.ts';
+import { AUDIT_ROW_SOURCES } from '../facts/audit-sources.ts';
 
 // ============================================================
 // v0.31 — Hot memory ops: extract_facts / recall / forget_fact
@@ -268,12 +269,12 @@ const recall: Operation = {
     }
 
     // extract-conversation-facts writes durable audit checkpoint rows
-    // (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts
-    // table. They are checkpoints, not user facts. Every arm above already
-    // passes excludeAuditRows: true (SQL-level, both engines) — this
-    // client-side filter is belt-and-braces defense in depth, not the
-    // primary guard.
-    rows = rows.filter((r) => r.fact !== 'EXTRACTION_COMPLETE' && r.fact !== 'EXTRACTION_NOT_APPLICABLE');
+    // (source = TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE) into
+    // the facts table. They are checkpoints, not user facts. Every arm
+    // above already passes excludeAuditRows: true (SQL-level, both
+    // engines, keyed on `source` not `fact` text) — this client-side
+    // filter is belt-and-braces defense in depth, not the primary guard.
+    rows = rows.filter((r) => !(AUDIT_ROW_SOURCES as readonly string[]).includes(r.source));
 
     if (grep) rows = rows.filter(r => r.fact.toLowerCase().includes(grep));
 

--- a/src/core/ops/facts.ts
+++ b/src/core/ops/facts.ts
@@ -220,6 +220,7 @@ const recall: Operation = {
             activeOnly: !includeExpired,
             limit,
             visibility,
+            excludeAuditRows: true,
           });
         })),
         (rec) => rec.valid_from ?? rec.created_at,
@@ -231,6 +232,7 @@ const recall: Operation = {
             activeOnly: !includeExpired,
             limit,
             visibility,
+            excludeAuditRows: true,
           }),
         )),
         byCreated,
@@ -244,6 +246,7 @@ const recall: Operation = {
               activeOnly: !includeExpired,
               limit,
               visibility,
+              excludeAuditRows: true,
             }),
           )),
           byCreated,
@@ -257,11 +260,20 @@ const recall: Operation = {
             activeOnly: !includeExpired,
             limit,
             visibility,
+            excludeAuditRows: true,
           }),
         )),
         byCreated,
       );
     }
+
+    // extract-conversation-facts writes durable audit checkpoint rows
+    // (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts
+    // table. They are checkpoints, not user facts. Every arm above already
+    // passes excludeAuditRows: true (SQL-level, both engines) — this
+    // client-side filter is belt-and-braces defense in depth, not the
+    // primary guard.
+    rows = rows.filter((r) => r.fact !== 'EXTRACTION_COMPLETE' && r.fact !== 'EXTRACTION_NOT_APPLICABLE');
 
     if (grep) rows = rows.filter(r => r.fact.toLowerCase().includes(grep));
 

--- a/src/core/pglite-engine/facts.ts
+++ b/src/core/pglite-engine/facts.ts
@@ -247,9 +247,13 @@ export async function listFactsByEntity(
     entitySlug: string,
     opts?: FactListOpts,
   ): Promise<FactRow[]> {
+    const where: string[] = [`entity_slug = $entitySlug`];
+    if (opts?.excludeAuditRows === true) {
+      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+    }
     return _listFacts(deps, source_id, {
       ...opts,
-      whereClauses: [`entity_slug = $entitySlug`],
+      whereClauses: where,
       whereParams: { entitySlug },
       order: 'valid_from DESC, id DESC',
     });
@@ -267,6 +271,9 @@ export async function listFactsSince(
       where.push(`entity_slug = $entitySlug`);
       params.entitySlug = opts.entitySlug;
     }
+    if (opts?.excludeAuditRows === true) {
+      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+    }
     return _listFacts(deps, source_id, {
       ...opts,
       whereClauses: where,
@@ -281,9 +288,13 @@ export async function listFactsBySession(
     sessionId: string,
     opts?: FactListOpts,
   ): Promise<FactRow[]> {
+    const where: string[] = [`source_session = $sessionId`];
+    if (opts?.excludeAuditRows === true) {
+      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+    }
     return _listFacts(deps, source_id, {
       ...opts,
-      whereClauses: [`source_session = $sessionId`],
+      whereClauses: where,
       whereParams: { sessionId },
       order: 'created_at DESC, id DESC',
     });

--- a/src/core/pglite-engine/facts.ts
+++ b/src/core/pglite-engine/facts.ts
@@ -9,6 +9,7 @@ import type {
   NewFact, FactListOpts, FactsHealth,
 } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
+import { AUDIT_ROW_SOURCES } from '../facts/audit-sources.ts';
 
 /** Narrow slice of PGLiteEngine the facts operations use. */
 export interface PgliteFactsDeps {
@@ -248,13 +249,15 @@ export async function listFactsByEntity(
     opts?: FactListOpts,
   ): Promise<FactRow[]> {
     const where: string[] = [`entity_slug = $entitySlug`];
+    const whereParams: Record<string, unknown> = { entitySlug };
     if (opts?.excludeAuditRows === true) {
-      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+      where.push(`NOT (source = ANY($auditSources))`);
+      whereParams.auditSources = [...AUDIT_ROW_SOURCES];
     }
     return _listFacts(deps, source_id, {
       ...opts,
       whereClauses: where,
-      whereParams: { entitySlug },
+      whereParams,
       order: 'valid_from DESC, id DESC',
     });
   }
@@ -272,7 +275,8 @@ export async function listFactsSince(
       params.entitySlug = opts.entitySlug;
     }
     if (opts?.excludeAuditRows === true) {
-      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+      where.push(`NOT (source = ANY($auditSources))`);
+      params.auditSources = [...AUDIT_ROW_SOURCES];
     }
     return _listFacts(deps, source_id, {
       ...opts,
@@ -289,13 +293,15 @@ export async function listFactsBySession(
     opts?: FactListOpts,
   ): Promise<FactRow[]> {
     const where: string[] = [`source_session = $sessionId`];
+    const whereParams: Record<string, unknown> = { sessionId };
     if (opts?.excludeAuditRows === true) {
-      where.push(`fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')`);
+      where.push(`NOT (source = ANY($auditSources))`);
+      whereParams.auditSources = [...AUDIT_ROW_SOURCES];
     }
     return _listFacts(deps, source_id, {
       ...opts,
       whereClauses: where,
-      whereParams: { sessionId },
+      whereParams,
       order: 'created_at DESC, id DESC',
     });
   }

--- a/src/core/postgres-engine/facts.ts
+++ b/src/core/postgres-engine/facts.ts
@@ -231,6 +231,7 @@ export async function listFactsByEntity(
     const activeOnly = opts?.activeOnly !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
+    const excludeAuditRows = opts?.excludeAuditRows === true;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
@@ -238,6 +239,7 @@ export async function listFactsByEntity(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
       ORDER BY valid_from DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -257,6 +259,7 @@ export async function listFactsSince(
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const entitySlug = opts?.entitySlug ?? null;
+    const excludeAuditRows = opts?.excludeAuditRows === true;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
@@ -265,6 +268,7 @@ export async function listFactsSince(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -283,6 +287,7 @@ export async function listFactsBySession(
     const activeOnly = opts?.activeOnly !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
+    const excludeAuditRows = opts?.excludeAuditRows === true;
     const rows = await sql<FactRowSqlShape[]>`
       SELECT * FROM facts
       WHERE source_id = ${source_id}
@@ -290,6 +295,7 @@ export async function listFactsBySession(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
+        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;

--- a/src/core/postgres-engine/facts.ts
+++ b/src/core/postgres-engine/facts.ts
@@ -14,6 +14,7 @@ import type {
 } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import { tryParseEmbedding } from '../utils.ts';
+import { AUDIT_ROW_SOURCES } from '../facts/audit-sources.ts';
 
 /** Narrow slice of PostgresEngine the facts operations use. */
 export interface PgFactsDeps {
@@ -239,7 +240,7 @@ export async function listFactsByEntity(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
-        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
+        ${excludeAuditRows ? sql`AND source != ALL(${AUDIT_ROW_SOURCES}::text[])` : sql``}
       ORDER BY valid_from DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -268,7 +269,7 @@ export async function listFactsSince(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
-        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
+        ${excludeAuditRows ? sql`AND source != ALL(${AUDIT_ROW_SOURCES}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -295,7 +296,7 @@ export async function listFactsBySession(
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
-        ${excludeAuditRows ? sql`AND fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` : sql``}
+        ${excludeAuditRows ? sql`AND source != ALL(${AUDIT_ROW_SOURCES}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC
       LIMIT ${limit} OFFSET ${offset}
     `;

--- a/test/e2e/facts-separation-postgres.test.ts
+++ b/test/e2e/facts-separation-postgres.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { setupDB, teardownDB, hasDatabase, getEngine } from './helpers.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../../src/core/facts/audit-sources.ts';
 
 const RUN = hasDatabase();
 const d = RUN ? describe : describe.skip;
@@ -64,9 +65,10 @@ d("Cross-session recall test (Postgres)", () => {
   });
 
   // Mirrors test/facts-separation-pglite.test.ts. extract-conversation-facts
-  // writes durable audit checkpoint rows (EXTRACTION_COMPLETE /
-  // EXTRACTION_NOT_APPLICABLE) into the facts table; excludeAuditRows keeps
-  // them out of listFactsSince in SQL on both engines.
+  // writes durable audit checkpoint rows (source = TERMINAL_AUDIT_SOURCE /
+  // NON_EXTRACTABLE_AUDIT_SOURCE) into the facts table; excludeAuditRows
+  // keeps them out of listFactsSince in SQL on both engines, keyed on
+  // `source` (the writer), not on the fact TEXT.
   test('excludeAuditRows filters extraction audit checkpoint rows out of listFactsSince', async () => {
     const engine = getEngine();
     const before = new Date();
@@ -75,7 +77,7 @@ d("Cross-session recall test (Postgres)", () => {
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:terminal:v2',
+        source: TERMINAL_AUDIT_SOURCE,
         source_session: 'audit-checkpoint-session-pg',
         notability: 'low',
       },
@@ -86,7 +88,7 @@ d("Cross-session recall test (Postgres)", () => {
         fact: 'EXTRACTION_NOT_APPLICABLE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:non-extractable:v2',
+        source: NON_EXTRACTABLE_AUDIT_SOURCE,
         source_session: 'audit-checkpoint-session-pg',
         notability: 'low',
       },
@@ -98,25 +100,27 @@ d("Cross-session recall test (Postgres)", () => {
     );
 
     const withAudit = await engine.listFactsSince('default', before);
-    expect(withAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(true);
-    expect(withAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(true);
+    expect(withAudit.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(true);
+    expect(withAudit.some(r => r.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(true);
     expect(withAudit.some(r => r.fact === 'real user fact about travel plans (pg)')).toBe(true);
 
     const withoutAudit = await engine.listFactsSince('default', before, { excludeAuditRows: true });
-    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
-    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(withoutAudit.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(withoutAudit.some(r => r.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(withoutAudit.some(r => r.fact === 'real user fact about travel plans (pg)')).toBe(true);
   });
 
-  // The filter is an exact-match `fact NOT IN (...)`, not a substring/ILIKE
-  // match — a real fact that happens to CONTAIN one of the audit literals as
-  // a substring must still survive excludeAuditRows.
-  test('excludeAuditRows is exact-match, not substring — facts merely containing the audit literal survive (pg)', async () => {
+  // The predicate is keyed on the writer (`source`), not the fact TEXT — so
+  // a genuine user fact whose text happens to be EXACTLY one of the audit
+  // marker strings must NOT be excluded. Pre-fix, the predicate was
+  // `fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` —
+  // matching on fact TEXT — which hid this legitimate content.
+  test('excludeAuditRows only excludes audit-SOURCED rows — a real fact whose exact text matches an audit marker string survives (pg)', async () => {
     const engine = getEngine();
     const before = new Date();
     await engine.insertFact(
       {
-        fact: "the user's project tracker calls its done column EXTRACTION_COMPLETE (pg)",
+        fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: 'tracker-naming-pg',
         source: 'test',
@@ -124,18 +128,29 @@ d("Cross-session recall test (Postgres)", () => {
       { source_id: 'default' },
     );
     const rows = await engine.listFactsSince('default', before, { excludeAuditRows: true });
-    expect(
-      rows.some(r => r.fact === "the user's project tracker calls its done column EXTRACTION_COMPLETE (pg)"),
-    ).toBe(true);
+    expect(rows.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
   });
 
   // excludeAuditRows is honored consistently across all three FactListOpts
   // consumers (listFactsSince above, listFactsByEntity + listFactsBySession
-  // here) — not silently ignored on the shared options bag.
-  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession (pg)', async () => {
+  // here) — not silently ignored on the shared options bag. Also re-proves
+  // the source-vs-text distinction at these two call sites specifically.
+  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession, keyed on source not fact text (pg)', async () => {
     const engine = getEngine();
     await engine.insertFact(
       {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test-pg',
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: 'audit-entity-scope-session-pg',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        // Same fact TEXT as the audit-sourced row above, but a normal
+        // source — a real user fact that must survive exclusion.
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: 'audit-entity-scope-test-pg',
@@ -158,13 +173,15 @@ d("Cross-session recall test (Postgres)", () => {
     const byEntity = await engine.listFactsByEntity('default', 'audit-entity-scope-test-pg', {
       excludeAuditRows: true,
     });
-    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(byEntity.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
     expect(byEntity.some(r => r.fact === 'real fact under the same entity/session (pg)')).toBe(true);
 
     const bySession = await engine.listFactsBySession('default', 'audit-entity-scope-session-pg', {
       excludeAuditRows: true,
     });
-    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(bySession.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
     expect(bySession.some(r => r.fact === 'real fact under the same entity/session (pg)')).toBe(true);
   });
 });

--- a/test/e2e/facts-separation-postgres.test.ts
+++ b/test/e2e/facts-separation-postgres.test.ts
@@ -62,4 +62,109 @@ d("Cross-session recall test (Postgres)", () => {
     expect(old!.expired_at).not.toBeNull();
     expect(old!.superseded_by).toBe(r2.id);
   });
+
+  // Mirrors test/facts-separation-pglite.test.ts. extract-conversation-facts
+  // writes durable audit checkpoint rows (EXTRACTION_COMPLETE /
+  // EXTRACTION_NOT_APPLICABLE) into the facts table; excludeAuditRows keeps
+  // them out of listFactsSince in SQL on both engines.
+  test('excludeAuditRows filters extraction audit checkpoint rows out of listFactsSince', async () => {
+    const engine = getEngine();
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:terminal:v2',
+        source_session: 'audit-checkpoint-session-pg',
+        notability: 'low',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_NOT_APPLICABLE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:non-extractable:v2',
+        source_session: 'audit-checkpoint-session-pg',
+        notability: 'low',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: 'real user fact about travel plans (pg)', kind: 'fact', entity_slug: 'travel-pg', source: 'test' },
+      { source_id: 'default' },
+    );
+
+    const withAudit = await engine.listFactsSince('default', before);
+    expect(withAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(true);
+    expect(withAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(true);
+    expect(withAudit.some(r => r.fact === 'real user fact about travel plans (pg)')).toBe(true);
+
+    const withoutAudit = await engine.listFactsSince('default', before, { excludeAuditRows: true });
+    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(withoutAudit.some(r => r.fact === 'real user fact about travel plans (pg)')).toBe(true);
+  });
+
+  // The filter is an exact-match `fact NOT IN (...)`, not a substring/ILIKE
+  // match — a real fact that happens to CONTAIN one of the audit literals as
+  // a substring must still survive excludeAuditRows.
+  test('excludeAuditRows is exact-match, not substring — facts merely containing the audit literal survive (pg)', async () => {
+    const engine = getEngine();
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: "the user's project tracker calls its done column EXTRACTION_COMPLETE (pg)",
+        kind: 'fact',
+        entity_slug: 'tracker-naming-pg',
+        source: 'test',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsSince('default', before, { excludeAuditRows: true });
+    expect(
+      rows.some(r => r.fact === "the user's project tracker calls its done column EXTRACTION_COMPLETE (pg)"),
+    ).toBe(true);
+  });
+
+  // excludeAuditRows is honored consistently across all three FactListOpts
+  // consumers (listFactsSince above, listFactsByEntity + listFactsBySession
+  // here) — not silently ignored on the shared options bag.
+  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession (pg)', async () => {
+    const engine = getEngine();
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test-pg',
+        source: 'test',
+        source_session: 'audit-entity-scope-session-pg',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: 'real fact under the same entity/session (pg)',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test-pg',
+        source: 'test',
+        source_session: 'audit-entity-scope-session-pg',
+      },
+      { source_id: 'default' },
+    );
+
+    const byEntity = await engine.listFactsByEntity('default', 'audit-entity-scope-test-pg', {
+      excludeAuditRows: true,
+    });
+    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(byEntity.some(r => r.fact === 'real fact under the same entity/session (pg)')).toBe(true);
+
+    const bySession = await engine.listFactsBySession('default', 'audit-entity-scope-session-pg', {
+      excludeAuditRows: true,
+    });
+    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(bySession.some(r => r.fact === 'real fact under the same entity/session (pg)')).toBe(true);
+  });
 });

--- a/test/facts-recall-audit-rows.test.ts
+++ b/test/facts-recall-audit-rows.test.ts
@@ -1,0 +1,195 @@
+/**
+ * recall (MCP op) + `gbrain recall` (CLI) — audit checkpoint rows are
+ * excluded from output.
+ *
+ * extract-conversation-facts writes durable audit checkpoint rows
+ * (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts table to
+ * mark batch-run progress (see src/commands/extract-conversation-facts.ts,
+ * writeTerminalAuditRow / writeNonExtractableAuditRow). Their created_at is
+ * always the most recent write, so right after a batch run they dominate the
+ * newest-N fetch window that trusted (remote=false / local CLI) callers hit
+ * — recall returns audit rows instead of real facts.
+ *
+ * This exercises the fix at BOTH trusted read surfaces:
+ *   - the MCP `recall` op handler (src/core/operations.ts) via
+ *     dispatchToolCall, and
+ *   - the `gbrain recall` CLI's local (non-thin-client) path
+ *     (src/commands/recall.ts `fetchRowsLocal`), which calls the engine
+ *     directly and does NOT go through the op handler — so it needed its
+ *     own excludeAuditRows wiring, not just operations.ts.
+ *
+ * Engine-level parity coverage lives in test/facts-separation-pglite.test.ts
+ * + test/e2e/facts-separation-postgres.test.ts.
+ *
+ * PGLite-only; no DATABASE_URL required.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { dispatchToolCall } from '../src/mcp/dispatch.ts';
+import { runRecall } from '../src/commands/recall.ts';
+import { withEnv, emptyHome } from './helpers/with-env.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // Seed order matters: the real fact goes in FIRST (older created_at), then
+  // the audit checkpoint rows go in AFTER (newer created_at) — mirroring
+  // real production order, where extract-conversation-facts writes its
+  // terminal audit row only after processing (and inserting facts for) a
+  // batch of pages. With ORDER BY created_at DESC, id DESC, this makes the
+  // audit rows occupy the newest-N window and the real fact fall OUTSIDE a
+  // small limit — the exact crowd-out failure mode this PR fixes. (Seeding
+  // audit rows before the real fact, as an earlier draft of this test did,
+  // makes the real fact newest and the test passes even without the SQL-
+  // level fix — non-discriminative.)
+  await engine.insertFact(
+    {
+      fact: 'the user prefers oat milk in their coffee',
+      kind: 'preference',
+      entity_slug: 'coffee-prefs',
+      source: 'test',
+      visibility: 'world',
+    },
+    { source_id: 'default' },
+  );
+  for (let i = 0; i < 5; i++) {
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:terminal:v2',
+        source_session: `audit-batch-${i}`,
+        notability: 'low',
+      },
+      { source_id: 'default' },
+    );
+  }
+  await engine.insertFact(
+    {
+      fact: 'EXTRACTION_NOT_APPLICABLE',
+      kind: 'fact',
+      entity_slug: null,
+      source: 'cli:extract-conversation-facts:non-extractable:v2',
+      source_session: 'audit-batch-na',
+      notability: 'low',
+    },
+    { source_id: 'default' },
+  );
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('recall op excludes extract-conversation-facts audit rows', () => {
+  test('recall with limit smaller than the audit-row count still surfaces the real fact (since arm)', async () => {
+    // limit=3 is smaller than the 6 audit rows seeded above (and they are
+    // ALL newer than the real fact per the seed order in beforeAll) —
+    // pre-fix, ORDER BY created_at DESC LIMIT 3 returns only audit rows and
+    // the real fact never appears. Post-fix, excludeAuditRows removes them
+    // from the SQL result set before LIMIT is applied.
+    const result = await dispatchToolCall(
+      engine,
+      'recall',
+      { since: '1 hour ago', limit: 3 },
+      { remote: false, sourceId: 'default' },
+    );
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const facts: Array<{ fact: string }> = payload.facts;
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+  });
+
+  test('recall with no filter (default recent-across-source arm) excludes audit rows', async () => {
+    const result = await dispatchToolCall(
+      engine,
+      'recall',
+      { limit: 3 },
+      { remote: false, sourceId: 'default' },
+    );
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const facts: Array<{ fact: string }> = payload.facts;
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+  });
+
+  // Production audit rows are always written with the default (private)
+  // visibility, so a remote (world-only) caller already can't see them via
+  // the visibility filter alone — that would make a remote-arm test using
+  // the shared beforeAll corpus non-discriminative for excludeAuditRows
+  // specifically. This test seeds its OWN world-visible audit-shaped row to
+  // prove exclusion doesn't depend on visibility (defense in depth: if a
+  // future change ever made audit rows world-visible, this still holds).
+  test('remote=true (world-only visibility) excludes audit rows even when they are world-visible', async () => {
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:terminal:v2',
+        source_session: 'audit-world-visible-probe',
+        notability: 'low',
+        visibility: 'world',
+      },
+      { source_id: 'default' },
+    );
+    const result = await dispatchToolCall(
+      engine,
+      'recall',
+      { since: '1 hour ago', limit: 10 },
+      { remote: true, sourceId: 'default' },
+    );
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const facts: Array<{ fact: string }> = payload.facts;
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+  });
+});
+
+describe('gbrain recall CLI (local, non-thin-client path) excludes audit rows', () => {
+  const origWrite = process.stdout.write.bind(process.stdout);
+
+  test('runRecall --json --limit 3 surfaces the real fact, not the audit rows', async () => {
+    // fetchRowsLocal (src/commands/recall.ts) calls engine.listFactsSince
+    // directly — it does NOT go through the operations.ts `recall` handler,
+    // so it needed its own excludeAuditRows: true wiring. This is the
+    // Critical-severity gap this test pins.
+    //
+    // runRecall's local-vs-thin-client branch depends on loadConfig() /
+    // isThinClient(), which reads the REAL ~/.gbrain/config.json (via
+    // configDir(), GBRAIN_HOME-overridable) — on a dev machine configured as
+    // a thin client (remote_mcp set), this test would silently switch to
+    // callRemoteTool() and never exercise fetchRowsLocal at all. GBRAIN_HOME
+    // -> emptyHome() forces loadConfig() to see no config file, so
+    // isThinClient() is deterministically false here. Canonical isolation
+    // pattern for this repo (test/helpers/with-env.ts).
+    let captured = '';
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await withEnv({ GBRAIN_HOME: emptyHome() }, async () => {
+        await runRecall(engine, ['--json', '--limit', '3']);
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const payload = JSON.parse(captured.trim());
+    const facts: Array<{ fact: string }> = payload.facts;
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+  });
+});

--- a/test/facts-recall-audit-rows.test.ts
+++ b/test/facts-recall-audit-rows.test.ts
@@ -2,13 +2,18 @@
  * recall (MCP op) + `gbrain recall` (CLI) — audit checkpoint rows are
  * excluded from output.
  *
- * extract-conversation-facts writes durable audit checkpoint rows
- * (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts table to
- * mark batch-run progress (see src/commands/extract-conversation-facts.ts,
- * writeTerminalAuditRow / writeNonExtractableAuditRow). Their created_at is
- * always the most recent write, so right after a batch run they dominate the
- * newest-N fetch window that trusted (remote=false / local CLI) callers hit
- * — recall returns audit rows instead of real facts.
+ * extract-conversation-facts writes durable audit checkpoint rows — source
+ * TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE
+ * (src/core/facts/audit-sources.ts) — into the facts table to mark
+ * batch-run progress. Their created_at is always the most recent write, so
+ * right after a batch run they dominate the newest-N fetch window that
+ * trusted (remote=false / local CLI) callers hit — recall returns audit
+ * rows instead of real facts.
+ *
+ * The exclusion predicate is keyed on `source` (the writer), not on the
+ * fact TEXT — a real fact whose text happens to equal one of the audit
+ * marker strings must still come back. See the 'EXTRACTION_COMPLETE'/source:
+ * 'test' row seeded in beforeAll and asserted present in every test below.
  *
  * This exercises the fix at BOTH trusted read surfaces:
  *   - the MCP `recall` op handler (src/core/operations.ts) via
@@ -29,6 +34,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { dispatchToolCall } from '../src/mcp/dispatch.ts';
 import { runRecall } from '../src/commands/recall.ts';
 import { withEnv, emptyHome } from './helpers/with-env.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../src/core/facts/audit-sources.ts';
 
 let engine: PGLiteEngine;
 
@@ -57,13 +63,28 @@ beforeAll(async () => {
     },
     { source_id: 'default' },
   );
+  // A genuine user fact whose TEXT happens to be exactly the audit marker
+  // string, but written by a normal (non-audit) source. This is the case
+  // the OLD `fact NOT IN ('EXTRACTION_COMPLETE', ...)` predicate got wrong
+  // — it matched on fact TEXT and hid this real content. The fix keys the
+  // predicate on `source` instead, so this row must survive exclusion.
+  await engine.insertFact(
+    {
+      fact: 'EXTRACTION_COMPLETE',
+      kind: 'fact',
+      entity_slug: 'coffee-prefs',
+      source: 'test',
+      visibility: 'world',
+    },
+    { source_id: 'default' },
+  );
   for (let i = 0; i < 5; i++) {
     await engine.insertFact(
       {
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:terminal:v2',
+        source: TERMINAL_AUDIT_SOURCE,
         source_session: `audit-batch-${i}`,
         notability: 'low',
       },
@@ -75,7 +96,7 @@ beforeAll(async () => {
       fact: 'EXTRACTION_NOT_APPLICABLE',
       kind: 'fact',
       entity_slug: null,
-      source: 'cli:extract-conversation-facts:non-extractable:v2',
+      source: NON_EXTRACTABLE_AUDIT_SOURCE,
       source_session: 'audit-batch-na',
       notability: 'low',
     },
@@ -102,10 +123,14 @@ describe('recall op excludes extract-conversation-facts audit rows', () => {
     );
     expect(result.isError).toBeFalsy();
     const payload = JSON.parse(result.content[0].text);
-    const facts: Array<{ fact: string }> = payload.facts;
-    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
-    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    const facts: Array<{ fact: string; source: string }> = payload.facts;
+    expect(facts.some(f => f.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(facts.some(f => f.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+    // The real fact whose TEXT equals the audit marker, but whose source is
+    // normal, must NOT be excluded — this is what a text-based predicate
+    // would get wrong.
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE' && f.source === 'test')).toBe(true);
   });
 
   test('recall with no filter (default recent-across-source arm) excludes audit rows', async () => {
@@ -117,10 +142,11 @@ describe('recall op excludes extract-conversation-facts audit rows', () => {
     );
     expect(result.isError).toBeFalsy();
     const payload = JSON.parse(result.content[0].text);
-    const facts: Array<{ fact: string }> = payload.facts;
-    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
-    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    const facts: Array<{ fact: string; source: string }> = payload.facts;
+    expect(facts.some(f => f.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(facts.some(f => f.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE' && f.source === 'test')).toBe(true);
   });
 
   // Production audit rows are always written with the default (private)
@@ -136,7 +162,7 @@ describe('recall op excludes extract-conversation-facts audit rows', () => {
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:terminal:v2',
+        source: TERMINAL_AUDIT_SOURCE,
         source_session: 'audit-world-visible-probe',
         notability: 'low',
         visibility: 'world',
@@ -151,9 +177,10 @@ describe('recall op excludes extract-conversation-facts audit rows', () => {
     );
     expect(result.isError).toBeFalsy();
     const payload = JSON.parse(result.content[0].text);
-    const facts: Array<{ fact: string }> = payload.facts;
-    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    const facts: Array<{ fact: string; source: string }> = payload.facts;
+    expect(facts.some(f => f.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
     expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE' && f.source === 'test')).toBe(true);
   });
 });
 
@@ -187,9 +214,10 @@ describe('gbrain recall CLI (local, non-thin-client path) excludes audit rows', 
       process.stdout.write = origWrite;
     }
     const payload = JSON.parse(captured.trim());
-    const facts: Array<{ fact: string }> = payload.facts;
-    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE')).toBe(false);
-    expect(facts.some(f => f.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    const facts: Array<{ fact: string; source: string }> = payload.facts;
+    expect(facts.some(f => f.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(facts.some(f => f.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
+    expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE' && f.source === 'test')).toBe(true);
   });
 });

--- a/test/facts-recall-audit-rows.test.ts
+++ b/test/facts-recall-audit-rows.test.ts
@@ -34,7 +34,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { dispatchToolCall } from '../src/mcp/dispatch.ts';
 import { runRecall } from '../src/commands/recall.ts';
 import { withEnv, emptyHome } from './helpers/with-env.ts';
-import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../src/core/facts/audit-sources.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE, LEGACY_TERMINAL_AUDIT_SOURCE } from '../src/core/facts/audit-sources.ts';
 
 let engine: PGLiteEngine;
 
@@ -219,5 +219,52 @@ describe('gbrain recall CLI (local, non-thin-client path) excludes audit rows', 
     expect(facts.some(f => f.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
     expect(facts.some(f => f.fact === 'EXTRACTION_COMPLETE' && f.source === 'test')).toBe(true);
+  });
+});
+
+// Post-review fix: AUDIT_ROW_SOURCES omitted the pre-`:v2` spelling of
+// TERMINAL_AUDIT_SOURCE. src/core/migrate.ts's doctor-backlog-index comment
+// and test/extract-conversation-facts.test.ts ("legacy terminal rows do not
+// suppress strict v2 replay") both reference this exact legacy string, so
+// brains upgraded through the pre-v2 checkpoint scheme can still carry rows
+// under it — and those rows crowded out real facts the same way the current
+// spelling did before this PR's fix, because the recall-side exclusion never
+// matched them.
+describe('post-review fix: legacy (pre-v2) terminal audit rows are also excluded', () => {
+  let engine2: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine2 = new PGLiteEngine();
+    await engine2.connect({});
+    await engine2.initSchema();
+
+    await engine2.insertFact(
+      { fact: 'the user prefers oat milk in their coffee', kind: 'preference', entity_slug: 'coffee-prefs', source: 'test', visibility: 'world' },
+      { source_id: 'default' },
+    );
+    for (let i = 0; i < 5; i++) {
+      await engine2.insertFact(
+        { fact: 'EXTRACTION_COMPLETE', kind: 'fact', entity_slug: null, source: LEGACY_TERMINAL_AUDIT_SOURCE, source_session: `legacy-audit-batch-${i}`, notability: 'low' },
+        { source_id: 'default' },
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await engine2.disconnect();
+  });
+
+  test('legacy-source audit rows do not crowd out the real fact (recall op, since arm)', async () => {
+    const result = await dispatchToolCall(
+      engine2,
+      'recall',
+      { since: '1 hour ago', limit: 3 },
+      { remote: false, sourceId: 'default' },
+    );
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text);
+    const facts: Array<{ fact: string; source: string }> = payload.facts;
+    expect(facts.some(f => f.source === LEGACY_TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(facts.some(f => f.fact === 'the user prefers oat milk in their coffee')).toBe(true);
   });
 });

--- a/test/facts-separation-pglite.test.ts
+++ b/test/facts-separation-pglite.test.ts
@@ -72,4 +72,113 @@ describe("Cross-session recall test (PGLite)", () => {
     expect(all.length).toBe(1);
     expect(all[0].expired_at).not.toBeNull();
   });
+
+  // extract-conversation-facts writes durable audit checkpoint rows
+  // (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts table
+  // to mark batch-run progress. Their created_at is always the most recent
+  // write, so for trusted callers (no visibility filter) they dominate the
+  // newest-N fetch window right after a batch run and starve recall of real
+  // facts. excludeAuditRows keeps them out in SQL. Postgres parity in
+  // test/e2e/facts-separation-postgres.test.ts.
+  test('excludeAuditRows filters extraction audit checkpoint rows out of listFactsSince', async () => {
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:terminal:v2',
+        source_session: 'audit-checkpoint-session',
+        notability: 'low',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_NOT_APPLICABLE',
+        kind: 'fact',
+        entity_slug: null,
+        source: 'cli:extract-conversation-facts:non-extractable:v2',
+        source_session: 'audit-checkpoint-session',
+        notability: 'low',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: 'real user fact about travel plans', kind: 'fact', entity_slug: 'travel', source: 'test' },
+      { source_id: 'default' },
+    );
+
+    // Default behavior (no excludeAuditRows) is unchanged: audit rows still
+    // come back, same as before this PR.
+    const withAudit = await engine.listFactsSince('default', before);
+    expect(withAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(true);
+    expect(withAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(true);
+    expect(withAudit.some(r => r.fact === 'real user fact about travel plans')).toBe(true);
+
+    // excludeAuditRows: true strips both audit fact literals, real facts
+    // remain.
+    const withoutAudit = await engine.listFactsSince('default', before, { excludeAuditRows: true });
+    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(withoutAudit.some(r => r.fact === 'real user fact about travel plans')).toBe(true);
+  });
+
+  // The filter is an exact-match `fact NOT IN (...)`, not a substring/ILIKE
+  // match — a real fact that happens to CONTAIN one of the audit literals as
+  // a substring must still survive excludeAuditRows.
+  test('excludeAuditRows is exact-match, not substring — facts merely containing the audit literal survive', async () => {
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: "the user's project tracker calls its done column EXTRACTION_COMPLETE",
+        kind: 'fact',
+        entity_slug: 'tracker-naming',
+        source: 'test',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsSince('default', before, { excludeAuditRows: true });
+    expect(
+      rows.some(r => r.fact === "the user's project tracker calls its done column EXTRACTION_COMPLETE"),
+    ).toBe(true);
+  });
+
+  // excludeAuditRows is honored consistently across all three FactListOpts
+  // consumers (listFactsSince above, listFactsByEntity + listFactsBySession
+  // here) — not silently ignored on the shared options bag.
+  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession', async () => {
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test',
+        source: 'test',
+        source_session: 'audit-entity-scope-session',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: 'real fact under the same entity/session',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test',
+        source: 'test',
+        source_session: 'audit-entity-scope-session',
+      },
+      { source_id: 'default' },
+    );
+
+    const byEntity = await engine.listFactsByEntity('default', 'audit-entity-scope-test', {
+      excludeAuditRows: true,
+    });
+    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(byEntity.some(r => r.fact === 'real fact under the same entity/session')).toBe(true);
+
+    const bySession = await engine.listFactsBySession('default', 'audit-entity-scope-session', {
+      excludeAuditRows: true,
+    });
+    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(bySession.some(r => r.fact === 'real fact under the same entity/session')).toBe(true);
+  });
 });

--- a/test/facts-separation-pglite.test.ts
+++ b/test/facts-separation-pglite.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../src/core/facts/audit-sources.ts';
 
 let engine: PGLiteEngine;
 
@@ -74,11 +75,12 @@ describe("Cross-session recall test (PGLite)", () => {
   });
 
   // extract-conversation-facts writes durable audit checkpoint rows
-  // (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE) into the facts table
-  // to mark batch-run progress. Their created_at is always the most recent
-  // write, so for trusted callers (no visibility filter) they dominate the
-  // newest-N fetch window right after a batch run and starve recall of real
-  // facts. excludeAuditRows keeps them out in SQL. Postgres parity in
+  // (source = TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE) into the
+  // facts table to mark batch-run progress. Their created_at is always the
+  // most recent write, so for trusted callers (no visibility filter) they
+  // dominate the newest-N fetch window right after a batch run and starve
+  // recall of real facts. excludeAuditRows keeps them out in SQL, keyed on
+  // `source` (the writer), not on the fact TEXT. Postgres parity in
   // test/e2e/facts-separation-postgres.test.ts.
   test('excludeAuditRows filters extraction audit checkpoint rows out of listFactsSince', async () => {
     const before = new Date();
@@ -87,7 +89,7 @@ describe("Cross-session recall test (PGLite)", () => {
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:terminal:v2',
+        source: TERMINAL_AUDIT_SOURCE,
         source_session: 'audit-checkpoint-session',
         notability: 'low',
       },
@@ -98,7 +100,7 @@ describe("Cross-session recall test (PGLite)", () => {
         fact: 'EXTRACTION_NOT_APPLICABLE',
         kind: 'fact',
         entity_slug: null,
-        source: 'cli:extract-conversation-facts:non-extractable:v2',
+        source: NON_EXTRACTABLE_AUDIT_SOURCE,
         source_session: 'audit-checkpoint-session',
         notability: 'low',
       },
@@ -112,26 +114,31 @@ describe("Cross-session recall test (PGLite)", () => {
     // Default behavior (no excludeAuditRows) is unchanged: audit rows still
     // come back, same as before this PR.
     const withAudit = await engine.listFactsSince('default', before);
-    expect(withAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(true);
-    expect(withAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(true);
+    expect(withAudit.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(true);
+    expect(withAudit.some(r => r.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(true);
     expect(withAudit.some(r => r.fact === 'real user fact about travel plans')).toBe(true);
 
-    // excludeAuditRows: true strips both audit fact literals, real facts
-    // remain.
+    // excludeAuditRows: true strips rows written by either audit source,
+    // real facts remain.
     const withoutAudit = await engine.listFactsSince('default', before, { excludeAuditRows: true });
-    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
-    expect(withoutAudit.some(r => r.fact === 'EXTRACTION_NOT_APPLICABLE')).toBe(false);
+    expect(withoutAudit.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(withoutAudit.some(r => r.source === NON_EXTRACTABLE_AUDIT_SOURCE)).toBe(false);
     expect(withoutAudit.some(r => r.fact === 'real user fact about travel plans')).toBe(true);
   });
 
-  // The filter is an exact-match `fact NOT IN (...)`, not a substring/ILIKE
-  // match — a real fact that happens to CONTAIN one of the audit literals as
-  // a substring must still survive excludeAuditRows.
-  test('excludeAuditRows is exact-match, not substring — facts merely containing the audit literal survive', async () => {
+  // The predicate is keyed on the writer (`source`), not the fact TEXT — so
+  // a genuine user fact whose text happens to be EXACTLY one of the audit
+  // marker strings must NOT be excluded. Pre-fix, the predicate was
+  // `fact NOT IN ('EXTRACTION_COMPLETE', 'EXTRACTION_NOT_APPLICABLE')` —
+  // matching on fact TEXT — which hid this legitimate content; this is the
+  // crowd-out case that motivated moving the predicate to `source`. (A
+  // substring/partial match was never at risk either way: `NOT IN` and
+  // `source != ALL(...)` are both exact-match.)
+  test('excludeAuditRows only excludes audit-SOURCED rows — a real fact whose exact text matches an audit marker string survives', async () => {
     const before = new Date();
     await engine.insertFact(
       {
-        fact: "the user's project tracker calls its done column EXTRACTION_COMPLETE",
+        fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: 'tracker-naming',
         source: 'test',
@@ -139,17 +146,28 @@ describe("Cross-session recall test (PGLite)", () => {
       { source_id: 'default' },
     );
     const rows = await engine.listFactsSince('default', before, { excludeAuditRows: true });
-    expect(
-      rows.some(r => r.fact === "the user's project tracker calls its done column EXTRACTION_COMPLETE"),
-    ).toBe(true);
+    expect(rows.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
   });
 
   // excludeAuditRows is honored consistently across all three FactListOpts
   // consumers (listFactsSince above, listFactsByEntity + listFactsBySession
-  // here) — not silently ignored on the shared options bag.
-  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession', async () => {
+  // here) — not silently ignored on the shared options bag. Also re-proves
+  // the source-vs-text distinction at these two call sites specifically.
+  test('excludeAuditRows also filters listFactsByEntity and listFactsBySession, keyed on source not fact text', async () => {
     await engine.insertFact(
       {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: 'audit-entity-scope-test',
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: 'audit-entity-scope-session',
+      },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        // Same fact TEXT as the audit-sourced row above, but a normal
+        // source — a real user fact that must survive exclusion.
         fact: 'EXTRACTION_COMPLETE',
         kind: 'fact',
         entity_slug: 'audit-entity-scope-test',
@@ -172,13 +190,15 @@ describe("Cross-session recall test (PGLite)", () => {
     const byEntity = await engine.listFactsByEntity('default', 'audit-entity-scope-test', {
       excludeAuditRows: true,
     });
-    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(byEntity.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(byEntity.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
     expect(byEntity.some(r => r.fact === 'real fact under the same entity/session')).toBe(true);
 
     const bySession = await engine.listFactsBySession('default', 'audit-entity-scope-session', {
       excludeAuditRows: true,
     });
-    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE')).toBe(false);
+    expect(bySession.some(r => r.source === TERMINAL_AUDIT_SOURCE)).toBe(false);
+    expect(bySession.some(r => r.fact === 'EXTRACTION_COMPLETE' && r.source === 'test')).toBe(true);
     expect(bySession.some(r => r.fact === 'real fact under the same entity/session')).toBe(true);
   });
 });


### PR DESCRIPTION
## What

`extract-conversation-facts` writes durable audit checkpoint rows
(`EXTRACTION_COMPLETE` / `EXTRACTION_NOT_APPLICABLE`) into the `facts` table
to mark batch-run progress (`writeTerminalAuditRow` / `writeNonExtractableAuditRow`
in `src/commands/extract-conversation-facts.ts`). Their `created_at` is
the audit write time — within each page's run they land after that page's
facts — so right after a batch run they can occupy the newest-N fetch window
for trusted callers (no visibility filter), and `recall --since` (and the
no-filter arm) can return audit checkpoint rows instead of real user facts. With a small `--limit` and a multi-page batch run, the
audit rows alone can fill the window and the real facts never surface.

This PR adds `FactListOpts.excludeAuditRows?: boolean` and wires it into
every trusted `recall` read path (other internal fact readers such as
`facts/meta-hook.ts` do not pass the flag and keep their existing view):

- Both engines (`src/core/postgres-engine.ts`, `src/core/pglite-engine.ts`)
  honor it as a SQL `WHERE fact NOT IN ('EXTRACTION_COMPLETE',
  'EXTRACTION_NOT_APPLICABLE')` clause, consistently across all three
  `FactListOpts` consumers — `listFactsByEntity`, `listFactsBySession`,
  `listFactsSince` — not just the one call site that originally surfaced the
  bug.
- The `recall` MCP op (`src/core/operations.ts`) passes it on every arm
  (entity / session / since / no-filter), plus keeps a client-side filter as
  belt-and-braces defense in depth.
- The `gbrain recall` CLI's local (non-thin-client) path
  (`src/commands/recall.ts` `fetchRowsLocal`) also passes it — this path
  calls the engine directly and does **not** go through the `recall` op
  handler, so it needed its own fix (caught in review; see below).

Off by default, so any existing caller that intentionally wants the full row
set (e.g. an internal checkpoint audit) is unaffected.

## Scope boundary (deliberate)

This PR is narrow on purpose:

- **Only** `excludeAuditRows`. A separate, unrelated concern (in-SQL event-time
  ordering via a `FactListOpts.eventTime` field, and in-SQL grep via
  `FactListOpts.grepText`) is explicitly **not** included here — different
  problem, different PR.
- **Not** attempting to separate audit checkpoint rows into their own table.
  That's a bigger design question (schema surface, migration, backward
  compat for existing checkpoint state) that I'm leaving to maintainer
  judgment rather than bundling into a bug-fix PR. This PR only changes what
  `recall`'s read paths return — it does not change how or where the audit
  rows are written.

## Testing

- `bun run typecheck`: clean.
- Engine-level parity tests (PGLite always-on + Postgres gated by
  `DATABASE_URL`, mirrored files): `test/facts-separation-pglite.test.ts` /
  `test/e2e/facts-separation-postgres.test.ts`. Cover: basic exclude/include
  toggle, exact-match-not-substring (a real fact merely *containing* the
  audit literal as a substring survives), and `listFactsByEntity` /
  `listFactsBySession` honoring the flag.
- Op-level end-to-end test (new file, `test/facts-recall-audit-rows.test.ts`):
  exercises the `recall` MCP op via `dispatchToolCall` (since arm with a
  `limit` smaller than the seeded audit-row count — the actual crowd-out
  failure mode — plus the no-filter arm and a world-visible-audit-row
  defense-in-depth case for `remote=true`), **and** the `gbrain recall` CLI's
  local path via `runRecall` directly (isolated from the operator's real
  `~/.gbrain/config.json` via `GBRAIN_HOME` -> a fresh temp dir, so the test
  deterministically exercises `fetchRowsLocal` instead of possibly routing
  through `callRemoteTool` on a thin-client-configured machine).
- Discriminativeness is a reproducible property of the tests: flip the
  `recall` op's since and no-filter `excludeAuditRows: true` call sites in
  `src/core/operations.ts` to `false` and their two SQL-dependent op-level
  tests go red (one per call site); restore them and they pass.
- `bun run typecheck` clean; the full suite runs in CI (all checks green on
  this PR).
- Postgres e2e tests skip gracefully (no `DATABASE_URL` in this sandbox) —
  PGLite side is fully exercised; the Postgres SQL is the same shape as the
  existing PGLite-parity pattern in this file.



