### PR TITLE
fix(cli): reach real usage block for gbrain auth --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,6 +153,11 @@ const CLI_ONLY_SELF_HELP = new Set([
   // would leave that help dead code behind the generic stub (the init.ts:117
   // trap ENG-2 names).
   'bootstrap', 'hook', 'sweep',
+  // #4003: auth ships its own detailed usage (token/OAuth-client commands +
+  // flags) in its `default:` switch case, hit whenever the subcommand isn't
+  // one of create/list/revoke/etc — including --help. Without this entry the
+  // generic short-circuit fires first and that usage block is dead code.
+  'auth',
 ]);
 
 /**
@@ -3177,6 +3182,9 @@ ADMIN
     --public-url URL                 Public issuer URL (required behind proxy/tunnel)
   connect <mcp-url> --token <t>      Wire Claude Code to a remote gbrain (bearer token)
         [--install] [--json]         Print the paste-ready command, or --install to run it
+  auth <create|list|revoke|...>      Manage legacy tokens + OAuth 2.1 clients
+  auth --help                        Full subcommand list (register-client,
+                                     rescope-client, revoke-client, permissions, test, ...)
   watch [--json]                     Push-based context: pipe conversation turns in,
                                      volunteered brain pages stream out (#2095)
   call <tool> '<json>'               Raw tool invocation

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -633,34 +633,7 @@ export function parseAuthCreateArgs(rest: string[]): { name: string; takesHolder
   return { name: positional || '', takesHolders };
 }
 
-export async function runAuth(args: string[]): Promise<void> {
-  const [cmd, ...rest] = args;
-  switch (cmd) {
-    case 'create': {
-      // v0.28: optional --takes-holders world,garry,brain (default: world only)
-      const parsed = parseAuthCreateArgs(rest);
-      await create(parsed.name, { takesHolders: parsed.takesHolders });
-      return;
-    }
-    case 'list': await list(); return;
-    case 'revoke': await revoke(rest[0]); return;
-    case 'permissions': {
-      // gbrain auth permissions <name> set-takes-holders world,garry
-      await permissions(rest[0] || '', rest[1] || '', rest[2]);
-      return;
-    }
-    case 'register-client': await registerClient(rest[0], rest.slice(1)); return;
-    case 'rescope-client': await rescopeClient(rest[0], rest.slice(1)); return;
-    case 'revoke-client': await revokeClient(rest[0]); return;
-    case 'test': {
-      const tokenIdx = rest.indexOf('--token');
-      const url = rest.find(a => !a.startsWith('--') && a !== rest[tokenIdx + 1]);
-      const token = tokenIdx >= 0 ? rest[tokenIdx + 1] : '';
-      await test(url || '', token || '');
-      return;
-    }
-    default:
-      console.log(`GBrain Token Management
+const AUTH_USAGE = `GBrain Token Management
 
 Usage:
   gbrain auth create <name> [--takes-holders world,garry,brain]
@@ -703,7 +676,48 @@ Usage:
      --bound-slug-prefixes <p1,p2|none>                   Replace the slug-prefix write fence ('none' clears it)
   gbrain auth revoke-client <client_id>                   Hard-delete an OAuth 2.1 client (cascades to tokens + codes)
   gbrain auth test <url> --token <token>                  Smoke-test a remote MCP server
-`);
+`;
+
+export async function runAuth(args: string[]): Promise<void> {
+  // #4083 follow-up: print usage whenever --help/-h appears ANYWHERE in
+  // args, before dispatching to a subcommand. Without this early return,
+  // `gbrain auth create foo --help` (or revoke/register-client/... +
+  // --help) actually EXECUTES the subcommand instead of showing help,
+  // once `auth` joined CLI_ONLY_SELF_HELP and the generic --help
+  // short-circuit in cli.ts stopped intercepting it first. Same pattern
+  // as sync.ts's own `args.includes('--help') || args.includes('-h')`
+  // early-return.
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(AUTH_USAGE);
+    return;
+  }
+  const [cmd, ...rest] = args;
+  switch (cmd) {
+    case 'create': {
+      // v0.28: optional --takes-holders world,garry,brain (default: world only)
+      const parsed = parseAuthCreateArgs(rest);
+      await create(parsed.name, { takesHolders: parsed.takesHolders });
+      return;
+    }
+    case 'list': await list(); return;
+    case 'revoke': await revoke(rest[0]); return;
+    case 'permissions': {
+      // gbrain auth permissions <name> set-takes-holders world,garry
+      await permissions(rest[0] || '', rest[1] || '', rest[2]);
+      return;
+    }
+    case 'register-client': await registerClient(rest[0], rest.slice(1)); return;
+    case 'rescope-client': await rescopeClient(rest[0], rest.slice(1)); return;
+    case 'revoke-client': await revokeClient(rest[0]); return;
+    case 'test': {
+      const tokenIdx = rest.indexOf('--token');
+      const url = rest.find(a => !a.startsWith('--') && a !== rest[tokenIdx + 1]);
+      const token = tokenIdx >= 0 ? rest[tokenIdx + 1] : '';
+      await test(url || '', token || '');
+      return;
+    }
+    default:
+      console.log(AUTH_USAGE);
   }
 }
 

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -141,6 +141,32 @@ describe('#1175 — main `gbrain --help` SOURCES block matches the real subcomma
   });
 });
 
+describe('#4003 — `gbrain auth --help` reaches the detailed usage block', () => {
+  test('output contains the real auth subcommand usage, not the generic stub', () => {
+    const { stdout, status } = runCli(['auth', '--help']);
+    expect(status).toBe(0);
+    // Pre-fix: `auth` was missing from CLI_ONLY_SELF_HELP, so this printed
+    // only "gbrain auth - run gbrain --help for the full command list."
+    expect(stdout).toContain('GBrain Token Management');
+    expect(stdout).toContain('gbrain auth create <name>');
+    expect(stdout).toContain('gbrain auth register-client');
+    expect(stdout).not.toContain('run gbrain --help for the full command list');
+  });
+
+  test('-h short flag also works', () => {
+    const { stdout, status } = runCli(['auth', '-h']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('GBrain Token Management');
+  });
+
+  test('main `gbrain --help` lists auth', () => {
+    const { stdout, status } = runCli(['--help']);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/^\s*auth </m);
+    expect(stdout).toMatch(/^\s*auth --help\s/m);
+  });
+});
+
 describe('#3834 — extract flags are discoverable from both help surfaces', () => {
   const implementedFlags = [
     '--by-mention',

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -167,6 +167,41 @@ describe('#4003 — `gbrain auth --help` reaches the detailed usage block', () =
   });
 });
 
+describe('#4083 follow-up — auth subcommand + --help shows usage, never executes', () => {
+  // Caught by automated PR review on #4083: once `auth` joined
+  // CLI_ONLY_SELF_HELP, the generic --help short-circuit in cli.ts stopped
+  // intercepting `gbrain auth <subcommand> --help` before it reached
+  // runAuth. Without an early --help check inside runAuth itself, a
+  // trailing --help on a real subcommand fell through to that
+  // subcommand's real handler instead of showing help — e.g. `gbrain auth
+  // create foo --help` would mint a real token named "foo".
+  test('`gbrain auth create <name> --help` shows usage, does not create a token', () => {
+    const { stdout, status } = runCli(['auth', 'create', 'definitely-not-a-real-token-name', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('GBrain Token Management');
+    expect(stdout).not.toContain('Token created for');
+  });
+
+  test('`gbrain auth revoke <name> --help` shows usage, does not attempt a revoke', () => {
+    const { stdout, status } = runCli(['auth', 'revoke', 'definitely-not-a-real-token-name', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('GBrain Token Management');
+  });
+
+  test('`gbrain auth register-client <name> --help` shows usage, does not register a client', () => {
+    const { stdout, status } = runCli(['auth', 'register-client', 'definitely-not-a-real-client', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('GBrain Token Management');
+  });
+
+  test('-h works the same way as --help on a subcommand', () => {
+    const { stdout, status } = runCli(['auth', 'create', 'definitely-not-a-real-token-name', '-h']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('GBrain Token Management');
+    expect(stdout).not.toContain('Token created for');
+  });
+});
+
 describe('#3834 — extract flags are discoverable from both help surfaces', () => {
   const implementedFlags = [
     '--by-mention',


### PR DESCRIPTION
## Problem

`gbrain auth --help` prints a generic one-line stub instead of the real usage block. `-h` hits the same stub. `gbrain --help` at the top level never lists `auth` either, even though `init.ts`'s own error hints point operators at `gbrain auth register-client ...` when auth fails.

## Root cause

`src/cli.ts` routes `--help` for any `CLI_ONLY` command through a generic short-circuit (`printCliOnlyHelp`), unless the command is also listed in `CLI_ONLY_SELF_HELP`. `auth` was missing from that second set. `runAuth`'s own `default:` case in `src/commands/auth.ts` already prints a full usage block — `--help` matches no real subcommand name, so it falls through to `default` — but the short-circuit above intercepts the call before `runAuth` ever runs.

`gbrain auth` itself works fine. This is a `--help`-only routing gap, the same class of bug ~15 other `CLI_ONLY` commands (`capture`, `sync`, `schema`, `bootstrap`, ...) hit before, each fixed by adding the command to `CLI_ONLY_SELF_HELP`.

## Fix

- Add `auth` to `CLI_ONLY_SELF_HELP` in `src/cli.ts`, so `--help`/`-h` reaches `runAuth`.
- Add an `auth` entry to the top-level `gbrain --help` output, in the ADMIN section next to `connect` and `serve --http` — the other two commands touching the same token/OAuth surface.

## Tests

Added three cases to `test/cli-help-discoverability.test.ts`, the file already used for ~15 prior fixes of this exact bug class:
- `gbrain auth --help` reaches the real usage block, not the stub
- `gbrain auth -h` does too
- `gbrain --help` lists `auth`

Verified red→green: reverted the `src/cli.ts` change with the tests still in place, confirmed all three failed with the exact pre-fix symptom, restored the fix, confirmed all three pass.

Commands run:
```
bun test test/cli-help-discoverability.test.ts   # 16 pass, 0 fail
bun run verify                                    # 38/38 checks green (incl. typecheck)
bun run test                                      # 486 pass, 10 fail
```

The 10 `bun run test` failures are the same pre-existing PGLite/sources-ops flake I traced on my previous PR (#4081) — identical test names, identical `oom-rescue ... confirmed real` tag, unrelated files (`test/pglite-engine.test.ts`, `test/sources-ops.test.ts`). Reproduces on a clean, unmodified `upstream/master` checkout with none of this branch's changes applied.

## Limitations

Left the third complaint from the original report alone — comma-separated `--scopes` parsing. That one's already fixed by merged PR #3990 and works fine on current master.

Fixes #4003.