### PR TITLE
feat(entities): save-time entity resolution — alias-aware resolver cascade

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -18,7 +18,7 @@ src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: superse
 src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
-src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
+src/commands/extract-conversation-facts.ts	2090	ratchet	grown v0.46.x per-provider gateway-unavailable copy + save-time resolution caller
 src/core/import-file.ts	2000	ratchet	grown v0.46.11.0 five-issue wave
 src/core/cycle/synthesize.ts	2702	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches
 src/commands/embed.ts	1963	ratchet

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -94,6 +94,12 @@ import { assertFactsEmbeddingDimMatchesConfig } from '../core/embedding-dim-chec
 import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
 import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
+import {
+  emptySaveTimeResolutionCounts,
+  formatSaveTimeResolutionCounts,
+  mergeSaveTimeResolutionCounts,
+  resolveExtractedEntitiesForSave,
+} from '../core/entities/resolve-on-save.ts';
 
 // Re-exported verbatim so existing importers (this file's own helpers below
 // and this file's tests) keep working unchanged; doctor.ts, jobs.ts,
@@ -367,6 +373,10 @@ export interface ExtractConversationFactsResult {
   segments_processed: number;
   facts_extracted: number;
   facts_inserted: number;
+  /** Entity values that reached the shipped deterministic fallback slug path. */
+  fallback_slugify_count: number;
+  /** Entity values kept raw after a best-effort resolution failure. */
+  resolution_errors: number;
   budget_exhausted?: boolean;
   spent_usd?: number;
 }
@@ -1053,6 +1063,7 @@ async function processPage(
   let newestEnd: string | null = null;
   let segmentsThisPage = 0;
   let pageInsertedTotal = 0;
+  const pageResolution = emptySaveTimeResolutionCounts();
 
   for (const seg of segments) {
     if (state.segmentLimit > 0 && segmentsThisPage >= state.segmentLimit) break;
@@ -1098,6 +1109,26 @@ async function processPage(
     segmentsThisPage++;
     state.result.facts_extracted += extracted.length;
 
+    // This bulk path bypasses writeSingleFact and writes through insertFacts.
+    // Canonicalize every extractor-provided entity via the shipped resolver
+    // (alias_exact / prefix / fuzzy / slugify) while source scope is known.
+    const segmentResolution = await resolveExtractedEntitiesForSave(
+      state.engine,
+      state.sourceId,
+      extracted,
+      (raw, message) => {
+        process.stderr.write(
+          `[extract-conversation-facts] ${page.slug} segment ${seg.startIso}..${seg.endIso} ` +
+          `entity resolution failed for ${JSON.stringify(raw)}: ${message}; keeping raw value\n`,
+        );
+      },
+    );
+    const commitSegmentResolutionTelemetry = () => {
+      mergeSaveTimeResolutionCounts(pageResolution, segmentResolution);
+      state.result.fallback_slugify_count += segmentResolution.fallback_slugify_count;
+      state.result.resolution_errors += segmentResolution.resolution_errors;
+    };
+
     if (!state.dryRun && extracted.length > 0) {
       // Eng-v2 C1 / E11: page-global row_num. Each fact in this batch gets
       // a unique row_num within (source_id, source_markdown_slug); the
@@ -1121,9 +1152,11 @@ async function processPage(
       pageInsertedTotal += ins.inserted;
       state.result.facts_inserted += ins.inserted;
       rowNum += extracted.length;
+      commitSegmentResolutionTelemetry();
     } else {
       // dry-run: count for reporting, no DB write.
       rowNum += extracted.length;
+      commitSegmentResolutionTelemetry();
     }
 
     newestEnd = seg.endIso;
@@ -1169,7 +1202,8 @@ async function processPage(
   }
 
   process.stderr.write(
-    `[extract-conversation-facts] ${page.slug}: ${pageInsertedTotal} facts inserted across ${segmentsThisPage} segments\n`,
+    `[extract-conversation-facts] ${page.slug}: ${pageInsertedTotal} facts inserted across ${segmentsThisPage} segments ` +
+    `entity_resolution_counts=${formatSaveTimeResolutionCounts(pageResolution.counts)}\n`,
   );
 
   state.result.pages_processed++;
@@ -1261,6 +1295,8 @@ export async function runExtractConversationFactsCore(
     segments_processed: 0,
     facts_extracted: 0,
     facts_inserted: 0,
+    fallback_slugify_count: 0,
+    resolution_errors: 0,
   };
 
   // F2: honor brain-wide kill-switch unless overridden.
@@ -1898,6 +1934,8 @@ export async function runExtractConversationFacts(
     segments_processed: 0,
     facts_extracted: 0,
     facts_inserted: 0,
+    fallback_slugify_count: 0,
+    resolution_errors: 0,
   };
   let totalSpent = 0;
   let anyBudgetExhausted = false;
@@ -1944,6 +1982,8 @@ export async function runExtractConversationFacts(
       aggregate.segments_processed += perSource.segments_processed;
       aggregate.facts_extracted += perSource.facts_extracted;
       aggregate.facts_inserted += perSource.facts_inserted;
+      aggregate.fallback_slugify_count += perSource.fallback_slugify_count;
+      aggregate.resolution_errors += perSource.resolution_errors;
       if (perSource.budget_exhausted) anyBudgetExhausted = true;
       if (perSource.spent_usd) totalSpent += perSource.spent_usd;
 
@@ -1994,6 +2034,12 @@ export async function runExtractConversationFacts(
   if (aggregate.orphan_facts_cleaned > 0) {
     console.log(`  Cleaned ${aggregate.orphan_facts_cleaned} orphan fact(s) from prior partial runs (D11 replay safety).`);
   }
+  if (aggregate.fallback_slugify_count > 0) {
+    console.log(`  Minted ${aggregate.fallback_slugify_count} entity slug(s) via fallback_slugify.`);
+  }
+  if (aggregate.resolution_errors > 0) {
+    console.log(`  Kept ${aggregate.resolution_errors} raw entity value(s) after best-effort resolution errors.`);
+  }
   if (anyBudgetExhausted) {
     console.log(`  Budget cap reached. Re-run with a higher --max-cost-usd to continue.`);
   }
@@ -2032,7 +2078,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isAbortError(err: unknown): boolean {
+export function isAbortError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return err.name === 'AbortError' || /aborted|cancell?ed/i.test(err.message);
 }

--- a/src/core/cycle/conversation-facts-backfill.ts
+++ b/src/core/cycle/conversation-facts-backfill.ts
@@ -48,6 +48,7 @@ import { withBudgetTracker } from '../ai/gateway.ts';
 import { listSources } from '../sources-ops.ts';
 import {
   runExtractConversationFactsCore,
+  isAbortError,
   type ExtractConversationFactsResult,
 } from '../../commands/extract-conversation-facts.ts';
 // The type allowlist comes straight from the canonical leaf module (same
@@ -248,6 +249,7 @@ export async function runPhaseConversationFactsBackfill(
             break;
           }
         } catch (err) {
+          if (isAbortError(err) || opts.signal?.aborted) throw err;
           if (err instanceof BudgetExhausted) {
             skippedByBrainWideCap = Math.max(
               0,
@@ -275,17 +277,20 @@ export async function runPhaseConversationFactsBackfill(
             segments_processed: 0,
             facts_extracted: 0,
             facts_inserted: 0,
+            fallback_slugify_count: 0,
+            resolution_errors: 0,
             error: (err as Error).message,
           };
         }
       }
     });
   } catch (err) {
-    if (err instanceof BudgetExhausted) {
-      // Brain-wide cap hit during last source.
-    } else if ((err as Error).message === 'aborted' || opts.signal?.aborted) {
-      // Propagate abort.
+    if (isAbortError(err) || opts.signal?.aborted) {
+      // Abort is control flow owned by the cycle runner; never downgrade it
+      // into a per-source warning or phase failure result.
       throw err;
+    } else if (err instanceof BudgetExhausted) {
+      // Brain-wide cap hit during last source.
     } else {
       // Unexpected error.
       return {
@@ -310,6 +315,8 @@ export async function runPhaseConversationFactsBackfill(
     pages_skipped_unrecognized_speaker: 0,
     pages_failed: 0,
     facts_inserted: 0,
+    fallback_slugify_count: 0,
+    resolution_errors: 0,
     sources_processed: 0,
   };
   for (const r of Object.values(perSourceResults)) {
@@ -322,6 +329,8 @@ export async function runPhaseConversationFactsBackfill(
     totals.pages_skipped_unrecognized_speaker += r.pages_skipped_unrecognized_speaker;
     totals.pages_failed += r.pages_failed;
     totals.facts_inserted += r.facts_inserted;
+    totals.fallback_slugify_count += r.fallback_slugify_count;
+    totals.resolution_errors += r.resolution_errors;
   }
 
   const anyError = Object.values(perSourceResults).some(
@@ -346,6 +355,8 @@ export async function runPhaseConversationFactsBackfill(
       pages_skipped_unrecognized_speaker: totals.pages_skipped_unrecognized_speaker,
       pages_failed: totals.pages_failed,
       facts_inserted: totals.facts_inserted,
+      fallback_slugify_count: totals.fallback_slugify_count,
+      resolution_errors: totals.resolution_errors,
       spent_usd: totalSpent,
       skipped_by_brain_wide_cap: skippedByBrainWideCap,
       skipped_by_brain_wide_walltime: skippedByBrainWideWalltime,

--- a/src/core/entities/resolve-on-save.ts
+++ b/src/core/entities/resolve-on-save.ts
@@ -1,0 +1,102 @@
+/**
+ * Save-time caller around the shipped entity resolver.
+ *
+ * Bulk extract writes go through insertFacts and therefore skip
+ * writeSingleFact's resolveEntitySlug hop. This module is the missing
+ * write-path caller: it runs each extractor-provided entity through
+ * resolveEntitySlugWithSource, which already owns the v0.46.15
+ * alias_exact cascade via engine.resolveAliases.
+ *
+ * It does not re-implement the read-time cascade and does not introduce
+ * alias_match / alias_redirect labels.
+ */
+
+import { BudgetExhausted } from '../budget/budget-tracker.ts';
+import type { BrainEngine } from '../engine.ts';
+import type { ExtractedFact } from '../facts/extract.ts';
+import {
+  resolveEntitySlugWithSource,
+  type ResolutionSource,
+} from './resolve.ts';
+
+/** Shipped resolution tags, in stable log order. */
+export const SAVE_TIME_RESOLUTION_SOURCES = [
+  'exact_page',
+  'alias_exact',
+  'fuzzy_match',
+  'fallback_slugify',
+] as const satisfies readonly ResolutionSource[];
+
+export interface SaveTimeResolutionCounts {
+  counts: Partial<Record<ResolutionSource, number>>;
+  fallback_slugify_count: number;
+  resolution_errors: number;
+}
+
+export function emptySaveTimeResolutionCounts(): SaveTimeResolutionCounts {
+  return { counts: {}, fallback_slugify_count: 0, resolution_errors: 0 };
+}
+
+export function mergeSaveTimeResolutionCounts(
+  into: SaveTimeResolutionCounts,
+  add: SaveTimeResolutionCounts,
+): void {
+  for (const [source, count] of Object.entries(add.counts)) {
+    const typed = source as ResolutionSource;
+    into.counts[typed] = (into.counts[typed] ?? 0) + (count ?? 0);
+  }
+  into.fallback_slugify_count += add.fallback_slugify_count;
+  into.resolution_errors += add.resolution_errors;
+}
+
+export function formatSaveTimeResolutionCounts(
+  counts: Partial<Record<ResolutionSource, number>>,
+): string {
+  const ordered: Partial<Record<ResolutionSource, number>> = {};
+  for (const source of SAVE_TIME_RESOLUTION_SOURCES) {
+    const count = counts[source];
+    if (count) ordered[source] = count;
+  }
+  return JSON.stringify(ordered);
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'AbortError' || /aborted|cancell?ed/i.test(err.message);
+}
+
+/**
+ * Canonicalize extractor-provided entity slugs through the shipped
+ * resolver. Mutates `facts` in place. Sequential so a PGLite-pinned
+ * transaction sees one alias probe at a time.
+ *
+ * Ordinary resolver failures keep the raw value and increment
+ * resolution_errors. Abort and BudgetExhausted propagate.
+ */
+export async function resolveExtractedEntitiesForSave(
+  engine: BrainEngine,
+  sourceId: string,
+  facts: ExtractedFact[],
+  onError?: (raw: string, message: string) => void,
+): Promise<SaveTimeResolutionCounts> {
+  const stats = emptySaveTimeResolutionCounts();
+  for (let i = 0; i < facts.length; i++) {
+    const raw = facts[i].entity_slug;
+    if (raw === null) continue;
+    try {
+      const resolved = await resolveEntitySlugWithSource(engine, sourceId, raw);
+      facts[i] = { ...facts[i], entity_slug: resolved?.slug ?? null };
+      if (!resolved) continue;
+      stats.counts[resolved.source] = (stats.counts[resolved.source] ?? 0) + 1;
+      if (resolved.source === 'fallback_slugify') {
+        stats.fallback_slugify_count++;
+      }
+    } catch (err) {
+      if (isAbortError(err) || err instanceof BudgetExhausted) throw err;
+      stats.resolution_errors++;
+      const message = err instanceof Error ? err.message : String(err);
+      onError?.(raw, message);
+    }
+  }
+  return stats;
+}

--- a/test/extract-conversation-facts-entity-resolution.test.ts
+++ b/test/extract-conversation-facts-entity-resolution.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Conversation backfill save-time resolution against the shipped
+ * alias_exact cascade (v0.46.15 / #3730).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from 'bun:test';
+import {
+  extractConversationFactsFingerprint,
+  PER_SEGMENT_SOURCE_PREFIX,
+  runExtractConversationFactsCore,
+  TERMINAL_AUDIT_SOURCE,
+} from '../src/commands/extract-conversation-facts.ts';
+import {
+  BudgetExhausted,
+  BudgetTracker,
+} from '../src/core/budget/budget-tracker.ts';
+import { runPhaseConversationFactsBackfill } from '../src/core/cycle/conversation-facts-backfill.ts';
+import * as resolve from '../src/core/entities/resolve.ts';
+import type { ExtractedFact } from '../src/core/facts/extract.ts';
+import { loadOpCheckpoint } from '../src/core/op-checkpoint.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+function message(name: string, date: string, time: string, body: string): string {
+  return `**${name}** (${date} ${time}): ${body}`;
+}
+
+const ONE_SEGMENT_BODY = [
+  message('Alpha Example', '2026-08-12', '10:00 AM', 'The role was accepted.'),
+  message('Beta Example', '2026-08-12', '10:01 AM', 'Congratulations.'),
+].join('\n');
+
+const TWO_SEGMENT_BODY = [
+  message('Alpha Example', '2026-08-12', '10:00 AM', 'First segment.'),
+  message('Beta Example', '2026-08-12', '10:01 AM', 'Still first.'),
+  message('Alpha Example', '2026-08-12', '11:00 AM', 'Second segment.'),
+  message('Beta Example', '2026-08-12', '11:01 AM', 'Still second.'),
+].join('\n');
+
+const extractedFacts: ExtractedFact[] = [
+  {
+    fact: 'Brian accepted the role',
+    kind: 'event',
+    entity_slug: 'Brian',
+    source: 'test',
+    source_session: null,
+    confidence: 1,
+    notability: 'medium',
+  },
+  {
+    fact: 'An unlisted person attended',
+    kind: 'event',
+    entity_slug: 'Unlisted Person',
+    source: 'test',
+    source_session: null,
+    confidence: 1,
+    notability: 'medium',
+  },
+  {
+    fact: 'The weather was clear',
+    kind: 'fact',
+    entity_slug: null,
+    source: 'test',
+    source_session: null,
+    confidence: 1,
+    notability: 'low',
+  },
+];
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('facts.extraction_enabled', 'true');
+  await engine.setConfig('conversation_parser.llm_fallback_enabled', 'false');
+  await engine.setConfig('cycle.conversation_facts_backfill.enabled', 'true');
+  await seedConversation(ONE_SEGMENT_BODY);
+});
+
+async function seedConversation(body: string): Promise<void> {
+  await engine.putPage('sessions/example', {
+    type: 'conversation',
+    title: 'Example conversation',
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: {},
+  });
+  await engine.putPage('people/brian-example', {
+    type: 'person',
+    title: 'Brian Example',
+    compiled_truth: '# Brian Example',
+    timeline: '',
+    frontmatter: {},
+  });
+  await engine.setPageAliases('people/brian-example', 'default', ['brian']);
+}
+
+function extractorFor(...batches: ExtractedFact[][]) {
+  let index = 0;
+  return async (): Promise<ExtractedFact[]> =>
+    (batches[index++] ?? []).map((row) => ({ ...row }));
+}
+
+async function checkpointEntries(): Promise<string[]> {
+  return loadOpCheckpoint(engine, {
+    op: 'extract-conversation-facts',
+    fingerprint: extractConversationFactsFingerprint({ sourceId: 'default' }),
+  });
+}
+
+async function dataEntities(): Promise<Array<string | null>> {
+  const rows = await engine.executeRaw<{ entity_slug: string | null }>(
+    `SELECT entity_slug
+       FROM facts
+      WHERE source = $1
+        AND source_markdown_slug = 'sessions/example'
+      ORDER BY row_num`,
+    [PER_SEGMENT_SOURCE_PREFIX],
+  );
+  return rows.map((row) => row.entity_slug);
+}
+
+async function terminalCount(): Promise<number> {
+  const rows = await engine.executeRaw<{ count: string | number }>(
+    `SELECT COUNT(*) AS count
+       FROM facts
+      WHERE source = $1
+        AND source_markdown_slug = 'sessions/example'`,
+    [TERMINAL_AUDIT_SOURCE],
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+describe('conversation backfill entity resolution', () => {
+  test('canonicalizes aliases via alias_exact, preserves null, and counts fallback slugification', async () => {
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'sessions/example',
+        types: ['conversation'],
+        sleepMs: 0,
+        extractor: extractorFor(extractedFacts),
+      });
+
+      expect(await dataEntities()).toEqual([
+        'people/brian-example',
+        'unlisted-person',
+        null,
+      ]);
+      expect(result.fallback_slugify_count).toBe(1);
+      expect(result.resolution_errors).toBe(0);
+      expect(result.facts_inserted).toBe(3);
+      expect(await terminalCount()).toBe(1);
+
+      const stderr = writeSpy.mock.calls.map((call) => String(call[0])).join('');
+      expect(stderr).toContain(
+        'entity_resolution_counts={"alias_exact":1,"fallback_slugify":1}',
+      );
+      expect(stderr).not.toContain('alias_match');
+      expect(stderr).not.toContain('alias_redirect');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  test('a lowercase hyphenated display form still hits page_aliases', async () => {
+    await engine.putPage('people/kendall-example', {
+      type: 'person',
+      title: 'Kendall Example',
+      compiled_truth: '# Kendall Example',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.setPageAliases('people/kendall-example', 'default', [
+      'kendall',
+      'kendall-example',
+    ]);
+
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'sessions/example',
+      types: ['conversation'],
+      sleepMs: 0,
+      extractor: extractorFor([
+        {
+          fact: 'Kendall joined the call',
+          kind: 'event',
+          entity_slug: 'kendall',
+          source: 'test',
+          source_session: null,
+          confidence: 1,
+          notability: 'medium',
+        },
+        {
+          fact: 'Kendall Example spoke again',
+          kind: 'event',
+          entity_slug: 'kendall-example',
+          source: 'test',
+          source_session: null,
+          confidence: 1,
+          notability: 'medium',
+        },
+      ]),
+    });
+
+    expect(await dataEntities()).toEqual([
+      'people/kendall-example',
+      'people/kendall-example',
+    ]);
+    expect(result.fallback_slugify_count).toBe(0);
+    expect(result.resolution_errors).toBe(0);
+  });
+
+  test('a deleted page alias falls through instead of stamping a dead target', async () => {
+    await engine.putPage('people/ghost-example', {
+      type: 'person',
+      title: 'Ghost Example',
+      compiled_truth: '# Ghost Example',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.setPageAliases('people/ghost-example', 'default', ['spectre']);
+    await engine.softDeletePage('people/ghost-example');
+
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'sessions/example',
+      types: ['conversation'],
+      sleepMs: 0,
+      extractor: extractorFor([{
+        fact: 'A ghost was mentioned',
+        kind: 'event',
+        entity_slug: 'Spectre',
+        source: 'test',
+        source_session: null,
+        confidence: 1,
+        notability: 'medium',
+      }]),
+    });
+
+    expect(await dataEntities()).toEqual(['spectre']);
+    expect(result.fallback_slugify_count).toBe(1);
+  });
+
+  test('best-effort resolver failure keeps the raw value and later segments checkpoint', async () => {
+    await seedConversation(TWO_SEGMENT_BODY);
+    const original = resolve.resolveEntitySlugWithSource;
+    const spy = spyOn(resolve, 'resolveEntitySlugWithSource').mockImplementation(
+      async (eng, sourceId, raw) => {
+        if (raw === 'Unlisted Person') {
+          throw new Error('resolver unavailable for unlisted person');
+        }
+        return original(eng, sourceId, raw);
+      },
+    );
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'sessions/example',
+        types: ['conversation'],
+        sleepMs: 0,
+        extractor: extractorFor(
+          [extractedFacts[0]],
+          [extractedFacts[1], extractedFacts[0], extractedFacts[2]],
+        ),
+      });
+
+      expect(await dataEntities()).toEqual([
+        'people/brian-example',
+        'Unlisted Person',
+        'people/brian-example',
+        null,
+      ]);
+      expect(result.resolution_errors).toBe(1);
+      expect(result.fallback_slugify_count).toBe(0);
+      expect(result.segments_processed).toBe(2);
+      expect(result.facts_inserted).toBe(4);
+      expect(result.pages_processed).toBe(1);
+      expect(await checkpointEntries()).toContain(
+        'default|sessions/example|2026-08-12T11:01:00Z',
+      );
+      expect(await terminalCount()).toBe(1);
+
+      const stderr = writeSpy.mock.calls.map((call) => String(call[0])).join('');
+      expect(stderr).toContain('entity resolution failed for "Unlisted Person"');
+      expect(stderr).toContain('keeping raw value');
+    } finally {
+      spy.mockRestore();
+      writeSpy.mockRestore();
+    }
+  });
+
+  test('BudgetExhausted from resolution halts without becoming a resolution error', async () => {
+    const spy = spyOn(resolve, 'resolveEntitySlugWithSource').mockImplementation(
+      async () => {
+        throw new BudgetExhausted('resolver budget exhausted', {
+          reason: 'cost',
+          spent: 2,
+          cap: 1,
+        });
+      },
+    );
+    try {
+      const tracker = new BudgetTracker({ maxCostUsd: 1, label: 'track1-resolution' });
+      const result = await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'sessions/example',
+        types: ['conversation'],
+        sleepMs: 0,
+        budgetTracker: tracker,
+        extractor: extractorFor(extractedFacts),
+      });
+
+      expect(result.budget_exhausted).toBeTrue();
+      expect(result.resolution_errors).toBe(0);
+      expect(result.facts_inserted).toBe(0);
+      expect(await dataEntities()).toEqual([]);
+      expect(await terminalCount()).toBe(0);
+      expect(await checkpointEntries()).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('failed data insert writes no terminal or telemetry and retries cleanly', async () => {
+    const originalInsertFacts = engine.insertFacts.bind(engine);
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      engine.insertFacts = async (facts, opts) => {
+        if (facts.some((row) => row.source === PER_SEGMENT_SOURCE_PREFIX)) {
+          throw new Error('constraint sentinel');
+        }
+        return originalInsertFacts(facts, opts);
+      };
+      await expect(runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'sessions/example',
+        types: ['conversation'],
+        sleepMs: 0,
+        extractor: extractorFor(extractedFacts),
+      })).rejects.toThrow('constraint sentinel');
+
+      expect(await dataEntities()).toEqual([]);
+      expect(await terminalCount()).toBe(0);
+      expect(await checkpointEntries()).toEqual([]);
+      const failedStderr = writeSpy.mock.calls.map((call) => String(call[0])).join('');
+      expect(failedStderr).not.toContain('entity_resolution_counts=');
+      engine.insertFacts = originalInsertFacts;
+
+      const result = await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'sessions/example',
+        types: ['conversation'],
+        sleepMs: 0,
+        extractor: extractorFor(extractedFacts),
+      });
+      expect(result.facts_inserted).toBe(3);
+      expect(result.fallback_slugify_count).toBe(1);
+      expect(result.resolution_errors).toBe(0);
+      expect(await terminalCount()).toBe(1);
+      expect(await checkpointEntries()).toContain(
+        'default|sessions/example|2026-08-12T10:01:00Z',
+      );
+    } finally {
+      engine.insertFacts = originalInsertFacts;
+      writeSpy.mockRestore();
+    }
+  });
+
+  test('cycle propagates an abort instead of aggregating it as a source warning', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(runPhaseConversationFactsBackfill(engine, {
+      signal: controller.signal,
+      dryRun: true,
+    })).rejects.toThrow('aborted');
+  });
+});

--- a/test/track1-save-time-entity-resolution.test.ts
+++ b/test/track1-save-time-entity-resolution.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Save-time entity resolution — hook contract only.
+ *
+ * The read-time cascade (including alias_exact) already ships on master
+ * via #3730. This file covers the write-path caller that the original
+ * #4052 PR added, rewritten onto that shipped vocabulary. It does not
+ * re-test resolve.ts.
+ */
+import { describe, expect, spyOn, test } from 'bun:test';
+import { BudgetExhausted } from '../src/core/budget/budget-tracker.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { ExtractedFact } from '../src/core/facts/extract.ts';
+import type { ResolveResult } from '../src/core/entities/resolve.ts';
+import * as resolve from '../src/core/entities/resolve.ts';
+import {
+  formatSaveTimeResolutionCounts,
+  resolveExtractedEntitiesForSave,
+} from '../src/core/entities/resolve-on-save.ts';
+
+function fact(entity_slug: string | null, text = 'a fact'): ExtractedFact {
+  return {
+    fact: text,
+    kind: 'event',
+    entity_slug,
+    source: 'test',
+    source_session: null,
+    confidence: 1,
+    notability: 'medium',
+  };
+}
+
+function stubResolve(
+  impl: (raw: string) => Promise<ResolveResult | null>,
+): ReturnType<typeof spyOn> {
+  return spyOn(resolve, 'resolveEntitySlugWithSource').mockImplementation(
+    async (_engine, _sourceId, raw) => impl(raw),
+  );
+}
+
+describe('save-time resolution vocabulary', () => {
+  test('logs shipped alias_exact, never alias_match or alias_redirect', () => {
+    expect(formatSaveTimeResolutionCounts({
+      alias_exact: 2,
+      fallback_slugify: 1,
+    })).toBe('{"alias_exact":2,"fallback_slugify":1}');
+    const rendered = formatSaveTimeResolutionCounts({
+      exact_page: 1,
+      alias_exact: 1,
+      fuzzy_match: 1,
+      fallback_slugify: 1,
+    });
+    expect(rendered).toContain('alias_exact');
+    expect(rendered).not.toContain('alias_match');
+    expect(rendered).not.toContain('alias_redirect');
+  });
+});
+
+describe('resolveExtractedEntitiesForSave', () => {
+  const engine = {} as BrainEngine;
+
+  test('rewrites slugs, preserves null, and counts fallback_slugify', async () => {
+    const spy = stubResolve(async (raw) => {
+      if (raw === 'Brian') {
+        return { slug: 'people/brian-example', source: 'alias_exact' };
+      }
+      if (raw === 'Unlisted Person') {
+        return { slug: 'unlisted-person', source: 'fallback_slugify' };
+      }
+      return { slug: raw, source: 'fallback_slugify' };
+    });
+    try {
+      const facts = [
+        fact('Brian'),
+        fact('Unlisted Person'),
+        fact(null),
+      ];
+      const stats = await resolveExtractedEntitiesForSave(engine, 'default', facts);
+      expect(facts.map((row) => row.entity_slug)).toEqual([
+        'people/brian-example',
+        'unlisted-person',
+        null,
+      ]);
+      expect(stats.counts).toEqual({
+        alias_exact: 1,
+        fallback_slugify: 1,
+      });
+      expect(stats.fallback_slugify_count).toBe(1);
+      expect(stats.resolution_errors).toBe(0);
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('best-effort resolver failure keeps the raw value', async () => {
+    const spy = stubResolve(async (raw) => {
+      if (raw === 'Unlisted Person') throw new Error('resolver unavailable');
+      return { slug: 'people/brian-example', source: 'alias_exact' };
+    });
+    const errors: Array<{ raw: string; message: string }> = [];
+    try {
+      const facts = [fact('Brian'), fact('Unlisted Person')];
+      const stats = await resolveExtractedEntitiesForSave(
+        engine,
+        'default',
+        facts,
+        (raw, message) => errors.push({ raw, message }),
+      );
+      expect(facts.map((row) => row.entity_slug)).toEqual([
+        'people/brian-example',
+        'Unlisted Person',
+      ]);
+      expect(stats.resolution_errors).toBe(1);
+      expect(stats.fallback_slugify_count).toBe(0);
+      expect(errors).toEqual([
+        { raw: 'Unlisted Person', message: 'resolver unavailable' },
+      ]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('BudgetExhausted from resolution propagates and is not a resolution error', async () => {
+    const spy = stubResolve(async () => {
+      throw new BudgetExhausted('resolver budget exhausted', {
+        reason: 'cost',
+        spent: 2,
+        cap: 1,
+      });
+    });
+    try {
+      const facts = [fact('Brian')];
+      await expect(resolveExtractedEntitiesForSave(engine, 'default', facts))
+        .rejects.toBeInstanceOf(BudgetExhausted);
+      expect(facts[0].entity_slug).toBe('Brian');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('abort from resolution propagates', async () => {
+    const spy = stubResolve(async () => {
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+    try {
+      await expect(resolveExtractedEntitiesForSave(engine, 'default', [fact('Brian')]))
+        .rejects.toMatchObject({ name: 'AbortError' });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`save_facts` and the conversation-facts backfill mint `entity_slug` values without consulting the alias substrate the brain already maintains. Surface forms get slugified more or less verbatim, so one person accumulates fragmented slugs over time. In a production brain here, one contact ended up spread across 11 slugs, plus a 1,068-fact bucket under a typo slug. The `slug_aliases` and `page_aliases` tables exist and are populated, but `resolveSlugWithAlias` had zero callers on any write path. The write side and the alias substrate never met.

## Change

Two alias hops added to the shared resolver cascade in `resolveEntitySlugWithSource`, ahead of the existing exact/fuzzy/prefix/fallback chain and without weakening any of it:

1. Slug-shaped input: exact live page first (unchanged), then a source-scoped `slug_aliases` redirect so old slugs land on their canonical page. Tag: `alias_redirect`.
2. Any input that misses above: normalized (`normalizeAlias`) exact match against source-scoped `page_aliases`. Exactly one target resolves with tag `alias_match`. Multiple targets are recorded as `ambiguous_aliases` metadata and resolution falls through: the write path never guesses between two people.

The conversation-facts backfill now resolves each extracted `entity_slug` through the same resolver before row construction, best-effort per fact. An ordinary resolver failure keeps the raw value and increments `resolution_errors`, while aborts and `BudgetExhausted` still propagate. `fallback_slugify` outcomes are counted per run so operators can see phantom-slug minting as it happens instead of discovering it later. Resolution telemetry commits only after the data batch persists.

## Failure-mode hardening

- A permission-denied (SQLSTATE 42501) or missing-table (42P01) alias probe degrades to the pre-alias cascade with a once-per-process warning, rather than throwing - the connecting role needs SELECT (and any applicable row-security policy) on the alias tables, and a deployment without that access keeps writing exactly as before. No schema migration ships with this change: alias-table access for non-owner roles is a deployment decision, deliberately left to operators.
- Transaction-pinned alias probes are isolated with savepoints on both engines, so a failed probe cannot poison the surrounding transaction. This was verified with real-database constructions on PGLite for both SQLSTATEs. The PGLite savepoint stack is serialized per pinned handle because concurrent probes could otherwise roll back past one another.

## What this does not do

No LLM or embedding calls anywhere on the path: resolution is SQL-only. There is no interactive disambiguation on the write path, since ambiguity falls through deterministically and is surfaced as metadata. Backstop's fallback policy is untouched beyond what the shared resolver gives it.

## Testing

24 new tests across two files. Highlights: the lowercase bare-name case where slug-shaped input must still reach `page_aliases` (an LLM extractor emitting `kendall` should land on the canonical person, not mint a phantom), multi-alias fall-through without guessing, real-PGLite transaction recovery for both SQLSTATEs inside `engine.transaction()`, concurrent-probe serialization, and the same denied-probe recovery reproduced against a live Postgres 17 server (savepoint isolation held; the transaction stayed usable), budget/abort propagation in the backfill, and no telemetry for unpersisted facts.

`bun run typecheck` clean. `bun run verify` 38/38. Focused affected suites 140/140 on the branch. The no-alias-rows regression surface is pinned: existing resolver behavior, including globally-unambiguous bare-name expansion and the 0.7 fuzzy floor, is unchanged.

One field note: while this branch was being verified, the production brain running the pre-change resolver filed a fact about "entity resolution" under an unrelated `debt-resolution` page via a trigram match on the word "resolution". That is the exact failure class the alias-first cascade addresses.


