### PR TITLE
fix(ai): claude-cli reports cachedInputTokens so cache reads stop counting as zero

### DIFF
--- a/src/core/ai/providers/claude-cli-language-model.ts
+++ b/src/core/ai/providers/claude-cli-language-model.ts
@@ -392,7 +392,12 @@ export class ClaudeCliLanguageModel implements LanguageModelV2 {
   async doGenerate(options: LanguageModelV2CallOptions): Promise<{
     content: LanguageModelV2Content[];
     finishReason: 'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown';
-    usage: { inputTokens: number | undefined; outputTokens: number | undefined; totalTokens: number | undefined };
+    usage: {
+      inputTokens: number | undefined;
+      outputTokens: number | undefined;
+      totalTokens: number | undefined;
+      cachedInputTokens: number | undefined;
+    };
     warnings: never[];
   }> {
     const { systemText, userPrompt } = renderPrompt(options.prompt);
@@ -422,6 +427,14 @@ export class ClaudeCliLanguageModel implements LanguageModelV2 {
     const inputTokens = result.usage?.input_tokens;
     const outputTokens = result.usage?.output_tokens;
     const totalTokens = (inputTokens ?? 0) + (outputTokens ?? 0);
+    // `cache_creation_input_tokens` is deliberately NOT surfaced here — the AI
+    // SDK's LanguageModelV2Usage has no corresponding field, and folding it in
+    // would need a claude-cli-specific branch in the gateway's usage assembly
+    // (src/core/ai/gateway.ts). Out of scope for this fix.
+    const cachedInputTokens =
+      result.usage?.cache_read_input_tokens !== undefined
+        ? Number(result.usage.cache_read_input_tokens)
+        : undefined;
 
     return {
       content,
@@ -430,6 +443,7 @@ export class ClaudeCliLanguageModel implements LanguageModelV2 {
         inputTokens,
         outputTokens,
         totalTokens: inputTokens !== undefined && outputTokens !== undefined ? totalTokens : undefined,
+        cachedInputTokens,
       },
       warnings: [],
     };

--- a/test/claude-cli-recipe.test.ts
+++ b/test/claude-cli-recipe.test.ts
@@ -120,6 +120,54 @@ describe('claude-cli LanguageModel — text-only round trip', () => {
       expect(result.content[0]).toEqual({ type: 'text', text: 'hello world' });
       expect(result.usage.inputTokens).toBe(12);
       expect(result.usage.outputTokens).toBe(34);
+      // baseEnvelope's default cache_read_input_tokens is 0 (present, not
+      // omitted) — pins "present zero" as distinct from the omitted/undefined
+      // case covered below.
+      expect(result.usage.cachedInputTokens).toBe(0);
+    });
+  });
+
+  test('maps cache_read_input_tokens onto usage.cachedInputTokens', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        baseEnvelope('hello world', {
+          usage: {
+            input_tokens: 12,
+            output_tokens: 34,
+            cache_read_input_tokens: 9001,
+            cache_creation_input_tokens: 0,
+          },
+        }),
+      );
+      const { ClaudeCliLanguageModel } = await import('../src/core/ai/providers/claude-cli-language-model.ts');
+      const model = new ClaudeCliLanguageModel('claude-sonnet-4-6');
+      const result = await model.doGenerate({
+        prompt: [userMessage('hi')],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.usage.cachedInputTokens).toBe(9001);
+    });
+  });
+
+  test('leaves usage.cachedInputTokens undefined when the CLI omits cache_read_input_tokens', async () => {
+    await withStubEnv(async () => {
+      stageResponse({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'hello world',
+        stop_reason: 'end_turn',
+        session_id: 'test-session',
+        num_turns: 1,
+        usage: { input_tokens: 12, output_tokens: 34 },
+      });
+      const { ClaudeCliLanguageModel } = await import('../src/core/ai/providers/claude-cli-language-model.ts');
+      const model = new ClaudeCliLanguageModel('claude-sonnet-4-6');
+      const result = await model.doGenerate({
+        prompt: [userMessage('hi')],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.usage.cachedInputTokens).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Symptom

Every `claude-cli`-routed gateway call reports `cache_read_tokens: 0`, regardless of
actual prompt-cache reads. Sampled 20/20 `claude-cli` gateway calls in one usage window
show `input_tokens=2` (min=max=2, i.e. structurally near-zero) and `cache_read_tokens=0`
for the whole sample, while a parallel `openai:gpt-5.6` recipe in the same window shows
avg `input_tokens=27,408` and a cumulative `cache_read_tokens` of 1,844,509 — consistent
with the cache-read count being zeroed out structurally rather than genuinely absent.

## Mechanism

`doGenerate()` in `src/core/ai/providers/claude-cli-language-model.ts` builds the
returned `LanguageModelV2` usage object from `inputTokens`/`outputTokens`/`totalTokens`
only. It never mapped `result.usage?.cache_read_input_tokens` — a field the
`ClaudeJsonResult` type already declares, and which `claude --print --output-format json`
already returns — onto the AI SDK's `cachedInputTokens` field.

Downstream, `src/core/ai/gateway.ts:3455` builds the reported `cache_read_tokens` as:

```ts
cache_read_tokens: Number(anthropicCache.cacheReadInputTokens ?? anthropicCache.cache_read_input_tokens ?? usage.cachedInputTokens ?? 0),
```

`claude-cli` never returns `providerMetadata`, so `anthropicCache` is always `{}`. With
`cachedInputTokens` also always `undefined` (this bug), the chain always fell through to
the literal `0` — for every call, permanently, regardless of real cache behavior.

## Fix

Map `result.usage?.cache_read_input_tokens` onto `cachedInputTokens` in the returned
usage object (`Number()`-coerced), leaving it `undefined` — not `0` — when the CLI omits
the field, so `gateway.ts`'s own `?? 0` normalization stays the single place that decides
the omitted-vs-zero default.

**Scope note — `cache_creation_input_tokens` intentionally untouched.** `LanguageModelV2Usage`
has no corresponding field for cache-creation tokens, and wiring it through would require a
`claude-cli`-specific branch in `gateway.ts`'s usage assembly (a separate, larger design
decision). Keeping this PR to the one already-supported field it can surface cleanly.

## Tests

Added to `test/claude-cli-recipe.test.ts` using the file's existing `GBRAIN_CLAUDE_CLI_BIN`
shell-stub pattern: present-zero, present-nonzero (pins the fix), and omitted/undefined.

**Red-green, both directions verified locally:**
- Fix removed (temporarily reverted just the source file, tests kept): `bun test
  test/claude-cli-recipe.test.ts` → 20 pass / 2 fail. Both failures are on
  `cachedInputTokens` assertions: the present-zero assertion in the existing "returns a
  single text content block with usage + stop finish reason" test (`Expected: 0,
  Received: undefined`), and the new "maps cache_read_input_tokens onto
  usage.cachedInputTokens" test (`Expected: 9001, Received: undefined`). The
  omitted/undefined test passes either way, as expected — it pins the deliberate
  `undefined` semantics, not the defect itself.
- Fix restored: 22 pass / 0 fail (62 `expect()` calls).
- `bun run typecheck` (`tsc --noEmit`): exit 0.

## Draft

Opening as Draft — happy to switch to Ready once maintainer bandwidth allows a look;
no urgency implied.
