### PR TITLE
fix(ci): stop check-wasm-embedded.sh false-failing under pipefail

### DIFF
--- a/scripts/check-wasm-embedded.sh
+++ b/scripts/check-wasm-embedded.sh
@@ -50,21 +50,26 @@ OUTPUT="$("$OUT_BIN" 2>&1)"
 # - calculateScore by name: specific function that MUST appear as a
 #   top-level semantic node. If it's missing, the chunker either fell
 #   through to recursive or the TypeScript grammar didn't load.
-if ! echo "$OUTPUT" | grep -q '"has_symbol_names": true'; then
+# Plain bash substring tests, not `echo "$OUTPUT" | grep -q`: under
+# `set -o pipefail`, grep -q exits as soon as it finds a match and can
+# close its end of the pipe before echo finishes writing $OUTPUT, so
+# echo gets SIGPIPE and the pipeline's exit status goes non-zero even
+# though grep matched. False-fails the build. #3927.
+if [[ "$OUTPUT" != *'"has_symbol_names": true'* ]]; then
   echo "[check-wasm-embedded] FAIL: compiled binary returned no symbol names (fallback chunks)." >&2
   echo "[check-wasm-embedded] Output was:" >&2
   echo "$OUTPUT" >&2
   exit 1
 fi
 
-if ! echo "$OUTPUT" | grep -q '"has_typescript_header": true'; then
+if [[ "$OUTPUT" != *'"has_typescript_header": true'* ]]; then
   echo "[check-wasm-embedded] FAIL: chunk header missing TypeScript language tag." >&2
   echo "[check-wasm-embedded] Output was:" >&2
   echo "$OUTPUT" >&2
   exit 1
 fi
 
-if ! echo "$OUTPUT" | grep -q '"calculateScore"'; then
+if [[ "$OUTPUT" != *'"calculateScore"'* ]]; then
   echo "[check-wasm-embedded] FAIL: tree-sitter did not extract the calculateScore function symbol." >&2
   echo "[check-wasm-embedded] Output was:" >&2
   echo "$OUTPUT" >&2

--- a/test/scripts/check-wasm-embedded-pipefail.test.ts
+++ b/test/scripts/check-wasm-embedded-pipefail.test.ts
@@ -1,0 +1,45 @@
+/**
+ * #3927 — check-wasm-embedded.sh could false-fail under pipefail.
+ *
+ * `if ! echo "$OUTPUT" | grep -q '<pattern>'; then FAIL` runs under
+ * `set -euo pipefail`. grep -q exits as soon as it finds a match and
+ * can close its end of the pipe before echo finishes writing $OUTPUT;
+ * echo then gets SIGPIPE and the pipeline's exit status goes non-zero
+ * even though grep matched. Reproduced 50/50 by the issue reporter with
+ * a ~300KB payload.
+ *
+ * The fix is a plain bash substring test instead of a pipe, so this is
+ * a source-shape guard rather than an execution test: exercising the
+ * real script means a `bun build --compile` + binary run per check:wasm
+ * invocation, which is already covered (slowly) by `bun run check:all`
+ * and isn't worth duplicating here. This test just pins that the
+ * vulnerable pipe shape doesn't come back.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..', '..');
+const SCRIPT = resolve(REPO_ROOT, 'scripts', 'check-wasm-embedded.sh');
+
+describe('check-wasm-embedded.sh (#3927)', () => {
+  const source = readFileSync(SCRIPT, 'utf8');
+
+  it('still runs under set -euo pipefail', () => {
+    expect(source).toContain('set -euo pipefail');
+  });
+
+  it('does not pipe $OUTPUT through grep -q', () => {
+    // Matches the vulnerable invocation shape (grep -q with a quoted
+    // pattern argument), not this file's own explanatory comment above,
+    // which mentions the pattern without a trailing pattern argument.
+    expect(source).not.toMatch(/echo "\$OUTPUT"\s*\|\s*grep -q '/);
+  });
+
+  it('uses a plain bash substring test for each of the three checks', () => {
+    expect(source).toContain(`if [[ "$OUTPUT" != *'"has_symbol_names": true'* ]]; then`);
+    expect(source).toContain(`if [[ "$OUTPUT" != *'"has_typescript_header": true'* ]]; then`);
+    expect(source).toContain(`if [[ "$OUTPUT" != *'"calculateScore"'* ]]; then`);
+  });
+});

--- a/test/scripts/check-wasm-embedded-pipefail.test.ts
+++ b/test/scripts/check-wasm-embedded-pipefail.test.ts
@@ -31,10 +31,8 @@ describe('check-wasm-embedded.sh (#3927)', () => {
   });
 
   it('does not pipe $OUTPUT through grep -q', () => {
-    // Matches the vulnerable invocation shape (grep -q with a quoted
-    // pattern argument), not this file's own explanatory comment above,
-    // which mentions the pattern without a trailing pattern argument.
-    expect(source).not.toMatch(/echo "\$OUTPUT"\s*\|\s*grep -q '/);
+    // Match the vulnerable pipeline shape in live code (ignore commented examples).
+    expect(source).not.toMatch(/^[^\n#]*echo "\$OUTPUT"\s*\|\s*grep\s+-q\b/m);
   });
 
   it('uses a plain bash substring test for each of the three checks', () => {


### PR DESCRIPTION
## Problem

`check-wasm-embedded.sh` can fail the build even when the underlying check passes. Three of its guards pipe a captured `$OUTPUT` variable through `echo | grep -q` under `set -euo pipefail`.

## Root cause

grep -q exits the moment it finds a match and can close its end of the pipe before echo finishes writing $OUTPUT. echo then gets SIGPIPE, and under pipefail the pipeline's exit status becomes non-zero — even though grep matched. The `if ! ... ; then FAIL` wrapper reads that non-zero status as a real failure.

A maintainer bot (`time-attack`) reproduced this 50/50 with a ~300KB payload and confirmed it's a genuine false-fail, not a flaky test.

## Fix

Replaced the three `echo "$OUTPUT" | grep -q '<pattern>'` checks with plain bash substring tests (`[[ "$OUTPUT" != *'<pattern>'* ]]`). No subshell, no pipe, no SIGPIPE risk.

## Tests

Building the real smoketest binary (`bun build --compile`) per check:wasm run is slow and already covered by `bun run check:all`, so instead of duplicating that, added a source-shape regression test (`test/scripts/check-wasm-embedded-pipefail.test.ts`) that pins the fix: asserts the script still runs under `set -euo pipefail`, no longer pipes `$OUTPUT` through `grep -q`, and uses the three bash substring tests instead.

Verified red→green: reverted just the script change with the test in place, confirmed both relevant assertions failed against the pre-fix source, restored the fix, confirmed green. Also ran the real guard end to end.

Commands run:
```
bun test test/scripts/check-wasm-embedded-pipefail.test.ts   # 3 pass, 0 fail
bash -n scripts/check-wasm-embedded.sh                        # syntax OK
bun run check:wasm                                             # OK — real binary build + check
bun run verify                                                 # 38/38 checks green (incl. typecheck)
bun run test                                                   # 486 pass, 10 fail
```

The 10 `bun run test` failures are the same pre-existing PGLite/sources-ops flake I've traced on my two previous PRs in this repo (#4081, #4083) — identical test names, identical `oom-rescue ... confirmed real` tag, unrelated files. Reproduces on a clean, unmodified `upstream/master` checkout with none of this branch's changes applied.

## Limitations

Two sibling scripts (`scripts/check-image-decoders-embedded.sh`, `scripts/check-pglite-embedded.sh`) have the identical `echo | grep -q` pattern and are exposed to the same bug class. Left them alone — out of scope for this issue, which named only `check-wasm-embedded.sh`.

Fixes #3927.