### PR TITLE
fix(dream): resolve context limits from model recipes

### DIFF
--- a/src/core/ai/capabilities.ts
+++ b/src/core/ai/capabilities.ts
@@ -21,7 +21,7 @@
  * decisions don't depend on it.
  */
 
-import { resolveRecipe } from './model-resolver.ts';
+import { resolveChatContextTokens, resolveRecipe } from './model-resolver.ts';
 import { listRecipes } from './recipes/index.ts';
 import { AIConfigError } from './errors.ts';
 
@@ -105,7 +105,7 @@ export function getProviderCapabilities(modelString: string): ProviderCapabiliti
     // a `supports_thinking` field later without breaking this helper (it'll
     // just keep returning false until a recipe sets it).
     supportsThinking: false,
-    maxContext: chat.max_context_tokens ?? 128_000,
+    maxContext: resolveChatContextTokens(modelString) ?? 128_000,
   };
 }
 

--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -77,6 +77,17 @@ export function resolveRecipe(modelId: string): { parsed: ParsedModelId; recipe:
   return { parsed, recipe };
 }
 
+/**
+ * Resolve the declared chat context window for a provider-qualified model.
+ * Model-specific recipe metadata wins over the provider-wide default.
+ * Returns undefined when the provider has no chat context declaration.
+ */
+export function resolveChatContextTokens(modelId: string): number | undefined {
+  const { parsed, recipe } = resolveRecipe(modelId);
+  const chat = recipe.touchpoints.chat;
+  return chat?.model_context_tokens?.[parsed.modelId] ?? chat?.max_context_tokens;
+}
+
 type KnownTouchpointKey = 'embedding' | 'expansion' | 'chat' | 'reranker';
 
 function getTouchpoint(recipe: Recipe, touchpoint: TouchpointKind): EmbeddingTouchpoint | ExpansionTouchpoint | ChatTouchpoint | RerankerTouchpoint | undefined {

--- a/src/core/ai/recipes/anthropic.ts
+++ b/src/core/ai/recipes/anthropic.ts
@@ -34,6 +34,14 @@ export const anthropic: Recipe = {
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: true,
+      model_context_tokens: {
+        'claude-fable-5': 1_000_000,
+        'claude-opus-5': 1_000_000,
+        'claude-sonnet-5': 1_000_000,
+        'claude-opus-4-8': 1_000_000,
+        'claude-opus-4-7': 1_000_000,
+        'claude-opus-4-6': 1_000_000,
+      },
       max_context_tokens: 200000,
       cost_per_1m_input_usd: 3.0, // sonnet-class baseline
       cost_per_1m_output_usd: 15.0,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -266,6 +266,8 @@ export interface ChatTouchpoint {
    * known to honor it.
    */
   supports_structured_outputs?: boolean;
+  /** Per-model overrides for providers whose chat models have different context windows. */
+  model_context_tokens?: Record<string, number>;
   max_context_tokens?: number;
   cost_per_1m_input_usd?: number;
   cost_per_1m_output_usd?: number;

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -31,6 +31,7 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { chat as gatewayChat, validateModelId, type ChatResult } from '../ai/gateway.ts';
 import { AIConfigError } from '../ai/errors.ts';
+import { resolveChatContextTokens } from '../ai/model-resolver.ts';
 import { normalizeModelId, splitProviderModelId } from '../model-id.ts';
 import { hasAnthropicKey } from '../ai/anthropic-key.ts';
 import { basename, join, dirname, isAbsolute, resolve } from 'node:path';
@@ -54,25 +55,6 @@ const SUMMARY_SLUG_RE = new RegExp(`^${PAGE_SLUG_SEG}(\\/${PAGE_SLUG_SEG})*$`, '
 
 // ── Model context budget (D1, D5, D7, D9) ─────────────────────────────
 
-/**
- * Anthropic model id → input context window (tokens).
- * Unknown id (non-Anthropic alias, custom string) → safe 200K-token fallback
- * via `computeChunkCharBudget`. Codex finding #4: `resolveModel()` does not
- * canonicalize to Anthropic-only; this map keys on the exact strings the
- * resolver returns for known Anthropic aliases.
- */
-const MODEL_CONTEXT_TOKENS: Record<string, number> = {
-  'claude-fable-5': 1_000_000,
-  'claude-opus-5': 1_000_000,
-  'claude-sonnet-5': 1_000_000,
-  'claude-opus-4-8': 1_000_000,
-  'claude-opus-4-7': 1_000_000,
-  'claude-opus-4-6': 1_000_000,
-  'claude-sonnet-4-6': 200_000,
-  'claude-sonnet-4-5': 200_000,
-  'claude-haiku-4-5-20251001': 200_000,
-};
-
 /** Token-to-char ratio. 3.5 matches PR #748; conservative for English text. */
 const CHARS_PER_TOKEN = 3.5;
 /** Reserve 10% of context window for system prompt + tool defs + output. */
@@ -91,8 +73,8 @@ const DEFAULT_SUBAGENT_WAIT_TIMEOUT_MS = 35 * 60 * 1000;
  *
  * Resolution:
  *   - configMaxPromptTokens (already floored at MIN_PROMPT_TOKENS) wins when set.
- *   - Else the model's MODEL_CONTEXT_TOKENS entry × HEADROOM_RATIO.
- *   - Else (non-Anthropic alias / custom id) UNKNOWN_MODEL_BUDGET_TOKENS, with
+ *   - Else the official recipe/model resolver's context declaration × HEADROOM_RATIO.
+ *   - Else (unqualified custom id / unknown provider / undeclared recipe) UNKNOWN_MODEL_BUDGET_TOKENS, with
  *     a once-per-process stderr warning.
  *
  * D7 scope: this bounds the INITIAL prompt size only. Tool-loop turn-N
@@ -106,14 +88,22 @@ export function computeChunkCharBudget(
   if (configMaxPromptTokens !== null) {
     return Math.floor(configMaxPromptTokens * CHARS_PER_TOKEN);
   }
-  // Lookup keyed on the bare model name (after prefix strip), mirroring
-  // ANTHROPIC_OUTPUT_CAPS in brainstorm/judges.ts: resolveModel returns
-  // provider-prefixed strings when TIER_DEFAULTS / config values carry a
-  // prefix (the current tier defaults all do), so a raw keyed lookup sent
-  // every tier-resolved brain to the unknown-model fallback — a 5x budget
-  // cut on 1M-context models.
-  const bare = splitProviderModelId(model).model || model;
-  const ctx = MODEL_CONTEXT_TOKENS[bare];
+  // Bare Claude ids are the one legacy shape resolveModel may still return;
+  // all other bare/custom ids remain unknown rather than guessing a provider.
+  const split = splitProviderModelId(model);
+  const qualified = split.provider
+    ? model
+    : model.startsWith('claude-')
+      ? normalizeModelId(model)
+      : null;
+  let ctx: number | undefined;
+  if (qualified) {
+    try {
+      ctx = resolveChatContextTokens(qualified);
+    } catch (err) {
+      if (!(err instanceof AIConfigError)) throw err;
+    }
+  }
   if (ctx === undefined) {
     warnUnknownModelOnce(model);
     return Math.floor(UNKNOWN_MODEL_BUDGET_TOKENS * CHARS_PER_TOKEN);
@@ -126,7 +116,7 @@ function warnUnknownModelOnce(model: string): void {
   if (_unknownModelWarned.has(model)) return;
   _unknownModelWarned.add(model);
   process.stderr.write(
-    `[dream] model "${model}" is not in MODEL_CONTEXT_TOKENS; ` +
+    `[dream] model "${model}" has no declared chat context window; ` +
     `using ${UNKNOWN_MODEL_BUDGET_TOKENS}-token fallback budget. ` +
     `Set dream.synthesize.max_prompt_tokens to override.\n`,
   );

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -10,6 +10,10 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(200000);
   });
 
+  it('uses model-specific recipe context metadata when declared', () => {
+    expect(getProviderCapabilities('anthropic:claude-opus-4-7').maxContext).toBe(1_000_000);
+  });
+
   it('returns capabilities for OpenAI (no prompt caching field set as true)', () => {
     const caps = getProviderCapabilities('openai:gpt-5.2');
     expect(caps.supportsToolCalling).toBe(true);

--- a/test/synthesize-chunk-budget.test.ts
+++ b/test/synthesize-chunk-budget.test.ts
@@ -1,5 +1,5 @@
 /**
- * computeChunkCharBudget — MODEL_CONTEXT_TOKENS resolution.
+ * computeChunkCharBudget — official recipe/model context resolution.
  *
  * Pins two things:
  *   1. Current-generation models resolve their real context budget instead
@@ -12,6 +12,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import { resolveChatContextTokens } from '../src/core/ai/model-resolver.ts';
 import { computeChunkCharBudget } from '../src/core/cycle/synthesize.ts';
 
 // Mirror the module's constants (deliberately duplicated: a silent change to
@@ -23,6 +24,22 @@ const budgetFor = (contextTokens: number) =>
   Math.floor(contextTokens * HEADROOM_RATIO * CHARS_PER_TOKEN);
 
 describe('computeChunkCharBudget — model resolution', () => {
+  test('official model resolver exposes recipe context metadata', () => {
+    expect(resolveChatContextTokens('deepseek:deepseek-v4-flash')).toBe(1_000_000);
+    expect(resolveChatContextTokens('deepseek:deepseek-v4-pro')).toBe(1_000_000);
+    expect(resolveChatContextTokens('anthropic:claude-opus-4-7')).toBe(1_000_000);
+    expect(resolveChatContextTokens('anthropic:claude-sonnet-4-6')).toBe(200_000);
+    expect(resolveChatContextTokens('openai:gpt-5')).toBe(200_000);
+    expect(computeChunkCharBudget('openai:gpt-5', null)).toBe(budgetFor(200_000));
+  });
+
+  test('DeepSeek v4 models use the 1M context declared by the official recipe', () => {
+    for (const model of ['deepseek:deepseek-v4-flash', 'deepseek:deepseek-v4-pro']) {
+      expect(computeChunkCharBudget(model, null)).toBe(budgetFor(1_000_000));
+      expect(computeChunkCharBudget(model, null)).not.toBe(UNKNOWN_BUDGET);
+    }
+  });
+
   test('current-generation 1M-context models get their real budget, not the fallback', () => {
     for (const model of ['claude-sonnet-5', 'claude-fable-5', 'claude-opus-5', 'claude-opus-4-8']) {
       expect(computeChunkCharBudget(model, null)).toBe(budgetFor(1_000_000));
@@ -42,8 +59,14 @@ describe('computeChunkCharBudget — model resolution', () => {
   });
 
   test('unknown models fall back to the conservative 180K budget', () => {
-    expect(computeChunkCharBudget('openai:gpt-5', null)).toBe(UNKNOWN_BUDGET);
     expect(computeChunkCharBudget('some-custom-model', null)).toBe(UNKNOWN_BUDGET);
+    expect(computeChunkCharBudget('unknown-provider:custom-model', null)).toBe(UNKNOWN_BUDGET);
+  });
+
+  test('existing known Anthropic model budgets do not regress', () => {
+    expect(computeChunkCharBudget('anthropic:claude-sonnet-5', null)).toBe(budgetFor(1_000_000));
+    expect(computeChunkCharBudget('anthropic:claude-sonnet-4-6', null)).toBe(budgetFor(200_000));
+    expect(computeChunkCharBudget('anthropic:claude-haiku-4-5-20251001', null)).toBe(budgetFor(200_000));
   });
 
   test('config override wins over the map', () => {


### PR DESCRIPTION
## Summary

- make the official provider recipes and model resolver the single source of truth for chat context limits
- use recipe-declared context limits when sizing synthesis chunks, including DeepSeek v4 Flash/Pro at 1M tokens
- preserve explicit model overrides, provider defaults, and the conservative 180K fallback for genuinely unknown models
- keep capability reporting aligned with the same resolver

## Motivation

`src/core/cycle/synthesize.ts` maintained a private context-size table. Models absent from that table silently fell back to 180K even when their official recipe declared a larger context. In particular, both DeepSeek v4 chat models declare a 1M context window, but synthesis sized chunks as though they had 180K.

This removes the duplicate table and resolves context limits from the canonical recipe metadata instead.

## Resolution order

1. explicit runtime prompt-token override
2. recipe model-level `model_context_tokens`
3. recipe provider-level `max_context_tokens`
4. explicit conservative 180K fallback for unknown model/provider ids

The Anthropic model-specific 1M entries are moved from the private synthesis table into recipe metadata; other Anthropic models retain the existing 200K provider default.

## Test plan

- RED reproduced the DeepSeek 1M model being truncated to the 180K fallback
- chunk budget suite: 7 passed, 0 failed
- focused model/context suite: 46 passed, 0 failed
- PGLite synthesis chunking: 6 passed, 0 failed
- `bun run typecheck`
- `bun run check:search-path`
- `git diff HEAD^ HEAD --check`

All test runs cleared database and provider environment variables.

## Scope

This PR is independent of #4077. Both touch `src/core/cycle/synthesize.ts`, but in separate hunks; a three-way merge against their shared base is conflict-free. It does not include cooperative-abort changes, verdict-cache/dry-run work, thinking configuration changes, or production configuration changes.
