### PR TITLE
fix(skills): citation-graph-ingest — check-backlinks requires a subcommand

### DIFF
--- a/skills/citation-graph-ingest/SKILL.md
+++ b/skills/citation-graph-ingest/SKILL.md
@@ -159,7 +159,7 @@ mismatch, typo'd `--type`) before reporting anything.
 
 ```bash
 gbrain link-sources          # citation-graph should appear with the expected count
-gbrain check-backlinks       # confirm no orphaned references
+gbrain check-backlinks check # confirm no orphaned references
 ```
 
 ## Run it (worked example, synthetic fixture)

--- a/skills/skills.lock.json
+++ b/skills/skills.lock.json
@@ -33,7 +33,7 @@
   "capture/SKILL.md": "98568ac96331f57397ea072749641d9748b1ce31e8b09d512b8db25c8fcda65f",
   "citation-fixer/SKILL.md": "abdadbf0740a529b9c4f86f05bba416417624503fdcbc6054402d5546afd08b4",
   "citation-fixer/routing-eval.jsonl": "52b23b71e66fdc18aee67d0576099b0c83997d648cf4ecf8fe7753b91b6c9c53",
-  "citation-graph-ingest/SKILL.md": "6510856cc14a653dcade510702890343bc0527de14bc2f1ed0d2524f248c798c",
+  "citation-graph-ingest/SKILL.md": "849b0cdc64b7ff14d0e6771bde15f0edc3c2fc29af08be015753a5f88a03205f",
   "citation-graph-ingest/routing-eval.jsonl": "a1ba605d35e736b741b9e8aac1e7d50b61a7cbcada893d67099b55bf5a0d2635",
   "cold-start/SKILL.md": "20be3d1b637621fd9fbd268072f6647533a23f596e30cb593523b051708aaddd",
   "company-brainify/SKILL.md": "2c058b39f5364b8ceb5c53b4525cce8645734f16cc3c229a490b005d58a78311",


### PR DESCRIPTION
The hygiene step in `citation-graph-ingest` (v0.45.6.0) invokes bare `gbrain check-backlinks`, which exits with a usage error — `runBacklinks` in `src/commands/backlinks.ts` requires `check` or `fix`. Changed to `check-backlinks check`, matching every other invocation across the skill pack.

`check:skill-refs` and `check:resolver` pass.

