### PR TITLE
fix(context-engine): reflex ignores turn delivered via `prompt` (empty `messages`)

### DIFF
--- a/src/core/context-engine.ts
+++ b/src/core/context-engine.ts
@@ -661,9 +661,19 @@ export function createGBrainContextEngine(ctx: {
       return { ingested: true };
     },
 
-    async assemble({ messages, tokenBudget, availableTools, citationsMode }) {
+    async assemble({ messages, tokenBudget, availableTools, citationsMode, prompt }) {
       // Lazy SDK load on first method call (was top-level await pre-L0-B).
       await ensureSdkLoaded();
+
+      // Some OpenClaw runtimes (e.g. the codex-app-server in 2026.7.x) deliver
+      // the current user turn via `prompt` with an empty `messages` array.
+      // Synthesize a single user turn so the Retrieval Reflex still sees the
+      // text (the deterministic live-context/pass-through path is unaffected).
+      const effectiveMessages = (Array.isArray(messages) && messages.length > 0)
+        ? messages
+        : (typeof prompt === 'string' && prompt.trim()
+            ? ([{ role: 'user', content: prompt }] as typeof messages)
+            : messages);
 
       // 1. Generate deterministic context (<5ms, zero LLM calls)
       const liveCtx = generateLiveContext(workspaceDir);
@@ -681,11 +691,11 @@ export function createGBrainContextEngine(ctx: {
       // nothing salient resolves. Detect + point, never auto-dump bodies.
       const reflexAddition = await buildReflexAddition({
         workspaceDir,
-        currentUserText: getLastUserText(messages),
-        priorContextText: getPriorContextText(messages),
+        currentUserText: getLastUserText(effectiveMessages),
+        priorContextText: getPriorContextText(effectiveMessages),
         // v0.43 (#2095): rolling window — assistant-introduced entities and
         // named-antecedent follow-ups from recent turns now resolve too.
-        windowTurns: getWindowTurns(messages),
+        windowTurns: getWindowTurns(effectiveMessages),
         resolveEntities: ctx.resolveEntities,
       });
 

--- a/test/retrieval-reflex.test.ts
+++ b/test/retrieval-reflex.test.ts
@@ -132,6 +132,49 @@ describe('context-engine assemble() — Retrieval Reflex integration', () => {
     });
   });
 
+  test('turn delivered via `prompt` with empty `messages` still fires the reflex (codex-app-server path)', async () => {
+    await withEnv(REFLEX_ON, async () => {
+      await seed('people/alice-example', 'Alice Example', 'Alice is a founder.');
+      const ce = createGBrainContextEngine({
+        workspaceDir: '/tmp/rr-test-ws-prompt',
+        resolveEntities: (candidates, opts) =>
+          resolveEntitiesToPointers(engine, 'default', candidates, opts),
+      });
+      // Runtimes like the codex-app-server (2026.7.x) deliver the current turn
+      // via `prompt` and leave `messages` empty. The reflex must still see it.
+      const res = await ce.assemble({
+        sessionId: 's-prompt',
+        messages: [],
+        prompt: 'what do you think about Alice Example?',
+      });
+      expect(res.systemPromptAddition).toContain('Brain pages mentioned this turn');
+      expect(res.systemPromptAddition).toContain('people/alice-example');
+    });
+  });
+
+  test('`prompt` is ignored when `messages` is non-empty (no double-count, back-compat)', async () => {
+    await withEnv(REFLEX_ON, async () => {
+      await seed('people/alice-example', 'Alice Example', 'Alice is a founder.');
+      const seen: string[] = [];
+      const ce = createGBrainContextEngine({
+        workspaceDir: '/tmp/rr-test-ws-prompt-ignored',
+        resolveEntities: (candidates, opts) => {
+          seen.push(...candidates.map((c) => c.text));
+          return resolveEntitiesToPointers(engine, 'default', candidates, opts);
+        },
+      });
+      // `messages` carries the real turn; `prompt` names a DIFFERENT entity that
+      // must never reach the resolver whenever `messages` is non-empty.
+      const res = await ce.assemble({
+        sessionId: 's-prompt-ignored',
+        messages: [{ role: 'user', content: 'what do you think about Alice Example?' }],
+        prompt: 'tell me about Bob Nonexistent',
+      });
+      expect(res.systemPromptAddition).toContain('people/alice-example');
+      expect(seen.join(' ')).not.toContain('Bob Nonexistent');
+    });
+  });
+
   test('no resolver available (PGLite, no serve/host) → no throw, live context still present', async () => {
     await withEnv(REFLEX_ON, async () => {
       const ce = createGBrainContextEngine({ workspaceDir: '/tmp/rr-test-ws-2' });


### PR DESCRIPTION
## Symptom

The Retrieval Reflex in the OpenClaw context engine never fires on live gateway turns. Salient entities in the current user turn that resolve to existing brain pages are silently not injected. The reflex only works in test harnesses that populate `messages`.

## Root cause

`assemble()` in `src/core/context-engine.ts` declares a `prompt?: string` param in its interface but only destructures `{ messages, tokenBudget, availableTools, citationsMode }`. The reflex reads the current turn's text exclusively from `messages` via `getLastUserText` / `getWindowTurns` / `getPriorContextText`.

Some OpenClaw runtimes — notably the codex-app-server in 2026.7.x — deliver the current user turn via `prompt` with an **empty** `messages` array. On those runtimes the reflex has nothing to read, so it never resolves any entity.

## Fix

When `messages` is empty, synthesize a single user turn from `prompt` and feed that (`effectiveMessages`) to the reflex resolution. The deterministic live-context block and the pass-through return path are untouched — they still return the original `messages`.

## Backward compatibility

The synthesis only activates when `messages` is empty. Whenever `messages` is non-empty (every existing runtime and all current tests), `effectiveMessages === messages`, so this is a no-op on those paths.

## Tests

Adds two regression tests to `test/retrieval-reflex.test.ts` (addressing the "zero tests" review blocker):

- **`prompt`-only turn (empty `messages`) still fires the reflex** — the codex-app-server delivery shape. Proven meaningful with a before/after run: it **fails** on the pre-fix `assemble()` (which reads only `messages`) and **passes** after the fix.
- **`prompt` is ignored when `messages` is non-empty** — guards the no-double-count / backward-compat claim by asserting an entity named only in `prompt` never reaches the resolver when `messages` is populated.

Full file: `24 pass, 0 fail`.

## Verification

Confirmed on a live gbrain v0.44.1.0 / OpenClaw 2026.7.1 instance: the reflex began firing on real gateway turns only after this change. The bug is still present on current `master` (v0.45.2.0) — `assemble()` there still destructures without `prompt` and passes `messages` straight into the reflex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
