### PR TITLE
test(e2e): make sync-lock-recovery independent of embedding credentials

### DIFF
--- a/test/e2e/sync-lock-recovery.test.ts
+++ b/test/e2e/sync-lock-recovery.test.ts
@@ -115,7 +115,7 @@ describeE2E('v0.41.6.0 — sync lock recovery scenarios', () => {
     expect(handle).not.toBeNull();
 
     try {
-      const result = runCli(['sync', '--repo', repoDir, '--full', '--yes']);
+      const result = runCli(['sync', '--repo', repoDir, '--full', '--yes', '--no-embed']);
       expect(result.code).not.toBe(0);
       const msg = result.stderr + result.stdout;
       expect(msg).toMatch(new RegExp(`pid ${process.pid}`));


### PR DESCRIPTION
## The problem

`test/e2e/sync-lock-recovery.test.ts` → *"lock-busy error message includes PID + hostname + age + `--break-lock` hint"* fails on any machine that has no embedding key in the environment.

The scenario shells out to `gbrain sync --repo … --full --yes`, which refuses before it ever reaches the lock check:

```
Embedding model "zeroentropyai:zembed-1" requires ZEROENTROPY_API_KEY.

Set it in your shell, or:
  • Re-run with --no-embed to import-only and embed later once the key is set.
  • Switch providers: gbrain init --force --embedding-model openai:text-embedding-3-small
```

So `expect(msg).toMatch(new RegExp(\`pid ${process.pid}\`))` is asserted against the credential error, not the lock-busy message, and fails.

## The change

One line — pass `--no-embed`, which is the remedy the error message itself suggests:

```diff
-      const result = runCli(['sync', '--repo', repoDir, '--full', '--yes']);
+      const result = runCli(['sync', '--repo', repoDir, '--full', '--yes', '--no-embed']);
```

The test is about lock recovery, not embedding. Making it independent of provider credentials means it asserts what its name says regardless of who runs it.

## Verification

Against a scratch Postgres (`gbrain_test`), all four combinations:

| | before | after |
|---|---|---|
| embedding key present | 7 pass / 0 fail | 7 pass / 0 fail |
| embedding key absent | 6 pass / **1 fail** | 7 pass / 0 fail |

No behavior change where it was already green — CI presumably has a key in the environment, which is why this has stayed green there.

Found while running the `DATABASE_URL`-gated e2e suite on a developer machine. Worth noting that between v0.45.18.0 and v0.46.6.0 several other e2e files in this area went from failing to passing on a keyless machine; this is the one that remains.
