### PR TITLE
feat(timeline): update/remove timeline entries by immutable id

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1491,6 +1491,48 @@ export interface BrainEngine {
     opts?: { skipExistenceCheck?: boolean; sourceId?: string },
   ): Promise<void>;
   /**
+   * Timeline mutation by immutable entry id (robert-cos patch; upstream PR
+   * pending). Reads join the owning page so op-layer fences and source
+   * verification can run before any mutation.
+   */
+  getTimelineEntryById(
+    id: number,
+  ): Promise<
+    | {
+        id: number;
+        page_id: number;
+        date: string;
+        source: string;
+        summary: string;
+        detail: string;
+        event_page_id: number | null;
+        page_slug: string;
+        page_source: string;
+      }
+    | null
+  >;
+  /**
+   * Update fields on one entry by id, guarded ATOMICALLY: the expected
+   * identity (summary, date, owning-page slug + source) is part of the
+   * mutation's WHERE predicate, so a concurrent change makes the statement
+   * match zero rows instead of overwriting it. Returns true iff a row
+   * changed. Timeline ids are database-local — the identity predicate is
+   * what makes a cross-brain id collision unable to mutate the wrong row.
+   */
+  updateTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+    changes: { date?: string; summary?: string; detail?: string; source?: string },
+  ): Promise<boolean>;
+  /**
+   * Delete one entry by id under the same atomic identity predicate.
+   * Returns true iff a row was deleted (missing id = false, idempotent).
+   */
+  removeTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+  ): Promise<boolean>;
+  /**
    * Bulk insert timeline entries via a single multi-row INSERT...SELECT FROM (VALUES)
    * JOIN pages statement with ON CONFLICT DO NOTHING. Returns the count of rows
    * actually inserted (RETURNING excludes conflicts and JOIN-dropped rows whose

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2897,6 +2897,263 @@ const get_timeline: Operation = {
   cliHints: { name: 'timeline', positional: ['slug'] },
 };
 
+// --- Timeline mutation (robert-cos patch; upstream PR pending) ---
+// Review-driven contract: entries are addressed by immutable id; mutations
+// carry the FULL expected identity (summary, date, owning-page slug, page
+// source) which the engine enforces ATOMICALLY inside the mutation predicate
+// — a concurrent change matches zero rows instead of being overwritten, and
+// database-local id collisions across brains cannot select the wrong row.
+// The acting brain comes only from trusted ctx.brainId, never from params.
+//
+// Audit is intent-first: an intent record is appended to
+// ~/.gbrain/audit/timeline-mutations-YYYY-Www.jsonl (dir 0700, files 0600)
+// BEFORE the mutation; if that append fails the mutation is refused. The
+// completion record is appended after; if THAT append fails, the intent
+// record still documents the mutation and the result says audit:
+// 'intent-only' — there is no path that silently produces an unaudited
+// mutation. Removal is idempotent: a missing id is a safe noop, never an
+// error.
+
+function parseTimelineEntryId(raw: unknown): number {
+  const n = typeof raw === 'number' ? raw : Number.parseInt(String(raw), 10);
+  if (!Number.isInteger(n) || n <= 0 || String(n) !== String(raw).trim()) {
+    throw new Error(`Invalid timeline entry id "${raw}" (expected a positive integer)`);
+  }
+  return n;
+}
+
+async function auditTimelineMutation(record: Record<string, unknown>): Promise<void> {
+  const { gbrainPath } = await import('./config.ts');
+  const fs = await import('fs');
+  const d = new Date();
+  const jan1 = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = String(
+    Math.ceil(((d.getTime() - jan1.getTime()) / 86400000 + jan1.getUTCDay() + 1) / 7),
+  ).padStart(2, '0');
+  const dir = gbrainPath('audit');
+  // Explicit restrictive modes: mkdir's mode is umask-filtered, so chmod
+  // enforces 0700/0600 regardless of the host umask (0002 here would
+  // otherwise leave group-readable audit files).
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
+  const file = `${dir}/timeline-mutations-${d.getUTCFullYear()}-W${week}.jsonl`;
+  fs.appendFileSync(file, JSON.stringify({ ts: d.toISOString(), ...record }) + '\n', {
+    mode: 0o600,
+  });
+  fs.chmodSync(file, 0o600);
+}
+
+/** Best-effort completion record: the intent record is already durable, so a
+ * failure here is reported (audit: 'intent-only'), never thrown. */
+async function auditTimelineMutationResult(record: Record<string, unknown>): Promise<boolean> {
+  try {
+    await auditTimelineMutation(record);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const TIMELINE_EXPECTED_PARAMS = {
+  expected_summary: {
+    type: 'string',
+    required: true,
+    description: 'Current summary of the entry; part of the atomic mutation predicate.',
+  },
+  expected_date: {
+    type: 'string',
+    required: true,
+    description: 'Current date of the entry (YYYY-MM-DD); part of the atomic mutation predicate.',
+  },
+  expected_slug: {
+    type: 'string',
+    required: true,
+    description: 'Slug of the owning page; part of the atomic mutation predicate.',
+  },
+  page_source: {
+    type: 'string',
+    required: true,
+    description: "Page source the entry's owning page must belong to (normally 'default'); part of the atomic mutation predicate. Named page_source because --source is the CLI's global source-selector flag.",
+  },
+} as const;
+
+function timelineExpectedFromParams(
+  p: Record<string, unknown>,
+): { summary: string; date: string; page_slug: string; page_source: string } {
+  return {
+    summary: p.expected_summary as string,
+    date: p.expected_date as string,
+    page_slug: p.expected_slug as string,
+    page_source: p.page_source as string,
+  };
+}
+
+function assertTimelineRowMatches(
+  id: number,
+  row: { summary: string; date: string; page_slug: string; page_source: string },
+  expected: { summary: string; date: string; page_slug: string; page_source: string },
+): void {
+  // Friendly precondition errors. The atomic predicate in the engine is the
+  // authoritative guard; these produce actionable messages for the common
+  // (non-racy) mismatch cases.
+  if (row.page_source !== expected.page_source) {
+    throw new Error(
+      `source mismatch: entry ${id} belongs to page source "${row.page_source}", not "${expected.page_source}"`,
+    );
+  }
+  if (row.page_slug !== expected.page_slug) {
+    throw new Error(
+      `slug mismatch: entry ${id} belongs to page "${row.page_slug}", not "${expected.page_slug}"`,
+    );
+  }
+  if (row.summary !== expected.summary) {
+    throw new Error(
+      `optimistic check failed for entry ${id}: current summary does not match expected_summary`,
+    );
+  }
+  if (String(row.date).slice(0, 10) !== expected.date) {
+    throw new Error(
+      `optimistic check failed for entry ${id}: current date "${String(row.date).slice(0, 10)}" does not match expected_date "${expected.date}"`,
+    );
+  }
+}
+
+function validateStrictDate(date: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Invalid date format "${date}" (expected YYYY-MM-DD)`);
+  }
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== date) {
+    throw new Error(`Invalid calendar date "${date}"`);
+  }
+}
+
+const update_timeline_entry: Operation = {
+  name: 'update_timeline_entry',
+  description:
+    'Update one timeline entry by immutable id. The full expected identity (summary, date, owning slug, page source) is enforced atomically inside the mutation predicate; every mutation is audited intent-first with brain attribution.',
+  params: {
+    id: { type: 'number', required: true, description: 'Immutable timeline entry id.' },
+    ...TIMELINE_EXPECTED_PARAMS,
+    date: { type: 'string', description: 'New date (strict YYYY-MM-DD).' },
+    summary: { type: 'string', description: 'New summary.' },
+    detail: { type: 'string', description: 'New detail.' },
+    entry_source: { type: 'string', description: 'New provenance ref for the entry.' },
+  },
+  mutating: true,
+  scope: 'write',
+  handler: async (ctx, p) => {
+    const id = parseTimelineEntryId(p.id);
+    const expected = timelineExpectedFromParams(p);
+    validateStrictDate(expected.date);
+    const row = await ctx.engine.getTimelineEntryById(id);
+    if (!row) return { status: 'noop', reason: 'not-found', id };
+    enforceSubagentSlugFence(ctx, row.page_slug, 'update_timeline_entry');
+    enforceClientSlugFence(ctx, row.page_slug, 'update_timeline_entry');
+    assertTimelineRowMatches(id, row, expected);
+    const changes: { date?: string; summary?: string; detail?: string; source?: string } = {};
+    if (typeof p.date === 'string') {
+      validateStrictDate(p.date);
+      changes.date = p.date;
+    }
+    if (typeof p.summary === 'string') changes.summary = p.summary;
+    if (typeof p.detail === 'string') changes.detail = p.detail;
+    if (typeof p.entry_source === 'string') changes.source = p.entry_source;
+    if (Object.keys(changes).length === 0) {
+      throw new Error('update_timeline_entry: no new values given (date/summary/detail/entry_source)');
+    }
+    if (ctx.dryRun) return { dry_run: true, action: 'update_timeline_entry', id, changes };
+    const brain = ctx.brainId ?? 'host';
+    // Intent record BEFORE the mutation: if this append fails, nothing mutates.
+    await auditTimelineMutation({
+      phase: 'intent',
+      op: 'update_timeline_entry',
+      brain,
+      id,
+      page_slug: row.page_slug,
+      page_source: row.page_source,
+      before: { date: row.date, summary: row.summary, detail: row.detail, source: row.source },
+      changes,
+    });
+    const changed = await ctx.engine.updateTimelineEntryById(id, expected, changes);
+    if (!changed) {
+      await auditTimelineMutationResult({
+        phase: 'result', op: 'update_timeline_entry', brain, id, changed: false,
+        reason: 'concurrent-modification',
+      });
+      throw new Error(
+        `concurrent modification: entry ${id} changed between check and mutation; re-read and retry`,
+      );
+    }
+    const audited = await auditTimelineMutationResult({
+      phase: 'result', op: 'update_timeline_entry', brain, id, changed: true,
+    });
+    return { status: 'ok', id, audit: audited ? 'complete' : 'intent-only' };
+  },
+  cliHints: { name: 'timeline-update', positional: ['id', 'expected_summary'] },
+};
+
+const remove_timeline_entry: Operation = {
+  name: 'remove_timeline_entry',
+  description:
+    'Remove one timeline entry by immutable id. The full expected identity (summary, date, owning slug, page source) is enforced atomically inside the deletion predicate; idempotent (missing id is a safe noop); audited intent-first with brain attribution.',
+  params: {
+    id: { type: 'number', required: true, description: 'Immutable timeline entry id.' },
+    ...TIMELINE_EXPECTED_PARAMS,
+  },
+  mutating: true,
+  scope: 'write',
+  handler: async (ctx, p) => {
+    const id = parseTimelineEntryId(p.id);
+    const expected = timelineExpectedFromParams(p);
+    validateStrictDate(expected.date);
+    const row = await ctx.engine.getTimelineEntryById(id);
+    if (!row) return { status: 'noop', reason: 'not-found', id };
+    enforceSubagentSlugFence(ctx, row.page_slug, 'remove_timeline_entry');
+    enforceClientSlugFence(ctx, row.page_slug, 'remove_timeline_entry');
+    assertTimelineRowMatches(id, row, expected);
+    if (ctx.dryRun) return { dry_run: true, action: 'remove_timeline_entry', id };
+    const brain = ctx.brainId ?? 'host';
+    // Intent record BEFORE the mutation: if this append fails, nothing mutates.
+    await auditTimelineMutation({
+      phase: 'intent',
+      op: 'remove_timeline_entry',
+      brain,
+      id,
+      page_slug: row.page_slug,
+      page_source: row.page_source,
+      before: {
+        date: row.date,
+        summary: row.summary,
+        detail: row.detail,
+        source: row.source,
+        event_page_id: row.event_page_id,
+      },
+    });
+    const removed = await ctx.engine.removeTimelineEntryById(id, expected);
+    if (!removed) {
+      // Disambiguate: concurrently deleted (idempotent success) vs
+      // concurrently mutated (conflict the caller must re-read).
+      const now = await ctx.engine.getTimelineEntryById(id);
+      await auditTimelineMutationResult({
+        phase: 'result', op: 'remove_timeline_entry', brain, id, removed: false,
+        reason: now ? 'concurrent-modification' : 'already-removed',
+      });
+      if (now) {
+        throw new Error(
+          `concurrent modification: entry ${id} changed between check and removal; re-read and retry`,
+        );
+      }
+      return { status: 'noop', reason: 'already-removed', id };
+    }
+    const audited = await auditTimelineMutationResult({
+      phase: 'result', op: 'remove_timeline_entry', brain, id, removed: true,
+    });
+    return { status: 'ok', id, audit: audited ? 'complete' : 'intent-only' };
+  },
+  cliHints: { name: 'timeline-rm', positional: ['id', 'expected_summary'] },
+};
+
 // --- Admin ---
 
 const get_stats: Operation = {
@@ -7281,6 +7538,7 @@ export const operations: Operation[] = [
   add_link, remove_link, get_links, get_backlinks, list_link_sources, traverse_graph,
   // Timeline
   add_timeline_entry, get_timeline,
+  update_timeline_entry, remove_timeline_entry,
   // Admin
   get_stats, get_health, run_doctor, get_versions, revert_version,
   // v0.31.1 (Issue #734): thin-client banner identity packet (read-scope, banner-only)
@@ -7393,6 +7651,7 @@ const OP_AREAS: Record<string, string> = {
   find_orphans: 'links',
   // timeline
   add_timeline_entry: 'timeline', get_timeline: 'timeline',
+  update_timeline_entry: 'timeline', remove_timeline_entry: 'timeline',
   // life chronicle
   chronicle_day: 'chronicle', chronicle_on_this_day: 'chronicle',
   chronicle_since: 'chronicle', chronicle_last_seen: 'chronicle',

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4129,6 +4129,86 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Timeline
+  // --- Timeline mutation by id (robert-cos patch; upstream PR pending) ---
+  async getTimelineEntryById(id: number): Promise<
+    | {
+        id: number;
+        page_id: number;
+        date: string;
+        source: string;
+        summary: string;
+        detail: string;
+        event_page_id: number | null;
+        page_slug: string;
+        page_source: string;
+      }
+    | null
+  > {
+    const { rows } = await this.db.query(
+      `SELECT t.id, t.page_id, t.date::text AS date, t.source, t.summary,
+              t.detail, t.event_page_id, p.slug AS page_slug,
+              p.source_id AS page_source
+         FROM timeline_entries t
+         JOIN pages p ON p.id = t.page_id
+        WHERE t.id = $1`,
+      [id],
+    );
+    return (rows[0] as any) ?? null;
+  }
+
+  async updateTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+    changes: { date?: string; summary?: string; detail?: string; source?: string },
+  ): Promise<boolean> {
+    const sets: string[] = [];
+    const args: unknown[] = [];
+    for (const key of ['date', 'summary', 'detail', 'source'] as const) {
+      if (changes[key] !== undefined) {
+        args.push(changes[key]);
+        sets.push(`${key} = $${args.length}`);
+      }
+    }
+    if (sets.length === 0) return false;
+    // Atomic optimistic check: the full expected identity is part of the
+    // mutation predicate. A concurrent change (or a same-id row in a
+    // different page/source) matches zero rows instead of being clobbered.
+    args.push(id, expected.summary, expected.date, expected.page_slug, expected.page_source);
+    const base = args.length - 5;
+    const { rows } = await this.db.query(
+      `UPDATE timeline_entries SET ${sets.join(', ')}
+         FROM pages p
+        WHERE timeline_entries.id = $${base + 1}
+          AND timeline_entries.page_id = p.id
+          AND timeline_entries.summary = $${base + 2}
+          AND timeline_entries.date::text = $${base + 3}
+          AND p.slug = $${base + 4}
+          AND p.source_id = $${base + 5}
+        RETURNING timeline_entries.id`,
+      args,
+    );
+    return rows.length > 0;
+  }
+
+  async removeTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+  ): Promise<boolean> {
+    const { rows } = await this.db.query(
+      `DELETE FROM timeline_entries
+        USING pages p
+        WHERE timeline_entries.id = $1
+          AND timeline_entries.page_id = p.id
+          AND timeline_entries.summary = $2
+          AND timeline_entries.date::text = $3
+          AND p.slug = $4
+          AND p.source_id = $5
+        RETURNING timeline_entries.id`,
+      [id, expected.summary, expected.date, expected.page_slug, expected.page_source],
+    );
+    return rows.length > 0;
+  }
+
   async addTimelineEntry(
     slug: string,
     entry: TimelineInput,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4066,6 +4066,78 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Timeline
+  // --- Timeline mutation by id (robert-cos patch; upstream PR pending) ---
+  async getTimelineEntryById(id: number): Promise<
+    | {
+        id: number;
+        page_id: number;
+        date: string;
+        source: string;
+        summary: string;
+        detail: string;
+        event_page_id: number | null;
+        page_slug: string;
+        page_source: string;
+      }
+    | null
+  > {
+    const sql = this.sql;
+    const rows = await sql`
+      SELECT t.id, t.page_id, t.date::text AS date, t.source, t.summary,
+             t.detail, t.event_page_id, p.slug AS page_slug,
+             p.source_id AS page_source
+        FROM timeline_entries t
+        JOIN pages p ON p.id = t.page_id
+       WHERE t.id = ${id}`;
+    return (rows[0] as any) ?? null;
+  }
+
+  async updateTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+    changes: { date?: string; summary?: string; detail?: string; source?: string },
+  ): Promise<boolean> {
+    const sql = this.sql;
+    const cols = (['date', 'summary', 'detail', 'source'] as const).filter(
+      (k) => changes[k] !== undefined,
+    );
+    if (cols.length === 0) return false;
+    const patch: Record<string, string> = {};
+    for (const k of cols) patch[k] = changes[k] as string;
+    // Atomic optimistic check: the full expected identity is part of the
+    // mutation predicate. A concurrent change (or a same-id row in a
+    // different page/source) matches zero rows instead of being clobbered.
+    const rows = await sql`
+      UPDATE timeline_entries SET ${sql(patch, ...cols)}
+        FROM pages p
+       WHERE timeline_entries.id = ${id}
+         AND timeline_entries.page_id = p.id
+         AND timeline_entries.summary = ${expected.summary}
+         AND timeline_entries.date::text = ${expected.date}
+         AND p.slug = ${expected.page_slug}
+         AND p.source_id = ${expected.page_source}
+       RETURNING timeline_entries.id`;
+    return rows.length > 0;
+  }
+
+  async removeTimelineEntryById(
+    id: number,
+    expected: { summary: string; date: string; page_slug: string; page_source: string },
+  ): Promise<boolean> {
+    const sql = this.sql;
+    const rows = await sql`
+      DELETE FROM timeline_entries
+       USING pages p
+       WHERE timeline_entries.id = ${id}
+         AND timeline_entries.page_id = p.id
+         AND timeline_entries.summary = ${expected.summary}
+         AND timeline_entries.date::text = ${expected.date}
+         AND p.slug = ${expected.page_slug}
+         AND p.source_id = ${expected.page_source}
+       RETURNING timeline_entries.id`;
+    return rows.length > 0;
+  }
+
   async addTimelineEntry(
     slug: string,
     entry: TimelineInput,

--- a/test/robert-cos-timeline-mutation.test.ts
+++ b/test/robert-cos-timeline-mutation.test.ts
@@ -1,0 +1,374 @@
+/**
+ * robert-cos timeline-mutation patch — durable regression tests.
+ *
+ * Ships WITH the patch (second review item 14) so the matrix reruns from the
+ * branch on every patch edit, instead of living only in canary transcripts.
+ *
+ * Coverage: get/update/remove by id; ATOMIC optimistic identity checks
+ * (summary + date + owning slug + page source inside the mutation
+ * predicate); wrong-source / wrong-slug refusals; same-numeric-id
+ * cross-brain collision (ids are database-local); audit-write failure
+ * refusing the mutation (intent-first); audit brain attribution and
+ * 0700/0600 permissions; repeated removal idempotence; dry-run.
+ *
+ * PGLite runs fully offline. The same matrix runs against real Postgres when
+ * ROBERT_COS_PG_TEST_URL_A and ROBERT_COS_PG_TEST_URL_B name two SCRATCH
+ * databases (both are schema-initialized and mutated — never point them at
+ * a real brain). Postgres engines connect with poolSize (instance-level
+ * pools): the default module-singleton path silently reuses the first
+ * connection for every later database_url, which would collapse the two
+ * brains into one. Identities are salted per process and the collision test
+ * aligns id sequences explicitly, so runs are robust against accumulated
+ * rows — periodically recreating the scratch databases is hygiene, not a
+ * requirement.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, chmodSync, statSync, readFileSync, readdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+import { operationsByName, type OperationContext } from '../src/core/operations.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { PageInput } from '../src/core/types.ts';
+
+const updateOp = operationsByName['update_timeline_entry'];
+const removeOp = operationsByName['remove_timeline_entry'];
+
+const DATE = '2026-08-14';
+const DETAIL = 'life/events/2026/08/14/test-session granola:fx_evt_0001';
+
+// Per-test unique identity, salted per process: scratch Postgres databases
+// persist rows across tests AND across runs, so a deterministic counter
+// alone would let a rerun's readbacks match the previous run's (already
+// mutated) rows.
+let seedCounter = 0;
+const RUN_SALT = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`;
+interface Identity { slug: string; summary: string }
+function freshIdentity(): Identity {
+  const n = ++seedCounter;
+  return {
+    slug: `entities/people/test-person-${RUN_SALT}-${n}--abc123`,
+    summary: `Attended: Test Session ${RUN_SALT}-${n} -> life/events/2026/08/14/test-session`,
+  };
+}
+
+function makeCtx(engine: BrainEngine, brainId: string): OperationContext {
+  return {
+    engine,
+    config: {},
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+    brainId,
+  } as unknown as OperationContext;
+}
+
+async function seedEntry(engine: BrainEngine, ident: Identity): Promise<number> {
+  await engine.putPage(
+    ident.slug,
+    { type: 'note', title: 'Test Person', compiled_truth: 'Synthetic test person.' } as unknown as PageInput,
+    { sourceId: 'default' },
+  );
+  await engine.addTimelineEntry(
+    ident.slug,
+    { date: DATE, summary: ident.summary, detail: DETAIL, source: 'granola-ingest' },
+    { sourceId: 'default' },
+  );
+  const entries = await engine.getTimeline(ident.slug, { sourceId: 'default' });
+  const mine = entries.find((e) => e.summary === ident.summary);
+  if (!mine) throw new Error('seed failed: entry not found after add');
+  return mine.id;
+}
+
+const EXPECTED = (ident: Identity, overrides: Partial<Record<string, string>> = {}) => ({
+  expected_summary: ident.summary,
+  expected_date: DATE,
+  expected_slug: ident.slug,
+  page_source: 'default',
+  ...overrides,
+});
+
+interface EngineVariant {
+  name: string;
+  make: () => Promise<BrainEngine>;
+  makeSecond: () => Promise<BrainEngine>;
+}
+
+const variants: EngineVariant[] = [
+  {
+    name: 'PGLite',
+    make: async () => {
+      const e = new PGLiteEngine();
+      await e.connect({});
+      await e.initSchema();
+      return e;
+    },
+    makeSecond: async () => {
+      const e = new PGLiteEngine();
+      await e.connect({});
+      await e.initSchema();
+      return e;
+    },
+  },
+];
+
+const PG_A = process.env.ROBERT_COS_PG_TEST_URL_A;
+const PG_B = process.env.ROBERT_COS_PG_TEST_URL_B;
+if (PG_A && PG_B) {
+  // poolSize forces an instance-level connection: the module-singleton path
+  // (no poolSize) silently reuses the FIRST database_url for every later
+  // connect, which would collapse the two test brains into one database.
+  const makePg = (url: string) => async () => {
+    const e = new PostgresEngine();
+    await e.connect({ database_url: url, poolSize: 2 });
+    await e.initSchema();
+    return e;
+  };
+  variants.push({ name: 'Postgres', make: makePg(PG_A), makeSecond: makePg(PG_B) });
+}
+
+let auditHome: string;
+let priorGbrainHome: string | undefined;
+
+beforeAll(() => {
+  priorGbrainHome = process.env.GBRAIN_HOME;
+  auditHome = mkdtempSync(join(tmpdir(), 'rc-tl-audit-'));
+  process.env.GBRAIN_HOME = auditHome;
+});
+
+afterAll(() => {
+  if (priorGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = priorGbrainHome;
+  try { chmodSync(join(auditHome, '.gbrain'), 0o700); } catch { /* may not exist */ }
+  rmSync(auditHome, { recursive: true, force: true });
+});
+
+function auditDir(): string {
+  return join(auditHome, '.gbrain', 'audit');
+}
+
+function auditRecords(): Array<Record<string, unknown>> {
+  if (!existsSync(auditDir())) return [];
+  const records: Array<Record<string, unknown>> = [];
+  // Only OUR weekly files: upstream gbrain audits (e.g. mount-ops) share
+  // the audit directory with their own formats and default modes.
+  for (const f of readdirSync(auditDir()).filter((n) => n.startsWith('timeline-mutations-'))) {
+    for (const line of readFileSync(join(auditDir(), f), 'utf-8').split('\n')) {
+      if (line.trim()) records.push(JSON.parse(line));
+    }
+  }
+  return records;
+}
+
+for (const variant of variants) {
+  describe(`timeline mutation by id (${variant.name})`, () => {
+    let engine: BrainEngine;
+    const cleanups: Array<() => Promise<void>> = [];
+
+    beforeEach(async () => {
+      engine = await variant.make();
+      cleanups.push(() => engine.disconnect());
+      // Restore the shared audit home in case a failure test degraded it.
+      process.env.GBRAIN_HOME = auditHome;
+    });
+
+    afterAll(async () => {
+      for (const c of cleanups.splice(0)) await c().catch(() => {});
+    });
+
+    test('get/update/remove round trip with full identity', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+
+      const row = await engine.getTimelineEntryById(id);
+      expect(row?.summary).toBe(ident.summary);
+      expect(row?.page_slug).toBe(ident.slug);
+      expect(row?.page_source).toBe('default');
+
+      const upd = (await updateOp.handler(ctx, {
+        id, ...EXPECTED(ident), summary: `${ident.summary} (renamed)`,
+      })) as Record<string, unknown>;
+      expect(upd.status).toBe('ok');
+      expect(upd.audit).toBe('complete');
+      expect((await engine.getTimelineEntryById(id))?.summary).toBe(`${ident.summary} (renamed)`);
+
+      const rm = (await removeOp.handler(ctx, {
+        id, ...EXPECTED(ident, { expected_summary: `${ident.summary} (renamed)` }),
+      })) as Record<string, unknown>;
+      expect(rm.status).toBe('ok');
+      expect(await engine.getTimelineEntryById(id)).toBeNull();
+    });
+
+    test('engine predicate is atomic: any stale identity field matches zero rows', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const good = { summary: ident.summary, date: DATE, page_slug: ident.slug, page_source: 'default' };
+
+      for (const stale of [
+        { ...good, summary: 'someone changed it' },
+        { ...good, date: '2026-08-15' },
+        { ...good, page_slug: 'entities/people/wrong-person--zzzzzz' },
+        { ...good, page_source: 'not-default' },
+      ]) {
+        expect(await engine.updateTimelineEntryById(id, stale, { detail: 'x' })).toBe(false);
+        expect(await engine.removeTimelineEntryById(id, stale)).toBe(false);
+      }
+      const row = await engine.getTimelineEntryById(id);
+      expect(row?.summary).toBe(ident.summary);
+      expect(row?.detail).toBe(DETAIL);
+
+      expect(await engine.removeTimelineEntryById(id, good)).toBe(true);
+      expect(await engine.getTimelineEntryById(id)).toBeNull();
+    });
+
+    test('op refuses stale expected_summary without mutating', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+      await expect(
+        updateOp.handler(ctx, { id, ...EXPECTED(ident, { expected_summary: 'stale' }), detail: 'x' }),
+      ).rejects.toThrow(/optimistic check failed/);
+      expect((await engine.getTimelineEntryById(id))?.detail).toBe(DETAIL);
+    });
+
+    test('op refuses wrong page_source and wrong expected_slug', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+      await expect(
+        removeOp.handler(ctx, { id, ...EXPECTED(ident, { page_source: 'other' }) }),
+      ).rejects.toThrow(/source mismatch/);
+      await expect(
+        removeOp.handler(ctx, { id, ...EXPECTED(ident, { expected_slug: 'entities/people/other--aaaaaa' }) }),
+      ).rejects.toThrow(/slug mismatch/);
+      expect(await engine.getTimelineEntryById(id)).not.toBeNull();
+    });
+
+    test('same numeric id in two brains: only the ctx brain mutates', async () => {
+      const engineB = await variant.makeSecond();
+      cleanups.push(() => engineB.disconnect());
+      // Manufacture the dangerous collision case deliberately: the two
+      // brains' id sequences drift apart as tests accumulate rows, so first
+      // seed filler entries into whichever brain lags until both sequences
+      // stand at the same value, then seed the SAME identity into both —
+      // same numeric id, summary, slug and source in two different brains.
+      let nA = await seedEntry(engine, freshIdentity());
+      let nB = await seedEntry(engineB, freshIdentity());
+      for (let i = 0; nA !== nB && i < 500; i++) {
+        if (nA < nB) nA = await seedEntry(engine, freshIdentity());
+        else nB = await seedEntry(engineB, freshIdentity());
+      }
+      expect(nA).toBe(nB);
+      const ident = freshIdentity();
+      const idA = await seedEntry(engine, ident);
+      const idB = await seedEntry(engineB, ident);
+      expect(idA).toBe(idB);
+
+      const ctxA = makeCtx(engine, 'brain-a');
+      const rm = (await removeOp.handler(ctxA, { id: idA, ...EXPECTED(ident) })) as Record<string, unknown>;
+      expect(rm.status).toBe('ok');
+
+      expect(await engine.getTimelineEntryById(idA)).toBeNull();
+      // Brain B's identical row is untouched.
+      const rowB = await engineB.getTimelineEntryById(idB);
+      expect(rowB?.summary).toBe(ident.summary);
+    });
+
+    test('wrong-brain invocation is a safe noop', async () => {
+      const engineB = await variant.makeSecond();
+      cleanups.push(() => engineB.disconnect());
+      const ident = freshIdentity();
+      const idB = await seedEntry(engineB, ident);
+      // The id must be absent in brain A: probe A and only assert the noop
+      // when A genuinely has no such row (guaranteed on fresh scratch DBs).
+      const inA = await engine.getTimelineEntryById(idB);
+      expect(inA).toBeNull();
+      const ctxA = makeCtx(engine, 'brain-a');
+      const rm = (await removeOp.handler(ctxA, { id: idB, ...EXPECTED(ident) })) as Record<string, unknown>;
+      expect(rm.status).toBe('noop');
+      expect(rm.reason).toBe('not-found');
+      expect(await engineB.getTimelineEntryById(idB)).not.toBeNull();
+    });
+
+    test('repeated removal is idempotent', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+      const first = (await removeOp.handler(ctx, { id, ...EXPECTED(ident) })) as Record<string, unknown>;
+      expect(first.status).toBe('ok');
+      const second = (await removeOp.handler(ctx, { id, ...EXPECTED(ident) })) as Record<string, unknown>;
+      expect(second.status).toBe('noop');
+      expect(second.reason).toBe('not-found');
+    });
+
+    test('audit-write failure refuses the mutation (intent-first)', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+      const lockedHome = mkdtempSync(join(tmpdir(), 'rc-tl-locked-'));
+      mkdirSync(join(lockedHome, '.gbrain'), { mode: 0o500 });
+      chmodSync(join(lockedHome, '.gbrain'), 0o500);
+      process.env.GBRAIN_HOME = lockedHome;
+      try {
+        await expect(
+          updateOp.handler(ctx, { id, ...EXPECTED(ident), detail: 'must not land' }),
+        ).rejects.toThrow();
+        // The mutation did NOT happen: no unaudited mutation is possible.
+        expect((await engine.getTimelineEntryById(id))?.detail).toBe(DETAIL);
+      } finally {
+        process.env.GBRAIN_HOME = auditHome;
+        chmodSync(join(lockedHome, '.gbrain'), 0o700);
+        rmSync(lockedHome, { recursive: true, force: true });
+      }
+    });
+
+    test('audit records carry brain attribution; dir 0700, files 0600', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const brainName = `brain-attribution-${variant.name}`;
+      const ctx = makeCtx(engine, brainName);
+      await updateOp.handler(ctx, { id, ...EXPECTED(ident), detail: 'audited change' });
+
+      const records = auditRecords().filter((r) => r.brain === brainName);
+      const phases = records.map((r) => r.phase);
+      expect(phases).toContain('intent');
+      expect(phases).toContain('result');
+      const intent = records.find((r) => r.phase === 'intent') as Record<string, unknown>;
+      expect(intent.op).toBe('update_timeline_entry');
+      expect(intent.page_slug).toBe(ident.slug);
+      expect((intent.before as Record<string, unknown>).detail).toBe(DETAIL);
+
+      expect(statSync(auditDir()).mode & 0o777).toBe(0o700);
+      // Our weekly files are 0600. Upstream gbrain writes its own audit
+      // files (mount-ops JSONL) into this directory with default modes —
+      // they are shielded by the 0700 directory, not by this contract.
+      const ours = readdirSync(auditDir()).filter((f) => f.startsWith('timeline-mutations-'));
+      expect(ours.length).toBeGreaterThan(0);
+      for (const f of ours) {
+        expect(statSync(join(auditDir(), f)).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    test('dry-run validates preconditions but mutates and audits nothing', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const before = auditRecords().length;
+      const ctx = { ...makeCtx(engine, 'brain-a'), dryRun: true } as OperationContext;
+      const res = (await updateOp.handler(ctx, { id, ...EXPECTED(ident), detail: 'dry' })) as Record<string, unknown>;
+      expect(res.dry_run).toBe(true);
+      expect((await engine.getTimelineEntryById(id))?.detail).toBe(DETAIL);
+      expect(auditRecords().length).toBe(before);
+    });
+
+    test('update with no new values is refused', async () => {
+      const ident = freshIdentity();
+      const id = await seedEntry(engine, ident);
+      const ctx = makeCtx(engine, 'brain-a');
+      await expect(updateOp.handler(ctx, { id, ...EXPECTED(ident) })).rejects.toThrow(/no new values/);
+    });
+  });
+}


### PR DESCRIPTION
Adds `update_timeline_entry` / `remove_timeline_entry` (CLI: `timeline-update` / `timeline-rm`): immutable-id addressing, optimistic identity check (`expected_summary`), explicit `page_source` verification (named to avoid the CLI-global `--source` selector), immutable before/after audit JSONL under `audit/timeline-mutations-*.jsonl`, idempotent not-found noop, strict id validation, existing slug fences enforced on the owning page. Engine-native implementations for both PGLite and Postgres.

**Why:** timeline entries carry immutable ids but expose no supported mutation path — corrections today mean deleting the owning page (cascade) or direct SQL. This closes that gap with an audited, fenced, idempotent surface.

**Validation:** functional matrix on both engines — update+verify, wrong-expected refused, wrong-source refused, cross-brain not-found noop, remove + idempotent re-remove, audit records written, physical deletion confirmed.

**Draft because of vintage:** built against 0c78213 / v0.46.2.0, before the 0.46.9.1 `src/core/ops/*` split — happy to rebase onto the current layout if maintainers are interested.