### PR TITLE
fix(doctor): effective_date_health re-parses frontmatter instead of trusting JSONB key-existence

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4291	ratchet	peel target: containment sprint C8-C13; grown v0.46.x keyless not_configured state
+src/commands/doctor.ts	4348	ratchet	peel target: containment sprint C8-C13; grown v0.46.x keyless not_configured state + #4072 frontmatter re-parse
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5816	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
 src/core/pglite-engine.ts	5744	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,6 +19,8 @@ import { gbrainPath, loadConfig } from '../core/config.ts';
 import { dirname, join } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { resolveEnvNumber, resolveHoursEnv } from '../core/env-number.ts';
+import { computeEffectiveDate } from '../core/effective-date.ts';
+import { parseFrontmatter } from '../core/backfill-effective-date.ts';
 import { hnswIndexExpected, hnswMaxDimsForType } from '../core/vector-index.ts';
 import { VERSION as GBRAIN_BINARY_VERSION } from '../version.ts';
 // Peeled doctor modules (containment sprint): each is a verbatim move out of
@@ -3392,32 +3394,87 @@ export async function buildChecks(
   //
   // Sample 1000 random rows by default to keep the check fast on 200K-page
   // brains. The expression index pages_coalesce_date_idx makes the future-
-  // date and pre-1990 scans cheap; the parseable-fm-date scan reads
-  // frontmatter JSONB and is the slow path.
+  // date and pre-1990 scans cheap. The "fell back despite parseable date"
+  // arm can't be a pure SQL COUNT(*) — JSONB `?` only proves a key exists,
+  // not that its value parses — so it fetches the candidate rows and
+  // re-runs computeEffectiveDate() in JS (same function `gbrain
+  // reindex-frontmatter` uses) to confirm a real date was missed.
   progress.heartbeat('effective_date_health');
   try {
     const result = await engine.executeRaw<{ kind: string; count: string }>(
       `WITH sample AS (
-         SELECT slug, frontmatter, effective_date, effective_date_source
+         SELECT effective_date
            FROM pages
           ORDER BY id DESC
           LIMIT 1000
        )
-       SELECT 'fallback_with_fm_date' AS kind, COUNT(*)::text AS count
-         FROM sample
-        WHERE effective_date_source = 'fallback'
-          AND (frontmatter ? 'event_date' OR frontmatter ? 'date' OR frontmatter ? 'published')
-       UNION ALL
-       SELECT 'future_dated', COUNT(*)::text FROM sample
+       SELECT 'future_dated' AS kind, COUNT(*)::text AS count FROM sample
         WHERE effective_date IS NOT NULL AND effective_date > NOW() + INTERVAL '1 year'
        UNION ALL
        SELECT 'pre_1990', COUNT(*)::text FROM sample
         WHERE effective_date IS NOT NULL AND effective_date < TIMESTAMPTZ '1990-01-01'`,
     );
     const counts = new Map(result.map(r => [r.kind, Number(r.count)]));
-    const fallbackWithFm = counts.get('fallback_with_fm_date') ?? 0;
     const future = counts.get('future_dated') ?? 0;
     const pre1990 = counts.get('pre_1990') ?? 0;
+
+    // `frontmatter ? 'date'` (JSONB key-existence) only proves the key is
+    // present — an empty string, null, or unparseable value still passes
+    // it, so a naive COUNT(*) on that predicate over-reports "fell back
+    // despite a parseable date". Fetch the candidate rows instead and run
+    // them through the SAME parse/range rules `gbrain reindex-frontmatter`
+    // uses (computeEffectiveDate) to confirm the frontmatter value itself
+    // is parseable. This is a ONE-DIRECTIONAL guarantee, not equivalence:
+    // every row counted here is a row reindex-frontmatter's dry run would
+    // also flag, but reindex-frontmatter's dry run additionally flags rows
+    // this arm intentionally excludes (filename-derived dates only, no
+    // parseable frontmatter — that's a different message). Two queries
+    // against the "last 1000 pages" window means this and the counts above
+    // can drift by a row or two under concurrent writes — acceptable for a
+    // sampled health check that already says "sample of last 1000 pages"
+    // in its message.
+    const candidates = await engine.executeRaw<{
+      slug: string;
+      frontmatter: unknown;
+      created_at: string;
+      updated_at: string;
+    }>(
+      `WITH sample AS (
+         SELECT slug, frontmatter, effective_date_source, created_at, updated_at
+           FROM pages
+          ORDER BY id DESC
+          LIMIT 1000
+       )
+       SELECT slug, frontmatter, created_at, updated_at
+         FROM sample
+        WHERE effective_date_source = 'fallback'
+          AND (frontmatter ? 'event_date' OR frontmatter ? 'date' OR frontmatter ? 'published')`,
+    );
+    let fallbackWithFm = 0;
+    for (const row of candidates) {
+      // filename: null — this arm asks "does the frontmatter ALONE have a
+      // parseable date", independent of whichever source wins the full
+      // precedence chain. Passing the row's real filename would let a
+      // daily/meetings-prefixed slug's filename-first precedence (see
+      // effective-date.ts) resolve to source='filename' whenever the slug
+      // also carries a YYYY-MM-DD prefix — silently hiding a genuinely
+      // parseable frontmatter date (Codex review: reproduced with
+      // `daily/2024-03-15-standup` + `{ date: '2024-04-01' }`, which
+      // reindex-frontmatter WOULD still act on). filename=null makes
+      // computeEffectiveDate fall straight through to the frontmatter
+      // fields regardless of slug prefix.
+      const recomputed = computeEffectiveDate({
+        slug: row.slug,
+        frontmatter: parseFrontmatter(row.frontmatter),
+        filename: null,
+        updatedAt: new Date(row.updated_at),
+        createdAt: new Date(row.created_at),
+      });
+      if (recomputed.source === 'event_date' || recomputed.source === 'date' || recomputed.source === 'published') {
+        fallbackWithFm++;
+      }
+    }
+
     if (fallbackWithFm > 0 || future > 0 || pre1990 > 0) {
       const parts: string[] = [];
       if (fallbackWithFm > 0) parts.push(`${fallbackWithFm} fell back to updated_at despite parseable frontmatter date`);

--- a/src/core/backfill-effective-date.ts
+++ b/src/core/backfill-effective-date.ts
@@ -77,7 +77,13 @@ interface PageRow {
   updated_at: string;
 }
 
-function parseFrontmatter(raw: unknown): Record<string, unknown> {
+/**
+ * Exported so callers outside this module (e.g. the doctor's
+ * `effective_date_health` check) can normalize a raw `pages.frontmatter`
+ * JSONB value the same way the backfill walk does, before feeding it to
+ * `computeEffectiveDate`.
+ */
+export function parseFrontmatter(raw: unknown): Record<string, unknown> {
   if (raw == null) return {};
   if (typeof raw === 'string') {
     try { return JSON.parse(raw) as Record<string, unknown>; }

--- a/test/doctor-effective-date-health.test.ts
+++ b/test/doctor-effective-date-health.test.ts
@@ -1,0 +1,128 @@
+/**
+ * doctor `effective_date_health` check — key-existence vs. parseable-value
+ * regression test.
+ *
+ * The check used to flag any `effective_date_source = 'fallback'` row whose
+ * frontmatter merely HAD an `event_date`/`date`/`published` key (JSONB `?`
+ * operator), even when the value was an empty string or otherwise
+ * unparseable. That over-reported: `gbrain reindex-frontmatter --dry-run`
+ * (which runs the real `computeEffectiveDate` precedence chain) would find
+ * nothing to fix for those rows, so the doctor warning never went away no
+ * matter how many times reindex-frontmatter ran.
+ *
+ * The fix re-runs `computeEffectiveDate` (the same function
+ * `backfillEffectiveDate` / `gbrain reindex-frontmatter` uses) with
+ * `filename: null` over the candidate rows in JS, so doctor only flags rows
+ * where a fresh parse finds a date attributable to the FRONTMATTER
+ * specifically — independent of whether a filename-derived date would win
+ * the full precedence chain for daily/meetings-prefixed slugs.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function insertFallbackPage(opts: {
+  slug: string;
+  frontmatter: Record<string, unknown>;
+}): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO pages (source_id, slug, type, title, frontmatter, effective_date, effective_date_source)
+     VALUES ('default', $1, 'note', $1, $2::text::jsonb, now(), 'fallback')`,
+    [opts.slug, JSON.stringify(opts.frontmatter)],
+  );
+}
+
+async function getEffectiveDateHealth() {
+  const checks = await buildChecks(engine, []);
+  const check = checks.find(c => c.name === 'effective_date_health');
+  expect(check).toBeDefined();
+  return check!;
+}
+
+describe('doctor effective_date_health — parseable-value check (not just key-existence)', () => {
+  test('clean brain (no pages) reports ok', async () => {
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('ok');
+  });
+
+  test('fallback row with an EMPTY string date value is NOT flagged', async () => {
+    await insertFallbackPage({ slug: 'wiki/empty-date', frontmatter: { date: '' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('ok');
+    expect(check.message).not.toContain('fell back to updated_at despite parseable');
+  });
+
+  test('fallback row with an UNPARSEABLE date value is NOT flagged', async () => {
+    await insertFallbackPage({ slug: 'wiki/garbage-date', frontmatter: { date: 'not-a-real-date' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('ok');
+  });
+
+  test('fallback row with a genuinely PARSEABLE date value IS still flagged (true positive preserved)', async () => {
+    await insertFallbackPage({ slug: 'wiki/real-date', frontmatter: { date: '2024-03-15' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('1 fell back to updated_at despite parseable frontmatter date');
+  });
+
+  test('mix of empty/garbage/real fallback rows counts only the real one', async () => {
+    await insertFallbackPage({ slug: 'wiki/empty', frontmatter: { date: '' } });
+    await insertFallbackPage({ slug: 'wiki/garbage', frontmatter: { published: 'soon' } });
+    await insertFallbackPage({ slug: 'wiki/real', frontmatter: { event_date: '2023-11-01' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('1 fell back to updated_at despite parseable frontmatter date');
+  });
+
+  test('fallback row with NO date-ish keys at all is not flagged (predicate short-circuits)', async () => {
+    await insertFallbackPage({ slug: 'wiki/no-date-keys', frontmatter: { title: 'no dates here' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('ok');
+  });
+
+  // Codex review (self-multi-model) caught this: computeEffectiveDate() also
+  // resolves a FILENAME-derived date. A row whose frontmatter date is empty
+  // but whose slug basename starts with YYYY-MM-DD would recompute to
+  // source='filename' — a genuinely non-fallback source, but NOT a
+  // "frontmatter date". Must not be counted under this check's specific
+  // "despite parseable frontmatter date" message.
+  test('fallback row with empty frontmatter date but a date-prefixed slug is NOT flagged (filename date != frontmatter date)', async () => {
+    await insertFallbackPage({ slug: 'daily/2024-03-15-standup', frontmatter: { date: '' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('ok');
+    expect(check.message).not.toContain('fell back to updated_at despite parseable');
+  });
+
+  // Second Codex review round caught the inverse of the case above: for
+  // daily/meetings-prefixed slugs, computeEffectiveDate's filename-first
+  // precedence means a genuinely parseable frontmatter date can be SHADOWED
+  // by an also-valid filename date — the full precedence chain resolves to
+  // source='filename', not 'date'. Checking only the winning source (as the
+  // first fix did) would silently undercount: reindex-frontmatter DOES still
+  // act on this row (it has a real date to move away from 'fallback'), so
+  // doctor must still flag it. filename:null in the implementation sidesteps
+  // this by testing frontmatter parseability independent of slug prefix.
+  test('fallback row under daily/ WITH a real frontmatter date IS flagged even though a filename date would also resolve (frontmatter checked independent of filename precedence)', async () => {
+    await insertFallbackPage({ slug: 'daily/2024-03-15-standup', frontmatter: { date: '2024-04-01' } });
+    const check = await getEffectiveDateHealth();
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('1 fell back to updated_at despite parseable frontmatter date');
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain doctor`'s `effective_date_health` check flags pages whose `effective_date_source =
'fallback'` "despite parseable frontmatter date". Its SQL used JSONB `?` (key-existence) as a
proxy for "has a parseable date": `frontmatter ? 'event_date' OR frontmatter ? 'date' OR
frontmatter ? 'published'`. Key-existence is not the same as "parses to a valid date" — an
empty string, `null`, or an unparseable value all satisfy `?` and still get counted.

This causes the warning to over-report and never clear: `gbrain reindex-frontmatter --dry-run`
(which runs the real `computeEffectiveDate` precedence chain) correctly finds nothing to fix for
those rows, so the doctor count and the reindex-frontmatter count disagree, and the warning
persists no matter how many times reindex-frontmatter runs.

## Changes

- `src/commands/doctor.ts`: the `effective_date_health` check's "fell back despite parseable
  date" arm now fetches the `effective_date_source = 'fallback'` candidate rows and re-runs
  `computeEffectiveDate()` — the same function `gbrain reindex-frontmatter` uses — over each one
  in JS, instead of trusting the JSONB key-existence predicate as a count. The call passes
  `filename: null` deliberately, so the row is only counted when the **frontmatter** fields
  (`event_date`/`date`/`published`) alone resolve to a valid date, independent of whichever
  source wins the full precedence chain:
  - a row whose frontmatter value is empty/unparseable but whose slug carries a `YYYY-MM-DD`
    prefix (so the full chain would resolve a *filename*-derived date) is correctly excluded —
    the message specifically says "despite parseable **frontmatter** date".
  - conversely, a `daily/`/`meetings/`-prefixed row with a genuinely parseable frontmatter date
    is still counted even though `computeEffectiveDate`'s filename-first precedence for those
    prefixes would otherwise resolve the *full* chain to `source: 'filename'` and mask it. This case is pinned by a dedicated test (`daily/2024-03-15-standup` + `{ date: '2024-04-01' }`).
- `src/core/backfill-effective-date.ts`: exported the existing `parseFrontmatter()` helper so
  the doctor check normalizes the raw `pages.frontmatter` JSONB value the same way the backfill
  walk does before feeding it to `computeEffectiveDate`.
- `test/doctor-effective-date-health.test.ts` (new): drives `buildChecks` against a real PGLite
  engine, covering:
  - a fallback row with an empty-string frontmatter date → not flagged
  - a clean brain (no pages) → reports ok
  - a fallback row with an unparseable frontmatter date → not flagged
  - a fallback row with a genuinely parseable frontmatter date → still flagged (true positive
    preserved), with the exact count asserted
  - a mix of empty/garbage/real fallback rows → only the real one is counted
  - a fallback row with no date-ish frontmatter keys at all → not flagged
  - a fallback row with an empty frontmatter date but a date-prefixed slug (`daily/2024-03-15-...`)
    → not flagged, since only a filename-derived date resolves, not a frontmatter field
  - a fallback row under `daily/` with an empty-vs-real distinction: a **real** frontmatter date
    on a `daily/`-prefixed, date-named slug → still flagged, confirming the filename-precedence
    shadowing case above doesn't suppress a genuine frontmatter date

**Known, intentional scope limit:** this check only ever flags rows where the *frontmatter*
itself is parseable. A `fallback` row whose frontmatter has no usable date at all, but whose
slug/filename carries a valid date, is a real "reindex-frontmatter would still update this row"
case that this specific check does not surface — because its message is scoped to frontmatter
dates, not filename dates. That's unchanged from the check's original intent (the sentinel column
comment above it), just now correctly evaluated.

## Test plan

- [x] `bun test test/doctor-effective-date-health.test.ts` — 8 pass, 0 fail
- [x] `bun test test/effective-date.test.ts` — 21 pass, 0 fail (no change to `computeEffectiveDate` itself)
- [x] `bun run typecheck` — clean
- [x] `scripts/check-privacy.sh` — clean
- [x] `scripts/check-test-isolation.sh` — clean (1167 non-serial unit files scanned)
- [x] `scripts/check-pglite-embedded.sh` — clean

