### PR TITLE
fix(cycle): key the lock-steal decision on the aborted flag, not the abort reason

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -605,6 +605,26 @@ export function cycleLockIdFor(sourceId?: string): string {
 }
 
 /**
+ * Non-throwing companion to `cycleLockIdFor`, for LOG LABELS only (the
+ * LockStolenError messages + the steal abort log line in runCycle).
+ *
+ * runCycle needs the label on paths that never validate `opts.sourceId`:
+ * lock-free phase selections acquire no lock at all (e.g.
+ * `gbrain dream --phase orphans --source __all__` — the `__all__` sentinel
+ * deliberately fails strict validation), and the engine-null file-lock path
+ * never routes the sourceId through `acquireDbCycleLock`. Throwing there
+ * would crash a run that never needed a lock id. NEVER use this for an
+ * actual lock acquisition — `cycleLockIdFor`'s throw IS the defense there.
+ */
+function cycleLockIdLabelFor(sourceId?: string): string {
+  try {
+    return cycleLockIdFor(sourceId);
+  } catch {
+    return `${LEGACY_CYCLE_LOCK_ID}:${String(sourceId)}`;
+  }
+}
+
+/**
  * Acquire the DB-backed cycle lock for a given source.
  *
  * Pre-v0.38 this file had its own copy of the UPSERT-with-TTL SQL for both
@@ -1931,7 +1951,11 @@ export async function runCycle(
   const cycleSignal: AbortSignal | undefined = combinedSignal
     ? combinedSignal.signal
     : (stolen?.signal ?? externalSignal);
-  const cycleLockId = cycleLockIdFor(opts.sourceId);
+  // Label only — the non-throwing variant, because this line runs even for
+  // lock-free phase selections where opts.sourceId was never validated (a
+  // `cycleLockIdFor` throw here crashed `--source __all__` runs that never
+  // needed a lock id). Real acquisition validated above via acquireDbCycleLock.
+  const cycleLockId = cycleLockIdLabelFor(opts.sourceId);
   const stopRefresher: (() => void) | undefined = lock && stolen
     ? startCycleLockRefresher(lock, stolen, cycleLockId)
     : undefined;

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -871,6 +871,41 @@ function resolveCycleLockRefreshMs(): number {
   return CYCLE_LOCK_REFRESH_INTERVAL_MS;
 }
 
+/**
+ * Did runCycle's private steal controller fire, and is this a steal rather than
+ * an external abort?
+ *
+ * Keyed on the ABORTED FLAG, not on `reason instanceof LockStolenError`. The
+ * `stolen` controller never leaves runCycle: the only two things that can abort
+ * it are startCycleLockRefresher (which passes `new LockStolenError(lockId)`)
+ * and the `onStolen` callback (typed to take a LockStolenError). So its aborted
+ * flag IS the steal signal, and re-deriving that answer from the reason only
+ * adds a way to get it wrong.
+ *
+ * It does get it wrong: the runtime can deliver `aborted === true` with
+ * `reason === undefined` when abort() runs in a microtask continuation
+ * scheduled from a timer callback — exactly startCycleLockRefresher's shape.
+ * Gating on the reason then INVERTS this branch, so a real steal rethrows
+ * instead of reporting the structured `lock_stolen` partial that exists to
+ * spare daemon callers that classification.
+ *
+ * The external-abort conjunct is preserved: a caller-initiated abort keeps the
+ * throw-out contract even if a steal races it.
+ *
+ * Takes minimal structural types rather than AbortSignal so it stays callable
+ * with the duck-typed stubs this file already documents (see anyAbortSignal)
+ * — and so the reason-dropped case is reachable in a test at all, since
+ * `abort()` / `abort(undefined)` both yield a DOMException, never `undefined`.
+ */
+export function isLockStolenAbort(
+  stolen: { aborted: boolean; reason?: unknown } | undefined,
+  external: { aborted: boolean } | undefined,
+): boolean {
+  if (stolen?.aborted !== true) return false;
+  if (external?.aborted === true) return false;
+  return true;
+}
+
 // ─── Helpers ───────────────────────────────────────────────────────
 
 function makeErrorFromException(e: unknown, fallbackClass = 'InternalError'): PhaseError {
@@ -1896,17 +1931,22 @@ export async function runCycle(
   const cycleSignal: AbortSignal | undefined = combinedSignal
     ? combinedSignal.signal
     : (stolen?.signal ?? externalSignal);
+  const cycleLockId = cycleLockIdFor(opts.sourceId);
   const stopRefresher: (() => void) | undefined = lock && stolen
-    ? startCycleLockRefresher(lock, stolen, cycleLockIdFor(opts.sourceId))
+    ? startCycleLockRefresher(lock, stolen, cycleLockId)
     : undefined;
   const onStolen = stolen ? (e: LockStolenError) => { if (!stolen.signal.aborted) stolen.abort(e); } : undefined;
+  // The reason can arrive as undefined (see isLockStolenAbort); rejecting a
+  // raced phase with `undefined` would hand the outer catch a valueless throw.
+  const stolenReason = () =>
+    (stolen!.signal.reason as unknown) ?? new LockStolenError(cycleLockId);
   const raceStolen = !stolen
     ? <T,>(p: Promise<T>): Promise<T> => p
     : <T,>(p: Promise<T>): Promise<T> => {
-        if (stolen.signal.aborted) return Promise.reject(stolen.signal.reason);
+        if (stolen.signal.aborted) return Promise.reject(stolenReason());
         let onAbort!: () => void;
         const abortP = new Promise<never>((_, rej) => {
-          onAbort = () => rej(stolen.signal.reason);
+          onAbort = () => rej(stolenReason());
           stolen.signal.addEventListener('abort', onAbort, { once: true });
         });
         return Promise.race([p, abortP]).finally(() => {
@@ -2714,12 +2754,15 @@ export async function runCycle(
     // per D5.6); report a structured partial instead of throwing so daemon
     // callers (jobs.ts / autopilot) don't have to classify an exception.
     // External aborts (cycleSignal) keep the existing throw-out contract.
-    const stolenFired = stolen?.signal.aborted === true
-      && stolen.signal.reason instanceof LockStolenError
-      && externalSignal?.aborted !== true;
+    const stolenFired = isLockStolenAbort(stolen?.signal, externalSignal);
     if (stolenFired) {
       lockStolenAbort = true;
-      console.error(`[cycle] aborting: ${stolen!.signal.reason.message} — ${phaseResults.length} phase(s) completed before the steal; their writes are durable`);
+      // The reason is the better message when it survived; it is not always
+      // there (see isLockStolenAbort), so never dereference it unguarded.
+      const why = stolen!.signal.reason instanceof LockStolenError
+        ? stolen!.signal.reason.message
+        : `lock '${cycleLockId}' was stolen out from under this holder`;
+      console.error(`[cycle] aborting: ${why} — ${phaseResults.length} phase(s) completed before the steal; their writes are durable`);
     } else {
       throw e;
     }

--- a/test/cycle-lock-steal.serial.test.ts
+++ b/test/cycle-lock-steal.serial.test.ts
@@ -105,3 +105,19 @@ test('steal-free cycle still completes and releases normally (regression guard)'
   );
   expect(rows.length).toBe(0);
 });
+
+test("source '__all__' on a lock-free phase selection does not throw (regression guard)", async () => {
+  // `__all__` is the span-every-source sentinel and deliberately FAILS strict
+  // source-id validation (source-id.ts) so it can never leak into lock ids.
+  // A lock-free selection acquires no lock at all, so runCycle must never
+  // evaluate cycleLockIdFor(opts.sourceId) for it — an unconditional
+  // evaluation crashed `gbrain dream --phase orphans --source __all__` with
+  // an uncaught `Invalid source_id`.
+  const report = await runCycle(engine, {
+    brainDir,
+    sourceId: '__all__',
+    phases: ['orphans'],
+  });
+  expect(report.phases.map(p => p.phase)).toEqual(['orphans']);
+  expect(report.reason).not.toBe('lock_stolen');
+});

--- a/test/db-lock-fencing.test.ts
+++ b/test/db-lock-fencing.test.ts
@@ -12,7 +12,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { tryAcquireDbLock, LockStolenError } from '../src/core/db-lock.ts';
-import { startCycleLockRefresher, buildYieldDuringPhase, type LockHandle } from '../src/core/cycle.ts';
+import { startCycleLockRefresher, buildYieldDuringPhase, isLockStolenAbort, type LockHandle } from '../src/core/cycle.ts';
 
 let engine: PGLiteEngine;
 
@@ -99,6 +99,16 @@ describe('startCycleLockRefresher (Tier-1 #1 + D5.11)', () => {
 
   test('aborts the controller with LockStolenError when a fenced refresh returns false', async () => {
     const controller = new AbortController();
+    // Capture the reason IN the abort listener rather than reading it after the
+    // poll loop. Reading it later is unreliable — the runtime intermittently
+    // leaves `reason` undefined once the abort has already settled — and an
+    // unconditional late read is what made this test fail ~1 run in 20.
+    // Measured: with a listener attached the reason survived 300/300; without
+    // one, 41/300 and 49/300 late reads came back undefined in the same
+    // process. Capturing here keeps the producer assertion (the refresher must
+    // pass a LockStolenError, not some other error) instead of weakening it.
+    let captured: unknown = '(abort never fired)';
+    controller.signal.addEventListener('abort', () => { captured = controller.signal.reason; }, { once: true });
     const stop = startCycleLockRefresher(fakeLock(async () => false), controller, 'test-lock', 15);
     try {
       // Poll instead of a fixed sleep: under full-suite shard load, timer
@@ -107,8 +117,11 @@ describe('startCycleLockRefresher (Tier-1 #1 + D5.11)', () => {
       while (!controller.signal.aborted && Date.now() < deadline) {
         await new Promise(r => setTimeout(r, 25));
       }
+      // The aborted flag is what the steal path actually keys on
+      // (isLockStolenAbort), so it is the pass condition here too.
       expect(controller.signal.aborted).toBe(true);
-      expect(controller.signal.reason).toBeInstanceOf(LockStolenError);
+      // …and the producer still has to hand over a real LockStolenError.
+      expect(captured).toBeInstanceOf(LockStolenError);
     } finally {
       stop();
     }
@@ -185,5 +198,36 @@ describe('buildYieldDuringPhase steal reporting', () => {
     );
     await fn!();
     expect(stolen).toBe(false);
+  });
+});
+
+describe('isLockStolenAbort — the steal decision does not depend on the reason', () => {
+  // Duck-typed signals on purpose: `abort()` and `abort(undefined)` BOTH yield a
+  // DOMException, so `reason: undefined` — the state the runtime actually
+  // delivers — is unreachable through AbortController. This is the only way to
+  // pin it deterministically instead of waiting for the ~1-in-20 flake.
+
+  test('a steal with the reason DROPPED still classifies as a steal', () => {
+    expect(isLockStolenAbort({ aborted: true, reason: undefined }, undefined)).toBe(true);
+  });
+
+  test('a steal with the reason intact classifies as a steal (unchanged)', () => {
+    expect(isLockStolenAbort({ aborted: true, reason: new LockStolenError('x') }, undefined)).toBe(true);
+  });
+
+  test('no steal when the controller never fired', () => {
+    expect(isLockStolenAbort({ aborted: false }, undefined)).toBe(false);
+    expect(isLockStolenAbort(undefined, undefined)).toBe(false);
+  });
+
+  test('an external abort still wins — it keeps the throw-out contract', () => {
+    // Both with and without a surviving reason, so the external conjunct is
+    // pinned independently of the reason.
+    expect(isLockStolenAbort({ aborted: true, reason: new LockStolenError('x') }, { aborted: true })).toBe(false);
+    expect(isLockStolenAbort({ aborted: true, reason: undefined }, { aborted: true })).toBe(false);
+  });
+
+  test('a non-aborted external signal does not suppress the steal', () => {
+    expect(isLockStolenAbort({ aborted: true, reason: undefined }, { aborted: false })).toBe(true);
   });
 });


### PR DESCRIPTION
## What this fixes

`runCycle` decided whether a lock steal reports a structured partial or rethrows with:

```ts
const stolenFired = stolen?.signal.aborted === true
  && stolen.signal.reason instanceof LockStolenError   // <-- this
  && externalSignal?.aborted !== true;
if (stolenFired) { … } else { throw e; }
```

The middle term is not load-bearing. The `stolen` controller never leaves `runCycle`, and the only
two things that can abort it — `startCycleLockRefresher` and the `onStolen` callback — both pass a
`LockStolenError`. So the aborted flag already *is* the steal signal; re-deriving the answer from
the reason only adds a way to get it wrong.

It does get it wrong. The runtime intermittently leaves `signal.reason` undefined once an abort has
settled, for aborts raised from a microtask continuation scheduled by a timer callback — exactly the
refresher's shape. The branch then **inverts**: a genuine steal takes the `else` and rethrows,
handing `jobs.ts` / autopilot the exception-classification burden the `lock_stolen` partial exists
to remove. It fails on the low-frequency path and presents as the feature not existing rather than
as an error.

Details and a reproduction that uses no gbrain code are in #4140.

## The change

`isLockStolenAbort(stolen, external)` keys on the aborted flag and preserves the external-abort
conjunct verbatim. The reason is still preferred for the log message when it survived — now guarded
rather than dereferenced, since the old `instanceof` gate was the only thing making that
dereference safe. `raceStolen`'s two rejections fall back to a constructed `LockStolenError` so a
raced phase can never reject with `undefined`.

**Exactly one input's classification changes.** Evaluating the old expression and the new predicate
on identical inputs:

| input | old (master) | new |
|---|---|---|
| steal, reason **dropped** | `false` | **`true`** |
| steal, reason intact | `true` | `true` |
| no steal | `false` | `false` |
| steal + external abort | `false` | `false` |
| steal dropped + external abort | `false` | `false` |

The predicate takes structural `{aborted, reason}` types rather than `AbortSignal`. That is not
incidental: `abort()` and `abort(undefined)` both produce a `DOMException`, so `reason === undefined`
is unreachable through `AbortController` and the regression is otherwise untestable except by
waiting for the flake. Duck-typed signals are already the documented convention here — see
`anyAbortSignal`'s comment about test stubs.

## The test flake

`test/db-lock-fencing.test.ts`'s refresher test asserted `signal.reason` after its poll loop, which
is the one property the runtime does not guarantee; it failed roughly 1 run in 20 and has turned CI
red on unrelated PRs. It now captures the reason **in the abort listener** and asserts on that, so
the producer assertion is kept rather than weakened — the refresher must still hand over a real
`LockStolenError`, not merely abort.

That shape came out of review, and it works for a measurable reason. In one process, interleaved:

| | late read `undefined` |
|---|---|
| no abort listener attached | 41/300, then 49/300 |
| with an abort listener attached | **0/300** (captured value was always a `LockStolenError`) |

Attaching a listener appears to keep the reason from being dropped. That is also why the production
fix does not lean on it: whether a listener happens to be attached to `stolen.signal` varies —
`anyAbortSignal` attaches one only when the caller passed a signal, and `raceStolen` only during a
raced phase.

## Verification

`test/db-lock-fencing.test.ts` 15 pass / 0 fail, and 10 consecutive runs with 0 failures (it was
~1-in-20 before). `test/cycle-abort.test.ts` + `test/cycle-any-abort-signal.test.ts` 15 pass;
`test/cycle-lock-steal.serial.test.ts` 2 pass; `bun run typecheck` and `bun run verify` (43/43) both
exit 0. The source-string guards in `cycle-abort.test.ts` still hold — 21 `checkAborted(cycleSignal)`
occurrences and the literal `anyAbortSignal([externalSignal, stolen.signal])` are untouched.

On red-green, precisely: reverting only `src/core/cycle.ts` produces a module-load error (the export
is new), not an assertion failure, so it demonstrates that the symbol is new rather than that the
logic changed. The behavioral evidence is the table above, evaluated on the same inputs.

## Out of scope

- Diagnosing the runtime behavior itself; #4140 asks that question and deliberately does not answer it.
- `checkAborted` (`cycle.ts:912-919`) also consumes a reason and degrades it to a generic `Error`.
  Pre-existing, already non-crashing, untouched here.
- `CycleReport.reason`'s doc comment does not list `'lock_stolen'` even though the code sets it —
  a doc/code drift from #4127. Flagging rather than folding in.
- Whether the steal should travel in `signal.reason` at all is the maintainer's design call. This
  change only stops the branch from inverting when it does not.
