### PR TITLE
feat(takes): human-review proposal queue + fence parser fix for proposal kinds (data-loss guard)

### DIFF
--- a/docs/takes-vs-facts.md
+++ b/docs/takes-vs-facts.md
@@ -21,6 +21,32 @@ The epistemological layer. WHO believes WHAT, with confidence weight and time.
 
 **Query surface:** `gbrain takes list`, `gbrain takes search`, `gbrain think`
 
+### Proposal review is a separate step
+
+The `propose_takes` cycle writes candidates to `take_proposals`; it does not
+promote them into canonical takes. Review the queue explicitly:
+
+```bash
+gbrain takes proposals --json
+gbrain takes accept <proposal-id> --by <reviewer>
+gbrain takes reject <proposal-id> --by <reviewer>
+```
+
+The queue is source-scoped, includes the proposing model/run and current
+evidence status, and refuses promotion when the source page has changed or
+has no registered local repository. Acceptance writes the Markdown take row
+and the derived DB row together under the page lock; repeating the same
+decision is idempotent. `takes.bootstrap_enabled` remains opt-in and is not
+required for manual proposal review.
+
+External reasoning layers (e.g. a Claude operator) enter the queue through
+the `takes_proposal_create` op: the content hash is stamped server-side from
+the page's current indexed content, creation is idempotent per (page,
+content, prompt_version, claim), and nothing is promoted without the manual
+review above. Proposal kinds are `prediction | judgment | bet`; the fence
+parser reads these alongside the seed kinds, and fence rewrites refuse to
+drop rows they cannot parse.
+
 ## Facts (hot memory — `facts` table, v0.31)
 
 Personal knowledge from the brain owner's conversations. Real-time capture.

--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -5,6 +5,9 @@
  *   takes <slug>                          — list takes for a page
  *   takes list                            — list all active takes (#2079)
  *   takes search "<query>" [--who h]       — keyword search across all takes
+ *   takes proposals ...                    — inspect pending generated proposals
+ *   takes accept <proposal-id> ...          — review + promote one proposal
+ *   takes reject <proposal-id> ...          — record a review rejection
  *   takes add <slug> ...flags              — append a take (markdown + DB)
  *   takes update <slug> --row N ...flags   — update mutable fields
  *   takes supersede <slug> --row N ...     — strikethrough old + append new
@@ -20,7 +23,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import type { BrainEngine, TakeKind } from '../core/engine.ts';
 import {
   parseTakesFence,
@@ -31,6 +34,17 @@ import {
 import { withPageLock } from '../core/page-lock.ts';
 import { resolveSourceId } from '../core/source-resolver.ts';
 import { resolveOwnerHolder } from '../core/owner-holder.ts';
+import { parseMarkdown } from '../core/markdown.ts';
+import {
+  acceptTakeProposal,
+  getTakeProposal,
+  isTakeProposalStatus,
+  listTakeProposals,
+  rejectTakeProposal,
+  takeProposalContentHash,
+  type TakeProposal,
+  type TakeProposalStatus,
+} from '../core/take-proposals.ts';
 
 // --- Helpers ---
 
@@ -113,8 +127,8 @@ async function getPageId(engine: BrainEngine, slug: string, sourceId?: string): 
 // reintroducing the pre-#2698 cross-source write bug whenever resolution
 // merely errored instead of resolving cleanly. Let it propagate so the
 // write is blocked instead of silently unscoped.
-async function resolveTakesSourceId(engine: BrainEngine): Promise<string> {
-  return resolveSourceId(engine, null);
+async function resolveTakesSourceId(engine: BrainEngine, explicit?: string): Promise<string> {
+  return resolveSourceId(engine, explicit ?? null);
 }
 
 function readBodyOrEmpty(path: string): string {
@@ -125,6 +139,210 @@ function readBodyOrEmpty(path: string): string {
 function writeBody(path: string, body: string): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, body, 'utf-8');
+}
+
+function proposalId(args: string[], action: 'accept' | 'reject'): number {
+  const raw = args[0];
+  const id = raw ? Number(raw) : NaN;
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    console.error(`Usage: gbrain takes ${action} <proposal-id> [--by <reviewer>] [--source-id <id>]`);
+    process.exit(1);
+  }
+  return id;
+}
+
+async function proposalActor(engine: BrainEngine, args: string[]): Promise<string> {
+  const configuredOwner = await engine.getConfig('emotional_weight.user_holder');
+  const actor = (flagValue(args, '--by') ?? resolveOwnerHolder({ configValue: configuredOwner })).trim();
+  if (!actor || actor.length > 200 || actor.includes('\0')) {
+    throw new Error('Reviewer identity must be a non-empty string up to 200 characters without NUL bytes.');
+  }
+  return actor;
+}
+
+/**
+ * Proposal promotion must write the actual source repository, not whichever
+ * global sync directory happens to be configured. A non-default source with
+ * no local path is therefore reviewable but intentionally not promotable.
+ */
+async function resolveProposalSourceDir(
+  engine: BrainEngine,
+  sourceId: string,
+  explicitDir: string | undefined,
+): Promise<string> {
+  const rows = await engine.executeRaw<{ local_path: string | null }>(
+    `SELECT local_path FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  const sourcePath = rows[0]?.local_path ?? null;
+  const configuredDefaultPath = sourceId === 'default'
+    ? await engine.getConfig('sync.repo_path')
+    : null;
+  if (sourceId !== 'default' && !sourcePath) {
+    throw new Error(
+      `Cannot promote a proposal for source '${sourceId}' without a registered local source path. ` +
+      `Review it with --json, then register the source before accepting it.`,
+    );
+  }
+  const target = sourcePath ?? configuredDefaultPath ?? explicitDir;
+  if (!target || !existsSync(target)) {
+    throw new Error(
+      `Cannot promote a proposal for source '${sourceId}' without its local source path. ` +
+      `Register the source path with \`gbrain sources add\` (or configure sync.repo_path for default).`,
+    );
+  }
+  if (explicitDir && sourcePath && resolve(explicitDir) !== resolve(sourcePath)) {
+    throw new Error(
+      `--dir must match the registered local path for source '${sourceId}'; refusing to write a different repository.`,
+    );
+  }
+  return target;
+}
+
+async function currentProposalForPromotion(
+  engine: BrainEngine,
+  proposalIdValue: number,
+  sourceId: string,
+): Promise<TakeProposal> {
+  const proposal = await getTakeProposal(engine, proposalIdValue, sourceId);
+  if (!proposal) {
+    throw new Error(`Proposal #${proposalIdValue} was not found in source '${sourceId}'.`);
+  }
+  return proposal;
+}
+
+function assertPendingProposal(proposal: TakeProposal): void {
+  if (proposal.status !== 'pending') {
+    throw new Error(`Proposal #${proposal.id} is already ${proposal.status}; only pending proposals can be promoted.`);
+  }
+  if (proposal.page_id === null || proposal.evidence.status !== 'current') {
+    throw new Error(
+      `Proposal #${proposal.id} no longer matches its indexed source evidence (${proposal.evidence.status}); ` +
+      `review the current page and generate a fresh proposal instead.`,
+    );
+  }
+}
+
+async function cmdProposals(engine: BrainEngine, args: string[]): Promise<void> {
+  const json = flagPresent(args, '--json');
+  const sourceId = await resolveTakesSourceId(engine, flagValue(args, '--source-id'));
+  const rawStatus = flagValue(args, '--status');
+  const allStatuses = flagPresent(args, '--all');
+  let status: TakeProposalStatus | undefined;
+  if (rawStatus !== undefined) {
+    if (!isTakeProposalStatus(rawStatus)) {
+      throw new Error(`Invalid proposal status '${rawStatus}'. Expected pending, accepted, rejected, or superseded.`);
+    }
+    status = rawStatus;
+  }
+  const limit = Number(flagValue(args, '--limit') ?? 100);
+  const offset = Number(flagValue(args, '--offset') ?? 0);
+  if (!Number.isSafeInteger(limit) || limit < 1 || !Number.isSafeInteger(offset) || offset < 0) {
+    throw new Error('Proposal --limit must be a positive integer and --offset must be a non-negative integer.');
+  }
+  const proposals = await listTakeProposals(engine, {
+    sourceId,
+    status,
+    allStatuses,
+    limit,
+    offset,
+    redactPrivateEvidence: false,
+  });
+  if (json) {
+    console.log(JSON.stringify(proposals, null, 2));
+    return;
+  }
+  if (proposals.length === 0) {
+    console.log(`No ${status ?? (allStatuses ? '' : 'pending ')}take proposals on ${sourceId}.`);
+    return;
+  }
+  console.log(`# Take proposals — ${sourceId}\n`);
+  for (const proposal of proposals) {
+    console.log(
+      `#${proposal.id} [${proposal.status}] ${proposal.page_slug} ` +
+      `[${proposal.kind} • ${proposal.holder} • w=${proposal.weight.toFixed(2)}]`,
+    );
+    console.log(`  ${proposal.claim_text}`);
+    console.log(
+      `  evidence=${proposal.evidence.status} model=${proposal.model_id} ` +
+      `prompt=${proposal.prompt_version} run=${proposal.proposal_run_id}`,
+    );
+  }
+}
+
+async function cmdAcceptProposal(engine: BrainEngine, args: string[]): Promise<void> {
+  const id = proposalId(args, 'accept');
+  const sourceId = await resolveTakesSourceId(engine, flagValue(args, '--source-id'));
+  const proposal = await currentProposalForPromotion(engine, id, sourceId);
+  if (proposal.status === 'accepted') {
+    console.log(`Proposal #${id} is already accepted (row #${proposal.promoted_row_num ?? '?'}).`);
+    return;
+  }
+  assertPendingProposal(proposal);
+  const reviewer = await proposalActor(engine, args);
+  const sourceDir = await resolveProposalSourceDir(engine, sourceId, flagValue(args, '--dir'));
+
+  await withPageLock(proposal.page_slug, async () => {
+    const path = pageFilePath(sourceDir, proposal.page_slug);
+    const rawBody = readBodyOrEmpty(path);
+    const parsed = parseMarkdown(rawBody, path);
+    const currentHash = takeProposalContentHash(parsed.compiled_truth);
+    if (currentHash !== proposal.content_hash) {
+      throw new Error(
+        `Proposal #${id} evidence is stale on disk; expected content hash ${proposal.content_hash.slice(0, 12)}, ` +
+        `got ${currentHash.slice(0, 12)}. Sync and generate a fresh proposal before accepting it.`,
+      );
+    }
+    const existingTakes = await engine.listTakes({
+      page_id: proposal.page_id!,
+      sourceId,
+      active: true,
+      limit: 500,
+    });
+    if (existingTakes.some(take => take.source === `proposal:${id}`)) {
+      throw new Error(`Proposal #${id} has an unrecorded canonical take row; refusing to create a duplicate.`);
+    }
+    const next = upsertTakeRow(rawBody, {
+      claim: proposal.claim_text,
+      kind: proposal.kind,
+      holder: proposal.holder,
+      weight: proposal.weight,
+      source: `proposal:${id}`,
+      active: true,
+    });
+    writeBody(path, next.body);
+    const result = await acceptTakeProposal(engine, {
+      proposal,
+      actedBy: reviewer,
+      promotedRowNum: next.rowNum,
+      takeSource: `proposal:${id}`,
+    });
+    console.log(
+      result.state === 'already_accepted'
+        ? `Proposal #${id} is already accepted (row #${result.promoted_row_num ?? next.rowNum}).`
+        : `Accepted proposal #${id} as take row #${next.rowNum} on ${proposal.page_slug}.`,
+    );
+  });
+}
+
+async function cmdRejectProposal(engine: BrainEngine, args: string[]): Promise<void> {
+  const id = proposalId(args, 'reject');
+  const sourceId = await resolveTakesSourceId(engine, flagValue(args, '--source-id'));
+  const proposal = await currentProposalForPromotion(engine, id, sourceId);
+  if (proposal.status === 'rejected') {
+    console.log(`Proposal #${id} is already rejected.`);
+    return;
+  }
+  if (proposal.status !== 'pending') {
+    throw new Error(`Proposal #${id} is already ${proposal.status}; only pending proposals can be rejected.`);
+  }
+  const reviewer = await proposalActor(engine, args);
+  const result = await rejectTakeProposal(engine, { proposalId: id, sourceId, actedBy: reviewer });
+  console.log(
+    result.state === 'already_rejected'
+      ? `Proposal #${id} is already rejected.`
+      : `Rejected proposal #${id} on ${proposal.page_slug}.`,
+  );
 }
 
 // --- Subcommands ---
@@ -561,6 +779,12 @@ Subcommands:
                                           List all active takes across the brain (#2079)
   takes search "<query>" [--limit N] [--json]
                                           Keyword search across all takes
+  takes proposals [--json] [--status pending|accepted|rejected|superseded] [--all]
+                                           Review proposals with evidence and provenance
+  takes accept <proposal-id> [--by <reviewer>] [--source-id <id>] [--dir <path>]
+                                           Promote one current proposal after human review
+  takes reject <proposal-id> [--by <reviewer>] [--source-id <id>]
+                                           Record a human rejection without promotion
   takes add <slug> --claim "..." --kind <fact|take|bet|hunch> --who <holder>
                    [--weight 0.5] [--source "..."] [--since YYYY-MM]
                                           Append a take (markdown + DB)
@@ -592,6 +816,9 @@ Common flags:
     // "No takes on list." — reading exactly like an empty takes table.
     case 'list':        return cmdList(engine, rest);
     case 'search':      return cmdSearch(engine, rest);
+    case 'proposals':   return cmdProposals(engine, rest);
+    case 'accept':      return cmdAcceptProposal(engine, rest);
+    case 'reject':      return cmdRejectProposal(engine, rest);
     case 'add':         return cmdAdd(engine, rest, await resolveTakesSourceId(engine));
     case 'update':      return cmdUpdate(engine, rest, await resolveTakesSourceId(engine));
     case 'supersede':   return cmdSupersede(engine, rest, await resolveTakesSourceId(engine));

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -135,7 +135,7 @@ async function listExistingFactsForPage(
 }
 
 export interface ExtractFactsOpts {
-  /** Subset of slugs to reconcile. undefined = walk every page in the brain. */
+  /** Subset of slugs to reconcile. undefined = full walk in the selected source, or brain-wide when unscoped. */
   slugs?: string[];
   /** Dry-run: parse + count, no DB writes. */
   dryRun?: boolean;
@@ -318,9 +318,11 @@ export async function runExtractFacts(
     // real incremental no-op; don't escalate to full-brain walk.
     slugs = opts.slugs;
   } else {
-    // Full walk: every page in the brain. Bounded by engine.getAllSlugs
-    // which is already the precedent for full-extract paths.
-    const allSlugs = await engine.getAllSlugs();
+    // Full walk: constrain enumeration when the caller explicitly selected a
+    // source; preserve the legacy brain-wide walk when it did not.
+    const allSlugs = await engine.getAllSlugs(
+      opts.sourceId === undefined ? undefined : { sourceId },
+    );
     slugs = Array.from(allSlugs);
   }
   // v0.35.5: union the canonicals touched by the phantom-redirect pass

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -30,6 +30,7 @@ import { packToBudget, estimateTokens, resultTokens } from './search/token-budge
 import { isAvailable } from './ai/gateway.ts';
 import { verbOperations, MEMORY_VERBS_VERSION } from './verbs.ts';
 export { MEMORY_VERBS_VERSION };
+import { createTakeProposal, isTakeProposalStatus, listTakeProposals, TAKE_PROPOSAL_KINDS } from './take-proposals.ts';
 import type { SearchResult } from './types.ts';
 import { CJK_SLUG_CHARS, PAGE_SLUG_SEG } from './cjk.ts';
 import { ALL_SOURCES } from './source-id.ts';
@@ -2250,6 +2251,74 @@ const takes_list: Operation = {
     });
   },
   cliHints: { name: 'takes-list' },
+};
+
+const takes_proposals_list: Operation = {
+  name: 'takes_proposals_list',
+  description: 'List human-review take proposals with source, model, run, and current evidence status. Proposals are not canonical takes.',
+  scope: 'read',
+  params: {
+    status: { type: 'string', description: 'pending (default), accepted, rejected, or superseded' },
+    all_statuses: { type: 'boolean', description: 'Include all proposal statuses instead of pending only' },
+    limit: { type: 'number', description: 'Max proposals (default 100, cap 500)' },
+    offset: { type: 'number', description: 'Skip first N proposals' },
+  },
+  handler: async (ctx, p) => {
+    const rawStatus = p.status as string | undefined;
+    if (rawStatus !== undefined && !isTakeProposalStatus(rawStatus)) {
+      throw new OperationError(
+        'invalid_params',
+        `Invalid proposal status '${rawStatus}'. Expected pending, accepted, rejected, or superseded.`,
+      );
+    }
+    return listTakeProposals(ctx.engine, {
+      ...sourceScopeOpts(ctx),
+      status: rawStatus,
+      allStatuses: p.all_statuses as boolean | undefined,
+      limit: p.limit as number | undefined,
+      offset: p.offset as number | undefined,
+      takesHoldersAllowList: ctx.takesHoldersAllowList,
+      redactPrivateEvidence: ctx.remote !== false,
+    });
+  },
+  cliHints: { name: 'takes-proposals-list' },
+};
+
+const takes_proposal_create: Operation = {
+  name: 'takes_proposal_create',
+  description: 'Create one human-review take proposal against the CURRENT indexed content of a page. The content hash is stamped server-side, so fresh proposals always start with evidence=current. Writes only to the review queue — never to canonical takes or Markdown. Idempotent per (page, content, prompt_version, claim).',
+  scope: 'write',
+  params: {
+    page_slug: { type: 'string', required: true, description: 'Page the claim is grounded in (must exist in the scoped source)' },
+    claim_text: { type: 'string', required: true, description: 'The gradeable claim (10-500 chars)' },
+    kind: { type: 'string', required: true, description: `One of ${TAKE_PROPOSAL_KINDS.join(', ')}` },
+    holder: { type: 'string', required: true, description: 'Who holds the belief (e.g. a person slug, "brain", or the proposing model)' },
+    weight: { type: 'number', required: true, description: 'Confidence in (0, 1]' },
+    domain: { type: 'string', required: false, description: 'Optional domain tag (e.g. ops, marketing)' },
+    run_id: { type: 'string', required: false, description: 'Proposal run id for provenance grouping' },
+    model_id: { type: 'string', required: false, description: 'Proposing model identity (default claude-operator)' },
+  },
+  handler: async (ctx, p) => {
+    const sourceId = ctx.sourceId;
+    if (!sourceId || sourceId === ALL_SOURCES) {
+      throw new OperationError(
+        'invalid_params',
+        'takes_proposal_create requires an explicit single source (pass --source; the all-sources sentinel is rejected).',
+      );
+    }
+    return createTakeProposal(ctx.engine, {
+      sourceId,
+      pageSlug: p.page_slug as string,
+      claimText: p.claim_text as string,
+      kind: p.kind as string,
+      holder: p.holder as string,
+      weight: p.weight as number,
+      domain: p.domain as string | undefined,
+      proposalRunId: p.run_id as string | undefined,
+      modelId: p.model_id as string | undefined,
+    });
+  },
+  cliHints: { name: 'takes-proposal-create' },
 };
 
 const takes_search: Operation = {
@@ -6396,7 +6465,7 @@ export const operations: Operation[] = [
   // v0.36.1.0 (T7) — Hindsight calibration wave: read profile via MCP
   get_calibration_profile,
   // v0.28: Takes + think
-  takes_list, takes_search, think,
+  takes_list, takes_proposals_list, takes_proposal_create, takes_search, think,
   // v0.30: calibration aggregates over takes
   takes_scorecard, takes_calibration,
   // v0.28: whoami + scoped sources management

--- a/src/core/take-proposals.ts
+++ b/src/core/take-proposals.ts
@@ -1,0 +1,446 @@
+/**
+ * Reviewed take-proposal queue helpers.
+ *
+ * Proposals are not canonical takes. The queue records model output and its
+ * provenance; only the local CLI may promote one after it has updated the
+ * source Markdown fence. Remote callers get a source- and holder-scoped,
+ * read-only review surface.
+ */
+
+import { createHash } from 'node:crypto';
+import { clampSearchLimit, type BrainEngine, type TakeKind } from './engine.ts';
+import { stripFactsFence } from './facts-fence.ts';
+import { stripTakesFence } from './takes-fence.ts';
+
+export const TAKE_PROPOSAL_STATUSES = ['pending', 'accepted', 'rejected', 'superseded'] as const;
+export type TakeProposalStatus = typeof TAKE_PROPOSAL_STATUSES[number];
+
+const EVIDENCE_EXCERPT_LIMIT = 600;
+
+export interface TakeProposalEvidence {
+  /** Whether the source page is missing, changed since proposal, or current in the DB. */
+  status: 'missing' | 'stale' | 'current';
+  page_present: boolean;
+  current_content_hash: string | null;
+  /** A bounded inspection aid, not a claim-level quotation guarantee. */
+  excerpt: string | null;
+  excerpt_truncated: boolean;
+}
+
+export interface TakeProposal {
+  id: number;
+  source_id: string;
+  page_slug: string;
+  content_hash: string;
+  prompt_version: string;
+  wave_version: string;
+  proposed_at: string;
+  proposal_run_id: string;
+  status: TakeProposalStatus;
+  claim_text: string;
+  kind: TakeKind;
+  holder: string;
+  weight: number;
+  domain: string | null;
+  dedup_against_fence_rows: unknown;
+  model_id: string;
+  acted_at: string | null;
+  acted_by: string | null;
+  promoted_row_num: number | null;
+  page_id: number | null;
+  evidence: TakeProposalEvidence;
+}
+
+export interface TakeProposalListOpts {
+  proposalId?: number;
+  status?: TakeProposalStatus;
+  /** Exact lookups need audit history; normal list calls default to pending. */
+  allStatuses?: boolean;
+  limit?: number;
+  offset?: number;
+  sourceId?: string;
+  sourceIds?: string[];
+  /** Mirrors the takes-holder grant on the remote MCP boundary. */
+  takesHoldersAllowList?: string[];
+  /** Remote review excerpts obey the same takes/facts fence redaction as get_page. */
+  redactPrivateEvidence?: boolean;
+}
+
+interface ProposalRow {
+  id: number | string;
+  source_id: string;
+  page_slug: string;
+  content_hash: string;
+  prompt_version: string;
+  wave_version: string | null;
+  proposed_at: string | Date;
+  proposal_run_id: string;
+  status: string;
+  claim_text: string;
+  kind: string;
+  holder: string;
+  weight: number | string;
+  domain: string | null;
+  dedup_against_fence_rows: unknown;
+  model_id: string;
+  acted_at: string | Date | null;
+  acted_by: string | null;
+  promoted_row_num: number | string | null;
+  page_id: number | string | null;
+  page_body: string | null;
+}
+
+interface ProposalActionRow {
+  status: TakeProposalStatus;
+  promoted_row_num: number | string | null;
+}
+
+export class TakeProposalActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TakeProposalActionError';
+  }
+}
+
+export function takeProposalContentHash(body: string): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+export function isTakeProposalStatus(value: unknown): value is TakeProposalStatus {
+  return typeof value === 'string' && (TAKE_PROPOSAL_STATUSES as readonly string[]).includes(value);
+}
+
+function timestamp(value: string | Date | null): string | null {
+  if (value === null) return null;
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function excerpt(body: string | null, redactPrivateEvidence: boolean): {
+  excerpt: string | null;
+  truncated: boolean;
+} {
+  if (body === null) return { excerpt: null, truncated: false };
+  const visible = redactPrivateEvidence
+    ? stripFactsFence(stripTakesFence(body), { keepVisibility: ['world'] })
+    : body;
+  const compact = visible.trim();
+  if (compact.length <= EVIDENCE_EXCERPT_LIMIT) return { excerpt: compact || null, truncated: false };
+  return { excerpt: `${compact.slice(0, EVIDENCE_EXCERPT_LIMIT)}…`, truncated: true };
+}
+
+function rowToProposal(row: ProposalRow, redactPrivateEvidence: boolean): TakeProposal {
+  const currentContentHash = row.page_body === null ? null : takeProposalContentHash(row.page_body);
+  const evidenceExcerpt = excerpt(row.page_body, redactPrivateEvidence);
+  const evidenceStatus = row.page_id === null
+    ? 'missing'
+    : currentContentHash === row.content_hash
+      ? 'current'
+      : 'stale';
+  if (!isTakeProposalStatus(row.status)) {
+    throw new Error(`take_proposals row ${row.id} has an unknown status`);
+  }
+  return {
+    id: Number(row.id),
+    source_id: row.source_id,
+    page_slug: row.page_slug,
+    content_hash: row.content_hash,
+    prompt_version: row.prompt_version,
+    wave_version: row.wave_version ?? 'unknown',
+    proposed_at: timestamp(row.proposed_at) ?? '',
+    proposal_run_id: row.proposal_run_id,
+    status: row.status,
+    claim_text: row.claim_text,
+    kind: row.kind,
+    holder: row.holder,
+    weight: Number(row.weight),
+    domain: row.domain,
+    dedup_against_fence_rows: parseJson(row.dedup_against_fence_rows),
+    model_id: row.model_id,
+    acted_at: timestamp(row.acted_at),
+    acted_by: row.acted_by,
+    promoted_row_num: row.promoted_row_num === null ? null : Number(row.promoted_row_num),
+    page_id: row.page_id === null ? null : Number(row.page_id),
+    evidence: {
+      status: evidenceStatus,
+      page_present: row.page_id !== null,
+      current_content_hash: currentContentHash,
+      excerpt: evidenceExcerpt.excerpt,
+      excerpt_truncated: evidenceExcerpt.truncated,
+    },
+  };
+}
+
+/**
+ * Lists proposal records joined to their current source page. The join is on
+ * `(source_id, slug)` so same-slug rows in neighboring sources never become
+ * review evidence for one another.
+ */
+export async function listTakeProposals(
+  engine: BrainEngine,
+  opts: TakeProposalListOpts = {},
+): Promise<TakeProposal[]> {
+  const params: unknown[] = [];
+  const where: string[] = [];
+  const status = opts.allStatuses ? undefined : (opts.status ?? 'pending');
+  if (opts.proposalId !== undefined) {
+    params.push(opts.proposalId);
+    where.push(`tp.id = $${params.length}`);
+  }
+  if (status !== undefined) {
+    params.push(status);
+    where.push(`tp.status = $${params.length}`);
+  }
+  if (opts.sourceIds && opts.sourceIds.length > 0) {
+    params.push(opts.sourceIds);
+    where.push(`tp.source_id = ANY($${params.length}::text[])`);
+  } else if (opts.sourceId) {
+    params.push(opts.sourceId);
+    where.push(`tp.source_id = $${params.length}`);
+  }
+  if (opts.takesHoldersAllowList !== undefined) {
+    params.push(opts.takesHoldersAllowList);
+    where.push(`tp.holder = ANY($${params.length}::text[])`);
+  }
+  const limit = clampSearchLimit(opts.limit, 100, 500);
+  const offset = Math.max(0, Math.floor(opts.offset ?? 0));
+  params.push(limit, offset);
+  const rows = await engine.executeRaw<ProposalRow>(
+    `SELECT tp.id, tp.source_id, tp.page_slug, tp.content_hash, tp.prompt_version,
+            tp.wave_version, tp.proposed_at, tp.proposal_run_id, tp.status,
+            tp.claim_text, tp.kind, tp.holder, tp.weight, tp.domain,
+            tp.dedup_against_fence_rows, tp.model_id, tp.acted_at, tp.acted_by,
+            tp.promoted_row_num, p.id AS page_id, p.compiled_truth AS page_body
+       FROM take_proposals tp
+       LEFT JOIN pages p
+         ON p.source_id = tp.source_id
+        AND p.slug = tp.page_slug
+        AND p.deleted_at IS NULL
+      ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY tp.proposed_at DESC, tp.id DESC
+      LIMIT $${params.length - 1} OFFSET $${params.length}`,
+    params,
+  );
+  return rows.map(row => rowToProposal(row, opts.redactPrivateEvidence === true));
+}
+
+export async function getTakeProposal(
+  engine: BrainEngine,
+  proposalId: number,
+  sourceId: string,
+): Promise<TakeProposal | null> {
+  const rows = await listTakeProposals(engine, {
+    proposalId,
+    sourceId,
+    allStatuses: true,
+    limit: 1,
+  });
+  return rows[0] ?? null;
+}
+
+async function actionState(
+  engine: BrainEngine,
+  proposalId: number,
+  sourceId: string,
+): Promise<ProposalActionRow | null> {
+  const rows = await engine.executeRaw<ProposalActionRow>(
+    `SELECT status, promoted_row_num
+       FROM take_proposals
+      WHERE id = $1 AND source_id = $2`,
+    [proposalId, sourceId],
+  );
+  return rows[0] ?? null;
+}
+
+function actionFailure(proposalId: number, sourceId: string, current: ProposalActionRow | null): never {
+  if (!current) {
+    throw new TakeProposalActionError(`Proposal #${proposalId} was not found in source '${sourceId}'.`);
+  }
+  throw new TakeProposalActionError(
+    `Proposal #${proposalId} is already ${current.status}; a pending proposal is required for this action.`,
+  );
+}
+
+export interface AcceptTakeProposalInput {
+  proposal: TakeProposal;
+  actedBy: string;
+  promotedRowNum: number;
+  /** The source pointer written into the canonical Markdown and derived index. */
+  takeSource: string;
+}
+
+export interface TakeProposalActionResult {
+  state: 'accepted' | 'rejected' | 'already_accepted' | 'already_rejected';
+  promoted_row_num: number | null;
+}
+
+/**
+ * Atomically marks a pending proposal accepted and writes its derived take
+ * index row. The caller must update canonical Markdown first; if this DB
+ * transaction fails, the Markdown remains the recoverable source of truth.
+ */
+export async function acceptTakeProposal(
+  engine: BrainEngine,
+  input: AcceptTakeProposalInput,
+): Promise<TakeProposalActionResult> {
+  const { proposal } = input;
+  const pageId = proposal.page_id;
+  if (pageId === null) {
+    throw new TakeProposalActionError(`Proposal #${proposal.id} has no current source page.`);
+  }
+  return engine.transaction(async tx => {
+    const changed = await tx.executeRaw<{ id: number }>(
+      `UPDATE take_proposals
+          SET status = 'accepted', acted_at = now(), acted_by = $3,
+              promoted_row_num = $4
+        WHERE id = $1 AND source_id = $2 AND status = 'pending'
+      RETURNING id`,
+      [proposal.id, proposal.source_id, input.actedBy, input.promotedRowNum],
+    );
+    if (changed.length === 0) {
+      const current = await actionState(tx, proposal.id, proposal.source_id);
+      if (current?.status === 'accepted') {
+        return {
+          state: 'already_accepted',
+          promoted_row_num: current.promoted_row_num === null ? null : Number(current.promoted_row_num),
+        };
+      }
+      return actionFailure(proposal.id, proposal.source_id, current);
+    }
+    await tx.addTakesBatch([{
+      page_id: pageId,
+      row_num: input.promotedRowNum,
+      claim: proposal.claim_text,
+      kind: proposal.kind,
+      holder: proposal.holder,
+      weight: proposal.weight,
+      source: input.takeSource,
+      active: true,
+      superseded_by: null,
+    }]);
+    return { state: 'accepted', promoted_row_num: input.promotedRowNum };
+  });
+}
+
+/** Records an explicit rejection; a repeat rejection is a no-op. */
+export async function rejectTakeProposal(
+  engine: BrainEngine,
+  opts: { proposalId: number; sourceId: string; actedBy: string },
+): Promise<TakeProposalActionResult> {
+  const changed = await engine.executeRaw<{ id: number }>(
+    `UPDATE take_proposals
+        SET status = 'rejected', acted_at = now(), acted_by = $3
+      WHERE id = $1 AND source_id = $2 AND status = 'pending'
+    RETURNING id`,
+    [opts.proposalId, opts.sourceId, opts.actedBy],
+  );
+  if (changed.length > 0) return { state: 'rejected', promoted_row_num: null };
+  const current = await actionState(engine, opts.proposalId, opts.sourceId);
+  if (current?.status === 'rejected') return { state: 'already_rejected', promoted_row_num: null };
+  return actionFailure(opts.proposalId, opts.sourceId, current);
+}
+
+/**
+ * Kinds a take PROPOSAL may carry. Mirrors the propose_takes cycle enum
+ * ('prediction' | 'judgment' | 'bet'); the fence parser reads the union of
+ * these and the fence seed kinds (see takes-fence.ts KIND_VALUES).
+ */
+export const TAKE_PROPOSAL_KINDS = ['prediction', 'judgment', 'bet'] as const;
+export type TakeProposalKind = typeof TAKE_PROPOSAL_KINDS[number];
+
+export function isTakeProposalKind(value: unknown): value is TakeProposalKind {
+  return typeof value === 'string' && (TAKE_PROPOSAL_KINDS as readonly string[]).includes(value);
+}
+
+export interface CreateTakeProposalInput {
+  sourceId: string;
+  pageSlug: string;
+  claimText: string;
+  kind: string;
+  holder: string;
+  weight: number;
+  domain?: string | null;
+  promptVersion?: string;
+  proposalRunId?: string;
+  modelId?: string;
+}
+
+export interface CreateTakeProposalResult {
+  /** null when an identical proposal already exists for the current page content. */
+  id: number | null;
+  deduped: boolean;
+  page_slug: string;
+  content_hash: string;
+}
+
+/**
+ * Insert one reviewed-queue proposal against the CURRENT indexed content of
+ * a page. The content hash is computed server-side from the page's
+ * `compiled_truth`, so a fresh proposal always starts with evidence
+ * `current`; callers cannot fabricate a hash. Idempotent on
+ * (source_id, page_slug, content_hash, prompt_version, md5(claim_text)).
+ * Writes ONLY to the review queue — never to canonical takes or Markdown.
+ */
+export async function createTakeProposal(
+  engine: BrainEngine,
+  input: CreateTakeProposalInput,
+): Promise<CreateTakeProposalResult> {
+  if (!isTakeProposalKind(input.kind)) {
+    throw new TakeProposalActionError(
+      `Invalid proposal kind '${input.kind}'. Expected ${TAKE_PROPOSAL_KINDS.join(', ')}.`,
+    );
+  }
+  const claim = input.claimText.trim();
+  if (claim.length < 10 || claim.length > 500) {
+    throw new TakeProposalActionError('Proposal claim_text must be between 10 and 500 characters.');
+  }
+  const holder = input.holder.trim();
+  if (holder.length === 0 || holder.length > 120) {
+    throw new TakeProposalActionError('Proposal holder is required (max 120 characters).');
+  }
+  if (!Number.isFinite(input.weight) || input.weight <= 0 || input.weight > 1) {
+    throw new TakeProposalActionError('Proposal weight must be in (0, 1].');
+  }
+  const pages = await engine.executeRaw<{ id: number; compiled_truth: string }>(
+    `SELECT id, compiled_truth FROM pages
+      WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL`,
+    [input.sourceId, input.pageSlug],
+  );
+  if (pages.length === 0) {
+    throw new TakeProposalActionError(
+      `Page '${input.pageSlug}' was not found in source '${input.sourceId}'.`,
+    );
+  }
+  const contentHash = takeProposalContentHash(pages[0].compiled_truth ?? '');
+  const inserted = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO take_proposals
+       (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+        claim_text, kind, holder, weight, domain, dedup_against_fence_rows, model_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, '[]'::jsonb, $11)
+     ON CONFLICT (source_id, page_slug, content_hash, prompt_version, md5(claim_text)) DO NOTHING
+     RETURNING id`,
+    [
+      input.sourceId,
+      input.pageSlug,
+      contentHash,
+      input.promptVersion ?? 'operator-claude-v1',
+      input.proposalRunId ?? `operator-${new Date().toISOString().slice(0, 10)}`,
+      claim,
+      input.kind,
+      holder,
+      input.weight,
+      input.domain ?? null,
+      input.modelId ?? 'claude-operator',
+    ],
+  );
+  const id = inserted.length > 0 ? Number(inserted[0].id) : null;
+  return { id, deduped: id === null, page_slug: input.pageSlug, content_hash: contentHash };
+}

--- a/src/core/takes-fence.ts
+++ b/src/core/takes-fence.ts
@@ -148,7 +148,12 @@ export function isValidHolder(holder: string): boolean {
   return HOLDER_REGEX.test(holder);
 }
 
-const KIND_VALUES: ReadonlySet<string> = new Set(['fact', 'take', 'bet', 'hunch']);
+// Union of the fence seed kinds and the take_proposals kind enum
+// ('prediction' | 'judgment' | 'bet', see cycle/propose-takes.ts): the accept
+// path writes proposal kinds verbatim into the fence, so the parser must read
+// every kind the proposal pipeline can emit or accepted rows become
+// unparseable — and an unparseable row is DROPPED on the next fence rewrite.
+const KIND_VALUES: ReadonlySet<string> = new Set(['fact', 'take', 'bet', 'hunch', 'prediction', 'judgment']);
 const QUALITY_VALUES: ReadonlySet<string> = new Set(['correct', 'incorrect', 'partial', 'unresolvable']);
 
 // v0.30.0: header tokens that mark a v0.30-shape fence. Presence of `quality`
@@ -309,7 +314,7 @@ export function parseTakesFence(body: string): ParseResult {
 
     const kind = kindRaw.trim().toLowerCase();
     if (!KIND_VALUES.has(kind)) {
-      warnings.push(`TAKES_TABLE_MALFORMED: unknown kind "${kindRaw}" (expected fact|take|bet|hunch)`);
+      warnings.push(`TAKES_TABLE_MALFORMED: unknown kind "${kindRaw}" (expected fact|take|bet|hunch|prediction|judgment)`);
       continue;
     }
 
@@ -442,6 +447,33 @@ function formatWeight(w: number): string {
 }
 
 /**
+ * Parse the fence and refuse to proceed when it contains rows the parser
+ * DROPPED (TAKES_TABLE_MALFORMED / TAKES_ROW_NUM_COLLISION `continue`
+ * paths): any caller that re-renders the fence from the parsed subset
+ * would silently erase those rows. This guards against the 2026-08-11
+ * data-loss class, where a proposal-kind the parser didn't know made an
+ * accepted take row unparseable and the NEXT accept on the same page
+ * clobbered it. TAKES_HOLDER_INVALID and other fall-through warnings keep
+ * their rows and must not block the write.
+ */
+function parseAndAssertRewritable(
+  body: string,
+  caller: string,
+): ReturnType<typeof parseTakesFence> {
+  const parsed = parseTakesFence(body);
+  const droppingWarnings = parsed.warnings.filter(w =>
+    w.startsWith('TAKES_TABLE_MALFORMED') || w.startsWith('TAKES_ROW_NUM_COLLISION'),
+  );
+  if (droppingWarnings.length > 0 && body.indexOf(TAKES_FENCE_BEGIN) !== -1) {
+    throw new Error(
+      `${caller}: refusing to rewrite a takes fence with unparseable rows ` +
+      `(rewriting would drop them): ${droppingWarnings.join('; ')}`,
+    );
+  }
+  return parsed;
+}
+
+/**
  * Append a new take row to the body. If a fenced takes table exists, the
  * row is added to the end of it. If not, a new `## Takes` section + fence
  * is created at the end of the body.
@@ -456,10 +488,7 @@ export function upsertTakeRow(
   body: string,
   newRow: Omit<ParsedTake, 'rowNum'> & { rowNum?: number },
 ): { body: string; rowNum: number } {
-  const { takes, warnings } = parseTakesFence(body);
-  // Surface warnings to caller via an attached marker — caller decides what to do.
-  // (We don't throw here so writes proceed; doctor surfaces the underlying issue.)
-  void warnings;
+  const { takes } = parseAndAssertRewritable(body, 'upsertTakeRow');
   const nextRowNum = newRow.rowNum
     ?? (takes.length > 0 ? Math.max(...takes.map(t => t.rowNum)) + 1 : 1);
 
@@ -506,7 +535,7 @@ export function supersedeRow(
   oldRowNum: number,
   replacement: Omit<ParsedTake, 'rowNum' | 'active'>,
 ): { body: string; oldRowNum: number; newRowNum: number } {
-  const { takes } = parseTakesFence(body);
+  const { takes } = parseAndAssertRewritable(body, 'supersedeRow');
   const idx = takes.findIndex(t => t.rowNum === oldRowNum);
   if (idx === -1) {
     throw new Error(`supersedeRow: row #${oldRowNum} not found in takes fence`);

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -305,16 +305,26 @@ describe('runExtractFacts — happy path', () => {
     expect(Number(rows.rows[0].n)).toBe(0);
   });
 
-  test('walks every brain page when no slugs filter is provided', async () => {
+  test('walks every brain page when no slugs or source filter is provided', async () => {
     await putPage('people/alice', FACT_FENCE(
       `| 1 | A1 | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
     ));
     await putPage('companies/acme', FACT_FENCE(
       `| 1 | C1 | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
     ));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO sources (id, name, config) VALUES ('unscoped-other', 'unscoped-other', '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    await engine.putPage('people/other-source', {
+      title: 'people/other-source', type: 'person',
+      compiled_truth: FACT_FENCE(`| 1 | other source fact | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`),
+      frontmatter: {}, timeline: '',
+    }, { sourceId: 'unscoped-other' });
 
     const r = await runExtractFacts(engine);  // no slugs filter
-    expect(r.pagesScanned).toBe(2);
+    expect(r.pagesScanned).toBe(3);
     expect(r.factsInserted).toBe(2);
   });
 });
@@ -672,6 +682,49 @@ describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {
 });
 
 describe('runExtractFacts — multi-source isolation', () => {
+  test('a full source-scoped run scans only that source and leaves other sources unchanged', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO sources (id, name, config) VALUES
+         ('alpha', 'alpha', '{}'::jsonb),
+         ('beta', 'beta', '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+    );
+
+    await engine.putPage('people/alpha-only', {
+      title: 'people/alpha-only', type: 'person',
+      compiled_truth: FACT_FENCE(`| 1 | alpha fence fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`),
+      frontmatter: {}, timeline: '',
+    }, { sourceId: 'alpha' });
+    await engine.putPage('people/beta-only', {
+      title: 'people/beta-only', type: 'person',
+      compiled_truth: FACT_FENCE(`| 1 | beta fence fact | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`),
+      frontmatter: {}, timeline: '',
+    }, { sourceId: 'beta' });
+    await engine.insertFacts(
+      [{
+        fact: 'beta existing fact', kind: 'fact', source: 'seed', row_num: 1,
+        source_markdown_slug: 'people/beta-only',
+      }],
+      { source_id: 'beta' },
+    );
+
+    const result = await runExtractFacts(engine, { sourceId: 'alpha' });
+
+    expect(result.pagesScanned).toBe(1);
+    expect(result.factsInserted).toBe(1);
+    expect(result.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT source_id, fact FROM facts ORDER BY source_id, fact`,
+    );
+    expect(rows.rows).toEqual([
+      expect.objectContaining({ source_id: 'alpha', fact: 'alpha fence fact' }),
+      expect.objectContaining({ source_id: 'beta', fact: 'beta existing fact' }),
+    ]);
+  });
+
   test('a pending legacy row in source A does NOT jam extraction for source B (#2646 source-scope)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (engine as any).db.query(

--- a/test/take-proposals-review.test.ts
+++ b/test/take-proposals-review.test.ts
@@ -1,0 +1,255 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runTakes } from '../src/commands/takes.ts';
+import { extractTakesFromPages } from '../src/core/extract-takes-from-pages.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { dispatchToolCall } from '../src/mcp/dispatch.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+let engine: PGLiteEngine;
+const tempDirs: string[] = [];
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function makeSourceDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-take-proposals-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.join(' ')); };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n');
+}
+
+async function addSource(id: string, localPath: string): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path)
+     VALUES ($1, $2, $3)`,
+    [id, id, localPath],
+  );
+}
+
+async function seedProposal(opts: {
+  sourceId: string;
+  sourceDir: string;
+  slug: string;
+  claim: string;
+  holder?: string;
+}): Promise<number> {
+  const sourcePath = join(opts.sourceDir, `${opts.slug}.md`);
+  const body = `# Review fixture\n\n${opts.claim}\n\nThis page is deliberately ordinary test evidence.\n`;
+  const parent = join(opts.sourceDir, opts.slug.split('/').slice(0, -1).join('/'));
+  if (parent !== opts.sourceDir) {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(parent, { recursive: true });
+  }
+  writeFileSync(sourcePath, body, 'utf8');
+  const page = await engine.putPage(opts.slug, {
+    title: 'Review fixture',
+    type: 'analysis',
+    compiled_truth: body.trim(),
+    frontmatter: {},
+    timeline: '',
+  }, { sourceId: opts.sourceId });
+  const rows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO take_proposals (
+       source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+       claim_text, kind, holder, weight, model_id
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING id`,
+    [
+      opts.sourceId,
+      opts.slug,
+      sha256(page.compiled_truth),
+      'test-prompt-v1',
+      'test-run-1',
+      opts.claim,
+      'take',
+      opts.holder ?? 'brain',
+      0.7,
+      'test:model',
+    ],
+  );
+  return rows[0]!.id;
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  for (const dir of tempDirs) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+describe('takes proposal review surface', () => {
+  test('lists pending proposals through the CLI and source-scoped API with evidence and provenance', async () => {
+    const reviewDir = makeSourceDir();
+    const otherDir = makeSourceDir();
+    await addSource('review-source', reviewDir);
+    await addSource('other-source', otherDir);
+    const proposalId = await seedProposal({
+      sourceId: 'review-source', sourceDir: reviewDir, slug: 'notes/review', claim: 'The review flow needs an explicit human decision.',
+    });
+    await seedProposal({
+      sourceId: 'review-source', sourceDir: reviewDir, slug: 'notes/private', claim: 'Private holder proposal.', holder: 'people/private' });
+    await seedProposal({
+      sourceId: 'other-source', sourceDir: otherDir, slug: 'notes/other', claim: 'Other source proposal.' });
+
+    await withEnv({ GBRAIN_SOURCE: 'review-source' }, async () => {
+      const cli = await captureStdout(() => runTakes(engine, ['proposals', '--json']));
+      const listed = JSON.parse(cli) as Array<Record<string, unknown>>;
+      expect(listed).toHaveLength(2);
+      expect(listed.map(row => row.id)).toContain(proposalId);
+      const proposal = listed.find(row => row.id === proposalId)!;
+      expect(proposal.source_id).toBe('review-source');
+      expect(proposal.page_slug).toBe('notes/review');
+      expect(proposal.model_id).toBe('test:model');
+      expect(proposal.evidence).toMatchObject({ status: 'current', page_present: true });
+      expect((proposal.evidence as { excerpt?: string }).excerpt).toContain('explicit human decision');
+    });
+
+    const api = await dispatchToolCall(engine, 'takes_proposals_list', { status: 'pending' }, {
+      remote: true,
+      sourceId: 'review-source',
+      takesHoldersAllowList: ['brain'],
+    });
+    expect(api.isError).toBeFalsy();
+    const listed = JSON.parse(api.content[0]!.text) as Array<Record<string, unknown>>;
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.id).toBe(proposalId);
+    expect(listed[0]!.source_id).toBe('review-source');
+  });
+
+  test('accept promotes one current, source-owned proposal and is idempotent', async () => {
+    const sourceDir = makeSourceDir();
+    await addSource('review-source', sourceDir);
+    const proposalId = await seedProposal({
+      sourceId: 'review-source', sourceDir, slug: 'notes/accept', claim: 'A reviewer accepted this proposal.',
+    });
+
+    await withEnv({ GBRAIN_SOURCE: 'review-source' }, async () => {
+      await runTakes(engine, ['accept', String(proposalId), '--by', 'reviewer']);
+      await runTakes(engine, ['accept', String(proposalId), '--by', 'reviewer']);
+    });
+
+    const proposalRows = await engine.executeRaw<{
+      status: string;
+      acted_by: string | null;
+      acted_at: string | null;
+      promoted_row_num: number | null;
+    }>(
+      `SELECT status, acted_by, acted_at, promoted_row_num
+         FROM take_proposals WHERE id = $1`,
+      [proposalId],
+    );
+    expect(proposalRows[0]).toMatchObject({ status: 'accepted', acted_by: 'reviewer', promoted_row_num: 1 });
+    expect(proposalRows[0]!.acted_at).toBeTruthy();
+
+    const takes = await engine.listTakes({ page_slug: 'notes/accept', sourceId: 'review-source' });
+    expect(takes).toHaveLength(1);
+    expect(takes[0]).toMatchObject({ claim: 'A reviewer accepted this proposal.', row_num: 1, source: `proposal:${proposalId}` });
+    expect(readFileSync(join(sourceDir, 'notes/accept.md'), 'utf8')).toContain(`proposal:${proposalId}`);
+  });
+
+  test('reject records the reviewer decision without promoting a canonical take', async () => {
+    const sourceDir = makeSourceDir();
+    await addSource('review-source', sourceDir);
+    const proposalId = await seedProposal({
+      sourceId: 'review-source', sourceDir, slug: 'notes/reject', claim: 'This proposal should not be promoted.',
+    });
+
+    await withEnv({ GBRAIN_SOURCE: 'review-source' }, async () => {
+      await runTakes(engine, ['reject', String(proposalId), '--by', 'reviewer']);
+      await runTakes(engine, ['reject', String(proposalId), '--by', 'reviewer']);
+    });
+
+    const rows = await engine.executeRaw<{ status: string; acted_by: string | null; promoted_row_num: number | null }>(
+      `SELECT status, acted_by, promoted_row_num FROM take_proposals WHERE id = $1`,
+      [proposalId],
+    );
+    expect(rows[0]).toEqual({ status: 'rejected', acted_by: 'reviewer', promoted_row_num: null });
+    expect(await engine.listTakes({ page_slug: 'notes/reject', sourceId: 'review-source' })).toEqual([]);
+  });
+
+  test('keeps the bootstrap boundary disabled without invoking extraction work', async () => {
+    const result = await extractTakesFromPages(engine, { bootstrapEnabled: false });
+    expect(result).toEqual({
+      pages_scanned: 0,
+      claims_extracted: 0,
+      consent_gate_blocked: true,
+      llm_unavailable: false,
+    });
+  });
+});
+
+// 2026-08-11: takes_proposal_create — the Claude-operator entry into the
+// review queue. Hash is stamped server-side; identical claims dedupe.
+describe('createTakeProposal', () => {
+  test('creates a pending proposal with server-side content hash, dedupes repeats, validates kind', async () => {
+    const { createTakeProposal } = await import('../src/core/take-proposals.ts');
+    const dir = makeSourceDir();
+    await addSource('cm-test', dir);
+    const body = '# Fixture\n\nProse that grounds a gradeable claim about the future.';
+    await engine.putPage('memory/fixture-page', {
+      title: 'Fixture', type: 'analysis', compiled_truth: body, frontmatter: {}, timeline: '',
+    }, { sourceId: 'cm-test' });
+
+    const first = await createTakeProposal(engine, {
+      sourceId: 'cm-test', pageSlug: 'memory/fixture-page',
+      claimText: 'This fixture claim will resolve true within a year',
+      kind: 'prediction', holder: 'brain', weight: 0.6,
+    });
+    expect(first.id).not.toBeNull();
+    expect(first.deduped).toBe(false);
+    expect(first.content_hash).toBe(sha256(body));
+
+    const repeat = await createTakeProposal(engine, {
+      sourceId: 'cm-test', pageSlug: 'memory/fixture-page',
+      claimText: 'This fixture claim will resolve true within a year',
+      kind: 'prediction', holder: 'brain', weight: 0.6,
+    });
+    expect(repeat.id).toBeNull();
+    expect(repeat.deduped).toBe(true);
+
+    await expect(createTakeProposal(engine, {
+      sourceId: 'cm-test', pageSlug: 'memory/fixture-page',
+      claimText: 'A claim with an unknown kind should be rejected loudly',
+      kind: 'conjecture', holder: 'brain', weight: 0.6,
+    })).rejects.toThrow(/Invalid proposal kind/);
+
+    await expect(createTakeProposal(engine, {
+      sourceId: 'cm-test', pageSlug: 'memory/absent-page',
+      claimText: 'A claim against a page that does not exist in the source',
+      kind: 'judgment', holder: 'brain', weight: 0.6,
+    })).rejects.toThrow(/was not found in source/);
+
+    const proposals = await (await import('../src/core/take-proposals.ts')).listTakeProposals(engine, {
+      sourceId: 'cm-test', redactPrivateEvidence: false,
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.evidence.status).toBe('current');
+  });
+});

--- a/test/takes-fence.test.ts
+++ b/test/takes-fence.test.ts
@@ -407,3 +407,79 @@ ${TAKES_FENCE_END}\n`;
     expect(oldRow.resolvedEvidence).toBe('Series A closed');
   });
 });
+
+// 2026-08-11 regression: the take_proposals accept path writes proposal
+// kinds ('prediction' | 'judgment' | 'bet') verbatim into the fence. The
+// parser must read them, and fence rewrites must never drop rows the
+// parser cannot read (the clobber that erased an accepted take).
+describe('proposal-kind vocabulary + no-clobber guard', () => {
+  const PROPOSAL_KIND_BODY = `# Page
+
+${TAKES_FENCE_BEGIN}
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Feature launch will lift retention | prediction | brain | 0.5 |  | proposal:3 |
+| 2 | Fix the systemic defect once | judgment | people/alice-example | 0.85 |  | proposal:2 |
+${TAKES_FENCE_END}
+`;
+
+  test('parses prediction and judgment kinds without warnings', () => {
+    const { takes, warnings } = parseTakesFence(PROPOSAL_KIND_BODY);
+    expect(warnings).toEqual([]);
+    expect(takes).toHaveLength(2);
+    expect(takes[0].kind).toBe('prediction');
+    expect(takes[1].kind).toBe('judgment');
+  });
+
+  test('upsertTakeRow appends after an existing proposal-kind row instead of clobbering it', () => {
+    const { body, rowNum } = upsertTakeRow(PROPOSAL_KIND_BODY, {
+      claim: 'A third claim',
+      kind: 'judgment',
+      holder: 'brain',
+      weight: 0.8,
+      source: 'proposal:15',
+      active: true,
+    });
+    expect(rowNum).toBe(3);
+    const { takes, warnings } = parseTakesFence(body);
+    expect(warnings).toEqual([]);
+    expect(takes).toHaveLength(3);
+    expect(takes.map(t => t.source)).toEqual(['proposal:3', 'proposal:2', 'proposal:15']);
+  });
+
+  test('upsertTakeRow refuses to rewrite a fence containing rows the parser drops', () => {
+    const MALFORMED_BODY = `# Page
+
+${TAKES_FENCE_BEGIN}
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Some claim | conjecture | claude | 0.5 |  | proposal:9 |
+${TAKES_FENCE_END}
+`;
+    expect(() => upsertTakeRow(MALFORMED_BODY, {
+      claim: 'New claim',
+      kind: 'take',
+      holder: 'brain',
+      weight: 0.5,
+      active: true,
+    })).toThrow(/refusing to rewrite a takes fence with unparseable rows/);
+  });
+
+  test('supersedeRow refuses to rewrite a fence containing rows the parser drops', () => {
+    const MALFORMED_BODY = `# Page
+
+${TAKES_FENCE_BEGIN}
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Good row | take | brain | 0.5 |  | src |
+| 2 | Bad row | conjecture | claude | 0.5 |  | proposal:9 |
+${TAKES_FENCE_END}
+`;
+    expect(() => supersedeRow(MALFORMED_BODY, 1, {
+      claim: 'Replacement',
+      kind: 'take',
+      holder: 'brain',
+      weight: 0.5,
+    })).toThrow(/refusing to rewrite a takes fence with unparseable rows/);
+  });
+});


### PR DESCRIPTION
## What

- **Fence parser reads proposal kinds.** `parseTakesFence` only knew the seed kinds (`fact|take|bet|hunch`), but the proposal pipeline emits `prediction|judgment|bet`. Accepting a proposal wrote a fence row the parser could not read.
- **Fence rewrites refuse to drop rows.** The unknown-kind warning was swallowed (`void warnings`), and the next rewrite of the same fence re-rendered from the parsed subset — silently erasing the previously accepted take. Observed as real data loss on a live brain: accept proposal A on a page, accept proposal B on the same page, A's row is gone from markdown and the derived DB row is clobbered. `upsertTakeRow`/`supersedeRow` now throw instead of rewriting a fence that contains rows the parser dropped.
- **Take-proposal review surface**: source-scoped `takes proposals` listing with evidence status (`current|stale|missing`) + bounded excerpt, explicit `takes accept|reject <id> --by <reviewer>` (idempotent; repeat decisions are no-ops), current-page content-hash check before promotion, and a read-only `takes_proposals_list` op for MCP with remote evidence redaction.
- **`takes_proposal_create` op**: lets an external reasoning layer (e.g. a Claude operator replacing the internal LLM extractor) enter the review queue. Content hash is stamped server-side from the page's current indexed content, creation is idempotent per (page, content, prompt_version, claim), and nothing is promoted without the manual review above.
- **Source-scoped `extract_facts` enumeration**: a source-scoped run no longer enumerates every slug in the brain.

## Tests

- Regression tests for the parser vocabulary, the no-clobber guard on both rewrite paths, proposal creation/dedup/kind validation, and the review CLI.
- Ran on top of current master (52306ed4): `bun run typecheck` clean; takes/fence/proposal/extract suites 135 pass / 0 fail.

## Notes for the wave

The no-clobber guard changes `upsertTakeRow`/`supersedeRow` from silent-warning to throw when the existing fence has unparseable rows — any caller that relied on rewriting past a malformed fence will now surface the malformation instead of erasing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
