### PR TITLE
fix(files,capture,delete): commands report success while storing nothing, corrupting, or deleting originals

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -172,9 +172,12 @@ function defaultSlug(content: string, now: Date = new Date(), type?: string): st
  * Returns the 0-indexed byte offset of the first NUL, or -1 if clean.
  * Caller decides the error shape (message vs JSON envelope).
  *
- * Known limit: a PNG-without-NUL-in-first-8KB slips through. v0.39
- * magic-byte allowlist (per CV10-B + TODOS.md) closes this hole. The
- * 8KB ceiling bounds the scan cost to ~microseconds even on huge files.
+ * The 8KB ceiling bounds the scan cost to ~microseconds even on huge files.
+ *
+ * This scan alone is NOT sufficient — a container with no NUL in its head (an
+ * ASCII-armored PDF being the common case) passes it. That hole is closed by
+ * `detectBinarySignature`, which runs first; keep both, since the NUL scan
+ * still catches binary formats that carry no signature in this list.
  */
 export function detectBinaryNullByte(buf: Buffer): number {
   const limit = Math.min(buf.length, 8 * 1024);
@@ -182,6 +185,81 @@ export function detectBinaryNullByte(buf: Buffer): number {
     if (buf[i] === 0) return i;
   }
   return -1;
+}
+
+/**
+ * Magic-byte signatures for container formats that must never be stored as a
+ * page body. Each entry matches `bytes` at a fixed `offset`.
+ *
+ * Entries are deliberately restricted to signatures that either contain a
+ * non-printable byte or are long/distinctive enough that a real markdown file
+ * opening with them is implausible. Weak two-letter ASCII magics (`MZ`, `BM`)
+ * and `ID3` are intentionally OMITTED: a legitimate text file can plausibly
+ * start with those, and the formats carrying them hold NUL bytes early anyway,
+ * so `detectBinaryNullByte` already covers them without the false-positive risk
+ * of refusing a valid capture.
+ */
+const BINARY_SIGNATURES: ReadonlyArray<{ offset: number; bytes: readonly number[]; label: string }> = [
+  { offset: 0, bytes: [0x25, 0x50, 0x44, 0x46, 0x2d], label: 'PDF' },                     // %PDF-
+  { offset: 0, bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], label: 'PNG' },
+  { offset: 0, bytes: [0xff, 0xd8, 0xff], label: 'JPEG' },
+  { offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61], label: 'GIF' },               // GIF87a
+  { offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], label: 'GIF' },               // GIF89a
+  { offset: 0, bytes: [0x50, 0x4b, 0x03, 0x04], label: 'ZIP / OOXML (docx, xlsx, pptx)' },
+  { offset: 0, bytes: [0x50, 0x4b, 0x05, 0x06], label: 'ZIP (empty archive)' },
+  { offset: 0, bytes: [0x50, 0x4b, 0x07, 0x08], label: 'ZIP (spanned archive)' },
+  { offset: 0, bytes: [0x1f, 0x8b], label: 'gzip' },
+  { offset: 0, bytes: [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c], label: '7-Zip' },
+  { offset: 0, bytes: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07], label: 'RAR' },
+  { offset: 0, bytes: [0x7f, 0x45, 0x4c, 0x46], label: 'ELF executable' },
+  { offset: 0, bytes: [0xcf, 0xfa, 0xed, 0xfe], label: 'Mach-O' },
+  { offset: 0, bytes: [0xce, 0xfa, 0xed, 0xfe], label: 'Mach-O' },
+  { offset: 0, bytes: [0xfe, 0xed, 0xfa, 0xcf], label: 'Mach-O' },
+  { offset: 0, bytes: [0xfe, 0xed, 0xfa, 0xce], label: 'Mach-O' },
+  { offset: 0, bytes: [0xca, 0xfe, 0xba, 0xbe], label: 'Mach-O universal / Java class' },
+  { offset: 0, bytes: [0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33], label: 'SQLite database' },
+  { offset: 0, bytes: [0x4f, 0x67, 0x67, 0x53], label: 'Ogg' },
+  { offset: 0, bytes: [0x66, 0x4c, 0x61, 0x43], label: 'FLAC' },
+  { offset: 0, bytes: [0x1a, 0x45, 0xdf, 0xa3], label: 'Matroska / WebM' },
+  { offset: 0, bytes: [0x49, 0x49, 0x2a, 0x00], label: 'TIFF' },
+  { offset: 0, bytes: [0x4d, 0x4d, 0x00, 0x2a], label: 'TIFF' },
+  { offset: 0, bytes: [0x77, 0x4f, 0x46, 0x46], label: 'WOFF font' },
+  { offset: 0, bytes: [0x77, 0x4f, 0x46, 0x32], label: 'WOFF2 font' },
+  { offset: 4, bytes: [0x66, 0x74, 0x79, 0x70], label: 'MP4 / MOV / HEIC' },              // ....ftyp
+  { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50], label: 'WebP' },                          // RIFF....WEBP
+  { offset: 8, bytes: [0x57, 0x41, 0x56, 0x45], label: 'WAV' },                           // RIFF....WAVE
+  { offset: 8, bytes: [0x41, 0x56, 0x49, 0x20], label: 'AVI' },                           // RIFF....AVI_
+];
+
+/**
+ * v0.44 — magic-byte binary guard. Closes the hole the CV10 NUL scan documented
+ * but never closed ("Known limit: a PNG-without-NUL-in-first-8KB slips
+ * through... magic-byte allowlist closes this hole").
+ *
+ * Why the NUL scan is insufficient: a container whose leading bytes happen to
+ * contain no 0x00 — a small ASCII-armored PDF is the common case — passes the
+ * NUL scan, gets UTF-8-decoded into U+FFFD replacement characters, and is
+ * stored as the page body. `capture` then reports success while the document's
+ * real text is lost, because in a PDF that text lives inside FlateDecode
+ * streams. The stored page is unsearchable mojibake with a `%PDF-1.4` title.
+ *
+ * Returns a format label for the matched signature, or null when nothing
+ * matches. Cheap: a handful of byte comparisons against the file head.
+ */
+export function detectBinarySignature(buf: Buffer): string | null {
+  for (const sig of BINARY_SIGNATURES) {
+    const end = sig.offset + sig.bytes.length;
+    if (buf.length < end) continue;
+    let matched = true;
+    for (let i = 0; i < sig.bytes.length; i++) {
+      if (buf[sig.offset + i] !== sig.bytes[i]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return sig.label;
+  }
+  return null;
 }
 
 async function readStdinBuffer(): Promise<Buffer> {
@@ -436,6 +514,23 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
     process.exit(1);
   }
 
+  // Magic-byte guard runs FIRST: it names the actual format, and it catches the
+  // containers the NUL scan structurally cannot (an ASCII-armored PDF has no
+  // NUL in its head, so pre-fix it was decoded to mojibake and stored as a page
+  // body with its real text silently dropped).
+  const binaryFormat = detectBinarySignature(rawBuffer!);
+  if (binaryFormat !== null) {
+    console.error(
+      `gbrain capture: refusing to capture ${binaryFormat} content from ${inputLabel}\n` +
+      `  Detected by magic bytes. Storing it would write UTF-8 replacement characters as the\n` +
+      `  page body — for container formats the real text is compressed, so it would be lost\n` +
+      `  entirely while the command reported success.\n` +
+      `  Extract the text first, then capture that. For a PDF:\n` +
+      `    pdftotext ${inputLabel === 'stdin' ? 'input.pdf' : inputLabel} - | gbrain capture --stdin --slug <slug>`,
+    );
+    process.exit(1);
+  }
+
   // CV10 binary guard. Scans the first 8KB for NUL bytes; rejects with a
   // friendly message before UTF-8 decode mangles arbitrary bytes.
   const nullByteOffset = detectBinaryNullByte(rawBuffer!);
@@ -637,6 +732,7 @@ export const __testing = {
   deriveTitle,
   parseArgs,
   detectBinaryNullByte,
+  detectBinarySignature,
   normalizeForHash,
   maybeRewriteSourceFkError,
 };

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -50,6 +50,53 @@ export function formatFileSizeKb(rawSizeBytes: number | bigint | string | null):
     : '?';
 }
 
+/**
+ * The message every storage-dependent `files` subcommand prints when there is
+ * no backend. Exported so tests assert the contract without spawning a CLI.
+ */
+export function noStorageBackendMessage(op: string): string {
+  return (
+    `gbrain files ${op}: no storage backend configured — refusing to continue.\n` +
+    `  The files table records metadata only (there is no blob column), so without a\n` +
+    `  backend the bytes go nowhere while the DB claims they are stored.\n` +
+    `  Fix: configure storage (see gbrain init storage settings), or keep the binary\n` +
+    `  outside the brain and capture its extracted text instead.`
+  );
+}
+
+/**
+ * Single precondition for every storage-dependent `files` subcommand.
+ *
+ * Class fix (see `noStorageBackendMessage`): `upload`, `sync`, and `redirect`
+ * each tested storage permissively (`if (config?.storage)`) and then carried on
+ * when the answer was "no" — inserting rows, printing "uploaded", and in
+ * `redirect` unlinking local originals whose bytes had never left the machine.
+ * Storage-dependent work must refuse up front rather than half-succeed, so this
+ * exits BEFORE any DB write or local mutation.
+ */
+async function requireStorageBackend(
+  op: string,
+): Promise<{ storage: StorageBackend; storageConfig: { bucket?: string } }> {
+  const { loadConfig } = await import('../core/config.ts');
+  const config = loadConfig();
+  if (!config?.storage) {
+    console.error(noStorageBackendMessage(op));
+    process.exit(1);
+  }
+  const { createStorage } = await import('../core/storage.ts');
+  return {
+    storage: (await createStorage(config.storage as any)) as StorageBackend,
+    storageConfig: config.storage as { bucket?: string },
+  };
+}
+
+/** The subset of the storage driver these commands rely on. */
+interface StorageBackend {
+  upload(path: string, data: Buffer, mime?: string): Promise<unknown>;
+  exists(path: string): Promise<boolean>;
+  getUrl(path: string): Promise<string>;
+}
+
 export async function runFiles(engine: BrainEngine, args: string[]) {
   const subcommand = args[0];
 
@@ -138,6 +185,11 @@ async function uploadFile(engine: BrainEngine, args: string[]) {
     process.exit(1);
   }
 
+  // Precondition first: a backend-less upload can only produce a phantom row
+  // (metadata for bytes that were never stored), so refuse before touching the
+  // DB or reporting anything as uploaded.
+  const { storage } = await requireStorageBackend('upload');
+
   const stat = statSync(filePath);
   const hash = fileHash(filePath);
   const filename = basename(filePath);
@@ -153,17 +205,10 @@ async function uploadFile(engine: BrainEngine, args: string[]) {
     return;
   }
 
-  // Upload to storage backend if configured
-  const { loadConfig } = await import('../core/config.ts');
-  const config = loadConfig();
-  if (config?.storage) {
-    const { createStorage } = await import('../core/storage.ts');
-    const storage = await createStorage(config.storage as any);
-    const content = readFileSync(filePath);
-    const method = content.length >= SIZE_THRESHOLD ? 'TUS resumable' : 'standard';
-    console.log(`Uploading ${humanSize(stat.size)} via ${method}...`);
-    await storage.upload(storagePath, content, mimeType || undefined);
-  }
+  const content = readFileSync(filePath);
+  const method = content.length >= SIZE_THRESHOLD ? 'TUS resumable' : 'standard';
+  console.log(`Uploading ${humanSize(stat.size)} via ${method}...`);
+  await storage.upload(storagePath, content, mimeType || undefined);
 
   await sql`
     INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
@@ -313,6 +358,11 @@ async function syncFiles(engine: BrainEngine, dir?: string) {
     process.exit(1);
   }
 
+  // Pre-fix this command inserted a `files` row per file and reported them as
+  // "uploaded" without ever calling the storage backend — every row it produced
+  // was a phantom, even on a brain WITH storage configured.
+  const { storage } = await requireStorageBackend('sync');
+
   const files = collectFiles(dir);
   console.log(`Found ${files.length} files to sync`);
 
@@ -345,6 +395,9 @@ async function syncFiles(engine: BrainEngine, dir?: string) {
     const pathParts = relativePath.split('/');
     const pageSlug = pathParts.length > 1 ? pathParts.slice(0, -1).join('/') : null;
 
+    // Actually put the bytes in storage before recording them as stored.
+    await storage.upload(storagePath, readFileSync(filePath), mimeType || undefined);
+
     await sql`
       INSERT INTO files (page_slug, filename, storage_path, mime_type, size_bytes, content_hash, metadata)
       VALUES (${pageSlug}, ${filename}, ${storagePath}, ${mimeType}, ${stat.size}, ${hash}, ${'{}'}::jsonb)
@@ -371,24 +424,58 @@ async function verifyFiles(engine: BrainEngine) {
     return;
   }
 
+  // Pre-fix this loop asked only "does the ROW carry a hash and a path" — true
+  // for any row an INSERT produced — and then printed a hardcoded
+  // "0 mismatches, 0 missing". `missing` was declared and never incremented.
+  // So the one command whose job is catching un-stored files reported phantom
+  // rows as "verified". The check that matters is byte existence at
+  // storage_path, which requires the backend.
+  const { loadConfig } = await import('../core/config.ts');
+  const config = loadConfig();
+  if (!config?.storage) {
+    console.error(
+      `gbrain files verify: ${rows.length} file row(s) recorded, but no storage backend is configured.\n` +
+      `  Byte existence cannot be checked and these rows cannot be retrieved, so they are\n` +
+      `  reported as UNVERIFIABLE rather than "verified" — almost certainly phantoms left by\n` +
+      `  a backend-less upload/sync. Configure storage, or delete the rows.`,
+    );
+    process.exit(1);
+  }
+  const { createStorage } = await import('../core/storage.ts');
+  const storage = (await createStorage(config.storage as any)) as StorageBackend;
+
   let verified = 0;
   let mismatches = 0;
   let missing = 0;
 
   for (const row of rows) {
-    // Note: full verification would check Supabase Storage hash
-    // For now, verify the DB record exists and has valid data
-    if (!row.content_hash || !row.storage_path) {
+    const storagePath = row.storage_path as string | null;
+    if (!row.content_hash || !storagePath) {
       mismatches++;
-      console.error(`  MISMATCH: ${row.storage_path} (missing hash or path)`);
-    } else {
+      console.error(`  MISMATCH: ${storagePath || '(no path)'} (missing hash or path)`);
+      continue;
+    }
+    let exists: boolean;
+    try {
+      exists = await storage.exists(storagePath);
+    } catch (e) {
+      mismatches++;
+      console.error(
+        `  MISMATCH: ${storagePath} (storage check failed: ${e instanceof Error ? e.message : String(e)})`,
+      );
+      continue;
+    }
+    if (exists) {
       verified++;
+    } else {
+      missing++;
+      console.error(`  MISSING: ${storagePath} (row recorded, no bytes in storage)`);
     }
   }
 
-  if (mismatches === 0 && missing === 0) {
-    console.log(`${verified} files verified, 0 mismatches, 0 missing`);
-  } else {
+  // Always report the real counts — never a hardcoded pair.
+  console.log(`${verified} files verified, ${mismatches} mismatches, ${missing} missing`);
+  if (mismatches > 0 || missing > 0) {
     console.error(`VERIFY FAILED: ${mismatches} mismatches, ${missing} missing.`);
     console.error(`Run: gbrain files sync --retry-failed`);
     process.exit(1);
@@ -404,13 +491,8 @@ async function mirrorFiles(args: string[]) {
   const dryRun = args.includes('--dry-run');
   if (!dir || !existsSync(dir)) { console.error('Usage: gbrain files mirror <dir> [--dry-run]'); process.exit(1); }
 
-  const { createStorage } = await import('../core/storage.ts');
-  const { loadConfig } = await import('../core/config.ts');
   const { stringify } = await import('../core/yaml-lite.ts');
-  const config = loadConfig();
-  if (!config?.storage) { console.error('No storage backend configured. Run gbrain init with storage settings.'); process.exit(1); }
-
-  const storage = await createStorage(config.storage as any);
+  const { storage, storageConfig } = await requireStorageBackend('mirror');
   const files = collectFiles(dir);
   console.log(`Found ${files.length} files to mirror`);
 
@@ -432,7 +514,7 @@ async function mirrorFiles(args: string[]) {
   // Write .supabase marker
   const marker = stringify({
     synced_at: new Date().toISOString(),
-    bucket: (config.storage as { bucket?: string })?.bucket || 'brain-files',
+    bucket: storageConfig?.bucket || 'brain-files',
     prefix: basename(dir) + '/',
     file_count: uploaded,
   });
@@ -475,14 +557,16 @@ async function redirectFiles(args: string[]) {
     return;
   }
 
-  // Verify remote files exist before deleting locals
-  const { loadConfig } = await import('../core/config.ts');
-  const config = loadConfig();
-  let storage: any = null;
-  if (config?.storage) {
-    const { createStorage } = await import('../core/storage.ts');
-    storage = await createStorage(config.storage as any);
-  }
+  // Verify remote files exist before deleting locals.
+  //
+  // This is the destructive path: it unlinks the local original and leaves a
+  // `supabase://` pointer behind. Pre-fix, `storage` was only built when a
+  // backend happened to be configured (`if (config?.storage)`) and the
+  // existence check was correspondingly conditional (`if (storage)`) — so with
+  // no backend the guard was skipped entirely and the loop deleted originals
+  // while writing pointers to bytes that had never been uploaded. Data loss,
+  // not a phantom row. The backend is now mandatory here.
+  const { storage } = await requireStorageBackend('redirect');
 
   let redirected = 0;
   let skippedMissing = 0;
@@ -490,14 +574,13 @@ async function redirectFiles(args: string[]) {
     const relPath = relative(dir, filePath);
     const hash = fileHash(filePath);
 
-    // Verify remote exists before deleting local
-    if (storage) {
-      const remoteExists = await storage.exists(relPath);
-      if (!remoteExists) {
-        console.error(`  Skipping ${relPath}: not found in remote storage (would lose data)`);
-        skippedMissing++;
-        continue;
-      }
+    // Unconditional: never unlink a local original we have not confirmed
+    // exists remotely.
+    const remoteExists = await storage.exists(relPath);
+    if (!remoteExists) {
+      console.error(`  Skipping ${relPath}: not found in remote storage (would lose data)`);
+      skippedMissing++;
+      continue;
     }
 
     const stat = statSync(filePath);

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -10,7 +10,7 @@ import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
-import { writePageThrough, type WriteThroughResult } from './write-through.ts';
+import { writePageThrough, deletePageThrough, type WriteThroughResult } from './write-through.ts';
 import { hybridSearch, hybridSearchCached, stampContentFlags, stampUnverifiedExtractions } from './search/hybrid.ts';
 import { looksConceptShaped } from './search/query-intent.ts';
 import { expandQuery } from './search/expansion.ts';
@@ -1886,9 +1886,31 @@ const delete_page: Operation = {
       if (!existing) {
         throw new OperationError('page_not_found', `Page not found: ${slug}`, 'Check the slug.');
       }
-      return { status: 'already_soft_deleted', slug, deleted_at: existing.deleted_at };
+      // Already soft-deleted, but the artifact may still be on disk from a
+      // pre-fix delete — reconcile it here so a re-issued delete is the
+      // documented way to clean up the leak.
+      const wt = await deletePageThrough(ctx.engine, slug, {
+        sourceId: ctx.sourceId,
+        logger: ctx.logger,
+      });
+      return { status: 'already_soft_deleted', slug, deleted_at: existing.deleted_at, write_through: wt };
     }
-    return { status: 'soft_deleted', slug, recoverable_until: 'now + 72h via restore_page' };
+    // Remove the on-disk artifact too. Pre-fix this was DB-only, so a deleted
+    // page's `.md` file survived and any timer-based commit (snapshot cron,
+    // hardened post-commit push) pushed it back into git — resurrecting the
+    // page on the next `gbrain sync`. Sandbox subagents stay DB-only, matching
+    // put_page's trust gate.
+    const isSandboxSubagent = ctx.viaSubagent === true
+      && !(Array.isArray(ctx.allowedSlugPrefixes) && ctx.allowedSlugPrefixes.length > 0);
+    const writeThrough = isSandboxSubagent
+      ? { removed: false, skipped: 'subagent_sandbox' as const }
+      : await deletePageThrough(ctx.engine, slug, { sourceId: ctx.sourceId, logger: ctx.logger });
+    return {
+      status: 'soft_deleted',
+      slug,
+      recoverable_until: 'now + 72h via restore_page',
+      write_through: writeThrough,
+    };
   },
   cliHints: { name: 'delete', positional: ['slug'] },
 };
@@ -1916,7 +1938,17 @@ const restore_page: Operation = {
       }
       return { status: 'already_active', slug };
     }
-    return { status: 'restored', slug };
+    // Re-render the artifact: delete_page now removes it, so without this a
+    // restored page exists in the DB with no file — and `sync --full`'s
+    // delete-reconcile treats a row with no artifact as deleted, silently
+    // re-deleting the page the user just restored. Keeps the two sinks
+    // symmetric across the delete/restore pair.
+    const isSandboxSubagent = ctx.viaSubagent === true
+      && !(Array.isArray(ctx.allowedSlugPrefixes) && ctx.allowedSlugPrefixes.length > 0);
+    const writeThrough = isSandboxSubagent
+      ? { written: false, skipped: 'subagent_sandbox' as const }
+      : await writePageThrough(ctx.engine, slug, { sourceId: ctx.sourceId, logger: ctx.logger });
+    return { status: 'restored', slug, write_through: writeThrough };
   },
   cliHints: { name: 'restore', positional: ['slug'] },
 };

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -151,6 +151,118 @@ function recordedPathFromFileUri(sourceUri: string | null | undefined, pageRoot:
  * `skipped` / `error` fields (the DB write is the durable sink; the file is
  * best-effort and reconciled by the next `gbrain sync`).
  */
+type ResolvedTarget =
+  | { ok: true; filePath: string; writeRoot: string }
+  | { ok: false; skipped: NonNullable<WriteThroughResult['skipped']> };
+
+/**
+ * Resolve the on-disk artifact path for `slug`, applying every containment and
+ * leak guard. Shared by `writePageThrough` and `deletePageThrough` so the two
+ * planes can never disagree about WHICH file backs a page — a delete that
+ * computed the path differently from the write would either miss the file
+ * (leaving a deleted page's artifact for the git cron to re-commit) or unlink
+ * something it shouldn't.
+ *
+ * #2018: pick the disk target so a page is NEVER written into a different
+ * source's working tree. Two legitimate topologies, plus the leak guard:
+ *   1. The assigned source has its OWN `local_path` (a separate working tree)
+ *      → use that tree's root (matches how `scanOneSource` reads it back;
+ *      never nested under `.sources/`).
+ *   2. No per-source `local_path` → nest under the host repo
+ *      (`sync.repo_path`): default at the root, non-default under
+ *      `.sources/<id>/` (the established multi-source layout).
+ *   3. LEAK GUARD: if `sync.repo_path` is literally ANOTHER source's own
+ *      `local_path`, nesting this page there would pollute that sibling's git
+ *      repo (the reported bug). Skip instead.
+ */
+export async function resolveWriteThroughTarget(
+  engine: BrainEngine,
+  slug: string,
+  sourceId: string,
+): Promise<ResolvedTarget> {
+  let filePath: string;
+  let writeRoot: string;
+  const srcRows = await engine.executeRaw<{ local_path: string | null }>(
+    `SELECT local_path FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  const sourceLocalPath = srcRows[0]?.local_path ?? null;
+
+  // Prefer the page's recorded `source_path` — the ACTUAL file this row was
+  // imported from — over a slug-derived name. Deriving `<slug>.md` mints a
+  // SECOND file beside the original whenever the on-disk name isn't the slug,
+  // which is the common case for a human-authored vault: `Library/People/
+  // Steve Jobs.md` has slug `library/people/steve-jobs`, so a later put_page
+  // dropped a lowercase `steve-jobs.md` twin next to it. Two artifacts, one
+  // row, and the newer content in whichever the caller didn't expect.
+  //
+  // It also desyncs `gbrain sync`, which keys delete-reconcile on
+  // `source_path` (see collectMissingSourcePaths): the twin is invisible to
+  // reconcile, so deleting the ORIGINAL file deletes the page even though a
+  // file for it is still on disk.
+  //
+  // A NULL `source_path` means the page was born via put/capture and has no
+  // file of record yet — the slug-derived path stays correct for those.
+  //
+  // Deliberately NOT filtered on `deleted_at IS NULL`: `deletePageThrough`
+  // runs AFTER `softDeletePage` has stamped the row, so that predicate would
+  // return nothing on the delete plane and silently fall back to the
+  // slug-derived twin — unlinking the wrong file (or none) and leaving the
+  // real artifact for the git cron to re-commit. That is the very no-op class
+  // this helper exists to close. `UNIQUE (source_id, slug)` guarantees at most
+  // one row, so there is no live/deleted ambiguity to resolve here.
+  const pathRows = await engine.executeRaw<{ source_path: string | null; source_uri: string | null }>(
+    `SELECT source_path, source_uri FROM pages WHERE source_id = $1 AND slug = $2 LIMIT 1`,
+    [sourceId, slug],
+  );
+  const recordedPath = sanitizeRecordedSourcePath(pathRows[0]?.source_path);
+  const recordedUri = pathRows[0]?.source_uri ?? null;
+
+  if (sourceLocalPath) {
+    if (!existsSync(sourceLocalPath) || !statSync(sourceLocalPath).isDirectory()) {
+      return { ok: false, skipped: 'repo_not_found' };
+    }
+    filePath = join(
+      sourceLocalPath,
+      recordedPath ?? recordedPathFromFileUri(recordedUri, sourceLocalPath) ?? `${slug}.md`,
+    );
+    writeRoot = sourceLocalPath;
+  } else {
+    const repoPath = await engine.getConfig('sync.repo_path');
+    if (!repoPath) {
+      return { ok: false, skipped: 'no_repo_configured' };
+    }
+    if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
+      return { ok: false, skipped: 'repo_not_found' };
+    }
+    // Leak guard: refuse to touch a path that is some OTHER source's own
+    // working tree (#2018).
+    const collide = await engine.executeRaw<{ one: number }>(
+      `SELECT 1 AS one FROM sources WHERE id <> $1 AND local_path = $2 LIMIT 1`,
+      [sourceId, repoPath],
+    );
+    if (collide.length > 0) {
+      return { ok: false, skipped: 'source_repo_belongs_to_other_source' };
+    }
+    const pageRoot = sourceId === 'default' ? repoPath : join(repoPath, '.sources', sourceId);
+    const knownPath = recordedPath ?? recordedPathFromFileUri(recordedUri, pageRoot);
+    filePath = knownPath ? join(pageRoot, knownPath) : resolvePageFilePath(repoPath, slug, sourceId);
+    writeRoot = repoPath;
+  }
+
+  // Defense-in-depth (#1647-slug / codex #6): confirm the computed file path
+  // stays within the source's working tree before any mkdir/write/unlink.
+  // validateSlug already rejects `..`/backslash/control/%2e in the slug at
+  // write time, so this guards a pre-existing hostile row or a symlinked
+  // intermediate dir under the source tree from escaping to an arbitrary
+  // filesystem location.
+  if (!isWriteTargetContained(filePath, writeRoot)) {
+    return { ok: false, skipped: 'path_escapes_source_root' };
+  }
+
+  return { ok: true, filePath, writeRoot };
+}
+
 export async function writePageThrough(
   engine: BrainEngine,
   slug: string,
@@ -158,87 +270,9 @@ export async function writePageThrough(
 ): Promise<WriteThroughResult> {
   const sourceId = opts.sourceId ?? 'default';
   try {
-    // #2018: pick the disk target so a page is NEVER written into a different
-    // source's working tree. Two legitimate topologies, plus the leak guard:
-    //   1. The assigned source has its OWN `local_path` (a separate working
-    //      tree) → write at that tree's root (matches how `scanOneSource` reads
-    //      it back; never nested under `.sources/`).
-    //   2. No per-source `local_path` → nest under the host repo
-    //      (`sync.repo_path`): default at the root, non-default under
-    //      `.sources/<id>/` (the established multi-source layout).
-    //   3. LEAK GUARD: if `sync.repo_path` is literally ANOTHER source's own
-    //      `local_path`, nesting this page there would pollute that sibling's
-    //      git repo (the reported bug). Skip instead.
-    let filePath: string;
-    let writeRoot: string;
-    const srcRows = await engine.executeRaw<{ local_path: string | null }>(
-      `SELECT local_path FROM sources WHERE id = $1`,
-      [sourceId],
-    );
-    const sourceLocalPath = srcRows[0]?.local_path ?? null;
-
-    // Prefer the page's recorded `source_path` — the ACTUAL file this row was
-    // imported from — over a slug-derived name. Deriving `<slug>.md` mints a
-    // SECOND file beside the original whenever the on-disk name isn't the slug,
-    // which is the common case for a human-authored vault: `Library/People/
-    // Steve Jobs.md` has slug `library/people/steve-jobs`, so a later put_page
-    // dropped a lowercase `steve-jobs.md` twin next to it. Two artifacts, one
-    // row, and the newer content in whichever the caller didn't expect.
-    //
-    // It also desyncs `gbrain sync`, which keys delete-reconcile on
-    // `source_path` (see collectMissingSourcePaths): the twin is invisible to
-    // reconcile, so deleting the ORIGINAL file deletes the page even though a
-    // file for it is still on disk.
-    //
-    // A NULL `source_path` means the page was born via put/capture and has no
-    // file of record yet — the slug-derived path stays correct for those.
-    const pathRows = await engine.executeRaw<{ source_path: string | null; source_uri: string | null }>(
-      `SELECT source_path, source_uri FROM pages WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL LIMIT 1`,
-      [sourceId, slug],
-    );
-    const recordedPath = sanitizeRecordedSourcePath(pathRows[0]?.source_path);
-    const recordedUri = pathRows[0]?.source_uri ?? null;
-
-    if (sourceLocalPath) {
-      if (!existsSync(sourceLocalPath) || !statSync(sourceLocalPath).isDirectory()) {
-        return { written: false, skipped: 'repo_not_found' };
-      }
-      filePath = join(
-        sourceLocalPath,
-        recordedPath ?? recordedPathFromFileUri(recordedUri, sourceLocalPath) ?? `${slug}.md`,
-      );
-      writeRoot = sourceLocalPath;
-    } else {
-      const repoPath = await engine.getConfig('sync.repo_path');
-      if (!repoPath) {
-        return { written: false, skipped: 'no_repo_configured' };
-      }
-      if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
-        return { written: false, skipped: 'repo_not_found' };
-      }
-      // Leak guard: refuse to write into a path that is some OTHER source's
-      // own working tree (#2018).
-      const collide = await engine.executeRaw<{ one: number }>(
-        `SELECT 1 AS one FROM sources WHERE id <> $1 AND local_path = $2 LIMIT 1`,
-        [sourceId, repoPath],
-      );
-      if (collide.length > 0) {
-        return { written: false, skipped: 'source_repo_belongs_to_other_source' };
-      }
-      const pageRoot = sourceId === 'default' ? repoPath : join(repoPath, '.sources', sourceId);
-      const knownPath = recordedPath ?? recordedPathFromFileUri(recordedUri, pageRoot);
-      filePath = knownPath ? join(pageRoot, knownPath) : resolvePageFilePath(repoPath, slug, sourceId);
-      writeRoot = repoPath;
-    }
-
-    // Defense-in-depth (#1647-slug / codex #6): confirm the computed file path
-    // stays within the source's working tree before any mkdir/write. validateSlug
-    // already rejects `..`/backslash/control/%2e in the slug at write time, so
-    // this guards a pre-existing hostile row or a symlinked intermediate dir
-    // under the source tree from escaping to an arbitrary filesystem location.
-    if (!isWriteTargetContained(filePath, writeRoot)) {
-      return { written: false, skipped: 'path_escapes_source_root' };
-    }
+    const target = await resolveWriteThroughTarget(engine, slug, sourceId);
+    if (!target.ok) return { written: false, skipped: target.skipped };
+    const { filePath, writeRoot } = target;
 
     const writtenPage = await engine.getPage(slug, { sourceId });
     if (!writtenPage) {
@@ -325,5 +359,62 @@ export async function writePageThrough(
     const msg = e instanceof Error ? e.message : String(e);
     opts.logger?.warn(`[write-through] failed for ${slug}: ${msg}`);
     return { written: false, error: msg };
+  }
+}
+
+export interface DeleteThroughResult {
+  /** True when an artifact existed and was unlinked. */
+  removed: boolean;
+  /** The path that was removed (or would have been). */
+  path?: string;
+  /**
+   * Non-error reasons nothing was removed. Shares the write-through skip
+   * vocabulary, plus:
+   *   - file_not_present: the page had no artifact on disk (DB-only page, or
+   *     already removed by hand) — a clean no-op, not a failure.
+   */
+  skipped?: NonNullable<WriteThroughResult['skipped']> | 'file_not_present';
+  /** Set when the unlink itself threw (EACCES, EPERM, read-only mount). */
+  error?: string;
+}
+
+/**
+ * Remove the on-disk markdown artifact for `slug` — the delete-side counterpart
+ * to `writePageThrough`.
+ *
+ * Why this exists: `put_page`/capture write BOTH sinks (DB row + `.md` file),
+ * but `delete_page` used to touch only the DB. The orphaned file then outlived
+ * the page, and on any repo whose brain is committed on a timer (a `snapshot`
+ * cron, `sources harden`'s post-commit push) the deleted page's artifact gets
+ * committed back into git *after* deletion — so the page reappears on the next
+ * `gbrain sync`, silently resurrecting content the user deleted.
+ *
+ * Deliberately mirrors `writePageThrough`'s contract: never throws, reports via
+ * `skipped`/`error`, and resolves its target through the shared
+ * `resolveWriteThroughTarget` so the two planes cannot disagree about which
+ * file backs a page. The DB row remains the durable sink — a failure here
+ * leaves a stale file that the next `gbrain sync` reconciles, never a lost row.
+ */
+export async function deletePageThrough(
+  engine: BrainEngine,
+  slug: string,
+  opts: { sourceId?: string; logger?: WriteThroughLogger } = {},
+): Promise<DeleteThroughResult> {
+  const sourceId = opts.sourceId ?? 'default';
+  try {
+    const target = await resolveWriteThroughTarget(engine, slug, sourceId);
+    if (!target.ok) return { removed: false, skipped: target.skipped };
+    const { filePath } = target;
+
+    if (!existsSync(filePath)) {
+      return { removed: false, path: filePath, skipped: 'file_not_present' };
+    }
+
+    unlinkSync(filePath);
+    return { removed: true, path: filePath };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    opts.logger?.warn(`[write-through] delete failed for ${slug}: ${msg}`);
+    return { removed: false, error: msg };
   }
 }

--- a/test/capture-runcapture.test.ts
+++ b/test/capture-runcapture.test.ts
@@ -23,7 +23,7 @@ import { describe, test, expect } from 'bun:test';
 import { __testing as captureTesting } from '../src/commands/capture.ts';
 import { computeContentHash } from '../src/core/ingestion/types.ts';
 
-const { detectBinaryNullByte, normalizeForHash, maybeRewriteSourceFkError } = captureTesting;
+const { detectBinaryNullByte, detectBinarySignature, normalizeForHash, maybeRewriteSourceFkError } = captureTesting;
 
 describe('CV10 — binary file guard (detectBinaryNullByte)', () => {
   test('returns -1 on plain ASCII', () => {
@@ -79,6 +79,72 @@ describe('CV10 — binary file guard (detectBinaryNullByte)', () => {
 
   test('empty buffer returns -1', () => {
     expect(detectBinaryNullByte(Buffer.alloc(0))).toBe(-1);
+  });
+});
+
+describe('magic-byte binary guard (detectBinarySignature)', () => {
+  // The regression that motivated this guard: a small ps2pdf-produced PDF with
+  // ZERO NUL bytes anywhere. It passed the CV10 NUL scan, was UTF-8-decoded to
+  // U+FFFD mojibake, and got stored as a page body titled '%PDF-1.4' — with the
+  // document's real text (inside FlateDecode streams) silently lost, while
+  // `capture` reported created_or_updated.
+  test('rejects a NUL-free PDF that the NUL scan cannot catch', () => {
+    const pdf = Buffer.from('%PDF-1.4\n1 0 obj\n<</Type/Catalog>>\nendobj\n');
+    expect(pdf.includes(0)).toBe(false);        // the exact hole: no NUL to find
+    expect(detectBinaryNullByte(pdf)).toBe(-1); // ...so the old guard passes it
+    expect(detectBinarySignature(pdf)).toBe('PDF'); // ...and the new one stops it
+  });
+
+  test('detects common container formats', () => {
+    const cases: Array<[Buffer, string]> = [
+      [Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), 'PNG'],
+      [Buffer.from([0xff, 0xd8, 0xff, 0xe0]), 'JPEG'],
+      [Buffer.from('GIF89a'), 'GIF'],
+      [Buffer.from([0x50, 0x4b, 0x03, 0x04]), 'ZIP / OOXML (docx, xlsx, pptx)'],
+      [Buffer.from([0x1f, 0x8b, 0x08]), 'gzip'],
+      [Buffer.from([0x7f, 0x45, 0x4c, 0x46]), 'ELF executable'],
+      [Buffer.from('SQLite format 3\0'), 'SQLite database'],
+      [Buffer.from('OggS'), 'Ogg'],
+      [Buffer.from([0x1a, 0x45, 0xdf, 0xa3]), 'Matroska / WebM'],
+    ];
+    for (const [buf, label] of cases) {
+      expect(detectBinarySignature(buf)).toBe(label);
+    }
+  });
+
+  test('matches signatures at non-zero offsets', () => {
+    // MP4: 4-byte box size, then 'ftyp' at offset 4.
+    const mp4 = Buffer.concat([Buffer.from([0x00, 0x00, 0x00, 0x18]), Buffer.from('ftypisom')]);
+    expect(detectBinarySignature(mp4)).toBe('MP4 / MOV / HEIC');
+    // RIFF containers are disambiguated by the tag at offset 8.
+    const webp = Buffer.concat([Buffer.from('RIFF'), Buffer.from([0, 0, 0, 0]), Buffer.from('WEBP')]);
+    expect(detectBinarySignature(webp)).toBe('WebP');
+    const wav = Buffer.concat([Buffer.from('RIFF'), Buffer.from([0, 0, 0, 0]), Buffer.from('WAVE')]);
+    expect(detectBinarySignature(wav)).toBe('WAV');
+  });
+
+  test('passes real text through, including the shapes that look risky', () => {
+    const texts = [
+      'hello world',
+      '# A markdown heading\n\nBody text.',
+      '測試 brain content',                       // multi-byte CJK
+      'thinking 🧠🔥 hot',                         // emoji
+      '﻿# BOM-prefixed markdown',            // UTF-8 BOM
+      '---\ntitle: T\ntype: note\n---\n\n# Body', // frontmatter
+      'MZ is a two-letter prefix in a sentence.', // deliberately-omitted weak magic
+      'BM is another one.',                       // deliberately-omitted weak magic
+      'ID3 tags are metadata containers.',        // deliberately-omitted weak magic
+      '%!PS-Adobe-3.0 is PostScript, which is text.',
+    ];
+    for (const t of texts) {
+      expect(detectBinarySignature(Buffer.from(t))).toBeNull();
+    }
+  });
+
+  test('handles buffers shorter than a signature without throwing', () => {
+    expect(detectBinarySignature(Buffer.alloc(0))).toBeNull();
+    expect(detectBinarySignature(Buffer.from('%PD'))).toBeNull(); // truncated PDF magic
+    expect(detectBinarySignature(Buffer.from([0x89]))).toBeNull();
   });
 });
 

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect, beforeAll, afterAll, spyOn } from 'bun:test';
-import { writeFileSync, mkdirSync, rmSync, symlinkSync, mkdtempSync } from 'fs';
+import { writeFileSync, readFileSync, mkdirSync, rmSync, symlinkSync, mkdtempSync } from 'fs';
 import { join, basename } from 'path';
 import { createHash } from 'crypto';
 import { extname } from 'path';
 import { tmpdir } from 'os';
-import { collectFiles, formatFileSizeKb } from '../src/commands/files.ts';
+import { collectFiles, formatFileSizeKb, noStorageBackendMessage } from '../src/commands/files.ts';
 import { operationsByName } from '../src/core/operations.ts';
 import * as db from '../src/core/db.ts';
 
@@ -246,5 +246,50 @@ describe('collectFiles (production import)', () => {
     } finally {
       rmSync(tmpDir, { recursive: true });
     }
+  });
+});
+
+describe('storage precondition — the silent-no-op class', () => {
+  test('refusal message names the subcommand and why it refuses', () => {
+    const msg = noStorageBackendMessage('upload');
+    expect(msg).toContain('gbrain files upload');
+    // The two facts a user needs: nothing was stored, and metadata-only is why.
+    expect(msg).toContain('refusing to continue');
+    expect(msg).toMatch(/metadata only|no blob column/);
+    expect(noStorageBackendMessage('redirect')).toContain('gbrain files redirect');
+  });
+
+  /**
+   * The guard rung: a bug is a sample, not the population. `upload`, `sync`, and
+   * `redirect` each tested storage permissively and continued when the answer
+   * was "no" — producing phantom rows and, in `redirect`, unlinking local
+   * originals whose bytes were never uploaded. This scan fails if anyone
+   * reintroduces the permissive form, so the whole class stays dead rather than
+   * just the three instances.
+   */
+  test('[GUARD] no storage-dependent path uses the permissive `if (config?.storage)` form', () => {
+    const src = readFileSync(join(import.meta.dir, '..', 'src', 'commands', 'files.ts'), 'utf8');
+    // Strip comments so prose describing the old bug doesn't trip the scan.
+    const code = src
+      .split('\n')
+      .filter((l) => {
+        const t = l.trim();
+        return !t.startsWith('*') && !t.startsWith('//') && !t.startsWith('/*');
+      })
+      .join('\n');
+
+    expect(code).not.toMatch(/if\s*\(\s*config\?\.storage\s*\)/);
+    // And the storage-dependent commands must route through the shared guard.
+    for (const op of ['upload', 'sync', 'mirror', 'redirect']) {
+      expect(code).toContain(`requireStorageBackend('${op}')`);
+    }
+  });
+
+  test('[GUARD] verify never hardcodes its mismatch/missing counts', () => {
+    const src = readFileSync(join(import.meta.dir, '..', 'src', 'commands', 'files.ts'), 'utf8');
+    // The original printed `${verified} files verified, 0 mismatches, 0 missing`
+    // with both counts literal, so phantom rows reported as verified.
+    expect(src).not.toMatch(/files verified, 0 mismatches, 0 missing/);
+    expect(src).toContain('${verified} files verified, ${mismatches} mismatches, ${missing} missing');
   });
 });

--- a/test/write-through.test.ts
+++ b/test/write-through.test.ts
@@ -14,7 +14,7 @@ import * as os from 'node:os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { resetGateway } from '../src/core/ai/gateway.ts';
-import { writePageThrough } from '../src/core/write-through.ts';
+import { writePageThrough, deletePageThrough } from '../src/core/write-through.ts';
 import { importFromContent } from '../src/core/import-file.ts';
 import { serializePageToMarkdown, resolvePageFilePath } from '../src/core/markdown.ts';
 
@@ -339,5 +339,109 @@ describe('writePageThrough', () => {
     const files = walkFiles(brainDir);
     expect(files.some((f) => f.endsWith('.md'))).toBe(false);
     expect(files.some((f) => f.includes('.tmp.'))).toBe(false);
+  });
+});
+
+describe('deletePageThrough', () => {
+  // The leak this closes: delete_page was DB-only, so the artifact outlived the
+  // page. On any brain committed on a timer (snapshot cron, hardened
+  // post-commit push) the orphan got committed AFTER deletion and the next
+  // `gbrain sync` resurrected the page.
+  test('removes the artifact written by writePageThrough', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'concepts/delete-me';
+    await seedPage(slug);
+
+    const written = await writePageThrough(engine, slug, { sourceId: 'default' });
+    expect(written.written).toBe(true);
+    expect(fs.existsSync(written.path!)).toBe(true);
+
+    const removed = await deletePageThrough(engine, slug, { sourceId: 'default' });
+    expect(removed.removed).toBe(true);
+    expect(removed.path).toBe(written.path);
+    expect(fs.existsSync(written.path!)).toBe(false);
+  });
+
+  test('resolves the SAME path writePageThrough uses', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'wiki/ideas/2026-01-01-path-parity-abc123';
+    await seedPage(slug);
+
+    const written = await writePageThrough(engine, slug, { sourceId: 'default' });
+    const removed = await deletePageThrough(engine, slug, { sourceId: 'default' });
+
+    // Path parity is the whole point of the shared resolver: a delete that
+    // computed the path differently would miss the file (leaving the orphan) or
+    // unlink the wrong one.
+    expect(removed.path).toBe(written.path);
+    expect(removed.path).toBe(resolvePageFilePath(brainDir, slug, 'default'));
+  });
+
+  test('[REGRESSION twin] resolves the recorded source_path even AFTER the row is soft-deleted', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'library/people/ada-lovelace';
+    const authored = 'Library/People/Ada Lovelace.md';
+    await importFromContent(engine, slug, `---\ntitle: Ada Lovelace\ntype: person\n---\n\n# Body\n`, {
+      noEmbed: true,
+      sourceId: 'default',
+      sourcePath: authored,
+    });
+
+    const written = await writePageThrough(engine, slug, { sourceId: 'default' });
+    expect(written.path).toBe(path.join(brainDir, authored));
+    expect(fs.existsSync(written.path!)).toBe(true);
+
+    // The delete_page op stamps `deleted_at` BEFORE it calls deletePageThrough.
+    // A target resolver that filtered rows on `deleted_at IS NULL` finds nothing
+    // at this point, silently falls back to the slug-derived twin, and reports a
+    // clean `file_not_present` no-op while the REAL artifact stays on disk for
+    // the next timer-based commit to resurrect. That is the exact silent-no-op
+    // class this file guards, reached through the delete plane instead of write.
+    await engine.softDeletePage(slug, { sourceId: 'default' });
+
+    const removed = await deletePageThrough(engine, slug, { sourceId: 'default' });
+
+    expect(removed.removed).toBe(true);
+    expect(removed.path).toBe(path.join(brainDir, authored));
+    expect(fs.existsSync(path.join(brainDir, authored))).toBe(false);
+  });
+
+  test('missing artifact is a clean no-op, not an error', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'concepts/db-only-page';
+    await seedPage(slug);
+
+    const res = await deletePageThrough(engine, slug, { sourceId: 'default' });
+    expect(res.removed).toBe(false);
+    expect(res.skipped).toBe('file_not_present');
+    expect(res.error).toBeUndefined();
+  });
+
+  test('no repo configured → skipped, never throws', async () => {
+    // sync.repo_path deliberately unset (DB-only brain by design).
+    const slug = 'concepts/no-repo';
+    await seedPage(slug);
+
+    const res = await deletePageThrough(engine, slug, { sourceId: 'default' });
+    expect(res.removed).toBe(false);
+    expect(res.skipped).toBe('no_repo_configured');
+  });
+
+  test('delete → restore round-trips the artifact back onto disk', async () => {
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'concepts/round-trip';
+    await seedPage(slug);
+
+    const written = await writePageThrough(engine, slug, { sourceId: 'default' });
+    expect(fs.existsSync(written.path!)).toBe(true);
+
+    await deletePageThrough(engine, slug, { sourceId: 'default' });
+    expect(fs.existsSync(written.path!)).toBe(false);
+
+    // restore_page re-renders the file; without that a restored page has a DB
+    // row and no artifact, and `sync --full` delete-reconcile re-deletes it.
+    const rewritten = await writePageThrough(engine, slug, { sourceId: 'default' });
+    expect(rewritten.written).toBe(true);
+    expect(fs.existsSync(written.path!)).toBe(true);
   });
 });


### PR DESCRIPTION
Four commands reported success while doing nothing — or, in one case, while destroying data. They share one shape: **storage/disk-dependent work that proceeds as if its precondition held.**

Found while answering a much smaller question ("can I attach a PDF?"), then widened by auditing for siblings.

## 1. `files upload` — phantom attachments

```ts
if (config?.storage) { ...upload... }    // no backend → silently skipped
await sql`INSERT INTO files ...`         // row written regardless
console.log(`Uploaded: ${storagePath}`)  // reports success
```

`files` has **no blob column**, so with no backend there is nowhere for bytes to go. Observed: `Uploaded: inbox/test/img.png (3 KB)`, a metadata row written, a filesystem-wide `find` for the payload returning nothing, and `files signed-url` on that exact path answering `No storage backend configured.`

## 2. `files sync` — never uploaded at all

Inserted a row per file and reported `N uploaded` **with no storage call anywhere in the function**. Every row it produced was a phantom, even on a correctly configured brain.

## 3. `files verify` — false-passes, hiding 1 and 2

```ts
if (!row.content_hash || !row.storage_path) mismatches++;  // tautological for any INSERT
else verified++;
console.log(`${verified} files verified, 0 mismatches, 0 missing`);  // both counts literal
```

`missing` was declared and never incremented. The one command whose job is catching un-stored files reported a phantom row as **verified**.

## 4. `files redirect` — data loss

The destructive path: it unlinks local originals and leaves `supabase://` pointers. It built `storage` only `if (config?.storage)` and made the "verify remote exists before deleting locals" check conditional on that — so with **no backend the guard was skipped entirely** and the loop deleted originals while writing pointers to bytes that had never been uploaded.

## 5. `capture --file <pdf>` — silent corruption

The CV10 comment documented the hole it left open — *"Known limit: a PNG-without-NUL-in-first-8KB slips through... magic-byte allowlist closes this hole"* — and that allowlist was never built. An ASCII-armored PDF contains **zero NUL bytes**, so it passed the scan, was UTF-8-decoded into U+FFFD mojibake, and stored as the page body with `title: '%PDF-1.4'`. The document's real text, living in FlateDecode streams, was **gone**, while the command reported `created_or_updated`.

## 6. `delete_page` — deleted pages resurrect

DB-only, so the write-through `.md` outlived the page. On any brain committed on a timer (a snapshot cron, `sources harden`'s post-commit push) the orphan gets committed *after* deletion and the next `gbrain sync` restores the page. `restore_page` was correspondingly asymmetric.

---

## Fixes

- **One shared `requireStorageBackend()`** gates `upload` / `sync` / `mirror` / `redirect`, failing *before* any DB write or unlink. `sync` now actually uploads.
- **`verify` really verifies**: `storage.exists()` per row, real counts, nonzero exit. Rows with no backend report **UNVERIFIABLE** rather than "verified".
- **`detectBinarySignature()`**: the 29-signature magic-byte allowlist CV10 specified, running before the NUL scan (both kept). Weak ASCII magics (`MZ`, `BM`, `ID3`) are deliberately **omitted** — real text can begin with those, and those formats carry NULs early anyway, so including them would trade a missed binary for a refused valid capture.
- **`deletePageThrough()`**, sharing a factored `resolveWriteThroughTarget()` with the write path so the two planes cannot disagree about which file backs a page. `delete_page` and `restore_page` both report `write_through`.

**Guards.** Two source scans fail the build if anyone reintroduces `if (config?.storage)` or a hardcoded verify count. Both were confirmed to *fail* against a deliberately reintroduced regression, rather than passing vacuously.

## Breaking-change note

`upload` / `sync` / `redirect` now **refuse** where they previously exited 0, and `verify` exits nonzero when rows exist with no backend. That's the point — the old behavior minted phantom rows and, in `redirect`, deleted originals — but anyone scripting against a backend-less install will see a hard failure instead of a silent no-op, and a green CI may correctly turn red.

## Verification

Unit: 75 pass across the three touched test files, 97 across delete/restore-adjacent suites, `tsc --noEmit` clean.

End-to-end against a live Postgres brain:

| Check | Result |
| --- | --- |
| `capture --file doc.pdf` | refuses, exit 1, no page created, suggests `pdftotext` |
| `pdftotext … \| capture --stdin` | text preserved — unique token present 3×, was **0×** |
| `files upload` | refuses; **0 phantom rows** |
| `files sync` | refuses; no rows |
| `files redirect` (mirrored fixture) | refuses; **original intact, no pointer written** |
| `delete` | `write_through: {removed: true}`; file gone |
| `restore` | `write_through: {written: true}`; file back, content intact |

Does not touch retrieval (search ranking, RRF, embeddings, intent classification, query expansion, source boost, or the `query`/`search` handlers), so per CONTRIBUTING the `gbrain eval replay` gate doesn't apply.

## Note

CI here will also show `cli-flag-validation` red until #4020 lands — pre-existing `master` drift, unrelated to this change.
