### PR TITLE
fix(dream): propagate cooperative abort through synthesis

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1858,6 +1858,7 @@ export async function runCycle(
           // (explicit --source wins, else derived from the checkout dir).
           sourceId: cycleSourceId,
           once: opts.onceForPhase === 'synthesize',
+          signal: opts.signal,
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
@@ -2070,6 +2071,7 @@ export async function runCycle(
           // source owns the page, which is what doctor reports as
           // multi_source_drift.
           sourceId: cycleSourceId,
+          signal: opts.signal,
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -40,10 +40,13 @@ import type { Page, PageType } from '../types.ts';
 import { loadAllowedSlugPrefixes, loadOutputRoot, runPgliteSubagentsInline } from './synthesize.ts';
 import { probeChatModel } from '../ai/gateway.ts';
 import { normalizeModelId } from '../model-id.ts';
+import { throwIfAborted } from '../abort-check.ts';
 
 export interface PatternsPhaseOpts {
   brainDir: string;
   dryRun: boolean;
+  /** Cooperative cancellation from the enclosing cycle/minion job. */
+  signal?: AbortSignal;
   yieldDuringPhase?: () => Promise<void>;
   /**
    * issue #2860 — `gbrain dream --phase patterns --once`. Bypasses the
@@ -117,6 +120,7 @@ export async function runPhasePatterns(
 ): Promise<PhaseResult> {
   const start = Date.now();
   try {
+    throwIfAborted(opts.signal, '[dream] patterns');
     const config = await loadPatternsConfig(engine);
 
     if (!config.enabled) {
@@ -216,20 +220,36 @@ export async function runPhasePatterns(
     const job = await queue.add('subagent', data as unknown as Record<string, unknown>, submitOpts, {
       allowProtectedSubmit: true,
     });
+    if (opts.signal?.aborted) {
+      await queue.cancelJob(job.id);
+      throwIfAborted(opts.signal, '[dream] patterns subagent');
+    }
 
     // PGLite cannot run a separate Minions worker because the embedded DB
     // holds an exclusive file lock. Drain this phase's private child queue
     // inline so the parent observes the terminal state instead of polling
     // waitForCompletion until subagentWaitTimeoutMs expires. No-op on
     // Postgres (a real worker process claims the job there).
-    await runPgliteSubagentsInline(engine, queue, childQueueName, opts.yieldDuringPhase);
+    await runPgliteSubagentsInline(
+      engine,
+      queue,
+      childQueueName,
+      opts.yieldDuringPhase,
+      undefined,
+      opts.signal,
+    );
 
     let outcome: string;
     try {
       const final = await waitForCompletion(queue, job.id, {
         timeoutMs: budgets.waitTimeoutMs,
         pollMs: 5 * 1000,
+        signal: opts.signal,
       });
+      if (opts.signal?.aborted) {
+        await queue.cancelJob(job.id);
+        throwIfAborted(opts.signal, '[dream] patterns completion wait');
+      }
       outcome = final.status;
     } catch (e) {
       if (e instanceof TimeoutError) {
@@ -246,6 +266,11 @@ export async function runPhasePatterns(
       }
     }
 
+    if (opts.signal?.aborted) {
+      await queue.cancelJob(job.id);
+      throwIfAborted(opts.signal, '[dream] patterns output');
+    }
+
     if (opts.yieldDuringPhase) {
       try { await opts.yieldDuringPhase(); } catch { /* best-effort */ }
     }
@@ -260,7 +285,7 @@ export async function runPhasePatterns(
     const writtenRefs = await collectChildPutPageSlugs(engine, [job.id], cycleSourceId);
 
     // Reverse-write to fs.
-    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs, cycleSourceId);
+    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs, cycleSourceId, opts.signal);
 
     const details = {
       reflections_considered: reflections.length,
@@ -501,15 +526,19 @@ async function reverseWriteRefs(
   brainDir: string,
   refs: Array<{ slug: string; source_id: string }>,
   nativeSourceId = 'default',
+  signal?: AbortSignal,
 ): Promise<number> {
   let count = 0;
   for (const { slug, source_id } of refs) {
+    throwIfAborted(signal, '[dream] patterns reverse-write');
     // v0.32.8 F6: guard against malformed source_id (would let join() break
     // out of brainDir). validateSourceId throws on `..`, `/`, etc.
     validateSourceId(source_id);
     const page = await engine.getPage(slug, { sourceId: source_id });
+    throwIfAborted(signal, '[dream] patterns reverse-write');
     if (!page) continue;
     const tags = await engine.getTags(slug, { sourceId: source_id });
+    throwIfAborted(signal, '[dream] patterns reverse-write');
     try {
       const md = renderPageToMarkdown(page, tags);
       // v0.32.8 F6: foreign-source pages land under brainDir/.sources/<id>/<slug>.md

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -46,6 +46,7 @@ import type { Page, PageType } from '../types.ts';
 import { validateSourceId } from '../utils.ts';
 import { safeSplitIndex } from '../text-safe.ts';
 import { PAGE_SLUG_SEG } from '../cjk.ts';
+import { anySignal, throwIfAborted } from '../abort-check.ts';
 
 // Slug grammar from validatePageSlug — shared via PAGE_SLUG_SEG (#738).
 // Used for the orchestrator-written summary index slug. `u` flag required
@@ -242,6 +243,8 @@ export function rewriteChunkedSlug(slug: string, hash6: string, idx: number): st
 export interface SynthesizePhaseOpts {
   brainDir: string;
   dryRun: boolean;
+  /** Cooperative cancellation from the enclosing cycle/minion job. */
+  signal?: AbortSignal;
   /** Generic in-cycle keepalive for cycle-lock TTL renewal during long waits. */
   yieldDuringPhase?: () => Promise<void>;
   /**
@@ -294,10 +297,12 @@ export async function runPgliteSubagentsInline(
   queueName: string,
   yieldDuringPhase?: () => Promise<void>,
   handler: MinionHandler = makeSubagentHandler({ engine }),
+  signal?: AbortSignal,
 ): Promise<void> {
   if (engine.kind !== 'pglite') return;
 
   while (true) {
+    throwIfAborted(signal, '[dream] inline subagent');
     // Housekeeping a worker would normally perform, so child rows can reach
     // terminal states (delayed retries promoted, timeouts dead-lettered)
     // before the synth parent enters waitForCompletion polling.
@@ -317,7 +322,7 @@ export async function runPgliteSubagentsInline(
       name: job.name,
       data: job.data,
       attempts_made: job.attempts_made,
-      signal: abort.signal,
+      signal: anySignal(abort.signal, signal),
       deadlineAtMs: job.timeout_at != null ? job.timeout_at.getTime() : null,
       shutdownSignal: shutdown.signal,
       updateProgress: async (progress: unknown) => {
@@ -366,12 +371,20 @@ export async function runPgliteSubagentsInline(
       : null;
     try {
       const result = await handler(context);
+      if (signal?.aborted) {
+        await queue.cancelJob(job.id);
+        throwIfAborted(signal, '[dream] inline subagent');
+      }
       await queue.completeJob(
         job.id,
         lockToken,
         result != null ? (typeof result === 'object' ? result as Record<string, unknown> : { value: result }) : undefined,
       );
     } catch (e) {
+      if (signal?.aborted) {
+        await queue.cancelJob(job.id);
+        throwIfAborted(signal, '[dream] inline subagent');
+      }
       // Timeout is terminal (handleTimeouts parity: stall → retry,
       // timeout → dead), never a delayed retry.
       const timedOut = abort.signal.aborted;
@@ -414,6 +427,7 @@ export async function runPhaseSynthesize(
     opts.brainDir = resolve(opts.brainDir);
   }
   try {
+    throwIfAborted(opts.signal, '[dream] synthesize');
     const config = await loadSynthConfig(engine);
 
     // Allow ad-hoc --input to run even when config is disabled.
@@ -483,6 +497,7 @@ export async function runPhaseSynthesize(
     // as the cheap pre-flight check).
     const judge = makeJudgeClient(config.verdictModel);
     for (const t of transcripts) {
+      throwIfAborted(opts.signal, '[dream] significance judge');
       const cached = await engine.getDreamVerdict(t.filePath, t.contentHash);
       if (cached) {
         verdicts.push({ filePath: t.filePath, worth: cached.worth_processing, reasons: cached.reasons, cached: true });
@@ -501,7 +516,8 @@ export async function runPhaseSynthesize(
         continue;
       }
       try {
-        const verdict = await judgeSignificance(judge, t, config.verdictModel);
+        const verdict = await judgeSignificance(judge, t, config.verdictModel, opts.signal);
+        throwIfAborted(opts.signal, '[dream] significance judge');
         if (verdict.unreliable) {
           // Degenerate judgement (truncated, refused/content-filtered, or
           // unparseable LLM output). Do
@@ -521,6 +537,7 @@ export async function runPhaseSynthesize(
         verdicts.push({ filePath: t.filePath, worth: verdict.worth_processing, reasons: verdict.reasons, cached: false });
         if (verdict.worth_processing) worthProcessing.push(t);
       } catch (e) {
+        throwIfAborted(opts.signal, '[dream] significance judge');
         // AIConfigError at chat time = provider auth/config went bad mid-run
         // (revoked key, recipe misconfig surfacing at first real call). Skip
         // this transcript with the gateway error message so the user sees the
@@ -579,6 +596,14 @@ export async function runPhaseSynthesize(
       ? `dream-inline-${Date.now()}-${randomUUID().slice(0, 8)}`
       : 'default';
     const childIds: number[] = [];
+    const cancelSubmittedChildren = async (): Promise<void> => {
+      await Promise.allSettled(childIds.map(id => queue.cancelJob(id)));
+    };
+    const throwIfPhaseAborted = async (label: string): Promise<void> => {
+      if (!opts.signal?.aborted) return;
+      await cancelSubmittedChildren();
+      throwIfAborted(opts.signal, label);
+    };
     /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
     const chunkInfo = new Map<number, { idx: number; hash6: string }>();
     /** #1978: map child job_id → source transcript path so written pages get a raw_source stamp. */
@@ -593,6 +618,7 @@ export async function runPhaseSynthesize(
     );
 
     for (const t of worthProcessing) {
+      await throwIfPhaseAborted('[dream] synthesize fan-out');
       const hash16 = t.contentHash.slice(0, 16);
       const hash6 = t.contentHash.slice(0, 6);
 
@@ -646,6 +672,7 @@ export async function runPhaseSynthesize(
           ? `anthropic:${config.model}`
           : config.model;
       for (let i = 0; i < chunks.length; i++) {
+        await throwIfPhaseAborted('[dream] synthesize fan-out');
         const childData: SubagentHandlerData = {
           prompt: buildSynthesisPrompt(t, chunks[i], i, chunks.length, priorContradictionsBlock, config.outputRoot),
           model: subagentModel,
@@ -678,6 +705,7 @@ export async function runPhaseSynthesize(
           { allowProtectedSubmit: true },
         );
         childIds.push(child.id);
+        await throwIfPhaseAborted('[dream] synthesize fan-out');
         jobRawSource.set(child.id, t.filePath);
         if (isChunked) {
           chunkInfo.set(child.id, { idx: i, hash6 });
@@ -689,7 +717,15 @@ export async function runPhaseSynthesize(
     // holds an exclusive file lock. Drain this phase's private child queue
     // inline so the parent observes terminal child states instead of polling
     // waiters until subagentWaitTimeoutMs expires. No-op on Postgres.
-    await runPgliteSubagentsInline(engine, queue, childQueueName, opts.yieldDuringPhase);
+    await runPgliteSubagentsInline(
+      engine,
+      queue,
+      childQueueName,
+      opts.yieldDuringPhase,
+      undefined,
+      opts.signal,
+    );
+    await throwIfPhaseAborted('[dream] synthesize subagents');
 
     // Wait for every child to reach a terminal state. Tick yieldDuringPhase
     // every 5 min so the cycle lock TTL refreshes.
@@ -699,7 +735,9 @@ export async function runPhaseSynthesize(
         const job = await waitForCompletion(queue, jobId, {
           timeoutMs: config.subagentWaitTimeoutMs,
           pollMs: 5 * 1000,
+          signal: opts.signal,
         });
+        await throwIfPhaseAborted('[dream] synthesize completion wait');
         childOutcomes.push({ jobId, status: job.status });
       } catch (e) {
         if (e instanceof TimeoutError) {
@@ -708,11 +746,14 @@ export async function runPhaseSynthesize(
           throw e;
         }
       }
+      await throwIfPhaseAborted('[dream] synthesize completion wait');
       // After each child terminal, give the cycle lock + worker job lock a chance.
       if (opts.yieldDuringPhase) {
         try { await opts.yieldDuringPhase(); } catch { /* best-effort */ }
       }
     }
+
+    await throwIfPhaseAborted('[dream] synthesize output');
 
     // Collect slugs from put_page tool executions across the children
     // (codex finding #2: deterministic provenance, NOT pages.updated_at).
@@ -724,6 +765,7 @@ export async function runPhaseSynthesize(
     // source (children write there via SubagentHandlerData.source_id).
     const cycleSourceId = opts.sourceId ?? 'default';
     const writtenRefs = await collectChildPutPageSlugs(engine, childIds, chunkInfo, cycleSourceId, jobRawSource);
+    await throwIfPhaseAborted('[dream] synthesize output');
 
     const summaryDate = opts.date ?? today();
 
@@ -731,10 +773,18 @@ export async function runPhaseSynthesize(
     // of every child-written page BEFORE reverse-rendering, so generated pages
     // are queryable (`frontmatter->>'dream_generated'`) and a later put_page
     // write-through (which re-renders from the DB row) can't erase the stamp.
-    await stampDreamProvenance(engine, writtenRefs, summaryDate);
+    await stampDreamProvenance(engine, writtenRefs, summaryDate, opts.signal);
+    await throwIfPhaseAborted('[dream] synthesize output');
 
     // Dual-write: reverse-render each DB row → markdown file.
-    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs, cycleSourceId);
+    const reverseWriteCount = await reverseWriteRefs(
+      engine,
+      opts.brainDir,
+      writtenRefs,
+      cycleSourceId,
+      opts.signal,
+    );
+    await throwIfPhaseAborted('[dream] synthesize output');
 
     // Summary index page (deterministic; orchestrator-written via direct
     // engine.putPage so no allow-list path needed).
@@ -742,8 +792,18 @@ export async function runPhaseSynthesize(
     // Back-compat: writeSummaryPage takes string[] for display; map refs back to slugs.
     const writtenSlugs = writtenRefs.map(r => r.slug);
     if (SUMMARY_SLUG_RE.test(summarySlug)) {
-      await writeSummaryPage(engine, opts.brainDir, summarySlug, summaryDate, writtenSlugs, childOutcomes, cycleSourceId);
+      await writeSummaryPage(
+        engine,
+        opts.brainDir,
+        summarySlug,
+        summaryDate,
+        writtenSlugs,
+        childOutcomes,
+        cycleSourceId,
+        opts.signal,
+      );
     }
+    await throwIfPhaseAborted('[dream] synthesize completion');
 
     // Write completion timestamp ON SUCCESS only.
     await engine.setConfig('dream.synthesize.last_completion_ts', new Date().toISOString());
@@ -963,9 +1023,9 @@ export async function loadAllowedSlugPrefixes(outputRoot = 'wiki'): Promise<stri
 
 // ── Significance judge (gateway-routed; provider-agnostic) ──────────────
 //
-// The JudgeClient interface is unchanged for test-seam stability — existing
-// tests that pass a mock client to judgeSignificance keep working byte-
-// identically. Only the construction path moved from `new Anthropic()` to
+// The JudgeClient interface keeps its existing create call compatible while
+// accepting an optional AbortSignal for cooperative cancellation. Only the
+// construction path moved from `new Anthropic()` to
 // `gateway.chat()` so any provider with a registered recipe (Anthropic,
 // DeepSeek, OpenRouter, Voyage, Ollama, llama-server, etc.) is reachable
 // via `gbrain config set models.dream.synthesize_verdict <provider>:<model>`.
@@ -977,7 +1037,10 @@ export async function loadAllowedSlugPrefixes(outputRoot = 'wiki'): Promise<stri
 // for AIConfigError surfacing mid-run.
 
 export interface JudgeClient {
-  create: (params: Anthropic.MessageCreateParamsNonStreaming) => Promise<Anthropic.Message>;
+  create: (
+    params: Anthropic.MessageCreateParamsNonStreaming,
+    options?: { signal?: AbortSignal },
+  ) => Promise<Anthropic.Message>;
 }
 
 /**
@@ -1015,7 +1078,7 @@ export function makeJudgeClient(verdictModel: string): JudgeClient | null {
   if (v.parsed.providerId === 'anthropic' && !hasAnthropicKey()) return null;
 
   return {
-    create: async (params): Promise<Anthropic.Message> => {
+    create: async (params, options): Promise<Anthropic.Message> => {
       // Map Anthropic.MessageCreateParamsNonStreaming → gateway.ChatOpts.
       // `judgeSignificance` always sends string content + string system,
       // and the adapter only TEXT-flattens the array-of-blocks shape —
@@ -1042,6 +1105,7 @@ export function makeJudgeClient(verdictModel: string): JudgeClient | null {
         system,
         messages,
         maxTokens: params.max_tokens,
+        abortSignal: options?.signal,
       });
 
       // Map gateway.ChatResult → Anthropic.Message shape. judgeSignificance
@@ -1109,6 +1173,7 @@ export async function judgeSignificance(
   client: JudgeClient,
   t: DiscoveredTranscript,
   verdictModel = 'claude-haiku-4-5-20251001',
+  signal?: AbortSignal,
 ): Promise<VerdictResult> {
   // Truncate the transcript at 8K chars for cost control. Haiku's verdict
   // doesn't need the full body; the opening + closing sections are usually
@@ -1162,7 +1227,7 @@ Two reasons max, one phrase each.`;
     max_tokens: 1024,
     system: sys,
     messages: [{ role: 'user', content: `Transcript ${t.basename}:\n\n${trimmed}` }],
-  });
+  }, { signal });
 
   // stop_reason === 'max_tokens' means the response was cut off; 'refusal'
   // means the model refused or a content filter blocked it. Even if a
@@ -1492,10 +1557,12 @@ async function stampDreamProvenance(
   engine: BrainEngine,
   refs: Array<{ slug: string; source_id: string; raw_source?: string }>,
   cycleDate: string,
+  signal?: AbortSignal,
 ): Promise<void> {
   if (refs.length === 0) return;
   const { executeRawJsonb } = await import('../sql-query.ts');
   for (const { slug, source_id, raw_source } of refs) {
+    throwIfAborted(signal, '[dream] synthesize provenance');
     try {
       await executeRawJsonb(
         engine,
@@ -1526,9 +1593,11 @@ async function reverseWriteRefs(
   brainDir: string,
   refs: Array<{ slug: string; source_id: string }>,
   nativeSourceId = 'default',
+  signal?: AbortSignal,
 ): Promise<number> {
   let count = 0;
   for (const { slug, source_id } of refs) {
+    throwIfAborted(signal, '[dream] synthesize reverse-write');
     // v0.32.8 F6: validate source_id is filesystem-safe before any join().
     validateSourceId(source_id);
     const page = await engine.getPage(slug, { sourceId: source_id });
@@ -1588,7 +1657,9 @@ async function writeSummaryPage(
   writtenSlugs: string[],
   childOutcomes: Array<{ jobId: number; status: string }>,
   sourceId = 'default',
+  signal?: AbortSignal,
 ): Promise<void> {
+  throwIfAborted(signal, '[dream] synthesize summary');
   const completed = childOutcomes.filter(c => c.status === 'completed').length;
   const failed = childOutcomes.length - completed;
 
@@ -1633,6 +1704,7 @@ async function writeSummaryPage(
   // unnecessarily; we go straight to the engine.
   const { parseMarkdown } = await import('../markdown.ts');
   const parsed = parseMarkdown(fullMarkdown);
+  throwIfAborted(signal, '[dream] synthesize summary');
   // #1586: summary lands in the cycle's resolved source too — otherwise the
   // children live in the named source while the index drifts to 'default'.
   await engine.putPage(summarySlug, {
@@ -1645,10 +1717,12 @@ async function writeSummaryPage(
 
   // Also write to disk (orchestrator dual-write).
   try {
+    throwIfAborted(signal, '[dream] synthesize summary');
     const filePath = join(brainDir, `${summarySlug}.md`);
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, fullMarkdown, 'utf8');
   } catch (e) {
+    throwIfAborted(signal, '[dream] synthesize summary');
     const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(`[dream] summary file-write failed: ${msg}\n`);
   }

--- a/test/cycle-abort.test.ts
+++ b/test/cycle-abort.test.ts
@@ -179,6 +179,8 @@ describe('#1972 — complete cooperative-abort coverage', () => {
     expect(body).toMatch(/runPhaseExtractFacts\([^)]*opts\.signal\)/);
     expect(body).toContain('signal: opts.signal'); // consolidate opts
     expect(body).toContain('runPhaseLint(brainDir, dryRun, engine, opts.signal)');
+    expect(body).toMatch(/runPhaseSynthesize\(engine, \{[\s\S]*?signal: opts\.signal,[\s\S]*?\}\)/);
+    expect(body).toMatch(/runPhasePatterns\(engine, \{[\s\S]*?signal: opts\.signal,[\s\S]*?\}\)/);
     // Reaper runs at cycle start.
     expect(body).toContain('reapDeadHolderLocks(engine)');
     // Terminal guard: the success stamp is gated on !aborted, and the report
@@ -187,6 +189,24 @@ describe('#1972 — complete cooperative-abort coverage', () => {
     expect(body).toContain("reason: 'aborted'");
     // Phase-duration force-evict attribution log (T11).
     expect(body).toContain('FORCE_EVICT_DEADLINE_MS');
+  });
+
+  test('synthesize threads its signal through judge, inline child, and completion wait', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(new URL('../src/core/cycle/synthesize.ts', import.meta.url), 'utf8');
+    expect(src).toContain('signal?: AbortSignal');
+    expect(src).toContain('judgeSignificance(judge, t, config.verdictModel, opts.signal)');
+    expect(src).toMatch(/runPgliteSubagentsInline\([\s\S]*?opts\.yieldDuringPhase,[\s\S]*?opts\.signal/);
+    expect(src).toMatch(/waitForCompletion\(queue, jobId, \{[\s\S]*?signal: opts\.signal/);
+  });
+
+  test('patterns sibling threads the same signal through inline child and completion wait', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(new URL('../src/core/cycle/patterns.ts', import.meta.url), 'utf8');
+    expect(src).toContain('signal?: AbortSignal');
+    expect(src).toMatch(/runPgliteSubagentsInline\([\s\S]*?opts\.yieldDuringPhase,[\s\S]*?opts\.signal/);
+    expect(src).toMatch(/waitForCompletion\(queue, job\.id, \{[\s\S]*?signal: opts\.signal/);
+    expect(src).toContain('reverseWriteRefs(engine, opts.brainDir, writtenRefs, cycleSourceId, opts.signal)');
   });
 
   test('every long phase core checks isAborted in its batch loop', async () => {

--- a/test/cycle-dream-output-root.test.ts
+++ b/test/cycle-dream-output-root.test.ts
@@ -70,10 +70,10 @@ describe('#2415: loadOutputRoot validation + patterns gather scope', () => {
     engine = new PGLiteEngine();
     await engine.connect({});
     await engine.initSchema();
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
   });
 
   test('unset → wiki; trailing slash trimmed; invalid → wiki fallback', async () => {

--- a/test/cycle-patterns-source-scope.test.ts
+++ b/test/cycle-patterns-source-scope.test.ts
@@ -62,11 +62,11 @@ beforeAll(async () => {
     title: 'A pattern',
     compiled_truth: 'a pattern',
   } as any, { sourceId: SOURCE_ID });
-});
+}, 60_000);
 
 afterAll(async () => {
-  await engine.disconnect();
-  rmSync(brainDir, { recursive: true, force: true });
+  if (engine) await engine.disconnect();
+  if (brainDir) rmSync(brainDir, { recursive: true, force: true });
 });
 
 describe('#1586: the patterns phase scopes its writes to the cycle source', () => {
@@ -109,6 +109,43 @@ describe('#1586: the patterns phase scopes its writes to the cycle source', () =
       expect(existsSync(join(foreignDir, `${SLUG}.md`))).toBe(false);
     } finally {
       rmSync(foreignDir, { recursive: true, force: true });
+    }
+  });
+
+  test('abort during reverse-write stops the current and all remaining file writes', async () => {
+    const abortDir = mkdtempSync(join(tmpdir(), 'gbrain-patterns-abort-'));
+    const controller = new AbortController();
+    const refs = [
+      { slug: 'wiki/personal/patterns/abort-first', source_id: SOURCE_ID },
+      { slug: 'wiki/personal/patterns/abort-second', source_id: SOURCE_ID },
+    ];
+    const fakeEngine = {
+      getPage: async (slug: string) => ({
+        slug,
+        type: 'note',
+        title: slug,
+        compiled_truth: slug,
+        frontmatter: {},
+        timeline: '',
+      }),
+      getTags: async () => {
+        controller.abort(new Error('patterns-reverse-write-cancelled'));
+        return [];
+      },
+    };
+
+    try {
+      await expect(reverseWriteRefs(
+        fakeEngine as any,
+        abortDir,
+        refs,
+        SOURCE_ID,
+        controller.signal,
+      )).rejects.toThrow('patterns-reverse-write-cancelled');
+      expect(existsSync(join(abortDir, `${refs[0]!.slug}.md`))).toBe(false);
+      expect(existsSync(join(abortDir, `${refs[1]!.slug}.md`))).toBe(false);
+    } finally {
+      rmSync(abortDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -99,6 +99,34 @@ describe('makeJudgeClient — construction-time provider probe', () => {
 });
 
 describe('JudgeClient.create — gateway routing + shape adapter', () => {
+  test('A2b: forwards a caller AbortSignal to gateway.chat', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: 'sk-test-A2b' }, async () => {
+      const judge = makeJudgeClient('claude-haiku-4-5-20251001');
+      const abort = new AbortController();
+      let receivedSignal: AbortSignal | undefined;
+      __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+        receivedSignal = opts.abortSignal;
+        return {
+          text: WORTH_PROCESSING_JSON,
+          blocks: [],
+          stopReason: 'end',
+          usage: { input_tokens: 10, output_tokens: 20, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'test:stub',
+          providerId: 'test',
+        };
+      });
+
+      await judge!.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 200,
+        system: 'judge system prompt',
+        messages: [{ role: 'user', content: 'judge this' }],
+      }, { signal: abort.signal });
+
+      expect(receivedSignal).toBe(abort.signal);
+    });
+  });
+
   test('A3: routes through gateway.chat (verified via __setChatTransportForTests stub)', async () => {
     await withEnv({ ANTHROPIC_API_KEY: 'sk-test-A3' }, async () => {
       const judge = makeJudgeClient('claude-haiku-4-5-20251001');

--- a/test/e2e/dream-synthesize-pglite.test.ts
+++ b/test/e2e/dream-synthesize-pglite.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, test, expect, afterEach } from 'bun:test';
-import { __setChatTransportForTests, resetGateway } from '../../src/core/ai/gateway.ts';
+import { __setChatTransportForTests, resetGateway, type ChatResult } from '../../src/core/ai/gateway.ts';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -531,6 +531,54 @@ describe('E2E synthesize — degenerate verdicts are NOT cached in dream_verdict
     resetGateway();
   });
 
+  test('abort during judge exits as failure before cache, job, or page writes', async () => {
+    const rig = await setupRig();
+    const abort = new AbortController();
+    try {
+      await rig.engine.setConfig('dream.synthesize.enabled', 'true');
+      await rig.engine.setConfig('dream.synthesize.session_corpus_dir', rig.corpusDir);
+      await rig.engine.setConfig('models.dream.synthesize_verdict', 'deepseek:deepseek-chat');
+      const filePath = join(rig.corpusDir, '2026-08-13-abort-during-judge.txt');
+      const body = 'a durable conversation about cancellation safety\n'.repeat(100);
+      writeFileSync(filePath, body);
+
+      __setChatTransportForTests(async (): Promise<ChatResult> => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return {
+          text: JSON.stringify({ worth_processing: true, reasons: ['durable cancellation contract'] }),
+          blocks: [],
+          stopReason: 'end',
+          usage: { input_tokens: 10, output_tokens: 20, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'deepseek:deepseek-chat',
+          providerId: 'deepseek',
+        };
+      });
+
+      setTimeout(() => abort.abort(new Error('test-cancel')), 10);
+      const result = await runPhaseSynthesize(rig.engine, {
+        brainDir: rig.brainDir,
+        dryRun: false,
+        signal: abort.signal,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(JSON.stringify(result.error)).toContain('test-cancel');
+      const { createHash } = await import('node:crypto');
+      const hash = createHash('sha256').update(body, 'utf8').digest('hex');
+      expect(await rig.engine.getDreamVerdict(filePath, hash)).toBeNull();
+      const jobs = await rig.engine.executeRaw<{ n: number }>(
+        `SELECT count(*)::int AS n FROM minion_jobs`,
+      );
+      const pages = await rig.engine.executeRaw<{ n: number }>(
+        `SELECT count(*)::int AS n FROM pages`,
+      );
+      expect(Number(jobs[0]?.n ?? 0)).toBe(0);
+      expect(Number(pages[0]?.n ?? 0)).toBe(0);
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
   async function captureStderr<T>(body: () => Promise<T>): Promise<{ result: T; stderr: string }> {
     const chunks: string[] = [];
     const original = process.stderr.write.bind(process.stderr);
@@ -630,6 +678,44 @@ describe('E2E synthesize — degenerate verdicts are NOT cached in dream_verdict
 });
 
 describe('E2E synthesize — PGLite inline subagent drain (takeover of #2699)', () => {
+  test('caller abort cancels an active inline child well inside the 30s force-evict grace', async () => {
+    const rig = await setupRig();
+    try {
+      const { MinionQueue } = await import('../../src/core/minions/queue.ts');
+      const queue = new MinionQueue(rig.engine);
+      const queueName = `dream-inline-test-abort-${Date.now()}`;
+      const child = await queue.add(
+        'subagent',
+        { prompt: 'test', model: 'anthropic:claude-sonnet-4-6', max_turns: 1 },
+        { queue: queueName, max_attempts: 1 },
+        { allowProtectedSubmit: true },
+      );
+      const controller = new AbortController();
+      const started = Date.now();
+      setTimeout(() => controller.abort(new Error('test-cancel-inline')), 10);
+
+      await expect(synthTesting.runPgliteSubagentsInline(
+        rig.engine,
+        queue,
+        queueName,
+        undefined,
+        async (ctx) => {
+          await new Promise((_, reject) => {
+            ctx.signal.addEventListener('abort', () => reject(new Error('provider aborted')), { once: true });
+          });
+        },
+        controller.signal,
+      )).rejects.toThrow('test-cancel-inline');
+
+      expect(Date.now() - started).toBeLessThan(30_000);
+      expect((await queue.getJob(child.id))?.status).toBe('cancelled');
+      const pages = await rig.engine.executeRaw<{ count: string }>('SELECT COUNT(*)::text AS count FROM pages');
+      expect(pages[0]?.count).toBe('0');
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
   test('drains private subagent queue inline so the parent can observe completion', async () => {
     const rig = await setupRig();
     try {


### PR DESCRIPTION
## Summary

- propagate the cycle `AbortSignal` through synthesize and patterns phases
- forward cancellation into judge gateway calls, inline PGLite subagents, and completion waits
- stop new cache, fan-out, provenance, reverse-write, summary, and completion-stamp work after cancellation
- cancel active child jobs with a truthful `cancelled` outcome instead of surfacing cancellation as provider failure or success
- add regression coverage for judge transport, active inline children, patterns reverse-write, and PGLite fixture stability

## Why

The cycle runner already accepted a cooperative cancellation signal, but the synthesize path did not carry it all the way through judge calls, subagent execution, completion waits, or the gateway transport. A cancelled cycle could therefore continue working during the force-eviction grace period and potentially write derived state after cancellation.

This change threads the existing signal through those boundaries and adds explicit abort checks before every downstream write boundary. The sibling patterns path receives the same treatment.

## Test plan

Run serially with production database/provider environment variables removed:

- `bun test test/cycle-patterns-source-scope.test.ts test/cycle-abort.test.ts` — 18 pass, 0 fail
- `bun test test/cycle/synthesize-gateway-adapter.test.ts test/cycle-abort.test.ts test/e2e/dream-synthesize-pglite.test.ts` — 46 pass, 0 fail
- focused synthesize/patterns regression suite — 79 pass, 0 fail
- `bun run typecheck`
- `bun run check:search-path`
- `git diff HEAD^ HEAD --check`

The PGLite-heavy fixtures use explicit 60-second setup timeouts and guarded teardown so cold schema initialization does not create false failures or mask the original setup error.

Related: #1972
