### PR TITLE
fix(transcripts): oversized codex rollouts import instead of throwing

### DIFF
--- a/src/commands/transcripts.ts
+++ b/src/commands/transcripts.ts
@@ -204,7 +204,10 @@ skip). Embedding is OFF by default; run the embed backfill later or opt in.
                     for a multi-GB hermes store). Omit to keep each
                     format's native safety default. Changing it starts a
                     fresh --since last scope (caps are part of the
-                    checkpoint fingerprint)
+                    checkpoint fingerprint). Adapters differ over budget:
+                    codex degrades to a bounded head+tail read, while
+                    claude-code, openclaw and hermes reject the file
+                    outright — so LOWERING this can drop those formats
   --json            Machine-readable result
   --quiet           Suppress the human summary
 

--- a/src/core/transcripts/codex.ts
+++ b/src/core/transcripts/codex.ts
@@ -14,7 +14,7 @@
  * text only (lossy by design).
  */
 
-import { readFileSync, statSync } from 'node:fs';
+import { closeSync, openSync, readFileSync, readSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import type { HostSpecTarget } from '../bootstrap/host-specs.ts';
 import type {
@@ -25,6 +25,13 @@ import type {
   TranscriptMessage,
 } from './types.ts';
 import { TRANSCRIPT_JSONL_HARD_CAP } from './types.ts';
+
+/**
+ * Head window kept when a rollout exceeds the parse budget. Only needs to
+ * cover `session_meta` (the first record) plus slack; capped at a quarter of
+ * the budget so a small --max-bytes cannot spend everything on the head.
+ */
+const CODEX_HEAD_WINDOW_BYTES = 256 * 1024;
 
 export const CODEX_SPEC_TARGET: HostSpecTarget = {
   id: 'codex-rollout-2026-08',
@@ -79,12 +86,45 @@ export const codexAdapter: TranscriptAdapter = {
   },
 
   async *parse(path: string, opts: ParseSessionsOpts = {}): AsyncGenerator<ParsedSession, FileDiagnostics> {
-    const cap = opts.maxBytes ?? TRANSCRIPT_JSONL_HARD_CAP;
+    const budget = Math.max(1, Math.floor(opts.maxBytes ?? TRANSCRIPT_JSONL_HARD_CAP));
     const size = statSync(path).size;
-    if (size > cap) {
-      throw new Error(`codex rollout too large for import: ${size} bytes (cap ${cap})`);
+    let raw: string;
+    let bytesRead: number;
+    let truncated = false;
+    if (size <= budget) {
+      raw = readFileSync(path, 'utf8');
+      bytesRead = size;
+    } else {
+      // Bounded degrade rather than rejecting the file: the read stays within
+      // budget, but a huge rollout still contributes its session.
+      //
+      // NOTE: this is NOT "what the claude-code adapter does". That adapter's
+      // import path (parseClaudeSessionFile) throws over cap like the others;
+      // only the hook lane's parseTranscript tail-reads. Oversized *claude*
+      // sessions still contribute nothing — this adapter is the first to
+      // degrade, which is a deliberate divergence, not parity.
+      //
+      // HEAD + TAIL, not tail alone: `session_meta` — session_id, cwd,
+      // cli_version, provenance — is the FIRST record of a rollout (verified:
+      // line 0, byte 0). A pure tail read imports the newest turns with no
+      // identity, so the head window is what keeps the session attributable.
+      truncated = true;
+      const head = Math.min(CODEX_HEAD_WINDOW_BYTES, Math.floor(budget / 4));
+      const tail = budget - head;
+      const fd = openSync(path, 'r');
+      try {
+        const hbuf = Buffer.alloc(head);
+        const hn = readSync(fd, hbuf, 0, head, 0);
+        const tbuf = Buffer.alloc(tail);
+        const tn = readSync(fd, tbuf, 0, tail, size - tail);
+        // The join is a line boundary neither side owns; both partials fail
+        // JSON.parse and land in skippedLines, which is the honest accounting.
+        raw = hbuf.subarray(0, hn).toString('utf8') + '\n' + tbuf.subarray(0, tn).toString('utf8');
+        bytesRead = hn + tn;
+      } finally {
+        closeSync(fd);
+      }
     }
-    const raw = readFileSync(path, 'utf8');
     let skippedLines = 0;
     let sessionId = '';
     let cwd: string | undefined;
@@ -151,9 +191,9 @@ export const codexAdapter: TranscriptAdapter = {
       };
     }
     return {
-      bytesRead: size,
+      bytesRead,
       skippedLines,
-      truncated: false,
+      truncated,
       sessions,
       zeroSessionsReason:
         sessions === 0 ? 'no user_message events or assistant message items in rollout' : undefined,

--- a/src/core/transcripts/types.ts
+++ b/src/core/transcripts/types.ts
@@ -77,7 +77,11 @@ export interface FileDiagnostics {
 }
 
 export interface ParseSessionsOpts {
-  /** Per-format byte budget; adapters REJECT (not truncate) monolithic JSON over budget. */
+  /**
+   * Per-format byte budget. Most adapters REJECT a monolithic file over budget
+   * rather than truncating it; codex instead degrades to a bounded head+tail
+   * read, so an over-budget rollout still imports.
+   */
   maxBytes?: number;
 }
 

--- a/test/e2e/transcripts-ingest-pglite.test.ts
+++ b/test/e2e/transcripts-ingest-pglite.test.ts
@@ -153,6 +153,76 @@ describe('cross-harness round-trip', () => {
   });
 });
 
+describe('--max-bytes reaches the adapters', () => {
+  // Pins the WIRING, not the adapter. ingest.ts used to call
+  // adapter.parse(path) with no opts at all, so maxBytes could never arrive
+  // from the import lane — and an adapter-level test cannot see that, because
+  // it calls codexAdapter.parse() directly. Revert the ingest.ts threading and
+  // this test is the only thing in the suite that fails.
+  test('a rollout over the budget drops mid-file turns but keeps head identity and the tail', async () => {
+    const p = join(tmp, 'oversized-rollout.jsonl');
+    const line = (payload: Record<string, unknown>, ts: string) =>
+      JSON.stringify({ type: 'event_msg', timestamp: ts, payload });
+    const filler = JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      payload: { type: 'reasoning', content: 'x'.repeat(4000) },
+    });
+    const lines = [
+      JSON.stringify({
+        type: 'session_meta',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        payload: { session_id: 'wired-sess-1', cwd: '/w', cli_version: '1.2.3' },
+      }),
+      // Past the 16KB head window (budget/4) and far from the tail, so a
+      // correctly-budgeted read MUST drop it. Without the ingest→adapter
+      // wiring the whole 1.6MB file is read and this turn survives — which is
+      // exactly what makes this test pin the wiring rather than the adapter.
+      ...Array(8).fill(filler),
+      line({ type: 'user_message', message: 'MIDDLE_TURN_MUST_BE_DROPPED' }, '2026-01-01T00:01:00.000Z'),
+      ...Array(400).fill(filler),
+      line({ type: 'user_message', message: 'NEWEST_TURN_SURVIVES' }, '2026-01-01T00:09:00.000Z'),
+    ];
+    writeFileSync(p, lines.join('\n') + '\n');
+
+    const r = await runTranscriptsIngest(engine, baseOpts([p], { maxBytes: 64 * 1024 }));
+    expect(r.erroredFiles).toBe(0);
+    expect(r.sessionsImported).toBe(1);
+
+    const pages = await engine.listPages({ type: 'conversation', sourceId: 'default', limit: 10 });
+    expect(pages).toHaveLength(1);
+    const page = await engine.getPage(pages[0].slug, { sourceId: 'default' });
+    expect(page).not.toBeNull();
+    expect(page!.compiled_truth).toContain('NEWEST_TURN_SURVIVES');
+    expect(page!.compiled_truth).not.toContain('MIDDLE_TURN_MUST_BE_DROPPED');
+  });
+
+  // A truncated read leaves seam partials in skippedLines, which freezes the
+  // since:last watermark. Pre-existing behaviour (the old throw froze it too),
+  // pinned here so a future change to seam accounting is a deliberate one.
+  test('a truncated read is never a clean scan', async () => {
+    const p = join(tmp, 'oversized-rollout-2.jsonl');
+    const meta = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      payload: { session_id: 'wired-sess-2', cwd: '/w' },
+    });
+    const filler = JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      payload: { type: 'reasoning', content: 'y'.repeat(4000) },
+    });
+    const newest = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-01-01T00:09:00.000Z',
+      payload: { type: 'user_message', message: 'tail turn' },
+    });
+    writeFileSync(p, [meta, ...Array(400).fill(filler), newest].join('\n') + '\n');
+    const r = await runTranscriptsIngest(engine, baseOpts([p], { maxBytes: 64 * 1024 }));
+    expect(r.cleanScan).toBe(false);
+  });
+});
+
 describe('dry-run', () => {
   test('writes NOTHING — no pages, no raw data — and never advances watermarks', async () => {
     const r = await runTranscriptsIngest(engine, baseOpts([CODEX_FIXTURE], { dryRun: true }));

--- a/test/transcript-adapters.test.ts
+++ b/test/transcript-adapters.test.ts
@@ -7,7 +7,7 @@
  * parseClaudeSessionFile must never change it.
  */
 import { describe, test, expect, afterEach } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -262,6 +262,54 @@ describe('claudeCodeAdapter', () => {
 // ── Codex adapter [structural turn selection, never preamble heuristics] ────
 
 describe('codexAdapter', () => {
+  // Regression: an oversized rollout used to throw and contribute NOTHING.
+  // It now degrades to a bounded head+tail read like the claude-code adapter.
+  // HEAD is load-bearing: `session_meta` — session_id, cwd, provenance — is the
+  // FIRST record of a rollout, so a tail-only read imports turns that cannot be
+  // attributed to a session.
+  test('oversized rollout degrades to head+tail instead of throwing, keeping session_meta', async () => {
+    const p = join(tdir(), 'huge-rollout.jsonl');
+    const meta = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      payload: { session_id: 'sess-head-1', cwd: '/w', cli_version: '1.2.3' },
+    });
+    const filler = JSON.stringify({
+      type: 'response_item',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      payload: { type: 'reasoning', content: 'x'.repeat(4000) },
+    });
+    const newest = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-01-01T00:09:00.000Z',
+      payload: { type: 'user_message', message: 'the newest turn' },
+    });
+    writeFileSync(p, [meta, ...Array(400).fill(filler), newest].join('\n') + '\n');
+
+    const { sessions, diag } = await drain(codexAdapter.parse(p, { maxBytes: 64 * 1024 }));
+    expect(sessions).toHaveLength(1);
+    // Identity came from the HEAD window...
+    expect(sessions[0].meta.sessionId).toBe('sess-head-1');
+    expect(sessions[0].meta.cwd).toBe('/w');
+    // ...and the newest turn from the TAIL window.
+    expect(sessions[0].messages.at(-1)?.text).toBe('the newest turn');
+    // Honest accounting: a partial read must say so, and must read less than
+    // the file. A `truncated: false` here would be the false-green this
+    // replaces.
+    expect(diag.truncated).toBe(true);
+    expect(diag.bytesRead).toBeLessThan(statSync(p).size);
+    // The head/tail seam leaves a partial line on each side; both must be
+    // counted, not silently swallowed. Untested, this is where a "clean"
+    // truncated read could quietly appear.
+    expect(diag.skippedLines).toBeGreaterThanOrEqual(2);
+  });
+
+  test('a rollout within budget is read whole and not marked truncated', async () => {
+    const { diag } = await drain(codexAdapter.parse(CODEX_FIXTURE));
+    expect(diag.truncated).toBe(false);
+    expect(diag.bytesRead).toBe(statSync(CODEX_FIXTURE).size);
+  });
+
   test('user turns from event_msg, assistant from output_text; injected preambles never leak', async () => {
     const { sessions, diag } = await drain(codexAdapter.parse(CODEX_FIXTURE));
     expect(sessions).toHaveLength(1);


### PR DESCRIPTION
## Two gaps: one behavioural, one wiring

### 1. Oversized Codex rollouts contributed nothing

`codexAdapter.parse` **threw** over the byte cap, so the largest rollouts were dropped entirely rather than partially imported. On my machine that was 4 sessions of 52–102 MB — the longest ones, contributing zero.

It now degrades to a bounded **head+tail** read.

**Head is load-bearing, not symmetry.** `session_meta` — `session_id`, `cwd`, `cli_version` — is the *first* record of a rollout (verified: line 0, byte 0 of a real 102 MB file). A tail-only read imports the newest turns with no identity to attach them to. Head window is `min(256KB, budget/4)`, so a small budget can't be spent entirely on the head.

**This is a deliberate divergence, not parity.** I want to be precise, because the obvious reading is wrong: `claude-code`'s *import* path (`parseClaudeSessionFile`) throws over cap exactly like `openclaw` and `hermes` — only the hook lane's `parseTranscript` tail-reads. So:

- oversized **claude** sessions still contribute nothing after this change
- **lowering** `--max-bytes` makes claude-code/openclaw/hermes reject per-file while codex degrades

Both are documented in the help text. If you'd rather codex kept rejecting for consistency, that's a reasonable call and I'll close this — the divergence is the part worth your opinion.

### 2. `maxBytes` could never reach an adapter

`ingest.ts` called `adapter.parse(path)` with **no opts at all**, so `ParseSessionsOpts.maxBytes` was unreachable from the import lane despite existing on the interface. Now threaded, and exposed as `--max-bytes` (accepts `64m` / `512k` / raw bytes).

**Capped at `TRANSCRIPT_EXPORT_JSON_HARD_CAP`.** Every adapter ends in `readFileSync(path, 'utf8')`, so an unbounded value is an OOM / string-length crash rather than a large import.

## Not a security relaxation

`S3#8` scopes to the **hook lane's** untrusted `transcript_path` (`confineTranscriptPath`, untouched and still rejecting). The import cap is same-trust CLI over user-chosen paths, so this is *non-applicability*, not equivalence. Reads stay bounded either way — the change is bounded-read-instead-of-reject, not unbounded-read.

## Known, pre-existing

A truncated read leaves seam partials in `skippedLines`, so `cleanScan` stays false and `since:last` won't advance while an oversized rollout exists. **The previous `throw` froze it identically**, so this isn't a regression — but it's now pinned by a test so any future change to seam accounting is deliberate. Happy to exclude by-design seam partials from that freeze if you'd prefer; it seemed like your call rather than mine.

Also noted while in here: `FileDiagnostics.truncated` has no consumer anywhere. This change sets it honestly; wiring it into ingest would be the principled follow-up.

## Tests

- **Adapter-level:** identity survives from the head window, newest turn from the tail, `truncated` reported, `skippedLines >= 2` for the seam
- **Ingest-level:** a mid-file turn is dropped while head identity and the tail survive

The ingest-level test exists because **reverting the `ingest.ts` threading left the entire suite green** — the adapter tests call `codexAdapter.parse` directly, so they can't see the wiring. Both are mutation-verified: reverting each fix fails the corresponding test, and the mutated code compiles, so they pin behaviour rather than syntax.

102 pass across the 5 affected suites; typecheck clean.

## Registry

`src/core/cli-flag-registry.generated.ts` was regenerated via the `build:flag-registry` script, not hand-edited; `test/cli-flag-validation.test.ts` passes. I included it since every merged commit touching it does — say the word if you'd rather regenerate it yourself at wave time.

## Relationship to #4221

Independent — branched from `master`, contains none of that PR's commits. They touch adjacent files but not the same functions, and either can merge first.
