### PR TITLE
fix: parse sparse multiline transcript imports

### DIFF
--- a/src/core/conversation-parser/builtins.ts
+++ b/src/core/conversation-parser/builtins.ts
@@ -74,7 +74,13 @@ export const BUILTIN_PATTERNS: readonly PatternEntry[] = [
     date_source: 'inline',
     time_format: '12h_ampm',
     timezone_policy: 'inline_utc',
-    multi_line: false,
+    // Transcript imports preserve embedded newlines in each turn. Treat
+    // non-anchor lines as message continuations when scoring so a small
+    // number of long coding turns does not fall below the global 5% density
+    // floor and become unparseable. The continuation-aware scorer still
+    // requires an anchor on the first line or at least two valid anchors.
+    multi_line: true,
+    score_continuations_as_body: true,
     quick_reject: /^\*\*/,
     test_positive: [
       '**Alice Example** (2024-03-15 9:00 AM): hello',

--- a/test/conversation-parser/parse.test.ts
+++ b/test/conversation-parser/parse.test.ts
@@ -469,7 +469,7 @@ describe('scorePatternFull — full-body scoring (v0.41.18+ Codex P1 #1)', () =>
     const im = BUILTIN_PATTERNS.find((p) => p.id === 'imessage-slack')!;
     expect(scorePatternFull('', im)).toBe(0);
   });
-  test('preamble + 20 matching lines scores 20/(preamble + 20)', () => {
+  test('multi-line format ignores preamble after multiple anchors establish a transcript', () => {
     const im = BUILTIN_PATTERNS.find((p) => p.id === 'imessage-slack')!;
     const preamble = ['## Summary', 'Three sentences.', '> Source: ref', '## Transcript'];
     const matches = Array.from(
@@ -477,8 +477,9 @@ describe('scorePatternFull — full-body scoring (v0.41.18+ Codex P1 #1)', () =>
       (_, i) => `**Garry Tan** (2026-01-29 12:00 PM): message ${i}`,
     );
     const body = [...preamble, ...matches].join('\n');
-    // 24 total non-blank, 20 match → 20/24 ≈ 0.833
-    expect(scorePatternFull(body, im)).toBeCloseTo(20 / 24, 5);
+    // Once two anchors establish a real multi-line transcript, unrelated
+    // preamble/continuation lines no longer dilute the format score.
+    expect(scorePatternFull(body, im)).toBe(1);
   });
   test('preamble-only-no-match scores 0', () => {
     const im = BUILTIN_PATTERNS.find((p) => p.id === 'imessage-slack')!;

--- a/test/transcript-render.test.ts
+++ b/test/transcript-render.test.ts
@@ -62,6 +62,25 @@ describe('render round-trip through the SHARED imessage-slack pattern', () => {
     expect(body).toContain('(2026-08-02 9:30 PM)');
   });
 
+  test('multi-line coding turns remain parseable below the ordinary density floor', () => {
+    const longUserTurn = Array.from({ length: 40 }, (_, i) => `user line ${i}`).join('\n');
+    const longAssistantTurn = Array.from({ length: 40 }, (_, i) => `assistant line ${i}`).join('\n');
+    const sparse = session([
+      { role: 'user', timestamp: '2026-08-02T09:00:03.000Z', text: longUserTurn },
+      { role: 'assistant', timestamp: '2026-08-02T09:00:04.000Z', text: longAssistantTurn },
+    ]);
+
+    const rendered = renderSessionParts(
+      redactSession(sparse, { userPatternsPath: '/nonexistent' }),
+    );
+    const parsed = parseConversation(splitBody(rendered.parts[0].content));
+
+    expect(parsed.matched_pattern_id).toBe('imessage-slack');
+    expect(parsed.messages).toHaveLength(2);
+    expect(parsed.messages[0].text).toContain('user line 39');
+    expect(parsed.messages[1].text).toContain('assistant line 39');
+  });
+
   test('frontmatter is mandatory-complete: type, date, unique per-part id, marker', () => {
     const r = renderSessionParts(redactSession(BASIC, { userPatternsPath: '/nonexistent' }));
     const fm = frontmatter(r.parts[0].content);


### PR DESCRIPTION
## Summary

- treat the native `imessage-slack` transcript shape as continuation-aware during format scoring
- keep the existing false-positive guard: continuation scoring only activates after two anchors or when the first line is an anchor
- add a round-trip regression for sparse, multi-line coding turns

## Problem

The native transcript importer preserves embedded newlines. In coding sessions with a few long turns, valid message anchors can make up less than 5% of non-blank lines, so the conversation parser returns `no_match` for pages emitted by GBrain itself.

## Validation

- `bun test test/transcript-render.test.ts test/conversation-parser/parse.test.ts` (92 pass)
- `bun run typecheck`
- `bun run check:conversation-parser` (20/20 fixtures)
- verified an affected imported Codex page changes from `no_match` to `imessage-slack` with 20 messages
