### PR TITLE
fix(path-confine): Windows path containment - use path.relative instead of '/' string prefix

### DIFF
--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -20,7 +20,7 @@
  */
 
 import { realpathSync, existsSync, type Stats } from 'fs';
-import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join } from 'path';
+import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join, sep } from 'path';
 
 /**
  * Symlink-safe path confinement: realpath BOTH sides, then a separator-aware
@@ -41,9 +41,13 @@ export function isPathContained(child: string, parent: string): boolean {
   } catch {
     return false; // missing / unresolvable path → not contained
   }
-  // Append a separator so /foo doesn't match /foobar.
-  const parentWithSep = resolvedParent.endsWith('/') ? resolvedParent : resolvedParent + '/';
-  return resolvedChild === resolvedParent || resolvedChild.startsWith(parentWithSep);
+  // Platform-aware containment via path.relative (not string prefix): a bare
+  // `startsWith(parent + '/')` hardcodes the POSIX separator, so on Windows
+  // (realpath returns `C:\...`) every child failed the check and the boundary
+  // rejected legitimate paths. `relative()` also handles case-insensitive
+  // drive letters and keeps /foo from matching /foobar.
+  const rel = relative(resolvedParent, resolvedChild);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
 }
 
 /**


### PR DESCRIPTION
## Problem

`isPathContained` (src/core/path-confine.ts) appends a hardcoded `'/'` to the resolved parent before the `startsWith` check. On Windows, `realpathSync` returns backslash-separated paths (`C:\Users\...`), so the prefix never matches and the containment check rejects **every** legitimate child path.

Observable symptom: `gbrain hook session-end` always degrades with `transcript_outside_projects_dir` on Windows, so the dream-corpus transcript pipeline never ingests anything on that platform.

## Repro

```js
const parent = realpathSync(join(homedir(), '.claude', 'projects'));
// => C:\Users\me\.claude\projects
const child = realpathSync(join(parent, 'proj', 'session.jsonl'));
child.startsWith(parent + '/');  // false — always
```

## Fix

Replace the string-prefix idiom with `path.relative()`: empty result = same dir; `..` prefix or absolute result = outside. This handles `\` vs `/`, case-insensitive drive letters, and cross-drive paths, and keeps `/foo` from matching `/foobar`. Fail-closed behavior (unresolvable paths = not contained) is unchanged.

Verified on Windows 11: direct child OK, parent itself OK, sibling with common prefix rejected, `..` traversal rejected, other drive rejected, lowercase drive letter OK, mixed separators OK. `test/path-confine.test.ts` goes from 7 failing to 6 on Windows (the remaining 6 are EPERM symlink-creation failures needing admin rights, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
