### PR TITLE
fix(bootstrap): enforce same-turn memory writeback

### DIFF
--- a/skills/_AGENT_README.md
+++ b/skills/_AGENT_README.md
@@ -50,6 +50,25 @@ carries the disambiguation rules for overlapping matches. If the two disagree,
 frontmatter wins. (There is no machine-managed block inside `RESOLVER.md` or
 `AGENTS.md`; that pattern was retired.)
 
+## The always-on memory loop
+
+Routing a requested skill is only half the job. On every inbound message,
+apply the bundled `signal-detector` contract directly (or through a host-native
+background lane when the user has authorized delegation), then close the turn
+with same-turn write-back:
+
+1. Read relevant entity/project context before answering.
+2. Detect durable new facts, preferences, decisions, commitments, relationships,
+   and original thinking in the user's message and in the resulting discussion.
+3. Write atomic facts with GBrain's `remember` verb and explicit provenance.
+   Route richer knowledge through `brain-ops` (`put_page`, timeline, links).
+4. Verify with `recall`, `entity`, or `get_page` before claiming the write landed.
+
+Context injection is read-side automation; it does not, by itself, capture what
+the agent just learned. A turn that learned something durable and recorded
+nothing is incomplete. Skip only transient logistics, acknowledgments, and facts
+already verified as present.
+
 ## When the user invokes a skill
 
 Read the entire `skills/<slug>/SKILL.md` file. Follow its `## Phases`,

--- a/skills/skills.lock.json
+++ b/skills/skills.lock.json
@@ -1,6 +1,6 @@
 {
   "RESOLVER.md": "3d32ec5cd8c15d83b18469277a5efc269bb6b60e67f4542de5a28a76760c36cd",
-  "_AGENT_README.md": "62613f7f1e061576b6c1b18844f59bd35f2df96ca5c45c8c41fae0772b9ce4d3",
+  "_AGENT_README.md": "cd61adb06fcd93928e4b565e14430b88cfe6879c57536ff6d15c3cad2f27a92f",
   "_brain-filing-rules.json": "cf850df6a7425464c6d63b3ace71991cc93497fa0cc8cd21acd31883e17939c6",
   "_brain-filing-rules.md": "2d2d75b7c76081c56f41b2c0a5a978c355ce957300f9b0a5575dc4079ef1f877",
   "_friction-protocol.md": "51353207240142024ff1facc25f225712275ecdb4a034ffffdd83740c8d328e3",

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -75,6 +75,7 @@ import {
   type StatusReport,
 } from '../core/bootstrap/status.ts';
 import { verifyWorkspace, deriveWorkspaceSourceId } from '../core/bootstrap/verify.ts';
+import { auditWritebackContract, repairWritebackContract } from '../core/bootstrap/contract.ts';
 
 export const BOOTSTRAP_HELP = `gbrain bootstrap — paste-in agent install (Claude Code / Codex)
 
@@ -92,6 +93,8 @@ Subcommands (run \`gbrain bootstrap status\` first — it is the resume entrypoi
   render [--force] [--only F] [--minimal]
                                   Render identity files from the confirmed answers.
                                   Never clobbers; --force backs up first.
+  contract [--repair]             Audit the same-turn GBrain write-back contract.
+                                  --repair appends it additively and backs up AGENTS.md.
   hooks [--harness claude-code|codex] [--repair] [--no-hooks] [--gbrain-bin <path>]
                                   Register MCP (+ per-turn hooks on Claude Code,
                                   ON by default; --no-hooks opts out, GBRAIN_HOOKS=0
@@ -132,6 +135,9 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   render:
     'gbrain bootstrap render [--force] [--only F] [--minimal]\n' +
     '  Render identity files from the confirmed interview answers. Never clobbers; --force backs up first.',
+  contract:
+    'gbrain bootstrap contract [--repair]\n' +
+    '  Audit AGENTS.md for the same-turn GBrain write-back contract. --repair appends a marker-owned block and backs up the original.',
   repo:
     'gbrain bootstrap repo\n' +
     '  Create the dedicated PRIVATE GitHub repo (or adopt an EMPTY private repo you created\n' +
@@ -454,6 +460,20 @@ async function runStatus(ws: string, rest: string[], home: string): Promise<numb
     );
   }
   return 0;
+}
+
+async function runContract(ws: string, rest: string[]): Promise<number> {
+  const repair = rest.includes('--repair');
+  if (!repair) {
+    const audit = auditWritebackContract(ws);
+    console.log(JSON.stringify(audit, null, 2));
+    return audit.ok ? 0 : 1;
+  }
+  return withLock(ws, async () => {
+    const result = repairWritebackContract(ws);
+    console.log(JSON.stringify(result, null, 2));
+    return result.ok ? 0 : 1;
+  });
 }
 
 /** One copy of the A8 invalidation warning — shared by --set and --skip so
@@ -1221,7 +1241,7 @@ export async function runBootstrap(args: string[], opts: RunBootstrapOpts = {}):
   const logCtx: LogCtx = { home, ws, ...(harnessForLog ? { harness: harnessForLog } : {}) };
   const t0 = Date.now();
 
-  const KNOWN = new Set(['status', 'interview', 'render', 'repo', 'hooks', 'verify', 'attach', 'uninstall', 'cloud-setup-script']);
+  const KNOWN = new Set(['status', 'interview', 'render', 'contract', 'repo', 'hooks', 'verify', 'attach', 'uninstall', 'cloud-setup-script']);
   if (!KNOWN.has(sub)) {
     console.error(`unknown subcommand: ${sub}`);
     console.error(BOOTSTRAP_HELP);
@@ -1260,6 +1280,9 @@ export async function runBootstrap(args: string[], opts: RunBootstrapOpts = {}):
         break;
       case 'render':
         code = await runRender(ws, rest, home);
+        break;
+      case 'contract':
+        code = await runContract(ws, rest);
         break;
       case 'repo':
         code = await runRepo(ws, rest, home, runner);

--- a/src/core/bootstrap/contract.ts
+++ b/src/core/bootstrap/contract.ts
@@ -1,0 +1,117 @@
+/**
+ * Additive bootstrap contract repair for legacy and custom agent workspaces.
+ *
+ * Fresh workspaces render the integrated write-back gate from
+ * templates/bootstrap/AGENTS.md.template. Existing workspaces are user-owned,
+ * so upgrades must never overwrite their AGENTS.md. This module audits for the
+ * integrated gate and, on explicit --repair, appends one small marker-owned
+ * block after backing up the original.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const WRITEBACK_CONTRACT_BEGIN = '<!-- gbrain:writeback-contract:begin -->';
+export const WRITEBACK_CONTRACT_END = '<!-- gbrain:writeback-contract:end -->';
+
+const INTEGRATED_HARD_GATE = 'WRITE IT DOWN — SAME TURN, THROUGH THE BRAIN';
+const INTEGRATED_TURN_GATE = 'Gate 7 — Write-back';
+
+export const WRITEBACK_CONTRACT_BLOCK = `${WRITEBACK_CONTRACT_BEGIN}
+
+## GBrain same-turn write-back
+
+Context injection is the read side of memory. Before ending any turn where
+something durable was learned, write it through GBrain in the same turn:
+
+- Atomic facts, preferences, decisions, and commitments → \`remember\` with
+  explicit provenance.
+- Richer entity or project knowledge → \`put_page\` / \`add_timeline_entry\`
+  through the brain tools; never edit indexed brain files behind GBrain's back.
+- Verify the write with \`recall\`, \`entity\`, or \`get_page\` before claiming it
+  was stored.
+
+Skip only transient logistics, acknowledgments, and facts already verified as
+present. A turn that learned something durable and recorded nothing is
+incomplete.
+
+${WRITEBACK_CONTRACT_END}`;
+
+export interface WritebackContractAudit {
+  ok: boolean;
+  agentsPath: string;
+  mode: 'integrated' | 'managed' | 'missing' | 'agents_missing';
+  detail: string;
+}
+
+export interface WritebackContractRepair extends WritebackContractAudit {
+  changed: boolean;
+  backupPath: string | null;
+}
+
+function hasIntegratedWritebackContract(content: string): boolean {
+  if (content.includes(INTEGRATED_HARD_GATE) && content.includes(INTEGRATED_TURN_GATE)) return true;
+  const normalized = content.toLowerCase();
+  return (
+    /same[- ]turn/.test(normalized) &&
+    /write[- ]back/.test(normalized) &&
+    (normalized.includes('gbrain remember') || normalized.includes('`remember`')) &&
+    normalized.includes('provenance')
+  );
+}
+
+export function hasWritebackContract(content: string): boolean {
+  const integrated = hasIntegratedWritebackContract(content);
+  const managed = content.includes(WRITEBACK_CONTRACT_BEGIN) && content.includes(WRITEBACK_CONTRACT_END);
+  return integrated || managed;
+}
+
+export function auditWritebackContract(workspaceDir: string): WritebackContractAudit {
+  const agentsPath = join(workspaceDir, 'AGENTS.md');
+  if (!existsSync(agentsPath)) {
+    return {
+      ok: false,
+      agentsPath,
+      mode: 'agents_missing',
+      detail: 'AGENTS.md is missing; render the bootstrap contract before wiring the agent',
+    };
+  }
+  const content = readFileSync(agentsPath, 'utf8');
+  if (hasIntegratedWritebackContract(content)) {
+    return { ok: true, agentsPath, mode: 'integrated', detail: 'integrated same-turn write-back gate present' };
+  }
+  if (content.includes(WRITEBACK_CONTRACT_BEGIN) && content.includes(WRITEBACK_CONTRACT_END)) {
+    return { ok: true, agentsPath, mode: 'managed', detail: 'additive same-turn write-back contract present' };
+  }
+  return {
+    ok: false,
+    agentsPath,
+    mode: 'missing',
+    detail: 'same-turn write-back contract missing; context can be injected without durable capture',
+  };
+}
+
+export function repairWritebackContract(workspaceDir: string): WritebackContractRepair {
+  const audit = auditWritebackContract(workspaceDir);
+  if (audit.ok) return { ...audit, changed: false, backupPath: null };
+  if (audit.mode === 'agents_missing') {
+    throw new Error(`${audit.detail}: ${audit.agentsPath}`);
+  }
+  if (lstatSync(audit.agentsPath).isSymbolicLink()) {
+    throw new Error(`refusing to replace symlinked AGENTS.md: ${audit.agentsPath}`);
+  }
+
+  const original = readFileSync(audit.agentsPath, 'utf8');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(workspaceDir, '.gbrain-bootstrap-backups', stamp, 'AGENTS.md');
+  mkdirSync(dirname(backupPath), { recursive: true });
+  writeFileSync(backupPath, original, { flag: 'wx' });
+
+  const next = `${original.trimEnd()}\n\n${WRITEBACK_CONTRACT_BLOCK}\n`;
+  const tmp = `${audit.agentsPath}.tmp-${process.pid}`;
+  writeFileSync(tmp, next, 'utf8');
+  renameSync(tmp, audit.agentsPath);
+
+  const repaired = auditWritebackContract(workspaceDir);
+  return { ...repaired, changed: true, backupPath };
+}

--- a/src/core/bootstrap/verify.ts
+++ b/src/core/bootstrap/verify.ts
@@ -48,6 +48,7 @@ import { BOOTSTRAP_TEMPLATES, loadQuestionBank } from './assets.ts';
 import { readManifest, writeManifest } from './format.ts';
 import { status as interviewStatus } from './interview.ts';
 import { gitOriginUrl, hooksInstalled } from './status.ts';
+import { auditWritebackContract } from './contract.ts';
 import {
   ensureIpcSecret,
   resolveSocketPath,
@@ -268,6 +269,21 @@ function checkByteFloors(ws: string): VerifyCheck {
   } catch (e) {
     return { id, ok: false, detail: `byte-floor check failed: ${(e as Error).message}` };
   }
+}
+
+/** A healthy retrieval surface without a same-turn write-back contract is a
+ * one-way memory: useful now, stale later. Fresh bootstrap renders this gate;
+ * the check catches pre-bootstrap/custom workspaces and points at the
+ * additive repair command rather than overwriting their AGENTS.md. */
+export function checkWritebackContract(ws: string): VerifyCheck {
+  const audit = auditWritebackContract(ws);
+  return audit.ok
+    ? { id: 'writeback_contract', ok: true, detail: audit.detail }
+    : {
+        id: 'writeback_contract',
+        ok: false,
+        detail: `${audit.detail}. Fix: run \`gbrain bootstrap contract --repair\` from the workspace (or pass --workspace explicitly).`,
+      };
 }
 
 /** Tracked files via git; falls back to the rendered file set + state/ when
@@ -929,6 +945,7 @@ export async function verifyWorkspace(
 
   checks.push(checkTokenSweep(ws));
   checks.push(checkByteFloors(ws));
+  checks.push(checkWritebackContract(ws));
   checks.push(checkSecretScan(ws));
   checks.push(checkDenyGlobs(ws));
   checks.push(await checkRepoPrivacy(ws));

--- a/templates/bootstrap/AGENTS.md.template
+++ b/templates/bootstrap/AGENTS.md.template
@@ -33,9 +33,10 @@ session death. Anything worth remembering is recorded in the turn it is learned:
   `add_timeline_entry` via the gbrain tools. On this machine the brain database is
   single-writer: **write through the brain tools, never by editing `brain/` files
   directly** — a file edited by hand is invisible to search until a sync can run.
-- Facts worth recalling ("X prefers Y", "deadline moved to Z") → write a `## Facts`
-  fence on the relevant page (each line one fact). The brain ingests these
-  deterministically — no API key required.
+- Atomic facts worth recalling ("X prefers Y", "deadline moved to Z") →
+  `remember` with explicit provenance. For facts maintained inside a richer
+  entity page, write a `## Facts` fence (each line one fact); the brain ingests
+  these deterministically — no API key required.
 - Operational state (open commitments, corrections, active context) → `MEMORY.md`
   and `memory/YYYY-MM-DD.md` (file edits are correct for these two — they are loaded
   by path, not by search).

--- a/templates/bootstrap/template-repo/AGENTS.md
+++ b/templates/bootstrap/template-repo/AGENTS.md
@@ -37,9 +37,10 @@ session death. Anything worth remembering is recorded in the turn it is learned:
   `add_timeline_entry` via the gbrain tools. On this machine the brain database is
   single-writer: **write through the brain tools, never by editing `brain/` files
   directly** — a file edited by hand is invisible to search until a sync can run.
-- Facts worth recalling ("X prefers Y", "deadline moved to Z") → write a `## Facts`
-  fence on the relevant page (each line one fact). The brain ingests these
-  deterministically — no API key required.
+- Atomic facts worth recalling ("X prefers Y", "deadline moved to Z") →
+  `remember` with explicit provenance. For facts maintained inside a richer
+  entity page, write a `## Facts` fence (each line one fact); the brain ingests
+  these deterministically — no API key required.
 - Operational state (open commitments, corrections, active context) → `MEMORY.md`
   and `memory/YYYY-MM-DD.md` (file edits are correct for these two — they are loaded
   by path, not by search).

--- a/test/bootstrap-contract.test.ts
+++ b/test/bootstrap-contract.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  auditWritebackContract,
+  repairWritebackContract,
+  WRITEBACK_CONTRACT_BEGIN,
+} from '../src/core/bootstrap/contract.ts';
+import { checkWritebackContract } from '../src/core/bootstrap/verify.ts';
+
+const created: string[] = [];
+afterEach(() => {
+  while (created.length) rmSync(created.pop()!, { recursive: true, force: true });
+});
+
+function workspace(agents = '# AGENTS\n\n## Per-message gates\n\n**Gate 3 — Entity lookup (brain first).**\n'): string {
+  const ws = mkdtempSync(join(tmpdir(), 'gbrain-writeback-contract-'));
+  created.push(ws);
+  writeFileSync(join(ws, 'AGENTS.md'), agents);
+  return ws;
+}
+
+describe('bootstrap same-turn write-back contract', () => {
+  test('the default skill bundle carries the memory loop contract', () => {
+    const root = join(import.meta.dir, '..');
+    const plugin = JSON.parse(readFileSync(join(root, 'openclaw.plugin.json'), 'utf8')) as {
+      shared_deps: string[];
+    };
+    expect(plugin.shared_deps).toContain('skills/_AGENT_README.md');
+    const onboarding = readFileSync(join(root, 'skills', '_AGENT_README.md'), 'utf8');
+    expect(onboarding).toContain('## The always-on memory loop');
+    expect(onboarding).toContain("GBrain's `remember` verb");
+    expect(onboarding).toContain('Context injection is read-side automation');
+  });
+
+  test('audits a legacy one-way contract as missing', () => {
+    const ws = workspace();
+    expect(auditWritebackContract(ws).ok).toBe(false);
+    const check = checkWritebackContract(ws);
+    expect(check.ok).toBe(false);
+    expect(check.detail).toContain('bootstrap contract --repair');
+  });
+
+  test('repair is additive, backed up, and idempotent', () => {
+    const ws = workspace('# custom agent rules\n');
+    const first = repairWritebackContract(ws);
+    expect(first.ok).toBe(true);
+    expect(first.changed).toBe(true);
+    expect(first.backupPath).not.toBeNull();
+    expect(existsSync(first.backupPath!)).toBe(true);
+    expect(readFileSync(first.backupPath!, 'utf8')).toBe('# custom agent rules\n');
+
+    const repaired = readFileSync(join(ws, 'AGENTS.md'), 'utf8');
+    expect(repaired).toContain('# custom agent rules');
+    expect(repaired).toContain(WRITEBACK_CONTRACT_BEGIN);
+
+    const second = repairWritebackContract(ws);
+    expect(second.changed).toBe(false);
+    expect(second.backupPath).toBeNull();
+    expect(readFileSync(join(ws, 'AGENTS.md'), 'utf8')).toBe(repaired);
+  });
+
+  test('repair refuses to replace a symlinked AGENTS.md', () => {
+    const ws = mkdtempSync(join(tmpdir(), 'gbrain-writeback-contract-'));
+    created.push(ws);
+    const target = join(ws, 'custom-rules.md');
+    writeFileSync(target, '# custom agent rules\n');
+    symlinkSync(target, join(ws, 'AGENTS.md'));
+    expect(() => repairWritebackContract(ws)).toThrow('refusing to replace symlinked AGENTS.md');
+    expect(readFileSync(target, 'utf8')).toBe('# custom agent rules\n');
+  });
+
+  test('accepts the integrated fresh-bootstrap gate', () => {
+    const ws = workspace(
+      '⛔ **WRITE IT DOWN — SAME TURN, THROUGH THE BRAIN.**\n\n' +
+        '**Gate 7 — Write-back.** Before ending the turn, persist durable learning.\n',
+    );
+    expect(auditWritebackContract(ws)).toMatchObject({ ok: true, mode: 'integrated' });
+  });
+
+  test('accepts a semantically equivalent custom workspace gate', () => {
+    const ws = workspace(
+      '## Durable write-back\n\n' +
+        'Use same-turn GBrain write-back for durable learning. Run `gbrain remember` with provenance, then verify it.\n',
+    );
+    expect(auditWritebackContract(ws)).toMatchObject({ ok: true, mode: 'integrated' });
+  });
+});

--- a/test/bootstrap-verify.serial.test.ts
+++ b/test/bootstrap-verify.serial.test.ts
@@ -88,6 +88,11 @@ beforeAll(async () => {
   expect(confirm(ws, h.hash).ok).toBe(true);
 
   const floors = byteFloors(required.length);
+  writeFileSync(
+    join(ws, 'AGENTS.md'),
+    '⛔ **WRITE IT DOWN — SAME TURN, THROUGH THE BRAIN.**\n\n' +
+      '**Gate 7 — Write-back.** Before ending the turn, persist durable learning.\n',
+  );
   writeFileSync(join(ws, 'SOUL.md'), pad('# Soul\n\nIdentity rendered from answers.\n', floors['SOUL.md'] + 200));
   writeFileSync(join(ws, 'USER.md'), pad('# User\n\nTheir literal words are ground truth.\n', floors['USER.md'] + 100));
   mkdirSync(join(ws, 'brain'), { recursive: true });
@@ -138,6 +143,7 @@ describe('verifyWorkspace — keyless pass', () => {
     expect(check(res.checks, 'doctor_green')[0].ok).toBe(true);
     expect(check(res.checks, 'token_sweep')[0].ok).toBe(true);
     expect(check(res.checks, 'byte_floors')[0].ok).toBe(true);
+    expect(check(res.checks, 'writeback_contract')[0].ok).toBe(true);
     expect(check(res.checks, 'secret_scan')[0].ok).toBe(true);
     expect(check(res.checks, 'deny_globs')[0].ok).toBe(true);
     expect(check(res.checks, 'repo_privacy')[0].ok).toBe(true); // local-only


### PR DESCRIPTION
## Problem

GBrain context injection is read-side only. A long-lived custom agent workspace could retrieve context on every turn while never persisting newly learned durable facts. Fresh bootstrap templates already described writeback, but upgrades and skillpack scaffolds preserve user-owned `AGENTS.md`, and `bootstrap verify` did not audit that contract. The result was a silent one-way memory loop: useful context today, stale context tomorrow.

## Error Log

This was a missing invariant rather than a thrown runtime exception. The structural reproduction on a legacy workspace was:

```json
{
  "ok": false,
  "agentsPath": "/tmp/example-workspace/AGENTS.md",
  "mode": "missing",
  "detail": "same-turn write-back contract missing; context can be injected without durable capture"
}
```

Before this change, `gbrain bootstrap verify` had no check that could surface this condition.

## What We Tried

1. Audited the context engine. It assembles retrieval context but intentionally does not author durable facts.
2. Audited conversation fact extraction. The batch extractor is useful for backfills, but it is opt-in and does not guarantee same-turn persistence.
3. Audited skillpack scaffold behavior. Scaffolds correctly refuse to overwrite user-owned `AGENTS.md`, so silently mutating that file during install would violate the ownership model.
4. Kept the ownership invariant and added an explicit, additive repair path with backup and idempotency.

## Solution

- Add a shared onboarding contract that makes the read, detect, write, verify memory loop explicit for every installed skill bundle.
- Teach fresh bootstrap templates to use `remember` with provenance for atomic facts and structured brain operations for richer knowledge.
- Add `gbrain bootstrap contract` to audit existing workspaces.
- Add `gbrain bootstrap contract --repair` to append a marker-owned writeback block only after backing up the original `AGENTS.md`.
- Make `gbrain bootstrap verify` fail when the same-turn writeback contract is absent and point to the repair command.
- Refuse repair for symlinked `AGENTS.md` and keep repeated repairs idempotent.

| Workspace state | Audit | Repair |
|---|---|---|
| Fresh integrated gate | Pass | No-op |
| Previously repaired marker block | Pass | No-op |
| Semantically equivalent custom gate | Pass | No-op |
| Legacy one-way contract | Fail | Backup plus additive block |
| Missing `AGENTS.md` | Fail | Refuse; render first |
| Symlinked `AGENTS.md` | Fail | Refuse without mutation |

## Results

Before: retrieval could be healthy while durable capture was absent, and verification still passed.

After: bootstrap verification treats writeback as a first-class contract; existing workspaces get an explicit migration, while fresh installs and default skillpacks carry the always-on memory loop.

## Testing

- 115 tests passed across bootstrap contract, render, verify, dispatcher, attach, Codex door, scaffold, and end-to-end skillpack flows.
- `bun run typecheck`
- `bash scripts/check-bootstrap-templates.sh`
- Public diff and PR metadata passed the PII scanner.
