### PR TITLE
fix(config): let DB-plane eval.* reach the runtime gate (#1475)

### DIFF
--- a/docs/eval-capture.md
+++ b/docs/eval-capture.md
@@ -155,6 +155,16 @@ Resolution order (most explicit wins):
 `eval.scrub_pii: false` to preserve raw query text (only if you control
 the brain's distribution).
 
-`gbrain config set eval.capture false` does **not** work — that
-command writes the DB-plane config, and the MCP server reads the
-file-plane. Edit the JSON directly or use the env var.
+`gbrain config set eval.capture <true|false>` applies to **CLI commands**
+(`gbrain query`, `gbrain recall`, …): the CLI merges the DB plane into the
+operation context it hands the capture gate.
+
+It does **not** yet apply to the **MCP server, `gbrain call`, or background
+subagents** — those build their context from the file plane only, so a
+DB-plane value is stored, echoed back by `gbrain config get`, and ignored.
+For those, edit `~/.gbrain/config.json` directly or export
+`GBRAIN_CONTRIBUTOR_MODE=1` in the service environment.
+
+Only the exact strings `true` and `false` are recognised on the DB plane.
+Anything else (`TRUE`, `1`, `yes`, a typo) is treated as unset and the
+default applies — it does not silently mean "false".

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1281,6 +1281,32 @@ export function findUnknownOpFlag(op: Operation, args: string[]): string | null 
   return null;
 }
 
+/**
+ * #1475 — the DB-plane merge `connectEngine` performs after connect, published
+ * for `makeContext` so the operation context carries it too.
+ *
+ * Why a map rather than a module-level variable: a process can hold more than
+ * one engine (`--brain <mount>` connects a second one), and the host brain's
+ * merged config must never be served for a mounted brain's context. Weak so a
+ * disconnected engine does not pin its config for the life of the process.
+ */
+const MERGED_CONFIG_BY_ENGINE = new WeakMap<BrainEngine, GBrainConfig>();
+
+/**
+ * @internal Exported for test/eval-capture-db-plane.serial.test.ts.
+ *
+ * Publishing the merge is the whole point of the map — if the `set` in
+ * connectEngine is ever dropped, makeContext silently falls back to
+ * re-merging and every command pays the per-key reads twice with no test
+ * going red. The seam lets a test prime the map the way connectEngine does
+ * and observe that no further reads happen.
+ */
+export const __testing = {
+  publishMergedConfig(engine: BrainEngine, config: GBrainConfig): void {
+    MERGED_CONFIG_BY_ENGINE.set(engine, config);
+  },
+};
+
 export async function makeContext(engine: BrainEngine, params: Record<string, unknown>): Promise<OperationContext> {
   // v0.31.8 (D11): resolve sourceId via the canonical 6-tier chain. Honors
   // --source / GBRAIN_SOURCE / .gbrain-source / path-match / brain default /
@@ -1317,20 +1343,24 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
   // them back, but every op-side gate reads `ctx.config` — so building this
   // from the sync, file-only `loadConfig()` made those writes inert
   // (`eval.capture` was the reported case: set, echoed back, still off).
-  // connectEngine already re-merges after connect, but it keeps the result to
-  // itself (env stashes + gateway reconfigure) and returns only the engine.
+  //
+  // connectEngine already performs exactly this merge after connect; it now
+  // publishes the result, so the normal CLI path costs ZERO additional config
+  // reads. The fallback merge below only runs for callers that reach
+  // makeContext with an engine connectEngine never saw (tests with a stub
+  // engine) — re-merging unconditionally would double the per-key reads that
+  // #3980 measures at ~1.5s per command on a hosted brain.
   //
   // Fail-open: a brain mid-migration whose config table is missing must still
   // get a usable context, so a merge failure falls back to the file plane.
-  // This runs once per invocation (single call site) alongside the sourceId
-  // resolution that is already DB I/O, and adds point lookups on a live
-  // connection — the same reads connectEngine performs.
   const fileConfig = loadConfig() || { engine: 'postgres' as const };
-  let mergedConfig = fileConfig;
-  try {
-    mergedConfig = (await loadConfigWithEngine(engine, fileConfig)) ?? fileConfig;
-  } catch {
-    mergedConfig = fileConfig;
+  let mergedConfig = MERGED_CONFIG_BY_ENGINE.get(engine) ?? fileConfig;
+  if (!MERGED_CONFIG_BY_ENGINE.has(engine)) {
+    try {
+      mergedConfig = (await loadConfigWithEngine(engine, fileConfig)) ?? fileConfig;
+    } catch {
+      mergedConfig = fileConfig;
+    }
   }
 
   return {
@@ -3087,6 +3117,13 @@ async function connectEngine(opts?: { probeOnly?: boolean }): Promise<BrainEngin
   try {
     const merged = await loadConfigWithEngine(engine, config);
     if (merged) {
+      // #1475 — hand the merged config to makeContext instead of letting it
+      // re-derive one. See MERGED_CONFIG_BY_ENGINE: the op-side gates read
+      // ctx.config, and re-running the merge there would double this
+      // function's per-key config reads on every command (the cost #3980 is
+      // about). Keyed on the engine so a mounted brain cannot be served the
+      // host brain's merge.
+      MERGED_CONFIG_BY_ENGINE.set(engine, merged);
       // Stash gate flags on process.env for downstream readers (import-file.ts
       // dispatches on GBRAIN_EMBEDDING_MULTIMODAL, OCR consumer reads
       // GBRAIN_EMBEDDING_IMAGE_OCR_*). The gateway itself doesn't read these

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1293,6 +1293,22 @@ export function findUnknownOpFlag(op: Operation, args: string[]): string | null 
 const MERGED_CONFIG_BY_ENGINE = new WeakMap<BrainEngine, GBrainConfig>();
 
 /**
+ * Adversarial-review fixup (PR #4186): which BrainEngine instances came from
+ * connectMountEngine. Keyed on the engine object itself — same engine-keyed
+ * weak-reference pattern as MERGED_CONFIG_BY_ENGINE above (a WeakMap; this is
+ * a WeakSet since there's no payload to store, just membership), and for the
+ * same reason that comment gives: a process can hold more than one engine,
+ * so any guard that decides per-engine behavior must bind to the specific
+ * engine instance, not to process-wide module state. (The prior version of
+ * this fixup checked a module-level `activeBrainId` variable instead; that
+ * drifts from the `engine` argument makeContext actually receives if a
+ * process ever holds a host engine and a mount engine at once — the CLI
+ * doesn't today, but nothing enforces that.) Weak so a disconnected mount
+ * engine does not pin memory.
+ */
+const MOUNT_ENGINES = new WeakSet<BrainEngine>();
+
+/**
  * @internal Exported for test/eval-capture-db-plane.serial.test.ts.
  *
  * Publishing the merge is the whole point of the map — if the `set` in
@@ -1304,6 +1320,13 @@ const MERGED_CONFIG_BY_ENGINE = new WeakMap<BrainEngine, GBrainConfig>();
 export const __testing = {
   publishMergedConfig(engine: BrainEngine, config: GBrainConfig): void {
     MERGED_CONFIG_BY_ENGINE.set(engine, config);
+  },
+  // Test-only seam for the mount-engine guard in makeContext's DB-plane
+  // fallback (see the #1475 comment there). Mirrors the MOUNT_ENGINES.add
+  // connectMountEngine makes on a real mount connect, without needing a live
+  // BrainRegistry.
+  markEngineAsMountForTests(engine: BrainEngine): void {
+    MOUNT_ENGINES.add(engine);
   },
 };
 
@@ -1344,12 +1367,24 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
   // from the sync, file-only `loadConfig()` made those writes inert
   // (`eval.capture` was the reported case: set, echoed back, still off).
   //
-  // connectEngine already performs exactly this merge after connect; it now
-  // publishes the result, so the normal CLI path costs ZERO additional config
-  // reads. The fallback merge below only runs for callers that reach
-  // makeContext with an engine connectEngine never saw (tests with a stub
-  // engine) — re-merging unconditionally would double the per-key reads that
-  // #3980 measures at ~1.5s per command on a hosted brain.
+  // connectEngine already performs exactly this merge after connect for the
+  // HOST brain; it publishes the result, so the normal CLI path costs ZERO
+  // additional config reads. The fallback merge below only runs when both
+  // (a) the engine was never published (callers that reach makeContext with
+  // an engine connectEngine never saw — tests with a stub engine) AND
+  // (b) the engine is not a mount engine (MOUNT_ENGINES, set by
+  // connectMountEngine). A mounted brain's engine never re-merges here.
+  // connectMountEngine's own docstring only promises that a mount's DB-plane
+  // model config is never merged into the caller's AI gateway; it says
+  // nothing about ctx.config, and this fallback — added for #1475 after that
+  // docstring was written — would otherwise happily merge a mount's DB-plane
+  // config into the caller's context too, which is the same kind of leak the
+  // gateway guarantee exists to prevent (a caller trusting a mount's config
+  // as if it were its own). Skipping the merge for mount engines closes that
+  // gap and, as a side effect, avoids adding a full per-key DB round-trip to
+  // every mounted-brain command (the #3980 cost this whole publish/consume
+  // split exists to avoid). Mounted brains keep the same file/env-only
+  // config makeContext built before #1475.
   //
   // Fail-open, but not silent. The expected failure — a brain mid-migration
   // whose config table does not exist yet — is already absorbed per key inside
@@ -1360,7 +1395,7 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
   // which is the whole shape of #1475. Warn and continue.
   const fileConfig = loadConfig() || { engine: 'postgres' as const };
   let mergedConfig = MERGED_CONFIG_BY_ENGINE.get(engine) ?? fileConfig;
-  if (!MERGED_CONFIG_BY_ENGINE.has(engine)) {
+  if (!MERGED_CONFIG_BY_ENGINE.has(engine) && !MOUNT_ENGINES.has(engine)) {
     try {
       mergedConfig = (await loadConfigWithEngine(engine, fileConfig)) ?? fileConfig;
     } catch (err) {
@@ -3047,6 +3082,11 @@ async function connectMountEngine(brainId: string): Promise<BrainEngine> {
   const { loadRegistry } = await import('./core/brain-registry.ts');
   const handle = await loadRegistry().getBrain(brainId);
   activeBrainId = brainId;
+  // Fixup (PR #4186): mark this specific engine as a mount engine so
+  // makeContext's DB-plane fallback (see MOUNT_ENGINES above) never re-merges
+  // a mount's config into the caller's context, regardless of what other
+  // engine — host or another mount — this process may also be holding.
+  MOUNT_ENGINES.add(handle.engine);
   return handle.engine;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1351,14 +1351,24 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
   // engine) — re-merging unconditionally would double the per-key reads that
   // #3980 measures at ~1.5s per command on a hosted brain.
   //
-  // Fail-open: a brain mid-migration whose config table is missing must still
-  // get a usable context, so a merge failure falls back to the file plane.
+  // Fail-open, but not silent. The expected failure — a brain mid-migration
+  // whose config table does not exist yet — is already absorbed per key inside
+  // loadConfigWithEngine, so anything that escapes to here is unexpected (a
+  // contract violation such as a malformed listConfigKeys result). Falling
+  // back to the file plane keeps the command usable, but swallowing it without
+  // a word would turn "the DB plane silently did nothing" back into a mystery —
+  // which is the whole shape of #1475. Warn and continue.
   const fileConfig = loadConfig() || { engine: 'postgres' as const };
   let mergedConfig = MERGED_CONFIG_BY_ENGINE.get(engine) ?? fileConfig;
   if (!MERGED_CONFIG_BY_ENGINE.has(engine)) {
     try {
       mergedConfig = (await loadConfigWithEngine(engine, fileConfig)) ?? fileConfig;
-    } catch {
+    } catch (err) {
+      console.warn(
+        `[config] DB-plane merge failed; using file/env config only. ` +
+        `Values set via \`gbrain config set\` will not apply to this command: ` +
+        `${(err as Error).message}`,
+      );
       mergedConfig = fileConfig;
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1312,9 +1312,30 @@ export async function makeContext(engine: BrainEngine, params: Record<string, un
     // to the cross-source view (D16 back-compat path).
     sourceId = undefined;
   }
+  // #1475 — the operation context must carry the DB plane, not just file/env.
+  // `gbrain config set` writes DB-plane keys and `gbrain config get` reads
+  // them back, but every op-side gate reads `ctx.config` — so building this
+  // from the sync, file-only `loadConfig()` made those writes inert
+  // (`eval.capture` was the reported case: set, echoed back, still off).
+  // connectEngine already re-merges after connect, but it keeps the result to
+  // itself (env stashes + gateway reconfigure) and returns only the engine.
+  //
+  // Fail-open: a brain mid-migration whose config table is missing must still
+  // get a usable context, so a merge failure falls back to the file plane.
+  // This runs once per invocation (single call site) alongside the sourceId
+  // resolution that is already DB I/O, and adds point lookups on a live
+  // connection — the same reads connectEngine performs.
+  const fileConfig = loadConfig() || { engine: 'postgres' as const };
+  let mergedConfig = fileConfig;
+  try {
+    mergedConfig = (await loadConfigWithEngine(engine, fileConfig)) ?? fileConfig;
+  } catch {
+    mergedConfig = fileConfig;
+  }
+
   return {
     engine,
-    config: loadConfig() || { engine: 'postgres' },
+    config: mergedConfig,
     logger: { info: console.log, warn: console.warn, error: console.error },
     dryRun: (params.dry_run as boolean) || false,
     // Local CLI invocation — the user owns the machine; do not apply remote-caller

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -964,8 +964,32 @@ export async function loadConfigWithEngine(
   // documented opt-out for a brain that has CONTRIBUTOR_MODE exported, and
   // eval.scrub_pii=false is an explicit privacy decision. dbBool already
   // distinguishes them ('' / null / undefined → undefined).
-  const dbEvalCapture = await dbBool('eval.capture');
-  const dbEvalScrubPii = await dbBool('eval.scrub_pii');
+  // Strict, not `dbBool`. `dbBool` maps every non-empty value other than the
+  // exact string 'true' to FALSE, and `config set` stores whatever it is given
+  // — so `gbrain config set eval.scrub_pii TRUE` (or `1`, or a typo like
+  // `tru`) would arrive here as `false` and silently DISABLE PII scrubbing.
+  // Measured: 'true'→true, 'false'→false, and 'tru' / 'TRUE' / '1' / 'yes' all
+  // →false under dbBool. Before this merge existed those values were inert, so
+  // adopting dbBool here would newly activate that footgun on a privacy knob.
+  // An unrecognised value is treated as unset, which falls back to the
+  // documented default (scrub on, capture per CONTRIBUTOR_MODE) — fail-safe.
+  //
+  // Deliberately scoped to the two keys this change introduces. The same
+  // looseness applies to the other dbBool keys, but tightening those is a
+  // behavior change for existing brains and belongs in its own PR.
+  async function dbBoolStrict(key: string): Promise<boolean | undefined> {
+    try {
+      const v = await engine.getConfig(key);
+      if (v === 'true') return true;
+      if (v === 'false') return false;
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const dbEvalCapture = await dbBoolStrict('eval.capture');
+  const dbEvalScrubPii = await dbBoolStrict('eval.scrub_pii');
 
   const mergedEval: NonNullable<GBrainConfig['eval']> = { ...(merged.eval ?? {}) };
   if (mergedEval.capture === undefined && dbEvalCapture !== undefined) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -951,6 +951,37 @@ export async function loadConfigWithEngine(
     merged.dream = mergedDream;
   }
 
+  // #1475 — eval.* DB-plane merge. Both keys are in KNOWN_CONFIG_KEYS, so
+  // `gbrain config set eval.capture true` is accepted and stored, and
+  // `gbrain config get` reads it back (it queries engine.getConfig directly
+  // and prints `source: db plane`). But the runtime gates read the MERGED
+  // config — isEvalCaptureEnabled/isEvalScrubEnabled take `ctx.config` — so
+  // without a merge branch here the write was accepted, echoed back, and had
+  // no effect: capture stayed off unless GBRAIN_CONTRIBUTOR_MODE=1 was also
+  // exported, which is what the config was supposed to make unnecessary.
+  //
+  // Both directions matter. `false` is not "unset": eval.capture=false is the
+  // documented opt-out for a brain that has CONTRIBUTOR_MODE exported, and
+  // eval.scrub_pii=false is an explicit privacy decision. dbBool already
+  // distinguishes them ('' / null / undefined → undefined).
+  const dbEvalCapture = await dbBool('eval.capture');
+  const dbEvalScrubPii = await dbBool('eval.scrub_pii');
+
+  const mergedEval: NonNullable<GBrainConfig['eval']> = { ...(merged.eval ?? {}) };
+  if (mergedEval.capture === undefined && dbEvalCapture !== undefined) {
+    mergedEval.capture = dbEvalCapture;
+  }
+  if (mergedEval.scrub_pii === undefined && dbEvalScrubPii !== undefined) {
+    mergedEval.scrub_pii = dbEvalScrubPii;
+  }
+  // Same container discipline as dream/content_sanity: a brain that sets
+  // neither key keeps `cfg.eval` undefined, so `config show` does not sprout
+  // an empty object and downstream `config?.eval?.x === undefined` reads are
+  // unchanged.
+  if (Object.keys(mergedEval).length > 0) {
+    merged.eval = mergedEval;
+  }
+
   return merged;
 }
 

--- a/test/eval-capture-db-plane.serial.test.ts
+++ b/test/eval-capture-db-plane.serial.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #1475 — `gbrain config set eval.capture true` must actually turn capture on.
+ *
+ * The reported symptom is that the write persists and `config get` reads it
+ * back as `true` (printing `source: db plane`), yet capture stays off unless
+ * `GBRAIN_CONTRIBUTOR_MODE=1` is also exported. Three people reproduced it
+ * independently, most recently on 0.46.1.0.
+ *
+ * There are two halves to it, and fixing either one alone leaves the symptom:
+ *
+ *   1. `loadConfigWithEngine` merges a fixed set of DB-plane keys and had no
+ *      `eval.*` branch — so even an explicit DB-merge produced nothing.
+ *   2. `makeContext` built `ctx.config` from the sync, file-only `loadConfig()`.
+ *      `connectEngine` does re-merge after connect, but keeps the result to
+ *      itself (env stashes + gateway reconfigure) and returns only the engine.
+ *
+ * The gate the runtime actually consults is `isEvalCaptureEnabled(ctx.config)`
+ * (src/core/operations.ts), so this test asserts on that composition rather
+ * than on either half — a unit test of the merge alone would have passed while
+ * the reported symptom survived.
+ *
+ * Serial because it mutates process.env (GBRAIN_CONTRIBUTOR_MODE / GBRAIN_HOME).
+ */
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withEnv } from './helpers/with-env.ts';
+import { makeContext } from '../src/cli.ts';
+import { isEvalCaptureEnabled, isEvalScrubEnabled } from '../src/core/eval-capture.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+/**
+ * Stub engine whose config table holds exactly `dbConfig`. Mirrors the shape
+ * `makeContext` touches: `getConfig` for the DB plane and `executeRaw` for the
+ * source resolver (no rows — the brain has no `sources` entries).
+ */
+function makeStub(dbConfig: Record<string, string>): BrainEngine {
+  return {
+    kind: 'pglite',
+    executeRaw: async <T>(): Promise<T[]> => [],
+    getConfig: async (key: string) => dbConfig[key] ?? null,
+    listConfigKeys: async (prefix: string) =>
+      Object.keys(dbConfig).filter(k => k.startsWith(prefix)),
+  } as unknown as BrainEngine;
+}
+
+/** An empty GBRAIN_HOME so the file plane cannot supply eval.* from the machine. */
+function scratchHome(): string {
+  return mkdtempSync(join(tmpdir(), 'gbrain-1475-'));
+}
+
+describe('eval.capture set on the DB plane reaches the runtime gate (#1475)', () => {
+  test('capture is ON when only the DB plane says so, with CONTRIBUTOR_MODE unset', async () => {
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(makeStub({ 'eval.capture': 'true' }), {});
+        expect(ctx.config?.eval?.capture).toBe(true);
+        // The assertion that matches the bug report: the gate, not the field.
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(true);
+      },
+    );
+  });
+
+  test('control: with no DB value and no CONTRIBUTOR_MODE, capture stays off', async () => {
+    // Without this the first test would also pass on a build that turned
+    // capture on unconditionally.
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(makeStub({}), {});
+        expect(ctx.config?.eval?.capture).toBeUndefined();
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(false);
+      },
+    );
+  });
+
+  test('DB eval.capture=false turns capture OFF even with CONTRIBUTOR_MODE=1', async () => {
+    // The opt-out direction has to arrive too: a contributor who exported
+    // CONTRIBUTOR_MODE and then asked a specific brain to stop capturing.
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: '1', GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(makeStub({ 'eval.capture': 'false' }), {});
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(false);
+      },
+    );
+  });
+
+  test('eval.scrub_pii travels the same path', async () => {
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(makeStub({ 'eval.scrub_pii': 'false' }), {});
+        expect(isEvalScrubEnabled(ctx.config)).toBe(false);
+      },
+    );
+  });
+
+  test('a brain whose config table is missing still builds a context (fail-open)', async () => {
+    // Mid-migration brains must not lose the CLI entirely just because the
+    // DB-plane read throws.
+    const throwing = {
+      kind: 'pglite',
+      executeRaw: async <T>(): Promise<T[]> => [],
+      getConfig: async () => {
+        throw new Error('relation "config" does not exist');
+      },
+    } as unknown as BrainEngine;
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(throwing, {});
+        expect(ctx.config).toBeDefined();
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(false);
+      },
+    );
+  });
+});

--- a/test/eval-capture-db-plane.serial.test.ts
+++ b/test/eval-capture-db-plane.serial.test.ts
@@ -26,7 +26,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { withEnv } from './helpers/with-env.ts';
-import { makeContext } from '../src/cli.ts';
+import { makeContext, __testing } from '../src/cli.ts';
 import { isEvalCaptureEnabled, isEvalScrubEnabled } from '../src/core/eval-capture.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
@@ -96,6 +96,63 @@ describe('eval.capture set on the DB plane reaches the runtime gate (#1475)', ()
         expect(isEvalScrubEnabled(ctx.config)).toBe(false);
       },
     );
+  });
+
+  test('reuses the merge connectEngine already did — zero extra config reads', async () => {
+    // The reason this fix does not make #3980 worse. connectEngine already
+    // merges the DB plane once per command; makeContext consumes that result
+    // instead of re-deriving it. If the publish in connectEngine is ever
+    // dropped, this count goes from 0 to the full per-key read set.
+    let keysRead: string[] = [];
+    const counting = {
+      kind: 'pglite',
+      executeRaw: async <T>(): Promise<T[]> => [],
+      getConfig: async (key: string) => {
+        keysRead.push(key);
+        return key === 'eval.capture' ? 'true' : null;
+      },
+    } as unknown as BrainEngine;
+
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        // Uncached: makeContext falls back to merging itself, so it walks the
+        // whole DB-plane key set. Measured at 25 reads on this tree — one for
+        // the source resolver plus the merge's 24 keys.
+        await makeContext(counting, {});
+        const uncached = keysRead;
+        expect(uncached).toContain('eval.capture');
+        expect(uncached.length).toBeGreaterThan(10);
+
+        // Primed exactly as connectEngine primes it.
+        keysRead = [];
+        __testing.publishMergedConfig(counting, { engine: 'pglite', eval: { capture: true } });
+        const ctx = await makeContext(counting, {});
+
+        // The only surviving read is the source resolver's, which is not
+        // config-merge work and predates this change. Asserting the key set
+        // rather than a bare count says WHICH read is allowed to remain, so a
+        // future reader can tell an intentional addition from a regression.
+        expect(keysRead).toEqual(['sources.default']);
+        // …and the published value is what the gate sees, so "cheap" did not
+        // come at the cost of "correct".
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(true);
+      },
+    );
+  });
+
+  test('connectEngine still publishes its merge (the half the runtime test cannot reach)', async () => {
+    // The test above primes the map directly, so it pins the CONSUMER. If the
+    // publish in connectEngine were deleted, production would quietly fall
+    // back to re-merging — correct output, 24 extra config reads per command,
+    // and nothing red. connectEngine is not exported and needs a live brain,
+    // so this is a source-level guard, the same shape test/cycle-abort.test.ts
+    // uses for its own hard-to-exercise seam.
+    const cli = await Bun.file(new URL('../src/cli.ts', import.meta.url).pathname).text();
+    expect(cli).toContain('MERGED_CONFIG_BY_ENGINE.set(engine, merged)');
+    // Guard the guard: if the map is ever renamed, the assertion above must
+    // not keep passing against a stale literal that no longer exists.
+    expect(cli).toContain('const MERGED_CONFIG_BY_ENGINE = new WeakMap');
   });
 
   test('a brain whose config table is missing still builds a context (fail-open)', async () => {

--- a/test/eval-capture-db-plane.serial.test.ts
+++ b/test/eval-capture-db-plane.serial.test.ts
@@ -148,6 +148,44 @@ describe('eval.capture set on the DB plane reaches the runtime gate (#1475)', ()
     );
   });
 
+  test('a mounted brain\'s engine never re-merges the DB plane', async () => {
+    // Adversarial-review fixup: the fallback merge above ran unconditionally
+    // for ANY unpublished engine, including mount engines — connectEngine
+    // only publishes for the host brain (MERGED_CONFIG_BY_ENGINE.set lives in
+    // its host-only branch), so every mounted-brain command paid the full
+    // per-key DB round-trip AND, worse, would have let the mount's DB-plane
+    // config leak into the caller's ctx.config, a leak connectMountEngine's
+    // gateway-scoped no-merge guarantee does not by itself prevent. This
+    // pins both: no config-merge reads, and the DB's eval.capture=true does
+    // not surface. Marks the engine object itself (not module-global brain
+    // state) — the same provenance-follows-the-engine binding
+    // MERGED_CONFIG_BY_ENGINE already uses, so this stays correct even if a
+    // process ever holds a host engine and a mount engine at once.
+    const { __testing } = await import('../src/cli.ts');
+    let keysRead: string[] = [];
+    const counting = {
+      kind: 'pglite',
+      executeRaw: async <T>(): Promise<T[]> => [],
+      getConfig: async (key: string) => {
+        keysRead.push(key);
+        return key === 'eval.capture' ? 'true' : null;
+      },
+    } as unknown as BrainEngine;
+    __testing.markEngineAsMountForTests(counting);
+
+    await withEnv(
+      { GBRAIN_HOME: scratchHome(), GBRAIN_CONTRIBUTOR_MODE: undefined, GBRAIN_SOURCE: undefined },
+      async () => {
+        const ctx = await makeContext(counting, {});
+        // Only the source resolver's read survives — the DB-plane merge
+        // branch is skipped entirely for a mount engine.
+        expect(keysRead).toEqual(['sources.default']);
+        expect(ctx.config?.eval?.capture).toBeUndefined();
+        expect(isEvalCaptureEnabled(ctx.config)).toBe(false);
+      },
+    );
+  });
+
   test('connectEngine still publishes its merge (the half the runtime test cannot reach)', async () => {
     // The test above primes the map directly, so it pins the CONSUMER. If the
     // publish in connectEngine were deleted, production would quietly fall
@@ -160,6 +198,23 @@ describe('eval.capture set on the DB plane reaches the runtime gate (#1475)', ()
     // Guard the guard: if the map is ever renamed, the assertion above must
     // not keep passing against a stale literal that no longer exists.
     expect(cli).toContain('const MERGED_CONFIG_BY_ENGINE = new WeakMap');
+  });
+
+  test('connectMountEngine still marks its engine as a mount engine', async () => {
+    // Mirrors the guard immediately above, for the mount-engine fixup
+    // (PR #4186): the test that exercises makeContext's mount branch marks
+    // the engine directly via __testing.markEngineAsMountForTests, so it
+    // pins the CONSUMER (makeContext honors MOUNT_ENGINES) but not the real
+    // wiring — if `MOUNT_ENGINES.add(handle.engine)` were ever deleted from
+    // connectMountEngine, that test would still pass while every real mount
+    // connection silently re-merged the mount's DB plane again.
+    // connectMountEngine is not exported and needs a live BrainRegistry, so
+    // this is a source-level guard, same shape as the one above.
+    const cli = await Bun.file(new URL('../src/cli.ts', import.meta.url).pathname).text();
+    expect(cli).toContain('MOUNT_ENGINES.add(handle.engine)');
+    // Guard the guard: if the set is ever renamed, the assertion above must
+    // not keep passing against a stale literal that no longer exists.
+    expect(cli).toContain('const MOUNT_ENGINES = new WeakSet');
   });
 
   test('a brain whose config table is missing still builds a context (fail-open)', async () => {

--- a/test/eval-capture-db-plane.serial.test.ts
+++ b/test/eval-capture-db-plane.serial.test.ts
@@ -26,7 +26,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { withEnv } from './helpers/with-env.ts';
-import { makeContext, __testing } from '../src/cli.ts';
+import { makeContext } from '../src/cli.ts';
 import { isEvalCaptureEnabled, isEvalScrubEnabled } from '../src/core/eval-capture.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
@@ -103,6 +103,13 @@ describe('eval.capture set on the DB plane reaches the runtime gate (#1475)', ()
     // merges the DB plane once per command; makeContext consumes that result
     // instead of re-deriving it. If the publish in connectEngine is ever
     // dropped, this count goes from 0 to the full per-key read set.
+    // Imported here rather than at module scope on purpose: a static named
+    // import of `__testing` makes this whole FILE fail to link against a tree
+    // that lacks the export, which would collapse the other cases' signal to a
+    // single load error. Deferring it keeps each case independently
+    // meaningful when someone reverts half the fix to see what breaks.
+    const { __testing } = await import('../src/cli.ts');
+
     let keysRead: string[] = [];
     const counting = {
       kind: 'pglite',

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -369,6 +369,27 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       expect(merged?.eval?.capture).toBeUndefined();
     });
 
+    test('an unrecognised boolean is treated as unset, not as false', async () => {
+      // The privacy-relevant case. `config set` stores whatever it is handed,
+      // and the shared dbBool helper maps every non-empty non-'true' value to
+      // FALSE — so `gbrain config set eval.scrub_pii TRUE` would arrive here
+      // as "scrubbing off". Before this merge branch existed those values were
+      // inert; adopting the loose helper would newly activate that footgun.
+      for (const bad of ['TRUE', 'True', '1', 'yes', 'tru', 'off', ' true']) {
+        const merged = await loadConfigWithEngine(
+          makeEngine({ 'eval.scrub_pii': bad, 'eval.capture': bad }),
+          { engine: 'pglite' },
+        );
+        expect(merged?.eval, `"${bad}" must not produce an eval container`).toBeUndefined();
+      }
+      // Control: the two values that ARE recognised still come through, so the
+      // strictness above cannot be satisfied by ignoring the keys entirely.
+      const on = await loadConfigWithEngine(makeEngine({ 'eval.scrub_pii': 'true' }), { engine: 'pglite' });
+      expect(on?.eval?.scrub_pii).toBe(true);
+      const off = await loadConfigWithEngine(makeEngine({ 'eval.scrub_pii': 'false' }), { engine: 'pglite' });
+      expect(off?.eval?.scrub_pii).toBe(false);
+    });
+
     test('no eval.* keys leaves cfg.eval undefined (no spurious container)', async () => {
       const base: GBrainConfig = { engine: 'pglite' };
       const merged = await loadConfigWithEngine(makeEngine({ embedding_multimodal: 'true' }), base);

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -331,4 +331,59 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       expect(merged?.engine).toBe('pglite');
     });
   });
+
+  // #1475 — `eval.capture` and `eval.scrub_pii` are accepted by
+  // `gbrain config set` (KNOWN_CONFIG_KEYS) and read back by `gbrain config
+  // get` (which queries engine.getConfig directly), but had no DB-merge
+  // branch here. The runtime gate reads the MERGED config
+  // (isEvalCaptureEnabled(ctx.config) in operations.ts), so the write landed,
+  // read back as `true`, and changed nothing — capture stayed off unless
+  // GBRAIN_CONTRIBUTOR_MODE=1 was also exported.
+  describe('eval.* DB-plane merge (#1475)', () => {
+    test('DB eval.capture=true fills in when the file plane is silent', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const engine = makeEngine({ 'eval.capture': 'true' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.eval?.capture).toBe(true);
+    });
+
+    test('DB eval.capture=false fills in too — the opt-out has to reach the runtime as well', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const engine = makeEngine({ 'eval.capture': 'false' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.eval?.capture).toBe(false);
+    });
+
+    test('file plane wins over DB (precedence file > DB, same as every other key here)', async () => {
+      const base: GBrainConfig = { engine: 'pglite', eval: { capture: false } };
+      const engine = makeEngine({ 'eval.capture': 'true' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.eval?.capture).toBe(false);
+    });
+
+    test('eval.scrub_pii merges independently of capture', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const engine = makeEngine({ 'eval.scrub_pii': 'false' });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.eval?.scrub_pii).toBe(false);
+      expect(merged?.eval?.capture).toBeUndefined();
+    });
+
+    test('no eval.* keys leaves cfg.eval undefined (no spurious container)', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const merged = await loadConfigWithEngine(makeEngine({ embedding_multimodal: 'true' }), base);
+      expect(merged?.eval).toBeUndefined();
+    });
+
+    test('engine.getConfig throwing leaves eval.* unset (non-fatal)', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const engine: FakeEngine = {
+        async getConfig() {
+          throw new Error('config table missing');
+        },
+      };
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.eval).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
`gbrain config set eval.capture true` is accepted, persisted, and read back by
`gbrain config get` as `true` — and changes nothing. Capture stays off unless
`GBRAIN_CONTRIBUTOR_MODE=1` is also exported. Reported in #1475 in May, and
re-confirmed there on 0.46.1.0 on 2026-08-15.

**Part of #1475** — this closes the CLI half only. See "What this does not fix".

## Two halves, and why fixing one is not enough

1. `loadConfigWithEngine` merges a fixed set of DB-plane keys. It had no
   `eval.*` branch. Both keys are in `KNOWN_CONFIG_KEYS`, which is why the
   write is accepted in the first place, and `config get` queries
   `engine.getConfig` directly, which is why it reads back.

2. `makeContext` built `ctx.config` from the sync, file-only `loadConfig()`.
   `connectEngine` *does* re-merge after connect — but it keeps the result to
   itself (env stashes + gateway reconfigure) and returns only the engine. The
   gate the runtime consults is `isEvalCaptureEnabled(ctx.config)`.

Measured by reverting each half against the new runtime test file (7 cases):

| tree | result |
|---|---|
| merge branch only, no plumbing | **5 fail** — including all 3 runtime-symptom cases |
| plumbing only, no merge branch | **4 fail** |
| both | 7 pass |

So a patch that adds the merge branch alone — the natural reading of the issue
— looks right and does not move the symptom. That is why the test asserts on
`isEvalCaptureEnabled(ctx.config)` rather than on either half's output.

## No new config reads on the host brain

Open PR #3980 reports 54 queries for a single `gbrain stats` against a hosted
brain, 44 of them `SELECT value FROM config WHERE key = $1`, and attributes
~1.5s of the 7.7s to `loadConfigWithEngine`'s per-key reads. Re-merging inside
`makeContext` would have doubled the merge's share of that. Instead
`connectEngine` publishes the merge it already performs on a `WeakMap` keyed by
engine, and `makeContext` consumes it.

Measured here: **25 config reads uncached, 1 cached** — the survivor being the
source resolver's `sources.default`, which is not merge work. The test asserts
the cached key set (`['sources.default']`) rather than a bare count, so a
future reader can tell an intentional addition from a regression.

**Two cases still pay the fallback reads.** `connectEngine` returns a mounted
engine (`--brain <mount>`) before reaching the publish, so mounted commands
fall through to the merge in `makeContext`. And `connectEngine` wraps its
merge in a non-fatal `catch`, so if the merge itself throws there the map stays
empty and `makeContext` retries — correct either way, just not free. That
is also why the map is keyed by engine rather than being a module global: it
keeps a mount on the correct fallback instead of serving it the host brain's
merged config.

## Strict boolean parsing on these two keys

`dbBool` maps every non-empty value other than the exact string `'true'` to
**false**. Measured on this tree, with the value stored by `config set` and
read back through the merge: `'tru'`, `'TRUE'`, `'1'`, `'yes'` all arrive as
`false`.

Routing `eval.scrub_pii` through it would mean `gbrain config set
eval.scrub_pii TRUE` silently **disables PII scrubbing** — a footgun this
change would newly activate, since those values were inert while no merge
branch existed. So `eval.*` parses strictly: anything that is not exactly
`true`/`false` is treated as unset and the documented default applies.

Deliberately scoped to the two keys added here. Five other keys still use the
loose helper (`embedding_multimodal`, `embedding_image_ocr`, and three
`content_sanity.*`); tightening those changes behavior for existing brains and
belongs in its own PR. Flagging it rather than folding it in.

## What this does not fix

**MCP, `gbrain call`, and background subagents still read the file plane only.**
`src/mcp/dispatch.ts:378` builds its context with `loadConfig()`, and
`src/core/minions/handlers/subagent.ts:196` does the same. That matters here
because #1475's own workaround is a systemd drop-in on `gbrain-mcp.service` and
`gbrain-worker.service` — so the reporter's deployment is not covered by this
PR.

I did not extend it there because the fix shape is different and the choice is
yours: `buildOperationContext` is synchronous, and an MCP server is long-lived,
so "merge once at boot" trades the bug for staleness after a later `config set`.
That is a policy question about how often a long-lived process re-reads DB
config, not a defect. Happy to implement whichever way you want it.

The same staleness caveat applies to the WeakMap here in principle; it does not
bite today because a CLI invocation builds one context and exits.
`docs/eval-capture.md` now says which surfaces honor the DB plane and which do
not, instead of stating flatly that `config set` does not work.

## Tests

`test/eval-capture-db-plane.serial.test.ts` (new, 7 cases) — the runtime
composition: DB-only `true` turns the gate on with `CONTRIBUTOR_MODE` unset; DB
`false` turns it off *with* `CONTRIBUTOR_MODE=1`; a control proving capture
stays off with no DB value (so the first case cannot pass on a build that
enables capture unconditionally); `scrub_pii` on the same path; the read-count
assertion; a source-level guard on the publish; and fail-open when the config
table is missing.

`test/loadConfig-merge.test.ts` (+7 cases) — the merge contract: both
directions, file-over-DB precedence, no spurious `cfg.eval` container,
non-fatal on a throwing `getConfig`, and the strict-parsing table (7 rejected
spellings plus `true`/`false` controls, so strictness cannot be satisfied by
ignoring the keys).

One weak spot, stated plainly: the read-count case primes the WeakMap through a
`__testing` seam, so it pins the consumer, not `connectEngine`'s publish. The
companion assertion for the publish is a source-string check — it fires if the
line is deleted (verified), but a comment containing the same literal would
satisfy it. `connectEngine` is neither exported nor runnable without a live
brain, so I did not find a behavioural way to cover it without changing that
function's signature; if you would rather it were exported for test access, say
so and I will.

`bun run verify` 50/50 and `bun run typecheck` clean locally; CI is the
authority.
