### PR TITLE
fix(recipes): Google supports_prompt_cache becomes a per-model predicate

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -1,5 +1,30 @@
 import type { Recipe } from '../types.ts';
 
+/**
+ * Version-scoped prompt-cache capability.
+ *
+ * Gemini's *implicit* caching is the only kind that applies here: the gateway
+ * sends no cache directives on the Google path, and the explicit CachedContent
+ * API is never called. Implicit caching is on by default for Gemini 2.5 and
+ * newer, so those ids cache (and bill cached input at a discount) with no
+ * request mutation; 1.5 and 2.0 cache only through the explicit API and stay
+ * false. Ids this recipe can also serve but that never cache (Gemma) are out.
+ *
+ * The version digits sit in different positions across ids (`gemini-2.5-pro`,
+ * `gemini-3-flash-preview`, `gemini-3.6-flash`), so match the first numeric
+ * token rather than a fixed segment. `-latest` aliases carry no digits and
+ * always resolve to a current-generation model, so they pass. Any other
+ * unversioned id reads false: a wrong `true` silently promises a discount the
+ * provider never applies.
+ */
+export function googleSupportsPromptCache(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized.startsWith('gemini-')) return false;
+  if (normalized.endsWith('-latest')) return true;
+  const version = normalized.match(/\d+(?:\.\d+)?/);
+  return version !== null && Number.parseFloat(version[0]) >= 2.5;
+}
+
 export const google: Recipe = {
   id: 'google',
   name: 'Google Gemini',
@@ -40,7 +65,11 @@ export const google: Recipe = {
       models: ['gemini-2.0-flash-exp', 'gemini-2.0-flash'],
       supports_tools: true,
       supports_subagent_loop: true,
-      supports_prompt_cache: false,
+      // Per-model: implicit caching is a 2.5+ capability, and this recipe
+      // accepts off-list ids (the config plane does not pin model ids to the
+      // list above), so a recipe-wide boolean mislabels whichever side it
+      // picks.
+      supports_prompt_cache: googleSupportsPromptCache,
       max_context_tokens: 1000000, // Gemini 2.0 Flash
       cost_per_1m_input_usd: 0.30,
       cost_per_1m_output_usd: 1.20,

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -45,14 +45,15 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('only Anthropic and model-family-gated OpenRouter claim supports_prompt_cache', () => {
+  test('only Anthropic claims supports_prompt_cache outright; others gate per model', () => {
     for (const r of listRecipes()) {
       if (!r.touchpoints.chat) continue;
       if (r.id === 'anthropic') {
         expect(r.touchpoints.chat.supports_prompt_cache).toBe(true);
-      } else if (r.id === 'openrouter') {
-        // Family-scoped predicate (openai/* + anthropic/claude-*), never a
-        // blanket true — see recipe-openrouter.test.ts for the model matrix.
+      } else if (r.id === 'openrouter' || r.id === 'google') {
+        // Scoped predicates, never a blanket true: OpenRouter by routed model
+        // family (openai/* + anthropic/claude-*), Google by Gemini version
+        // (implicit caching is 2.5+). Matrices live in each recipe's test.
         expect(typeof r.touchpoints.chat.supports_prompt_cache).toBe('function');
       } else {
         expect(r.touchpoints.chat.supports_prompt_cache ?? false).toBe(false);

--- a/test/ai/recipe-google-prompt-cache.test.ts
+++ b/test/ai/recipe-google-prompt-cache.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Google/Gemini prompt-cache capability is a per-model predicate, not a flat
+ * boolean: Gemini's implicit caching (the only kind the gateway can benefit
+ * from — it sends no cache directives on the Google path) is default-on for
+ * 2.5 and newer, and absent on 1.5/2.0.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { googleSupportsPromptCache } from '../../src/core/ai/recipes/google.ts';
+import { getProviderCapabilities } from '../../src/core/ai/capabilities.ts';
+
+describe('recipe: google prompt cache', () => {
+  test('chat touchpoint wires the predicate, not a boolean', () => {
+    const chat = getRecipe('google')!.touchpoints.chat!;
+    expect(chat.supports_prompt_cache).toBe(googleSupportsPromptCache);
+  });
+
+  test('2.5 and newer cache; older families and non-Gemini ids do not', () => {
+    expect(googleSupportsPromptCache('gemini-2.5-flash')).toBe(true);
+    expect(googleSupportsPromptCache('gemini-2.5-pro')).toBe(true);
+    expect(googleSupportsPromptCache('gemini-3-flash-preview')).toBe(true);
+    // Version digits trail the family name on this one — position varies.
+    expect(googleSupportsPromptCache('gemini-3.6-flash')).toBe(true);
+    // `-latest` aliases carry no digits but always point at current models.
+    expect(googleSupportsPromptCache('gemini-flash-latest')).toBe(true);
+    expect(googleSupportsPromptCache('gemini-pro-latest')).toBe(true);
+
+    expect(googleSupportsPromptCache('gemini-2.0-flash')).toBe(false);
+    expect(googleSupportsPromptCache('gemini-2.0-flash-exp')).toBe(false);
+    expect(googleSupportsPromptCache('gemini-1.5-pro')).toBe(false);
+    expect(googleSupportsPromptCache('gemini-embedding-001')).toBe(false);
+    expect(googleSupportsPromptCache('gemma-3-27b-it')).toBe(false);
+  });
+
+  test('off-list passthrough ids resolve through the capability layer', () => {
+    // The recipe's `models` list is not enforced for native Google ids at the
+    // config plane, so a newer Gemini the list has not caught up to still has
+    // to be classified correctly.
+    expect(getProviderCapabilities('google:gemini-2.5-flash').supportsPromptCaching).toBe(true);
+    expect(getProviderCapabilities('google:gemini-1.5-pro').supportsPromptCaching).toBe(false);
+  });
+});


### PR DESCRIPTION
## fix(recipes): Google `supports_prompt_cache` becomes a per-model predicate

### What

`src/core/ai/recipes/google.ts` declared a single recipe-wide
`supports_prompt_cache: false`. Gemini's **implicit** caching — the only kind that applies
here, since the gateway sends no cache directives on the Google path and never calls the
explicit `CachedContent` API — is enabled by default for Gemini 2.5 and newer. So the flag
made `classifyCapabilities` return `degraded:no_caching` for every Gemini id, and both
`enforceSubagentCapable` (`src/core/model-config.ts`) and `doctor` told users their subagent
loop would "run hot" on models that cache 99% of a stable prefix.

A blanket `true` would be wrong in the other direction: the recipe's listed models
(`gemini-2.0-flash`, `gemini-2.0-flash-exp`) predate implicit caching. And the models list is
not a gate — the config plane accepts arbitrary Google ids, so newer models the list has not
caught up to inherit the recipe-wide value too. One boolean cannot be correct for both.

This PR uses the predicate form `supports_prompt_cache` already supports
(`boolean | ((modelId: string) => boolean)`, `src/core/ai/types.ts`), mirroring
`openrouterSupportsPromptCache`:

```ts
export function googleSupportsPromptCache(modelId: string): boolean {
  const normalized = modelId.trim().toLowerCase();
  if (!normalized.startsWith('gemini-')) return false;
  if (normalized.endsWith('-latest')) return true;
  const version = normalized.match(/\d+(?:\.\d+)?/);
  return version !== null && Number.parseFloat(version[0]) >= 2.5;
}
```

Version digits sit in different positions across real ids (`gemini-2.5-pro`,
`gemini-3-flash-preview`, `gemini-3.6-flash`), hence the first-numeric-token match rather
than a fixed segment. The `-latest` aliases (`gemini-flash-latest`, `gemini-pro-latest`)
carry no digits and always resolve to a current-generation model, so they pass. Any other
unversioned id reads false — a wrong `true` silently promises a discount the provider never
applies. Non-Gemini ids this recipe can serve (Gemma) never cache.

### Verification

Measured against the live Gemini API rather than inferred from the docs. A 27,905-token
stable system prefix on `gemini-2.5-flash`, sent through `gateway.chat()` with
`cacheSystem: true`, eight sampled calls:

```
call 1: input=27905 output=59 cache_read=27621
call 2: input=27905 output=60 cache_read=27621
call 3: input=27905 output=60 cache_read=27621
call 4: input=27905 output=55 cache_read=0
call 5: input=27906 output=60 cache_read=0
call 6: input=27906 output=60 cache_read=0
call 7: input=27906 output=42 cache_read=0
call 8: input=27906 output=58 cache_read=27621
cache hits observed through gateway.chat(): 4/8
```

Two things worth recording from that run:

1. **No plumbing change is needed.** `@ai-sdk/google` maps Gemini's
   `usageMetadata.cachedContentTokenCount` onto `usage.cachedInputTokens`, which
   `gateway.chat()` already reads into `usage.cache_read_tokens`. The cache reads were
   already being reported correctly; only the recipe metadata disagreed.
2. **Implicit caching is best-effort.** A hit is not guaranteed on any individual call, so a
   single cold/warm pair is not sufficient evidence either way — an early 3-call sample of
   mine showed 0 hits before a longer sample showed 4/8. That non-determinism is a real
   property of the feature, but it is a cost-variance question, not a capability question,
   and it is not what the `degraded:no_caching` verdict is measuring.

### Testing

New `test/ai/recipe-google-prompt-cache.test.ts` pins the predicate is wired into the recipe
(not a boolean), the version matrix (2.5/3.x/`-latest` true; 2.0/1.5/embedding/Gemma false),
and that off-list passthrough ids classify correctly through `getProviderCapabilities`. Red
before the change (the export did not exist), green after.

`test/ai/gateway-chat.test.ts`'s registry sweep asserted that OpenRouter was the only recipe
using a predicate; widened to include Google. Its intent — no recipe blanket-claims caching
except Anthropic — is unchanged.

Ran the prompt-cache-adjacent suite: `recipe-google-prompt-cache`, `capabilities`,
`gateway-chat`, `recipe-openrouter`, `recipes-existing-regression`,
`gateway-cache-breakpoint`, `model-config.serial` — 118 pass, 0 fail. `tsc --noEmit` clean.

### Not in scope

Every other chat recipe (`ollama`, `together`, `deepseek`, `groq`, `zhipu`, `mistral`,
`moonshot`, `litellm-proxy`, `openai`) still hardcodes `supports_prompt_cache: false`, and at
least a couple of those providers document automatic context caching today. Left alone
deliberately — each needs its own provider-specific verification, and the proxy-fronted ones
may not be knowable from the recipe at all. Raised as an aside in the companion issue.

Closes #4158