### PR TITLE
fix(gateway): two Anthropic-compatible-provider defects that fail silently

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -23,7 +23,7 @@
 
 import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -2740,6 +2740,23 @@ function safeStringify(value: unknown): string {
   }
 }
 
+/**
+ * Some Anthropic-compatible providers (notably z.ai/GLM) occasionally return a
+ * tool-call part WITHOUT a `toolCallId`. AI SDK v6's ModelMessage schema requires
+ * `toolCallId: z.string()`, so an undefined id is invisible on the turn it is
+ * produced but throws "The messages do not match the ModelMessage[] schema" the
+ * moment that assistant turn is replayed as history on the next tool-loop turn —
+ * permanently wedging the job (observed as ~528 identical autopilot failures).
+ * Synthesize a stable, unique id AT THE SOURCE (`chat()` block-normalization) so
+ * the SAME id flows to both the persisted tool-call block and its matching
+ * tool-result block within a turn. Also used defensively in `toModelMessages` to
+ * keep any already-persisted poisoned rows from throwing on replay.
+ */
+function ensureToolCallId(id: unknown, toolName: string): string {
+  if (typeof id === 'string' && id.length > 0) return id;
+  return `glmfix-${toolName}-${randomUUID()}`;
+}
+
 export function toModelMessages(messages: ChatMessage[]): unknown[] {
   return messages.map((m) => {
     if (typeof m.content === 'string') return { role: m.role, content: m.content };
@@ -2772,7 +2789,10 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
         .filter((b) => b.type !== 'text' || typeof b.text === 'string')
         .map((b) => {
           if (b.type === 'text') return { type: 'text' as const, text: b.text };
-          if (b.type === 'tool-call') return { type: 'tool-call' as const, toolCallId: b.toolCallId, toolName: b.toolName, input: b.input };
+          // ensureToolCallId here is the defensive half: rows persisted before
+          // the chat()-side fix can still carry an undefined id, and replaying
+          // one would throw on the ModelMessage schema.
+          if (b.type === 'tool-call') return { type: 'tool-call' as const, toolCallId: ensureToolCallId(b.toolCallId, b.toolName), toolName: b.toolName, input: b.input };
           return b;
         }),
     };
@@ -3428,7 +3448,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
         else if (part.type === 'tool-call') {
           blocks.push({
             type: 'tool-call',
-            toolCallId: part.toolCallId,
+            toolCallId: ensureToolCallId(part.toolCallId, part.toolName),
             toolName: part.toolName,
             input: part.input ?? part.args,
           });
@@ -3442,7 +3462,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
       for (const tc of (result as any).toolCalls ?? []) {
         blocks.push({
           type: 'tool-call',
-          toolCallId: tc.toolCallId,
+          toolCallId: ensureToolCallId(tc.toolCallId, tc.toolName),
           toolName: tc.toolName,
           input: tc.input ?? tc.args,
         });

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2500,6 +2500,21 @@ export async function expand(query: string): Promise<string[]> {
       const result = await generateObject({
         model,
         schema: ExpansionSchema,
+        // Name the schema. On the native-anthropic path the SDK turns the schema
+        // into a tool, and without a name+description that tool carries no
+        // `description` field. api.anthropic.com tolerates that; an
+        // Anthropic-COMPATIBLE endpoint need not, and at least one (z.ai/GLM)
+        // then ignores `tool_choice: {type:'tool'}` and answers with
+        // markdown-fenced JSON as ordinary text. Measured 3/3 deterministic both
+        // ways against z.ai: with a description, 3/3 tool_use; without it, 3/3
+        // end_turn+text. generateObject then sees no object, `result.object` is
+        // undefined, and expansion degrades to the bare query — on EVERY call,
+        // with no error line, because the catch below only reports AIConfigError.
+        // The two openai-compatible branches already recover via viaText(); this
+        // native branch has no such fallback, so naming the schema is its only
+        // guard.
+        schemaName: 'query_expansions',
+        schemaDescription: 'The rewritten search queries used to retrieve relevant documents.',
         abortSignal: withDefaultTimeout(undefined, AI_CHAT_TIMEOUT_MS),
         prompt: expansionPrompt,
       });

--- a/test/ai/gateway-tools-schema.test.ts
+++ b/test/ai/gateway-tools-schema.test.ts
@@ -93,4 +93,29 @@ describe('gateway tool schema + message shape (real AI SDK v6)', () => {
       generateText({ model: model as any, tools: tools as any, messages: preFixMessages as any }),
     ).rejects.toThrow();
   });
+
+  it('FIX: a tool-call with undefined toolCallId (GLM omission) is coerced to a non-empty string', () => {
+    // The exact poisoned shape z.ai/GLM produced: a tool-call part with NO
+    // toolCallId. Replayed as assistant history on turn N+1, pre-fix this threw
+    // "The messages do not match the ModelMessage[] schema" (toolCallId: z.string())
+    // and wedged the job across all 528 autopilot retries. ensureToolCallId()
+    // synthesizes a stable id so the v6 ModelMessage schema no longer rejects it.
+    // (chat() applies the SAME coercion at the source, so the id it emits flows
+    // to BOTH the assistant tool-call block AND its matching tool-result block —
+    // a complete matched conversation is covered by the first test above.)
+    const poisoned: ChatMessage[] = [
+      { role: 'user', content: 'find foo' },
+      { role: 'assistant', content: [{ type: 'tool-call', toolCallId: undefined as unknown as string, toolName: 'search', input: { q: 'foo' } }] },
+    ];
+    const converted = toModelMessages(poisoned) as any[];
+    const asst = converted.find((m) => m.role === 'assistant');
+    const toolCallPart = asst.content.find((p: any) => p.type === 'tool-call');
+    expect(typeof toolCallPart.toolCallId).toBe('string');
+    expect(toolCallPart.toolCallId.length).toBeGreaterThan(0);
+    // An empty-string id must also be coerced (not just undefined).
+    const emptyId = toModelMessages([
+      { role: 'assistant', content: [{ type: 'tool-call', toolCallId: '', toolName: 'search', input: {} }] },
+    ]) as any[];
+    expect(emptyId[0].content[0].toolCallId.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Two independent fixes for running gbrain against an **Anthropic-compatible** endpoint rather than `api.anthropic.com`. Both were found on z.ai/GLM, both fail *silently* — no error line, no failed op — which is why they survived a long time. Neither changes behaviour on the native Anthropic path.

Happy to split this into two PRs if you'd prefer.

---

### 1. `expand()` degrades to the bare query — name the schema

`generateObject` turns the Zod schema into a tool. Without `schemaName`/`schemaDescription` the emitted tool carries **no `description` field**. `api.anthropic.com` tolerates that; at least one compatible endpoint does not — it ignores `tool_choice: { type: 'tool' }` and replies with markdown-fenced JSON as ordinary text.

`generateObject` then finds no object, `result.object` is `undefined`, and:

```ts
expansions = result.object?.queries ?? [];
```

quietly yields `[]`, so **query expansion silently reduces to the original query on every call**. Nothing is logged, because the `catch` only reports `AIConfigError`.

Measured against z.ai, deterministic both ways: **with** a description 3/3 `tool_use`; **without** it 3/3 `end_turn` + text.

This lands on the `recipe.implementation !== 'openai-compatible'` branch specifically. The two `openai-compatible` branches already recover through `viaText()`; the native branch has no fallback, so naming the schema is its only guard.

### 2. A missing `toolCallId` wedges the tool loop one turn later

The same class of provider intermittently returns a tool-call part with `toolCallId` **undefined**. AI SDK v6's `ModelMessage` schema requires a non-empty string, so the bad turn is invisible when produced and throws

> The messages do not match the ModelMessage[] schema

the moment it is replayed as history on turn N+1 — permanently wedging the job. We observed ~528 identical failures on one recurring subagent job before locating it.

`ensureToolCallId()` synthesizes a stable id **at the source** (`chat()` block-normalization) so the same id reaches both the persisted tool-call block and its matching tool-result block. It is also applied defensively in `toModelMessages`, so rows already persisted with a poisoned id stop throwing on replay.

---

**Scope:** `src/core/ai/gateway.ts` + one test file. No config, schema or dependency changes.

**Tests:** `bun test test/ai/` → 494 pass / 0 fail. The full suite has one pre-existing failure (`dream-postgres.serial` A1 per-source scope, `PGLite not connected`) which reproduces identically on unmodified `master` — 8 pass / 1 fail on both, checked side by side rather than assumed.

---

*Separately, and not part of this PR:* `provider_base_urls.<provider>` is documented and works for openai-compatible recipes, but is **inert for the two native providers** — `resolveNativeBaseUrl` reads only `cfg.env.<PROVIDER>_BASE_URL` and the native branches never consult `cfg.base_urls`. I wrote the obvious one-line fold and then withdrew it: the base URL and the API key travel through different planes, so folding only the URL can pair a config-plane endpoint with an env-plane key belonging to a different vendor. That seemed worth reporting rather than patching blind — happy to open it as an issue if useful.