### PR TITLE
docs(cli): point the self-help map at the test file that actually pins it

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,7 +175,7 @@ const CLI_ONLY_SELF_HELP = new Set([
  * answerable with no brain configured.
  *
  * Membership is behaviour, not taste: each entry is pinned by
- * test/cli-help-without-brain.test.ts, which runs the CLI with an empty
+ * test/cli-help-without-brain.serial.test.ts, which runs the CLI with an empty
  * GBRAIN_HOME and requires exit 0 plus real help output.
  */
 const SELF_HELP_WITHOUT_ENGINE: Record<string, () => Promise<(engine: never, args: string[]) => unknown>> = {


### PR DESCRIPTION
`SELF_HELP_WITHOUT_ENGINE` in `src/cli.ts` documents its own membership rule:

> Membership is behaviour, not taste: each entry is pinned by
> `test/cli-help-without-brain.test.ts` …

That path does not exist. The file is `test/cli-help-without-brain.serial.test.ts`.
So the single pointer telling a contributor *where to add their pin* when they
add a command to that map resolves to nothing — and the map's whole stated
contract depends on that pin existing.

Comment only; no behaviour change. `grep -rF 'cli-help-without-brain.test.ts'`
across the repo finds no other reference, so this is the only stale copy.

Found while adding `sources` to that map in #4133 — `bun test` treats its
arguments as filters, so the wrong path was silently dropped from the run
rather than erroring, and the shard reported green having never executed it.