### PR TITLE
fix(facts): avoid embedding rejected high-only facts

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -496,6 +496,10 @@ async function runPipelineWithBody(
     return { inserted: 0, duplicate: 0, superseded: 0, fact_ids: [], entity_slugs: [] };
   }
 
+  const filter = ctx.notabilityFilter ?? 'all';
+  const notabilityAdmission = filter === 'high-only'
+    ? { allowed: ['high'] as const, invalid: 'drop' as const }
+    : undefined;
   const outcome = await extractFactsFromTurnWithOutcome({
     turnText: input.turnText,
     sessionId: ctx.sessionId,
@@ -505,6 +509,7 @@ async function runPipelineWithBody(
     engine: ctx.engine,
     abortSignal,
     model: ctx.model,
+    notabilityAdmission,
   });
 
   if (!outcome.ok) {
@@ -531,7 +536,6 @@ async function runPipelineWithBody(
 
   const facts = outcome.facts;
 
-  const filter = ctx.notabilityFilter ?? 'all';
   // [ENG-8] Explicit ctx.visibility wins; unset resolves the operator-set
   // facts.default_visibility (fail-closed to 'private').
   const { resolveDefaultVisibility } = await import('./visibility.ts');

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -88,6 +88,8 @@ export const ALL_EXTRACT_KINDS: readonly FactKind[] = [
   'event', 'preference', 'commitment', 'belief', 'fact',
 ] as const;
 
+export type FactNotability = 'high' | 'medium' | 'low';
+
 export interface ExtractInput {
   turnText: string;
   /** Opaque session id (MCP _meta.session_id, CLI --session, or null). */
@@ -110,6 +112,11 @@ export interface ExtractInput {
   abortSignal?: AbortSignal;
   /** Cap on number of facts returned per turn. Defaults to 10. */
   maxFactsPerTurn?: number;
+  /** Optional pre-embedding admission selector for extracted fact tiers. */
+  notabilityAdmission?: {
+    allowed: readonly FactNotability[];
+    invalid: 'drop';
+  };
 }
 
 /** A pre-INSERT fact ready for the engine.insertFact path. */
@@ -420,8 +427,13 @@ export async function extractFactsFromTurnWithOutcome(
       ? (candidate.kind as FactKind)
       : 'fact';
     const confidence = clampConfidence(candidate.confidence);
-    const notability = ['high', 'medium', 'low'].includes(candidate.notability || '')
-      ? (candidate.notability as 'high' | 'medium' | 'low')
+    const validTier = ['high', 'medium', 'low'].includes(candidate.notability ?? '');
+    if (input.notabilityAdmission) {
+      const tier = validTier ? candidate.notability as FactNotability : null;
+      if (!tier || !input.notabilityAdmission.allowed.includes(tier)) continue;
+    }
+    const notability: FactNotability = validTier
+      ? candidate.notability as FactNotability
       : 'medium';
 
     let embedding: Float32Array | null = null;

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -20,6 +20,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import {
   __setChatTransportForTests,
   __setEmbedTransportForTests,
+  configureGateway,
   resetGateway,
   type ChatResult,
 } from '../src/core/ai/gateway.ts';
@@ -325,6 +326,7 @@ describe('runExtractConversationFactsCore', () => {
   let chatHook: (() => Promise<void>) | null = null;
   let chatStopReason: ChatResult['stopReason'] = 'end';
   let chatTextOverride: string | null = null;
+  let embeddedTexts: string[] = [];
   let fallbackCalls = 0;
   let fallbackContents: string[] = [];
   let fallbackControlError: Error | null = null;
@@ -408,9 +410,10 @@ describe('runExtractConversationFactsCore', () => {
 
     // Deterministic embedding stub.
     __setEmbedTransportForTests(
-      (async () => ({
-        embeddings: [Array.from({ length: 1536 }, () => 0.1)],
-      })) as never,
+      (async ({ values }: { values: string[] }) => {
+        embeddedTexts.push(...values);
+        return { embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)) };
+      }) as never,
     );
   });
 
@@ -427,6 +430,7 @@ describe('runExtractConversationFactsCore', () => {
     chatHook = null;
     chatStopReason = 'end';
     chatTextOverride = null;
+    embeddedTexts = [];
     fallbackCalls = 0;
     fallbackContents = [];
     fallbackControlError = null;
@@ -525,6 +529,60 @@ describe('runExtractConversationFactsCore', () => {
     expect(result.pages_processed).toBe(1);
     expect(result.facts_inserted).toBe(0);
     expect(result.segments_processed).toBeGreaterThanOrEqual(1);
+  });
+
+  test('historical backfill embeds and retains high, medium, low, and absent-tier facts', async () => {
+    // Regression target: passing high-only admission into the historical
+    // extractor call would suppress low (and absent-tier) facts before embed.
+    chatTextOverride = JSON.stringify({
+      facts: [
+        { fact: 'historical-high', kind: 'event', notability: 'high' },
+        { fact: 'historical-medium', kind: 'fact', notability: 'medium' },
+        { fact: 'historical-low', kind: 'fact', notability: 'low' },
+        { fact: 'historical-absent', kind: 'fact' },
+      ],
+    });
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'test' },
+    });
+    await engine.putPage('conversations/historical-tier-coverage', {
+      type: 'conversation',
+      title: 'Historical tier coverage',
+      compiled_truth: [
+        fmt('Alice Example', '2024-03-15', '9:00 AM', 'first message'),
+        fmt('Bob Demo', '2024-03-15', '9:05 AM', 'second message'),
+      ].join('\n'),
+      timeline: '',
+      frontmatter: {},
+    });
+
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'conversations/historical-tier-coverage',
+      sleepMs: 0,
+    });
+    const rows = await engine.executeRaw<{ fact: string; notability: string; has_embedding: boolean }>(
+      `SELECT fact, notability, embedding IS NOT NULL AS has_embedding
+       FROM facts WHERE source = $1 ORDER BY row_num`,
+      [PER_SEGMENT_SOURCE_PREFIX],
+    );
+
+    expect(result.facts_extracted).toBe(4);
+    expect(result.facts_inserted).toBe(4);
+    expect(embeddedTexts).toEqual([
+      'historical-high',
+      'historical-medium',
+      'historical-low',
+      'historical-absent',
+    ]);
+    expect(rows).toEqual([
+      { fact: 'historical-high', notability: 'high', has_embedding: true },
+      { fact: 'historical-medium', notability: 'medium', has_embedding: true },
+      { fact: 'historical-low', notability: 'low', has_embedding: true },
+      { fact: 'historical-absent', notability: 'medium', has_embedding: true },
+    ]);
   });
 
   test('dry-run does not write the extract_rollup_7d cache row', async () => {

--- a/test/facts-backstop.test.ts
+++ b/test/facts-backstop.test.ts
@@ -15,6 +15,8 @@ import { runFactsBackstop } from '../src/core/facts/backstop.ts';
 import type { FactsBackstopCtx } from '../src/core/facts/backstop.ts';
 import {
   __setChatTransportForTests,
+  __setEmbedTransportForTests,
+  configureGateway,
   resetGateway,
   type ChatResult,
 } from '../src/core/ai/gateway.ts';
@@ -40,7 +42,7 @@ afterEach(() => {
 
 const LONG_BODY = 'this is a real meeting note longer than 80 chars '.repeat(3);
 
-function chatStub(facts: Array<{ fact: string; kind: string; notability: 'high' | 'medium' | 'low'; entity?: string | null }>) {
+function chatStub(facts: Array<{ fact: string; kind: string; notability?: string; entity?: string | null }>) {
   __setChatTransportForTests(async (): Promise<ChatResult> => ({
     text: JSON.stringify({
       facts: facts.map(f => ({
@@ -75,6 +77,16 @@ const meetingPage = (slug = 'meetings/test-' + Math.random().toString(36).slice(
   compiled_truth: LONG_BODY,
   frontmatter: {} as Record<string, unknown>,
 });
+
+async function factsForIds(ids: number[]): Promise<Array<{ fact: string }>> {
+  return Promise.all(ids.map(async (id) => {
+    // PGLite's test engine deliberately exposes its raw query client for
+    // storage assertions where the public API only offers scoped listings.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query('SELECT fact FROM facts WHERE id = $1', [id]);
+    return rows.rows[0];
+  }));
+}
 
 describe('runFactsBackstop — eligibility + kill-switch gates', () => {
   test('skips with extraction_disabled when kill-switch off', async () => {
@@ -120,12 +132,24 @@ describe('runFactsBackstop — mode: inline', () => {
     }
   });
 
-  test('notabilityFilter=high-only drops MEDIUM + LOW from the insert path', async () => {
+  test('notabilityFilter=high-only embeds and persists only HIGH facts', async () => {
+    const embeddedTexts: string[] = [];
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'test' },
+    });
     chatStub([
       { fact: 'high-only-1', kind: 'event', notability: 'high', entity: 'people/bob-test' },
-      { fact: 'high-only-2-skip', kind: 'event', notability: 'medium', entity: 'people/bob-test' },
-      { fact: 'high-only-3-skip', kind: 'event', notability: 'low', entity: 'people/bob-test' },
+      { fact: 'high-only-medium-skip', kind: 'event', notability: 'medium', entity: 'people/bob-test' },
+      { fact: 'high-only-low-skip', kind: 'event', notability: 'low', entity: 'people/bob-test' },
+      { fact: 'high-only-absent-skip', kind: 'event', entity: 'people/bob-test' },
+      { fact: 'high-only-unknown-skip', kind: 'event', notability: 'unknown', entity: 'people/bob-test' },
     ]);
+    __setEmbedTransportForTests((async ({ values }: { values: string[] }) => {
+      embeddedTexts.push(...values);
+      return { embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)) };
+    }) as never);
     const r = await runFactsBackstop(
       meetingPage(),
       makeCtx({ mode: 'inline', notabilityFilter: 'high-only' }),
@@ -134,6 +158,35 @@ describe('runFactsBackstop — mode: inline', () => {
     if (r.mode === 'inline') {
       expect(r.inserted).toBe(1);
       expect(r.fact_ids.length).toBe(1);
+      const rows = await factsForIds(r.fact_ids);
+      expect(embeddedTexts).toEqual(['high-only-1']);
+      expect(rows.map(f => f.fact)).toEqual(['high-only-1']);
+    }
+  });
+
+  test('notabilityFilter=all embeds and persists every tier', async () => {
+    const embeddedTexts: string[] = [];
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'test' },
+    });
+    chatStub([
+      { fact: 'all-high', kind: 'event', notability: 'high', entity: 'people/all-test' },
+      { fact: 'all-medium', kind: 'event', notability: 'medium', entity: 'people/all-test' },
+      { fact: 'all-low', kind: 'event', notability: 'low', entity: 'people/all-test' },
+      { fact: 'all-absent', kind: 'event', entity: 'people/all-test' },
+    ]);
+    __setEmbedTransportForTests((async ({ values }: { values: string[] }) => {
+      embeddedTexts.push(...values);
+      return { embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)) };
+    }) as never);
+    const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline', notabilityFilter: 'all' }));
+    expect(r.mode).toBe('inline');
+    if (r.mode === 'inline') {
+      const rows = await factsForIds(r.fact_ids);
+      expect(embeddedTexts).toEqual(['all-high', 'all-medium', 'all-low', 'all-absent']);
+      expect(rows.map(f => f.fact)).toEqual(['all-high', 'all-medium', 'all-low', 'all-absent']);
     }
   });
 

--- a/test/facts-extract-smoke.test.ts
+++ b/test/facts-extract-smoke.test.ts
@@ -18,13 +18,19 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import {
   __setChatTransportForTests,
+  __setEmbedTransportForTests,
+  configureGateway,
   resetGateway,
   type ChatResult,
 } from '../src/core/ai/gateway.ts';
-import { extractFactsFromTurn } from '../src/core/facts/extract.ts';
+import {
+  extractFactsFromTurn,
+  extractFactsFromTurnWithOutcome,
+} from '../src/core/facts/extract.ts';
 
 afterEach(() => {
   __setChatTransportForTests(null);
+  __setEmbedTransportForTests(null);
   resetGateway();
 });
 
@@ -141,5 +147,79 @@ describe('extractFactsFromTurn — B1 end-to-end smoke', () => {
 
     expect(facts).toHaveLength(3);
     expect(facts.map(f => f.notability)).toEqual(['high', 'medium', 'low']);
+  });
+
+  test('high-only admission embeds only high-tier candidates', async () => {
+    const embeddedTexts: string[] = [];
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 1280,
+      env: { ZEROENTROPY_API_KEY: 'test' },
+    });
+    __setChatTransportForTests(async (): Promise<ChatResult> => ({
+      text: JSON.stringify({
+        facts: [
+          { fact: 'H', kind: 'event', notability: 'high' },
+          { fact: 'M', kind: 'fact', notability: 'medium' },
+          { fact: 'L', kind: 'fact', notability: 'low' },
+          { fact: 'missing', kind: 'fact' },
+          { fact: 'unknown', kind: 'fact', notability: 'critical' },
+        ],
+      }),
+      blocks: [],
+      stopReason: 'end',
+      usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'test:stub',
+      providerId: 'test',
+    }));
+    __setEmbedTransportForTests((async ({ values }: { values: string[] }) => {
+      embeddedTexts.push(...values);
+      return { embeddings: values.map(() => Array.from({ length: 1280 }, () => 0.1)) };
+    }) as never);
+
+    const outcome = await extractFactsFromTurnWithOutcome({
+      turnText: 'content',
+      source: 'test',
+      notabilityAdmission: { allowed: ['high'], invalid: 'drop' },
+    });
+
+    expect(outcome).toEqual(expect.objectContaining({ ok: true }));
+    expect(embeddedTexts).toEqual(['H']);
+  });
+
+  test('without admission, high, medium, low, and absent tiers embed', async () => {
+    const embeddedTexts: string[] = [];
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 1280,
+      env: { ZEROENTROPY_API_KEY: 'test' },
+    });
+    __setChatTransportForTests(async (): Promise<ChatResult> => ({
+      text: JSON.stringify({
+        facts: [
+          { fact: 'H', kind: 'event', notability: 'high' },
+          { fact: 'M', kind: 'fact', notability: 'medium' },
+          { fact: 'L', kind: 'fact', notability: 'low' },
+          { fact: 'missing', kind: 'fact' },
+        ],
+      }),
+      blocks: [],
+      stopReason: 'end',
+      usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'test:stub',
+      providerId: 'test',
+    }));
+    __setEmbedTransportForTests((async ({ values }: { values: string[] }) => {
+      embeddedTexts.push(...values);
+      return { embeddings: values.map(() => Array.from({ length: 1280 }, () => 0.1)) };
+    }) as never);
+
+    const outcome = await extractFactsFromTurnWithOutcome({
+      turnText: 'content',
+      source: 'test',
+    });
+
+    expect(outcome).toEqual(expect.objectContaining({ ok: true }));
+    expect(embeddedTexts).toEqual(['H', 'M', 'L', 'missing']);
   });
 });


### PR DESCRIPTION
## Summary

Moves the existing live `high-only` fact admission decision ahead of embedding.

- High-only sync now skips medium, low, missing, and unknown notability tiers before they are embedded.
- Historical conversation backfill remains unchanged: valid high, medium, low, and missing-tier facts are still embedded and retained.
- Mixed malformed/valid extractor output retains #3894's salvage-and-warn behavior; no strict-fail policy is added.

## Root cause

The live backstop applied its existing high-only filter after extraction, so rejected candidates had already been embedded.

## Validation

- `GBRAIN_HOME=/private/tmp/gbrain-preembed-publish-check bun test test/facts-extract-smoke.test.ts test/facts-extract-salvage.test.ts test/facts-backstop.test.ts test/extract-conversation-facts.test.ts` — 90 passed
- `bun run check:test-isolation`
- `bun run typecheck`
- `git diff --check origin/master...HEAD`

All tests use synthetic fixtures only.