### PR TITLE
Add GLM-5.2 (Z.ai) to CANONICAL_PRICING

### DIFF
--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -102,6 +102,10 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   // DeepSeek v4 (verified 2026-07-27 at api-docs.deepseek.com): cache-miss rates.
   'deepseek:deepseek-v4-flash':           { input:  0.14, output:  0.28 },
   'deepseek:deepseek-v4-pro':             { input:  0.435, output: 0.87 },
+  // ── Z.ai / GLM (via LiteLLM proxy) ───────────────────────────────────
+  // GLM-5.2 from Z.ai: $1.40/M input, $4.40/M output (verified 2026-08-16
+  // against OpenRouter provider listings — z.ai's own direct rates).
+  'litellm:z-ai/glm-5.2':                 { input: 1.40, output: 4.40 },
 };
 
 /**


### PR DESCRIPTION
## Summary

Add `litellm:z-ai/glm-5.2` to the `CANONICAL_PRICING` table so the BudgetTracker can enforce cost caps on cycle phases that use GLM-5.2 via a LiteLLM proxy.

## Problem

Without a pricing entry, the BudgetTracker cannot price GLM-5.2, causing cycle phases (extract_atoms, propose_takes, etc.) to either:
- **TX2 hard-fail** with `BudgetExhausted(reason:'no_pricing')` when a cost cap is set (the default for extract_atoms is $0.30/source/run)
- **Warn-once** and run without cost enforcement when no cap is set

In both cases, the `isModelPriceable()` guard in `extract-atoms.ts` disables the cap, and the `BUDGET_METER_NO_PRICING` warning fires on every run.

## Pricing

Verified 2026-08-16 against [OpenRouter provider listings](https://openrouter.ai/z-ai/glm-5.2):
- Z.ai direct rates: **$1.40/M input, $4.40/M output**
- These match z.ai's published API pricing at https://z.ai/model-api

The `litellm:` prefix is used when routing through a LiteLLM proxy (e.g. Hermes Agent's Nous Portal proxy), so the key mirrors the model id consumers pass to `gateway.chat()`.

## Testing

```typescript
import { canonicalLookup } from './src/core/model-pricing.ts';
canonicalLookup('litellm:z-ai/glm-5.2'); // → { input: 1.40, output: 4.40 }
```

```typescript
import { isModelPriceable } from './src/core/budget/budget-tracker.ts';
isModelPriceable('litellm:z-ai/glm-5.2', 'chat'); // → true
```
