### PR TITLE
fix(test): unit suite isn't hermetic against the operator's env — 12 spurious failures

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -23,4 +23,18 @@ timeout = 60_000
 # were appending rows into the operator's real ~/.gbrain/sync-failures.jsonl,
 # which `gbrain doctor` reads and warns on. See
 # test/helpers/sync-failures-preload.ts.
-preload = ["./test/helpers/legacy-embedding-preload.ts", "./test/helpers/audit-dir-preload.ts", "./test/helpers/sync-failures-preload.ts"]
+#
+# hermetic-env-preload.ts: drop the operator's ambient CONDUCTOR_/MCP_/OPENCLAW_/
+# GBRAIN_ overrides and provider *_API_KEYs, mirroring the scrub run-e2e.sh
+# already performs for the E2E lane. Measured on one operator machine, the
+# ambient environment alone produced 12 failures with no defect in the product
+# (a stray GBRAIN_SOURCE, a GBRAIN_CYCLE_FRESHNESS_WARN_HOURS, and three
+# exported provider keys). Provider keys are left alone when argv names a
+# test/e2e/ path, since that lane needs live providers.
+#
+# ORDER IS LOAD-BEARING: it must precede legacy-embedding-preload, which
+# snapshots `env: {...process.env}` into the gateway. isAvailable() reads that
+# snapshot, not process.env — so keys must be gone BEFORE the snapshot is taken.
+# (This is why a test's own `delete process.env.OPENAI_API_KEY` does not make the
+# gateway unavailable.)
+preload = ["./test/helpers/hermetic-env-preload.ts", "./test/helpers/legacy-embedding-preload.ts", "./test/helpers/audit-dir-preload.ts", "./test/helpers/sync-failures-preload.ts"]

--- a/test/facts-classify.test.ts
+++ b/test/facts-classify.test.ts
@@ -9,12 +9,48 @@
  *   - 4-strategy parse fallback for malformed JSON
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import {
   cosineSimilarity,
   classifyAgainstCandidates,
 } from '../src/core/facts/classify.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 import type { FactRow } from '../src/core/engine.ts';
+
+/**
+ * Two tests below pin the NO-CHAT-PROVIDER branch (classifier unavailable →
+ * cosine fallback). They used to just assume it, with a comment reading
+ * "Without API key in test env, isAvailable('chat') is false".
+ *
+ * That assumption is false on any machine where the operator exports provider
+ * keys: `test/helpers/legacy-embedding-preload.ts` builds the gateway config
+ * with `env: { ...process.env }`, so an exported ANTHROPIC_API_KEY /
+ * OPENAI_API_KEY makes `isAvailable('chat')` return true. The tests then take
+ * the LLM classifier path and fail (`Expected "duplicate" / Received
+ * "independent"`) — and, worse, a unit test starts making real billable
+ * provider calls.
+ *
+ * Configure the gateway explicitly with an empty `env` so the precondition is
+ * guaranteed rather than inherited. This is the override mechanism the legacy
+ * preload documents ("tests that need a different gateway config call
+ * configureGateway() in their own beforeAll"). resetGateway() in afterAll
+ * returns the baseline for later files in the shard.
+ */
+const NO_PROVIDER_GATEWAY = {
+  embedding_model: 'openai:text-embedding-3-large',
+  embedding_dimensions: 1536,
+  chat_model: 'anthropic:claude-sonnet-4-6',
+  env: {},
+  base_urls: {},
+} as const;
+
+beforeAll(() => {
+  configureGateway({ ...NO_PROVIDER_GATEWAY });
+});
+
+afterAll(() => {
+  resetGateway();
+});
 
 function makeFact(overrides: Partial<FactRow> & { id: number }): FactRow {
   return {
@@ -94,8 +130,8 @@ describe('classifyAgainstCandidates', () => {
       { fact: 'new', kind: 'fact', embedding: a },
       candidates,
     );
-    // Without API key in test env, isAvailable('chat') is false → straight to
-    // cosine fallback. cos ≈ 0.93 ≥ 0.92 → duplicate.
+    // Gateway configured with env:{} above → isAvailable('chat') is false →
+    // straight to cosine fallback. cos ≈ 0.93 ≥ 0.92 → duplicate.
     expect(result.decision).toBe('duplicate');
     expect((result as { reason: string }).reason).toBe('cosine_fallback');
   });
@@ -106,8 +142,9 @@ describe('classifyAgainstCandidates', () => {
       { fact: 'new', kind: 'fact', embedding: null },
       candidates,
     );
-    // Without API key in test env, isAvailable('chat') is false → cosine fallback path.
-    // newFact has no embedding so cosine fallback can't compute → independent.
+    // Gateway configured with env:{} above → isAvailable('chat') is false →
+    // cosine fallback path. newFact has no embedding so cosine fallback can't
+    // compute → independent.
     expect(result.decision).toBe('independent');
     expect((result as { reason: string }).reason).toBe('cosine_fallback');
   });

--- a/test/helpers/hermetic-env-preload.ts
+++ b/test/helpers/hermetic-env-preload.ts
@@ -1,0 +1,124 @@
+/**
+ * Pre-test setup: neutralize the operator's ambient environment so the unit
+ * suite's result depends on the code under test, not on whoever's shell started
+ * it.
+ *
+ * ## Why
+ *
+ * `scripts/run-e2e.sh` already does exactly this for the E2E lane (see its
+ * "Hermetic env scrub" block): it drops `CONDUCTOR_* / MCP_* / OPENCLAW_* /
+ * GBRAIN_*` before bun starts, because "a dev shell or a Conductor workspace
+ * exports ... GBRAIN_* config overrides (e.g. a stray GBRAIN_BRAIN_ID,
+ * GBRAIN_SOURCE, GBRAIN_*_THRESHOLD ...) that would silently change test
+ * behavior — making 'hermetic' E2E non-hermetic and its failures unreproducible
+ * across machines."
+ *
+ * The unit lane never got that treatment. Measured on one operator machine
+ * (2026-08-11), the ambient environment alone produced **12 failures** with no
+ * defect in the product:
+ *
+ * | Ambient value | Failures it caused |
+ * | --- | --- |
+ * | `GBRAIN_SOURCE=default` | 8 in `source-resolver-with-tier` + `source-resolver-silent-fallback`, 1 in `extract-fs-source-id` — resolution short-circuits at tier `env` before reaching the tier under test |
+ * | `GBRAIN_CYCLE_FRESHNESS_WARN_HOURS=10` | 1 in `doctor-cycle-freshness` — moves the very threshold the test asserts (11 pass / 0 fail once unset) |
+ * | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` | 2 in `memory-verbs-conformance`, 2 in `mcp-eval-capture`, 2 in `facts-classify` — tests pinning provider-unavailable branches take the live-provider path instead |
+ *
+ * A red suite that is red for environmental reasons is worse than a slow one:
+ * it trains you to ignore failures.
+ *
+ * ## Why a preload rather than a scrub in the runner script
+ *
+ * `run-e2e.sh` scrubs in the shell, which only protects `bun run test`. A
+ * preload also protects a direct `bun test test/foo.test.ts` — how anyone
+ * actually iterates on a single file. The cost is that this file must handle the
+ * E2E gate itself (below), since `run-e2e.sh` also invokes `bun test` and
+ * therefore inherits `bunfig.toml`'s preload list.
+ *
+ * ## Load order matters
+ *
+ * This MUST precede `legacy-embedding-preload.ts` in `bunfig.toml`. That preload
+ * snapshots `env: { ...process.env }` into the gateway config, and
+ * `gateway.isAvailable()` reads `_config.env[k]` — NOT `process.env[k]`. So a key
+ * present when the snapshot is taken makes the gateway "available" for the rest
+ * of the process, and a test that later does `delete process.env.OPENAI_API_KEY`
+ * does **not** undo it. That is exactly why `mcp-eval-capture` failed despite
+ * deleting the key in its own setup. Strip before the snapshot or don't bother.
+ *
+ * ## The E2E gate
+ *
+ * E2E tests legitimately need live providers. They are detected by argv: this
+ * repo's E2E runner invokes `bun test <file>` one file at a time with paths
+ * under `test/e2e/`. When any argv entry names an E2E path, provider keys are
+ * left ALONE. The gate is deliberately fail-safe in that direction — a
+ * misdetection leaves keys in place (E2E keeps working, at worst a unit file
+ * stays non-hermetic) rather than stripping them out from under a live-provider
+ * suite.
+ *
+ * The operator-context scrub is NOT gated: `run-e2e.sh` already performs it for
+ * E2E, so applying it here is idempotent for that lane and additionally protects
+ * direct invocations.
+ *
+ * ## Escape hatches
+ *
+ * - `GBRAIN_TEST_KEEP_AMBIENT_ENV=1` — disable this preload entirely.
+ * - `GBRAIN_TEST_KEEP_PROVIDER_KEYS=1` — keep provider keys, still scrub operator
+ *   context. Use to reproduce a live-provider bug from a unit file.
+ * - `GBRAIN_DEBUG_PRELOAD=1` — log what was removed.
+ *
+ * ## Deliberately NOT stripped
+ *
+ * Provider `*_BASE_URL` vars and `AZURE_OPENAI_USE_ENTRA` redirect endpoints and
+ * auth mode, so they are a plausible leak of the same shape — but no test has
+ * been observed failing because of them, and someone may point tests at a local
+ * Ollama on purpose. Left alone pending evidence rather than widened on
+ * speculation. A `_API_KEY$` pattern is used instead of a hardcoded list of the
+ * 21 provider vars so new recipes are covered without touching this file.
+ */
+
+const KEEP_EXACT = new Set([
+  'GBRAIN_HOME',           // config/HOME isolation — run-e2e.sh keeps this too
+  'GBRAIN_DEBUG_PRELOAD',  // needed for the logging below to be reachable
+]);
+
+/** Operator-context prefixes, mirroring run-e2e.sh's denylist. */
+const OPERATOR_PREFIX = /^(CONDUCTOR_|MCP_|OPENCLAW_|GBRAIN_)/;
+
+/** Test-control vars must survive their own scrub, or the hatches can't work. */
+const KEEP_PREFIX = /^GBRAIN_TEST_/;
+
+/** Any provider credential. Pattern, not a list, so new recipes are covered. */
+const PROVIDER_KEY = /_API_KEY$/;
+
+function isE2eRun(): boolean {
+  return process.argv.some(
+    (a) => a.includes('test/e2e/') || a.includes('test\\e2e\\'),
+  );
+}
+
+// Read the hatches BEFORE scrubbing, since they live under GBRAIN_*.
+const keepAll = process.env.GBRAIN_TEST_KEEP_AMBIENT_ENV === '1';
+const keepProviderKeys = process.env.GBRAIN_TEST_KEEP_PROVIDER_KEYS === '1';
+const debug = process.env.GBRAIN_DEBUG_PRELOAD === '1';
+
+if (!keepAll) {
+  const removed: string[] = [];
+
+  for (const name of Object.keys(process.env)) {
+    if (KEEP_EXACT.has(name) || KEEP_PREFIX.test(name)) continue;
+
+    const isOperatorVar = OPERATOR_PREFIX.test(name);
+    const isProviderKey = PROVIDER_KEY.test(name);
+    if (!isOperatorVar && !isProviderKey) continue;
+
+    // The only gated category: live-provider credentials during an E2E run.
+    if (isProviderKey && !isOperatorVar && (keepProviderKeys || isE2eRun())) continue;
+
+    delete process.env[name];
+    removed.push(name);
+  }
+
+  if (debug && removed.length > 0) {
+    // Names only — never values.
+    console.error(`[hermetic-env-preload] cleared ${removed.length}: ${removed.sort().join(', ')}`);
+  }
+}


### PR DESCRIPTION
`scripts/run-e2e.sh` already scrubs `CONDUCTOR_* / MCP_* / OPENCLAW_* / GBRAIN_*` before bun starts, with a comment naming the failure mode exactly:

> A dev shell or a Conductor workspace exports … `GBRAIN_*` config overrides (e.g. a stray `GBRAIN_BRAIN_ID`, `GBRAIN_SOURCE`, `GBRAIN_*_THRESHOLD`) that would silently change test behavior — making "hermetic" E2E non-hermetic and its failures unreproducible across machines.

The unit lane never got that treatment. Measured on one operator machine, the ambient environment alone produced **12 failures with no defect in the product**:

| Ambient value | Failures |
| --- | --- |
| `GBRAIN_SOURCE=default` | 8 in `source-resolver-with-tier` + `source-resolver-silent-fallback`, 1 in `extract-fs-source-id` — resolution short-circuits at tier `env` before reaching the tier under test (`Expected: "seed_default" / Received: "env"`) |
| `GBRAIN_CYCLE_FRESHNESS_WARN_HOURS=10` | 1 in `doctor-cycle-freshness` — it moves the very threshold the test asserts (11 pass / 0 fail once unset) |
| `ANTHROPIC_` / `OPENAI_` / `OPENROUTER_API_KEY` | 2 in `memory-verbs-conformance`, 2 in `mcp-eval-capture`, 2 in `facts-classify` — tests pinning provider-*unavailable* branches take the live-provider path |

A suite that is red for environmental reasons is worse than a slow one: it trains you to ignore failures.

## Why per-test cleanup doesn't fix the API-key group

`test/helpers/legacy-embedding-preload.ts` snapshots `env: { ...process.env }` into the gateway, and `gateway.isAvailable()` ends at:

```ts
return required.every(k => !!_config!.env[k]);   // the snapshot — not process.env
```

So a key present when the snapshot is taken makes the gateway "available" for the rest of the process, and a test that later does `delete process.env.OPENAI_API_KEY` does **not** undo it. `mcp-eval-capture` deletes the key in its own setup and still failed.

That's why the new preload must load **first** in `bunfig.toml` — strip before the snapshot, or don't bother. Load order is load-bearing and commented as such.

## Why a preload rather than a shell scrub

`run-e2e.sh`'s approach only protects `bun run test`. A preload also protects `bun test test/foo.test.ts`, which is how anyone iterates on a single file. The cost is that this file has to own the E2E gate, since `run-e2e.sh` also invokes `bun test` and inherits the preload list.

**Happy to move it into the runner scripts instead** if you'd rather keep the harness shell-side — it's a small rewrite and this is the most opinionated piece here.

## The E2E gate

Provider keys are left **alone** when argv names a `test/e2e/` path (that runner passes one file at a time). Deliberately fail-safe in that direction: a misdetection keeps keys — E2E keeps working, at worst a unit file stays non-hermetic — rather than pulling credentials out from under a live-provider suite. The operator-context scrub is ungated, since E2E already does it and it's idempotent there.

Verified directly with doctored argv:

| argv | provider keys | `GBRAIN_SOURCE` |
| --- | --- | --- |
| `test/facts-classify.test.ts` | stripped | stripped |
| `test/e2e/cjk-roundtrip.test.ts` | **kept** | stripped |

## Also in here

`facts-classify` asserted the classifier-unavailable branch via a *comment* — `// Without API key in test env, isAvailable('chat') is false`. It now pins that precondition with `configureGateway({ env: {} })`. Runtime there went **1401ms → 141ms**: those "pure threshold math" unit tests had been making real billable provider calls on any machine with keys configured.

## Scope choices

- `_API_KEY$` pattern rather than a hardcoded list of the 21 provider vars, so new recipes are covered without editing this file.
- **Not** stripped: provider `*_BASE_URL` and `AZURE_OPENAI_USE_ENTRA`. Same shape, but no observed failure, and someone may point tests at a local Ollama on purpose. Left pending evidence rather than widened on speculation.
- Hatches: `GBRAIN_TEST_KEEP_AMBIENT_ENV=1`, `GBRAIN_TEST_KEEP_PROVIDER_KEYS=1`, `GBRAIN_DEBUG_PRELOAD=1` (logs names, never values).

## Verification

With all ambient vars still exported: **54 pass** across the four previously-failing files, **51 pass** across `source-resolver-*` / `extract-fs-source-id` / `cli-flag-validation`, `tsc --noEmit` clean.

## Note

CI here will also show `cli-flag-validation` red until #4020 lands — pre-existing `master` drift, unrelated to this change.
