### PR TITLE
fix(config): route vendor *_api_key writes to the file plane

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -29,6 +29,31 @@ export function isSensitiveConfigKey(key: string): boolean {
   return /(^|[._-])(key|secret|token|password|pwd|passwd|auth)([._-]|$)/.test(lower);
 }
 
+/**
+ * Vendor credential keys that `buildGatewayConfig` folds into the gateway env.
+ * That seam reads the FILE plane (~/.gbrain/config.json) plus process.env and
+ * never the DB plane, so `config set <vendor>_api_key` must not write the DB:
+ * it would report success, `config get` would read it straight back, and every
+ * provider call would still fail "requires <VENDOR>_API_KEY".
+ *
+ * Same bug class the v0.37.11.0 wave closed for embedding_model. That field
+ * could only be fixed by refusing, because changing it needs a wipe-and-reinit.
+ * A credential carries no such constraint, so the honest fix is to route the
+ * write to the plane the consumer actually reads.
+ *
+ * Keep in sync with the `envFromConfig` mappings in
+ * src/core/ai/build-gateway-config.ts.
+ */
+export const FILE_PLANE_API_KEYS: readonly string[] = [
+  'openai_api_key',
+  'anthropic_api_key',
+  'zeroentropy_api_key',
+  'openrouter_api_key',
+  'voyage_api_key',
+  'dashscope_api_key',
+  'google_api_key',
+];
+
 export function redactConfigValue(key: string, value: string): string {
   if (value.includes('postgresql://')) return redactUrl(value);
   if (isSensitiveConfigKey(key)) return '***';
@@ -99,6 +124,19 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
       if (cfg && branch && leaf in branch) {
         delete branch[leaf];
         saveConfig(cfg);
+        console.log(`Unset ${key} (file plane)`);
+      } else {
+        console.error(`Config key not found: ${key}`);
+        process.exit(1);
+      }
+      return;
+    }
+    if (FILE_PLANE_API_KEYS.includes(key)) {
+      const { loadConfigFileOnly, saveConfig } = await import('../core/config.ts');
+      const cfg = loadConfigFileOnly() as unknown as Record<string, unknown> | null;
+      if (cfg && key in cfg) {
+        delete cfg[key];
+        saveConfig(cfg as unknown as Parameters<typeof saveConfig>[0]);
         console.log(`Unset ${key} (file plane)`);
       } else {
         console.error(`Config key not found: ${key}`);
@@ -183,6 +221,19 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
       }
       return;
     }
+    // Vendor credentials are file-plane canonical (see FILE_PLANE_API_KEYS).
+    // Routed, not refused: unlike embedding_model there is nothing to re-init,
+    // so the user's intent is satisfiable exactly as typed.
+    if (FILE_PLANE_API_KEYS.includes(key)) {
+      const { loadConfigFileOnly, saveConfig } = await import('../core/config.ts');
+      const cfg = (loadConfigFileOnly() ?? { engine: 'pglite' }) as Parameters<typeof saveConfig>[0];
+      (cfg as unknown as Record<string, unknown>)[key] = value;
+      saveConfig(cfg);
+      // #892: redact — the raw secret must not reach scrollback or shell history.
+      console.log(`Set ${key} = ${redactConfigValue(key, value)} (file plane: ~/.gbrain/config.json)`);
+      return;
+    }
+
     // v0.37.11.0 fix wave (Lane C.2 + CDX2-13): refuse writes to schema-sizing
     // fields unconditionally. These fields size the `content_chunks.embedding`
     // column at init time and are file-plane canonical. `gbrain config set

--- a/test/config-file-plane-keys.test.ts
+++ b/test/config-file-plane-keys.test.ts
@@ -69,3 +69,77 @@ describe('config set — file-plane bootstrap hook-lane keys [D18]', () => {
     });
   });
 });
+
+/**
+ * Vendor API keys are FILE-plane canonical too.
+ *
+ * `buildGatewayConfig` folds credentials into the gateway env from the file
+ * plane (config.json) + process env ONLY — it never reads the DB plane. So
+ * `gbrain config set openai_api_key sk-...` writing the DB was a silent
+ * no-op: it printed "Set openai_api_key = ***", exited 0, and `config get`
+ * read it straight back, while every provider call still failed with
+ * "requires OPENAI_API_KEY".
+ *
+ * This is the same bug class the v0.37.11.0 wave closed for embedding_model
+ * ("writes the DB plane, which the embed pipeline never reads — silent lie
+ * that took users hours to diagnose"). embedding_model can only be fixed by
+ * refusing, since changing it needs a wipe-and-reinit. A credential has no
+ * such constraint, so the better fix is to route the write to the plane the
+ * consumer actually reads.
+ *
+ * A null engine is the discriminator: the file-plane branch must return
+ * before any DB access, so these pass only if nothing reaches the engine.
+ */
+const GATEWAY_MAPPED_KEYS = [
+  'openai_api_key',
+  'anthropic_api_key',
+  'zeroentropy_api_key',
+  'openrouter_api_key',
+  'voyage_api_key',
+  'dashscope_api_key',
+  'google_api_key',
+] as const;
+
+describe('config set — vendor API keys are FILE-plane canonical', () => {
+  test('openai_api_key lands in config.json, is redacted in output, and never touches the engine', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'gb-cfg-apikey-'));
+    await withEnv({ GBRAIN_HOME: parent }, async () => {
+      const out = await captureLog(() => runConfig(noEngine, ['set', 'openai_api_key', 'sk-TEST-VALUE-123']));
+      expect(out).toContain('file plane');
+      // #892: the raw secret must never reach stdout/scrollback.
+      expect(out).not.toContain('sk-TEST-VALUE-123');
+      expect(out).toContain('***');
+
+      const cfgPath = join(parent, '.gbrain', 'config.json');
+      const cfg = JSON.parse(readFileSync(cfgPath, 'utf8')) as { openai_api_key?: string };
+      expect(cfg.openai_api_key).toBe('sk-TEST-VALUE-123');
+    });
+  });
+
+  test('every gateway-mapped vendor key routes to the file plane', async () => {
+    for (const key of GATEWAY_MAPPED_KEYS) {
+      const parent = mkdtempSync(join(tmpdir(), 'gb-cfg-apikey-all-'));
+      await withEnv({ GBRAIN_HOME: parent }, async () => {
+        await captureLog(() => runConfig(noEngine, ['set', key, `secret-for-${key}`]));
+        const cfgPath = join(parent, '.gbrain', 'config.json');
+        const cfg = JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>;
+        expect(cfg[key]).toBe(`secret-for-${key}`);
+      });
+    }
+  });
+
+  test('unset removes the key from the file plane, so set/unset round-trip on one plane', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'gb-cfg-apikey-unset-'));
+    await withEnv({ GBRAIN_HOME: parent }, async () => {
+      await captureLog(() => runConfig(noEngine, ['set', 'openai_api_key', 'sk-TO-BE-REMOVED']));
+      const cfgPath = join(parent, '.gbrain', 'config.json');
+      expect((JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>).openai_api_key)
+        .toBe('sk-TO-BE-REMOVED');
+
+      const out = await captureLog(() => runConfig(noEngine, ['unset', 'openai_api_key']));
+      expect(out).toContain('file plane');
+      expect((JSON.parse(readFileSync(cfgPath, 'utf8')) as Record<string, unknown>).openai_api_key)
+        .toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## The bug

`gbrain config set openai_api_key sk-...` writes the **DB plane**. The gateway never reads it.

`buildGatewayConfig` (`src/core/ai/build-gateway-config.ts`) folds vendor credentials into the
gateway env from the **file plane** (`~/.gbrain/config.json`) plus `process.env` — and nothing
else. So the documented way to set a credential is a silent no-op:

```
$ gbrain config set openai_api_key sk-real-key
Set openai_api_key = ***          # exit 0

$ gbrain config get openai_api_key
sk-real-key                       # reads straight back

$ gbrain embed ...
Error: ... requires OPENAI_API_KEY
```

The feedback loop actively misleads. `config get` resolves file-plane-first and then falls through
to the DB, so a key that is in the wrong plane looks identical to a key that is in the right one.
Nothing on any surface names which plane you are looking at, so there is no way to tell a working
setup from a broken one without making a real provider call and reading the failure.

## Why route rather than refuse

This is the same bug class the **v0.37.11.0** wave closed for `embedding_model` — "writes the DB
plane, which the embed pipeline never reads." That field was fixed by refusing the write outright,
and correctly so: `embedding_model` sizes the `content_chunks.embedding` column at init time, so
changing it after the fact needs a wipe-and-reinit. Refusal is the only honest answer there.

A credential carries no such constraint. There is nothing to re-initialize and nothing to
invalidate, so the user's intent is satisfiable exactly as typed. Refusing would teach the same
lesson at the same cost for no benefit. This PR routes the write to the plane the consumer
actually reads.

## The change

`src/commands/config.ts`

- New exported `FILE_PLANE_API_KEYS` — the seven gateway-mapped vendor keys.
- `set` routes those keys to `~/.gbrain/config.json` and prints the destination plane explicitly:
  `Set openai_api_key = *** (file plane: ~/.gbrain/config.json)`.
- `unset` routes the same way, so `set`/`unset` round-trip on **one** plane instead of leaving an
  orphan DB row behind.
- `get` already resolved file-plane-first and is unchanged.
- Output stays redacted through the existing `redactConfigValue`, preserving **#892** — the raw
  secret never reaches scrollback or shell history.

The `set` branch sits immediately above the v0.37.11.0 `embedding_model` refusal, so the two
plane-correctness rules read together.

### Keeping the list honest

`FILE_PLANE_API_KEYS` must stay in sync with the `envFromConfig` mappings in
`build-gateway-config.ts`; the doc comment says so at the definition. As of this commit the seven
entries are **exactly** the `c.*_api_key` reads that file makes — verified, not assumed:

| `FILE_PLANE_API_KEYS` | `build-gateway-config.ts` | → gateway env |
|---|---|---|
| `openai_api_key` | :29 | `OPENAI_API_KEY` |
| `anthropic_api_key` | :30 | `ANTHROPIC_API_KEY` |
| `zeroentropy_api_key` | :36 | `ZEROENTROPY_API_KEY` |
| `openrouter_api_key` | :40 | `OPENROUTER_API_KEY` |
| `voyage_api_key` | :46 | `VOYAGE_API_KEY` |
| `dashscope_api_key` | :52 | `DASHSCOPE_API_KEY` |
| `google_api_key` | :58 | `GOOGLE_GENERATIVE_AI_API_KEY` |

There are no other `c.*_api_key` reads in that file, so the list has no gaps today. If a
maintainer prefers this derived from a single shared constant rather than duplicated, say the word
— happy to refactor it that way instead.

## Tests

`test/config-file-plane-keys.test.ts` — 3 tests appended to the existing file:

1. `openai_api_key` lands in `config.json`, output is redacted, engine untouched.
2. All seven gateway-mapped keys route to the file plane.
3. `unset` removes the key from the file plane — set/unset round-trip on one plane.

**A null engine is the discriminator.** The file-plane branch must return before any DB access, so
these pass only if nothing reaches the engine — a fix that wrote both planes would still fail them.

Confirmed failing for the right reason before the fix: 3 failures at `config.ts` `engine.setConfig`,
i.e. reaching the DB. Tests use `withEnv()` and touch no process-global state (isolation rules R1–R4).

## Verification

- `bun run verify` — **38/38 checks green** (includes typecheck).
- `bun run test` — full parallel unit suite: **17,726 pass / 6 fail**. All six fail identically on
  `master` (`1ec6a6e8`) with this branch checked out or not, so none are introduced here:
  `volunteer-events-delivery` (7/1), `retrieval-reflex` (21/1), `frontmatter-validate-slug-565`
  (2/1) and `doctor` (29/56) reproduce byte-for-byte on master; `sync-all-parallel` passes alone
  (17/0) and only fails under the parallel shard, i.e. cross-file isolation; `build-llms` fails
  solely because of a local uncommitted edit to `CLAUDE.md`, which `scripts/llms-config.ts` folds
  into the bundle — 12/0 with that edit removed. No config test fails.
- Confirmed against the **real CLI**, not only unit tests: the value lands in `config.json` and the
  output names the plane.
- Confirmed the original bug **empirically**, which reading the code could not settle — `cli.ts`
  re-merges the DB plane after connect, so static inspection is genuinely ambiguous about which
  plane wins. The discriminator is a live provider call: a fake key set via `config set` fails
  `requires OPENAI_API_KEY` (never reached the gateway), while the same fake key placed in
  `config.json` fails `Incorrect API key provided: sk-FAKE-…` (reached the gateway and was
  rejected by OpenAI). Two different failures, one plane apart.

**Not verified:** E2E (`bun run test:e2e`) was not run — no `DATABASE_URL` / Docker Postgres on this
machine. The change is DB-free by construction (its whole point is returning before engine access),
but I have not run that tier and am not claiming it.

Developed against **v0.45.9.0**; not tested against other versions.
