### PR TITLE
fix(serve-http): redirect bare /admin to /admin/ on embedded-manifest path

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -1844,7 +1844,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     }
     // Bare /admin (no trailing slash) never matches the '/admin/{*path}'
     // pattern below — path-to-regexp requires the literal '/' that
-    // precedes the optional group. The dev-path branch above doesn't need
+    // precedes the wildcard segment. The dev-path branch above doesn't need
     // this: express.static() issues its own redirect-to-trailing-slash for
     // a directory index request. Mirror that behavior explicitly here.
     // Express route matching is non-strict by default, so the '/admin'

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -1842,6 +1842,20 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       cache.set(asset.path, buf);
       return buf;
     }
+    // Bare /admin (no trailing slash) never matches the '/admin/{*path}'
+    // pattern below — path-to-regexp requires the literal '/' that
+    // precedes the optional group. The dev-path branch above doesn't need
+    // this: express.static() issues its own redirect-to-trailing-slash for
+    // a directory index request. Mirror that behavior explicitly here.
+    // Express route matching is non-strict by default, so the '/admin'
+    // pattern below also matches '/admin/' — guard on the exact path so
+    // it doesn't shadow the '/admin/{*path}' handler and redirect-loop.
+    app.get('/admin', (req: Request, res: Response, next: NextFunction) => {
+      if (req.path !== '/admin') {
+        return next();
+      }
+      res.redirect('/admin/');
+    });
     app.get('/admin/{*path}', (req: Request, res: Response, next: NextFunction) => {
       if (req.path.startsWith('/admin/api/') || req.path === '/admin/events' || req.path === '/admin/login') {
         return next();

--- a/test/admin-embed-spawn.serial.test.ts
+++ b/test/admin-embed-spawn.serial.test.ts
@@ -166,7 +166,7 @@ describe('admin embed E2E — /admin served from embedded manifest (v0.36.1.x #1
       });
       // Pre-fix this 404'd: the embedded-manifest branch only registered
       // '/admin/{*path}', which requires the literal '/' before the
-      // optional group and never matches a bare '/admin' request.
+      // wildcard segment and never matches a bare '/admin' request.
       expect([301, 302, 303, 307, 308]).toContain(res.status);
       expect(res.headers.get('location')).toBe('/admin/');
 

--- a/test/admin-embed-spawn.serial.test.ts
+++ b/test/admin-embed-spawn.serial.test.ts
@@ -157,6 +157,32 @@ describe('admin embed E2E — /admin served from embedded manifest (v0.36.1.x #1
     }
   }, 90_000);
 
+  test('GET /admin (no trailing slash) redirects to /admin/', async () => {
+    const s = await spawnServer();
+    try {
+      const res = await fetch(`http://127.0.0.1:${s.port}/admin`, {
+        signal: AbortSignal.timeout(5000),
+        redirect: 'manual',
+      });
+      // Pre-fix this 404'd: the embedded-manifest branch only registered
+      // '/admin/{*path}', which requires the literal '/' before the
+      // optional group and never matches a bare '/admin' request.
+      expect([301, 302, 303, 307, 308]).toContain(res.status);
+      expect(res.headers.get('location')).toBe('/admin/');
+
+      // Following the redirect lands on the same SPA shell as GET /admin/.
+      const followed = await fetch(`http://127.0.0.1:${s.port}/admin`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      expect(followed.status).toBe(200);
+      const html = await followed.text();
+      expect(html).toContain('GBrain Admin');
+      expect(html).toContain('<div id="root">');
+    } finally {
+      await s.cleanup();
+    }
+  }, 90_000);
+
   test('GET /admin/index.html (explicit path) also returns the SPA HTML', async () => {
     const s = await spawnServer();
     try {


### PR DESCRIPTION
## Problem

`gbrain serve --http` 404s on `GET /admin` (no trailing slash) when running from a globally-installed binary — the exact URL both the startup banner (`Admin: http://localhost:<port>/admin`) and `docs/mcp/DEPLOY.md` tell users to open. `GET /admin/` (with the trailing slash) works fine.

## Root cause

`src/commands/serve-http.ts` resolves the admin SPA two ways: a dev-path branch (cwd-relative `admin/dist`, used when developing the SPA with `admin/dist` present) and an embedded-manifest branch (used by every compiled/globally-installed binary, which is what a real user actually runs).

The embedded branch only registers `app.get('/admin/{*path}', ...)`. In Express 5's path-to-regexp syntax, the `/` immediately before `{*path}` is a required literal, so this pattern never matches a bare `/admin` request — it falls through to Express's default 404 handler.

The dev-path branch doesn't have this problem: it's mounted via `express.static(adminDistPath)`, which issues its own redirect-to-trailing-slash for a directory-index request. The embedded branch had no equivalent.

## Fix

Adds an explicit `GET /admin` route in the embedded-manifest branch that redirects to `/admin/`, mirroring the `res.redirect('/admin/')` call already used elsewhere in this same file (the magic-link login success handler).

One subtlety: Express route matching is non-strict by default, so an unguarded `/admin` pattern also matches `/admin/` itself — which would shadow the existing `/admin/{*path}` handler and redirect-loop. The new handler guards on `req.path !== '/admin'` and calls `next()` otherwise, so it only fires for the bare path.

The dev-path branch is untouched — it already redirects correctly via `express.static`'s built-in behavior.

## Tests

Added a new case to the existing `test/admin-embed-spawn.serial.test.ts` E2E harness (spawns a real `gbrain serve --http` subprocess from a fresh tmpdir so the embedded-manifest branch is actually exercised): `GET /admin (no trailing slash) redirects to /admin/`. Asserts a 3xx with `Location: /admin/`, then follows the redirect and asserts the SPA shell HTML loads.

Verified red→green manually: reverted just the source change (keeping the new test) and confirmed it fails with the exact pre-fix symptom (404, not a redirect), then restored the fix and confirmed all 5 tests in the file pass.

Commands run:
```
bun test test/admin-embed-spawn.serial.test.ts   # 5 pass, 0 fail
bun run verify                                    # 38/38 checks green (incl. typecheck)
bun run test                                      # 486 pass, 10 fail
```

The 10 `bun run test` failures (all tagged `oom-rescue ... confirmed real` in the runner's own output) are in `test/pglite-engine.test.ts` and `test/sources-ops.test.ts` — unrelated files this PR doesn't touch. I confirmed they're pre-existing by running the same two test files against a clean, unmodified checkout of `upstream/master` in a separate worktree: identical 10 failures reproduce there with none of this branch's changes applied. Not caused by this PR.

## Limitations

- Did not run `bun run test:e2e` / `bun run ci:local` (Docker-based Postgres E2E) — not needed for this change (the affected code path is PGLite-local per the test file's own doc comment: "No DATABASE_URL needed; PGLite is the engine"), and the fix + its regression coverage don't touch anything Postgres-specific.
- Fixes #3979.