### PR TITLE
fix(recipes): providers that cache prompts automatically no longer read as cache-less (#3660)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -9,7 +9,7 @@ src/core/postgres-engine.ts	5837	ratchet	grown v0.46.23.0: putPage empty-overwri
 src/core/pglite-engine.ts	5881	ratchet	grown v0.46.23.0: putPage empty-overwrite guard (#4335)
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4327	ratchet	grown v0.46.24.0 serve-delegated sync: onProgress seam + help text
-src/core/ai/gateway.ts	4428	ratchet	watchlist; merged: dream-wave turn permits + key-aware effective-model reconfigure + env-only worker refresh + discovery endpoint-trust docstring
+src/core/ai/gateway.ts	4439	ratchet	watchlist; merged: dream-wave turn permits + key-aware effective-model reconfigure + env-only worker refresh + discovery endpoint-trust docstring + #4037 prompt-cache fix
 src/cli.ts	3499	ratchet	grown v0.46.24.0: serve-delegated sync preflight hook
 src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyclePhases + normalizeQueuedSourcePhases + deriveStatus exclusion filter)
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match

--- a/src/core/ai/capabilities.ts
+++ b/src/core/ai/capabilities.ts
@@ -30,9 +30,17 @@ export interface ProviderCapabilities {
   supportsToolCalling: boolean;
 
   /**
-   * Anthropic-style ephemeral prompt cache markers honored. When false, the
-   * loop runs hot (no cache_control injection) and per-turn costs scale
-   * linearly with conversation length. Doesn't break the loop; just costs more.
+   * The provider caches prompt prefixes at all — by either mechanism:
+   * automatically server-side (OpenAI, DeepSeek; nothing to attach, and the
+   * Anthropic-namespace marker the gateway adds is inert on them), or when the
+   * request carries explicit `cache_control` markers (Anthropic). When false,
+   * the loop runs hot and per-turn costs scale linearly with conversation
+   * length. Doesn't break the loop; just costs more.
+   *
+   * This is deliberately "does it cache", not "does it honor our markers":
+   * `enforceSubagentCapable` and `doctor` use it to decide whether to warn an
+   * operator off a provider for cost reasons, and that advice is wrong for a
+   * provider that caches without being asked.
    */
   supportsPromptCaching: boolean;
 

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -3169,8 +3169,13 @@ export interface ChatOpts {
   maxTokens?: number;
   abortSignal?: AbortSignal;
   /**
-   * Anthropic-specific: cache the system prompt + last tool def. Silently
-   * ignored on providers without `supports_prompt_cache`.
+   * Ask for the stable prefix (system prompt + last tool def) to be cached.
+   * Silently ignored on providers whose recipe declares no prompt caching.
+   *
+   * Only Anthropic reads the resulting `cache_control` markers. Providers that
+   * cache prefixes automatically (OpenAI, DeepSeek) need no markers, and the
+   * Anthropic-namespace `providerOptions` this attaches never reach their
+   * request body — the AI SDK routes provider options by provider key.
    */
   cacheSystem?: boolean;
 }
@@ -3344,8 +3349,10 @@ function mapStopReason(
 
 /**
  * Run one chat completion turn. Provider-neutral wrapper over Vercel AI SDK's
- * `generateText`. Tool-use blocks are normalized; cache_control markers are
- * applied only on Anthropic when `cacheSystem: true`.
+ * `generateText`. Tool-use blocks are normalized. `cacheSystem: true` engages
+ * the caching path on any provider whose recipe declares prompt caching; the
+ * `cache_control` markers it attaches are read only by Anthropic, and are inert
+ * on providers that cache prefixes automatically.
  *
  * Crash-resumable replay is the caller's responsibility (subagent.ts persists
  * blocks via the provider-neutral schema landing in commit 2a).
@@ -3842,7 +3849,11 @@ export interface ToolLoopOpts {
   /** Per-turn max output tokens. Default 4096. */
   maxTokens?: number;
   abortSignal?: AbortSignal;
-  /** Apply Anthropic cache_control to system + last tool. Silently ignored elsewhere. */
+  /**
+   * Ask for the stable prefix (system + last tool) to be cached. Forwarded to
+   * `chat()`; see `ChatOpts.cacheSystem` for what each provider does with it.
+   * Silently ignored on recipes that declare no prompt caching.
+   */
   cacheSystem?: boolean;
 
   /** Crash-replay state. When set, the loop resumes from the recorded position. */

--- a/src/core/ai/recipes/deepseek.ts
+++ b/src/core/ai/recipes/deepseek.ts
@@ -95,7 +95,13 @@ export const deepseek: Recipe = {
       models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
       supports_tools: true,
       supports_subagent_loop: true,
-      supports_prompt_cache: false,
+      // DeepSeek's context caching is on by default for every account — the
+      // API reports prompt_cache_hit_tokens / prompt_cache_miss_tokens and
+      // there is no client opt-in to make. Declaring false contradicted this
+      // touchpoint's own cost_per_1m_input_usd, annotated as the *cache-miss*
+      // baseline — i.e. it already assumes a cache exists — and produced advice
+      // telling operators to move to a more expensive provider "for lower cost".
+      supports_prompt_cache: true,
       // Thinking mode is DEFAULT ON for both v4 models (see module docstring):
       // reasoning bills as output and counts against max_tokens, so callers
       // that size output caps must grant reasoning headroom (gbrain#4172).

--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -1,5 +1,44 @@
 import type { Recipe } from '../types.ts';
 
+/**
+ * Model-family prompt-cache capability for OpenAI ids.
+ *
+ * OpenAI caches prompt prefixes automatically — no request mutation and no
+ * client opt-in — but only from the `gpt-4o` / `gpt-4.1` / o-series generation
+ * onward. Earlier ids (`gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`) predate it, and
+ * recipe model lists are advisory, so any id a user configures reaches here.
+ *
+ * A per-model predicate rather than a provider-wide boolean for exactly that
+ * reason: a blanket `true` would suppress the cost warning on a legacy id that
+ * really does run hot, which is the same wrong-advice failure — pointing the
+ * other way — as the blanket `false` this replaces.
+ *
+ * Every branch is boundary-anchored (family token then `-`, `.` or end), so an
+ * unrecognized id that merely shares a prefix — `gpt-4oops`, `o9anything`, a
+ * custom base-url alias — does NOT inherit the family's answer. Unrecognized
+ * ids return false on purpose: under-claiming costs an operator one unnecessary
+ * warning, over-claiming silently hides a real cost regression.
+ *
+ * Shared with the OpenRouter predicate so the same model cannot report
+ * different capabilities depending on the route taken to reach it.
+ */
+export function openaiModelSupportsPromptCache(modelId: string): boolean {
+  let normalized = modelId.trim().toLowerCase();
+  // Fine-tunes are `ft:<base>:<org>::<id>` and inherit the base model's
+  // caching behavior, so match on the base.
+  if (normalized.startsWith('ft:')) normalized = normalized.slice(3).split(':', 1)[0] ?? '';
+  return (
+    // gpt-4o, gpt-4o-mini, dated snapshots.
+    /^gpt-4o(?:[-.]|$)/.test(normalized) ||
+    // gpt-4.1 (incl. mini/nano) and gpt-4.5-preview.
+    /^gpt-4\.[15](?:[-.]|$)/.test(normalized) ||
+    // gpt-5 and any later numbered family.
+    /^gpt-(?:[5-9]|\d{2,})(?:[-.]|$)/.test(normalized) ||
+    // Reasoning series: o1, o3, o4, …
+    /^o[1-9]\d*(?:[-.]|$)/.test(normalized)
+  );
+}
+
 export const openai: Recipe = {
   id: 'openai',
   name: 'OpenAI',
@@ -42,7 +81,7 @@ export const openai: Recipe = {
       models: ['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.2', 'gpt-4o-mini'],
       supports_tools: true,
       supports_subagent_loop: true,
-      supports_prompt_cache: false,
+      supports_prompt_cache: openaiModelSupportsPromptCache,
       max_context_tokens: 1_050_000, // gpt-5.6 family window (GA 2026-07-09)
       cost_per_1m_input_usd: 2.50, // gpt-5.6-terra baseline (the reasoning-tier default)
       cost_per_1m_output_usd: 15.0,

--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -1,4 +1,5 @@
 import type { Recipe } from '../types.ts';
+import { openaiModelSupportsPromptCache } from './openai.ts';
 
 /**
  * Private in-process marker header. `gateway.chat()` sets it when the caller
@@ -16,7 +17,12 @@ export const OPENROUTER_CACHE_HEADER = 'x-gbrain-anthropic-prompt-cache';
 
 /**
  * Family-scoped prompt-cache capability (per OpenRouter docs):
- * - OpenAI chat routes cache automatically (no request mutation needed).
+ * - OpenAI chat routes cache automatically, from the generation that shipped
+ *   automatic caching onward. The family test is the SAME predicate the native
+ *   `openai` recipe uses, so a model cannot report different capabilities
+ *   depending on which route reaches it.
+ * - DeepSeek routes cache automatically too (context caching is on by default
+ *   for every account), matching the native `deepseek` recipe.
  * - Anthropic Claude routes cache when the request carries `cache_control`
  *   on a content block (applied by the fetch shim below).
  * Everything else is not marked cacheable — deliberately narrow rather than
@@ -24,7 +30,14 @@ export const OPENROUTER_CACHE_HEADER = 'x-gbrain-anthropic-prompt-cache';
  */
 export function openrouterSupportsPromptCache(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
-  if (normalized.startsWith('openai/gpt-') || /^openai\/o\d/.test(normalized)) return true;
+  if (normalized.startsWith('openai/')) {
+    // OpenRouter appends routing variants (`:online`, `:nitro`, `:floor`, …)
+    // that are not part of the upstream model id. Strip before delegating, or
+    // every variant of a cache-capable model would read as cache-less.
+    const upstreamId = normalized.slice('openai/'.length).split(':', 1)[0] ?? '';
+    return openaiModelSupportsPromptCache(upstreamId);
+  }
+  if (normalized.startsWith('deepseek/')) return true;
   if (normalized.startsWith('anthropic/claude-')) return true;
   return false;
 }

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -10,10 +10,13 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(200000);
   });
 
-  it('returns capabilities for OpenAI (no prompt caching field set as true)', () => {
+  it('returns capabilities for OpenAI (automatic prefix caching counts)', () => {
     const caps = getProviderCapabilities('openai:gpt-5.2');
     expect(caps.supportsToolCalling).toBe(true);
-    expect(caps.supportsPromptCaching).toBe(false); // OpenAI implicit caching doesn't get marked
+    // Automatic server-side caching counts, same as the OpenRouter OpenAI
+    // routes below — otherwise the identical model reads as cache-capable
+    // through OpenRouter and cache-less natively.
+    expect(caps.supportsPromptCaching).toBe(true);
     expect(caps.maxContext).toBe(1_050_000); // gpt-5.6 family window (recipe-driven)
   });
 
@@ -42,7 +45,9 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
   });
 
   it('does not mark every OpenRouter route as cache-capable', () => {
-    const caps = getProviderCapabilities('openrouter:deepseek/deepseek-chat');
+    // A family the predicate deliberately does not list — the point is that it
+    // stays an allow-list rather than becoming a blanket true.
+    const caps = getProviderCapabilities('openrouter:google/gemini-3-flash-preview');
     expect(caps.supportsToolCalling).toBe(true);
     expect(caps.supportsPromptCaching).toBe(false);
   });
@@ -77,8 +82,12 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
     expect(classifyCapabilities('llama-server:qwen-local-cache-probe')).toBe('ok');
   });
 
-  it('returns degraded:no_caching for OpenAI (tools yes, caching no)', () => {
-    expect(classifyCapabilities('openai:gpt-5.2')).toBe('degraded:no_caching');
+  it('returns ok for providers that cache automatically', () => {
+    // Pre-fix these were degraded:no_caching, which made
+    // enforceSubagentCapable advise moving to an Anthropic model "for lower
+    // cost on long loops" on providers that were already caching.
+    expect(classifyCapabilities('openai:gpt-5.2')).toBe('ok');
+    expect(classifyCapabilities('deepseek:deepseek-v4-flash')).toBe('ok');
   });
 
   it('returns degraded:no_caching for Google Gemini', () => {
@@ -88,7 +97,59 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
   it('returns ok for cacheable OpenRouter routes, degraded:no_caching otherwise', () => {
     expect(classifyCapabilities('openrouter:openai/gpt-5.2')).toBe('ok');
     expect(classifyCapabilities('openrouter:anthropic/claude-sonnet-4.6')).toBe('ok');
-    expect(classifyCapabilities('openrouter:deepseek/deepseek-chat')).toBe('degraded:no_caching');
+    // Routes to the same provider agree with the native recipe.
+    expect(classifyCapabilities('openrouter:deepseek/deepseek-chat')).toBe('ok');
+    // A family the predicate does not list. This pins the allow-list shape,
+    // not a claim that Google never caches — whether that family belongs on
+    // the list is a separate question from the two providers fixed here.
+    expect(classifyCapabilities('openrouter:google/gemini-3-flash-preview')).toBe('degraded:no_caching');
+  });
+
+  it('OpenAI caching is per model generation, not provider-wide', () => {
+    // Recipe model lists are advisory, so any id a user configures lands here.
+    // Automatic caching starts at the gpt-4o / gpt-4.1 / o-series generation;
+    // older ids really do run hot and must keep their cost warning.
+    const CACHES = [
+      'gpt-4o', 'gpt-4o-mini', 'gpt-4o-2024-08-06',
+      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4.5-preview',
+      'gpt-5', 'gpt-5.2', 'gpt-5.6-terra',
+      'o1', 'o1-mini', 'o4-mini',
+      'ft:gpt-4o-mini:acme::abc', // fine-tunes inherit the base model
+    ];
+    // Legacy families, plus ids that merely SHARE a prefix — the boundary
+    // anchors are what stop those from inheriting a family's answer.
+    const RUNS_HOT = [
+      'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo',
+      'gpt-4oops', 'gpt-5bogus', 'o9anything',
+      'ft:gpt-4-turbo:acme::x',
+    ];
+    for (const id of CACHES) {
+      expect(getProviderCapabilities(`openai:${id}`).supportsPromptCaching, id).toBe(true);
+    }
+    for (const id of RUNS_HOT) {
+      expect(getProviderCapabilities(`openai:${id}`).supportsPromptCaching, id).toBe(false);
+    }
+  });
+
+  it('a provider reachable two ways reports the same caching verdict either way', () => {
+    // The bug this guards: a provider's caching behavior is a property of the
+    // provider, not of the route taken to reach it. Letting the native recipe
+    // and the OpenRouter predicate drift apart is what made the same model read
+    // as cache-capable one way and cache-less the other.
+    for (const [native, routed] of [
+      ['openai:gpt-5.2', 'openrouter:openai/gpt-5.2'],
+      // The negative side matters just as much: a legacy id must be cache-less
+      // on BOTH routes, which is only structurally true because the two share
+      // one predicate.
+      ['openai:gpt-4-turbo', 'openrouter:openai/gpt-4-turbo'],
+      ['deepseek:deepseek-v4-flash', 'openrouter:deepseek/deepseek-chat'],
+      ['anthropic:claude-sonnet-4-6', 'openrouter:anthropic/claude-sonnet-4.6'],
+    ] as const) {
+      expect(
+        getProviderCapabilities(routed).supportsPromptCaching,
+        `${routed} disagrees with ${native}`,
+      ).toBe(getProviderCapabilities(native).supportsPromptCaching);
+    }
   });
 
   it('returns unknown for unrecognized providers', () => {

--- a/test/ai/gateway-cache-breakpoint.test.ts
+++ b/test/ai/gateway-cache-breakpoint.test.ts
@@ -136,7 +136,13 @@ describe('gbrain#2490 — Anthropic cache breakpoint placement', () => {
     expect(args.tools).toBeUndefined();
   });
 
-  test('cacheSystem:true on a non-Anthropic model is silently ignored (supports_prompt_cache=false)', async () => {
+  test('cacheSystem:true on a recipe that declares no caching leaves system a bare string', async () => {
+    // This test needs SOME recipe that declares no caching; it is not a claim
+    // about what Google's API does. If this guard ever fails, that recipe was
+    // corrected — re-point the test at another undeclared one, don't delete it.
+    const { getProviderCapabilities } = await import('../../src/core/ai/capabilities.ts');
+    expect(getProviderCapabilities('google:gemini-1.5-pro').supportsPromptCaching).toBe(false);
+
     let captured: any;
     __setGenerateTextTransportForTests(async (args: any) => {
       captured = args;
@@ -147,18 +153,59 @@ describe('gbrain#2490 — Anthropic cache breakpoint placement', () => {
       } as any;
     });
     configureGateway({
-      chat_model: 'openai:gpt-4o-mini',
-      env: { OPENAI_API_KEY: 'fake' },
+      chat_model: 'google:gemini-1.5-pro',
+      env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
     });
     await chat({
-      model: 'openai:gpt-4o-mini',
+      model: 'google:gemini-1.5-pro',
       system: 'SYS',
       cacheSystem: true,
       messages: [{ role: 'user', content: 'hello' }],
     });
-    // Still a bare string — the recipe doesn't support prompt caching, so
-    // useCache is false regardless of the caller's request.
+    // useCache is false regardless of the caller's request, so no breakpoint
+    // machinery runs at all.
     expect(captured.system).toBe('SYS');
+  });
+
+  test('an auto-caching provider gets the same shape the OpenRouter OpenAI route already gets', async () => {
+    // Native OpenAI and OpenRouter's openai/* routes are the same upstream
+    // models with the same automatic prefix caching, and
+    // `openrouterSupportsPromptCache` has always returned true for them. This
+    // pins that the native recipe now produces an identical breakpoint shape
+    // rather than a second, divergent one.
+    //
+    // The Anthropic-namespace marker rides along on both. It is inert off
+    // Anthropic: the AI SDK routes `providerOptions` by provider key, so an
+    // `anthropic` entry never reaches an OpenAI request body — the same
+    // reason the shipped OpenRouter OpenAI route can carry it safely.
+    const capture = async (model: string, env: Record<string, string>) => {
+      let captured: any;
+      __setGenerateTextTransportForTests(async (args: any) => {
+        captured = args;
+        return {
+          content: [{ type: 'text', text: 'ok' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1 },
+        } as any;
+      });
+      configureGateway({ chat_model: model, env } as any);
+      await chat({
+        model,
+        system: 'SYS',
+        cacheSystem: true,
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      return captured;
+    };
+
+    const viaOpenRouter = await capture('openrouter:openai/gpt-5.2', { OPENROUTER_API_KEY: 'fake' });
+    const native = await capture('openai:gpt-4o-mini', { OPENAI_API_KEY: 'fake' });
+
+    expect(native.system).toEqual(viaOpenRouter.system);
+    expect(native.providerOptions?.anthropic).toEqual(viaOpenRouter.providerOptions?.anthropic);
+    // Native OpenAI additionally carries its own routing hint, which is gated
+    // on the recipe implementation and not on this flag.
+    expect(native.providerOptions?.openai?.promptCacheKey).toBeString();
   });
 
   test('a configured cacheControl TTL override applies to every breakpoint, not just the call-level one', async () => {
@@ -245,9 +292,23 @@ describe('OpenRouter prompt caching (takeover of PR #1988)', () => {
   });
 
   test('cacheSystem:true on a non-cacheable OpenRouter route is silently ignored', async () => {
-    const args = await captureOpenRouterArgs('openrouter:deepseek/deepseek-chat', true);
+    // A family the predicate does not list, so useCache stays false.
+    const args = await captureOpenRouterArgs('openrouter:google/gemini-3-flash-preview', true);
     expect(args.headers).toBeUndefined();
     // useCache is false → system stays a bare string.
     expect(args.system).toBe('stable system prompt');
+  });
+
+  test('a cacheable-but-implicit OpenRouter route gets the breakpoint without the rewrite header', async () => {
+    // DeepSeek routes cache automatically: the marker rides along (inert off
+    // Anthropic) but the fetch shim's rewrite header must NOT be set, since
+    // only Anthropic Claude routes need the explicit cache_control block.
+    const args = await captureOpenRouterArgs('openrouter:deepseek/deepseek-chat', true);
+    expect(args.headers).toBeUndefined();
+    expect(args.system).toEqual({
+      role: 'system',
+      content: 'stable system prompt',
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+    });
   });
 });

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -45,18 +45,35 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('only known cache-capable recipes claim supports_prompt_cache', () => {
+  test('the set of recipes declaring supports_prompt_cache is the expected one', () => {
+    // The flag answers "does this provider cache prompts at all" — what
+    // capabilities.ts reads to decide whether the subagent loop runs hot.
+    // Explicit client-side markers (Anthropic's cache_control), automatic
+    // server-side prefix caching (OpenAI, DeepSeek), and a local server that
+    // always caches (llama-server) all count.
+    //
+    // This pins the CURRENT declarations, not a claim that every other
+    // provider is cache-less: some recipes here still declare false while
+    // their vendor does cache (moonshot). Correcting those needs per-model
+    // predicates rather than a boolean, so they are tracked separately —
+    // when one is fixed, add it here.
+    // Per-model predicate where caching depends on the model generation or the
+    // routed family — OpenRouter by routed model family (openai/* +
+    // anthropic/claude-*), Google by Gemini version (implicit caching is
+    // 2.5+), OpenAI by the gpt-4o/o-series generation; a plain boolean where
+    // it is a property of the whole provider. Anything else must declare no
+    // caching.
+    const PREDICATE = new Set(['openai', 'openrouter', 'google']);
+    const ALWAYS_CACHES = new Set(['anthropic', 'deepseek', 'llama-server']);
     for (const r of listRecipes()) {
       if (!r.touchpoints.chat) continue;
-      if (r.id === 'anthropic' || r.id === 'llama-server') {
-        expect(r.touchpoints.chat.supports_prompt_cache).toBe(true);
-      } else if (r.id === 'openrouter' || r.id === 'google') {
-        // Scoped predicates, never a blanket true: OpenRouter by routed model
-        // family (openai/* + anthropic/claude-*), Google by Gemini version
-        // (implicit caching is 2.5+). Matrices live in each recipe's test.
-        expect(typeof r.touchpoints.chat.supports_prompt_cache).toBe('function');
+      const flag = r.touchpoints.chat.supports_prompt_cache;
+      if (PREDICATE.has(r.id)) {
+        expect(typeof flag, `${r.id} should gate caching per model`).toBe('function');
+      } else if (ALWAYS_CACHES.has(r.id)) {
+        expect(flag, `${r.id} should declare caching`).toBe(true);
       } else {
-        expect(r.touchpoints.chat.supports_prompt_cache ?? false).toBe(false);
+        expect(flag ?? false, `${r.id} should not declare caching`).toBe(false);
       }
     }
   });

--- a/test/ai/recipe-openrouter.test.ts
+++ b/test/ai/recipe-openrouter.test.ts
@@ -181,8 +181,19 @@ describe('recipe: openrouter', () => {
     expect(openrouterSupportsPromptCache('openai/text-embedding-3-small')).toBe(false);
     expect(openrouterSupportsPromptCache('anthropic/claude-sonnet-4.6')).toBe(true);
     expect(openrouterSupportsPromptCache('anthropic/claude-opus-4.7')).toBe(true);
-    expect(openrouterSupportsPromptCache('deepseek/deepseek-chat')).toBe(false);
+    // DeepSeek routes cache automatically, same as the OpenAI ones — and the
+    // native `deepseek` recipe says so too, so the two routes must agree.
+    expect(openrouterSupportsPromptCache('deepseek/deepseek-chat')).toBe(true);
     expect(openrouterSupportsPromptCache('google/gemini-3-flash-preview')).toBe(false);
+
+    // Routing variants (`:online`, `:nitro`, `:floor`, …) are an OpenRouter
+    // concept, not part of the upstream model id, so they must not change the
+    // answer either way.
+    expect(openrouterSupportsPromptCache('openai/gpt-4o:online')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/gpt-4.1:nitro')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/o1:floor')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/gpt-4-turbo:online')).toBe(false);
+    expect(openrouterSupportsPromptCache('deepseek/deepseek-chat:free')).toBe(true);
   });
 
   test('13. only Anthropic Claude routes require the explicit cache_control rewrite', () => {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -55,7 +55,9 @@ describe('doctor command', () => {
   test('subagent_capability checks explicit models.subagent before tier/default fallbacks', async () => {
     const { checkSubagentCapability } = await import('../src/commands/doctor.ts');
     const config = new Map<string, string | null>([
-      ['models.subagent', 'openai:gpt-5.2'],
+      // A model whose recipe declares no prompt caching, so the precedence
+      // this test is about is visible through the resulting warn.
+      ['models.subagent', 'google:gemini-1.5-pro'],
       ['models.tier.subagent', 'anthropic:claude-sonnet-4-6'],
       ['models.default', 'anthropic:claude-sonnet-4-6'],
     ]);
@@ -65,7 +67,7 @@ describe('doctor command', () => {
       },
     } as any);
     expect(check.status).toBe('warn');
-    expect(check.message).toContain('models.subagent is "openai:gpt-5.2"');
+    expect(check.message).toContain('models.subagent is "google:gemini-1.5-pro"');
     expect(check.message).toContain('prompt caching');
   });
 
@@ -88,7 +90,7 @@ describe('doctor command', () => {
     const { checkSubagentCapability } = await import('../src/commands/doctor.ts');
     const config = new Map<string, string | null>([
       ['models.tier.subagent', 'anthropic:claude-sonnet-4-6'],
-      ['models.default', 'openai:gpt-5.2'],
+      ['models.default', 'google:gemini-1.5-pro'],
     ]);
     const check = await checkSubagentCapability({
       async getConfig(key: string): Promise<string | null> {
@@ -96,7 +98,7 @@ describe('doctor command', () => {
       },
     } as any);
     expect(check.status).toBe('warn');
-    expect(check.message).toContain('models.default is "openai:gpt-5.2"');
+    expect(check.message).toContain('models.default is "google:gemini-1.5-pro"');
   });
 
   test('reranker_health warns on repeated unknown rerank failures', async () => {

--- a/test/model-config.serial.test.ts
+++ b/test/model-config.serial.test.ts
@@ -204,15 +204,28 @@ describe('resolveModel — v0.31.12 tier system', () => {
   test('v0.38 D7: tier.subagent accepts non-Anthropic models that support tools (with cost warn)', async () => {
     // Pre-v0.38 the resolver hard-fell-back to TIER_DEFAULTS.subagent for any
     // non-Anthropic model. v0.38 (D6/D7) replaces that with a capability check:
-    // OpenAI/Gemini/etc. support tools → resolved unchanged + warn about
-    // missing prompt caching (cost regression on long loops, not a refusal).
+    // a provider with tools but no prompt caching → resolved unchanged + warn
+    // about the cost regression on long loops (not a refusal).
+    stub.set('models.default', 'google:gemini-1.5-pro');
+    const m = await resolveModel(stub as never, {
+      tier: 'subagent',
+      fallback: 'sonnet',
+    });
+    expect(m).toBe('google:gemini-1.5-pro');
+    expect(stderrCapture).toContain('caching');
+  });
+
+  test('v0.38 D7: a provider that caches automatically is accepted WITHOUT the cost warn', async () => {
+    // The warn advises moving to an Anthropic model "for lower cost on long
+    // loops". On providers that already cache prompt prefixes server-side that
+    // advice is backwards, so the capability check must not fire it.
     stub.set('models.default', 'openai:gpt-5.2');
     const m = await resolveModel(stub as never, {
       tier: 'subagent',
       fallback: 'sonnet',
     });
     expect(m).toBe('openai:gpt-5.2');
-    expect(stderrCapture).toContain('caching');
+    expect(stderrCapture).not.toContain('caching');
   });
 
   test('v0.38 D7: tier.subagent rejects unknown providers (falls back to default)', async () => {
@@ -365,15 +378,15 @@ describe('resolveModelDetailed — sources + key-aware step 7', () => {
     expect(noTier.model).toBe(DEFAULT_ALIASES.sonnet);
   });
 
-  test('subagent + openai-only: returns openai with once-per-process no-caching warn', async () => {
+  test('subagent + openai-only: returns cache-capable openai without a no-caching warn', async () => {
     process.env.OPENAI_API_KEY = 'sk-test';
     try {
       const r = await resolveModelDetailed(null, { tier: 'subagent', fallback: 'sonnet' });
       expect(r.model).toBe(openaiStaticTierFallback().subagent);
-      expect(stderrCapture).toContain('caching');
+      expect(stderrCapture).not.toContain('caching');
       const before = stderrCapture.length;
       await resolveModelDetailed(null, { tier: 'subagent', fallback: 'sonnet' });
-      expect(stderrCapture.length).toBe(before); // warned once
+      expect(stderrCapture.length).toBe(before); // remains warning-free
     } finally {
       delete process.env.OPENAI_API_KEY;
     }


### PR DESCRIPTION
## What

`supports_prompt_cache` answers one question: *does this provider cache prompts
at all?* `capabilities.ts` reads it to classify a chat model as `ok` vs
`degraded:no_caching`, and `enforceSubagentCapable` turns `degraded:no_caching`
into operator-facing advice — *"provider does not support prompt caching. The
loop will run hot ... For lower cost on long loops, set `models.tier.subagent`
to an Anthropic model."*

Two recipes declared `false` while their providers cache by default, so that
advice fired against providers that were already caching — and pointed at a more
expensive one.

## The two providers

**DeepSeek** (`recipes/deepseek.ts`) — the subject of #3660. Context caching is
on by default for every account, the API reports
`prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`, and there is no client
opt-in to make. The recipe contradicted itself: the same touchpoint's
`cost_per_1m_input_usd` is annotated *"cache-miss baseline"*, which already
presupposes a cache.

**Native OpenAI** (`recipes/openai.ts`) — named in #3660's triage as the same
class. OpenAI caches prompt prefixes automatically. gbrain already implements
the OpenAI half of this: `openAIPromptCacheKey()` derives a `prompt_cache_key`
routing hint for `native-openai` recipes, and its own docstring opens with
*"OpenAI caches prefixes automatically"* — while the recipe two files away said
the provider has no prompt caching.

OpenAI gets a **per-model predicate**, not a blanket `true`: automatic caching
starts at the `gpt-4o` / `gpt-4.1` / o-series generation, and recipe model lists
are advisory, so any id a user configures reaches the flag. A blanket `true`
would suppress the cost warning on a legacy id like `gpt-4-turbo` that really
does run hot — the same wrong-advice failure, pointing the other way.

Every branch is boundary-anchored (family token, then `-`, `.` or end), so an id
that merely shares a prefix — `gpt-4oops`, `o9anything`, a custom base-url alias
— does not inherit the family's answer. Fine-tunes (`ft:<base>:…`) resolve
through their base model. Unrecognized ids return `false` on purpose: an
unnecessary warning is cheaper than a silently hidden cost regression.

OpenRouter routing variants (`:online`, `:nitro`, `:floor`) are stripped before
delegating, since they are an OpenRouter concept rather than part of the
upstream id.

DeepSeek stays a plain boolean because there the behavior is a property of the
whole provider, not of the model.

An allow-list will always trail OpenAI's naming — an id outside the listed
families (a new alias, a custom base-url name) reads as `false` and earns one
unnecessary warning. That is the deliberate direction of failure, and adding a
family later is a one-line change with a test row.

**One thing I could not verify, flagged rather than assumed:** how the newest
GPT-5.6 generation places its implicit cache breakpoint in a *growing* tool
loop. If it anchors on the latest message rather than falling back to a matching
earlier prefix, a long subagent loop could miss more often than the "caches
automatically" framing suggests, and gbrain currently emits only
`prompt_cache_key` (a routing hint), not an explicit breakpoint. That does not
change the older generations or DeepSeek, and it is a separate question from the
stale declaration this PR fixes — but if you know the answer, it is worth
deciding whether the predicate should be narrower at the top end.

## The inconsistency this removes

The repo already counts automatic server-side caching as `true`:
`openrouterSupportsPromptCache()` returns `true` for `openai/gpt-*` routes,
commented *"OpenAI chat routes cache automatically"*.

So before this change, the **same OpenAI model** classified as:

| Route | verdict |
|---|---|
| `openrouter:openai/gpt-5.2` | `ok` |
| `openai:gpt-5.2` | `degraded:no_caching` |

`test/ai/capabilities.test.ts` asserted both, a few assertions apart in the same
`describe` block.

### …and does not create the mirror image of it

Fixing only the native recipes would leave `deepseek:deepseek-v4-flash` as `ok`
while `openrouter:deepseek/*` stayed `degraded:no_caching` — the same bug
pointing the other way. So `openrouterSupportsPromptCache()` gains the
`deepseek/` family, which is also what #3660's triage suggests ("Consider the
same for openrouter's deepseek/* routes").

For OpenAI the two routes now **share one predicate**: the OpenRouter branch
strips the `openai/` prefix and defers to the same function the native recipe
uses. Agreement is structural rather than two lists that happen to match today —
and it fixes the routed side's own over-claim, since the old branch returned
`true` for every `openai/gpt-*`, legacy ids included.

The predicate stays an allow-list, not a blanket true: the "does not mark every
OpenRouter route as cache-capable" test keeps its job, re-pointed at a family
the predicate does not list. And a new test makes the underlying rule explicit
— *a provider reachable two ways reports the same caching verdict either way* —
so native and routed views cannot silently drift apart again.

## Wire safety

Once the flag resolves `true`, a `cacheSystem: true` caller makes the gateway
pass `system` as a `SystemModelMessage` carrying
`providerOptions.anthropic.cacheControl`.

That is not a new shape — it is exactly what the shipped
`openrouter:openai/*` route produces today, captured from the transport args:

```
openrouter:openai/gpt-5.2  system = {"role":"system","content":"SYS",
                                    "providerOptions":{"anthropic":{"cacheControl":{"type":"ephemeral"}}}}
openai:gpt-4o-mini         system = (identical)
```

The Anthropic-namespace marker is inert off Anthropic: the AI SDK routes
`providerOptions` by provider key, so an `anthropic` entry never reaches an
OpenAI request body. That is the same reason the OpenRouter OpenAI route can
already carry it safely. A new test pins that the native and OpenRouter shapes
**agree** rather than diverging, so a future change cannot quietly split them.

The "leaves `system` a bare string" path is untouched — see Scope below for how
its test picks a model without smuggling in a vendor claim.

## Everything the verdict feeds

`classifyCapabilities` has four consumers, so here is the complete blast radius
rather than just the advice surface:

| Consumer | Before | After |
|---|---|---|
| `model-config.ts` `enforceSubagentCapable` | warns "provider does not support prompt caching … set `models.tier.subagent` to an Anthropic model" | no warn for these providers |
| `doctor.ts` `subagent_capability` | same message as a `warn` check | `ok` |
| `minions/queue.ts` + `handlers/subagent.ts` submit gates | reject only on `unusable:no_tools` / `unknown` | unchanged — `degraded:*` was never a refusal |
| `handlers/subagent.ts:959` `cacheSystem = verdict === 'ok' \|\| 'degraded:no_parallel'` | `false` for these providers | **`true`** — the loop now asks for caching |

That last row is the only behavior change beyond advice, and it is the point of
the fix: the subagent loop stops assuming these providers cannot cache. On the
wire it resolves to the shape documented above — inert off Anthropic, identical
to what the OpenRouter OpenAI route already sends.

## Scope

Only `deepseek` and `openai` change (plus the OpenRouter routes that must move
with them).

**Known remaining cases, named rather than quietly left behind:**

- `moonshot` — #3660's triage lists it as the same class. Not verified here, so
  not flipped on a guess.
- `google` — Gemini does have caching (implicit on recent models, plus explicit
  context caching), so the recipe's `false` is likely stale for the same reason.
  The mechanism to fix it now exists here — a per-model predicate — but drawing
  the right generation boundary for Gemini needs research I have not done, and
  guessing it is what this PR argues against. Left for someone who can state the
  boundary with a source.
  Where the tests needed a recipe that declares no caching, they use `google`
  and say so explicitly — including a guard assertion that fails loudly if that
  declaration is ever corrected, so the test gets re-pointed instead of quietly
  testing nothing.

Noticed while working here but deliberately **not** touched, since it predates
this change and the diff does not go near it: `ChatResult.usage`'s doc says the
`cache_*` counters are "present only when the active provider returned them
(Anthropic)", while the implementation has long also read the AI SDK's
provider-neutral `usage.cachedInputTokens` for OpenAI-compatible routes. Making
non-Anthropic caching real here makes that wording more visible, but correcting
it belongs in its own change.

This PR also does not touch the overloaded-flag question the triage raises
(splitting "caches automatically" from "needs an explicit `cache_control`
marker"). That is a design call for the maintainer; this PR corrects factual
declarations and leaves the flag's shape as-is.


## Sequencing note

This overlaps textually with the open #3904 (provider freshness): that PR
rewrites the same `openai` chat touchpoint block (`models`,
`max_context_tokens`, prices) and renames the model ids these tests use
(`openai:gpt-5.2` → `gpt-5.6-terra`, `google:gemini-1.5-pro` →
`gemini-3.6-flash`). Nothing here changes the same *fields* it changes — this
touches one flag in that block, plus test model-id strings — so whichever lands
first, the other is a mechanical rebase. Happy to rebase on request. (The
predicate here already returns `true` for `gpt-5.6-*`, so that rename needs no
follow-up on this side.)

(Worth noting for that PR's own scope: after its rename, the "recipe that
declares no caching" example becomes a Gemini 3.x id, which makes the stale
`google` declaration more visible. The guard assertion added here fails loudly
if that declaration is ever corrected, so the test gets re-pointed rather than
silently testing nothing.)

## Tests

- `capabilities.test.ts` — OpenAI reads as cache-capable; `classifyCapabilities`
  returns `ok` for both auto-caching providers; **new** test pinning the
  generation boundary (`gpt-4o`/`gpt-5.x`/o-series cache, `gpt-4-turbo` and
  older do not); **new** invariant *a provider reachable two ways reports the
  same caching verdict either way*, including a legacy id that must be
  cache-less on both routes.
- `gateway-chat.test.ts` — the registry invariant enumerates which recipes
  declare caching, instead of hardcoding "only Anthropic + OpenRouter". It is
  scoped to *current declarations*, with the known-stale ones called out in the
  test itself so it does not read as a claim that everything else is cache-less.
- `gateway-cache-breakpoint.test.ts` — **new** native-vs-OpenRouter parity test;
  **new** case pinning that a cacheable-but-implicit route (DeepSeek) gets the
  breakpoint *without* the Anthropic rewrite header; the no-caching case
  re-pointed, with a guard assertion on the declaration it depends on.
- `recipe-openrouter.test.ts` — `deepseek/*` now cacheable; a non-listed family
  keeps the negative case honest.
- `model-config.serial.test.ts` — the cost-warn test re-pointed at
  `google:gemini-1.5-pro`, plus a new test asserting an auto-caching provider is
  accepted **without** the warn.

**Red check:** reverting the three declaration sites (both recipe flags and the
OpenRouter branch) turns 10 tests red, including the new "no warn",
generation-boundary and route-parity assertions.

**Green:** 103 pass / 0 fail across the five directly affected files;
`bun run verify` is 37/37; the full unit suite is green apart from one failure
that reproduces identically on an unmodified checkout.

Addresses #3660.
