### PR TITLE
fix(doctor): count only live entity pages in graph_coverage

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7324,7 +7324,12 @@ export async function buildChecks(
   try {
     const health = await engine.getHealth();
     const entityCount = (await engine.executeRaw<{ count: number }>(
-      "SELECT COUNT(*)::int AS count FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')",
+      // deleted_at IS NULL: a brain whose only entity pages are soft-deleted has
+      // zero LIVE entities, and must take the short-circuit below rather than
+      // warn about coverage on pages the rest of the system treats as gone.
+      // buildGazetteer (src/core/by-mention.ts) already filters this way, so
+      // without it the two disagree about whether entity pages exist at all.
+      "SELECT COUNT(*)::int AS count FROM pages WHERE deleted_at IS NULL AND type IN ('entity', 'person', 'company', 'organization')",
     ))[0]?.count ?? 0;
 
     // Compute coverage against eligible entities only — exclude test fixtures
@@ -7335,7 +7340,8 @@ export async function buildChecks(
     const eligibleStats = (await engine.executeRaw<{ entities: number; linked_from: number; timeline: number }>(
       `WITH eligible AS (
         SELECT id FROM pages
-        WHERE type IN ('entity','person','company','organization')
+        WHERE deleted_at IS NULL
+          AND type IN ('entity','person','company','organization')
           AND slug NOT LIKE 'tools/gbrain/test/%'
           AND slug <> 'templates/new-person'
       )

--- a/test/doctor-graph-coverage-soft-deleted.test.ts
+++ b/test/doctor-graph-coverage-soft-deleted.test.ts
@@ -1,0 +1,102 @@
+/**
+ * graph_coverage must count LIVE entity pages only.
+ *
+ * A brain whose only entity pages are soft-deleted has zero live entities, so
+ * the check has to take its existing short-circuit ("No entity pages —
+ * graph_coverage not applicable") rather than warn about coverage on pages the
+ * rest of the system treats as gone.
+ *
+ * Without the deleted_at filter the WARN is unclearable: doctor recommends
+ * `gbrain extract all`, but buildGazetteer (src/core/by-mention.ts) already
+ * filters soft-deleted pages, so `extract links --by-mention` answers "No
+ * linkable entity pages found" on the same brain. The two disagree about
+ * whether entity pages exist at all.
+ *
+ * Reported on #3754 (deleted_at not filtered), doctor surface.
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { sqlQueryForEngine } from '../src/core/sql-query.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+/** Two entity pages plus a plain note; the entity pages are then soft-deleted. */
+async function seedSoftDeletedEntities(eng: PGLiteEngine): Promise<void> {
+  const sql = sqlQueryForEngine(eng);
+  await sql`
+    INSERT INTO pages (slug, source_id, type, title, compiled_truth, frontmatter, content_hash, created_at, updated_at)
+    VALUES
+      ('acme-example', 'default', 'company', 'Acme', '', '{}', 'sd1', now(), now()),
+      ('alice-example', 'default', 'person', 'Alice', '', '{}', 'sd2', now(), now()),
+      ('technical-a', 'default', 'note', 'Tech A', '', '{}', 'sd3', now(), now())
+  `;
+  await sql`UPDATE pages SET deleted_at = now() WHERE slug IN ('acme-example', 'alice-example')`;
+}
+
+/** Same shape, but the entity pages stay live — the control. */
+async function seedLiveEntities(eng: PGLiteEngine): Promise<void> {
+  const sql = sqlQueryForEngine(eng);
+  await sql`
+    INSERT INTO pages (slug, source_id, type, title, compiled_truth, frontmatter, content_hash, created_at, updated_at)
+    VALUES
+      ('acme-example', 'default', 'company', 'Acme', '', '{}', 'lv1', now(), now()),
+      ('alice-example', 'default', 'person', 'Alice', '', '{}', 'lv2', now(), now()),
+      ('technical-a', 'default', 'note', 'Tech A', '', '{}', 'lv3', now(), now())
+  `;
+}
+
+describe('graph_coverage counts live entity pages only (#3754, doctor surface)', () => {
+  test('all entity pages soft-deleted -> takes the not-applicable short-circuit', async () => {
+    await seedSoftDeletedEntities(engine);
+    const checks = await buildChecks(engine, [], null);
+    const graph = checks.find((c) => c.name === 'graph_coverage');
+    expect(graph, 'graph_coverage check must be present').toBeDefined();
+    expect(graph!.message).toContain('No entity pages');
+    // The unclearable WARN this guards against names a count and a percentage.
+    expect(graph!.message).not.toMatch(/entity page(s)?\)/);
+    expect(graph!.message).not.toMatch(/coverage \d+%/);
+  });
+
+  test('control: live entity pages still produce a real coverage report', async () => {
+    await seedLiveEntities(engine);
+    const checks = await buildChecks(engine, [], null);
+    const graph = checks.find((c) => c.name === 'graph_coverage');
+    expect(graph, 'graph_coverage check must be present').toBeDefined();
+    // Not the short-circuit — the filter must not hide live pages.
+    expect(graph!.message).not.toContain('No entity pages');
+    expect(graph!.message).toMatch(/coverage \d+%/);
+  });
+
+  test('a soft-deleted entity page does not inflate the reported denominator', async () => {
+    const sql = sqlQueryForEngine(engine);
+    await seedLiveEntities(engine);
+    await sql`
+      INSERT INTO pages (slug, source_id, type, title, compiled_truth, frontmatter, content_hash, created_at, updated_at, deleted_at)
+      VALUES ('ghost-example', 'default', 'person', 'Ghost', '', '{}', 'gh1', now(), now(), now())
+    `;
+    const checks = await buildChecks(engine, [], null);
+    const graph = checks.find((c) => c.name === 'graph_coverage');
+    expect(graph, 'graph_coverage check must be present').toBeDefined();
+    // 2 live entity pages + 1 soft-deleted. The count doctor reports — and
+    // divides its percentages by — must be the live 2.
+    expect(graph!.message).toContain('(2 entity pages)');
+    expect(graph!.message).not.toContain('(3 entity pages)');
+  });
+});


### PR DESCRIPTION
The doctor surface of #3754, where I reported it two days ago.

## The bug

A brain whose only entity pages are soft-deleted has zero live entities, but `graph_coverage`
counted the deleted rows. So it never reached its own short-circuit —
`No entity pages — graph_coverage not applicable` — and warned about coverage on pages the rest of
the system treats as gone.

The WARN could not be cleared. doctor recommends `gbrain extract all`, but `buildGazetteer`
(`src/core/by-mention.ts`) already filters soft-deleted pages, so on the same brain:

```
$ gbrain extract links --by-mention --source db
No linkable entity pages found in this brain (need pages with type IN person/company/organization/entity).
```

Two surfaces disagreeing about whether entity pages exist at all, with the recommended command
unable to link pages that are deleted.

## The change

`deleted_at IS NULL` on the `entityCount` query and the `eligible` CTE — the same filter
`buildGazetteer` already applies. `linked_from` and `timeline` select from `eligible`, so they
inherit it. No schema change.

Deliberately not included: links whose *endpoints* are soft-deleted still feed the numerator. That
is the `page_links` traversal #3754 is actually about, and belongs with that fix rather than here.

## Verification

New `test/doctor-graph-coverage-soft-deleted.test.ts`, three cases. Red-green with the fix
committed first, then `src/commands/doctor.ts` reverted to master:

| case | unfixed | fixed |
|---|---|---|
| all entity pages soft-deleted | `Entity link coverage 0%, entity timeline coverage 0% (2 entity pages). Run: gbrain extract all` | `No entity pages — graph_coverage not applicable` |
| 2 live + 1 soft-deleted | `(3 entity pages)` | `(2 entity pages)` |
| control: entity pages live | real coverage report | unchanged |

1 pass / 2 fail before, 3 pass / 0 fail after. The control passes in both directions, which is the
half that matters for a filter — it proves the change does not hide live pages.

Neighbouring doctor suites (`doctor`, `doctor-categories`, `doctor-timeline-metric-labels-2298`,
`doctor-brain-checks-score`): 134 pass / 0 fail. `bun run typecheck` exit 0; `bun run verify` 44/44
exit 0.

## Related

#4147 is adjacent but distinct: it covers what `get_health` reports when the entity page set is
genuinely empty (0/0 guarded to 0/1). This is the case where the set only *looks* non-empty because
a deleted row is counted — with this filter, such a brain becomes the empty case #4147 describes.
