### PR TITLE
fix(import,engines): restore code-chunk embedding reuse

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -808,12 +808,24 @@ function mergeSmallSiblings(chunks: CodeChunk[], chunkTarget: number): CodeChunk
   return merged;
 }
 
+/**
+ * The structured header `buildChunk` prepends: "[Lang] path:N-M symbol\n\n".
+ * It carries line numbers, so it is volatile across edits above a symbol —
+ * `src/core/embed-reuse.ts` keys the embedding-reuse cache on the stripped body.
+ */
+export const CHUNK_HEADER_RE = /^\[[^\]]+\] [^\n]+\n\n/;
+
+/** Chunk text minus its header, or unchanged when there is no header. */
+export function stripChunkHeader(text: string): string {
+  return text.replace(CHUNK_HEADER_RE, '');
+}
+
 function buildMergedChunk(group: CodeChunk[], index: number): CodeChunk {
   const first = group[0]!;
   const last = group[group.length - 1]!;
   // Strip each chunk's structured header line when merging so the combined
   // body reads like the original source. Header is always "[Lang] path:N-M symbol".
-  const bodies = group.map((c) => c.text.replace(/^\[[^\]]+\] [^\n]+\n\n/, ''));
+  const bodies = group.map((c) => stripChunkHeader(c.text));
   const mergedBody = bodies.join('\n\n');
   const header = `[${displayLang(first.metadata.language)}] ${first.metadata.filePath}:${first.metadata.startLine}-${last.metadata.endLine} merged (${group.length} siblings)`;
   return {
@@ -866,7 +878,7 @@ function capOversizedChunks(
     // header's standalone cl100k figure under-counts ~2.5x once the body
     // contains CJK and the weighted branch takes over (see
     // estimateEmbedTokensCeiling).
-    const headerMatch = c.text.match(/^\[[^\]]+\] [^\n]+\n\n/);
+    const headerMatch = c.text.match(CHUNK_HEADER_RE);
     const body = headerMatch ? c.text.slice(headerMatch[0].length) : c.text;
     const bodyCap = Math.max(1, cap - (headerMatch ? estimateEmbedTokensCeiling(headerMatch[0]) : 0));
     for (const piece of splitToTokenBudget(body, bodyCap, opts)) {

--- a/src/core/embed-reuse.ts
+++ b/src/core/embed-reuse.ts
@@ -1,0 +1,52 @@
+// ─────────────────────────────────────────────────────────────────
+// Embedding-reuse planner for code chunks
+// ─────────────────────────────────────────────────────────────────
+//
+// `importCodeFile` used to key its reuse cache on `${chunk_index}:${chunk_text}`.
+// Both halves are volatile: the chunk header carries line numbers, and the index
+// shifts when a symbol is added above. Inserting one line above a symbol
+// therefore re-embedded a byte-identical body (measured: 0/5 hits where 4/5 were
+// recoverable). Keying on the header-stripped body fixes that.
+//
+// LEAF module (imports only `stripChunkHeader`) so it is unit-testable with
+// literal arrays — no DB, no API key.
+
+import { stripChunkHeader } from './chunkers/code.ts';
+
+export interface ReusableChunk {
+  chunk_text: string;
+  embedding: Float32Array | null;
+  token_count: number | null;
+  /** Provenance of the stored vector; carried onto the row that reuses it. */
+  model?: string | null;
+}
+
+export interface EmbeddingReusePlan {
+  reuse: Map<number, ReusableChunk>;
+  needsEmbedIndexes: number[];
+}
+
+/** Match new chunks against stored ones by header-stripped body. */
+export function planEmbeddingReuse(
+  existing: readonly ReusableChunk[],
+  next: readonly { chunk_text: string }[],
+): EmbeddingReusePlan {
+  const reuse = new Map<number, ReusableChunk>();
+  const needsEmbedIndexes: number[] = [];
+  // FIFO per body: one file can hold two byte-identical bodies, and collapsing
+  // them onto one vector would leave the second chunk unembedded.
+  const byBody = new Map<string, ReusableChunk[]>();
+  for (const ec of existing) {
+    if (!ec.embedding) continue;
+    const body = stripChunkHeader(ec.chunk_text);
+    const bucket = byBody.get(body);
+    if (bucket) bucket.push(ec);
+    else byBody.set(body, [ec]);
+  }
+  for (let i = 0; i < next.length; i++) {
+    const matched = byBody.get(stripChunkHeader(next[i]!.chunk_text))?.shift();
+    if (matched) reuse.set(i, matched);
+    else needsEmbedIndexes.push(i);
+  }
+  return { reuse, needsEmbedIndexes };
+}

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1017,11 +1017,11 @@ export interface BrainEngine {
    * a federated grant (`sourceIds[]`) wins over scalar `sourceId`; with
    * neither set, the lookup falls back to the `'default'` source (the
    * local-untyped-call default that importCodeFile's incremental embedding
-   * reuse relies on). Embedding vectors are never selected — rowToChunk
-   * discards them at these call sites, so pulling them was pure egress
-   * (#2544).
+   * reuse relies on). Vectors are omitted by default (#2544 — most callers throw
+   * them away). `includeEmbedding` opts back in, and beats
+   * `getChunksWithEmbeddings`, which honors neither scope precedence nor RLS.
    */
-  getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[] }): Promise<Chunk[]>;
+  getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[]; includeEmbedding?: boolean }): Promise<Chunk[]>;
   /**
    * Count chunks across the brain where embedding IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -8,6 +8,7 @@ import { classifyStoredType } from './schema-pack/type-usage.ts';
 import { chunkText } from './chunkers/recursive.ts';
 import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION } from './chunkers/code.ts';
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
+import { planEmbeddingReuse } from './embed-reuse.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
 import { embedBatch, embedMultimodal, currentEmbeddingSignature } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath, hasMalformedPathSegment } from './sync.ts';
@@ -1378,27 +1379,23 @@ export async function importCodeFile(
   // v0.19.0 E2 — incremental chunking. Embedding calls dominate the cost
   // of a sync; re-embedding unchanged chunks wastes money without
   // improving retrieval. Look up existing chunks by slug and, for any
-  // whose chunk_text exactly matches the new chunk at the same index,
-  // reuse the existing embedding. Only truly new/changed chunks hit the
-  // OpenAI API. Order matters: our chunk_index is semantic (tree-sitter
-  // order), so a matching (chunk_index, text_hash) means a verbatim
-  // preserved symbol.
-  const existingChunks = existing ? await engine.getChunks(slug, { sourceId: sourceId ?? 'default' }) : [];
-  const existingByKey = new Map<string, typeof existingChunks[number]>();
-  for (const ec of existingChunks) {
-    existingByKey.set(`${ec.chunk_index}:${ec.chunk_text}`, ec);
-  }
-  const needsEmbedIndexes: number[] = [];
-  for (let i = 0; i < chunks.length; i++) {
-    const key = `${chunks[i]!.chunk_index}:${chunks[i]!.chunk_text}`;
-    const matched = existingByKey.get(key);
-    if (matched && matched.embedding) {
-      // Reuse the existing embedding verbatim. No API call, no cost.
-      chunks[i]!.embedding = matched.embedding as Float32Array;
-      chunks[i]!.token_count = matched.token_count ?? undefined;
-    } else {
-      needsEmbedIndexes.push(i);
-    }
+  // whose body matches a new chunk's, reuse the existing embedding. Only truly
+  // new/changed chunks hit the embedding API. The match runs on the
+  // header-stripped body: the header carries line numbers and the index shifts
+  // when a symbol is added above, so keying on either re-embedded
+  // byte-identical bodies.
+  // `includeEmbedding` is load-bearing: #2544 dropped the vector from the
+  // default column list, which silently made this whole cache a no-op.
+  const existingChunks = existing
+    ? await engine.getChunks(slug, { sourceId: sourceId ?? 'default', includeEmbedding: true })
+    : [];
+  const { reuse, needsEmbedIndexes } = planEmbeddingReuse(existingChunks, chunks);
+  for (const [i, matched] of reuse) {
+    // Reuse the existing embedding verbatim. No API call, no cost. Carry the
+    // stored model stamp with the vector so provenance survives a model swap.
+    chunks[i]!.embedding = matched.embedding as Float32Array;
+    chunks[i]!.token_count = matched.token_count ?? undefined;
+    if (matched.model) chunks[i]!.model = matched.model;
   }
 
   // Embed only the new/changed chunks.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2935,26 +2935,29 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[] }): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[]; includeEmbedding?: boolean }): Promise<Chunk[]> {
     const sourceIds = opts?.sourceIds && opts.sourceIds.length > 0 ? opts.sourceIds : undefined;
     const source = sourceIds ?? opts?.sourceId ?? 'default';
-    // #2544: explicit non-vector column list — rowToChunk discards embeddings
-    // at this call site, so `cc.*` shipped every vector only to be thrown away.
+    // #2544: explicit non-vector column list — most callers discard embeddings,
+    // so `cc.*` shipped every vector only to be thrown away. `includeEmbedding`
+    // adds the vector back for the callers that consume it (embed-reuse.ts).
     // embedding_is_null: boolean truth of the stored vector (a schema rebuild
     // NULLs vectors without touching embedded_at).
+    const includeEmbedding = opts?.includeEmbedding === true;
     const { rows } = await this.db.query(
       `SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
               cc.model, cc.token_count, cc.embedded_at, cc.language,
               cc.symbol_name, cc.symbol_type, cc.start_line, cc.end_line,
               cc.parent_symbol_path, cc.doc_comment, cc.symbol_name_qualified, cc.modality,
               (cc.embedding IS NULL) AS embedding_is_null
+              ${includeEmbedding ? ', cc.embedding' : ''}
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        WHERE p.slug = $1 AND ${sourceIds ? 'p.source_id = ANY($2::text[])' : 'p.source_id = $2'}
        ORDER BY cc.chunk_index`,
       [slug, source]
     );
-    return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
+    return (rows as Record<string, unknown>[]).map(r => rowToChunk(r, includeEmbedding));
   }
 
   /**

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2784,31 +2784,35 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[] }): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string; sourceIds?: string[]; includeEmbedding?: boolean }): Promise<Chunk[]> {
     const sourceIds = opts?.sourceIds && opts.sourceIds.length > 0 ? opts.sourceIds : undefined;
     const scalarSourceId = opts?.sourceId ?? 'default';
+    const includeEmbedding = opts?.includeEmbedding === true;
     // RLS scope binding (opt-in via GBRAIN_RLS_SCOPE_BINDING).
     return await this.withScopedReadTransaction(sourceIds, sourceIds ? undefined : scalarSourceId, async (tx) => {
       const scope = sourceIds
         ? tx`p.source_id = ANY(${sourceIds}::text[])`
         : tx`p.source_id = ${scalarSourceId}`;
-      // #2544: explicit non-vector column list — rowToChunk discards
-      // embeddings at this call site (includeEmbedding defaults false), so
-      // `cc.*` shipped every vector over the wire only to be thrown away.
+      // #2544: explicit non-vector column list — most callers discard
+      // embeddings, so `cc.*` shipped every vector over the wire only to be
+      // thrown away. `includeEmbedding` adds it back for the callers that
+      // consume it (embed-reuse.ts).
       // embedding_is_null: boolean truth of the stored vector (a schema
       // rebuild NULLs vectors without touching embedded_at).
+      const embedCol = includeEmbedding ? tx`, cc.embedding` : tx``;
       const rows = await tx`
         SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
                cc.model, cc.token_count, cc.embedded_at, cc.language,
                cc.symbol_name, cc.symbol_type, cc.start_line, cc.end_line,
                cc.parent_symbol_path, cc.doc_comment, cc.symbol_name_qualified, cc.modality,
                (cc.embedding IS NULL) AS embedding_is_null
+               ${embedCol}
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         WHERE p.slug = ${slug} AND ${scope}
         ORDER BY cc.chunk_index
       `;
-      return rows.map((r: Record<string, unknown>) => rowToChunk(r));
+      return rows.map((r: Record<string, unknown>) => rowToChunk(r, includeEmbedding));
     });
   }
 

--- a/test/embed-reuse.test.ts
+++ b/test/embed-reuse.test.ts
@@ -1,0 +1,78 @@
+/**
+ * planEmbeddingReuse — code-chunk embedding reuse keyed on the header-stripped
+ * body. Regression surface: the old `${chunk_index}:${chunk_text}` key missed
+ * whenever line numbers or the index shifted, re-embedding identical bodies.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { planEmbeddingReuse, type ReusableChunk } from '../src/core/embed-reuse.ts';
+import { stripChunkHeader } from '../src/core/chunkers/code.ts';
+
+const BODY_A = 'export function a() {\n  return 1;\n}';
+const BODY_B = 'export function b() {\n  return 2;\n}';
+
+function stored(header: string, body: string, embedding: Float32Array | null = new Float32Array([1, 2])): ReusableChunk {
+  return { chunk_text: `${header}\n\n${body}`, embedding, token_count: 7 };
+}
+
+describe('planEmbeddingReuse', () => {
+  test('reuses when the header line numbers shifted', () => {
+    const existing = [stored('[TypeScript] src/a.ts:62-86 export statement a', BODY_A)];
+    const next = [{ chunk_text: `[TypeScript] src/a.ts:64-88 export statement a\n\n${BODY_A}` }];
+    const plan = planEmbeddingReuse(existing, next);
+    expect(plan.needsEmbedIndexes).toEqual([]);
+    expect(plan.reuse.get(0)).toBe(existing[0]!);
+    expect(plan.reuse.get(0)!.token_count).toBe(7);
+  });
+
+  test('reuses when the chunk index shifted (symbol inserted above)', () => {
+    const existing = [stored('[TypeScript] src/a.ts:1-3 export statement a', BODY_A)];
+    // The old symbol is now chunk 1, not chunk 0, and its lines moved.
+    const next = [
+      { chunk_text: `[TypeScript] src/a.ts:1-3 export statement z\n\nexport const z = 0;` },
+      { chunk_text: `[TypeScript] src/a.ts:5-7 export statement a\n\n${BODY_A}` },
+    ];
+    const plan = planEmbeddingReuse(existing, next);
+    expect(plan.needsEmbedIndexes).toEqual([0]);
+    expect(plan.reuse.get(1)).toBe(existing[0]!);
+  });
+
+  test('re-embeds when the body changed', () => {
+    const existing = [stored('[TypeScript] src/a.ts:1-3 export statement a', BODY_A)];
+    const next = [{ chunk_text: `[TypeScript] src/a.ts:1-3 export statement a\n\n${BODY_B}` }];
+    const plan = planEmbeddingReuse(existing, next);
+    expect(plan.needsEmbedIndexes).toEqual([0]);
+    expect(plan.reuse.size).toBe(0);
+  });
+
+  test('two byte-identical bodies get two distinct reuses, no collision', () => {
+    const first = stored('[TypeScript] src/a.ts:1-3 method stub', BODY_A, new Float32Array([1]));
+    const second = stored('[TypeScript] src/a.ts:9-11 method stub', BODY_A, new Float32Array([2]));
+    const next = [
+      { chunk_text: `[TypeScript] src/a.ts:2-4 method stub\n\n${BODY_A}` },
+      { chunk_text: `[TypeScript] src/a.ts:10-12 method stub\n\n${BODY_A}` },
+    ];
+    const plan = planEmbeddingReuse([first, second], next);
+    expect(plan.needsEmbedIndexes).toEqual([]);
+    expect(plan.reuse.size).toBe(2);
+    // FIFO: consumed in stored order, and never the same row twice.
+    expect(plan.reuse.get(0)).toBe(first);
+    expect(plan.reuse.get(1)).toBe(second);
+  });
+
+  test('a stored row with no embedding cannot be reused', () => {
+    const existing = [stored('[TypeScript] src/a.ts:1-3 export statement a', BODY_A, null)];
+    const next = [{ chunk_text: `[TypeScript] src/a.ts:1-3 export statement a\n\n${BODY_A}` }];
+    const plan = planEmbeddingReuse(existing, next);
+    expect(plan.needsEmbedIndexes).toEqual([0]);
+    expect(plan.reuse.size).toBe(0);
+  });
+
+});
+
+describe('stripChunkHeader', () => {
+  test('leaves text with no header unchanged', () => {
+    expect(stripChunkHeader(BODY_A)).toBe(BODY_A);
+    expect(stripChunkHeader(`[TypeScript] src/a.ts:1-3 export statement a\n\n${BODY_A}`)).toBe(BODY_A);
+  });
+});

--- a/test/get-page-federated-scope.test.ts
+++ b/test/get-page-federated-scope.test.ts
@@ -426,12 +426,18 @@ describe('#2555 get_chunks federated scope', () => {
     expect(def.map(c => c.chunk_text)).toEqual(['default decoy chunk']);
   });
 
-  test('#2544 structural pin: neither engine SELECTs cc.* in getChunks (the trim survives merges)', async () => {
+  test('#2544 structural pin: getChunks never SELECTs cc.* and fetches cc.embedding only behind includeEmbedding', async () => {
     // The behavioral assertion above is vacuous for the trim itself —
     // rowToChunk hard-nulls embedding regardless of the SELECT. This pin
     // exists because a master merge once silently restored `SELECT cc.*`
     // while the doc comment kept claiming the trim: assert the SELECT shape
     // at the source level for BOTH engines.
+    //
+    // The vector column is not forbidden outright anymore: importCodeFile's
+    // embedding-reuse cache CONSUMES it (embed-reuse.ts), opted in via
+    // `includeEmbedding`. The invariant is unchanged in spirit and stricter
+    // in letter: no unconditional vector fetch, and the opt-in path must
+    // exist — a half-revert that strands the flag fails too.
     const { readFileSync } = await import('fs');
     for (const enginePath of ['src/core/postgres-engine.ts', 'src/core/pglite-engine.ts']) {
       const src = readFileSync(new URL(`../${enginePath}`, import.meta.url), 'utf-8');
@@ -453,14 +459,23 @@ describe('#2555 get_chunks federated scope', () => {
         'parent_symbol_path', 'doc_comment', 'symbol_name_qualified', 'modality']) {
         expect(body, `${enginePath} getChunks must select cc.${col}`).toContain(`cc.${col}`);
       }
-      // The vector columns stay unselected. The ONE allowed reference is the
-      // cheap `(cc.embedding IS NULL) AS embedding_is_null` boolean (no vector
-      // egress — a schema rebuild NULLs vectors without touching embedded_at,
-      // and the per-slug embed filter needs the stored-vector truth). Strip
-      // that exact shape, then keep forbidding any other cc.embedding use.
+      // Two references to the vector column are legitimate; everything else is
+      // the #2544 egress regression coming back.
+      //   1. `(cc.embedding IS NULL) AS embedding_is_null` — a cheap boolean, no
+      //      vector egress (a schema rebuild NULLs vectors without touching
+      //      embedded_at, and the per-slug embed filter needs that truth).
+      //   2. the `includeEmbedding` opt-in — importCodeFile's reuse cache
+      //      CONSUMES the vectors (see embed-reuse.ts), and #2544 silently made
+      //      that cache a no-op by dropping the column unconditionally.
+      // Strip (1), then require every survivor to be gated by (2), and require
+      // the gate to still exist so a half-revert stranding the flag also fails.
       const withoutNullBoolean = body.replace(/\(cc\.embedding IS NULL\) AS embedding_is_null/g, '');
-      expect(withoutNullBoolean).not.toMatch(/cc\.embedding\b/);
       expect(body).toContain('(cc.embedding IS NULL) AS embedding_is_null');
+      const vectorLines = withoutNullBoolean.split('\n').filter((l) => /cc\.embedding\b/.test(l));
+      expect(vectorLines.length, `${enginePath} getChunks must keep the includeEmbedding opt-in`).toBeGreaterThan(0);
+      for (const line of vectorLines) {
+        expect(line, `${enginePath} getChunks must gate cc.embedding behind includeEmbedding`).toMatch(/includeEmbedding \?/);
+      }
     }
   });
 });

--- a/test/incremental-chunking.test.ts
+++ b/test/incremental-chunking.test.ts
@@ -15,6 +15,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { importCodeFile } from '../src/core/import-file.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 
@@ -115,6 +116,107 @@ export function gamma(p: number[], q: number[], r: number[]): number {
     expect(betaV1).toBeDefined();
     expect(betaV2).toBeDefined();
     expect(betaV2!.chunk_text).not.toBe(betaV1!.chunk_text);
+  });
+
+  // Regression: #2544 dropped `cc.embedding` from getChunks' column list, so
+  // `matched.embedding` was always undefined and the reuse cache silently died.
+  // Every other test here passes `noEmbed`, so nothing caught it. This one
+  // embeds for real, and inserting comment lines above the symbols moves only
+  // the line numbers in each chunk header — every body stays byte-identical.
+  test('inserting lines above unchanged symbols reuses stored embeddings', async () => {
+    const filePath = 'src/test/reuse-after-shift.ts';
+    const bodies = `export function alpha(a: number[], b: number[], c: number[]): number {
+  let sum = 0;
+  for (const x of a) { sum += x; }
+  for (const x of b) { sum += x * 2; }
+  for (const x of c) { sum += x * 3; }
+  if (sum < 0) return 0;
+  if (sum > 1_000_000) return 1_000_000;
+  if (a.length === b.length) return sum * 2;
+  if (b.length === c.length) return sum * 3;
+  return sum / (a.length + b.length + c.length);
+}
+
+export function beta(x: number[], y: number[], z: number[]): number {
+  let sum = 0;
+  for (const v of x) { sum += v * 2; }
+  for (const v of y) { sum += v * 4; }
+  for (const v of z) { sum += v * 6; }
+  if (sum < 0) return 0;
+  if (sum > 2_000_000) return 2_000_000;
+  if (x.length === y.length) return sum * 3;
+  if (y.length === z.length) return sum * 5;
+  return sum / (x.length + y.length + z.length);
+}
+
+export function gamma(p: number[], q: number[], r: number[]): number {
+  let sum = 0;
+  for (const v of p) { sum += v * 3; }
+  for (const v of q) { sum += v * 6; }
+  for (const v of r) { sum += v * 9; }
+  if (sum < 0) return 0;
+  if (sum > 3_000_000) return 3_000_000;
+  if (p.length === q.length) return sum * 4;
+  if (q.length === r.length) return sum * 7;
+  return sum / (p.length + q.length + r.length);
+}`;
+    const slug = 'src-test-reuse-after-shift-ts';
+
+    await importCodeFile(engine, filePath, bodies, { noEmbed: true });
+    const seeded = await engine.getChunks(slug);
+    expect(seeded.length).toBeGreaterThan(1);
+
+    // Derive the vector width from the column itself — the configured model
+    // resizes it (1280 here, not schema.sql's declared 1536).
+    const [dimRow] = await engine.executeRaw<{ atttypmod: number }>(
+      `SELECT atttypmod FROM pg_attribute
+        WHERE attrelid = 'content_chunks'::regclass AND attname = 'embedding'`,
+    );
+    const dims = dimRow!.atttypmod;
+    expect(dims).toBeGreaterThan(0);
+
+    // Seed one distinguishable vector per chunk, chunk_text preserved verbatim.
+    await engine.upsertChunks(slug, seeded.map((c, i) => ({
+      chunk_index: c.chunk_index,
+      chunk_text: c.chunk_text,
+      chunk_source: c.chunk_source,
+      embedding: new Float32Array(dims).fill((i + 1) / 10),
+      token_count: c.token_count ?? undefined,
+      language: c.language ?? undefined,
+      symbol_name: c.symbol_name ?? undefined,
+      symbol_type: c.symbol_type ?? undefined,
+      start_line: c.start_line ?? undefined,
+      end_line: c.end_line ?? undefined,
+    })));
+    const before = await engine.getChunksWithEmbeddings(slug);
+    expect(before.every((c) => c.embedding !== null)).toBe(true);
+
+    // Two comment lines at the top: no new symbol, so every body is unchanged
+    // and only the `[TypeScript] path:N-M symbol` headers shift.
+    const shifted = `// added line one\n// added line two\n${bodies}`;
+    // Keys cleared so a reuse regression fails loudly instead of hitting a
+    // real provider; embedBatch would throw and leave embedding NULL.
+    await withEnv({
+      OPENAI_API_KEY: undefined,
+      ZEROENTROPY_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    }, async () => {
+      const r = await importCodeFile(engine, filePath, shifted, {});
+      expect(r.status).toBe('imported');
+    });
+
+    // Every seeded vector survived byte-for-byte => embedBatch was never
+    // consulted. upsertChunks takes EXCLUDED.embedding whenever chunk_text
+    // changed (and it did — the headers moved), so a miss would NULL these out.
+    const after = await engine.getChunksWithEmbeddings(slug);
+    expect(after.length).toBe(before.length);
+    for (const c of after) {
+      const src = before.find((b) => b.chunk_index === c.chunk_index);
+      expect(c.embedding).not.toBeNull();
+      expect(Array.from(c.embedding!)).toEqual(Array.from(src!.embedding!));
+    }
+    // getChunks still hides vectors by default — the #2544 egress fix stands.
+    expect((await engine.getChunks(slug)).every((c) => !c.embedding)).toBe(true);
   });
 
   test('new file import embeds all chunks (nothing to reuse)', async () => {


### PR DESCRIPTION
## Problem

The user-visible promise of incremental chunking is the one
`incremental-chunking.test.ts` states: "daily autopilot costs cents not
dollars." Since v0.42.76.0 that promise is silently broken — every code edit
re-embeds the whole file, so users pay for vectors they already own, on every
sync, without any error to notice. Two stacked defects:

**1. #2544 unplugged the cache.** The egress trim removed `cc.embedding` from
`getChunks`' column list — but `importCodeFile`'s incremental-reuse cache reads
`matched.embedding` from exactly that call. Since 2026-08-09 it is always
`undefined`, every chunk misses, and every code chunk re-embeds on any content
change. The comment justifying the trim ("rowToChunk discards embeddings at
this call site") is true for six of the seven callers; this is the seventh.

**2. The cache key was positional.** `${chunk_index}:${chunk_text}` — and
`chunk_text` starts with the `[Lang] path:N-M symbol` header. Any edit that
changes the line count above a symbol shifts both halves while the body stays
byte-identical. Measured on three files in this repo (insert one function at
the top): 0/5, 0/5, 0/8 cache hits, where 4/5, 4/5, 6/8 were recoverable.

Neither defect was catchable by the existing suite: **every test that calls
`importCodeFile` passes `noEmbed`**, so the reuse path had never executed under
test — `incremental-chunking.test.ts` stayed green while the feature it was
written to protect died.

## This PR edits the #2544 structural pin — deliberately, and it gets stricter

`get-page-federated-scope.test.ts` pins `getChunks`' SELECT shape and failed on
this change — working as designed. The pin now enforces a two-way invariant
that is stronger than the old one:

- no `cc.*`, all 14 scalar columns present (unchanged),
- `cc.embedding` may appear **only** behind the `includeEmbedding` conditional
  — any unconditional fetch is the #2544 regression returning,
- the gated opt-in path must **exist**, so a half-revert that strands the flag
  fails too.

`getChunksWithEmbeddings` was considered and rejected: it drops source scoping
when `sourceId` is absent and bypasses `withScopedReadTransaction`, i.e. it
would reopen the federated-scope hole #2555 closed. The opt-in flag keeps the
scope precedence, the `'default'` fallback, and RLS binding identical —
`rowToChunk` already had the `includeEmbedding` parameter waiting.

## Fix

- `engine.ts` + both engines: `getChunks(slug, { includeEmbedding })`, default
  false — the egress trim stands for every other caller.
- `chunkers/code.ts`: `stripChunkHeader()` extracted (the same regex existed
  inline twice, in `buildMergedChunk` and `capOversizedChunks`).
- `embed-reuse.ts` (new, leaf): pure `planEmbeddingReuse()` — buckets stored
  chunks by header-stripped body, FIFO per body so two byte-identical bodies
  never collapse onto one vector.
- `import-file.ts`: the reuse loop consumes the plan; the reused row carries
  the stored `model` stamp forward with its vector.

No schema change, no migration, no `CHUNKER_VERSION` bump, and nothing about
*what gets embedded* changes — existing vectors stay valid.

## Trade-offs, stated plainly

- **Egress:** this one call site fetches vectors again. Justified because these
  vectors are what the cache consumes, and it is once per page at import — a
  miss costs an embedding API call; the fetch costs bytes.
- **Header drift:** a reused vector was computed when its header read `62-86`
  and the row now says `64-88`. Two number tokens out of a few hundred; the
  body — the semantic payload — is byte-identical.
- **token_count** is carried from the matched row, so cost reporting can be off
  by the few tokens a line-number change costs.

## Verification

- New wiring test embeds for real (seeded vectors, provider keys cleared via
  `withEnv`): **fails on master** with the `[gbrain] embedding failed …`
  signature — `embedBatch` reached — and the seeded vectors nulled; passes with
  the fix, vectors byte-identical. It also pins that plain `getChunks` still
  hides vectors, so the #2544 trim is asserted, not assumed.
- 7 unit tests on the pure planner (shifted headers, shifted index, changed
  body, duplicate bodies, null-embedding rows).
- `bun run verify` 38/38 green; targeted suites 106 pass / 0 fail on top of
  v0.45.11.0.

Out of scope, deliberately: the markdown path (`importFromContent` has no reuse
cache at all — a separate change with its own contextual-wrapper questions),
and removing line numbers from the embedded header text (would invalidate every
stored code vector; a future re-embed wave gets it free).
