### PR TITLE
fix(path-confine): use the OS separator in the containment check

### DIFF
--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -20,7 +20,7 @@
  */
 
 import { realpathSync, existsSync, type Stats } from 'fs';
-import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join } from 'path';
+import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join, sep } from 'path';
 
 /**
  * Symlink-safe path confinement: realpath BOTH sides, then a separator-aware
@@ -41,8 +41,10 @@ export function isPathContained(child: string, parent: string): boolean {
   } catch {
     return false; // missing / unresolvable path → not contained
   }
-  // Append a separator so /foo doesn't match /foobar.
-  const parentWithSep = resolvedParent.endsWith('/') ? resolvedParent : resolvedParent + '/';
+  // Append the OS separator so /foo doesn't match /foobar. `sep`, not a
+  // hardcoded '/': realpathSync returns backslash paths on Windows, so a '/'
+  // suffix would make the prefix test fail for every real subdirectory.
+  const parentWithSep = resolvedParent.endsWith(sep) ? resolvedParent : resolvedParent + sep;
   return resolvedChild === resolvedParent || resolvedChild.startsWith(parentWithSep);
 }
 

--- a/test/path-confine.test.ts
+++ b/test/path-confine.test.ts
@@ -122,6 +122,22 @@ describe('isPathContained', () => {
     mkdirSync(sub);
     expect(isPathContained(sub, dir)).toBe(true);
   });
+  test('containment uses the OS separator, not a hardcoded "/"', () => {
+    // The boundary check appended '/' unconditionally. realpathSync returns
+    // backslash paths on Windows, so no real child ever matched the
+    // 'C:\\...\\parent/' prefix and every containment check returned false —
+    // which made the skills-dir auto-detector miss a skills/ directory that
+    // was present. Exercised through the public API with OS-native paths.
+    const dir = scratch();
+    const nested = join(dir, 'a', 'b');
+    mkdirSync(nested, { recursive: true });
+    expect(isPathContained(nested, dir)).toBe(true);
+    expect(isPathContained(nested, join(dir, 'a'))).toBe(true);
+    // The separator must remain a real boundary, not a bare string prefix.
+    const sibling = join(dir, 'a-sibling');
+    mkdirSync(sibling);
+    expect(isPathContained(sibling, join(dir, 'a'))).toBe(false);
+  });
   test('symlink escaping the parent is NOT contained', () => {
     const dir = scratch();
     const outside = scratch('pc-outside-');


### PR DESCRIPTION
Closes #3643

## Summary

On Windows, `gbrain doctor` reports `[WARN] resolver_health → Could not find skills directory` for a `skills/` directory that is present and readable, as reported in #3643.

`isPathContained` appends a separator to the resolved parent before the prefix test, so `/foo` cannot match `/foobar`. That separator was a hardcoded `'/'`. `realpathSync` returns backslash paths on Windows, so the probe string becomes `C:\dir/` and `resolvedChild.startsWith(...)` is false for **every** real subdirectory. The function is fail-closed, so the miss is silent — callers see "not contained" rather than an error.

Because `autoDetectSkillsDir` runs each of its tiers through `isPathContained`, every tier fails, including `cwd_walk_up` — which is why the directory is never found.

The fix is `path.sep` in place of the literal:

```ts
const parentWithSep = resolvedParent.endsWith(sep) ? resolvedParent : resolvedParent + sep;
```

On POSIX `sep` is `'/'`, so this is a no-op on Linux and macOS.

## Design decisions

- **`sep` alone, not `endsWith('/') || endsWith(sep)`.** #3643 suggested testing both. On Windows `realpathSync` returns no forward slashes at all (verified on this machine: `realpath` of a temp dir is `C:\Users\...\Temp\sepchk-SW08fg`, `.includes('/')` is `false`), and on POSIX `sep === '/'` makes the second test redundant. One condition covers both platforms.
- Using `sep` also fixes the drive-root case for free: `C:\` already ends with the separator, so it is not doubled to `C:\\`.

## What is deliberately unchanged

- **The containment semantics and the threat model.** This is a security boundary — it realpaths both sides so a `parent/skills → /etc` symlink cannot escape. Both sides are still realpath'd, the boundary is still a separator-terminated prefix test, and the function is still fail-closed on any unresolvable path. Only the separator character changes.
- **`isWriteTargetContained` was not switched over.** It already solves the same problem a different way (`path.relative` + `..`/absolute rejection). Unifying the two is a refactor of a security check, not a bug fix, so it is out of scope here.
- **Linux behaviour.** `sep === '/'` on POSIX, so the compiled comparison is identical.

## Testing

All numbers below are from `bun test` on native Windows 11 (bun 1.3.14), the platform the bug is specific to.

**Fail-before.** The bug already breaks a test that exists on `master` — `isPathContained > real subdir is contained`, which creates a real subdirectory and asserts containment:

```
error: expect(received).toBe(expected)
Expected: true
Received: false
      at test/path-confine.test.ts:123:39
(fail) isPathContained > real subdir is contained
```

**Pass-after, across every test file that exercises `isPathContained`** (`path-confine`, `sources-ops`, `repo-root`, `claude-code-jsonl`, `bootstrap-uninstall.serial`):

| | tests | pass | fail |
|---|---|---|---|
| `master` | 153 | 98 | 55 |
| this branch | 154 | 121 | 33 |

+23 passing, of which 1 is the regression test added here — so **22 tests that fail on `master` pass on this branch, and no test that passed now fails.** The repaired tests are concentrated in the skills-dir detector and the uninstall containment guard, e.g. `findRepoRoot > auto-detect: cwd has ./skills directory → cwd_walk_up tier (v0.33)` and `uninstallWorkspace > removes exactly receipt.created_paths; ...`.

`tsc --noEmit` exits 0 with no output.

**The 33 remaining failures are pre-existing and unrelated — I am not claiming this PR fixes them.** I diffed the failure names with and without the change and they are name-identical. They are Windows environment limitations, not logic bugs: the tests call `symlinkSync`, which needs Administrator or Developer Mode on Windows, so they fail with `EPERM: operation not permitted, symlink` before reaching any assertion. Several sibling tests already guard this class with `if (typeof process.getuid !== 'function') return;`; the ones that fail are the positive cases that carry no such guard. That looks like a real second Windows gap, but it is a different defect from #3643 and I have left it alone rather than widen this PR.

## Scope notes and limitations

- **The reported symptom was verified by code path, not by running `gbrain doctor` end to end.** Reproducing the exact `[WARN] resolver_health` line needs an initialized brain; I confirmed instead that `isPathContained` returns `false` for a genuine parent/child pair on Windows, and that `autoDetectSkillsDir`'s tiers route through it — which the 13 repaired `findRepoRoot` auto-detect tests demonstrate directly.
- **I could not run the full suite or `bun run verify`.** Both dispatch through `bash scripts/*.sh`; I ran the five affected test files directly instead, plus `tsc`. CI is the authority for the rest.
- **No Linux or macOS run.** I have Windows only. The change is a no-op on POSIX by construction (`sep === '/'`), but that claim rests on the constant, not on an execution I performed.
- CI will not exercise the fixed path: `test.yml`, `e2e.yml` and `heavy-tests.yml` all run on `ubuntu-latest`, and `release.yml`'s matrix is `ubuntu-latest` + `macos-latest`, so there is no Windows runner to catch this class. That is also why the bug survived — the assertion is correct on the platform CI runs.
