### PR TITLE
fix: v0.32.2 verify ignores conversation-miner facts

### DIFF
--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -11,9 +11,11 @@
  *   A. Schema       — assert migration v51 has run.
  *   B. Fence facts  — backfill DB facts → entity-page fences (dry-run
  *                     by default; explicit --write required).
- *   C. Verify       — re-parse each touched page, count rows, compare
+ *   C. Verify       — re-parse each fence-owned page, count rows, compare
  *                     against the DB rows for that page; partial on
- *                     mismatch.
+ *                     mismatch. Conversation-miner (`cli:`) facts are not
+ *                     fence-owned (extract-conversation-facts writes the
+ *                     chat log as source of truth) and are excluded.
  *   D. Record       — runner-owned ledger write (apply-migrations.ts).
  *
  * Idempotency: phase B only touches rows with row_num IS NULL. Re-runs
@@ -372,10 +374,15 @@ async function phaseCVerify(
     const localPathById = new Map<string, string | null>();
     for (const s of sources) localPathById.set(s.id, s.local_path);
 
+    // Conversation-miner rows stamp row_num without a ## Facts fence
+    // (chat-log shape is the source of truth). Same cli: exclusion as
+    // extract_facts reconciliation. Counting them here fails every brain
+    // that ran extract-conversation-facts.
     const groups = await engine.executeRaw<{ source_id: string; source_markdown_slug: string; n: string }>(
       `SELECT source_id, source_markdown_slug, COUNT(*) AS n
          FROM facts
         WHERE row_num IS NOT NULL
+          AND COALESCE(source, '') NOT LIKE 'cli:%'
         GROUP BY source_id, source_markdown_slug`,
     );
 

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -314,6 +314,31 @@ describe('phaseCVerify', () => {
     expect(r.detail).toContain('drifted');
     expect(r.detail).toContain('people/alice');
   });
+
+  test('ignores conversation-miner facts that have no markdown fence', async () => {
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'F1' });
+    await __testing.phaseBFenceFacts(engine, OPTS);
+
+    const slug = 'cursor-sessions/chat-1';
+    mkdirSync(join(brainDir, 'cursor-sessions'), { recursive: true });
+    writeFileSync(
+      join(brainDir, `${slug}.md`),
+      '---\ntype: conversation\n---\n\n# chat\n\nhello\n',
+      'utf-8',
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', NULL, 'Said hello', 'fact', 'private', 'medium',
+               now(), 'cli:extract-conversation-facts:seg', 1.0, 1, $1)`,
+      [slug],
+    );
+
+    const r = await __testing.phaseCVerify(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('pages_checked=1');
+  });
 });
 
 describe('orchestrator end-to-end', () => {


### PR DESCRIPTION
extract-conversation-facts stamps row_num without a markdown fence because the chat log is the source of truth. Phase C was counting those rows anyway, so any brain that ran conversation extraction could not complete the migration.