### PR TITLE
fix(dream): disable DeepSeek thinking and expire verdict cache

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2851,6 +2851,8 @@ export interface ChatOpts {
   tools?: ChatToolDef[];
   maxTokens?: number;
   abortSignal?: AbortSignal;
+  /** Per-call provider options, merged after configured provider options. */
+  providerOptions?: Record<string, Record<string, unknown>>;
   /**
    * Anthropic-specific: cache the system prompt + last tool def. Silently
    * ignored on providers without `supports_prompt_cache`.
@@ -3291,7 +3293,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
 
   const tools = toAISDKTools(opts.tools);
 
-  const providerOptions: Record<string, any> = {};
+  let providerOptions: Record<string, any> = {};
   if (useCache) {
     // Call-level `providerOptions.anthropic.cacheControl` is NOT a no-op:
     // @ai-sdk/anthropic 3.0.47+ passes it through as a top-level
@@ -3330,6 +3332,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     if (promptCacheKey) providerOptions.openai = { promptCacheKey };
   }
   applyConfiguredChatProviderOptions(providerOptions, cfg, recipe.id, modelId);
+  providerOptions = deepMergeRecords(providerOptions, opts.providerOptions);
 
   // Derive ONE canonical cache-control value AFTER config merging and reuse
   // it for every breakpoint (system block, last tool def, call-level). If

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -1042,6 +1042,9 @@ export function makeJudgeClient(verdictModel: string): JudgeClient | null {
         system,
         messages,
         maxTokens: params.max_tokens,
+        ...(v.parsed.providerId === 'deepseek'
+          ? { providerOptions: { deepseek: { thinking: { type: 'disabled' } } } }
+          : {}),
       });
 
       // Map gateway.ChatResult → Anthropic.Message shape. judgeSignificance

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -474,6 +474,14 @@ export async function runPhaseSynthesize(
     }
 
     // Significance verdicts (cached in dream_verdicts; Haiku on miss).
+    // Best-effort housekeeping: expiry is enforced on reads regardless, so a
+    // sweep failure must not block synthesis when the database is otherwise usable.
+    try {
+      const swept = await engine.sweepDreamVerdicts();
+      if (swept > 0) process.stderr.write(`[dream] swept ${swept} expired verdict cache row(s)\n`);
+    } catch (e) {
+      process.stderr.write(`[dream] warning: verdict cache sweep failed: ${e instanceof Error ? e.message : String(e)}\n`);
+    }
     const worthProcessing: DiscoveredTranscript[] = [];
     const verdicts: Array<{ filePath: string; worth: boolean; reasons: string[]; cached: boolean }> = [];
     // Provider-aware judge client routes through gateway.chat, so any

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -457,6 +457,9 @@ export interface DreamVerdictInput {
   reasons: string[];
 }
 
+/** Default lifetime for cached dream significance verdicts. */
+export const DREAM_VERDICT_TTL_SECONDS = 30 * 86400;
+
 // ============================================================
 // v0.31 Hot Memory: facts table + recall surface
 // ============================================================
@@ -1630,6 +1633,8 @@ export interface BrainEngine {
   // page-scoped — transcripts being judged aren't pages yet.
   getDreamVerdict(filePath: string, contentHash: string): Promise<DreamVerdict | null>;
   putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void>;
+  /** Delete expired dream verdicts and return the number removed. */
+  sweepDreamVerdicts(): Promise<number>;
 
   // ============================================================
   // v0.32.6 Contradiction probe — batched takes fetch + cache + trends

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5652,6 +5652,27 @@ export const MIGRATIONS: Migration[] = [
         ON session_context_state (updated_at);
     `,
   },
+  {
+    version: 127,
+    name: 'dream_verdicts_ttl',
+    // Bound the significance-verdict cache and expire legacy verdicts from
+    // before #3918 stopped degenerate responses from being cached. Backfill
+    // preserves each row's original age instead of granting old rows a fresh
+    // 30-day lifetime.
+    idempotent: true,
+    sql: `
+      ALTER TABLE dream_verdicts
+        ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+      UPDATE dream_verdicts
+        SET expires_at = judged_at + interval '30 days'
+        WHERE expires_at IS NULL;
+      ALTER TABLE dream_verdicts
+        ALTER COLUMN expires_at SET DEFAULT (now() + interval '30 days'),
+        ALTER COLUMN expires_at SET NOT NULL;
+      CREATE INDEX IF NOT EXISTS dream_verdicts_expires_idx
+        ON dream_verdicts (expires_at);
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -19,7 +19,7 @@ import type {
   NewFact, FactListOpts, FactsHealth,
   SourceRow,
 } from './engine.ts';
-import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { DREAM_VERDICT_TTL_SECONDS, MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 // Engine-path imports stay static unless a call site carries an explicit
 // engine-dynamic-import-ok justification. The gateway is the only current
 // exception because its local try/catch preserves a soft fallback.
@@ -4385,7 +4385,8 @@ export class PGLiteEngine implements BrainEngine {
     }>(
       `SELECT worth_processing, reasons, judged_at
        FROM dream_verdicts
-       WHERE file_path = $1 AND content_hash = $2`,
+       WHERE file_path = $1 AND content_hash = $2
+         AND expires_at > now()`,
       [filePath, contentHash]
     );
     if (result.rows.length === 0) return null;
@@ -4398,15 +4399,24 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void> {
+    const expiresAt = new Date(Date.now() + DREAM_VERDICT_TTL_SECONDS * 1000);
     await this.db.query(
-      `INSERT INTO dream_verdicts (file_path, content_hash, worth_processing, reasons)
-       VALUES ($1, $2, $3, $4::jsonb)
+      `INSERT INTO dream_verdicts (file_path, content_hash, worth_processing, reasons, expires_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5)
        ON CONFLICT (file_path, content_hash) DO UPDATE SET
          worth_processing = EXCLUDED.worth_processing,
          reasons = EXCLUDED.reasons,
-         judged_at = now()`,
-      [filePath, contentHash, verdict.worth_processing, JSON.stringify(verdict.reasons)]
+         judged_at = now(),
+         expires_at = EXCLUDED.expires_at`,
+      [filePath, contentHash, verdict.worth_processing, JSON.stringify(verdict.reasons), expiresAt]
     );
+  }
+
+  async sweepDreamVerdicts(): Promise<number> {
+    const result = await this.db.query(
+      `DELETE FROM dream_verdicts WHERE expires_at <= now()`
+    );
+    return result.affectedRows ?? 0;
   }
 
   // ============================================================

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -610,6 +610,19 @@ CREATE TABLE IF NOT EXISTS gbrain_cycle_locks (
 );
 CREATE INDEX IF NOT EXISTS idx_cycle_locks_ttl ON gbrain_cycle_locks(ttl_expires_at);
 
+-- Dream-cycle significance verdict cache. Expired rows are ignored on read
+-- and swept at the beginning of the synthesize significance phase.
+CREATE TABLE IF NOT EXISTS dream_verdicts (
+  file_path        TEXT        NOT NULL,
+  content_hash     TEXT        NOT NULL,
+  worth_processing BOOLEAN     NOT NULL,
+  reasons          JSONB,
+  judged_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '30 days'),
+  PRIMARY KEY (file_path, content_hash)
+);
+CREATE INDEX IF NOT EXISTS dream_verdicts_expires_idx ON dream_verdicts (expires_at);
+
 -- Eval capture (v0.25.0). PGLite ignores RLS — see src/schema.sql for the
 -- cross-engine spec.
 CREATE TABLE IF NOT EXISTS eval_candidates (

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -40,7 +40,7 @@ import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatch
 import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
 } from './types.ts';
-import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { DREAM_VERDICT_TTL_SECONDS, MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
@@ -4329,6 +4329,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT worth_processing, reasons, judged_at
       FROM dream_verdicts
       WHERE file_path = ${filePath} AND content_hash = ${contentHash}
+        AND expires_at > now()
     `;
     if (rows.length === 0) return null;
     const r = rows[0];
@@ -4341,14 +4342,22 @@ export class PostgresEngine implements BrainEngine {
 
   async putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void> {
     const sql = this.sql;
+    const expiresAt = new Date(Date.now() + DREAM_VERDICT_TTL_SECONDS * 1000);
     await sql`
-      INSERT INTO dream_verdicts (file_path, content_hash, worth_processing, reasons)
-      VALUES (${filePath}, ${contentHash}, ${verdict.worth_processing}, ${sql.json(verdict.reasons as Parameters<typeof sql.json>[0])})
+      INSERT INTO dream_verdicts (file_path, content_hash, worth_processing, reasons, expires_at)
+      VALUES (${filePath}, ${contentHash}, ${verdict.worth_processing}, ${sql.json(verdict.reasons as Parameters<typeof sql.json>[0])}, ${expiresAt})
       ON CONFLICT (file_path, content_hash) DO UPDATE SET
         worth_processing = EXCLUDED.worth_processing,
         reasons = EXCLUDED.reasons,
-        judged_at = now()
+        judged_at = now(),
+        expires_at = EXCLUDED.expires_at
     `;
+  }
+
+  async sweepDreamVerdicts(): Promise<number> {
+    const sql = this.sql;
+    const result = await sql`DELETE FROM dream_verdicts WHERE expires_at <= now()`;
+    return result.count ?? 0;
   }
 
   // ============================================================

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -766,7 +766,7 @@ CREATE INDEX IF NOT EXISTS context_volunteer_events_src_slug_idx
   ON context_volunteer_events (source_id, slug);
 
 -- session_context_state (v0.45.7 / migration v126 — ambient recall issue #1):
--- per-session cursor + surfaced-slug dedup for the \`delta\` verb + heartbeat
+-- per-session cursor + boundary-tie dedup for the \`delta\` verb + heartbeat
 -- runtime. Key (source_id, client_id, session_id); client_id 'local' sentinel
 -- for CLI/hook, remote auth client id otherwise. jsonb DDL-literal defaults.
 CREATE TABLE IF NOT EXISTS session_context_state (
@@ -1110,8 +1110,10 @@ CREATE TABLE IF NOT EXISTS dream_verdicts (
   worth_processing BOOLEAN     NOT NULL,
   reasons          JSONB,
   judged_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '30 days'),
   PRIMARY KEY (file_path, content_hash)
 );
+CREATE INDEX IF NOT EXISTS dream_verdicts_expires_idx ON dream_verdicts (expires_at);
 
 -- ============================================================
 -- Cycle coordination lock — v0.17 runCycle primitive

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1106,8 +1106,10 @@ CREATE TABLE IF NOT EXISTS dream_verdicts (
   worth_processing BOOLEAN     NOT NULL,
   reasons          JSONB,
   judged_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '30 days'),
   PRIMARY KEY (file_path, content_hash)
 );
+CREATE INDEX IF NOT EXISTS dream_verdicts_expires_idx ON dream_verdicts (expires_at);
 
 -- ============================================================
 -- Cycle coordination lock — v0.17 runCycle primitive

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -381,4 +381,20 @@ describe('chat touchpoint — provider_chat_options passthrough', () => {
       },
     });
   });
+
+  test('call-scoped providerOptions merge last without dropping configured siblings', async () => {
+    const providerOptions = await captureProviderOptions({
+      chat_model: 'deepseek:deepseek-v4-flash',
+      provider_chat_options: {
+        deepseek: { temperature: 0.2 },
+      },
+      env: { DEEPSEEK_API_KEY: 'fake' },
+    }, {
+      providerOptions: { deepseek: { thinking: { type: 'disabled' } } },
+    });
+
+    expect(providerOptions).toEqual({
+      deepseek: { temperature: 0.2, thinking: { type: 'disabled' } },
+    });
+  });
 });

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -107,10 +107,12 @@ describe('JudgeClient.create — gateway routing + shape adapter', () => {
       let transportCalled = false;
       let receivedSystem: string | undefined;
       let receivedModel: string | undefined;
+      let receivedProviderOptions: Record<string, unknown> | undefined;
       __setChatTransportForTests(async (opts): Promise<ChatResult> => {
         transportCalled = true;
         receivedSystem = opts.system;
         receivedModel = opts.model;
+        receivedProviderOptions = opts.providerOptions;
         return {
           text: WORTH_PROCESSING_JSON,
           blocks: [],
@@ -132,9 +134,39 @@ describe('JudgeClient.create — gateway routing + shape adapter', () => {
       expect(receivedSystem).toBe('judge system prompt');
       // Gateway model gets the anthropic: prefix normalized
       expect(receivedModel).toBe('anthropic:claude-haiku-4-5-20251001');
+      expect(receivedProviderOptions).toBeUndefined();
       // Anthropic.Message shape returned
       expect(result.content?.[0]?.type).toBe('text');
       expect((result.content?.[0] as { type: string; text: string }).text).toBe(WORTH_PROCESSING_JSON);
+    });
+  });
+
+  test('A3b: DeepSeek verdict judge disables thinking only for its call', async () => {
+    const judge = makeJudgeClient('deepseek:deepseek-v4-flash');
+    expect(judge).not.toBeNull();
+
+    let receivedProviderOptions: Record<string, unknown> | undefined;
+    __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+      receivedProviderOptions = opts.providerOptions;
+      return {
+        text: WORTH_PROCESSING_JSON,
+        blocks: [],
+        stopReason: 'end',
+        usage: { input_tokens: 10, output_tokens: 20, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'deepseek:deepseek-v4-flash',
+        providerId: 'deepseek',
+      };
+    });
+
+    await judge!.create({
+      model: 'deepseek:deepseek-v4-flash',
+      max_tokens: 1024,
+      system: 'judge system prompt',
+      messages: [{ role: 'user', content: 'judge this' }],
+    });
+
+    expect(receivedProviderOptions).toEqual({
+      deepseek: { thinking: { type: 'disabled' } },
     });
   });
 

--- a/test/dream-verdict-cache-ttl.test.ts
+++ b/test/dream-verdict-cache-ttl.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { DREAM_VERDICT_TTL_SECONDS } from '../src/core/engine.ts';
+import { MIGRATIONS, LATEST_VERSION, runMigrations } from '../src/core/migrate.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM dream_verdicts');
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('dream_verdicts TTL', () => {
+  test('migration v127 adds a 30-day expiry and index', async () => {
+    const migration = MIGRATIONS.find(item => item.version === 127);
+    expect(migration?.name).toBe('dream_verdicts_ttl');
+    expect(migration?.idempotent).toBe(true);
+    expect(LATEST_VERSION).toBeGreaterThanOrEqual(127);
+
+    const columns = await engine.executeRaw<{
+      column_name: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>(`SELECT column_name, is_nullable, column_default
+          FROM information_schema.columns
+         WHERE table_name = 'dream_verdicts' AND column_name = 'expires_at'`);
+    expect(columns).toHaveLength(1);
+    expect(columns[0].is_nullable).toBe('NO');
+    expect(columns[0].column_default).toContain('30 days');
+
+    const indexes = await engine.executeRaw<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+        WHERE tablename = 'dream_verdicts'
+          AND indexname = 'dream_verdicts_expires_idx'`,
+    );
+    expect(indexes).toHaveLength(1);
+  });
+
+  test('put assigns the default TTL and get returns a fresh verdict', async () => {
+    const before = Date.now();
+    await engine.putDreamVerdict('/tmp/fresh.md', 'fresh-hash', {
+      worth_processing: true,
+      reasons: ['fresh'],
+    });
+
+    const hit = await engine.getDreamVerdict('/tmp/fresh.md', 'fresh-hash');
+    expect(hit?.worth_processing).toBe(true);
+    const rows = await engine.executeRaw<{ expires_at: string }>(
+      `SELECT expires_at FROM dream_verdicts WHERE content_hash = 'fresh-hash'`,
+    );
+    const ttlMs = new Date(rows[0].expires_at).getTime() - before;
+    expect(ttlMs).toBeGreaterThan((DREAM_VERDICT_TTL_SECONDS - 5) * 1000);
+    expect(ttlMs).toBeLessThanOrEqual((DREAM_VERDICT_TTL_SECONDS + 5) * 1000);
+  });
+
+  test('expired rows miss on read and sweep deletes only expired rows', async () => {
+    await engine.putDreamVerdict('/tmp/expired.md', 'expired-hash', {
+      worth_processing: false,
+      reasons: ['legacy poison'],
+    });
+    await engine.putDreamVerdict('/tmp/fresh.md', 'fresh-hash', {
+      worth_processing: true,
+      reasons: ['fresh'],
+    });
+    await engine.executeRaw(
+      `UPDATE dream_verdicts SET expires_at = now() - interval '1 second'
+        WHERE content_hash = 'expired-hash'`,
+    );
+
+    expect(await engine.getDreamVerdict('/tmp/expired.md', 'expired-hash')).toBeNull();
+    expect(await engine.getDreamVerdict('/tmp/fresh.md', 'fresh-hash')).not.toBeNull();
+    expect(await engine.sweepDreamVerdicts()).toBe(1);
+
+    const rows = await engine.executeRaw<{ content_hash: string }>(
+      'SELECT content_hash FROM dream_verdicts ORDER BY content_hash',
+    );
+    expect(rows.map(row => row.content_hash)).toEqual(['fresh-hash']);
+  });
+
+  test('upgrade backfill derives expiry from judged_at and is idempotent', async () => {
+    await engine.executeRaw('ALTER TABLE dream_verdicts DROP COLUMN expires_at');
+    await engine.executeRaw(`
+      INSERT INTO dream_verdicts (file_path, content_hash, worth_processing, reasons, judged_at)
+      VALUES ('/tmp/legacy.md', 'legacy-hash', false, '[]'::jsonb, now() - interval '45 days')
+    `);
+    await engine.setConfig('version', '126');
+
+    const applied = await runMigrations(engine);
+    expect(applied.applied).toBeGreaterThanOrEqual(1);
+    expect(await engine.getDreamVerdict('/tmp/legacy.md', 'legacy-hash')).toBeNull();
+    expect(await engine.sweepDreamVerdicts()).toBe(1);
+    expect((await runMigrations(engine)).applied).toBe(0);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- add call-scoped gateway provider options and explicitly disable DeepSeek thinking for dream significance verdicts
- add a 30-day TTL to `dream_verdicts`, with expiry-aware reads and TTL refresh on successful upsert
- backfill existing rows from their original `judged_at`, add an expiry index, and run a best-effort sweep at the start of the significance phase

## Relationship to #3918 / #4050

#3918, assembled into master by #4050 in `3fa0a5acb5`, already fixes the core poison-verdict path: it increases verdict headroom, preserves provider stop reasons, marks truncated/refused/unparseable results unreliable, and avoids caching those degenerate results. This PR intentionally does not duplicate the proposed `JudgeParseError`/retry work.

It only fills two remaining gaps:

1. DeepSeek can still spend the verdict budget on reasoning. The verdict call now sends DeepSeek-specific `thinking: { type: "disabled" }` without changing other callers or providers.
2. Existing and ordinary cached verdicts had no lifecycle. Migration v127 gives them a 30-day expiry; legacy rows retain their original age, expired rows miss immediately, and periodic best-effort sweep keeps the table bounded.

## Testing

- `bun test` focused matrix: **135 pass, 0 fail**
- `test/e2e/dream-synthesize-pglite.test.ts`: **18 pass, 0 fail**
- `bun run typecheck`
- `bash scripts/check-search-path.sh`
- `git diff --check`

No production database or running release was modified while preparing this PR.