### PR TITLE
fix(transcripts): claude-code detection rejects every real session (first-line probe vs control-record head)

### DIFF
--- a/src/core/transcripts/claude-code.ts
+++ b/src/core/transcripts/claude-code.ts
@@ -16,14 +16,80 @@ import type {
 import { TRANSCRIPT_JSONL_HARD_CAP } from './types.ts';
 import { parseClaudeSessionFile, SPEC_TARGET } from './claude-code-jsonl.ts';
 import { basename } from 'node:path';
+import { closeSync, openSync, readSync } from 'node:fs';
 
-/** First-line keys that mark a Claude Code project transcript. */
+/**
+ * Non-turn control records Claude Code writes into the session JSONL. These now
+ * routinely LEAD the file, and they carry no `parentUuid`/`isSidechain`, so a
+ * detector keyed only on turn shape rejects the whole transcript.
+ *
+ * Measured 2026-08-16 over 400 files in ~/.claude/projects: 273 led with
+ * `queue-operation`, 115 with `last-prompt`, 10 with `mode`, 2 with `ai-title`
+ * — and ZERO led with a user/assistant turn. Detection failure was total.
+ */
+const CLAUDE_CONTROL_TYPES = new Set([
+  'queue-operation',
+  'last-prompt',
+  'ai-title',
+  'mode',
+  'summary',
+  'attachment',
+]);
+
+/** Keys that mark a Claude Code project transcript. */
 function looksLikeClaudeLine(obj: Record<string, unknown>): boolean {
-  if (typeof obj.sessionId === 'string' && (obj.type === 'user' || obj.type === 'assistant')) {
+  if (
+    typeof obj.sessionId === 'string' &&
+    (obj.type === 'user' || obj.type === 'assistant')
+  ) {
+    return true;
+  }
+  // Control records: `sessionId` + a known control `type` is a specific enough
+  // pair that no other supported harness collides with it.
+  if (
+    typeof obj.sessionId === 'string' &&
+    typeof obj.type === 'string' &&
+    CLAUDE_CONTROL_TYPES.has(obj.type)
+  ) {
     return true;
   }
   // Non-turn head lines (summary, attachment) still carry the shape family.
   return 'isSidechain' in obj || 'parentUuid' in obj;
+}
+
+/**
+ * How many leading lines of the sample to examine. Scanning past line 1 is
+ * defence-in-depth for control types not in the set above: a single unknown
+ * record at the head must not disqualify the file. Bounded so detection stays
+ * cheap — the sample is only 64KB, and a single queued-prompt record can exceed
+ * that on its own (observed: the first real turn at byte 88,283).
+ */
+const DETECT_SCAN_LINES = 25;
+
+/**
+ * Bounded re-read used when the sample yields no parseable record. A single
+ * leading control record can exceed the 64KB sample on its own, leaving the
+ * sample holding one truncated partial line and nothing else.
+ */
+const DETECT_FALLBACK_BYTES = 2 * 1024 * 1024;
+
+/** True when any of the first DETECT_SCAN_LINES lines is Claude-shaped. */
+function scanForClaudeLine(text: string): boolean {
+  for (const raw of text.split('\n', DETECT_SCAN_LINES)) {
+    const line = raw.trim();
+    if (!line) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      // Byte-bounded reads routinely end mid-line; keep scanning.
+      continue;
+    }
+    if (typeof obj === 'object' && obj !== null && looksLikeClaudeLine(obj as Record<string, unknown>)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export const claudeCodeAdapter: TranscriptAdapter = {
@@ -32,17 +98,34 @@ export const claudeCodeAdapter: TranscriptAdapter = {
 
   detect(path: string, sample: Buffer): boolean {
     if (!path.endsWith('.jsonl')) return false;
-    const firstLine = sample.toString('utf8').split('\n', 1)[0]?.trim();
-    if (!firstLine) return false;
+    if (scanForClaudeLine(sample.toString('utf8'))) return true;
+    // The sample can be entirely consumed by one oversized leading record
+    // (observed: first real turn at byte 88,283 against a 64KB sample), so a
+    // negative result there is inconclusive. Re-read a bounded window before
+    // rejecting the file.
+    // Only worth re-reading when the sample holds no line terminator at all:
+    // that means one record already exceeded the sample and we never saw a
+    // complete line. Files with short lines fail fast here, as they should.
+    if (sample.includes(0x0a)) return false;
+    let fd: number | undefined;
     try {
-      const obj = JSON.parse(firstLine) as Record<string, unknown>;
-      return typeof obj === 'object' && obj !== null && looksLikeClaudeLine(obj);
+      fd = openSync(path, 'r');
+      const buf = Buffer.allocUnsafe(DETECT_FALLBACK_BYTES);
+      const read = readSync(fd, buf, 0, DETECT_FALLBACK_BYTES, 0);
+      return scanForClaudeLine(buf.subarray(0, read).toString('utf8'));
     } catch {
       return false;
+    } finally {
+      if (fd !== undefined) {
+        try { closeSync(fd); } catch { /* best effort */ }
+      }
     }
   },
 
-  async *parse(path: string, opts: ParseSessionsOpts = {}): AsyncGenerator<ParsedSession, FileDiagnostics> {
+  async *parse(
+    path: string,
+    opts: ParseSessionsOpts = {},
+  ): AsyncGenerator<ParsedSession, FileDiagnostics> {
     const r = parseClaudeSessionFile(path, {
       maxBytes: opts.maxBytes ?? TRANSCRIPT_JSONL_HARD_CAP,
     });
@@ -58,7 +141,11 @@ export const claudeCodeAdapter: TranscriptAdapter = {
           startedAt: r.startedAt || undefined,
           raw: { sessionId, cwd: r.cwd ?? null, source_path: path },
         },
-        messages: r.turns.map((t) => ({ role: t.role, timestamp: t.timestamp, text: t.text })),
+        messages: r.turns.map((t) => ({
+          role: t.role,
+          timestamp: t.timestamp,
+          text: t.text,
+        })),
       };
     }
     return {
@@ -66,7 +153,8 @@ export const claudeCodeAdapter: TranscriptAdapter = {
       skippedLines: r.skippedLines,
       truncated: false,
       sessions,
-      zeroSessionsReason: sessions === 0 ? 'no user or assistant turns in file' : undefined,
+      zeroSessionsReason:
+        sessions === 0 ? 'no user or assistant turns in file' : undefined,
     };
   },
 };

--- a/test/transcript-adapters.test.ts
+++ b/test/transcript-adapters.test.ts
@@ -257,6 +257,35 @@ describe('claudeCodeAdapter', () => {
   test('detect sniffs the first line shape', () => {
     expect(claudeCodeAdapter.detect(FIXTURE, readSample(FIXTURE))).toBe(true);
   });
+
+  // Regression: Claude Code leads its transcripts with non-turn control
+  // records (`queue-operation`, `last-prompt`, `mode`, `ai-title`). Measured
+  // 2026-08-16 over 400 live files: 273/115/10/2 led with those and ZERO led
+  // with a turn, so a line-1-only probe rejected 100% of real sessions.
+  test('detect accepts a transcript led by control records', () => {
+    const p = join(tdir(), 'led-by-control.jsonl');
+    writeFileSync(
+      p,
+      [
+        JSON.stringify({ type: 'queue-operation', operation: 'add', sessionId: 's1', timestamp: '2026-08-16T00:00:00Z', content: 'x' }),
+        JSON.stringify({ type: 'mode', mode: 'default', sessionId: 's1' }),
+        JSON.stringify({ type: 'user', sessionId: 's1', message: { role: 'user', content: 'hi' } }),
+      ].join('\n') + '\n',
+    );
+    expect(claudeCodeAdapter.detect(p, readSample(p))).toBe(true);
+  });
+
+  // A control-record head must not turn every .jsonl into a Claude transcript:
+  // hook-telemetry files under ~/.claude/projects have no sessionId and must
+  // still be rejected.
+  test('detect still rejects non-transcript jsonl', () => {
+    const p = join(tdir(), 'hook-telemetry.jsonl');
+    writeFileSync(
+      p,
+      JSON.stringify({ event: 'skill-injection', hookEvent: 'UserPromptSubmit', matchedSkills: [], contextChunks: 0 }) + '\n',
+    );
+    expect(claudeCodeAdapter.detect(p, readSample(p))).toBe(false);
+  });
 });
 
 // ── Codex adapter [structural turn selection, never preamble heuristics] ────


### PR DESCRIPTION
## The problem

`claudeCodeAdapter.detect()` reads only the **first line** of the sample and requires a `user`/`assistant` turn there (or `isSidechain`/`parentUuid`).

Current Claude Code doesn't write a turn first. It leads the session JSONL with non-turn control records, so detection rejects the file before any turn is reached.

Measured over **400 live files** in `~/.claude/projects` (Claude Code 2.1.233):

| Leading record type | Files |
| --- | ---: |
| `queue-operation` | 273 |
| `last-prompt` | 115 |
| `mode` | 10 |
| `ai-title` | 2 |
| a `user`/`assistant` turn | **0** |

Every real transcript fails with `unknown format (tried: hermes, openclaw, codex, claude-code, claude-export, chatgpt)` while containing perfectly parseable turns — one sampled file held 48.

Net effect: on a machine with 833 Claude Code transcripts, `gbrain transcripts ingest` imported **0**. Codex import was unaffected (1,629 sessions), which is what made the cause look narrower than it is.

### Why CI didn't catch it

`test/fixtures/conversation-formats/claude-code.jsonl` begins with `type: "user"`. No real session does. The suite passes against a shape the harness no longer emits.

## The fix

**1. Recognise control records.** `looksLikeClaudeLine` accepts a known control `type` paired with a string `sessionId`. That pair is specific enough that no other supported harness collides with it — hook-telemetry `.jsonl` under the same roots (`hookEvent`, `injectedSkills`, no `sessionId`) is still rejected, pinned by a negative test.

**2. Scan the sample head, plus a bounded fallback.** Detection now examines the first `DETECT_SCAN_LINES` (25) lines instead of line 1, and falls back to a bounded 2 MB re-read **only when the sample contains no newline at all**.

That fallback isn't defensive padding — it's a real case. A single queued-prompt record can exceed the 64 KB sample on its own; in the file I traced, the first genuine turn began at **byte 88,283**, so the sample held one truncated partial line and nothing else. Files with short lines still fail fast.

## Result

- **829 of 833** Claude Code files import (was 0)
- Combined dry run: **2,458 sessions** (claude-code 829 + codex 1,629), 2,572 pages
- Residual ~142 rejections are hook telemetry and subagent sidecars — correctly rejected

## Tests

Two added to `test/transcript-adapters.test.ts`: one asserting a control-record-led transcript is detected, one asserting non-transcript `.jsonl` is still rejected.

**Mutation-verified** — reverting `detect()` to the line-1 probe fails the control-record test. 54 pass / 0 fail across `transcript-adapters`, `claude-code-jsonl`, and `transcripts`.

## Scope

`detect()` shipped in 4922905f (v0.46.0.0). The control record types have been present for at least a month, and they come from ordinary features — message queuing, prompt history, modes, auto-titles — so this should affect any 0.46.x user on a current Claude Code, not one setup.

Happy to adjust the control-type set or the fallback threshold if you'd prefer different bounds.
