### PR TITLE
v0.46.9.1 fix(plugins): complete the plugin-manifest version lockstep missed at landing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gbrain",
-  "version": "0.46.8.0",
+  "version": "0.46.9.1",
   "description": "Personal knowledge brain for your coding agent — hybrid search, synthesis, graph traversal, and durable cross-session memory over Postgres/PGLite with pgvector, plus a curated brain-first skill set.",
   "author": { "name": "Garry Tan", "url": "https://github.com/garrytan" },
   "homepage": "https://github.com/garrytan/gbrain",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gbrain",
-  "version": "0.46.8.0",
+  "version": "0.46.9.1",
   "description": "Personal knowledge brain for your coding agent — hybrid search, synthesis, graph traversal, and durable cross-session memory over Postgres/PGLite with pgvector, plus a curated brain-first skill set.",
   "author": { "name": "Garry Tan", "url": "https://github.com/garrytan" },
   "homepage": "https://github.com/garrytan/gbrain",


### PR DESCRIPTION
## Summary

Master's Test run went red after the v0.46.9.1 containment-sprint landing (#4173): the re-version bumped VERSION, package.json, openclaw.plugin.json, and every derived stamp, but missed the two plugin manifests added to the version lockstep by #4167. `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` still said `0.46.8.0`, so the merge-drift-catcher test (`test/codex-plugin-manifest.test.ts` → "every plugin manifest ships at the repo version") correctly failed on shard 5.

This bumps both manifests to `0.46.9.1`. Two-line diff, no functional change, no VERSION bump — it completes the existing v0.46.9.1 release's lockstep (the release itself is already published and complete).

## Verification

- `bun test test/codex-plugin-manifest.test.ts test/openclaw-plugin-manifest.test.ts` → 39 pass / 0 fail (the exact failing suite)
- `bash scripts/check-plugin-tree.sh` → OK (tree stamp derives from package.json, already 0.46.9.1)
- `bash scripts/check-bootstrap-tag.sh` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)