### PR TITLE
test(sweep): reset console-prefix's stdout redirect in the shared afterEach — the ENG-5 serve harness leaks it across files

### DIFF
--- a/test/sweep.test.ts
+++ b/test/sweep.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../src/core/sweep.ts';
 import { isTotalFailure, runSweep, SWEEP_HELP } from '../src/commands/sweep.ts';
 import { currentExitCode, _resetCliExitVerdictForTests } from '../src/core/cli-force-exit.ts';
+import { _resetStdoutRedirectForTests } from '../src/core/console-prefix.ts';
 import type { CapabilityReport } from '../src/core/capability.ts';
 import { __setChatTransportForTests, type ChatResult } from '../src/core/ai/gateway.ts';
 import { runServe, type ServeOptions } from '../src/commands/serve.ts';
@@ -68,6 +69,14 @@ beforeEach(async () => {
 
 afterEach(() => {
   __setChatTransportForTests(null);
+  // The ENG-5 harness drives the real runServe(), whose stdio path flips
+  // console-prefix's module-global stdout→stderr redirect (#3844). bun runs
+  // every test file in one process, so without this reset the flag stays on
+  // and poisons any later file that pins slog's stdout routing
+  // (test/sync-all-parallel.test.ts, test/console-prefix.test.ts) — whether
+  // it bites depends on CI shard composition. Same reset the donor harness
+  // (test/serve-stdio-lifecycle.test.ts) already carries.
+  _resetStdoutRedirectForTests();
 });
 
 async function seedPage(slug: string, type: string, body: string, timeline = '') {


### PR DESCRIPTION
## Problem

`test/sweep.test.ts`'s ENG-5 serve-wiring harness drives the real `runServe()`, whose stdio path calls `redirectStdoutLoggingToStderr()` (#3844) — flipping `console-prefix.ts`'s module-global `__stdoutLoggingRedirected`. bun runs every test file in one process, and sweep.test.ts never resets the flag, so every file that runs *after* it in a shard inherits stdout-logging routed to stderr.

Two shipped test files pin the opposite — that `slog` under `withSourcePrefix` writes to `process.stdout`:

- `test/sync-all-parallel.test.ts` ("per-source line prefix under withSourcePrefix")
- `test/console-prefix.test.ts` ("slog / serr line prefixing")

Whether the leak bites depends entirely on CI shard composition, so it surfaces as a flake that appears and disappears as unrelated PRs add or remove test files. Observed in the wild on #3584's run ([test (9) failure](https://github.com/garrytan/gbrain/actions/runs/31661077282/job/94325873835)): that PR touches only the embedding gateway, but adding one test file reshuffled shard 9 and placed `sweep.test.ts` ahead of `sync-all-parallel.test.ts` for the first time. The same shard passes on sibling #3617 pushed minutes earlier from the same base, and passes on master — the leak just hasn't been paired with a victim there yet.

The donor harness this file's header cites (`test/serve-stdio-lifecycle.test.ts`) already carries the reset — added in the same commit that introduced the global (#3844's `810d1c55`, which also added `_resetStdoutRedirectForTests()` for exactly this purpose). sweep.test.ts predates that commit's sweep of runServe-driving tests and was missed.

## Repro

Two lines against unmodified master `1ec6a6e8`:

```
bun test test/sweep.test.ts test/sync-all-parallel.test.ts
# → (fail) per-source line prefix under withSourcePrefix > slog under wrap emits [source-id] prefix … Received: ""
```

The prefixed line lands on stderr (visible in the console capture) while the test's `process.stdout.write` spy receives nothing — the exact signature of the redirect being left on.

Checked the other `runServe` importers (`test/serve-http-embedding-width.test.ts`, `test/sources-webhook.test.ts`): type-only imports, no call sites, and empirically no leak when paired with the victim.

## Change

One import + one line in the file-level `afterEach` — `_resetStdoutRedirectForTests()`, mirroring the donor harness. Test-only; no `src/` change.

## Verification

- The 2-file repro above: 1 fail on unmodified master → **48/48** with this change.
- The failing shard's full 95-file prefix in CI order, locally: 1299 pass / 3 fail before → **1302 pass / 0 fail** after (the 3 = the sync-all-parallel pin + console-prefix's two, all victims of the same leak under bun's local file ordering).
- `bun run verify` — **38/38 green** · `bunx tsc --noEmit` — clean.
- Related suites together (`sweep`, `console-prefix`, `sync-all-parallel`, `serve-stdio-lifecycle`) — **90/90**.