### PR TITLE
fix(facts): exclude internal extraction audit rows from fact reads

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -93,6 +93,16 @@ import { withRefreshingLock, LockUnavailableError } from '../core/db-lock.ts';
 import { assertFactsEmbeddingDimMatchesConfig } from '../core/embedding-dim-check.ts';
 import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
+import {
+  TERMINAL_AUDIT_SOURCE,
+  NON_EXTRACTABLE_AUDIT_SOURCE,
+} from '../core/facts/audit-sources.ts';
+
+// Re-exported verbatim so existing importers (eval write-back, this file's
+// own tests, the doctor backlog tests) keep working unchanged. Moved to
+// src/core/facts/audit-sources.ts so both engines can filter these rows out
+// of listFacts* reads via a static import (see that file for why).
+export { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE };
 
 // ---------------------------------------------------------------------------
 // Tunables (exported for tests).
@@ -201,21 +211,11 @@ export const CHECKPOINT_OP = 'extract-conversation-facts';
  */
 export const PER_SEGMENT_SOURCE_PREFIX = 'cli:extract-conversation-facts';
 
-/**
- * Source string written on the page-level terminal audit row (Eng-v2 C7).
- * Doctor's backlog query matches THIS source + source_session, not
- * the per-segment source. Partial extraction = no terminal row = page
- * stays in backlog.
- */
-export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2';
-
-/**
- * Durable outcome for a successfully scanned page that contains no eligible
- * multi-message segment. Kept distinct from successful extraction so operator
- * surfaces can report the truth without rescanning the page forever.
- */
-export const NON_EXTRACTABLE_AUDIT_SOURCE =
-  'cli:extract-conversation-facts:non-extractable:v2';
+// TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE now live in
+// ../core/facts/audit-sources.ts (imported + re-exported above). Doctor's
+// backlog query matches TERMINAL_AUDIT_SOURCE + source_session, not the
+// per-segment source; partial extraction = no terminal row = page stays in
+// backlog.
 
 // ---------------------------------------------------------------------------
 // Public types.

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -552,6 +552,9 @@ export interface FactListOpts {
    * are returned. Remote (untrusted) callers must supply ['world'].
    */
   visibility?: FactVisibility[];
+  /** Hide internal extraction audit rows (EXTRACTION_COMPLETE / EXTRACTION_NOT_APPLICABLE,
+   *  written by extract-conversation-facts as per-page completion markers). Default true. */
+  excludeAuditRows?: boolean;
 }
 
 /** Per-source operational health snapshot consumed by `gbrain doctor`. */

--- a/src/core/facts/audit-sources.ts
+++ b/src/core/facts/audit-sources.ts
@@ -1,0 +1,41 @@
+/**
+ * Source strings written on internal extraction-audit rows by
+ * `src/commands/extract-conversation-facts.ts` (Eng-v2 C7). These are
+ * per-page completion markers, not user-facing knowledge: kind:'fact',
+ * entity_slug:null, never expired. `extract-conversation-facts`'s own
+ * resume logic reads them via raw SQL (`findFreshExtractionOutcomes`),
+ * not via listFacts* — so filtering listFacts* by these sources does
+ * not affect resume.
+ *
+ * Lives in `src/core/` (not `src/commands/`) so both engines
+ * (`postgres-engine.ts`, `pglite-engine.ts`) can import it via a static
+ * top-level import — engine-live paths must not use runtime dynamic
+ * `import()`, and pulling the whole extract-conversation-facts module
+ * into both engines would be unnecessarily heavy.
+ *
+ * `src/commands/extract-conversation-facts.ts` re-exports both names
+ * verbatim so existing importers (eval write-back, its own tests, the
+ * doctor backlog tests) keep working unchanged.
+ */
+
+/**
+ * Source string written on the page-level terminal audit row (Eng-v2 C7).
+ * Doctor queries this source + source_session; this variant marks the
+ * page as fully scanned (as opposed to PER_SEGMENT_SOURCE_PREFIX, which
+ * marks individual fact provenance).
+ */
+export const TERMINAL_AUDIT_SOURCE = 'cli:extract-conversation-facts:terminal:v2';
+
+/**
+ * Durable outcome for a successfully scanned page that contains no eligible
+ * multi-message segment. Kept distinct from successful extraction so operator
+ * surfaces can report the truth without rescanning the page forever.
+ */
+export const NON_EXTRACTABLE_AUDIT_SOURCE =
+  'cli:extract-conversation-facts:non-extractable:v2';
+
+/** Both audit sources together, for use in exclusion predicates. */
+export const AUDIT_SOURCES: readonly string[] = [
+  TERMINAL_AUDIT_SOURCE,
+  NON_EXTRACTABLE_AUDIT_SOURCE,
+];

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4881,6 +4881,15 @@ export class PGLiteEngine implements BrainEngine {
     }
     return this._listFacts(source_id, {
       activeOnly: false,
+      // Engine parity (postgres-engine.ts's listSupersessions does not
+      // filter audit rows either): this is a supersession AUDIT LOG, not a
+      // knowledge-recall surface. An audit row CAN be superseded (any row
+      // can — expireFact(id, { supersededBy }) sets expired_at/superseded_by
+      // on whatever id it's given), and when it is, this log should show it
+      // like any other superseded row, on both engines identically. Do not
+      // default this to true just because _listFacts defaults it to true
+      // for the knowledge-facing methods.
+      excludeAuditRows: false,
       limit: opts?.limit,
       whereClauses: where,
       whereParams: params,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -25,6 +25,7 @@ import type {
   SourceRow,
 } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { AUDIT_SOURCES } from './facts/audit-sources.ts';
 // Engine-path imports stay static unless a call site carries an explicit
 // engine-dynamic-import-ok justification. The gateway is the only current
 // exception because its local try/catch preserves a soft fallback.
@@ -5096,6 +5097,10 @@ export class PGLiteEngine implements BrainEngine {
     const params: Record<string, unknown> = { source_id };
     if (opts.activeOnly !== false) {
       whereParts.push(`expired_at IS NULL`);
+    }
+    if (opts.excludeAuditRows !== false) {
+      whereParts.push(`NOT (source = ANY($auditSources))`);
+      params.auditSources = AUDIT_SOURCES;
     }
     if (opts.kinds && opts.kinds.length > 0) {
       whereParts.push(`kind = ANY($kinds)`);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -41,6 +41,7 @@ import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
 } from './types.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { AUDIT_SOURCES } from './facts/audit-sources.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
@@ -4711,6 +4712,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const excludeAudit = opts?.excludeAuditRows !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -4718,6 +4720,7 @@ export class PostgresEngine implements BrainEngine {
       WHERE source_id = ${source_id}
         AND entity_slug = ${entitySlug}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${excludeAudit ? sql`AND NOT (source = ANY(${AUDIT_SOURCES}::text[]))` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY valid_from DESC, id DESC
@@ -4735,6 +4738,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const excludeAudit = opts?.excludeAuditRows !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const entitySlug = opts?.entitySlug ?? null;
@@ -4744,6 +4748,7 @@ export class PostgresEngine implements BrainEngine {
         AND created_at >= ${since}
         ${entitySlug ? sql`AND entity_slug = ${entitySlug}` : sql``}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${excludeAudit ? sql`AND NOT (source = ANY(${AUDIT_SOURCES}::text[]))` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC
@@ -4761,6 +4766,7 @@ export class PostgresEngine implements BrainEngine {
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const excludeAudit = opts?.excludeAuditRows !== false;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -4768,6 +4774,7 @@ export class PostgresEngine implements BrainEngine {
       WHERE source_id = ${source_id}
         AND source_session = ${sessionId}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${excludeAudit ? sql`AND NOT (source = ANY(${AUDIT_SOURCES}::text[]))` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC

--- a/test/e2e/engine-parity.test.ts
+++ b/test/e2e/engine-parity.test.ts
@@ -19,6 +19,7 @@ import type { ChunkInput, SearchResult } from '../../src/core/types.ts';
 import type { BrainEngine } from '../../src/core/engine.ts';
 import { getSessionContextState, upsertSessionContextState } from '../../src/core/context/session-state.ts';
 import { hasDatabase, setupDB, teardownDB, getEngine } from './helpers.ts';
+import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../../src/core/facts/audit-sources.ts';
 
 const SKIP_PG = !hasDatabase();
 const describeBoth = SKIP_PG ? describe.skip : describe;
@@ -1168,6 +1169,134 @@ describeBoth('Engine parity — ambient recall keyset + session cursor (v0.45.7)
       expect(st!.standing_entities).toEqual(entities);
       expect(st!.surfaced_slugs).toEqual(['ks/tie-04']);
       expect(st!.last_wake_at).toBe(KS_LATE_TS);
+    }
+  });
+});
+
+describeBoth('Engine parity — extraction audit-row exclusion (recall-audit-rows)', () => {
+  // extract-conversation-facts writes per-page terminal audit rows
+  // (kind:'fact', entity_slug:null, never expired) as internal completion
+  // markers, source=TERMINAL_AUDIT_SOURCE / NON_EXTRACTABLE_AUDIT_SOURCE.
+  // FactListOpts.excludeAuditRows (default true) hides them from the
+  // knowledge-facing listFacts* methods; listSupersessions is deliberately
+  // NOT filtered (it's a supersession AUDIT LOG, and Postgres never
+  // filtered it). This block pins that BOTH engines behave identically —
+  // an adversarial review found PGLite's listSupersessions diverging from
+  // Postgres's (a superseded audit row vanished from PGLite's log while
+  // staying visible on Postgres's); see pglite-engine.ts's listSupersessions
+  // for the fix.
+  let pgEngine: BrainEngine;
+  let pgliteEngine: PGLiteEngine;
+
+  beforeAll(async () => {
+    pgEngine = await setupDB();
+    pgliteEngine = new PGLiteEngine();
+    await pgliteEngine.connect({});
+    await pgliteEngine.initSchema();
+  }, 90_000);
+
+  afterAll(async () => {
+    await pgliteEngine.disconnect();
+    await teardownDB();
+  }, 30_000);
+
+  test('listFactsSince excludes audit rows identically on both engines', async () => {
+    for (const eng of [pgEngine, pgliteEngine]) {
+      await eng.insertFact(
+        { fact: 'real fact', kind: 'fact', source: 'test', source_session: 'audit-parity-since-real' },
+        { source_id: 'default' },
+      );
+      await eng.insertFact(
+        {
+          fact: 'EXTRACTION_COMPLETE',
+          kind: 'fact',
+          entity_slug: null,
+          source: TERMINAL_AUDIT_SOURCE,
+          source_session: 'audit-parity-since-audit',
+        },
+        { source_id: 'default' },
+      );
+    }
+    for (const eng of [pgEngine, pgliteEngine]) {
+      const rows = await eng.listFactsSince('default', new Date(0));
+      expect(rows.find(r => r.source_session === 'audit-parity-since-real')).toBeDefined();
+      expect(rows.find(r => r.source_session === 'audit-parity-since-audit')).toBeUndefined();
+    }
+  });
+
+  test('listFactsByEntity excludes an audit-sourced row that IS reachable by entity_slug, identically on both engines', async () => {
+    // Audit rows always ship entity_slug:null in production, so a
+    // null-entity_slug seed here would pass vacuously (excluded by the
+    // entity_slug predicate alone, regardless of the source filter). Give
+    // this one a real entity_slug so the query can actually reach it and
+    // the source predicate is the thing under test.
+    const entity = 'people/audit-parity-entity-test';
+    for (const eng of [pgEngine, pgliteEngine]) {
+      await eng.insertFact(
+        { fact: 'real entity fact', kind: 'fact', entity_slug: entity, source: 'test', source_session: 'audit-parity-entity-real' },
+        { source_id: 'default' },
+      );
+      await eng.insertFact(
+        {
+          fact: 'EXTRACTION_COMPLETE',
+          kind: 'fact',
+          entity_slug: entity,
+          source: TERMINAL_AUDIT_SOURCE,
+          source_session: 'audit-parity-entity-audit',
+        },
+        { source_id: 'default' },
+      );
+    }
+    for (const eng of [pgEngine, pgliteEngine]) {
+      const rows = await eng.listFactsByEntity('default', entity);
+      expect(rows.find(r => r.source_session === 'audit-parity-entity-real')).toBeDefined();
+      expect(rows.find(r => r.source_session === 'audit-parity-entity-audit')).toBeUndefined();
+    }
+  });
+
+  test('listFactsBySession excludes audit rows identically on both engines', async () => {
+    const session = 'audit-parity-bysession-test';
+    for (const eng of [pgEngine, pgliteEngine]) {
+      await eng.insertFact(
+        { fact: 'real session fact', kind: 'fact', source: 'test', source_session: session },
+        { source_id: 'default' },
+      );
+      await eng.insertFact(
+        { fact: 'EXTRACTION_NOT_APPLICABLE', kind: 'fact', entity_slug: null, source: NON_EXTRACTABLE_AUDIT_SOURCE, source_session: session },
+        { source_id: 'default' },
+      );
+    }
+    for (const eng of [pgEngine, pgliteEngine]) {
+      const rows = await eng.listFactsBySession('default', session);
+      expect(rows.length).toBe(1);
+      expect(rows[0].fact).toBe('real session fact');
+    }
+  });
+
+  test('listSupersessions is NOT filtered — a superseded audit row is visible identically on both engines', async () => {
+    for (const eng of [pgEngine, pgliteEngine]) {
+      const audit = await eng.insertFact(
+        {
+          fact: 'EXTRACTION_COMPLETE',
+          kind: 'fact',
+          entity_slug: null,
+          source: TERMINAL_AUDIT_SOURCE,
+          source_session: 'audit-parity-supersession',
+        },
+        { source_id: 'default' },
+      );
+      const newer = await eng.insertFact(
+        { fact: 'superseder of audit row', kind: 'fact', source: 'test' },
+        { source_id: 'default' },
+      );
+      const didExpire = await eng.expireFact(audit.id, { supersededBy: newer.id });
+      expect(didExpire).toBe(true);
+
+      const supersessions = await eng.listSupersessions('default');
+      const row = supersessions.find(r => r.id === audit.id);
+      expect(row).toBeDefined();
+      expect(row!.source).toBe(TERMINAL_AUDIT_SOURCE);
+      expect(row!.superseded_by).toBe(newer.id);
     }
   });
 });

--- a/test/facts-engine.test.ts
+++ b/test/facts-engine.test.ts
@@ -14,6 +14,10 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+import {
+  TERMINAL_AUDIT_SOURCE,
+  NON_EXTRACTABLE_AUDIT_SOURCE,
+} from '../src/core/facts/audit-sources.ts';
 
 let engine: PGLiteEngine;
 
@@ -162,6 +166,73 @@ describe('listFactsSince + listFactsBySession', () => {
     expect(a.every(r => r.source_session === 'topic-A')).toBe(true);
     expect(b.every(r => r.source_session === 'topic-B')).toBe(true);
     expect(a.find(r => r.source_session === 'topic-B')).toBeUndefined();
+  });
+});
+
+describe('listFactsSince excludeAuditRows (internal extraction audit rows)', () => {
+  // extract-conversation-facts writes per-page terminal audit rows
+  // (kind:'fact', entity_slug:null, never expired) as internal completion
+  // markers. Every non-engine caller of listFacts* is a user-facing
+  // knowledge surface (recall, entity, ambient turn-context, meta-hook,
+  // CLI recall) — none of them are diagnostic, so these rows must not leak
+  // into them by default. extract-conversation-facts' own resume logic
+  // reads them via raw SQL, not listFacts*, so this filter cannot affect
+  // resume.
+  test('audit row (TERMINAL_AUDIT_SOURCE) is NOT returned by listFactsSince by default', async () => {
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: 'audit-row-filter-test-complete',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsSince('default', before);
+    expect(rows.find(r => r.source_session === 'audit-row-filter-test-complete')).toBeUndefined();
+  });
+
+  test('audit row IS returned when excludeAuditRows: false is passed explicitly (proves it is a filter, not a delete)', async () => {
+    const before = new Date();
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_NOT_APPLICABLE',
+        kind: 'fact',
+        entity_slug: null,
+        source: NON_EXTRACTABLE_AUDIT_SOURCE,
+        source_session: 'audit-row-filter-test-non-applicable',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsSince('default', before, { excludeAuditRows: false });
+    const row = rows.find(r => r.source_session === 'audit-row-filter-test-non-applicable');
+    expect(row).toBeDefined();
+    expect(row!.source).toBe(NON_EXTRACTABLE_AUDIT_SOURCE);
+  });
+
+  test('real facts seeded alongside an audit row are still returned (filter is not over-broad)', async () => {
+    const before = new Date();
+    const session = 'audit-row-filter-test-mixed';
+    await engine.insertFact(
+      { fact: 'real user fact', kind: 'fact', source: 'test', source_session: session },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: session,
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsSince('default', before);
+    const scoped = rows.filter(r => r.source_session === session);
+    expect(scoped.length).toBe(1);
+    expect(scoped[0].fact).toBe('real user fact');
   });
 });
 

--- a/test/facts-engine.test.ts
+++ b/test/facts-engine.test.ts
@@ -169,7 +169,7 @@ describe('listFactsSince + listFactsBySession', () => {
   });
 });
 
-describe('listFactsSince excludeAuditRows (internal extraction audit rows)', () => {
+describe('excludeAuditRows (internal extraction audit rows) — listFactsSince', () => {
   // extract-conversation-facts writes per-page terminal audit rows
   // (kind:'fact', entity_slug:null, never expired) as internal completion
   // markers. Every non-engine caller of listFacts* is a user-facing
@@ -233,6 +233,136 @@ describe('listFactsSince excludeAuditRows (internal extraction audit rows)', () 
     const scoped = rows.filter(r => r.source_session === session);
     expect(scoped.length).toBe(1);
     expect(scoped[0].fact).toBe('real user fact');
+  });
+});
+
+describe('excludeAuditRows — listFactsByEntity', () => {
+  // In production, writeTerminalAuditRow/writeNonExtractableAuditRow always
+  // set entity_slug: null, so listFactsByEntity (which requires an
+  // entity_slug match) would never reach a real audit row regardless of
+  // this filter — that would make a test seeding a null-entity_slug audit
+  // row here VACUOUS (it'd pass whether or not the source predicate exists,
+  // since the entity_slug predicate alone already excludes it). To actually
+  // exercise the source predicate, seed an audit-sourced row WITH a
+  // non-null entity_slug the query COULD otherwise reach.
+  const ENTITY = 'people/audit-row-filter-entity-test';
+
+  test('audit-sourced row reachable by entity_slug is NOT returned by default', async () => {
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: ENTITY,
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: 'audit-row-filter-entity-test-complete',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsByEntity('default', ENTITY);
+    expect(rows.find(r => r.source_session === 'audit-row-filter-entity-test-complete')).toBeUndefined();
+  });
+
+  test('audit-sourced row IS returned when excludeAuditRows: false is passed explicitly', async () => {
+    await engine.insertFact(
+      {
+        fact: 'EXTRACTION_NOT_APPLICABLE',
+        kind: 'fact',
+        entity_slug: ENTITY,
+        source: NON_EXTRACTABLE_AUDIT_SOURCE,
+        source_session: 'audit-row-filter-entity-test-non-applicable',
+      },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsByEntity('default', ENTITY, { excludeAuditRows: false });
+    const row = rows.find(r => r.source_session === 'audit-row-filter-entity-test-non-applicable');
+    expect(row).toBeDefined();
+    expect(row!.source).toBe(NON_EXTRACTABLE_AUDIT_SOURCE);
+  });
+
+  test('a real fact under the same entity_slug is still returned (filter is not over-broad)', async () => {
+    await engine.insertFact(
+      { fact: 'real entity fact', kind: 'fact', entity_slug: ENTITY, source: 'test', source_session: 'audit-row-filter-entity-test-real' },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsByEntity('default', ENTITY);
+    const row = rows.find(r => r.source_session === 'audit-row-filter-entity-test-real');
+    expect(row).toBeDefined();
+    expect(row!.fact).toBe('real entity fact');
+  });
+});
+
+describe('excludeAuditRows — listFactsBySession', () => {
+  test('audit row (entity_slug: null, as production writes it) is NOT returned by listFactsBySession by default', async () => {
+    const session = 'audit-row-filter-bysession-test';
+    await engine.insertFact(
+      { fact: 'EXTRACTION_COMPLETE', kind: 'fact', entity_slug: null, source: TERMINAL_AUDIT_SOURCE, source_session: session },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsBySession('default', session);
+    expect(rows.length).toBe(0);
+  });
+
+  test('audit row IS returned when excludeAuditRows: false is passed explicitly', async () => {
+    const session = 'audit-row-filter-bysession-test-override';
+    await engine.insertFact(
+      { fact: 'EXTRACTION_NOT_APPLICABLE', kind: 'fact', entity_slug: null, source: NON_EXTRACTABLE_AUDIT_SOURCE, source_session: session },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsBySession('default', session, { excludeAuditRows: false });
+    expect(rows.length).toBe(1);
+    expect(rows[0].source).toBe(NON_EXTRACTABLE_AUDIT_SOURCE);
+  });
+
+  test('a real fact in the same session is still returned (filter is not over-broad)', async () => {
+    const session = 'audit-row-filter-bysession-test-mixed';
+    await engine.insertFact(
+      { fact: 'real session fact', kind: 'fact', source: 'test', source_session: session },
+      { source_id: 'default' },
+    );
+    await engine.insertFact(
+      { fact: 'EXTRACTION_COMPLETE', kind: 'fact', entity_slug: null, source: TERMINAL_AUDIT_SOURCE, source_session: session },
+      { source_id: 'default' },
+    );
+    const rows = await engine.listFactsBySession('default', session);
+    expect(rows.length).toBe(1);
+    expect(rows[0].fact).toBe('real session fact');
+  });
+});
+
+describe('listSupersessions is NOT filtered by excludeAuditRows (audit-log parity, Item 1)', () => {
+  // listSupersessions is a supersession AUDIT LOG, not a knowledge-recall
+  // surface — postgres-engine.ts's listSupersessions never filtered audit
+  // rows, so pglite-engine.ts's must not either, or the two engines
+  // diverge (adversarial-review finding: PGLite's shared `_listFacts`
+  // helper defaults excludeAuditRows to true, and without an explicit
+  // override at the listSupersessions call site, a superseded audit row
+  // would vanish from PGLite's log while staying visible on Postgres's).
+  // Any row — including an audit row — can be superseded: expireFact(id,
+  // { supersededBy }) sets expired_at/superseded_by on whatever id it's
+  // given, with nothing that special-cases audit sources.
+  test('a superseded audit row IS returned by listSupersessions (matches Postgres, which never filtered it)', async () => {
+    const audit = await engine.insertFact(
+      {
+        fact: 'EXTRACTION_COMPLETE',
+        kind: 'fact',
+        entity_slug: null,
+        source: TERMINAL_AUDIT_SOURCE,
+        source_session: 'audit-row-supersession-test',
+      },
+      { source_id: 'default' },
+    );
+    const newer = await engine.insertFact(
+      { fact: 'superseder of audit row', kind: 'fact', source: 'test' },
+      { source_id: 'default' },
+    );
+    const didExpire = await engine.expireFact(audit.id, { supersededBy: newer.id });
+    expect(didExpire).toBe(true);
+
+    const supersessions = await engine.listSupersessions('default');
+    const row = supersessions.find(r => r.id === audit.id);
+    expect(row).toBeDefined();
+    expect(row!.source).toBe(TERMINAL_AUDIT_SOURCE);
+    expect(row!.superseded_by).toBe(newer.id);
   });
 });
 


### PR DESCRIPTION
## Summary

`extract-conversation-facts` writes a per-page terminal marker into the `facts` table for every
page it finishes — `EXTRACTION_COMPLETE` (`TERMINAL_AUDIT_SOURCE`) or `EXTRACTION_NOT_APPLICABLE`
(`NON_EXTRACTABLE_AUDIT_SOURCE`). The insert's own comment says it plainly:

> this is internal audit state, not user-facing knowledge

But the rows are written with `kind: 'fact'`, `entity_slug: null`, and no `expired_at`, and
`FactListOpts` offered only `activeOnly` / `limit` / `offset` / `kinds` / `visibility`. None of
those can separate a marker from a fact: the kind is the same, the row is never expired, and
visibility is unset. So there was no way for a reader to ask for knowledge and not get audit state.

Every non-engine caller of `listFactsByEntity` / `listFactsSince` / `listFactsBySession` is a
knowledge surface — the `recall` op, the `entity` verb's card, ambient turn-context, the facts
meta-hook, the consolidate phase, and the `recall` CLI. There are no diagnostic callers.
`extract-conversation-facts`'s own resume path reads the markers through `engine.executeRaw`, not
these methods, so it is unaffected.

## Scale, measured on a real brain

165 of 1,517 active facts (10.9%) are markers. During the two batch-extraction hours they were
13.7% and 8.4% of the facts created in that hour. One minute-level window created 73 facts of
which 73 were markers — a newest-50 read issued there returns internal audit state and no
knowledge at all.

## What changed

`FactListOpts.excludeAuditRows`, defaulting to true — the same shape and default as the
neighbouring `activeOnly`, which already hides a non-user-facing row class by default. Both
engines filter it across the three list methods. `excludeAuditRows: false` restores the previous
behavior. The two source constants moved to `src/core/facts/audit-sources.ts` so both engines can
import them statically (engine-live paths must not use runtime dynamic `import()`);
`extract-conversation-facts.ts` re-exports them under their existing names, so current importers
are untouched.

`listSupersessions` deliberately does NOT filter. It is the supersession audit log — it should
keep showing every superseded row. PGLite reaches it through the shared `_listFacts` helper, so it
passes `excludeAuditRows: false` explicitly to match Postgres. Review caught this as an
engine-parity divergence before it was pushed; it is now pinned by a test on both engines.

Deliberately out of scope: `countUnconsolidatedFacts` and `getFactsHealth` (both engines) still
count markers, so `include_pending` and the doctor health numbers can exceed what a default read
returns. Changing a health surface's numbers is a separate behavior change and is not folded in
here.

## Verification

`test/facts-engine.test.ts` 24 pass; `test/extract-conversation-facts.test.ts` +
`test/doctor-conversation-facts-backlog.test.ts` 69 pass; `bun run typecheck` and `bun run verify`
(39/39) both exit 0.

Coverage was verified by removal, not assumed:

| reverted | result |
|---|---|
| all three engine files | 5 failures across since / byEntity / bySession |
| only PGLite's `listSupersessions` override | 1 failure |
| only Postgres's three predicates | 3 failures in the dual-engine block |

The last row is the one that matters — the new `DATABASE_URL`-gated block in
`test/e2e/engine-parity.test.ts` seeds identical rows into real Postgres and PGLite side by side,
so a one-engine-only regression cannot pass. It was run green against a real pgvector container,
and skips gracefully without `DATABASE_URL`.
