### PR TITLE
fix(transcripts): remove 512MB hard cap on Hermes store import

### DIFF
--- a/src/core/transcripts/hermes.ts
+++ b/src/core/transcripts/hermes.ts
@@ -49,8 +49,8 @@ export const HERMES_SPEC_TARGET: HostSpecTarget = {
     'context window). PROVISIONAL: no populated production sample verified.',
 };
 
-/** Hard cap for the store copy (FTS indexes make legitimate stores large). */
-export const HERMES_DB_HARD_CAP = 512 * 1024 * 1024;
+/** Default cap for the store copy — Infinity removes the limit. Pass maxBytes via opts to override. */
+export const HERMES_DB_HARD_CAP = Infinity;
 
 const SQLITE_MAGIC = 'SQLite format 3\u0000';
 
@@ -113,16 +113,16 @@ export const hermesAdapter: TranscriptAdapter = {
   async *parse(path: string, opts: ParseSessionsOpts = {}): AsyncGenerator<ParsedSession, FileDiagnostics> {
     const cap = opts.maxBytes ?? HERMES_DB_HARD_CAP;
     const size = statSync(path).size;
-    // The cap bounds the TOTAL copied (db + sidecars) — a runaway WAL can
-    // dwarf the main file, and only capping the db would let the copy blow
-    // through temp storage while advertising a 512MB bound.
+    // The cap bounds the TOTAL copied (db + sidecars). Default is Infinity
+    // (no limit) since the adapter reads sessions incrementally. Pass
+    // maxBytes via opts to cap when temp disk space is constrained.
     let totalBytes = size;
     for (const suffix of ['-wal', '-shm']) {
       if (existsSync(path + suffix)) totalBytes += statSync(path + suffix).size;
     }
     if (totalBytes > cap) {
       throw new Error(
-        `hermes store too large for import: ${totalBytes} bytes incl. sidecars (cap ${cap})`,
+        `hermes store too large for import: ${totalBytes} bytes incl. sidecars (cap ${cap}) — pass a higher maxBytes or omit the cap`,
       );
     }
 


### PR DESCRIPTION
## Summary

Remove the 512MB hard cap (`HERMES_DB_HARD_CAP`) on Hermes store files during transcript import. The default is now `Infinity` (no limit).

## Problem

The Hermes adapter rejected stores larger than 512MB (including WAL/SHM sidecars). In multi-profile Hermes setups, this blocks the most active profiles:

| Profile | state.db size | Importable |
|---------|--------------|------------|
| herme (default) | 1.5 GB | ❌ blocked |
| agent_arch | 1.8 GB | ❌ blocked |
| aevum | 571 MB | ❌ blocked |
| reviewer | 267 MB | ✅ |
| researcher | 133 MB | ✅ |

The tool call results stored in these databases (32,479+ tool messages per profile) represent accumulated knowledge that is currently invisible to the brain.

## Why the cap is unnecessary

The adapter reads sessions **incrementally** via SQLite queries — it does not load the entire store into memory. The only real constraint is temp disk space for the copy-then-read pattern, which is:
- Inherited from the OS (typically many GB)
- Already bounded by the `maxBytes` opt-in via `ParseSessionsOpts`
- Not meaningfully different at 512MB vs 2GB

## Changes

- `src/core/transcripts/hermes.ts`: Set `HERMES_DB_HARD_CAP` from `512 * 1024 * 1024` to `Infinity`
- Updated comments to reflect the new default and explain the `maxBytes` opt-in
- Enhanced error message to guide users toward `maxBytes` when a cap is needed

## Backward compatibility

- Users who never hit the 512MB cap see no behavior change
- Users who need a cap can still pass `maxBytes` via `ParseSessionsOpts`
- The `HERMES_DB_HARD_CAP` export is preserved (value changed, not removed)

Closes #4149