### PR TITLE
fix(config): register two keys the runtime reads but `config set` rejects

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1061,6 +1061,13 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'models.brainstorm.judge',
   'models.eval.longmemeval',
   'facts.extraction_model',
+  // Brain-wide kill switch for fact extraction, read by
+  // src/core/facts/extract.ts:isFactsExtractionEnabled and honored by
+  // sweep.ts, operations.ts and transcripts/ingest-facts.ts. That function's
+  // own docstring tells operators to flip it with
+  // `gbrain config set facts.extraction_enabled false` — which was rejected
+  // as an unknown key until this registration.
+  'facts.extraction_enabled',
   // #2113: output-token cap for the per-turn facts extractor (default 4000).
   'facts.extraction_max_tokens',
   // [ENG-8] Brain-level default visibility for facts writes when the caller
@@ -1221,6 +1228,7 @@ export const KNOWN_CONFIG_KEY_PREFIXES: readonly string[] = [
   //   minions.ttl_notice_shown flag. Booleans via the canonical truthiness
   //   parser; numeric 0 disables.
   'minions.',
+  'pace.',              // pace.mode + PACE_MODE_CONFIG_KEYS (src/core/pace-mode.ts)
 ];
 
 /**


### PR DESCRIPTION
## The problem

`gbrain config set` rejects two key families that the runtime reads, and that the source itself tells operators to set.

**`facts.extraction_enabled`** — read by `isFactsExtractionEnabled` (`src/core/facts/extract.ts`), honored by `sweep.ts`, `operations.ts` and `transcripts/ingest-facts.ts`. That function's own docstring says:

> Operators flip it to `'false'` / `'0'` / `'no'` / `'off'` (case-insensitive) via `gbrain config set facts.extraction_enabled false` to disable extraction across the brain without requiring a binary downgrade.

That exact command fails.

**`pace.*`** — `src/core/pace-mode.ts` exports `PACE_MODE_KEY` plus a frozen `PACE_MODE_CONFIG_KEYS` listing `pace.enabled`, `pace.max_concurrency`, `pace.pace_at_ms`, `pace.max_sleep_ms`, `pace.ewma_alpha`. They are consumed by `embed.ts`, `jobs.ts` and `sync.ts`, and CLAUDE.md documents the pace-mode bundle table. None of them were registerable.

## Reproduce on master

Fresh PGLite brain, `gbrain init --pglite --non-interactive`:

```
$ gbrain config set facts.extraction_enabled false
[config] Unknown config key "facts.extraction_enabled".
[config] No similar known key. Run `gbrain config show` to see currently-set keys.
[config] If this is intentional (downstream tooling, forward-compat), re-run with --force.

$ gbrain config set pace.mode balanced
[config] Unknown config key "pace.mode".
```

`--force` does work, but it is documented as the escape hatch for downstream tooling and forward-compat keys — not for a brain's own documented switches.

For contrast, `cycle.conversation_facts_backfill.enabled` sets fine today, because the `cycle.` prefix is already in `KNOWN_CONFIG_KEY_PREFIXES`. This PR gives `pace.` the same treatment.

## The change

Eight lines in `src/core/config.ts`:

- `facts.extraction_enabled` added to `KNOWN_CONFIG_KEYS` (single key — it has no sub-keys).
- `pace.` added to `KNOWN_CONFIG_KEY_PREFIXES`, mirroring how `search.`, `cycle.`, `autopilot.` and `self_upgrade.` already cover their own families.

## Verification

- Both families now set successfully; values read back through `config show`.
- Typo rejection is unaffected — `gbrain config set pacemode 4` still fails with the unknown-key error, so the guard is not weakened.
- `bun test test/config-set.test.ts test/config.test.ts test/config-file-plane-keys.test.ts` → 61 pass, 0 fail.
- `bun run typecheck` clean.

Found while rebasing a downstream fork onto v0.45.18 — the fork had been carrying local registrations for these keys and it turned out the upstream readers were already there.
