### PR TITLE
fix(facts): make the conversation-type allowlist single-source instead of 5 hand-copied lists

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,8 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { REPAIR_SOURCE_CONFIG_SQL } from '../core/source-config-sql.ts';
+// Leaf module (no flag surface of its own) — see that file for why this
+// isn't imported from extract-conversation-facts.ts directly (#4135).
+import { ALLOWED_TYPES } from '../core/facts/conversation-types.ts';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION, getIdleBlockers } from '../core/migrate.ts';
@@ -3831,9 +3834,8 @@ export async function computeConversationFactsBacklogCheck(
     const typesRaw = await engine.getConfig(
       'cycle.conversation_facts_backfill.types',
     );
-    // Default mirrors extract-conversation-facts.ts's ALLOWED_TYPES — the
-    // single source of truth for the conversation-facts type allowlist.
-    const { ALLOWED_TYPES } = await import('./extract-conversation-facts.ts');
+    // Default mirrors ALLOWED_TYPES — the single source of truth for the
+    // conversation-facts type allowlist.
     let types: string[] = [...ALLOWED_TYPES];
     if (typesRaw) {
       try {
@@ -6277,7 +6279,7 @@ export async function buildChecks(
       const { readConversationBodyForParsing } = await import('../core/conversation-parser/body.ts');
       const { parseConversation } = await import('../core/conversation-parser/parse.ts');
       // Single source of truth for the conversation-facts type allowlist.
-      const { ALLOWED_TYPES: allowedTypes } = await import('./extract-conversation-facts.ts');
+      const allowedTypes = ALLOWED_TYPES;
       // PageFilters supports singular `type` only; iterate the allowed types
       // and cap at ~50/each to land at ~200 total max.
       const sample: import('../core/types.ts').Page[] = [];

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3831,7 +3831,10 @@ export async function computeConversationFactsBacklogCheck(
     const typesRaw = await engine.getConfig(
       'cycle.conversation_facts_backfill.types',
     );
-    let types = ['conversation', 'meeting', 'slack', 'email', 'imessage', 'imessage-daily'];
+    // Default mirrors extract-conversation-facts.ts's ALLOWED_TYPES — the
+    // single source of truth for the conversation-facts type allowlist.
+    const { ALLOWED_TYPES } = await import('./extract-conversation-facts.ts');
+    let types: string[] = [...ALLOWED_TYPES];
     if (typesRaw) {
       try {
         const parsed = JSON.parse(typesRaw);
@@ -6273,7 +6276,8 @@ export async function buildChecks(
     try {
       const { readConversationBodyForParsing } = await import('../core/conversation-parser/body.ts');
       const { parseConversation } = await import('../core/conversation-parser/parse.ts');
-      const allowedTypes = ['conversation', 'meeting', 'slack', 'email', 'imessage', 'imessage-daily'] as const;
+      // Single source of truth for the conversation-facts type allowlist.
+      const { ALLOWED_TYPES: allowedTypes } = await import('./extract-conversation-facts.ts');
       // PageFilters supports singular `type` only; iterate the allowed types
       // and cap at ~50/each to land at ~200 total max.
       const sample: import('../core/types.ts').Page[] = [];

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -93,6 +93,16 @@ import { withRefreshingLock, LockUnavailableError } from '../core/db-lock.ts';
 import { assertFactsEmbeddingDimMatchesConfig } from '../core/embedding-dim-check.ts';
 import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
+import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
+
+// Re-exported verbatim so existing importers (this file's own helpers below,
+// doctor.ts, jobs.ts, sources.ts, the cycle backfill phase, and this file's
+// tests) keep working unchanged. Moved to
+// src/core/facts/conversation-types.ts (see that file for why) so a
+// consumer that only needs the six values doesn't also pull in this file's
+// own CLI flag surface.
+export { ALLOWED_TYPES };
+export type { AllowedType };
 
 // ---------------------------------------------------------------------------
 // Tunables (exported for tests).
@@ -135,21 +145,11 @@ export const MAX_PAGE_BODY_BYTES = 25 * 1024 * 1024;
 /** Default cost cap when no tracker is passed explicitly. */
 export const DEFAULT_MAX_COST_USD = 5.0;
 
-/**
- * Allowlist of page types this command operates on. Mirrors
- * cycle.conversation_facts_backfill.types config default. CLI's
- * `--types` flag is an explicit per-run override; cycle config is
- * the single source of truth.
- */
-export const ALLOWED_TYPES = [
-  'conversation',
-  'meeting',
-  'slack',
-  'email',
-  'imessage',
-  'imessage-daily',
-] as const;
-export type AllowedType = (typeof ALLOWED_TYPES)[number];
+// ALLOWED_TYPES / AllowedType now live in
+// ../core/facts/conversation-types.ts (imported + re-exported above).
+// Mirrors cycle.conversation_facts_backfill.types config default. CLI's
+// `--types` flag is an explicit per-run override; cycle config is the
+// single source of truth.
 
 /**
  * Granular collector page-types that alias into each canonical conversation

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -95,9 +95,9 @@ import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
 import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
 
-// Re-exported verbatim so existing importers (this file's own helpers below,
-// doctor.ts, jobs.ts, sources.ts, the cycle backfill phase, and this file's
-// tests) keep working unchanged. Moved to
+// Re-exported verbatim so existing importers (this file's own helpers below
+// and this file's tests) keep working unchanged; doctor.ts, jobs.ts,
+// sources.ts, and the cycle backfill phase import the leaf directly. Moved to
 // src/core/facts/conversation-types.ts (see that file for why) so a
 // consumer that only needs the six values doesn't also pull in this file's
 // own CLI flag surface.

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -4,6 +4,9 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
+// Leaf module (no flag surface of its own) — see that file for why this
+// isn't imported from extract-conversation-facts.ts directly (#4135).
+import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
 import { MinionQueue } from '../core/minions/queue.ts';
 import { MinionWorker } from '../core/minions/worker.ts';
 import { WORKER_EXIT_RSS_WATCHDOG } from '../core/minions/worker-exit-codes.ts';
@@ -1828,9 +1831,7 @@ export async function registerBuiltinHandlers(
   // the core level and returned as `result.budget_exhausted: true` (NOT
   // a job failure) so the user can resume with a higher cap.
   registerBuiltinJob(worker, engine, 'extract-conversation-facts', async (job) => {
-    // ALLOWED_TYPES is the single source of truth for the conversation-facts
-    // type allowlist (see extract-conversation-facts.ts).
-    const { runExtractConversationFactsCore, ALLOWED_TYPES } = await import('./extract-conversation-facts.ts');
+    const { runExtractConversationFactsCore } = await import('./extract-conversation-facts.ts');
     const sourceId = typeof job.data.sourceId === 'string' ? job.data.sourceId : undefined;
     if (!sourceId) {
       // Multi-source iteration not supported in the Minion-handler path;
@@ -1838,10 +1839,11 @@ export async function registerBuiltinHandlers(
       // SHOULD pin to one source per call (job_id is per-call).
       throw new Error('extract-conversation-facts Minion job requires data.sourceId');
     }
+    // ALLOWED_TYPES is the single source of truth for the conversation-facts
+    // type allowlist (see src/core/facts/conversation-types.ts).
     const types = Array.isArray(job.data.types)
       ? (job.data.types as string[]).filter(
-          (t): t is import('./extract-conversation-facts.ts').AllowedType =>
-            (ALLOWED_TYPES as readonly string[]).includes(t),
+          (t): t is AllowedType => (ALLOWED_TYPES as readonly string[]).includes(t),
         )
       : undefined;
     const result = await runExtractConversationFactsCore(engine, {

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1828,7 +1828,9 @@ export async function registerBuiltinHandlers(
   // the core level and returned as `result.budget_exhausted: true` (NOT
   // a job failure) so the user can resume with a higher cap.
   registerBuiltinJob(worker, engine, 'extract-conversation-facts', async (job) => {
-    const { runExtractConversationFactsCore } = await import('./extract-conversation-facts.ts');
+    // ALLOWED_TYPES is the single source of truth for the conversation-facts
+    // type allowlist (see extract-conversation-facts.ts).
+    const { runExtractConversationFactsCore, ALLOWED_TYPES } = await import('./extract-conversation-facts.ts');
     const sourceId = typeof job.data.sourceId === 'string' ? job.data.sourceId : undefined;
     if (!sourceId) {
       // Multi-source iteration not supported in the Minion-handler path;
@@ -1837,13 +1839,14 @@ export async function registerBuiltinHandlers(
       throw new Error('extract-conversation-facts Minion job requires data.sourceId');
     }
     const types = Array.isArray(job.data.types)
-      ? (job.data.types as string[]).filter((t) =>
-          ['conversation', 'meeting', 'slack', 'email', 'imessage', 'imessage-daily'].includes(t),
+      ? (job.data.types as string[]).filter(
+          (t): t is import('./extract-conversation-facts.ts').AllowedType =>
+            (ALLOWED_TYPES as readonly string[]).includes(t),
         )
       : undefined;
     const result = await runExtractConversationFactsCore(engine, {
       sourceId,
-      types: types as ('conversation' | 'meeting' | 'slack' | 'email')[] | undefined,
+      types,
       slug: typeof job.data.slug === 'string' ? job.data.slug : undefined,
       dryRun: !!job.data.dryRun,
       limit: typeof job.data.limit === 'number' ? job.data.limit : undefined,

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -1313,14 +1313,8 @@ async function runAudit(engine: BrainEngine, args: string[]): Promise<void> {
   // frontmatter.type and estimates per-page segment count from body
   // bytes. Estimated per-segment Sonnet cost is a rough heuristic
   // (~2000 in + 500 out tokens at $3/MTok in + $15/MTok out ≈ $0.013).
-  const FACTS_BACKFILL_ALLOWED = [
-    'conversation',
-    'meeting',
-    'slack',
-    'email',
-    'imessage',
-    'imessage-daily',
-  ];
+  // Single source of truth for the conversation-facts type allowlist.
+  const { ALLOWED_TYPES: FACTS_BACKFILL_ALLOWED } = await import('./extract-conversation-facts.ts');
   const FACTS_BACKFILL_CHARS_PER_SEGMENT = 6500; // matches SEGMENT_TEXT_CHAR_LIMIT
   const FACTS_BACKFILL_USD_PER_SEGMENT = 0.013;
   let factsBackfillPages = 0;
@@ -1364,7 +1358,7 @@ async function runAudit(engine: BrainEngine, args: string[]): Promise<void> {
     }
     // Facts-backfill estimator: counts pages matching allowed types.
     const fmType = (parsed.frontmatter?.type as string | undefined) ?? null;
-    if (fmType && FACTS_BACKFILL_ALLOWED.includes(fmType)) {
+    if (fmType && (FACTS_BACKFILL_ALLOWED as readonly string[]).includes(fmType)) {
       factsBackfillPages++;
       const totalBytes = sanity.bytes;
       const segmentsEstimate = Math.max(

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -1314,7 +1314,7 @@ async function runAudit(engine: BrainEngine, args: string[]): Promise<void> {
   // bytes. Estimated per-segment Sonnet cost is a rough heuristic
   // (~2000 in + 500 out tokens at $3/MTok in + $15/MTok out ≈ $0.013).
   // Single source of truth for the conversation-facts type allowlist.
-  const { ALLOWED_TYPES: FACTS_BACKFILL_ALLOWED } = await import('./extract-conversation-facts.ts');
+  const { ALLOWED_TYPES: FACTS_BACKFILL_ALLOWED } = await import('../core/facts/conversation-types.ts');
   const FACTS_BACKFILL_CHARS_PER_SEGMENT = 6500; // matches SEGMENT_TEXT_CHAR_LIMIT
   const FACTS_BACKFILL_USD_PER_SEGMENT = 0.013;
   let factsBackfillPages = 0;

--- a/src/core/cycle/conversation-facts-backfill.ts
+++ b/src/core/cycle/conversation-facts-backfill.ts
@@ -36,7 +36,7 @@
  *   cycle.conversation_facts_backfill.max_total_cost_usd   (5.00)
  *   cycle.conversation_facts_backfill.max_walltime_min     (20)
  *   cycle.conversation_facts_backfill.max_total_walltime_min (30)
- *   cycle.conversation_facts_backfill.types                (["conversation","meeting","slack","email"])
+ *   cycle.conversation_facts_backfill.types                (all of ALLOWED_TYPES — src/core/facts/conversation-types.ts)
  *
  * `.types` is the single source of truth for "enabled types" — the CLI
  * default reads from the same key (Eng-v2 A2).
@@ -48,10 +48,12 @@ import { withBudgetTracker } from '../ai/gateway.ts';
 import { listSources } from '../sources-ops.ts';
 import {
   runExtractConversationFactsCore,
-  ALLOWED_TYPES,
-  type AllowedType,
   type ExtractConversationFactsResult,
 } from '../../commands/extract-conversation-facts.ts';
+// The type allowlist comes straight from the canonical leaf module (same
+// binding extract-conversation-facts.ts re-exports) so this phase is part of
+// the drift-guarded set in test/conversation-facts-type-allowlist-drift.test.ts.
+import { ALLOWED_TYPES, type AllowedType } from '../facts/conversation-types.ts';
 
 /** Per-phase wrapper opts. */
 export interface ConversationFactsBackfillPhaseOpts {

--- a/src/core/facts/conversation-types.ts
+++ b/src/core/facts/conversation-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical allowlist of `pages.type` values the conversation-facts
+ * extraction pipeline operates on: conversation, meeting, slack, email,
+ * imessage, imessage-daily.
+ *
+ * Lives in `src/core/facts/` (not `src/commands/`) so a consumer that only
+ * needs these six values — doctor.ts's backlog-check default and its
+ * conversation_format_coverage sample scan, jobs.ts's extract-conversation-
+ * facts Minion job handler, sources.ts's facts-backfill audit estimator —
+ * can import just this leaf instead of pulling in
+ * `src/commands/extract-conversation-facts.ts`'s own CLI flag surface (that
+ * command's help text and its own command-line option parsing).
+ *
+ * That's not a hypothetical: this file exists BECAUSE `scripts/generate-
+ * flag-registry.ts` scans every command-line-option-shaped string literal in
+ * a module it finds via a relative import, one level deep. Importing the
+ * constant straight from extract-conversation-facts.ts (even just for this
+ * constant) transitively attributed that whole option surface to doctor,
+ * jobs, and sources — three commands that don't otherwise accept those
+ * options — in the generated CLI_ONLY registry (#4135).
+ *
+ * `src/commands/extract-conversation-facts.ts` imports from here and
+ * re-exports both names verbatim so its existing importers (this file's
+ * own tests, the cycle backfill phase) keep working unchanged.
+ */
+export const ALLOWED_TYPES = [
+  'conversation',
+  'meeting',
+  'slack',
+  'email',
+  'imessage',
+  'imessage-daily',
+] as const;
+
+export type AllowedType = (typeof ALLOWED_TYPES)[number];

--- a/src/core/facts/conversation-types.ts
+++ b/src/core/facts/conversation-types.ts
@@ -20,16 +20,18 @@
  * options — in the generated CLI_ONLY registry (#4135).
  *
  * `src/commands/extract-conversation-facts.ts` imports from here and
- * re-exports both names verbatim so its existing importers (this file's
- * own tests, the cycle backfill phase) keep working unchanged.
+ * re-exports both names verbatim so its remaining existing importers (its
+ * own tests) keep working unchanged; the cycle backfill phase
+ * (`src/core/cycle/conversation-facts-backfill.ts`) imports this leaf
+ * directly and is part of the drift-guarded set.
  */
-export const ALLOWED_TYPES = [
+export const ALLOWED_TYPES = Object.freeze([
   'conversation',
   'meeting',
   'slack',
   'email',
   'imessage',
   'imessage-daily',
-] as const;
+] as const);
 
 export type AllowedType = (typeof ALLOWED_TYPES)[number];

--- a/test/conversation-facts-type-allowlist-drift.test.ts
+++ b/test/conversation-facts-type-allowlist-drift.test.ts
@@ -18,21 +18,42 @@
  * Every other table is a DERIVED view, never a hand-copied duplicate — so
  * cross-table ... drift is structurally impossible."
  *
- * Two kinds of guard below, mirroring test/model-pricing.test.ts:
+ * ALLOWED_TYPES/AllowedType now live in a leaf module,
+ * src/core/facts/conversation-types.ts, NOT in extract-conversation-facts.ts
+ * (which re-exports both verbatim). That's a second-order fix: sites 2-5
+ * originally imported the constant straight from extract-conversation-
+ * facts.ts, and scripts/generate-flag-registry.ts scans every relative
+ * import of a command module for `--flag`-shaped string literals — so
+ * importing anything from that command module (even just this constant)
+ * transitively attributed its whole CLI flag surface (`--background`,
+ * `--concurrency`, `--limit`, ... about ten flags) to doctor/repos/sources
+ * in the generated registry, silently widening what those three commands'
+ * strict unknown-flag validation (#2185) accepts (#4135 CI failure). The
+ * leaf module has no flags of its own, so importing it doesn't leak
+ * anything, regardless of whether the importer uses a static or dynamic
+ * import (generate-flag-registry.ts's one-level relative-import scan
+ * matches both forms identically).
+ *
+ * Guards below, mirroring test/model-pricing.test.ts:
  *   - identity/behavioral assertions where a site's resolved list is
  *     reachable at runtime (doctor.ts's backlog-check `details.types`);
  *   - source-text drift guards (mirroring model-pricing.test.ts's "no heavy
  *     import" cycle guard) for sites whose list isn't independently
  *     reachable/exported — these fail if anyone re-hardcodes a duplicate
- *     array/union literal instead of deriving from ALLOWED_TYPES.
+ *     array/union literal instead of deriving from ALLOWED_TYPES, or points
+ *     a site back at extract-conversation-facts.ts instead of the leaf;
+ *   - a flag-registry regression guard pinning the exact bug this file's
+ *     history hit: doctor/repos/sources must never carry
+ *     extract-conversation-facts.ts's own flags.
  */
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { ALLOWED_TYPES } from '../src/commands/extract-conversation-facts.ts';
+import { ALLOWED_TYPES } from '../src/core/facts/conversation-types.ts';
 import { computeConversationFactsBacklogCheck } from '../src/commands/doctor.ts';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { buildFlagRegistry } from '../scripts/generate-flag-registry.ts';
 
 const EXPECTED_TYPES = [
   'conversation',
@@ -43,13 +64,14 @@ const EXPECTED_TYPES = [
   'imessage-daily',
 ] as const;
 
-function readSrc(path: string): string {
-  return readFileSync(fileURLToPath(new URL(`../src/commands/${path}`, import.meta.url)), 'utf8');
+function readSrc(relPath: string): string {
+  return readFileSync(fileURLToPath(new URL(`../src/${relPath}`, import.meta.url)), 'utf8');
 }
 
 // The exact hand-copied array literal that used to live at all 5 sites
-// (whitespace-tolerant). Should appear ONLY in extract-conversation-facts.ts
-// (the canonical ALLOWED_TYPES definition) after the fix.
+// (whitespace-tolerant). Should appear ONLY in
+// src/core/facts/conversation-types.ts (the canonical ALLOWED_TYPES
+// definition) after the fix.
 const HARDCODED_SIX_LITERAL =
   /\[\s*['"]conversation['"]\s*,\s*['"]meeting['"]\s*,\s*['"]slack['"]\s*,\s*['"]email['"]\s*,\s*['"]imessage['"]\s*,\s*['"]imessage-daily['"]\s*,?\s*\]/g;
 
@@ -57,61 +79,94 @@ const HARDCODED_SIX_LITERAL =
 const STALE_FOUR_ELEMENT_UNION_CAST =
   /\(\s*['"]conversation['"]\s*\|\s*['"]meeting['"]\s*\|\s*['"]slack['"]\s*\|\s*['"]email['"]\s*\)\s*\[\]/g;
 
-// A site deriving its list from the canonical ALLOWED_TYPES via dynamic
-// import, e.g. `const { ALLOWED_TYPES } = await import('./extract-conversation-facts.ts')`
-// or `const { ALLOWED_TYPES: allowedTypes } = await import(...)`.
-function countAllowedTypesImports(src: string): number {
-  const re =
-    /\{\s*[^}]*\bALLOWED_TYPES\b[^}]*\}\s*=\s*await\s+import\(\s*['"]\.\/extract-conversation-facts\.ts['"]\s*\)/g;
-  return [...src.matchAll(re)].length;
+// Any import (static `from '...'` or dynamic `import('...')`) of
+// ALLOWED_TYPES (optionally aliased) from the given relative module path.
+function countAllowedTypesImportsFrom(src: string, modulePathEscaped: string): number {
+  const staticRe = new RegExp(
+    `import\\s*\\{[^}]*\\bALLOWED_TYPES\\b[^}]*\\}\\s*from\\s*['"]${modulePathEscaped}['"]`,
+    'g',
+  );
+  const dynamicRe = new RegExp(
+    `\\{\\s*[^}]*\\bALLOWED_TYPES\\b[^}]*\\}\\s*=\\s*await\\s+import\\(\\s*['"]${modulePathEscaped}['"]\\s*\\)`,
+    'g',
+  );
+  return [...src.matchAll(staticRe)].length + [...src.matchAll(dynamicRe)].length;
 }
 
-describe('ALLOWED_TYPES — canonical source of truth', () => {
+// A site still pointed at extract-conversation-facts.ts for ALLOWED_TYPES
+// (the exact regression this file's history hit) rather than the leaf.
+function countAllowedTypesImportsFromCommandModule(src: string): number {
+  return countAllowedTypesImportsFrom(src, '\\.\\/extract-conversation-facts\\.ts');
+}
+
+describe('ALLOWED_TYPES — canonical source of truth (leaf module)', () => {
   test('has exactly the 6 expected types, in order', () => {
     expect([...ALLOWED_TYPES]).toEqual([...EXPECTED_TYPES]);
   });
 
-  test('appears as a hardcoded literal exactly once (its own definition)', () => {
-    const src = readSrc('extract-conversation-facts.ts');
+  test('appears as a hardcoded literal exactly once, in the leaf module', () => {
+    const src = readSrc('core/facts/conversation-types.ts');
     const matches = [...src.matchAll(HARDCODED_SIX_LITERAL)];
     expect(matches.length).toBe(1);
   });
+
+  test('the leaf module carries no CLI-flag-shaped literals of its own', () => {
+    // This is the actual invariant the leaf module exists to guarantee: it
+    // must never gain a `--flag`-shaped string (e.g. from a comment example
+    // or a hand-added constant), or generate-flag-registry.ts's relative-
+    // import scan would once again attribute flags to every consumer that
+    // imports ALLOWED_TYPES from here — reopening #4135.
+    const src = readSrc('core/facts/conversation-types.ts');
+    expect([...src.matchAll(/--[a-z0-9][a-z0-9-]*/g)]).toEqual([]);
+  });
+
+  test('extract-conversation-facts.ts no longer hardcodes the literal; re-exports from the leaf', () => {
+    const src = readSrc('commands/extract-conversation-facts.ts');
+    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
+    expect(src).toContain('export { ALLOWED_TYPES }');
+    expect(src).toContain('export type { AllowedType }');
+  });
 });
 
-describe('DRIFT GUARD — consumer sites derive from ALLOWED_TYPES (re-hardcode trip-wire)', () => {
-  test('doctor.ts: no hand-copied 6-element literal remains', () => {
-    const src = readSrc('doctor.ts');
-    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
-  });
+describe('DRIFT GUARD — consumer sites derive from the leaf module (re-hardcode + wrong-import trip-wire)', () => {
+  for (const [label, relPath] of [
+    ['doctor.ts', 'commands/doctor.ts'],
+    ['jobs.ts', 'commands/jobs.ts'],
+    ['sources.ts', 'commands/sources.ts'],
+  ] as const) {
+    test(`${label}: no hand-copied 6-element literal remains`, () => {
+      const src = readSrc(relPath);
+      expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+    });
 
-  test('doctor.ts: both sites (backlog default + format-coverage sample) import ALLOWED_TYPES', () => {
-    const src = readSrc('doctor.ts');
-    expect(countAllowedTypesImports(src)).toBe(2);
-  });
+    test(`${label}: does not import ALLOWED_TYPES from extract-conversation-facts.ts`, () => {
+      const src = readSrc(relPath);
+      expect(countAllowedTypesImportsFromCommandModule(src)).toBe(0);
+    });
+  }
 
-  test('jobs.ts: no hand-copied 6-element literal remains', () => {
-    const src = readSrc('jobs.ts');
-    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+  test('doctor.ts: imports ALLOWED_TYPES from the leaf exactly once (both sites reference the same binding)', () => {
+    const src = readSrc('commands/doctor.ts');
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
+    // Both call sites reference the top-level import, not a re-import.
+    expect((src.match(/\bALLOWED_TYPES\b/g) ?? []).length).toBeGreaterThanOrEqual(3); // import + 2 usages
   });
 
   test('jobs.ts: no stale 4-element union cast remains (the #2756-drift class)', () => {
-    const src = readSrc('jobs.ts');
+    const src = readSrc('commands/jobs.ts');
     expect([...src.matchAll(STALE_FOUR_ELEMENT_UNION_CAST)]).toEqual([]);
   });
 
-  test('jobs.ts: extract-conversation-facts job handler imports ALLOWED_TYPES', () => {
-    const src = readSrc('jobs.ts');
-    expect(countAllowedTypesImports(src)).toBe(1);
+  test('jobs.ts: imports ALLOWED_TYPES + AllowedType from the leaf exactly once', () => {
+    const src = readSrc('commands/jobs.ts');
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
+    expect(src).toContain("type AllowedType } from '../core/facts/conversation-types.ts'");
   });
 
-  test('sources.ts: no hand-copied 6-element literal remains', () => {
-    const src = readSrc('sources.ts');
-    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
-  });
-
-  test('sources.ts: FACTS_BACKFILL_ALLOWED imports ALLOWED_TYPES', () => {
-    const src = readSrc('sources.ts');
-    expect(countAllowedTypesImports(src)).toBe(1);
+  test('sources.ts: FACTS_BACKFILL_ALLOWED imports ALLOWED_TYPES from the leaf', () => {
+    const src = readSrc('commands/sources.ts');
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
   });
 });
 
@@ -119,11 +174,12 @@ describe('DRIFT GUARD — jobs.ts filter accepts all 6 canonical types at runtim
   // jobs.ts's filter is `(t): t is AllowedType => (ALLOWED_TYPES as readonly
   // string[]).includes(t)` — the same predicate shape as
   // extract-conversation-facts.ts's own resolveTypesFromConfig filter. Since
-  // the source-text guard above proves jobs.ts's filter is wired to
-  // ALLOWED_TYPES (not a hand-copied duplicate), proving ALLOWED_TYPES itself
-  // accepts every canonical type closes the loop: jobs.ts accepts all 6,
-  // including `imessage`/`imessage-daily`, which the stale cast's *type*
-  // (but not its runtime behavior — see below) used to exclude.
+  // the source-text guard above proves jobs.ts's filter is wired to the
+  // canonical ALLOWED_TYPES (not a hand-copied duplicate), proving
+  // ALLOWED_TYPES itself accepts every canonical type closes the loop:
+  // jobs.ts accepts all 6, including `imessage`/`imessage-daily`, which the
+  // stale cast's *type* (but not its runtime behavior — see the commit
+  // message) used to exclude.
   test('ALLOWED_TYPES accepts every canonical type via .includes()', () => {
     for (const t of EXPECTED_TYPES) {
       expect((ALLOWED_TYPES as readonly string[]).includes(t)).toBe(true);
@@ -156,5 +212,57 @@ describe('DRIFT GUARD — doctor.ts conversation_facts_backlog default is reacha
     const resolvedTypes = (check.details as { types?: string[] } | undefined)?.types;
     expect(resolvedTypes).toBeDefined();
     expect([...(resolvedTypes ?? [])].sort()).toEqual([...EXPECTED_TYPES].sort());
+  });
+});
+
+describe('DRIFT GUARD — #4135 regression: doctor.ts/sources.ts never relative-import extract-conversation-facts.ts', () => {
+  // The exact bug: doctor.ts (both sites) and sources.ts each imported
+  // ALLOWED_TYPES straight from extract-conversation-facts.ts.
+  // generate-flag-registry.ts's one-level relative-import scan
+  // (`from '...'` AND `import('...')`, matched identically) then read that
+  // whole command module's text for `--flag`-shaped literals and folded
+  // them into doctor/repos/sources's registry entries — silently widening
+  // what those commands' #2185 strict unknown-flag validation accepts.
+  // Reproduces the generator's own relative-import regex (scripts/
+  // generate-flag-registry.ts:relativeImports) rather than guessing which
+  // flag names are "foreign": other legitimately-imported modules can
+  // independently contribute overlapping flag names, so a flag-allowlist
+  // test would be both wrong and fragile. jobs.ts is deliberately excluded:
+  // it independently, legitimately imports extract-conversation-facts.ts
+  // for runExtractConversationFactsCore, so its registry entry already (and
+  // correctly) carries that command's flag surface — see the "no #2756-
+  // drift-class" jobs.ts guards above for what DOES need to hold there.
+  const RELATIVE_IMPORT_RE = /(?:from\s+'(\.\.?\/[^']+\.ts)'|import\('(\.\.?\/[^']+\.ts)'\))/g;
+
+  function relativeImportPaths(src: string): string[] {
+    return [...src.matchAll(RELATIVE_IMPORT_RE)].map((m) => m[1] ?? m[2]);
+  }
+
+  for (const [label, relPath] of [
+    ['doctor.ts', 'commands/doctor.ts'],
+    ['sources.ts', 'commands/sources.ts'],
+  ] as const) {
+    test(`${label}: source contains no relative import path ending in extract-conversation-facts.ts`, () => {
+      const src = readSrc(relPath);
+      const hits = relativeImportPaths(src).filter((p) => p.endsWith('extract-conversation-facts.ts'));
+      expect(hits).toEqual([]);
+    });
+  }
+
+  test('flag-registry freshness: rebuilding the registry now produces the exact same doctor/repos/sources/jobs entries as committed', () => {
+    // Narrow, targeted companion to test/cli-flag-validation.test.ts's
+    // whole-registry freshness guard (#2185) — pinned specifically to the
+    // four command names this bug touched (or, for jobs, deliberately did
+    // NOT touch), so a regression here fails right next to its cause.
+    const registry = buildFlagRegistry();
+    const committedSrc = readSrc('core/cli-flag-registry.generated.ts');
+    for (const command of ['doctor', 'repos', 'sources', 'jobs']) {
+      const entryMatch = committedSrc.match(
+        new RegExp(`'${command}': \\[([^\\]]*)\\]`),
+      );
+      expect(entryMatch, `no committed registry entry found for '${command}'`).not.toBeNull();
+      const committedFlags = [...(entryMatch![1].matchAll(/'([^']+)'/g))].map((m) => m[1]).sort();
+      expect(registry[command]).toEqual(committedFlags);
+    }
   });
 });

--- a/test/conversation-facts-type-allowlist-drift.test.ts
+++ b/test/conversation-facts-type-allowlist-drift.test.ts
@@ -1,0 +1,160 @@
+/**
+ * conversation-facts type allowlist — single source of truth + drift guard.
+ *
+ * The conversation-facts type allowlist (`conversation`, `meeting`, `slack`,
+ * `email`, `imessage`, `imessage-daily`) used to be hand-copied into five
+ * places across four files:
+ *   1. extract-conversation-facts.ts's ALLOWED_TYPES (canonical)
+ *   2. doctor.ts's conversation_facts_backlog config default
+ *   3. doctor.ts's conversation_format_coverage sample scan
+ *   4. jobs.ts's extract-conversation-facts Minion job handler filter
+ *   5. sources.ts's facts-backfill audit estimator
+ *
+ * It had already drifted: jobs.ts's runExtractConversationFactsCore call cast
+ * `types` to `('conversation' | 'meeting' | 'slack' | 'email')[] | undefined`
+ * — the pre-#2756 four-element set, missing `imessage` and `imessage-daily`
+ * that the runtime filter one line above it already accepted. Same class of
+ * bug CLAUDE.md calls out for pricing tables: "One canonical ... table ...
+ * Every other table is a DERIVED view, never a hand-copied duplicate — so
+ * cross-table ... drift is structurally impossible."
+ *
+ * Two kinds of guard below, mirroring test/model-pricing.test.ts:
+ *   - identity/behavioral assertions where a site's resolved list is
+ *     reachable at runtime (doctor.ts's backlog-check `details.types`);
+ *   - source-text drift guards (mirroring model-pricing.test.ts's "no heavy
+ *     import" cycle guard) for sites whose list isn't independently
+ *     reachable/exported — these fail if anyone re-hardcodes a duplicate
+ *     array/union literal instead of deriving from ALLOWED_TYPES.
+ */
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { ALLOWED_TYPES } from '../src/commands/extract-conversation-facts.ts';
+import { computeConversationFactsBacklogCheck } from '../src/commands/doctor.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+const EXPECTED_TYPES = [
+  'conversation',
+  'meeting',
+  'slack',
+  'email',
+  'imessage',
+  'imessage-daily',
+] as const;
+
+function readSrc(path: string): string {
+  return readFileSync(fileURLToPath(new URL(`../src/commands/${path}`, import.meta.url)), 'utf8');
+}
+
+// The exact hand-copied array literal that used to live at all 5 sites
+// (whitespace-tolerant). Should appear ONLY in extract-conversation-facts.ts
+// (the canonical ALLOWED_TYPES definition) after the fix.
+const HARDCODED_SIX_LITERAL =
+  /\[\s*['"]conversation['"]\s*,\s*['"]meeting['"]\s*,\s*['"]slack['"]\s*,\s*['"]email['"]\s*,\s*['"]imessage['"]\s*,\s*['"]imessage-daily['"]\s*,?\s*\]/g;
+
+// The stale pre-#2756 four-element union type cast that drifted in jobs.ts.
+const STALE_FOUR_ELEMENT_UNION_CAST =
+  /\(\s*['"]conversation['"]\s*\|\s*['"]meeting['"]\s*\|\s*['"]slack['"]\s*\|\s*['"]email['"]\s*\)\s*\[\]/g;
+
+// A site deriving its list from the canonical ALLOWED_TYPES via dynamic
+// import, e.g. `const { ALLOWED_TYPES } = await import('./extract-conversation-facts.ts')`
+// or `const { ALLOWED_TYPES: allowedTypes } = await import(...)`.
+function countAllowedTypesImports(src: string): number {
+  const re =
+    /\{\s*[^}]*\bALLOWED_TYPES\b[^}]*\}\s*=\s*await\s+import\(\s*['"]\.\/extract-conversation-facts\.ts['"]\s*\)/g;
+  return [...src.matchAll(re)].length;
+}
+
+describe('ALLOWED_TYPES — canonical source of truth', () => {
+  test('has exactly the 6 expected types, in order', () => {
+    expect([...ALLOWED_TYPES]).toEqual([...EXPECTED_TYPES]);
+  });
+
+  test('appears as a hardcoded literal exactly once (its own definition)', () => {
+    const src = readSrc('extract-conversation-facts.ts');
+    const matches = [...src.matchAll(HARDCODED_SIX_LITERAL)];
+    expect(matches.length).toBe(1);
+  });
+});
+
+describe('DRIFT GUARD — consumer sites derive from ALLOWED_TYPES (re-hardcode trip-wire)', () => {
+  test('doctor.ts: no hand-copied 6-element literal remains', () => {
+    const src = readSrc('doctor.ts');
+    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+  });
+
+  test('doctor.ts: both sites (backlog default + format-coverage sample) import ALLOWED_TYPES', () => {
+    const src = readSrc('doctor.ts');
+    expect(countAllowedTypesImports(src)).toBe(2);
+  });
+
+  test('jobs.ts: no hand-copied 6-element literal remains', () => {
+    const src = readSrc('jobs.ts');
+    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+  });
+
+  test('jobs.ts: no stale 4-element union cast remains (the #2756-drift class)', () => {
+    const src = readSrc('jobs.ts');
+    expect([...src.matchAll(STALE_FOUR_ELEMENT_UNION_CAST)]).toEqual([]);
+  });
+
+  test('jobs.ts: extract-conversation-facts job handler imports ALLOWED_TYPES', () => {
+    const src = readSrc('jobs.ts');
+    expect(countAllowedTypesImports(src)).toBe(1);
+  });
+
+  test('sources.ts: no hand-copied 6-element literal remains', () => {
+    const src = readSrc('sources.ts');
+    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+  });
+
+  test('sources.ts: FACTS_BACKFILL_ALLOWED imports ALLOWED_TYPES', () => {
+    const src = readSrc('sources.ts');
+    expect(countAllowedTypesImports(src)).toBe(1);
+  });
+});
+
+describe('DRIFT GUARD — jobs.ts filter accepts all 6 canonical types at runtime', () => {
+  // jobs.ts's filter is `(t): t is AllowedType => (ALLOWED_TYPES as readonly
+  // string[]).includes(t)` — the same predicate shape as
+  // extract-conversation-facts.ts's own resolveTypesFromConfig filter. Since
+  // the source-text guard above proves jobs.ts's filter is wired to
+  // ALLOWED_TYPES (not a hand-copied duplicate), proving ALLOWED_TYPES itself
+  // accepts every canonical type closes the loop: jobs.ts accepts all 6,
+  // including `imessage`/`imessage-daily`, which the stale cast's *type*
+  // (but not its runtime behavior — see below) used to exclude.
+  test('ALLOWED_TYPES accepts every canonical type via .includes()', () => {
+    for (const t of EXPECTED_TYPES) {
+      expect((ALLOWED_TYPES as readonly string[]).includes(t)).toBe(true);
+    }
+  });
+});
+
+describe('DRIFT GUARD — doctor.ts conversation_facts_backlog default is reachable + correct', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('with no cycle.conversation_facts_backfill.types override, the resolved default equals ALLOWED_TYPES', async () => {
+    await resetPgliteState(engine);
+    await engine.setConfig('cycle.conversation_facts_backfill.enabled', 'true');
+    // No pages of any conversation type exist, so backlog === 0 and the
+    // check takes the 'ok' branch, which reports the resolved `types` it
+    // used in `details.types` — the actual default this code path runs
+    // with, not a value we're asserting in isolation.
+    const check = await computeConversationFactsBacklogCheck(engine);
+    expect(check.status).toBe('ok');
+    const resolvedTypes = (check.details as { types?: string[] } | undefined)?.types;
+    expect(resolvedTypes).toBeDefined();
+    expect([...(resolvedTypes ?? [])].sort()).toEqual([...EXPECTED_TYPES].sort());
+  });
+});

--- a/test/conversation-facts-type-allowlist-drift.test.ts
+++ b/test/conversation-facts-type-allowlist-drift.test.ts
@@ -37,11 +37,21 @@
  * Guards below, mirroring test/model-pricing.test.ts:
  *   - identity/behavioral assertions where a site's resolved list is
  *     reachable at runtime (doctor.ts's backlog-check `details.types`);
- *   - source-text drift guards (mirroring model-pricing.test.ts's "no heavy
- *     import" cycle guard) for sites whose list isn't independently
- *     reachable/exported — these fail if anyone re-hardcodes a duplicate
- *     array/union literal instead of deriving from ALLOWED_TYPES, or points
- *     a site back at extract-conversation-facts.ts instead of the leaf;
+ *   - a SEMANTIC hand-copy detector (set-membership over array literals and
+ *     string-literal union chains, order- and length-insensitive) for sites
+ *     whose list isn't independently reachable/exported. An earlier version
+ *     used byte-exact canonical-order regexes, which mutation testing showed
+ *     only tripped on an exact canonical-order re-add — permuted re-adds,
+ *     subset re-adds (the harmful direction: silently dropping types), and a
+ *     narrowed jobs.ts runtime filter all passed. The detector fails on ANY
+ *     re-hardcoded conversation-type list (>=2 canonical members, code or
+ *     comment) and on pointing a site back at extract-conversation-facts.ts
+ *     instead of the leaf. The guarded set includes the cycle backfill phase
+ *     (src/core/cycle/conversation-facts-backfill.ts), where the detector
+ *     immediately caught a stale pre-#2756 four-element default in the
+ *     header comment;
+ *   - ALLOWED_TYPES itself is Object.frozen, so runtime mutation throws
+ *     instead of silently drifting every derived consumer at once;
  *   - a flag-registry regression guard pinning the exact bug this file's
  *     history hit: doctor/repos/sources must never carry
  *     extract-conversation-facts.ts's own flags.
@@ -68,16 +78,45 @@ function readSrc(relPath: string): string {
   return readFileSync(fileURLToPath(new URL(`../src/${relPath}`, import.meta.url)), 'utf8');
 }
 
-// The exact hand-copied array literal that used to live at all 5 sites
-// (whitespace-tolerant). Should appear ONLY in
-// src/core/facts/conversation-types.ts (the canonical ALLOWED_TYPES
-// definition) after the fix.
-const HARDCODED_SIX_LITERAL =
-  /\[\s*['"]conversation['"]\s*,\s*['"]meeting['"]\s*,\s*['"]slack['"]\s*,\s*['"]email['"]\s*,\s*['"]imessage['"]\s*,\s*['"]imessage-daily['"]\s*,?\s*\]/g;
+// Semantic hand-copy detector (replaces the earlier byte-exact literal/order
+// matchers, which only tripped on a canonical-order re-add — a permuted
+// re-add, a subset re-add (the harmful direction: silently dropping types),
+// and a narrowed runtime filter all sailed past them). Finds EVERY
+// conversation-type list shape regardless of order or length:
+//   - array literals of >=2 string elements (`['meeting', 'slack', ...]`)
+//   - string-literal union chains of >=2 members (`'meeting' | 'slack' | ...`)
+// and flags any whose elements intersect the canonical set in >=2 places.
+// Set-membership, not sequence match — so permutations, subsets, and
+// supersets all trip it. It deliberately scans comments too: a hand-copied
+// list in a doc comment goes stale the same way code does (adding this
+// detector immediately caught a pre-#2756 four-element default documented in
+// conversation-facts-backfill.ts's header while the code default was six).
+// The >=2 threshold keeps single-membership arrays like extract-conversation-
+// facts.ts's ALLOWED_TYPE_ALIASES values (`['slack', 'slack-dm-day', ...]`,
+// one canonical member each) from false-positiving.
+const CANONICAL_SET: ReadonlySet<string> = new Set(EXPECTED_TYPES);
+const STRING_LIT = `(?:'[^'\\n]*'|"[^"\\n]*")`;
+const ARRAY_LIST_RE = new RegExp(
+  `\\[\\s*${STRING_LIT}(?:\\s*,\\s*${STRING_LIT})+\\s*,?\\s*\\]`,
+  'g',
+);
+const UNION_LIST_RE = new RegExp(`${STRING_LIT}(?:\\s*\\|\\s*${STRING_LIT})+`, 'g');
 
-// The stale pre-#2756 four-element union type cast that drifted in jobs.ts.
-const STALE_FOUR_ELEMENT_UNION_CAST =
-  /\(\s*['"]conversation['"]\s*\|\s*['"]meeting['"]\s*\|\s*['"]slack['"]\s*\|\s*['"]email['"]\s*\)\s*\[\]/g;
+function stringElements(listText: string): string[] {
+  return [...listText.matchAll(/['"]([^'"\n]*)['"]/g)].map((m) => m[1]);
+}
+
+function findSuspectTypeLists(src: string): Array<{ snippet: string; elements: string[] }> {
+  const suspects: Array<{ snippet: string; elements: string[] }> = [];
+  for (const re of [ARRAY_LIST_RE, UNION_LIST_RE]) {
+    for (const m of src.matchAll(re)) {
+      const elements = stringElements(m[0]);
+      const canonicalHits = elements.filter((e) => CANONICAL_SET.has(e));
+      if (canonicalHits.length >= 2) suspects.push({ snippet: m[0], elements });
+    }
+  }
+  return suspects;
+}
 
 // Any import (static `from '...'` or dynamic `import('...')`) of
 // ALLOWED_TYPES (optionally aliased) from the given relative module path.
@@ -104,10 +143,22 @@ describe('ALLOWED_TYPES — canonical source of truth (leaf module)', () => {
     expect([...ALLOWED_TYPES]).toEqual([...EXPECTED_TYPES]);
   });
 
-  test('appears as a hardcoded literal exactly once, in the leaf module', () => {
+  test('is Object.frozen — runtime mutation throws instead of silently drifting every consumer', () => {
+    expect(Object.isFrozen(ALLOWED_TYPES)).toBe(true);
+    // Module code runs in strict mode, so a frozen-array write throws
+    // (it would be a silent no-op in sloppy mode — assert the throw so the
+    // guard is about behavior, not just the flag).
+    expect(() => {
+      (ALLOWED_TYPES as unknown as string[]).push('sms');
+    }).toThrow();
+    expect(ALLOWED_TYPES.length).toBe(6);
+  });
+
+  test('exactly one conversation-type list exists in the leaf module, and it is set-equal to the canonical 6', () => {
     const src = readSrc('core/facts/conversation-types.ts');
-    const matches = [...src.matchAll(HARDCODED_SIX_LITERAL)];
-    expect(matches.length).toBe(1);
+    const suspects = findSuspectTypeLists(src);
+    expect(suspects.length).toBe(1);
+    expect([...suspects[0].elements].sort()).toEqual([...EXPECTED_TYPES].sort());
   });
 
   test('the leaf module carries no CLI-flag-shaped literals of its own', () => {
@@ -120,9 +171,9 @@ describe('ALLOWED_TYPES — canonical source of truth (leaf module)', () => {
     expect([...src.matchAll(/--[a-z0-9][a-z0-9-]*/g)]).toEqual([]);
   });
 
-  test('extract-conversation-facts.ts no longer hardcodes the literal; re-exports from the leaf', () => {
+  test('extract-conversation-facts.ts no longer hand-copies any type list; re-exports from the leaf', () => {
     const src = readSrc('commands/extract-conversation-facts.ts');
-    expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+    expect(findSuspectTypeLists(src)).toEqual([]);
     expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
     expect(src).toContain('export { ALLOWED_TYPES }');
     expect(src).toContain('export type { AllowedType }');
@@ -134,17 +185,29 @@ describe('DRIFT GUARD — consumer sites derive from the leaf module (re-hardcod
     ['doctor.ts', 'commands/doctor.ts'],
     ['jobs.ts', 'commands/jobs.ts'],
     ['sources.ts', 'commands/sources.ts'],
+    ['conversation-facts-backfill.ts', 'core/cycle/conversation-facts-backfill.ts'],
   ] as const) {
-    test(`${label}: no hand-copied 6-element literal remains`, () => {
+    test(`${label}: no hand-copied conversation-type list remains (any order, any length >= 2)`, () => {
+      // Set-membership detector, NOT a canonical-order literal match: a
+      // permuted re-add, a subset re-add (dropping a type), and a widened
+      // re-add all fail here. Code and comments alike.
       const src = readSrc(relPath);
-      expect([...src.matchAll(HARDCODED_SIX_LITERAL)]).toEqual([]);
+      expect(findSuspectTypeLists(src)).toEqual([]);
     });
 
     test(`${label}: does not import ALLOWED_TYPES from extract-conversation-facts.ts`, () => {
       const src = readSrc(relPath);
-      expect(countAllowedTypesImportsFromCommandModule(src)).toBe(0);
+      expect(
+        countAllowedTypesImportsFrom(src, '\\.\\.?(?:/\\.\\.)?/commands/extract-conversation-facts\\.ts') +
+          countAllowedTypesImportsFromCommandModule(src),
+      ).toBe(0);
     });
   }
+
+  test('conversation-facts-backfill.ts: imports ALLOWED_TYPES from the leaf exactly once', () => {
+    const src = readSrc('core/cycle/conversation-facts-backfill.ts');
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./facts/conversation-types\\.ts')).toBe(1);
+  });
 
   test('doctor.ts: imports ALLOWED_TYPES from the leaf exactly once (both sites reference the same binding)', () => {
     const src = readSrc('commands/doctor.ts');
@@ -153,9 +216,17 @@ describe('DRIFT GUARD — consumer sites derive from the leaf module (re-hardcod
     expect((src.match(/\bALLOWED_TYPES\b/g) ?? []).length).toBeGreaterThanOrEqual(3); // import + 2 usages
   });
 
-  test('jobs.ts: no stale 4-element union cast remains (the #2756-drift class)', () => {
+  test('jobs.ts: the extract-conversation-facts handler filters job.data.types against ALLOWED_TYPES', () => {
+    // Closes the narrowed-runtime-filter hole: the `job.data.types` filter
+    // must reference the canonical ALLOWED_TYPES binding. Together with the
+    // hand-copy detector above (no shadow list may exist anywhere in
+    // jobs.ts) and the single-leaf-import guard below, narrowing the filter
+    // requires either dropping this reference (fails here) or re-adding a
+    // hand-copied list (fails the detector). The old guard was a byte-exact
+    // match on the stale 4-element union cast, which a 4-element runtime
+    // filter re-add sailed straight past.
     const src = readSrc('commands/jobs.ts');
-    expect([...src.matchAll(STALE_FOUR_ELEMENT_UNION_CAST)]).toEqual([]);
+    expect(src).toMatch(/job\.data\.types[\s\S]{0,400}?\bALLOWED_TYPES\b/);
   });
 
   test('jobs.ts: imports ALLOWED_TYPES + AllowedType from the leaf exactly once', () => {


### PR DESCRIPTION
## Summary

The conversation-facts type allowlist — `conversation`, `meeting`, `slack`, `email`, `imessage`,
`imessage-daily` — is hand-copied into five places across four files:

| # | site |
|---|---|
| 1 | `src/commands/extract-conversation-facts.ts` — `export const ALLOWED_TYPES` (canonical) |
| 2 | `src/commands/doctor.ts` — the default when `cycle.conversation_facts_backfill.types` is unset |
| 3 | `src/commands/doctor.ts` — `const allowedTypes` in the parse-coverage sampler |
| 4 | `src/commands/jobs.ts` — inline `.includes(t)` filter |
| 5 | `src/commands/sources.ts` — `FACTS_BACKFILL_ALLOWED` |

It has already drifted. In `jobs.ts`, one line below a runtime filter that accepts all six values,
the result was cast as `('conversation' | 'meeting' | 'slack' | 'email')[] | undefined` — the
four-element set from before `imessage`/`imessage-daily` were added. To be precise about severity:
this was **type-level only**. The `as` assertion is unchecked, the narrower array type is
assignable to the wider parameter under array covariance, and the values flowed through as
strings, so `typecheck` passed before and after and no runtime behavior differed. It was a
declared type that had stopped describing its data.

CLAUDE.md already states the principle this violates, for pricing:

> One canonical chat-pricing table ... Every other table ... is a DERIVED view, never a
> hand-copied duplicate — so cross-table price drift is structurally impossible.

Same situation, without the discipline. The stale cast is exactly the drift that rule predicts.

## What changed

The six values move to a new leaf module, `src/core/facts/conversation-types.ts`, exporting
`ALLOWED_TYPES` and the derived `AllowedType`. `extract-conversation-facts.ts` imports from there
and re-exports both names verbatim, so its existing importers are untouched. Sites 2-5 import the
leaf. `jobs.ts`'s cast is replaced by a `(t): t is AllowedType` type guard, so the narrowing is
checked rather than asserted. `doctor.ts` site 2 keeps its config-overridable-default semantic
exactly — only where the default comes from changed.

**The set of allowed types is unchanged.** This PR changes where the six values are defined, not
what they are.

### Why a leaf module and not a direct import

The first version of this PR had sites 2-5 import the constant straight from
`extract-conversation-facts.ts`. CI caught the problem: `scripts/generate-flag-registry.ts` scans
a command module's own text plus one level of its relative imports for flag-shaped literals, and
treats static and dynamic imports identically. Importing anything from that command therefore
attributed its entire flag surface to the importers — the regenerated registry gained about ten
entries each on `doctor`, `repos` and `sources` (`--segment-limit`, `--types`, `--slug`,
`--sleep`, `--override-disabled`, and friends).

That registry backs #2185's strict unknown-flag validation, so the naive version would have made
three commands start accepting flags they had been correctly rejecting — a silent widening of
their surface, in a PR that claims to change nothing about behavior. Regenerating the registry to
get a green build would have baked that in. The leaf module has no flag surface of its own, so the
committed registry is byte-identical before and after.

## Verification

`bun run build:flag-registry` followed by `git diff --stat` on the generated registry is empty —
that is the load-bearing check for the paragraph above, and it is pinned by a new test that
reproduces the generator's own relative-import scan for `doctor`/`repos`/`sources`/`jobs` rather
than hardcoding an assumed flag list.

`test/conversation-facts-type-allowlist-drift.test.ts` is modelled on `test/model-pricing.test.ts`'s
drift guard, which asserts each derived view equals canonical. It also asserts the leaf itself
carries no flag-shaped literals, so the fix cannot silently regress.

Red-green: reverting the four source files and deleting the leaf makes the drift test fail hard.
Against the earlier hand-copied state the structural guards failed while the value-level
assertions passed — which is the point: the values had not drifted yet, only the source had, and a
value-only test would never have caught the `jobs.ts` cast.

`bash scripts/test-shard.sh 5 10` 1755 pass / 0 fail; `test/cli-flag-validation.test.ts` 25/25;
the drift test plus `test/extract-conversation-facts.test.ts` and
`test/doctor-conversation-facts-backlog.test.ts` 88 pass / 0 fail; `bun run typecheck` exit 0;
`bun run verify` 43/43 exit 0.

Related to #2756, which added `imessage`/`imessage-daily` and is where the cast fell behind.
