### PR TITLE
v0.45.12.0 docs(claude-md): route per-file detail to KEY_FILES.md in the post-ship checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,7 +694,14 @@ before considering the ship complete.
 
 Files that MUST be checked on every ship:
 - README.md — does it reflect new features, commands, or setup steps?
-- CLAUDE.md — does it reflect new files, test files, or architecture changes?
+- `docs/architecture/KEY_FILES.md` — new or changed files in `src/`, and their
+  invariants, are recorded HERE. This is the on-demand layer behind the Reference
+  map, and it is where per-file and per-version detail belongs.
+- CLAUDE.md — only if an always-loaded rule, the Reference map, or the dispatcher
+  changed. **CLAUDE.md is a map, not a log**: it is read in full at the start of every
+  session, so entries are condensed or deleted as they go stale, never appended to.
+  If an update adds a file inventory, a test inventory, or an "as of vX.Y.Z" note,
+  it belongs in the on-demand layer above instead.
 - CHANGELOG.md — does it cover every commit?
 - TODOS.md — are completed items marked done?
 - docs/ — do any guides need updating?


### PR DESCRIPTION
## What

One bullet in **Post-ship requirements (MANDATORY)** currently reads:

> - CLAUDE.md — does it reflect new files, test files, or architecture changes?

This PR routes that detail to `docs/architecture/KEY_FILES.md` and states explicitly that CLAUDE.md is a map rather than a log.

## Why

The Reference-map refactor already moved per-file and per-version detail out of CLAUDE.md and into `KEY_FILES.md`, behind the on-demand layer. The post-ship checklist was never updated to match — so on every ship it still directs `/document-release` to record new files, test files, and architecture changes **in the always-loaded file**.

That is the append-only pressure, and it is measurable. On an older checkout (v0.18.2) CLAUDE.md had grown to **67,278 bytes**, of which:

| | |
|---|---|
| "Key files" — 121 entries | 28,620 bytes (43%) |
| …of that, trailing `As of v0.X.Y…` detail | **17,713 bytes (62% of the section)** |
| "Testing" — test-file inventory | 10,056 bytes, naming **56** test files while **128** existed on disk |

Every identifier I sampled from that trailing detail (`addLinksBatch`, `tryParseEmbedding`, `statement_timeout`, `max_stalled`, `rate-leases`, `DRY_PROXIMITY`) already appeared in `CHANGELOG.md`, usually more often — CLAUDE.md held the unversioned second copy, so it was the one that drifted. The test inventory had drifted too: a list that names 56 of 128 files reads as "coverage does not exist" when it does.

Current master is much healthier at 50,369 bytes, precisely because the Reference map moved that material out. The concern is only that the instruction which produced the 67KB version is still in place and still aimed at CLAUDE.md, so the growth recurs.

The asymmetry is the whole argument: **CLAUDE.md is read in full at the start of every session; `KEY_FILES.md` is read only when someone is working in `src/`.** Detail that grows without bound belongs on the on-demand side of that line — which is exactly what the Reference map already established.

## Scope

Docs only. One bullet becomes two, in `CLAUDE.md`. No code, no schema, no tests, no behavior change. The MANDATORY post-ship gate itself is unchanged — this only redirects *where* each kind of update lands.