### PR TITLE
fix(ai): claude-cli scrubs cloud-auth routing env vars, not just the three ANTHROPIC_* keys

### DIFF
--- a/src/core/ai/providers/claude-cli-language-model.ts
+++ b/src/core/ai/providers/claude-cli-language-model.ts
@@ -219,10 +219,22 @@ function runClaude(
     // (subscription), never via an inherited API key. Without this, an
     // ANTHROPIC_API_KEY in gbrain's env (the exact setup this recipe is meant
     // to replace) silently flips billing to per-token API usage.
+    //
+    // Also scrub the CLAUDE_CODE_USE_* backend-switch flags: Bedrock, Vertex
+    // AI, Mantle, Microsoft Foundry, and Claude Platform on AWS are each
+    // gated by one of these, take priority over subscription OAuth when set,
+    // and route billing through a cloud account instead. Clearing the switch
+    // is sufficient — provider-specific creds (AWS_*, ANTHROPIC_VERTEX_*,
+    // ANTHROPIC_FOUNDRY_*, ANTHROPIC_AWS_*, ...) are inert without it.
     const env = { ...process.env };
     delete env.ANTHROPIC_API_KEY;
     delete env.ANTHROPIC_AUTH_TOKEN;
     delete env.ANTHROPIC_BASE_URL;
+    delete env.CLAUDE_CODE_USE_BEDROCK;
+    delete env.CLAUDE_CODE_USE_VERTEX;
+    delete env.CLAUDE_CODE_USE_MANTLE;
+    delete env.CLAUDE_CODE_USE_FOUNDRY;
+    delete env.CLAUDE_CODE_USE_ANTHROPIC_AWS;
     const child = spawn(claudeBin(), args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: ensureCleanCwd(),

--- a/test/claude-cli-recipe.test.ts
+++ b/test/claude-cli-recipe.test.ts
@@ -377,19 +377,24 @@ describe('claude-cli LanguageModel — context isolation', () => {
     });
   });
 
-  test('scrubs ANTHROPIC_* credentials from the child env (subscription-only auth)', async () => {
+  test('scrubs ANTHROPIC_* credentials and cloud-auth backend switches from the child env (subscription-only auth)', async () => {
     await withStubEnv(async () => {
       await withEnv(
         {
           ANTHROPIC_API_KEY: 'sk-should-never-leak',
           ANTHROPIC_AUTH_TOKEN: 'tok-should-never-leak',
           ANTHROPIC_BASE_URL: 'https://proxy.should.never.leak',
+          CLAUDE_CODE_USE_BEDROCK: '1',
+          CLAUDE_CODE_USE_VERTEX: '1',
+          CLAUDE_CODE_USE_MANTLE: '1',
+          CLAUDE_CODE_USE_FOUNDRY: '1',
+          CLAUDE_CODE_USE_ANTHROPIC_AWS: '1',
         },
         async () => {
           const envLog = join(stubDir, 'env.log');
           const envStub = [
             '#!/bin/sh',
-            `printf "key=%s\\ntoken=%s\\nbase=%s\\n" "\${ANTHROPIC_API_KEY:-UNSET}" "\${ANTHROPIC_AUTH_TOKEN:-UNSET}" "\${ANTHROPIC_BASE_URL:-UNSET}" > "${envLog}"`,
+            `printf "key=%s\\ntoken=%s\\nbase=%s\\nbedrock=%s\\nvertex=%s\\nmantle=%s\\nfoundry=%s\\nanthropicAws=%s\\n" "\${ANTHROPIC_API_KEY:-UNSET}" "\${ANTHROPIC_AUTH_TOKEN:-UNSET}" "\${ANTHROPIC_BASE_URL:-UNSET}" "\${CLAUDE_CODE_USE_BEDROCK:-UNSET}" "\${CLAUDE_CODE_USE_VERTEX:-UNSET}" "\${CLAUDE_CODE_USE_MANTLE:-UNSET}" "\${CLAUDE_CODE_USE_FOUNDRY:-UNSET}" "\${CLAUDE_CODE_USE_ANTHROPIC_AWS:-UNSET}" > "${envLog}"`,
             'cat > /dev/null',
             `cat "${stubResponsePath}"`,
           ].join('\n');
@@ -409,6 +414,11 @@ describe('claude-cli LanguageModel — context isolation', () => {
             expect(seen).toContain('key=UNSET');
             expect(seen).toContain('token=UNSET');
             expect(seen).toContain('base=UNSET');
+            expect(seen).toContain('bedrock=UNSET');
+            expect(seen).toContain('vertex=UNSET');
+            expect(seen).toContain('mantle=UNSET');
+            expect(seen).toContain('foundry=UNSET');
+            expect(seen).toContain('anthropicAws=UNSET');
           } finally {
             const fastStub = [
               '#!/bin/sh',


### PR DESCRIPTION
## What

`src/core/ai/providers/claude-cli-language-model.ts` spawns `claude --print` as a subprocess for this recipe's language-model adapter. It scrubs the child env of `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` before spawning, specifically to guarantee the subprocess authenticates via its own subscription OAuth session rather than an inherited API key (`test/claude-cli-recipe.test.ts` pins this as "subscription-only auth").

That scrub doesn't cover Claude Code's cloud-backend switch flags. Claude Code supports routing through Amazon Bedrock, Google Cloud's Agent Platform (Vertex AI), the Bedrock Mantle endpoint, Microsoft Foundry, and Claude Platform on AWS — each gated by its own `CLAUDE_CODE_USE_*` environment variable, all of which take priority over subscription OAuth when set. If any of these flags is present in the parent process's environment (e.g. inherited from a shell profile, CI runner, or another tool in the same environment), it survives the existing scrub and the subprocess silently routes through a paid cloud backend instead of the subscription auth this recipe is built around — the same class of gap the existing `ANTHROPIC_API_KEY` scrub exists to close, just on a different set of variables.

Per the official docs, each backend requires its switch flag explicitly:
- Bedrock — `CLAUDE_CODE_USE_BEDROCK` ([amazon-bedrock](https://code.claude.com/docs/en/amazon-bedrock))
- Vertex AI / Google Cloud's Agent Platform — `CLAUDE_CODE_USE_VERTEX` ([google-vertex-ai](https://code.claude.com/docs/en/google-vertex-ai))
- Bedrock Mantle endpoint — `CLAUDE_CODE_USE_MANTLE` ([amazon-bedrock](https://code.claude.com/docs/en/amazon-bedrock))
- Microsoft Foundry — `CLAUDE_CODE_USE_FOUNDRY` ([microsoft-foundry](https://code.claude.com/docs/en/microsoft-foundry))
- Claude Platform on AWS — `CLAUDE_CODE_USE_ANTHROPIC_AWS` ([claude-platform-on-aws](https://code.claude.com/docs/en/claude-platform-on-aws), which states explicitly: *"Claude Platform on AWS is opt-in even when AWS credentials are present in your environment"*)

Since every backend is opt-in behind its switch flag, clearing the five flags is sufficient — the provider-specific credential vars (`AWS_*`, `ANTHROPIC_VERTEX_PROJECT_ID`, `ANTHROPIC_FOUNDRY_RESOURCE`, `ANTHROPIC_AWS_WORKSPACE_ID`, `ANTHROPIC_BEDROCK_BASE_URL`, etc.) are inert without their flag regardless of presence. This PR does not touch those credential vars, to keep the diff to the minimal set that closes the gap.

## Test

`test/claude-cli-recipe.test.ts`'s existing "subscription-only auth" test now also sets all five `CLAUDE_CODE_USE_*` flags in the parent env before invoking the model, and asserts all eight scrubbed vars come back `UNSET` in the spawned child's env (verified via a stub `claude` binary that dumps its own env to a file). Confirmed red→green: reverting only the source change against this test fails (`1 fail`); with the fix, `bun test test/claude-cli-recipe.test.ts` passes (`20 pass`, `0 fail`). `bun run typecheck` is clean.

## Note

Gap identified during a Codex-assisted security review of our own subscription-launch wrappers (2026-08-15).
