### PR TITLE
docs(cli): tell contributors how to resolve a flag-registry conflict

### DIFF
--- a/scripts/generate-flag-registry.ts
+++ b/scripts/generate-flag-registry.ts
@@ -156,6 +156,12 @@ export function renderRegistryModule(registry: Record<string, string[]>): string
 // Regenerate: bun run build:flag-registry
 // Freshness + drift pinned by test/cli-flag-validation.test.ts (#2185).
 //
+// Merge conflict here? Do not hand-merge it. This file is regenerated on most
+// upstream waves, so a branch that also regenerates it conflicts on the whole
+// body. Take the base branch's copy wholesale, then re-run the command above —
+// the freshness test named above fails loudly if that regeneration was done
+// against the wrong base.
+//
 // Per-command legal flags for CLI_ONLY commands, derived from each command's
 // source (case block + imported modules + one level of relative imports +
 // scripts/generate-flag-registry.ts EXTRA_FLAGS). Deliberately over-inclusive

--- a/src/core/cli-flag-registry.generated.ts
+++ b/src/core/cli-flag-registry.generated.ts
@@ -2,6 +2,12 @@
 // Regenerate: bun run build:flag-registry
 // Freshness + drift pinned by test/cli-flag-validation.test.ts (#2185).
 //
+// Merge conflict here? Do not hand-merge it. This file is regenerated on most
+// upstream waves, so a branch that also regenerates it conflicts on the whole
+// body. Take the base branch's copy wholesale, then re-run the command above —
+// the freshness test named above fails loudly if that regeneration was done
+// against the wrong base.
+//
 // Per-command legal flags for CLI_ONLY commands, derived from each command's
 // source (case block + imported modules + one level of relative imports +
 // scripts/generate-flag-registry.ts EXTRA_FLAGS). Deliberately over-inclusive


### PR DESCRIPTION
## The problem

`src/core/cli-flag-registry.generated.ts` is a committed generated artifact, and upstream
regenerates it on most waves — every one of the last twelve commits touching that path is a wave,
including two dedicated `chore: regenerate CLI flag registry` commits. Any open PR that also
regenerates it therefore conflicts on the whole body, and rebasing only resets the clock until the
next wave.

That is not hypothetical. Sweeping the 127 currently-open PRs, **8 touch that file and 4 of those
are `CONFLICTING` right now** (#4027, #3974, #3776, #4104) — four different contributors, none of
whom did anything wrong. I have two of the eight myself; one of them went `CONFLICTING`, was
rebased, and went `CONFLICTING` again two days later.

The conflict is mechanical and the resolution is always the same, but nothing tells you that. The
header explains how to *regenerate*; it says nothing about what to do when the file *conflicts*,
which is the moment a contributor is actually reading it.

## The change

Five comment lines in the header template (`scripts/renderRegistryModule`), plus the regenerated
artifact carrying them:

> Merge conflict here? Do not hand-merge it. This file is regenerated on most upstream waves, so a
> branch that also regenerates it conflicts on the whole body. Take the base branch's copy
> wholesale, then re-run the command above — the freshness test named above fails loudly if that
> regeneration was done against the wrong base.

Deliberately scoped to documenting the existing workflow. I have NOT proposed a `.gitattributes`
merge driver, or stopping committing the artifact, or changing what CI diffs — those are workflow
decisions that belong to you, and the freshness guard in `test/cli-flag-validation.test.ts` already
makes the manual procedure safe. This just points at it from where the confusion happens.

## Verification

`bun test test/cli-flag-validation.test.ts` 25 pass / 0 fail; `bun run typecheck` exit 0;
`bun run verify` 43/43 exit 0.

`git diff` on the generated file is the five comment lines and nothing else — no flag entries move,
which is the property that matters for a change to a file whose whole job is being byte-stable.
