### PR TITLE
fix(code-intel): route unqualified graph queries to the code-bearing source on federated brains

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2056,12 +2056,29 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       // verifyAccessToken. The env-fallback is gone.
       const tokenSourceId = authInfo.sourceId ?? 'default';
 
+      // #3242 parity: the legacy-transport and stdio dispatch sites widen a
+      // no-grant caller's unqualified reads across the federated source set
+      // (localFederatedSourceIds); this SDK-transport site never did, so the
+      // same token saw federated pages over /mcp on one serve mode and scalar
+      // 'default' on the other. hasSourceGrant === false is set ONLY for
+      // legacy bearer tokens with no operator source grant (oauth-provider);
+      // granted tokens and OAuth clients never widen. Best-effort: a resolver
+      // failure keeps the scalar scope.
+      let localFederated: string[] | undefined;
+      if (authInfo.hasSourceGrant === false && tokenSourceId) {
+        try {
+          const { localFederatedSourceIds } = await import('../core/source-resolver.ts');
+          localFederated = await localFederatedSourceIds(engine, tokenSourceId, 'seed_default');
+        } catch { /* scalar scope stands */ }
+      }
+
       let toolResult: Awaited<ReturnType<typeof dispatchToolCall>>;
       try {
         toolResult = await dispatchToolCall(engine, name, params as Record<string, unknown> | undefined, {
           remote: true,
           takesHoldersAllowList: tokenAllowList,
           sourceId: tokenSourceId,
+          ...(localFederated ? { localFederatedSourceIds: localFederated } : {}),
           metaHook: getBrainHotMemoryMeta,
           // MEMORY_VERBS v1: fail-closed surface enforcement + usage attribution.
           ...(surfaceAllowedOps ? { allowedOps: surfaceAllowedOps } : {}),

--- a/src/core/code-graph-readiness.ts
+++ b/src/core/code-graph-readiness.ts
@@ -67,7 +67,7 @@ function effectiveSourceId(scope: ReadinessScope): string | undefined {
 }
 
 /** EXISTS probe: does any code chunk exist in scope? Matches the def/refs result query. */
-async function codeChunksExist(engine: BrainEngine, sourceId: string | undefined): Promise<boolean> {
+export async function codeChunksExist(engine: BrainEngine, sourceId: string | undefined): Promise<boolean> {
   const params: unknown[] = [];
   let scopeClause = '';
   if (sourceId) {

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -815,6 +815,9 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // allowedSources for federated reads, matching legacy HTTP transport.
         sourceId,
         allowedSources,
+        // #3242 parity with src/mcp/http-transport.ts: only the historical
+        // no-grant floor may widen unqualified reads to the federated set.
+        hasSourceGrant: permissions?.source_id != null,
         takesHoldersAllowList,
       } as CoreAuthInfo as SdkAuthInfo;
     }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -914,6 +914,51 @@ export function resolveCodeIntelScope(
 }
 
 /**
+ * Federated re-route for the graph four (code_callers / code_callees /
+ * code_blast / code_flow) — the #3242 sibling. An UNQUALIFIED graph query from
+ * a no-grant caller collapses to the scalar seed source (usually 'default'),
+ * which on vault+code brains holds no code — so the graph ops report
+ * `not_built` while code_def / code_refs (which widen across
+ * `ctx.localFederatedSourceIds`) answer fine. Graph traversal must stay
+ * single-source (engine API + cache key take ONE sourceId), so instead of
+ * widening we RE-ROUTE: when the collapsed source has no code chunks and
+ * exactly one source in the caller's federated read set does, traverse that
+ * one — the multi-source cousin of the CLI's `sole_non_default` tier (#1434).
+ *
+ * Fail-closed, in order: never fires when the caller passed `source_id` or
+ * `all_sources` (explicit wins), when the scope is already brain-wide, when
+ * there is no federated read set (a granted token never widens), when the
+ * collapsed source itself has code, or when zero or 2+ federated sources have
+ * code (ambiguous → original scope stands and readiness reports honestly).
+ * Probe errors also keep the original scope.
+ */
+export async function routeCodeIntelScope(
+  ctx: OperationContext,
+  sourceIdParam: string | undefined,
+  allSourcesParam = false,
+): Promise<{ allSources: boolean; sourceId?: string }> {
+  const scope = resolveCodeIntelScope(ctx, sourceIdParam, allSourcesParam);
+  if (
+    sourceIdParam !== undefined || allSourcesParam ||
+    scope.allSources || scope.sourceId === undefined ||
+    !ctx.localFederatedSourceIds || ctx.localFederatedSourceIds.length < 2
+  ) {
+    return scope;
+  }
+  try {
+    const { codeChunksExist } = await import('./code-graph-readiness.ts');
+    if (await codeChunksExist(ctx.engine, scope.sourceId)) return scope;
+    const withCode: string[] = [];
+    for (const id of ctx.localFederatedSourceIds) {
+      if (id === scope.sourceId) continue;
+      if (await codeChunksExist(ctx.engine, id)) withCode.push(id);
+    }
+    if (withCode.length === 1) return { allSources: false, sourceId: withCode[0] };
+  } catch { /* probe failure → original scope stands */ }
+  return scope;
+}
+
+/**
  * T4/D5 — resolve a per-call search-mode override. Honored ONLY for trusted/
  * local callers (ctx.remote === false) so a remote OAuth client can't escalate
  * to the costly tokenmax bundle. Local + unknown mode → loud reject; remote +
@@ -4898,9 +4943,10 @@ const code_callers: Operation = {
     const symbol = p.symbol as string;
     const limit = (p.limit as number) ?? 100;
     const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
-    // Single trust+grant resolver: remote callers can't span sources outside
-    // their grant, and `__all__` collapses to their grant (not the whole brain).
-    const { allSources, sourceId } = resolveCodeIntelScope(ctx, sourceIdParam, p.all_sources === true);
+    // Single trust+grant resolver + federated code-source re-route (see
+    // routeCodeIntelScope): remote callers can't span sources outside their
+    // grant, and `__all__` collapses to their grant (not the whole brain).
+    const { allSources, sourceId } = await routeCodeIntelScope(ctx, sourceIdParam, p.all_sources === true);
     const edges = await ctx.engine.getCallersOf(symbol, {
       limit,
       allSources,
@@ -4929,8 +4975,8 @@ const code_callees: Operation = {
     const symbol = p.symbol as string;
     const limit = (p.limit as number) ?? 100;
     const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
-    // Single trust+grant resolver (see code_callers).
-    const { allSources, sourceId } = resolveCodeIntelScope(ctx, sourceIdParam, p.all_sources === true);
+    // Single trust+grant resolver + federated re-route (see code_callers).
+    const { allSources, sourceId } = await routeCodeIntelScope(ctx, sourceIdParam, p.all_sources === true);
     const edges = await ctx.engine.getCalleesOf(symbol, {
       limit,
       allSources,
@@ -5015,7 +5061,7 @@ const code_blast: Operation = {
     // source outside its grant (pre-fix this scoped by bare ctx.sourceId only).
     // Falls back to ctx.sourceId (a required string) for the trusted-local case,
     // exactly preserving pre-fix local behavior.
-    const { sourceId: scopedSourceId } = resolveCodeIntelScope(ctx, typeof p.source_id === 'string' ? p.source_id : undefined);
+    const { sourceId: scopedSourceId } = await routeCodeIntelScope(ctx, typeof p.source_id === 'string' ? p.source_id : undefined);
     const sourceId = scopedSourceId ?? ctx.sourceId;
     return getCachedOrCompute(
       ctx.engine,
@@ -5051,7 +5097,7 @@ const code_flow: Operation = {
     const max_nodes = Math.min((p.max_nodes as number) ?? 200, 200);
     const exact = (p.exact as boolean) ?? false;
     // Single trust+grant resolver (see code_blast).
-    const { sourceId: scopedSourceId } = resolveCodeIntelScope(ctx, typeof p.source_id === 'string' ? p.source_id : undefined);
+    const { sourceId: scopedSourceId } = await routeCodeIntelScope(ctx, typeof p.source_id === 'string' ? p.source_id : undefined);
     const sourceId = scopedSourceId ?? ctx.sourceId;
     return getCachedOrCompute(
       ctx.engine,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -508,6 +508,15 @@ export interface AuthInfo {
    */
   sourceId?: string;
   /**
+   * #3242 (serve --http parity): distinguishes an operator-set source scope
+   * from the historical no-grant 'default' floor. `false` ONLY for a legacy
+   * bearer token whose `access_tokens.permissions.source_id` is absent —
+   * the one case whose unqualified reads may widen to the federated set.
+   * `true` (or undefined, e.g. OAuth clients) never widens. Mirrors
+   * `AuthResult.hasSourceGrant` in `src/mcp/http-transport.ts`.
+   */
+  hasSourceGrant?: boolean;
+  /**
    * v0.34.1 (#876): array of source ids this OAuth client may READ
    * from (federation). Sourced from `oauth_clients.federated_read`.
    * Independent of `sourceId` (write authority): a "WeCare L3 dept"

--- a/test/source-scope-resolver.test.ts
+++ b/test/source-scope-resolver.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   resolveRequestedScope,
   resolveCodeIntelScope,
+  routeCodeIntelScope,
   thinkSourceScopeOpts,
   OperationError,
   type OperationContext,
@@ -134,5 +135,76 @@ describe('resolveCodeIntelScope — single-source code traversal', () => {
   test('remote with no source in scope is denied, never widened to all', () => {
     const ctx = ctxOf({ remote: true, sourceId: '' });
     expect(() => resolveCodeIntelScope(ctx, '__all__')).toThrow(OperationError);
+  });
+});
+
+describe('routeCodeIntelScope — federated code-source re-route (#3242 sibling)', () => {
+  /** Engine stub whose codeChunksExist probe answers true for the given sources. */
+  function engineWithCodeIn(...sourcesWithCode: string[]) {
+    return {
+      executeRaw: async (_sql: string, params: unknown[] = []) => {
+        const sourceId = params[params.length - 1] as string | undefined;
+        return [{ e: sourceId !== undefined && sourcesWithCode.includes(sourceId) }];
+      },
+    } as any;
+  }
+
+  test('unqualified query on a code-less seed source re-routes to the sole code-bearing federated source', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: engineWithCodeIn('code-src'),
+      localFederatedSourceIds: ['default', 'code-src'],
+    });
+    expect(await routeCodeIntelScope(ctx, undefined)).toEqual({ allSources: false, sourceId: 'code-src' });
+  });
+
+  test('does NOT re-route when the collapsed source itself has code', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: engineWithCodeIn('default', 'code-src'),
+      localFederatedSourceIds: ['default', 'code-src'],
+    });
+    expect(await routeCodeIntelScope(ctx, undefined)).toEqual({ allSources: false, sourceId: 'default' });
+  });
+
+  test('explicit source_id always wins — never re-routed even to a code-bearing source', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: engineWithCodeIn('code-src'),
+      localFederatedSourceIds: ['default', 'code-src'],
+    });
+    expect(await routeCodeIntelScope(ctx, 'default')).toEqual({ allSources: false, sourceId: 'default' });
+  });
+
+  test('ambiguous (2+ federated sources with code) keeps the original scope', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: engineWithCodeIn('code-a', 'code-b'),
+      localFederatedSourceIds: ['default', 'code-a', 'code-b'],
+    });
+    expect(await routeCodeIntelScope(ctx, undefined)).toEqual({ allSources: false, sourceId: 'default' });
+  });
+
+  test('no federated read set (granted token) never widens', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: engineWithCodeIn('code-src'),
+    });
+    expect(await routeCodeIntelScope(ctx, undefined)).toEqual({ allSources: false, sourceId: 'default' });
+  });
+
+  test('probe failure fails closed to the original scope', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      engine: { executeRaw: async () => { throw new Error('db down'); } } as any,
+      localFederatedSourceIds: ['default', 'code-src'],
+    });
+    expect(await routeCodeIntelScope(ctx, undefined)).toEqual({ allSources: false, sourceId: 'default' });
   });
 });


### PR DESCRIPTION
## Problem

On a brain with two federated sources — a notes/vault source and a code source — the four
graph ops (`code_callers`, `code_callees`, `code_blast`, `code_flow`) return
`status: "not_built"` for symbols that are demonstrably indexed, while `code_def` and
`code_refs` answer correctly for the same symbol.

Reproduced on a live PGLite brain: `code_def` finds `fires_in_window` at
`routines/weekly-rollup/expected_runs.py:67`, and the call graph holds both of its caller
edges, but `code_callers` over MCP reports `not_built` with zero callers. The CLI answers
fine, which makes it look like a stale index rather than a routing bug.

Two independent causes, one per commit.

### 1. Graph ops collapse to a source that holds no code

`code_def` / `code_refs` are brain-wide. The graph four are single-source by design (the
engine API and the traversal cache key take one `sourceId`), so an unqualified call
collapses to the caller's scalar scope — the seed `default` source, which on a vault+code
brain contains no code chunks. The readiness probe then honestly reports `not_built` for
that scope, and the agent concludes the graph was never built.

`routeCodeIntelScope` re-routes instead of widening (widening isn't available to a
single-source traversal): when the collapsed source has no code chunks and exactly one
source in the caller's federated read set does, traverse that one. This is the
multi-source cousin of the CLI's existing `sole_non_default` tier (#1434).

Fail-closed, in precedence order — explicit `source_id` or `all_sources` wins; an already
brain-wide scope is untouched; no federated read set (a granted token) never widens; a
collapsed source that *does* have code stands; 0 or 2+ candidate sources is ambiguous and
keeps the original scope so readiness reports honestly; a probe error keeps the original
scope.

### 2. `serve --http` never threaded the federated read set

Even with the above, the fix couldn't fire under `serve --http`. The legacy HTTP transport
(`src/mcp/http-transport.ts`) and stdio (`src/mcp/server.ts`) both thread
`localFederatedSourceIds` into dispatch for no-grant callers per #3242; the SDK-transport
dispatch site in `serve-http.ts` never did. The same legacy bearer token therefore saw
federated pages on two transports and scalar `default` on the third — a pre-existing
visibility split that reaches well beyond code intel.

`AuthInfo` gains `hasSourceGrant`, set only by the legacy verify path in `oauth-provider.ts`
(mirroring the field the legacy transport already computes). OAuth clients leave it
undefined and never widen, so the widening condition matches the other two transports
exactly.

## Testing

- 6 new unit tests pin the re-route matrix: re-routes to the sole code-bearing source;
  does not re-route when the collapsed source has code; explicit `source_id` always wins;
  ambiguous (2+ code sources) keeps the original scope; no federated set never widens;
  probe failure fails closed.
- 300 tests green across the scope-resolver, code-intel, code-graph-readiness, transport
  and OAuth suites; `bun run typecheck` clean.
- Verified end to end against a live two-source PGLite brain over MCP: the same unqualified
  `code_callers` call that returned `not_built` now returns `ready` with both real caller
  edges.

## Note

Branched off `master` and independent of #4010 (PGLite edge batching) — no overlapping
files.
