### PR TITLE
fix(models): doctor chat probe honors slow-start providers instead of a hardcoded 5s abort

### DIFF
--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -564,7 +564,7 @@ export async function probeEmbeddingReachability(deps: ProbeDeps = {}): Promise<
  *
  * Pre-fix `probeModel` hardcoded 5000ms for every provider. That's fine for
  * a plain network round-trip, but `claude-cli:` dispatches through a
- * `claude --print` subprocess (CLI cold start + user-level CLAUDE.md load),
+ * `claude -p (print mode)` subprocess (CLI cold start + user-level CLAUDE.md load),
  * which routinely takes 5-6s even when healthy — so the probe aborted on
  * every run and reported 'unknown — claude-cli adapter aborted', not
  * because the model was actually unreachable. Mirrors the reranker probe's

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -557,13 +557,40 @@ export async function probeEmbeddingReachability(deps: ProbeDeps = {}): Promise<
   }
 }
 
+/**
+ * Resolve the chat/expansion probe timeout: the recipe's declared
+ * `touchpoints.<kind>.default_timeout_ms` when set, else the probe's
+ * historical flat 5000ms.
+ *
+ * Pre-fix `probeModel` hardcoded 5000ms for every provider. That's fine for
+ * a plain network round-trip, but `claude-cli:` dispatches through a
+ * `claude --print` subprocess (CLI cold start + user-level CLAUDE.md load),
+ * which routinely takes 5-6s even when healthy — so the probe aborted on
+ * every run and reported 'unknown — claude-cli adapter aborted', not
+ * because the model was actually unreachable. Mirrors the reranker probe's
+ * recipe-default fallback (`resolveLiveRerankerTimeoutMs` / mode.ts), but
+ * simpler: unlike `search.reranker.timeout_ms`, there's no config-key
+ * override for chat/expansion timeouts, so the chain is just per-call
+ * default (5000) unless the recipe overrides it.
+ */
+export async function resolveChatProbeTimeoutMs(modelStr: string, touchpoint: 'chat' | 'expansion'): Promise<number> {
+  try {
+    const { resolveRecipe } = await import('../core/ai/model-resolver.ts');
+    const { recipe } = resolveRecipe(modelStr);
+    return recipe.touchpoints[touchpoint]?.default_timeout_ms ?? 5000;
+  } catch {
+    return 5000;
+  }
+}
+
 export async function probeModel(modelStr: string, touchpoint: 'chat' | 'expansion', deps: ProbeDeps = {}): Promise<ProbeResult> {
   const start = Date.now();
+  const probeTimeoutMs = await resolveChatProbeTimeoutMs(modelStr, touchpoint);
   try {
     const chat = deps.chat ?? (await import('../core/ai/gateway.ts')).chat;
-    // Use AbortController so the 5s timeout doesn't hang on a stuck network.
+    // Use AbortController so the resolved timeout doesn't hang on a stuck network.
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(new Error('probe timed out after 5s')), 5000);
+    const timeoutId = setTimeout(() => controller.abort(new Error(`probe timed out after ${probeTimeoutMs}ms`)), probeTimeoutMs);
     try {
       await chat({
         model: modelStr,

--- a/src/core/ai/recipes/claude-cli.ts
+++ b/src/core/ai/recipes/claude-cli.ts
@@ -57,7 +57,7 @@ export const claudeCli: Recipe = {
       cost_per_1m_input_usd: 3.0,
       cost_per_1m_output_usd: 15.0,
       price_last_verified: '2026-06-17',
-      // The gateway dispatches via a `claude --print` subprocess (CLI cold
+      // The gateway dispatches via a `claude -p (print mode)` subprocess (CLI cold
       // start + user-level CLAUDE.md load), which routinely takes 5-6s even
       // when the CLI and subscription are perfectly healthy. `gbrain models
       // doctor`'s chat probe used to hardcode a flat 5000ms abort, so this

--- a/src/core/ai/recipes/claude-cli.ts
+++ b/src/core/ai/recipes/claude-cli.ts
@@ -57,6 +57,15 @@ export const claudeCli: Recipe = {
       cost_per_1m_input_usd: 3.0,
       cost_per_1m_output_usd: 15.0,
       price_last_verified: '2026-06-17',
+      // The gateway dispatches via a `claude --print` subprocess (CLI cold
+      // start + user-level CLAUDE.md load), which routinely takes 5-6s even
+      // when the CLI and subscription are perfectly healthy. `gbrain models
+      // doctor`'s chat probe used to hardcode a flat 5000ms abort, so this
+      // recipe always false-failed the doctor check ('unknown — claude-cli
+      // adapter aborted') despite `chat()` succeeding fine at normal call
+      // sites. 30s gives the subprocess room to start without masking a truly
+      // dead/unauthenticated CLI for anywhere near that long.
+      default_timeout_ms: 30_000,
     },
   },
   // Friendly aliases mirror the `anthropic` recipe so config strings stay

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -192,6 +192,14 @@ export interface ExpansionTouchpoint {
   models: string[];
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string;
+  /**
+   * Recipe-level timeout fallback for `gbrain models doctor`'s expansion
+   * reachability probe. Mirrors `RerankerTouchpoint.default_timeout_ms`: lets
+   * a slow-start provider (e.g. a subprocess-dispatched CLI with real cold-start
+   * latency) declare the headroom it needs instead of the probe's flat 5000ms
+   * default false-failing on every run.
+   */
+  default_timeout_ms?: number;
 }
 
 /**
@@ -270,6 +278,14 @@ export interface ChatTouchpoint {
   cost_per_1m_input_usd?: number;
   cost_per_1m_output_usd?: number;
   price_last_verified?: string;
+  /**
+   * Recipe-level timeout fallback for `gbrain models doctor`'s chat
+   * reachability probe. Mirrors `RerankerTouchpoint.default_timeout_ms`: lets
+   * a slow-start provider (e.g. a subprocess-dispatched CLI with real cold-start
+   * latency) declare the headroom it needs instead of the probe's flat 5000ms
+   * default false-failing on every run.
+   */
+  default_timeout_ms?: number;
 }
 
 export interface Recipe {

--- a/test/models-doctor-chat-probe-timeout.slow.test.ts
+++ b/test/models-doctor-chat-probe-timeout.slow.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `gbrain models doctor` chat probe timeout — end-to-end wall-clock proof.
+ *
+ * Companion to `models-doctor-chat-probe-timeout.test.ts` (the fast,
+ * zero-wait unit tests for `resolveChatProbeTimeoutMs`). These two tests
+ * each inject a `deps.chat` mock that stalls ~5.5s — comfortably past the
+ * old hardcoded 5000ms probe budget — to prove `probeModel()` actually
+ * wires the resolved timeout through end-to-end, not just that the
+ * resolver function returns the right number in isolation:
+ *
+ *   - claude-cli: now succeeds (its recipe declares 30_000ms).
+ *   - every other provider: UNCHANGED, still aborts at the historical
+ *     5000ms (pinned by asserting the exact abort message).
+ *
+ * Per `docs/TESTING.md`, real multi-second waits belong in `*.slow.test.ts`
+ * (run via `bun run test:slow`), not the fast unit loop that
+ * `scripts/run-unit-shard.sh` fans out on every inner-loop run.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { probeModel } from '../src/commands/models.ts';
+
+type ChatFn = typeof import('../src/core/ai/gateway.ts').chat;
+
+function stallingChat(ms: number): ChatFn {
+  return (async (opts: { abortSignal?: AbortSignal }) => {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, ms);
+      opts.abortSignal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(opts.abortSignal!.reason ?? new Error('aborted'));
+      });
+    });
+    return {} as Awaited<ReturnType<ChatFn>>;
+  }) as unknown as ChatFn;
+}
+
+describe('probeModel — honors the resolved timeout end-to-end', () => {
+  // Explicit per-test timeout: empirically, a bare `bun test <file>` (no
+  // --timeout flag) enforces bun's built-in 5000ms per-test default even
+  // though bunfig.toml declares `[test].timeout = 60_000` — verified
+  // locally (a standalone 5.5s-wait test times out at 5005ms without this
+  // override). scripts/run-unit-*.sh pass --timeout=60000 explicitly, but
+  // pin it here too so this test doesn't depend on invocation method.
+  test('claude-cli: a >5s chat call (realistic subprocess cold start) succeeds instead of false-failing at the old 5s budget', async () => {
+    const r = await probeModel('claude-cli:claude-sonnet-5', 'chat', { chat: stallingChat(5500) });
+    expect(r.status).toBe('ok');
+    expect(r.message).toBe('reachable');
+  }, 15_000);
+
+  test('non-claude-cli provider: a >5s stall still aborts at the unchanged 5000ms budget', async () => {
+    const r = await probeModel('anthropic:claude-sonnet-4-6', 'chat', { chat: stallingChat(5500) });
+    expect(r.status).not.toBe('ok');
+    expect(r.message).toBe('probe timed out after 5000ms');
+  }, 15_000);
+});

--- a/test/models-doctor-chat-probe-timeout.test.ts
+++ b/test/models-doctor-chat-probe-timeout.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `gbrain models doctor` chat/expansion probe timeout — defect fix.
+ *
+ * Pre-fix, `probeModel()` hardcoded a flat 5000ms abort for every provider.
+ * `claude-cli:` dispatches through a `claude --print` subprocess (CLI cold
+ * start + user-level CLAUDE.md load), which routinely takes 5-6s even when
+ * the CLI and subscription are perfectly healthy — so the doctor probe
+ * always aborted and reported `'unknown — claude-cli adapter aborted'`,
+ * not because anything was actually broken. `chat()` itself succeeds fine
+ * at normal call sites; only the probe's flat 5s budget was too tight.
+ *
+ * `resolveChatProbeTimeoutMs()` now reads `touchpoints.<kind>.default_timeout_ms`
+ * off the resolved recipe (mirrors the reranker probe's recipe-default
+ * fallback in `resolveLiveRerankerTimeoutMs` / mode.ts) before falling back
+ * to the historical 5000ms. These fast, zero-wait tests pin the resolution
+ * logic: (1) claude-cli's declared 30s override, (2) every other provider
+ * keeps the unchanged 5000ms default, (3) an unresolvable model string
+ * still degrades to 5000ms rather than throwing. The end-to-end wall-clock
+ * proof that `probeModel` actually honors the resolved timeout lives in
+ * `models-doctor-chat-probe-timeout.slow.test.ts` (per `docs/TESTING.md`,
+ * tests with real multi-second waits belong in `*.slow.test.ts`, not the
+ * fast unit loop).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { resolveChatProbeTimeoutMs } from '../src/commands/models.ts';
+
+describe('resolveChatProbeTimeoutMs', () => {
+  test('claude-cli chat touchpoint resolves to its declared 30s override', async () => {
+    const ms = await resolveChatProbeTimeoutMs('claude-cli:claude-sonnet-5', 'chat');
+    expect(ms).toBe(30_000);
+  });
+
+  test('a provider without a declared default_timeout_ms keeps the historical 5000ms', async () => {
+    const ms = await resolveChatProbeTimeoutMs('anthropic:claude-sonnet-4-6', 'chat');
+    expect(ms).toBe(5000);
+  });
+
+  test('expansion touchpoint on a provider with no override keeps 5000ms', async () => {
+    const ms = await resolveChatProbeTimeoutMs('openai:gpt-5-mini', 'expansion');
+    expect(ms).toBe(5000);
+  });
+
+  test('an unresolvable model string degrades to 5000ms instead of throwing', async () => {
+    const ms = await resolveChatProbeTimeoutMs('not-a-real-provider:nope', 'chat');
+    expect(ms).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Symptom

`gbrain models doctor` reports the `claude-cli:` chat touchpoint as `unknown` on essentially every run, even on a fully healthy CLI + subscription:

```
✘ chat              claude-cli:claude-sonnet-5     unknown (5004ms)
    claude-cli adapter aborted
```

Real-world observation: doctor reported `unknown@5004ms` and the *very next* real call through the same provider (a normal chat/agent turn) succeeded fine. The probe was never actually testing reachability — it was testing whether the `claude --print` subprocess could start, authenticate, and return in under 5 seconds, which it routinely doesn't (CLI process start + loading user-level `CLAUDE.md` takes ~5-6s even when nothing is wrong).

## Root cause

`probeModel()` in `src/commands/models.ts` hardcoded a flat `5000` for its `AbortController` timeout, for every provider, with no way for a slow-start provider to declare it needs more headroom.

## Fix

Same shape as the existing reranker probe's recipe-default timeout fallback (`resolveLiveRerankerTimeoutMs` / `src/core/search/mode.ts`, already on master): a recipe can declare `touchpoints.<chat|expansion>.default_timeout_ms`, and the probe uses it instead of the flat default.

- `src/core/ai/types.ts`: added `default_timeout_ms?: number` to `ChatTouchpoint` and `ExpansionTouchpoint` (mirrors the field already on `RerankerTouchpoint`).
- `src/core/ai/recipes/claude-cli.ts`: declared `default_timeout_ms: 30_000` on its `chat` touchpoint (30s comfortably covers the observed 5-6s cold start without masking a genuinely dead/unauthenticated CLI for anywhere near that long; claude-cli has no expansion touchpoint, so nothing else changes).
- `src/commands/models.ts`: new exported `resolveChatProbeTimeoutMs(modelStr, touchpoint)` reads `recipe.touchpoints[touchpoint]?.default_timeout_ms ?? 5000` (fail-open to 5000 on any resolution error, same shape as the reranker helper). `probeModel()` calls it once and uses the resolved value for both the abort timer and the abort-error message, instead of the literal `5000`.

No config-key override exists for chat/expansion timeouts (unlike `search.reranker.timeout_ms`), so the precedence chain here is intentionally simpler than the reranker one: recipe declaration, else the unchanged historical 5000ms. Every provider other than `claude-cli` is unaffected — same 5000ms as before.

Scope is deliberately narrow to this one probe. `probeEmbeddingReachability` (same file, same hardcoded-5000ms pattern) is left untouched — no embedding touchpoint currently declares this kind of slow-start behavior, and this PR is a single logical change.

## Tests

- `test/models-doctor-chat-probe-timeout.test.ts` (fast, zero-wait): pins `resolveChatProbeTimeoutMs` — claude-cli → 30000, every other provider/touchpoint → unchanged 5000, unresolvable model string → fails open to 5000.
- `test/models-doctor-chat-probe-timeout.slow.test.ts` (per `docs/TESTING.md`'s `*.slow.test.ts` convention, since these use real multi-second waits): end-to-end proof via injected `deps.chat` mocks that stall ~5.5s — claude-cli now succeeds past the old 5s cliff, every other provider is provably unchanged (aborts at exactly 5000ms, exact message pinned).

`bun run typecheck` and `bun run verify` (39/39 checks) both pass; targeted + `bun run test:slow` all green.
