### PR TITLE
feat(doctor): policy-aware checks — pack-gated atoms backlog and opt-in takes report ok instead of warn

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3895,12 +3895,13 @@ export async function checkDbOnlyCollectorCollision(
 /**
  * issue #1678 — extract_atoms_backlog doctor check.
  *
- * Closes the "silent backlog" gap: extract_atoms is pack-gated, so on a brain
- * whose active pack doesn't declare the phase it NEVER runs in the routine
- * cycle and pages accumulate forever with zero signal (the cycle reports a
- * clean `skipped`). This check counts the eligible-but-unextracted pages and,
- * when the pack doesn't run the phase AND the backlog is real, WARNs with the
- * exact `--drain` command.
+ * Counts the eligible-but-unextracted pages and reports whether the active
+ * pack runs extract_atoms at all. When the pack doesn't declare the phase,
+ * that is a policy choice (intentionally off) — the check reports `ok` with
+ * the count + the manual `--drain` command instead of warning, so an
+ * intentionally-disabled feature stops dragging the health score. When the
+ * pack DOES declare the phase, the routine cycle drains the backlog in
+ * bounded batches — informational `ok` either way.
  *
  * PAGE-BACKLOG-ONLY (Codex #11): extract_atoms also discovers transcript files
  * at runtime; this counts DB pages only — labeled in details. No
@@ -3931,17 +3932,6 @@ export async function computeExtractAtomsBacklogCheck(
       };
     }
 
-    // The incident: pack does NOT run the phase but a real backlog exists →
-    // it will grow forever without a signal. WARN with the drain command.
-    if (!declared && backlog > 10) {
-      const fix = 'gbrain dream --phase extract_atoms --drain --window 120 (or declare extract_atoms in your active schema pack)';
-      return {
-        name, status: 'warn',
-        message: `${backlog} pages eligible for atom extraction but the active pack does not run extract_atoms — backlog growing. Fix: ${fix}`,
-        details: { backlog, pack_declares_phase: false, fix_hint: fix, known_approximation: approx },
-      };
-    }
-
     if (declared) {
       // Pack runs it; the routine cycle drains in bounded batches. Informational.
       return {
@@ -3951,11 +3941,16 @@ export async function computeExtractAtomsBacklogCheck(
       };
     }
 
-    // Not declared but below the warn threshold.
+    // Policy-aware (2026-08): the active pack not declaring extract_atoms is
+    // an intentional configuration choice, not a fault — do not drag the
+    // health score with a warn. Surface the count + the manual drain command
+    // as an informational ok, mirroring checkHiddenBySearchPolicy's pattern
+    // for policy-derived state.
+    const fix = 'gbrain dream --phase extract_atoms --drain';
     return {
       name, status: 'ok',
-      message: `${backlog} page(s) eligible (below warn threshold; pack does not run extract_atoms)`,
-      details: { backlog, pack_declares_phase: false, known_approximation: approx },
+      message: `${backlog} pages eligible; extract_atoms not declared by active pack (intentionally off — drain with \`${fix}\`)`,
+      details: { backlog, pack_declares_phase: false, fix_hint: fix, known_approximation: approx },
     };
   } catch (err) {
     return { name, status: 'warn', message: `extract_atoms_backlog check failed: ${(err as Error).message}` };
@@ -5762,10 +5757,10 @@ export async function buildChecks(
     }
   }
 
-  // 3d.2b issue #1678 — extract_atoms_backlog. Surfaces the silent
-  // pack-gated-phase backlog: when the active pack doesn't run extract_atoms
-  // but eligible pages pile up, WARN with the `--drain` command. OK when the
-  // pack runs the phase (routine cycle drains it) or there's no backlog.
+  // 3d.2b issue #1678 — extract_atoms_backlog. Surfaces the pack-gated-phase
+  // backlog: when the active pack doesn't run extract_atoms, that's a policy
+  // choice — OK, with the count + `--drain` command in the message. OK when
+  // the pack runs the phase (routine cycle drains it) or there's no backlog.
   if (engine) {
     try {
       checks.push(await computeExtractAtomsBacklogCheck(engine));

--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -322,8 +322,8 @@ export async function checkTakesCount(
   if (takesCount >= 100) {
     message = `${takesCount} takes (calibration ready)`;
   } else if (takesCount === 0) {
-    status = 'warn';
     if (bootstrapEnabled) {
+      status = 'warn';
       message = `0 takes (bootstrap eligible — gbrain takes extract --from-pages)`;
       remediations.push(makeRemediationStep({
         id: 'onboard.takes_bootstrap',
@@ -337,6 +337,11 @@ export async function checkTakesCount(
         status: 'remediable',
       }));
     } else {
+      // Policy-aware (2026-08): takes.bootstrap_enabled is an explicit opt-in
+      // (A12 two-gate consent). 0 takes with bootstrap OFF is the expected
+      // resting state, not a fault — report ok instead of dragging the
+      // health score with a warn the operator can't act on without opting in.
+      status = 'ok';
       message = '0 takes (takes.bootstrap_enabled is false; opt in to enable)';
     }
   } else {

--- a/test/doctor-extract-atoms-backlog.test.ts
+++ b/test/doctor-extract-atoms-backlog.test.ts
@@ -4,8 +4,11 @@
  * Pins:
  *  - countExtractAtomsBacklog counts eligible-but-unextracted pages (scoped +
  *    brain-wide) and excludes pages that already have an atom (NOT EXISTS).
- *  - computeExtractAtomsBacklogCheck WARNs with a `--drain` hint when the pack
- *    doesn't run the phase and the backlog is real; OK at 0.
+ *  - computeExtractAtomsBacklogCheck is policy-aware (2026-08): OK with a
+ *    `--drain` hint when the pack doesn't run the phase (intentionally off,
+ *    regardless of backlog size — an undeclared phase must never drag the
+ *    health score); OK at 0; OK when the pack declares the phase (routine
+ *    cycle drains it).
  *
  * Real in-memory PGLite (canonical block, R3+R4). GBRAIN_HOME is pointed at an
  * empty tmpdir for the doctor-check cases so packDeclaresPhase resolves the
@@ -97,13 +100,24 @@ describe('computeExtractAtomsBacklogCheck (issue #1678)', () => {
     expect((check.details as { backlog: number }).backlog).toBe(0);
   });
 
-  it('WARNs with a --drain hint when the pack does not run the phase and backlog > 10', async () => {
+  it('is OK (policy-aware) with a --drain hint when the pack does not run the phase, even with a large backlog', async () => {
     for (let i = 0; i < 11; i++) await seedArticle(`article-${i}`);
     const check = await withEnv({ GBRAIN_HOME: EMPTY_HOME }, () =>
       computeExtractAtomsBacklogCheck(engine));
-    expect(check.status).toBe('warn');
+    expect(check.status).toBe('ok');
     expect(check.message).toContain('--drain');
+    expect(check.message).toContain('not declared by active pack');
+    expect(check.message).toContain('intentionally off');
     expect((check.details as { pack_declares_phase: boolean }).pack_declares_phase).toBe(false);
     expect((check.details as { known_approximation: string }).known_approximation).toContain('page backlog only');
+  });
+
+  it('is OK (policy-aware) with a small undeclared backlog too — no warn threshold anymore', async () => {
+    await seedArticle('article-solo');
+    const check = await withEnv({ GBRAIN_HOME: EMPTY_HOME }, () =>
+      computeExtractAtomsBacklogCheck(engine));
+    expect(check.status).toBe('ok');
+    expect((check.details as { backlog: number }).backlog).toBe(1);
+    expect((check.details as { pack_declares_phase: boolean }).pack_declares_phase).toBe(false);
   });
 });

--- a/test/e2e/onboard-full-flow.test.ts
+++ b/test/e2e/onboard-full-flow.test.ts
@@ -16,7 +16,7 @@ import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { computeRemediationPlan } from '../../src/core/remediation/index.ts';
 import { captureMetric } from '../../src/core/onboard/impact-capture.ts';
 import { buildOnboardReport, toOnboardRecommendation } from '../../src/core/onboard/render.ts';
-import { runAllOnboardChecks } from '../../src/core/onboard/checks.ts';
+import { runAllOnboardChecks, checkTakesCount } from '../../src/core/onboard/checks.ts';
 import { makeRemediationStep } from '../../src/core/remediation-step.ts';
 
 let engine: PGLiteEngine;
@@ -72,13 +72,15 @@ describe('onboard E2E — runAllOnboardChecks', () => {
     ]);
   });
 
-  test('empty brain: stale/link/timeline ok, takes_count warns (0 takes)', async () => {
+  test('empty brain: stale/link/timeline/takes_count all ok (takes.bootstrap_enabled defaults false)', async () => {
     const results = await runAllOnboardChecks(engine);
     const byName = Object.fromEntries(results.map((r) => [r.check.name, r.check.status]));
     expect(byName.embed_staleness).toBe('ok');
     expect(byName.entity_link_coverage).toBe('ok');
     expect(byName.timeline_coverage).toBe('ok');
-    expect(byName.takes_count).toBe('warn'); // 0 takes is a warn
+    // Policy-aware (2026-08): 0 takes with bootstrap opt-in OFF is the
+    // expected resting state, not a fault — ok, not warn.
+    expect(byName.takes_count).toBe('ok');
   });
 
   test('empty brain remediations: takes_count gated, pack_upgrade_available may surface', async () => {
@@ -95,6 +97,30 @@ describe('onboard E2E — runAllOnboardChecks', () => {
       .filter((r) => r.check.name === 'takes_count')
       .reduce((s, r) => s + r.remediations.length, 0);
     expect(takesRemediations).toBe(0);
+  });
+});
+
+describe('onboard E2E — checkTakesCount policy-aware (2026-08)', () => {
+  afterAll(async () => {
+    // Restore default (unset) so later describe blocks in this file see the
+    // stock config, matching the rest of this file's shared-engine tests.
+    await engine.unsetConfig('takes.bootstrap_enabled');
+  });
+
+  test('0 takes + bootstrap OFF (default) → ok, opt-in message, no remediation', async () => {
+    await engine.unsetConfig('takes.bootstrap_enabled');
+    const result = await checkTakesCount(engine);
+    expect(result.check.status).toBe('ok');
+    expect(result.check.message).toContain('takes.bootstrap_enabled is false');
+    expect(result.remediations.length).toBe(0);
+  });
+
+  test('0 takes + bootstrap ON → warn (existing behavior), with remediation', async () => {
+    await engine.setConfig('takes.bootstrap_enabled', 'true');
+    const result = await checkTakesCount(engine);
+    expect(result.check.status).toBe('warn');
+    expect(result.check.message).toContain('bootstrap eligible');
+    expect(result.remediations.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What

Makes two doctor checks policy-aware so intentionally-disabled features stop dragging the health score, following the existing `checkHiddenBySearchPolicy` pattern (policy-derived state reports `ok`, not `warn`). Both derive the classification from EXISTING signals — no new config keys, no suppression list.

- **`extract_atoms_backlog`**: when the active pack does not declare the `extract_atoms` phase, the backlog is a configuration choice, not a fault — the check now reports `ok` with the count and the manual `--drain` command in the message. Behavior when the pack DOES declare the phase is unchanged.
- **`takes_count`**: the check already read `takes.bootstrap_enabled` but only changed the message. `0 takes` with bootstrap OFF (the A12 two-gate consent resting state) now reports `ok`; `0 takes` with bootstrap ON still warns with the remediation step.

Motivation: on an install that deliberately runs without the internal LLM phases, doctor's score punishes the policy itself — we observed the score *drop* after the system objectively improved, because every policy-off feature costs 5 points forever. Score should reflect actionable risk.

## Open design question (deliberately NOT included)

`cycle_freshness` has the same problem on cycle-less installs, but there is no clean existing signal: the pack `phases:` list only gates lens phases (`manifest-v1.ts`), the 17 core phases always run, and the default `gbrain-base` pack declares no `phases:` at all — so gating freshness on "empty phases" would silence real staleness for default installs. Left for a maintainer call (e.g. an explicit `cycle.enabled` config, or gating on cycle-eligibility of the sources).

## Tests

- New: undeclared-phase backlog (large and small) → `ok`; `checkTakesCount` bootstrap-off → `ok`, bootstrap-on → `warn`.
- On top of current master: `bun run typecheck` clean; `doctor-extract-atoms-backlog`, `onboard-full-flow`, `doctor-cycle-freshness`, `doctor-categories` → 43 pass / 0 fail; pack-gating/onboard regression suites → 39 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
