### PR TITLE
search: supersession-aware rerank — down-rank + SUPERSEDED flag for superseded pages

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -614,6 +614,80 @@ export async function runPostFusionStages(
   } catch {
     // Non-fatal; preserves the per-stage contract.
   }
+
+  // supersession stage — runs LAST so the penalty applies to the fully-boosted
+  // score. Down-ranks results whose page is the target of a `supersedes` link
+  // (a newer/canon page supersedes it) and stamps `superseded`/`superseded_by`
+  // for --explain, the contradiction probe, and agent renderers. The page-level
+  // analogue of the superseded_by/expired_at awareness recall.ts applies to
+  // facts. Fail-open per the per-stage contract: a brain with no `supersedes`
+  // edges (or a pre-links schema) finds 0 rows / throws and no-ops.
+  try {
+    await applySupersedeDownrank(results, engine);
+  } catch {
+    // Non-fatal; preserves the per-stage contract.
+  }
+}
+
+/**
+ * Down-rank results whose page is superseded by a newer/canon page, and stamp
+ * the SUPERSEDED annotation.
+ *
+ * A page X is "superseded" when it is the `to_page_id` of a `supersedes` link
+ * (`A supersedes B` → from=A canon, to=B stale). This is the page-level
+ * analogue of the `superseded_by`/`expired_at` awareness recall.ts already
+ * applies to the facts table. Stamps `superseded=true`, `superseded_by` (the
+ * superseding page's slug), and multiplies score by SUPERSEDE_PENALTY so
+ * current canon out-scores stale material without hiding it — the flag lets
+ * callers still surface it, and it is authoritative even in reranked modes
+ * where the cross-encoder owns the final head order.
+ *
+ * Single index-hit query bounded by top-K (links.to_page_id is indexed;
+ * `supersedes` edges are sparse). page_id is globally unique, so the lookup is
+ * by page_id array — no source-composite needed. Fail-soft: a brain with no
+ * `supersedes` edges (or a pre-links schema) returns 0 rows / throws and the
+ * stage no-ops (matches applyAliasResolvedBoost's pre-v104 guard).
+ */
+const SUPERSEDE_PENALTY = 0.5;
+
+async function applySupersedeDownrank(
+  results: SearchResult[],
+  engine: import('../engine.ts').BrainEngine,
+): Promise<void> {
+  if (results.length === 0) return;
+  const pageIds = Array.from(
+    new Set(results.map(r => r.page_id).filter((id): id is number => typeof id === 'number')),
+  );
+  if (pageIds.length === 0) return;
+  let rows: Array<{ to_page_id: number; by_slug: string }> = [];
+  try {
+    rows = await engine.executeRaw<{ to_page_id: number; by_slug: string }>(
+      `SELECT DISTINCT l.to_page_id, pf.slug AS by_slug
+         FROM links l
+         JOIN pages pf ON pf.id = l.from_page_id
+        WHERE l.link_type = 'supersedes'
+          AND l.to_page_id = ANY($1::bigint[])`,
+      [pageIds],
+    );
+  } catch {
+    // Pre-links schema or SQL miss; no-op.
+    return;
+  }
+  if (rows.length === 0) return;
+  const supersededBy = new Map<number, string>();
+  for (const row of rows) {
+    const id = Number(row.to_page_id);
+    if (!supersededBy.has(id)) supersededBy.set(id, row.by_slug);
+  }
+  for (const r of results) {
+    const by = supersededBy.get(r.page_id);
+    if (by !== undefined) {
+      r.score *= SUPERSEDE_PENALTY;
+      r.superseded = true;
+      r.superseded_by = by;
+      r.supersede_penalty = SUPERSEDE_PENALTY;
+    }
+  }
 }
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -828,6 +828,22 @@ export interface SearchResult {
    */
   alias_resolved_boost?: number;
   /**
+   * supersession — set when this page is the target of a `supersedes` link
+   * (a newer/canon page supersedes it). The page-level analogue of the
+   * `superseded_by`/`expired_at` temporal awareness recall.ts already applies
+   * to the facts table: the post-fusion supersession stage stamps
+   * `superseded=true`, records the superseding (canon) page's slug in
+   * `superseded_by`, and multiplies score by `supersede_penalty` (<1.0) so
+   * current canon out-scores stale material. Absent when the page is current.
+   * Consumers (`gbrain search --explain`, the contradiction probe, agent
+   * renderers) surface a SUPERSEDED flag. The flag is authoritative even in
+   * reranked modes where the cross-encoder owns the final head order.
+   */
+  superseded?: boolean;
+  superseded_by?: string;
+  /** Multiplier applied by the supersession stage (<1.0; absent = unchanged). */
+  supersede_penalty?: number;
+  /**
    * T2 (retrieval-maxpool incident) — multiplier applied by applyTitleBoost
    * (1.0 = unchanged; default ~1.25x). Fires when the normalized query is a
    * contiguous token-run inside the page title (or an exact full-title match).


### PR DESCRIPTION
## Motivation
`recall.ts` already honors `superseded_by` / `expired_at` on the **facts** table, but
`hybridSearch`'s post-fusion stages had no equivalent awareness at the **page** level. A
page that is the target of a `supersedes` link — i.e. a newer/canon page has explicitly
superseded it — still ranked purely on semantic score, so stale material could out-rank
the current canon that replaced it. Agents doing retrieval (and the contradiction probe)
had no signal that a hit was superseded.

## Change
A new final post-fusion stage, `applySupersedeDownrank`, modeled on the existing
`applyAliasResolvedBoost`:

- One source-agnostic index lookup on `links` where `link_type = 'supersedes'` and
  `to_page_id = ANY(result page_ids)` (a page is *superseded* when it is the `to` side of
  a `supersedes` edge; `A supersedes B` → `from = A` canon, `to = B` stale).
- For each superseded result: stamp `superseded = true`, `superseded_by = <canon slug>`,
  and multiply `score` by `SUPERSEDE_PENALTY` (0.5).
- Runs **last** so the penalty applies to the fully-boosted score; **fail-soft** per the
  established per-stage contract (a brain with no `supersedes` edges, or a pre-`links`
  schema, gets 0 rows / a caught throw → no-op).

`SearchResult` gains three optional, back-compatible fields — `superseded`,
`superseded_by`, `supersede_penalty` — surfaced for `gbrain search --explain`, the
contradiction probe, and agent renderers. The annotation is authoritative even in
reranked modes, where the cross-encoder owns the final head order and the score penalty
governs head entry / non-reranked ordering.

## Why this shape
- Mirrors `applyAliasResolvedBoost` (same composite-lookup + stamp pattern, inverse sign)
  so it slots into the existing staged pipeline with no new plumbing or opts.
- No new migration, no schema change — reads the existing `links` + `pages`.
- Additive fields only; every existing caller is unaffected when there are no
  `supersedes` edges.

## Testing
- `tsc --noEmit` clean (strict), on current `master`.
- Verified live against a production brain: a page that was the #1 organic hit
  (`base_score 0.896`) and the target of a `supersedes` link was demoted to rank 4
  (`score 0.464`) with `superseded=true`, `supersede_penalty=0.5`,
  `superseded_by=<canon slug>`; the superseding canon page ranked #1 on the same query.
  `sources`, `capture`, `embed`, and the contradiction eval were all unaffected.

## Open questions for the maintainer
- Penalty is a fixed `0.5` — happy to make it a `mode`/config knob if you'd prefer it tunable.
- Deliberately does **not** re-order within the cross-encoder reranked head (to avoid
  perturbing autocut's rerank-score-cliff logic); the SUPERSEDED flag is the guaranteed
  signal there. Open to a post-rerank demotion variant if you want stronger ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
