### PR TITLE
fix(pglite): batch code edge inserts below bind limit

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -95,6 +95,12 @@ import { hasCJK, escapeLikePattern } from './cjk.ts';
 
 type PGLiteDB = PGlite;
 
+// PGLite's parameter bridge corrupts the current engine session when a single
+// statement crosses the signed-int16 bind ceiling (32,767 parameters). Keep
+// bulk code-edge writes comfortably below it; the two edge shapes use 7 and 6
+// binds per row respectively.
+const PGLITE_EDGE_BATCH_MAX_BIND_PARAMS = 30_000;
+
 // Tier 3 snapshot fast-restore. Reads a tar dump produced by
 // `bun run scripts/build-pglite-snapshot.ts`. Snapshot is matched against
 // the current MIGRATIONS hash via a sidecar `.version` file; on mismatch we
@@ -5987,11 +5993,13 @@ export class PGLiteEngine implements BrainEngine {
     const resolved = edges.filter(e => e.to_chunk_id != null);
     const unresolved = edges.filter(e => e.to_chunk_id == null);
 
-    if (resolved.length > 0) {
+    const resolvedBatchSize = Math.floor(PGLITE_EDGE_BATCH_MAX_BIND_PARAMS / 7);
+    for (let offset = 0; offset < resolved.length; offset += resolvedBatchSize) {
+      const batch = resolved.slice(offset, offset + resolvedBatchSize);
       const rowParts: string[] = [];
       const params: unknown[] = [];
       let p = 1;
-      for (const e of resolved) {
+      for (const e of batch) {
         rowParts.push(`($${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}::jsonb, $${p++})`);
         params.push(
           e.from_chunk_id, e.to_chunk_id, e.from_symbol_qualified,
@@ -6009,11 +6017,14 @@ export class PGLiteEngine implements BrainEngine {
       );
       inserted += res.affectedRows ?? 0;
     }
-    if (unresolved.length > 0) {
+
+    const unresolvedBatchSize = Math.floor(PGLITE_EDGE_BATCH_MAX_BIND_PARAMS / 6);
+    for (let offset = 0; offset < unresolved.length; offset += unresolvedBatchSize) {
+      const batch = unresolved.slice(offset, offset + unresolvedBatchSize);
       const rowParts: string[] = [];
       const params: unknown[] = [];
       let p = 1;
-      for (const e of unresolved) {
+      for (const e of batch) {
         rowParts.push(`($${p++}, $${p++}, $${p++}, $${p++}, $${p++}::jsonb, $${p++})`);
         params.push(
           e.from_chunk_id, e.from_symbol_qualified, e.to_symbol_qualified, e.edge_type,

--- a/test/code-edges.test.ts
+++ b/test/code-edges.test.ts
@@ -139,4 +139,40 @@ describe('Layer 5 (A1) — code-edges engine methods', () => {
     const inserted = await engine.addCodeEdges([]);
     expect(inserted).toBe(0);
   });
+
+  test('batches edge writes before PGLite parameter overflow poisons later writes', async () => {
+    // Six binds per unresolved edge. 5,462 rows require 32,772 binds, which
+    // crosses PGLite's signed-int16 ceiling. Before batching, addCodeEdges
+    // misleadingly returned success but every subsequent putPage produced no
+    // row until the process restarted.
+    const edgeCount = 5_462;
+    const inserted = await engine.addCodeEdges(
+      Array.from({ length: edgeCount }, (_, i) => ({
+        from_chunk_id: chunkA,
+        to_chunk_id: null,
+        from_symbol_qualified: 'run',
+        to_symbol_qualified: `overflow-target-${i}`,
+        edge_type: 'calls',
+      })),
+    );
+    expect(inserted).toBe(edgeCount);
+
+    const rows = await engine.executeRaw<{ count: number | string }>(
+      `SELECT COUNT(*) AS count
+         FROM code_edges_symbol
+        WHERE from_chunk_id = $1
+          AND to_symbol_qualified LIKE 'overflow-target-%'`,
+      [chunkA],
+    );
+    expect(Number(rows[0]!.count)).toBe(edgeCount);
+
+    const page = await engine.putPage('post-edge-batch-smoke', {
+      type: 'code', page_kind: 'code',
+      title: 'Post-edge batch smoke',
+      compiled_truth: 'export const stillWritable = true;',
+      timeline: '',
+    });
+    expect(page.slug).toBe('post-edge-batch-smoke');
+    expect((await engine.getPage('post-edge-batch-smoke'))?.slug).toBe(page.slug);
+  });
 });


### PR DESCRIPTION
## Summary

Batch PGLite code-edge inserts below its signed-16-bit parameter limit.

A generated TypeScript declaration produced 5,826 unresolved edges in one statement (34,956 bind parameters). Above 32,767 parameters PGLite reported success but poisoned the session, causing later imports to silently fail.

This caps batches at 30,000 parameters: 5,000 unresolved edges or 4,285 resolved edges.

## Validation

- `bun test test/code-edges.test.ts` (9 passing), including a 5,462-edge regression followed by a successful page write
- `bun test test/import-code-edges-source-id.test.ts` (2 passing)
- `bun run typecheck`
- `git diff --check`