### PR TITLE
v0.45.18.1 fix(sync): accept Windows path casing and index Astro/Svelte (#4044)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1246,6 +1246,10 @@ export function createSyncBaselineCommit(repoPath: string): void {
  * returns backslash paths there, and a literal `rootReal + '/'` prefix can
  * never match one. A sibling (`root-evil`) is rejected because `relative`
  * yields `../root-evil`, and a cross-drive path because it yields an absolute.
+ * On Windows this intentionally follows the platform path semantics exposed by
+ * `win32.relative`, including case-insensitive segment matching; detecting rare
+ * per-directory case-sensitive NTFS siblings would require filesystem identity
+ * checks rather than a pure path check.
  */
 interface PathContainmentOps {
   relative(from: string, to: string): string;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1247,10 +1247,23 @@ export function createSyncBaselineCommit(repoPath: string): void {
  * never match one. A sibling (`root-evil`) is rejected because `relative`
  * yields `../root-evil`, and a cross-drive path because it yields an absolute.
  */
-export function isWithinRoot(childReal: string, rootReal: string): boolean {
+interface PathContainmentOps {
+  relative(from: string, to: string): string;
+  isAbsolute(path: string): boolean;
+  sep: string;
+}
+
+const nativePathContainmentOps: PathContainmentOps = { relative, isAbsolute, sep };
+
+export function isWithinRoot(
+  childReal: string,
+  rootReal: string,
+  pathOps: PathContainmentOps = nativePathContainmentOps,
+): boolean {
   if (childReal === rootReal) return true;
-  const rel = relative(rootReal, childReal);
-  return rel !== '' && rel !== '..' && !rel.startsWith('..' + sep) && !isAbsolute(rel);
+  const rel = pathOps.relative(rootReal, childReal);
+  if (rel === '') return true;
+  return rel !== '..' && !rel.startsWith('..' + pathOps.sep) && !pathOps.isAbsolute(rel);
 }
 
 /**

--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -464,6 +464,7 @@ export function detectCodeLanguage(filePath: string, content?: string): Supporte
   if (lower.endsWith('.sh') || lower.endsWith('.bash')) return 'bash';
   if (lower.endsWith('.css')) return 'css';
   if (lower.endsWith('.html') || lower.endsWith('.htm')) return 'html';
+  if (lower.endsWith('.astro') || lower.endsWith('.svelte')) return 'html';
   if (lower.endsWith('.vue')) return 'vue';
   if (lower.endsWith('.json')) return 'json';
   if (lower.endsWith('.yaml') || lower.endsWith('.yml')) return 'yaml';

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -253,7 +253,7 @@ export interface CodeRef {
 // The extension list is aligned with detectCodeLanguage in chunkers/code.ts.
 // Paths NOT matching these extensions are ignored because they wouldn't
 // have a code page to edge to anyway.
-const CODE_REF_REGEX = /\b((?:src|lib|app|test|tests|scripts|docs|packages|internal|cmd|examples)\/[\w\-./]+\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|cs|cpp|cc|hpp|c|h|php|swift|kt|scala|lua|ex|exs|elm|ml|dart|zig|sol|sh|bash|css|html|vue|json|yaml|yml|toml))(?::(\d+))?\b/g;
+const CODE_REF_REGEX = /\b((?:src|lib|app|test|tests|scripts|docs|packages|internal|cmd|examples)\/[\w\-./]+\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|cs|cpp|cc|hpp|c|h|php|swift|kt|scala|lua|ex|exs|elm|ml|dart|zig|sol|sh|bash|css|html|astro|svelte|vue|json|yaml|yml|toml))(?::(\d+))?\b/g;
 
 /**
  * Extract code-path references (e.g. 'src/core/sync.ts:42') from markdown

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -76,6 +76,7 @@ const CODE_EXTENSIONS = new Set<string>([
   '.sh', '.bash',
   '.css',
   '.html', '.htm',
+  '.astro', '.svelte',
   '.vue',
   '.json',
   '.yaml', '.yml',

--- a/test/chunkers/code.test.ts
+++ b/test/chunkers/code.test.ts
@@ -16,7 +16,7 @@ describe('CHUNKER_VERSION', () => {
 });
 
 describe('detectCodeLanguage', () => {
-  test('recognizes all 30 supported extensions', () => {
+  test('recognizes supported extensions', () => {
     const cases: Record<string, string> = {
       'foo.ts': 'typescript', 'foo.tsx': 'tsx', 'foo.mts': 'typescript', 'foo.cts': 'typescript',
       'foo.js': 'javascript', 'foo.jsx': 'javascript', 'foo.mjs': 'javascript', 'foo.cjs': 'javascript',
@@ -28,7 +28,7 @@ describe('detectCodeLanguage', () => {
       'foo.scala': 'scala', 'foo.lua': 'lua', 'foo.ex': 'elixir',
       'foo.elm': 'elm', 'foo.ml': 'ocaml', 'foo.dart': 'dart',
       'foo.zig': 'zig', 'foo.sol': 'solidity', 'foo.sh': 'bash',
-      'foo.css': 'css', 'foo.html': 'html', 'foo.vue': 'vue',
+      'foo.css': 'css', 'foo.html': 'html', 'foo.astro': 'html', 'foo.svelte': 'html', 'foo.vue': 'vue',
       'foo.json': 'json', 'foo.yaml': 'yaml', 'foo.toml': 'toml',
       // v0.41 D2 wave: SQL via DerekStride/tree-sitter-sql.
       'foo.sql': 'sql', 'migrations/001_init.sql': 'sql',

--- a/test/link-extraction-code-refs.test.ts
+++ b/test/link-extraction-code-refs.test.ts
@@ -43,7 +43,7 @@ describe('extractCodeRefs — basic patterns', () => {
       'cpp', 'cc', 'hpp', 'c', 'h',
       'php', 'swift', 'kt', 'scala', 'lua',
       'ex', 'exs', 'elm', 'ml', 'dart', 'zig', 'sol',
-      'sh', 'bash', 'css', 'html', 'vue',
+      'sh', 'bash', 'css', 'html', 'astro', 'svelte', 'vue',
       'json', 'yaml', 'yml', 'toml',
     ];
     for (const ext of exts) {

--- a/test/sync-classifier-widening.test.ts
+++ b/test/sync-classifier-widening.test.ts
@@ -66,9 +66,11 @@ describe('Layer 2 — isCodeFilePath widening', () => {
     expect(isCodeFilePath('contracts/Token.sol')).toBe(true);
   });
 
-  test('Web + config extensions (CSS, HTML, Vue, JSON, YAML, TOML)', () => {
+  test('Web + config extensions (CSS, HTML, Astro, Svelte, Vue, JSON, YAML, TOML)', () => {
     expect(isCodeFilePath('src/app.css')).toBe(true);
     expect(isCodeFilePath('public/index.html')).toBe(true);
+    expect(isCodeFilePath('src/pages/index.astro')).toBe(true);
+    expect(isCodeFilePath('src/routes/App.svelte')).toBe(true);
     expect(isCodeFilePath('src/App.vue')).toBe(true);
     expect(isCodeFilePath('package.json')).toBe(true);
     expect(isCodeFilePath('config.yaml')).toBe(true);

--- a/test/sync-path-containment.test.ts
+++ b/test/sync-path-containment.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { join, sep, parse } from 'path';
+import { join, sep, parse, win32 } from 'path';
 import { isWithinRoot } from '../src/commands/sync.ts';
 
 describe('isWithinRoot path containment (#774 NAV-1/NAV-2)', () => {
@@ -57,5 +57,13 @@ describe('isWithinRoot path containment (#774 NAV-1/NAV-2)', () => {
     // `root + '/'` prefix test would have rejected it.
     const child = `${root}${sep}sub${sep}page.md`;
     expect(isWithinRoot(child, root)).toBe(true);
+  });
+
+  test('accepts Windows paths that differ only by directory casing', () => {
+    const winRoot = 'C:\\Users\\person\\Projects\\Tally';
+
+    expect(isWithinRoot('C:\\Users\\person\\projects\\Tally', winRoot, win32)).toBe(true);
+    expect(isWithinRoot('C:\\Users\\person\\projects\\Tally\\wiki\\page.md', winRoot, win32)).toBe(true);
+    expect(isWithinRoot('C:\\Users\\person\\projects\\Tally-evil\\page.md', winRoot, win32)).toBe(false);
   });
 });

--- a/test/sync-path-containment.test.ts
+++ b/test/sync-path-containment.test.ts
@@ -31,6 +31,10 @@ describe('isWithinRoot path containment (#774 NAV-1/NAV-2)', () => {
     expect(isWithinRoot(join(root, 'page.md'), root)).toBe(true);
   });
 
+  test('accepts the root with a trailing separator', () => {
+    expect(isWithinRoot(root + sep, root)).toBe(true);
+  });
+
   test('accepts a nested descendant (the case a hardcoded "/" broke on win32)', () => {
     expect(isWithinRoot(join(root, 'wiki', 'notes', 'page.md'), root)).toBe(true);
   });


### PR DESCRIPTION
## Summary

Fixes #4044.

This tightens two ingest/indexing edges from the issue:

- sync path containment now accepts Windows paths that resolve to the same directory even when the stored source path and git-discovered root differ only by casing, while still rejecting sibling escapes
- Astro and Svelte files are classified as code by routing them through the existing HTML tree-sitter grammar, so they become indexed instead of being silently skipped
- markdown code-reference extraction now recognizes .astro and .svelte paths to stay aligned with the code classifier

## Tests

- `bun test test/sync-path-containment.test.ts test/chunkers/code.test.ts test/sync-classifier-widening.test.ts test/link-extraction-code-refs.test.ts` - 71 pass
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL GBRAIN_TEST_ALLOW_DATABASE_URL=1 bash scripts/gbrain-gate.sh <worktree> test/sync-path-containment.test.ts test/chunkers/code.test.ts test/sync-classifier-widening.test.ts test/link-extraction-code-refs.test.ts` - RESULT: GREEN; verify green, 71 focused unit tests pass, 72 mapped e2e tests pass
