### PR TITLE
fix(ai): expansion calls record to the budget tracker instead of spending invisibly

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -160,6 +160,11 @@ type EmbedManyFn = typeof embedMany;
 let _embedTransport: EmbedManyFn = embedMany;
 type GenerateTextFn = typeof generateText;
 let _generateTextTransport: GenerateTextFn = generateText;
+// Test-only seam for expand()'s structured-output SDK call. Mirrors
+// _generateTextTransport (see __setGenerateObjectTransportForTests). Never
+// swapped in production — expand() always calls the real generateObject.
+type GenerateObjectFn = typeof generateObject;
+let _generateObjectTransport: GenerateObjectFn = generateObject;
 // v0.41.6.0 D1: tests that install a transport stub also pass the
 // embedding-creds preflight, matching the chat-transport fast-path
 // pattern. Set when __setEmbedTransportForTests is called with a
@@ -615,6 +620,7 @@ function clearGatewayState(): void {
   _shrinkState.clear();
   _embedTransport = embedMany;
   _generateTextTransport = generateText;
+  _generateObjectTransport = generateObject;
   _embedTransportInstalled = false;
   _chatTransport = null;
   _warnedRecipes.clear();
@@ -670,6 +676,17 @@ export function __setEmbedTransportForTests(fn: EmbedManyFn | null): void {
  */
 export function __setGenerateTextTransportForTests(fn: GenerateTextFn | null): void {
   _generateTextTransport = fn ?? generateText;
+}
+
+/**
+ * Test-only seam for expand()'s generateObject call (the structured-output
+ * path used for native providers and openai-compatible recipes that declare
+ * supportsStructuredOutputs). Same shape as __setGenerateTextTransportForTests.
+ *
+ * @internal exported for tests; not part of the public gateway API.
+ */
+export function __setGenerateObjectTransportForTests(fn: GenerateObjectFn | null): void {
+  _generateObjectTransport = fn ?? generateObject;
 }
 
 /**
@@ -2476,8 +2493,34 @@ export async function expand(query: string): Promise<string[]> {
     `Query: ${query}`,
   ].join('\n');
 
+  // #4121: expand() calls generateObject/generateText directly and never
+  // goes through chat()'s _recordBudget closure, so every expansion LLM
+  // call was invisible to BudgetTracker — spend happened but was never
+  // recorded, even inside a withBudgetTracker() scope. Resolve the ambient
+  // tracker once and record on every SUCCESSFUL call site below. Fail-open
+  // (no tracker → no-op) and swallow BudgetExhausted the same way chat()'s
+  // _recordBudget does — TX1 surfaces on the NEXT reserve(), not here.
+  const tracker = getCurrentBudgetTracker();
+  const recordExpansionUsage = (
+    modelLabel: string,
+    usage: { inputTokens?: number; outputTokens?: number } | undefined,
+  ): void => {
+    if (!tracker) return;
+    try {
+      tracker.record({
+        modelId: modelLabel,
+        inputTokens: Number(usage?.inputTokens ?? 0),
+        outputTokens: Number(usage?.outputTokens ?? 0),
+        label: 'gateway.expand',
+      });
+    } catch {
+      // BudgetExhausted (TX1) raised here; surfaced via the next reserve().
+    }
+  };
+
   try {
     const { model, recipe, modelId } = await resolveExpansionProvider(getExpansionModel());
+    const modelLabel = `${recipe.id}:${modelId}`;
 
     let expansions: string[];
 
@@ -2486,35 +2529,38 @@ export async function expand(query: string): Promise<string[]> {
     // there, so generateObject would warn and silently degrade. generateText + a
     // tolerant parse recovers the queries instead. Fresh abortSignal per call.
     const viaText = async (): Promise<string[]> => {
-      const { text } = await generateText({
+      const { text, usage } = await _generateTextTransport({
         model,
         abortSignal: withDefaultTimeout(undefined, AI_CHAT_TIMEOUT_MS),
         prompt: expansionPrompt,
       });
+      recordExpansionUsage(modelLabel, usage);
       return parseExpansionResponse(text) ?? [];
     };
 
     if (recipe.implementation !== 'openai-compatible') {
       // Native providers (Anthropic, OpenAI, Google) support generateObject's
       // structured output natively — unchanged path.
-      const result = await generateObject({
+      const result = await _generateObjectTransport({
         model,
         schema: ExpansionSchema,
         abortSignal: withDefaultTimeout(undefined, AI_CHAT_TIMEOUT_MS),
         prompt: expansionPrompt,
       });
+      recordExpansionUsage(modelLabel, result.usage);
       expansions = result.object?.queries ?? [];
     } else if (recipeSupportsStructuredOutputs(recipe)) {
       // openai-compatible backend that honors strict json_schema: request the
       // schema (strict validation), and fall back to the text path if it is
       // rejected at call time so a mis-declared capability never drops expansion.
       try {
-        const result = await generateObject({
+        const result = await _generateObjectTransport({
           model,
           schema: ExpansionSchema,
           abortSignal: withDefaultTimeout(undefined, AI_CHAT_TIMEOUT_MS),
           prompt: expansionPrompt,
         });
+        recordExpansionUsage(modelLabel, result.usage);
         expansions = result.object?.queries ?? [];
       } catch {
         expansions = await viaText();

--- a/test/core/budget/expand-records-budget.test.ts
+++ b/test/core/budget/expand-records-budget.test.ts
@@ -38,7 +38,8 @@ import {
   BudgetTracker,
   _resetBudgetTrackerWarningsForTest,
 } from '../../../src/core/budget/budget-tracker.ts';
-import { RECIPES } from '../../../src/core/ai/recipes/index.ts';
+import { getRecipe, __setTestRecipesForTests } from '../../../src/core/ai/recipes/index.ts';
+import type { Recipe } from '../../../src/core/ai/types.ts';
 
 let tmp: string;
 let auditPath: string;
@@ -190,24 +191,35 @@ describe('expand() budget accounting — openai-compatible structured-output (ge
   // No built-in recipe currently opts into supports_structured_outputs (it's
   // an opt-in per-backend capability declared in ChatTouchpoint — see
   // recipeSupportsStructuredOutputs()'s own unit test in gateway-chat.test.ts
-  // for the same "no shipped recipe exercises this today" situation). Flip it
-  // on litellm's live recipe object for the duration of this test only, so
-  // expand() takes the SECOND generateObject call site (the one guarded by
-  // `recipeSupportsStructuredOutputs(recipe)`) through the real resolution
-  // path instead of the native-provider branch already covered above.
-  const litellmRecipe = RECIPES.get('litellm')!;
-  const originalSupportsStructuredOutputs = litellmRecipe.touchpoints.chat?.supports_structured_outputs;
+  // for the same "no shipped recipe exercises this today" situation). Rather
+  // than mutating a shipped recipe singleton, use the established synthetic-
+  // recipe seam (__setTestRecipesForTests, already used by
+  // no-batch-cap-suppression.serial.test.ts / adaptive-embed-batch.test.ts):
+  // clone litellm under a test-only id with supports_structured_outputs
+  // flipped on, so expand() takes the SECOND generateObject call site (the
+  // one guarded by recipeSupportsStructuredOutputs(recipe)) through the real
+  // resolution path instead of the native-provider branch already covered
+  // above — without touching the real `litellm` recipe object at all.
+  const baseLitellm = getRecipe('litellm')!;
+  const structuredLitellm: Recipe = {
+    ...baseLitellm,
+    id: 'synthetic-structured-litellm',
+    touchpoints: {
+      ...baseLitellm.touchpoints,
+      chat: { ...baseLitellm.touchpoints.chat!, supports_structured_outputs: true },
+    },
+  };
 
   beforeEach(() => {
-    litellmRecipe.touchpoints.chat!.supports_structured_outputs = true;
+    __setTestRecipesForTests([structuredLitellm]);
     configureGateway({
-      expansion_model: 'litellm:my-proxied-model',
+      expansion_model: 'synthetic-structured-litellm:my-proxied-model',
       env: {},
     });
   });
 
   afterEach(() => {
-    litellmRecipe.touchpoints.chat!.supports_structured_outputs = originalSupportsStructuredOutputs;
+    __setTestRecipesForTests([]);
   });
 
   test('a successful structured-output expansion records usage — NOT via viaText()', async () => {
@@ -240,7 +252,7 @@ describe('expand() budget accounting — openai-compatible structured-output (ge
     const recordRow = rows.find(r => r.event === 'record' || r.event === 'record_unpriced');
     expect(recordRow).toBeTruthy();
     expect(recordRow.sub_label).toBe('gateway.expand');
-    expect(recordRow.model).toBe('litellm:my-proxied-model');
+    expect(recordRow.model).toBe('synthetic-structured-litellm:my-proxied-model');
     expect(recordRow.input_tokens).toBe(55);
     expect(recordRow.output_tokens).toBe(22);
   });

--- a/test/core/budget/expand-records-budget.test.ts
+++ b/test/core/budget/expand-records-budget.test.ts
@@ -1,0 +1,186 @@
+/**
+ * #4121 — expand() (query expansion) calls generateObject/generateText
+ * directly and never went through chat()'s `_recordBudget` closure, so
+ * expansion LLM spend was invisible to BudgetTracker even inside a
+ * `withBudgetTracker()` scope.
+ *
+ * Pins the fix's public contract:
+ *   - Every SUCCESSFUL expand() call site (native generateObject path,
+ *     openai-compatible structured-output generateObject path, and the
+ *     schemaless generateText fallback path) records usage on the ambient
+ *     BudgetTracker with a distinct `sub_label: 'gateway.expand'` — never
+ *     conflated with chat()'s `gateway.chat` audit rows.
+ *   - expand() outside any withBudgetTracker scope stays a budget no-op
+ *     (back-compat, mirrors gateway-budget-composition.test.ts).
+ *   - record() throwing BudgetExhausted (TX1, over-cap) is swallowed —
+ *     expand() still returns its best-effort result, matching chat()'s
+ *     fail-open posture.
+ *
+ * Hermetic: routes through __setGenerateObjectTransportForTests /
+ * __setGenerateTextTransportForTests so no network / provider / env
+ * variable is touched.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  expand,
+  configureGateway,
+  resetGateway,
+  withBudgetTracker,
+  getCurrentBudgetTracker,
+  __setGenerateObjectTransportForTests,
+  __setGenerateTextTransportForTests,
+} from '../../../src/core/ai/gateway.ts';
+import {
+  BudgetTracker,
+  _resetBudgetTrackerWarningsForTest,
+} from '../../../src/core/budget/budget-tracker.ts';
+
+let tmp: string;
+let auditPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'gbrain-expand-budget-'));
+  auditPath = join(tmp, 'budget.jsonl');
+  _resetBudgetTrackerWarningsForTest();
+});
+
+afterEach(() => {
+  __setGenerateObjectTransportForTests(null);
+  __setGenerateTextTransportForTests(null);
+  resetGateway();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Read + parse every JSONL line in the tracker's audit file. */
+function readAudit(): any[] {
+  return readFileSync(auditPath, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+describe('expand() budget accounting — native generateObject path', () => {
+  beforeEach(() => {
+    configureGateway({
+      expansion_model: 'anthropic:claude-haiku-4-5-20251001',
+      env: { ANTHROPIC_API_KEY: 'sk-test-fake' },
+    });
+  });
+
+  test('a successful expansion records usage under the ambient tracker', async () => {
+    __setGenerateObjectTransportForTests(async () => ({
+      object: { queries: ['alt one', 'alt two'] },
+      usage: { inputTokens: 120, outputTokens: 40 },
+    }) as any);
+
+    const tracker = new BudgetTracker({ maxCostUsd: 1.0, label: 'test-expand', auditPath });
+
+    let result: string[] = [];
+    await withBudgetTracker(tracker, async () => {
+      result = await expand('original query');
+    });
+
+    expect(result).toContain('original query');
+    expect(result).toContain('alt one');
+    expect(tracker.snapshot().callsRecorded).toBe(1);
+    // Haiku pricing is non-zero, so a priced call must move totalSpent.
+    expect(tracker.totalSpent).toBeGreaterThan(0);
+
+    const rows = readAudit();
+    const recordRow = rows.find(r => r.event === 'record');
+    expect(recordRow).toBeTruthy();
+    // The core of #4121: expansion spend must carry its own sub_label, never
+    // the chat() one — that conflation is exactly what made it invisible.
+    expect(recordRow.sub_label).toBe('gateway.expand');
+    expect(recordRow.sub_label).not.toBe('gateway.chat');
+    expect(recordRow.model).toBe('anthropic:claude-haiku-4-5-20251001');
+    expect(recordRow.input_tokens).toBe(120);
+    expect(recordRow.output_tokens).toBe(40);
+  });
+
+  test('outside any withBudgetTracker scope, expand() is a budget no-op (back-compat)', async () => {
+    __setGenerateObjectTransportForTests(async () => ({
+      object: { queries: ['alt one'] },
+      usage: { inputTokens: 120, outputTokens: 40 },
+    }) as any);
+
+    expect(getCurrentBudgetTracker()).toBeNull();
+    const result = await expand('original query');
+    expect(result).toContain('original query');
+    expect(result).toContain('alt one');
+    // No tracker was ever installed — nothing to assert beyond "no throw".
+    expect(getCurrentBudgetTracker()).toBeNull();
+  });
+
+  test('BudgetExhausted from record() (TX1) is swallowed — expand() still returns its result', async () => {
+    // Tiny cap: reserve() has no pre-flight for expand() (only chat() calls
+    // reserve()), so the first record() itself pushes cumulative > cap and
+    // throws internally. recordExpansionUsage must swallow it.
+    __setGenerateObjectTransportForTests(async () => ({
+      object: { queries: ['alt one'] },
+      usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+    }) as any);
+
+    const tracker = new BudgetTracker({ maxCostUsd: 0.0001, label: 'tight-expand', auditPath });
+
+    let result: string[] = [];
+    let threw: unknown = null;
+    await withBudgetTracker(tracker, async () => {
+      try {
+        result = await expand('original query');
+      } catch (err) {
+        threw = err;
+      }
+    });
+
+    expect(threw).toBeNull();
+    expect(result).toContain('original query');
+    expect(tracker.totalSpent).toBeGreaterThan(0.0001);
+  });
+});
+
+describe('expand() budget accounting — openai-compatible schemaless (viaText) path', () => {
+  beforeEach(() => {
+    // litellm: requires no auth env and declares no chat.supports_structured_outputs,
+    // so recipeSupportsStructuredOutputs() is false and expand() routes straight
+    // to viaText() — the generateText fallback path, not generateObject.
+    configureGateway({
+      expansion_model: 'litellm:my-proxied-model',
+      env: {},
+    });
+  });
+
+  test('a successful viaText() expansion records usage with the same sub_label', async () => {
+    __setGenerateTextTransportForTests(async () => ({
+      text: '{"queries": ["alt one", "alt two"]}',
+      usage: { inputTokens: 80, outputTokens: 30 },
+    }) as any);
+
+    const tracker = new BudgetTracker({ label: 'test-expand-viatext', auditPath });
+
+    let result: string[] = [];
+    await withBudgetTracker(tracker, async () => {
+      result = await expand('original query');
+    });
+
+    expect(result).toContain('original query');
+    expect(result).toContain('alt one');
+    expect(tracker.snapshot().callsRecorded).toBe(1);
+
+    const rows = readAudit();
+    // litellm has no pricing entry, so this lands as record_unpriced — still
+    // proves the call site fired (this is the exact code path #4121 reported
+    // as never reaching the tracker at all).
+    const recordRow = rows.find(r => r.event === 'record' || r.event === 'record_unpriced');
+    expect(recordRow).toBeTruthy();
+    expect(recordRow.sub_label).toBe('gateway.expand');
+    expect(recordRow.model).toBe('litellm:my-proxied-model');
+    expect(recordRow.input_tokens).toBe(80);
+    expect(recordRow.output_tokens).toBe(30);
+  });
+});

--- a/test/core/budget/expand-records-budget.test.ts
+++ b/test/core/budget/expand-records-budget.test.ts
@@ -38,6 +38,7 @@ import {
   BudgetTracker,
   _resetBudgetTrackerWarningsForTest,
 } from '../../../src/core/budget/budget-tracker.ts';
+import { RECIPES } from '../../../src/core/ai/recipes/index.ts';
 
 let tmp: string;
 let auditPath: string;
@@ -182,5 +183,65 @@ describe('expand() budget accounting — openai-compatible schemaless (viaText) 
     expect(recordRow.model).toBe('litellm:my-proxied-model');
     expect(recordRow.input_tokens).toBe(80);
     expect(recordRow.output_tokens).toBe(30);
+  });
+});
+
+describe('expand() budget accounting — openai-compatible structured-output (generateObject) path', () => {
+  // No built-in recipe currently opts into supports_structured_outputs (it's
+  // an opt-in per-backend capability declared in ChatTouchpoint — see
+  // recipeSupportsStructuredOutputs()'s own unit test in gateway-chat.test.ts
+  // for the same "no shipped recipe exercises this today" situation). Flip it
+  // on litellm's live recipe object for the duration of this test only, so
+  // expand() takes the SECOND generateObject call site (the one guarded by
+  // `recipeSupportsStructuredOutputs(recipe)`) through the real resolution
+  // path instead of the native-provider branch already covered above.
+  const litellmRecipe = RECIPES.get('litellm')!;
+  const originalSupportsStructuredOutputs = litellmRecipe.touchpoints.chat?.supports_structured_outputs;
+
+  beforeEach(() => {
+    litellmRecipe.touchpoints.chat!.supports_structured_outputs = true;
+    configureGateway({
+      expansion_model: 'litellm:my-proxied-model',
+      env: {},
+    });
+  });
+
+  afterEach(() => {
+    litellmRecipe.touchpoints.chat!.supports_structured_outputs = originalSupportsStructuredOutputs;
+  });
+
+  test('a successful structured-output expansion records usage — NOT via viaText()', async () => {
+    __setGenerateObjectTransportForTests(async () => ({
+      object: { queries: ['alt one', 'alt two'] },
+      usage: { inputTokens: 55, outputTokens: 22 },
+    }) as any);
+    // If the code regresses to falling through to viaText() (e.g. the
+    // try/catch around the structured call swallows a non-error condition),
+    // this transport must NOT be reached — assert it never fires.
+    let viaTextCalled = false;
+    __setGenerateTextTransportForTests(async () => {
+      viaTextCalled = true;
+      return { text: '{"queries": ["fallback"]}', usage: { inputTokens: 1, outputTokens: 1 } } as any;
+    });
+
+    const tracker = new BudgetTracker({ label: 'test-expand-structured', auditPath });
+
+    let result: string[] = [];
+    await withBudgetTracker(tracker, async () => {
+      result = await expand('original query');
+    });
+
+    expect(viaTextCalled).toBe(false);
+    expect(result).toContain('original query');
+    expect(result).toContain('alt one');
+    expect(tracker.snapshot().callsRecorded).toBe(1);
+
+    const rows = readAudit();
+    const recordRow = rows.find(r => r.event === 'record' || r.event === 'record_unpriced');
+    expect(recordRow).toBeTruthy();
+    expect(recordRow.sub_label).toBe('gateway.expand');
+    expect(recordRow.model).toBe('litellm:my-proxied-model');
+    expect(recordRow.input_tokens).toBe(55);
+    expect(recordRow.output_tokens).toBe(22);
   });
 });


### PR DESCRIPTION
## Symptom

`expand()` (query expansion) spend is invisible to `BudgetTracker`, even inside a `withBudgetTracker()` scope. `gateway.chat()` composes with the ambient tracker via an internal `_recordBudget` closure that calls `tracker.record({..., label: 'gateway.chat'})`. `expand()` calls the AI SDK's `generateObject()` / `generateText()` directly and never goes through that closure, so its usage was never recorded.

Observed on a real v0.45.11.0 brain: for a single `query` op where `eval_candidates.expansion_applied: true` was recorded, the same-window chat-boundary usage rows were 0, and grepping 3 weeks of `~/.gbrain/audit/budget-2026-W{31,32,33}.jsonl` for `expan*` returned 0 hits — while the same files carry many `sub_label: "gateway.chat"` rows from other phases. Re-measuring this exact number isn't necessary to evaluate the fix; it's cited to show the gap is real, not theoretical.

Related to #4121

## Fix

Resolves the ambient tracker inside `expand()` via the existing exported `getCurrentBudgetTracker()` and records on every **successful** LLM call site (there are 3: native-provider `generateObject`, the openai-compatible structured-output `generateObject` path, and the schemaless `generateText` "viaText" fallback), tagged with `label: 'gateway.expand'` so it's distinguishable in the audit JSONL (`sub_label`) instead of silently merging into `gateway.chat`. Fails open — no ambient tracker means no-op — and swallows `BudgetExhausted` (TX1) the same way `chat()`'s `_recordBudget` does (surfaced on the next `reserve()`, not thrown out of `expand()`).

One new test-only transport seam is added (`_generateObjectTransport`), and `viaText()` is rewired from a direct `generateText()` call to the already-existing `_generateTextTransport` so all 3 call sites are interceptable in tests, mirroring the `_chatTransport` / `_generateTextTransport` / `_rerankTransport` pattern already used repeatedly in this file. They default to the real SDK functions in production and are reset in `clearGatewayState()`.

## Deliberately out of scope

- **No refactor of `expand()` to go through `chat()`.** `chat()`'s retry/providerMetadata/stop-reason handling is a much larger surface than an accounting fix warrants.
- **`gbrain doctor`'s expansion probe is untouched** (separate concern from #4121).
- **Failed LLM calls are not recorded** — only successful calls. Mirrors the issue's own scope (successful expansion spend going unrecorded). Recording failures the way `chat()` does would need a pessimistic-fallback input/output-token estimate (`chat()` has `estimateChatInputTokens()` + a precomputed `maxOutputTokens` to build one on error; `expand()` has neither today), which is a materially bigger diff. Confirmed via review that this omission is honest — a failed call simply produces no audit row, it's never double-counted or misattributed to `gateway.chat`.

## Tests

`test/core/budget/expand-records-budget.test.ts` (new, 5 tests) — hermetic, no network/provider/env touched:
- Native `generateObject` path records usage under the ambient tracker, with the correct `sub_label`/model/token counts in the audit JSONL, and moves `tracker.totalSpent`.
- `expand()` outside any `withBudgetTracker` scope stays a no-op (back-compat).
- `BudgetExhausted` from `record()` is swallowed — `expand()` still returns its best-effort result.
- openai-compatible schemaless (`viaText`) path records usage with the same `sub_label`.
- openai-compatible structured-output `generateObject` path records usage — verified it's NOT reached via `viaText()` (no shipped recipe currently opts into `supports_structured_outputs`, so this uses the existing `__setTestRecipesForTests()` seam, already used by `no-batch-cap-suppression.serial.test.ts`, to register a synthetic recipe rather than mutating any shipped one).

Red-green, stated precisely because the two halves differ in strength:

- **Main fix**: reverting `gateway.ts` to upstream while keeping the new test does not produce a failing assertion — the module fails to load (`Export named '__setGenerateObjectTransportForTests' not found`, exit 1), because the test seam ships with the fix. That proves the test cannot pass without the change, but it is a load error rather than a red assertion.
- **Structured-output branch**: removing just that one `recordExpansionUsage()` call site produces the sharper signal — exactly that test fails (`callsRecorded 1 -> 0`) while the other four stay green. Restoring it returns 5/5.

```
bun test test/ai/ test/core/budget/   -> 532 pass / 0 fail
bun run typecheck                      -> clean
bun run verify                         -> 39/39 checks green
```

## Review

Passed 3 rounds of independent Codex review (`model_reasoning_effort=high`). Round 1 flagged missing coverage for the structured-output `generateObject` branch (added). Round 2 flagged that the added test mutated the shipped `litellm` recipe singleton with a shape-inexact restore (switched to the established `__setTestRecipesForTests()` synthetic-recipe seam). Round 3: 0 Critical, 0 Warning.


