### PR TITLE
fix(think): gather stream failures surface typed warning codes instead of stderr-only

### DIFF
--- a/src/core/think/gather.ts
+++ b/src/core/think/gather.ts
@@ -48,6 +48,13 @@ export interface ThinkGatherResult {
   takes: TakeHit[];
   /** Graph nodes — slugs reachable from anchor within graphDepth. Empty when no anchor. */
   graphSlugs: string[];
+  /**
+   * Machine-stable warning codes for per-stream failures (D6: code-only on the
+   * wire; the raw error text goes to stderr/server logs). Lets MCP/remote
+   * callers distinguish "stream errored" from "stream legitimately returned 0"
+   * — the diagnostics counts alone can't. Empty when every stream succeeded.
+   */
+  warnings: string[];
   /** Diagnostics for telemetry / `--explain` path (Lane D follow-up). */
   diagnostics: {
     pagesFromHybrid: number;
@@ -116,12 +123,15 @@ export async function runGather(
   // (Direct DB search is fine — those are parameterized queries.)
   const sanitizedQuestion = sanitizeQueryForPrompt(opts.question);
 
+  const warnings: string[] = [];
+
   // Stream 1: hybrid page search (existing primitive).
   const pagesPromise = hybridSearch(engine, opts.question, {
     limit: gatherLimit,
     expansion: false,  // think provides its own anchor + graph context; no need for re-expansion
     ...sourceScope,
   }).catch((e) => {
+    warnings.push('GATHER_HYBRID_FAILED');
     process.stderr.write(`[think.gather] hybrid stream failed: ${(e as Error).message}\n`);
     return [] as SearchResult[];
   });
@@ -132,6 +142,7 @@ export async function runGather(
     takesHoldersAllowList: opts.takesHoldersAllowList,
     ...sourceScope,
   }).catch((e) => {
+    warnings.push('GATHER_TAKES_KEYWORD_FAILED');
     process.stderr.write(`[think.gather] takes-keyword stream failed: ${(e as Error).message}\n`);
     return [] as TakeHit[];
   });
@@ -143,6 +154,7 @@ export async function runGather(
         takesHoldersAllowList: opts.takesHoldersAllowList,
         ...sourceScope,
       }).catch((e) => {
+        warnings.push('GATHER_TAKES_VECTOR_FAILED');
         process.stderr.write(`[think.gather] takes-vector stream failed: ${(e as Error).message}\n`);
         return [] as TakeHit[];
       })
@@ -160,6 +172,7 @@ export async function runGather(
           return Array.from(slugs);
         })
         .catch((e) => {
+          warnings.push('GATHER_GRAPH_FAILED');
           process.stderr.write(`[think.gather] graph stream failed: ${(e as Error).message}\n`);
           return [] as string[];
         })
@@ -179,6 +192,7 @@ export async function runGather(
     pages: pages.slice(0, gatherLimit),
     takes: fusedTakes,
     graphSlugs,
+    warnings,
     diagnostics: {
       pagesFromHybrid: pages.length,
       takesFromKeyword: takesKw.length,

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -403,6 +403,10 @@ export async function runThink(
     ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
     ...(opts.allowedSources !== undefined ? { sourceIds: opts.allowedSources } : {}),
   });
+  // D6: per-stream gather failures surface as typed codes (GATHER_*_FAILED);
+  // raw error text stays on stderr. Distinguishes an errored stream from a
+  // legitimately-empty one for MCP/remote callers.
+  for (const w of gather.warnings) warnings.push(w);
 
   // Render evidence blocks for the prompt
   const pagesBlock = renderPagesBlock(gather.pages, 600, opts.question);

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -141,6 +141,78 @@ describe('runGather', () => {
   });
 });
 
+describe('runGather — per-stream typed warnings (GATHER_*_FAILED)', () => {
+  /** Delegating wrapper: listed methods reject; everything else hits the real engine. */
+  function withFailing(methods: string[]): PGLiteEngine {
+    return new Proxy(engine, {
+      get(target, prop) {
+        if (typeof prop === 'string' && methods.includes(prop)) {
+          return async () => { throw new Error(`${prop} boom`); };
+        }
+        const v = Reflect.get(target, prop, target);
+        return typeof v === 'function' ? v.bind(target) : v;
+      },
+    }) as PGLiteEngine;
+  }
+
+  test('clean run reports no gather warnings', async () => {
+    const r = await runGather(engine, { question: 'technical founder' });
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('a throwing hybrid stream surfaces GATHER_HYBRID_FAILED and stays fail-open', async () => {
+    const r = await runGather(withFailing(['searchKeyword']), { question: 'technical founder' });
+    expect(r.warnings).toContain('GATHER_HYBRID_FAILED');
+    expect(r.pages).toEqual([]);
+    // Fail-open: the takes stream keeps working.
+    expect(r.takes.length).toBeGreaterThan(0);
+  });
+
+  test('each failing stream maps to its own code', async () => {
+    const r = await runGather(
+      withFailing(['searchKeyword', 'searchTakes', 'searchTakesVector', 'traversePaths']),
+      {
+        question: 'technical founder',
+        anchor: 'people/alice-example',
+        questionEmbedding: new Float32Array(8),
+      },
+    );
+    expect([...r.warnings].sort()).toEqual([
+      'GATHER_GRAPH_FAILED',
+      'GATHER_HYBRID_FAILED',
+      'GATHER_TAKES_KEYWORD_FAILED',
+      'GATHER_TAKES_VECTOR_FAILED',
+    ]);
+    expect(r.pages).toEqual([]);
+    expect(r.takes).toEqual([]);
+    expect(r.graphSlugs).toEqual([]);
+  });
+
+  test('runThink folds gather warnings into ThinkResult.warnings', async () => {
+    const stubClient: ThinkLLMClient = {
+      create: async () => ({
+        id: 'msg_gather_warn',
+        type: 'message',
+        role: 'assistant',
+        model: 'stub',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ answer: 'stubbed answer', citations: [], gaps: [] }),
+        }],
+      }),
+    };
+    const result = await runThink(withFailing(['searchTakes']), {
+      question: 'technical founder',
+      client: stubClient,
+    });
+    expect(result.warnings).toContain('GATHER_TAKES_KEYWORD_FAILED');
+    expect(result.warnings).not.toContain('GATHER_HYBRID_FAILED');
+  });
+});
+
 describe('runThink (with stub client)', () => {
   test('full pipeline: gather → stub synthesize → result', async () => {
     const stubClient: ThinkLLMClient = {


### PR DESCRIPTION
## Problem

`runGather` (`src/core/think/gather.ts`) catches per-stream failures in all four
retrieval streams — hybrid pages, takes-keyword, takes-vector, graph walk — and
correctly degrades fail-open with labeled stderr diagnostics. But no typed code
reaches the think result's `warnings[]`. `diagnostics` carries counts and a sanitizer flag but no error signal, so
`pagesFromHybrid: 0` is ambiguous for MCP/remote callers whose stderr goes to
server logs: did the stream error, or was it legitimately empty?

Sibling degradations in the same pipeline already follow the code-only-on-the-wire
idiom ("D6: code-only on the wire; raw exception text goes to server logs"):

- `QUESTION_EMBED_FAILED` — `src/core/think/index.ts:392`
- `CALIBRATION_FETCH_FAILED` — `src/core/think/index.ts:445`
- `TRAJECTORY_INJECTION_FAILED` — `src/core/think/index.ts:527`

Gather's four streams are top-level retrieval arms that degrade fail-open without any typed code.

## Fix

Align gather with the existing mechanism — additive only:

- `ThinkGatherResult` gains `warnings: string[]`; each existing per-stream catch
  additionally pushes a machine-stable code: `GATHER_HYBRID_FAILED`,
  `GATHER_TAKES_KEYWORD_FAILED`, `GATHER_TAKES_VECTOR_FAILED`,
  `GATHER_GRAPH_FAILED`.
- `runThink` folds them into `ThinkResult.warnings` (same fold pattern as the
  `resolveCitations` warnings at `src/core/think/index.ts:695-696`).

Unchanged by design: the fail-open behavior, the stderr diagnostics text, and the
`diagnostics` counts.

## Tests

`test/think-pipeline.serial.test.ts` — new describe with a delegating engine
wrapper (listed methods reject, the rest hit the real PGLite engine):

- clean run reports no gather warnings
- a throwing hybrid stream surfaces `GATHER_HYBRID_FAILED` and stays fail-open
  (takes still gathered)
- each failing stream maps to its own code (all four at once, empty results)
- `runThink` folds gather warnings into `ThinkResult.warnings`

Red-green verified: without the src change the 4 new tests fail (31 pass / 4 fail);
with it, 35 pass / 0 fail.

- targeted suite: 35/35 pass (DATABASE_URL unset, PGLite)
- `bun run typecheck`: clean
- `bun run verify`: 44/44 checks green

