### PR TITLE
feat(ai): register llama-server chat prompt caching

### DIFF
--- a/src/core/ai/recipes/llama-server.ts
+++ b/src/core/ai/recipes/llama-server.ts
@@ -2,16 +2,19 @@ import type { Recipe } from '../types.ts';
 import { probeLlamaServer } from '../probes.ts';
 
 /**
- * llama.cpp's `llama-server --embeddings` (also published as
- * `@llama.cpp/llama-server`). Exposes an OpenAI-compatible /v1/embeddings
- * endpoint. Distinct from Ollama: different default port (8080), different
- * model-management story (you launch it with `--model <path>`; the server
- * serves whatever model was passed).
+ * llama.cpp's `llama-server` (also published as `@llama.cpp/llama-server`).
+ * It exposes OpenAI-compatible chat and embedding endpoints, depending on
+ * how the server is launched. Distinct from Ollama: different default port
+ * (8080), different model-management story (you launch it with
+ * `--model <path>`; the server serves whatever model was passed).
  *
- * Like LiteLLM, this recipe ships with `models: []` because the model
- * identity is whatever the user launched llama-server with. They MUST
- * pass `--embedding-model llama-server:<id>` and `--embedding-dimensions
- * <N>`. The wizard refuses to pick implicit defaults.
+ * The embedding touchpoint ships with `models: []` because the model identity
+ * is whatever the user launched llama-server with. Users MUST pass
+ * `--embedding-model llama-server:<id>` and `--embedding-dimensions <N>`.
+ * The chat touchpoint follows the same user-provided model identity. Its
+ * prompt-cache capability reflects llama-server's default `--cache-prompt`
+ * behavior; a deployment launched with `--no-cache-prompt` must not use this
+ * recipe as a cache-capable subagent route.
  *
  * Reference: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md
  */
@@ -42,6 +45,18 @@ export const llamaServer: Recipe = {
       // server launched with a larger `-b` can raise this. v0.32 (#779).
       max_batch_items: 32,
     },
+    chat: {
+      // The model id is the value supplied to llama-server's --alias flag.
+      models: [],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: true,
+      // The launched server's --ctx-size is deployment-specific. Keep the
+      // recipe conservative and let the gateway's standard fallback apply.
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-08-11',
+    },
   },
   /**
    * Probe via the OpenAI-compatible /v1/models endpoint. Caller passes the
@@ -55,7 +70,7 @@ export const llamaServer: Recipe = {
     if (!result.reachable) {
       return {
         ready: false,
-        hint: `llama-server not reachable at ${url}. Start it with \`./llama-server --model <path> --embeddings\` or set LLAMA_SERVER_BASE_URL.`,
+        hint: `llama-server not reachable at ${url}. Start it with \`llama-server --model <path> --alias <id> --jinja --cache-prompt\` (omit --embeddings for chat) or set LLAMA_SERVER_BASE_URL.`,
       };
     }
     if (!result.models_endpoint_valid) {
@@ -67,5 +82,5 @@ export const llamaServer: Recipe = {
     return { ready: true };
   },
   setup_hint:
-    'Build llama.cpp, then `llama-server --model <gguf-path> --embeddings`. Set --embedding-model llama-server:<id> + --embedding-dimensions <N>.',
+    'Install/build llama.cpp, then `llama-server --model <gguf-path> --alias <id> --jinja --cache-prompt` for chat or add `--embeddings` for embeddings. Set LLAMA_SERVER_BASE_URL for a non-default port.',
 };

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -24,6 +24,13 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(1000000); // Gemini 1.5 Pro
   });
 
+  it('returns full capabilities for a local llama-server model', () => {
+    const caps = getProviderCapabilities('llama-server:qwen-local-cache-probe');
+    expect(caps.supportsToolCalling).toBe(true);
+    expect(caps.supportsPromptCaching).toBe(true);
+    expect(caps.supportsParallelTools).toBe(true);
+  });
+
   it('marks OpenRouter OpenAI/Anthropic routes as cache-capable (per-model predicate)', () => {
     const openaiCaps = getProviderCapabilities('openrouter:openai/gpt-5.2');
     expect(openaiCaps.supportsToolCalling).toBe(true);
@@ -64,6 +71,10 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
   it('returns ok for fully-capable Anthropic models', () => {
     expect(classifyCapabilities('anthropic:claude-sonnet-4-6')).toBe('ok');
     expect(classifyCapabilities('anthropic:claude-opus-4-7')).toBe('ok');
+  });
+
+  it('returns ok for a cache-capable local llama-server model', () => {
+    expect(classifyCapabilities('llama-server:qwen-local-cache-probe')).toBe('ok');
   });
 
   it('returns degraded:no_caching for OpenAI (tools yes, caching no)', () => {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -45,10 +45,10 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('only Anthropic and model-family-gated OpenRouter claim supports_prompt_cache', () => {
+  test('only known cache-capable recipes claim supports_prompt_cache', () => {
     for (const r of listRecipes()) {
       if (!r.touchpoints.chat) continue;
-      if (r.id === 'anthropic') {
+      if (r.id === 'anthropic' || r.id === 'llama-server') {
         expect(r.touchpoints.chat.supports_prompt_cache).toBe(true);
       } else if (r.id === 'openrouter') {
         // Family-scoped predicate (openai/* + anthropic/claude-*), never a

--- a/test/ai/recipe-llama-server.test.ts
+++ b/test/ai/recipe-llama-server.test.ts
@@ -38,6 +38,16 @@ describe('recipe: llama-server', () => {
     expect(r.touchpoints.embedding!.default_dims).toBe(0);
   });
 
+  test('chat touchpoint declares tool calling and native prefix caching', () => {
+    const r = getRecipe('llama-server')!;
+    const chat = r.touchpoints.chat;
+    expect(chat).toBeDefined();
+    expect(chat!.models).toEqual([]);
+    expect(chat!.supports_tools).toBe(true);
+    expect(chat!.supports_subagent_loop).toBe(true);
+    expect(chat!.supports_prompt_cache).toBe(true);
+  });
+
   test('declares a probe function', () => {
     const r = getRecipe('llama-server')!;
     expect(typeof r.probe).toBe('function');


### PR DESCRIPTION
## What

Registers chat prompt caching for the `llama-server` recipe so repeated system-prefix turns hit the server-side prompt cache instead of re-evaluating the full prefix.

## Tests

Ran on top of current master (52306ed4): `test/ai/recipe-llama-server.test.ts`, `test/ai/capabilities.test.ts`, `test/ai/gateway-chat.test.ts` — 59 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
