### PR TITLE
fix(consolidate): fetch pending facts before limit

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -163,6 +163,7 @@ The quarantine has grown to dozens of files — treat it as debt: every addition
 
 Unit tests and what they cover:
 
+- `test/facts-engine.test.ts` / `test/consolidate-valid-until.test.ts` — facts-list filtering and consolidate correctness (#4057): `unconsolidatedOnly` is applied before the 100-row limit, so newer consolidated facts cannot permanently hide older pending facts; the phase regression seeds 100 consolidated rows plus three older pending rows and requires all three to progress.
 - `test/markdown.test.ts` — frontmatter parsing; `splitBody` sentinel precedence, horizontal-rule preservation, `inferType` wiki subtypes.
 - `test/chunkers/recursive.test.ts` — chunking.
 - `test/parity.test.ts` — operations contract parity.
@@ -267,6 +268,8 @@ Unit tests and what they cover:
 ### E2E test inventory
 
 E2E tests live in `test/e2e/` and run against real Postgres+pgvector (require `DATABASE_URL`), except where noted as PGLite in-memory (no `DATABASE_URL` needed).
+
+- `test/e2e/facts-separation-postgres.test.ts` — real-Postgres parity for cross-session facts, supersession, and the pre-limit `unconsolidatedOnly` predicate used by consolidation.
 
 - `bun run test:e2e` runs Tier 1 (mechanical, all operations, no API keys). Includes dedicated cases for the postgres-engine `addLinksBatch` / `addTimelineEntriesBatch` bind path — postgres-js's JSONB bind (`jsonb_to_recordset(($1::jsonb)->'rows')`) differs from PGLite's and gets its own coverage.
 - `test/e2e/search-quality.test.ts` — search quality against PGLite (no API keys, in-memory).

--- a/src/core/cycle/phases/consolidate.ts
+++ b/src/core/cycle/phases/consolidate.ts
@@ -99,12 +99,11 @@ export async function runPhaseConsolidate(
       try { await opts.yieldDuringPhase(); } catch { /* keepalive errors non-fatal */ }
     }
 
-    const facts = await engine.listFactsByEntity(b.source_id, b.entity_slug, {
+    const unconsolidated = await engine.listFactsByEntity(b.source_id, b.entity_slug, {
       activeOnly: true,
+      unconsolidatedOnly: true,
       limit: 100,
     });
-    // Re-filter to unconsolidated since listFactsByEntity returns all active.
-    const unconsolidated = facts.filter(f => f.consolidated_at == null);
     if (unconsolidated.length < minPerBucket) {
       bucketsSkipped += 1;
       continue;

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -543,6 +543,8 @@ export interface NewFact {
 export interface FactListOpts {
   /** Hide expired_at IS NOT NULL rows. Default true. */
   activeOnly?: boolean;
+  /** Return only facts where consolidated_at IS NULL. Default false. */
+  unconsolidatedOnly?: boolean;
   limit?: number;
   offset?: number;
   /** Restrict to specific kinds. Default: all kinds. */

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4908,6 +4908,9 @@ export class PGLiteEngine implements BrainEngine {
     if (opts.activeOnly !== false) {
       whereParts.push(`expired_at IS NULL`);
     }
+    if (opts.unconsolidatedOnly === true) {
+      whereParts.push(`consolidated_at IS NULL`);
+    }
     if (opts.kinds && opts.kinds.length > 0) {
       whereParts.push(`kind = ANY($kinds)`);
       params.kinds = opts.kinds;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4607,6 +4607,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -4614,6 +4615,7 @@ export class PostgresEngine implements BrainEngine {
       WHERE source_id = ${source_id}
         AND entity_slug = ${entitySlug}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY valid_from DESC, id DESC
@@ -4631,6 +4633,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const entitySlug = opts?.entitySlug ?? null;
@@ -4640,6 +4643,7 @@ export class PostgresEngine implements BrainEngine {
         AND created_at >= ${since}
         ${entitySlug ? sql`AND entity_slug = ${entitySlug}` : sql``}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC
@@ -4657,6 +4661,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -4664,6 +4669,7 @@ export class PostgresEngine implements BrainEngine {
       WHERE source_id = ${source_id}
         AND source_session = ${sessionId}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC

--- a/test/consolidate-valid-until.test.ts
+++ b/test/consolidate-valid-until.test.ts
@@ -81,6 +81,56 @@ async function insertFact(args: {
   return r[0].id;
 }
 
+describe('#4057 — consolidation work-window eligibility', () => {
+  test('#4057: consolidated rows cannot hide older unconsolidated facts beyond the 100-row window', async () => {
+    const slug = 'cdx4-over-100-active';
+    const pageId = await seedPage(slug);
+    const oldDate = new Date('2025-01-01T00:00:00Z');
+    const recentDate = new Date('2026-01-01T00:00:00Z');
+
+    for (let i = 0; i < 100; i++) {
+      await insertFact({
+        entity_slug: slug,
+        text: 'already consolidated claim',
+        valid_from: new Date(recentDate.getTime() + i * 60_000),
+      });
+    }
+    const take = await engine.executeRaw<{ id: number }>(
+      `INSERT INTO takes (page_id, row_num, claim, kind, holder)
+       VALUES ($1, 1, 'already consolidated claim', 'fact', 'self')
+       RETURNING id`,
+      [pageId],
+    );
+    await engine.executeRaw(
+      `UPDATE facts
+          SET consolidated_at = now(), consolidated_into = $1
+        WHERE entity_slug = $2`,
+      [take[0].id, slug],
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await insertFact({
+        entity_slug: slug,
+        text: 'still pending claim',
+        valid_from: new Date(oldDate.getTime() + i * 60_000),
+      });
+    }
+
+    const result = await runPhaseConsolidate(engine, {});
+
+    expect(result.details.facts_consolidated).toBe(3);
+    const pending = await engine.executeRaw<{ count: number }>(
+      `SELECT COUNT(*)::int AS count
+         FROM facts
+        WHERE entity_slug = $1
+          AND expired_at IS NULL
+          AND consolidated_at IS NULL`,
+      [slug],
+    );
+    expect(Number(pending[0].count)).toBe(0);
+  });
+});
+
 describe('R4a — chronological valid_until writeback', () => {
   test('cluster of 3 chronologically-ordered facts: 2 older get valid_until set, newest stays NULL', async () => {
     await seedPage('cdx4-acme-mrr');

--- a/test/e2e/facts-separation-postgres.test.ts
+++ b/test/e2e/facts-separation-postgres.test.ts
@@ -62,4 +62,28 @@ d("Cross-session recall test (Postgres)", () => {
     expect(old!.expired_at).not.toBeNull();
     expect(old!.superseded_by).toBe(r2.id);
   });
+
+  test('unconsolidatedOnly filters before the result limit on real Postgres', async () => {
+    const engine = getEngine();
+    const entitySlug = 'consolidation-filter-postgres';
+    const pending = await engine.insertFact(
+      { fact: 'still pending', kind: 'fact', entity_slug: entitySlug, source: 'test' },
+      { source_id: 'default' },
+    );
+    const consolidated = await engine.insertFact(
+      { fact: 'already consolidated', kind: 'fact', entity_slug: entitySlug, source: 'test' },
+      { source_id: 'default' },
+    );
+    await engine.executeRaw(
+      `UPDATE facts SET consolidated_at = now() WHERE id = $1`,
+      [consolidated.id],
+    );
+
+    const rows = await engine.listFactsByEntity('default', entitySlug, {
+      unconsolidatedOnly: true,
+      limit: 1,
+    });
+
+    expect(rows.map(f => f.id)).toEqual([pending.id]);
+  });
 });

--- a/test/facts-engine.test.ts
+++ b/test/facts-engine.test.ts
@@ -69,6 +69,30 @@ describe('insertFact + listFactsByEntity', () => {
     expect(ours!.confidence).toBe(1.0);
   });
 
+  test('unconsolidatedOnly excludes active facts with consolidated_at set', async () => {
+    const entitySlug = 'people/consolidation-filter-example';
+    const consolidated = await engine.insertFact(
+      { fact: 'already consolidated', kind: 'fact', entity_slug: entitySlug, source: 'test' },
+      { source_id: 'default' },
+    );
+    const pending = await engine.insertFact(
+      { fact: 'still pending', kind: 'fact', entity_slug: entitySlug, source: 'test' },
+      { source_id: 'default' },
+    );
+    await engine.executeRaw(
+      `UPDATE facts SET consolidated_at = now() WHERE id = $1`,
+      [consolidated.id],
+    );
+
+    const active = await engine.listFactsByEntity('default', entitySlug);
+    const unconsolidated = await engine.listFactsByEntity('default', entitySlug, {
+      unconsolidatedOnly: true,
+    });
+
+    expect(new Set(active.map(f => f.id))).toEqual(new Set([consolidated.id, pending.id]));
+    expect(unconsolidated.map(f => f.id)).toEqual([pending.id]);
+  });
+
   test('respects kind CHECK', async () => {
     const r = await engine.insertFact(
       { fact: 'durable', kind: 'preference', entity_slug: 'alice-test', source: 'test' },


### PR DESCRIPTION
## Summary

- add an `unconsolidatedOnly` predicate to the shared facts-list options in both engines
- apply the predicate before ordering and the 100-row consolidation limit
- cover the starvation case with 100 newer consolidated facts hiding three older pending facts
- verify the predicate-before-limit behavior against real Postgres

Fixes #4057.

## Why

The consolidate phase selected eligible buckets by counting active facts with `consolidated_at IS NULL`, but fetched each bucket from all active facts and filtered only after `LIMIT 100`. Consolidated rows could fill the entire window, so an eligible bucket was skipped forever and its older pending facts were never evaluated.

The fetch now uses the same predicate as the eligibility query. The work window therefore contains only pending facts; the existing cap, ordering, age gate, and clustering behavior remain unchanged.

## Verification

- red-first regression: 100 consolidated facts backed by a real take plus three older pending facts produced `facts_consolidated = 0` before the fix and `3` after it
- `bun test test/consolidate-valid-until.test.ts test/facts-engine.test.ts test/facts-separation-pglite.test.ts test/build-llms.test.ts` — 34 pass, 0 fail
- `bun run typecheck` — pass
- `gitleaks dir . --redact --no-banner` and `gitleaks git --redact --no-banner` — pass
