### PR TITLE
fix(conversation-parser): surface out-of-set heading labels folded by markdown-heading-turn (#4136)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -18,7 +18,7 @@ src/core/search/hybrid.ts	2479	ratchet
 src/core/engine.ts	2343	ratchet
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
-src/commands/extract-conversation-facts.ts	1968	ratchet
+src/commands/extract-conversation-facts.ts	1982	ratchet	grown #4136 suspect_heading_labels warn
 src/core/import-file.ts	2000	ratchet	grown v0.46.11.0 five-issue wave
 src/core/cycle/synthesize.ts	2685	ratchet	grown v0.46.11.0 five-issue wave
 src/commands/embed.ts	1963	ratchet

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -907,6 +907,20 @@ async function processPage(
   if (parseResult.timezone_warning) {
     process.stderr.write(parseResult.timezone_warning + '\n');
   }
+  // #4136: fail-loud surfacing for heading-shaped continuation lines whose
+  // label fell outside a heading-anchored pattern's closed speaker set
+  // (e.g. a '## Claude' turn folded into the previous speaker's body under
+  // markdown-heading-turn). This is observability only — a decline
+  // threshold is a follow-on decision, not implemented here — so
+  // extraction proceeds on `messages` unchanged.
+  if (parseResult.suspect_heading_labels && parseResult.suspect_heading_labels.length > 0) {
+    const labelsDesc = parseResult.suspect_heading_labels
+      .map((s) => `${JSON.stringify(s.label)} x${s.count}`)
+      .join(', ');
+    process.stderr.write(
+      `[extract-conversation-facts] WARN ${page.slug}: heading-shaped line(s) outside pattern=${parseResult.matched_pattern_id}'s closed speaker set were folded into the previous turn: ${labelsDesc}\n`,
+    );
+  }
   // The fallback runs only for a true built-in miss. It never replaces or
   // polishes a deterministic parse, and it remains unreachable unless the
   // operator explicitly enables conversation_parser.llm_fallback_enabled.

--- a/src/core/conversation-parser/builtins.ts
+++ b/src/core/conversation-parser/builtins.ts
@@ -692,6 +692,9 @@ export const BUILTIN_PATTERNS: readonly PatternEntry[] = [
     timezone_policy: 'utc_assumed_with_warn',
     multi_line: true,
     score_continuations_as_body: true,
+    // #4136: closed speaker set (User|Assistant|Human|System) anchored on
+    // a markdown `#{2,3}` heading — see PatternEntry.heading_anchored.
+    heading_anchored: true,
     // Narrowed to a role-prefix superset (NOT bare `/^#{2,3}\s/`): a body
     // that pastes unrelated markdown headings (e.g. a document with many
     // '## Section' headings) would otherwise inflate the D18 scorer's

--- a/src/core/conversation-parser/parse.ts
+++ b/src/core/conversation-parser/parse.ts
@@ -292,6 +292,62 @@ function buildIso(
   return null;
 }
 
+/**
+ * #4136: generic markdown-heading shape — `## <label>` / `### <label>`
+ * with a non-empty label. Used ONLY to detect a folded continuation line
+ * that LOOKS like a turn heading, independent of any single pattern's own
+ * closed-speaker-set regex (so it also catches lines that fail
+ * `quick_reject` outright, before `entry.regex` is even tried).
+ */
+const HEADING_SHAPE_RE = /^#{2,3}\s+(\S.*)$/;
+
+/**
+ * #4136: "this pattern anchors on markdown `#{2,3}` headings AND has a
+ * closed speaker set" (e.g. `markdown-heading-turn`), as opposed to other
+ * `multi_line` + continuation-folding patterns like `bold-time-dash` that
+ * have nothing to do with headings. Reads the explicit
+ * `PatternEntry.heading_anchored` metadata flag rather than sniffing
+ * `quick_reject`/`regex` source text for a `^#{` prefix: prefix-sniffing
+ * only recognizes the exact shape a pattern happens to be written in
+ * today (misses equivalent anchors like `^(?:##|###)`, and can't tell
+ * whether `quick_reject` matching that shape actually implies `regex`
+ * has a closed speaker set). The explicit flag is the single source of
+ * truth other call sites already require (D11's documented
+ * `quick_reject` ⊇ `regex` invariant), so any future heading-anchored
+ * builtin declares it directly instead of being reverse-engineered from
+ * regex text.
+ */
+function isHeadingAnchoredPattern(entry: PatternEntry): boolean {
+  return entry.heading_anchored === true;
+}
+
+/**
+ * #4136: record a heading-shaped continuation line whose label is outside
+ * a heading-anchored pattern's closed speaker set. Reaching this call
+ * already implies "out-of-set": `applyPattern` only takes the continuation
+ * path when `entry.regex` failed to match `line` as a complete anchor, and
+ * `quick_reject` is a documented strict superset of `regex` (D11 —
+ * `validatePatternEntry` requires every `test_positive` sample to pass
+ * both), so a `quick_reject` failure implies a `regex` failure too. Purely
+ * observability: does not change `phase` or `messages`.
+ *
+ * The captured text after `## `/`### ` is trimmed but otherwise recorded
+ * verbatim — NOT normalized against any single pattern's own trailing-colon
+ * tolerance (`markdown-heading-turn`'s regex treats `## User` and `## User:`
+ * as equivalent, but that's specific to its own closed set). Stripping a
+ * trailing colon here would silently collapse two distinct suspect labels
+ * (`## Claude` and `## Claude:`) into one count, breaking the "one entry per
+ * distinct out-of-set label text" contract documented on
+ * `ParseResult.suspect_heading_labels`.
+ */
+function recordSuspectHeadingLabel(line: string, out: Map<string, number>): void {
+  const m = HEADING_SHAPE_RE.exec(line);
+  if (!m) return;
+  const label = m[1].trim();
+  if (!label) return;
+  out.set(label, (out.get(label) ?? 0) + 1);
+}
+
 const MONTHS_SHORT = [
   'jan', 'feb', 'mar', 'apr', 'may', 'jun',
   'jul', 'aug', 'sep', 'oct', 'nov', 'dec',
@@ -313,11 +369,18 @@ function monthNameToIndex(name: string): number {
  * previous message's body.
  *
  * Exported for unit tests + the eval CLI debug command.
+ *
+ * `suspectHeadingLabels` (#4136) is an optional accumulator: when
+ * provided, a heading-shaped continuation line folded under a
+ * heading-anchored `multi_line` pattern increments its label's count.
+ * Omit it (as every existing caller does) to opt out with zero behavior
+ * change.
  */
 export function applyPattern(
   body: string,
   entry: PatternEntry,
   dateCtx: DateContext,
+  suspectHeadingLabels?: Map<string, number>,
 ): MatchedMessage[] {
   if (!body) return [];
   const out: MatchedMessage[] = [];
@@ -327,6 +390,11 @@ export function applyPattern(
   // while advancing a local date anchor as those headings are encountered.
   const runningCtx: DateContext = { ...dateCtx };
   const dateHeaderRe = /^#{1,4}\s+(\d{4}-\d{2}-\d{2})\s*$/;
+  // #4136: only heading-anchored multi_line patterns (e.g.
+  // markdown-heading-turn) have a closed speaker set that a folded
+  // heading-shaped line can fall outside of.
+  const trackHeadingSuspects =
+    !!suspectHeadingLabels && entry.multi_line && isHeadingAnchoredPattern(entry);
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
     const line = rawLine.trim();
@@ -342,6 +410,7 @@ export function applyPattern(
     if (entry.quick_reject && !entry.quick_reject.test(line)) {
       // Continuation handling for orphan lines.
       if (out.length > 0) {
+        if (trackHeadingSuspects) recordSuspectHeadingLabel(line, suspectHeadingLabels!);
         out[out.length - 1].text = out[out.length - 1].text
           ? `${out[out.length - 1].text}\n${line}`
           : line;
@@ -365,6 +434,7 @@ export function applyPattern(
       out.push({ speaker, timestamp: iso, text });
     } else if (out.length > 0) {
       // Continuation line.
+      if (trackHeadingSuspects) recordSuspectHeadingLabel(line, suspectHeadingLabels!);
       out[out.length - 1].text = out[out.length - 1].text
         ? `${out[out.length - 1].text}\n${line}`
         : line;
@@ -568,7 +638,11 @@ export function parseConversation(
     };
   }
 
-  const messages = applyPattern(body, top.entry, dateCtx);
+  // #4136: accumulate heading-shaped continuation lines folded outside a
+  // heading-anchored pattern's closed speaker set. Purely observational —
+  // does not affect messages/phase below.
+  const suspectHeadingLabelCounts = new Map<string, number>();
+  const messages = applyPattern(body, top.entry, dateCtx, suspectHeadingLabelCounts);
 
   // Timezone warning surface (D19).
   let timezone_warning: string | undefined;
@@ -586,6 +660,10 @@ export function parseConversation(
     matched_pattern_id: top.entry.id,
     patterns_scored: patternsScored,
     timezone_warning,
+    suspect_heading_labels:
+      suspectHeadingLabelCounts.size > 0
+        ? Array.from(suspectHeadingLabelCounts, ([label, count]) => ({ label, count }))
+        : undefined,
     unmatched_line_count: opts.diagnostic
       ? body
           .split(/\r?\n/)

--- a/src/core/conversation-parser/types.ts
+++ b/src/core/conversation-parser/types.ts
@@ -78,6 +78,22 @@ export interface ParseResult {
   /** Once-per-page warn from timezone_policy = utc_assumed_with_warn
    *  patterns when no frontmatter timezone is set. */
   timezone_warning?: string;
+  /**
+   * #4136: heading-shaped continuation lines (e.g. `## Claude`) that were
+   * folded into the PREVIOUS turn's body because their label fell outside
+   * a heading-anchored `multi_line` pattern's closed speaker set (e.g.
+   * `markdown-heading-turn`'s `User|Assistant|Human|System`). The closed
+   * set itself is deliberate — it is what stops ordinary `## Summary`
+   * section headings from anchoring a turn — but the fold was previously
+   * silent: `phase` still reads `regex_match` and nothing downstream
+   * declines the page even though a speaker's turn (and its heading) got
+   * absorbed into another speaker's text. This field is purely
+   * observability: populated when at least one such fold happened,
+   * `undefined` otherwise. It does NOT change acceptance — `phase` and
+   * `messages` are unaffected. One entry per distinct out-of-set label
+   * text, with `count` = how many times that exact label was folded.
+   */
+  suspect_heading_labels?: { label: string; count: number }[];
 }
 
 /**
@@ -167,6 +183,26 @@ export interface PatternEntry {
    * Requires `multi_line: true` and a `quick_reject`.
    */
   score_continuations_as_body?: boolean;
+  /**
+   * #4136: declares that this pattern anchors on a markdown `#{2,3}`
+   * heading line (e.g. `markdown-heading-turn`'s `## User` / `## Assistant`)
+   * AND that its speaker set is closed (a fixed label list, not free text).
+   * Only patterns with `heading_anchored: true` have a closed speaker set
+   * that a heading-SHAPED continuation line (any `## <label>`) can fall
+   * outside of — `bold-time-dash` and other `multi_line` +
+   * continuation-folding patterns have nothing to do with headings, so a
+   * `## Not a speaker turn` line inside their body is ordinary prose, not a
+   * suspect out-of-set label. Explicit boolean metadata rather than
+   * sniffing `quick_reject`/`regex` source text for a `^#{` prefix: a
+   * pattern's regex SHAPE is free to vary (`^#{2,3}\s+(?:...)\b`,
+   * `^(?:##|###)\s+...`, etc.) without silently losing this classification,
+   * and a future heading-anchored builtin just sets the field instead of
+   * being reverse-engineered from its regex text. Requires
+   * `multi_line: true` (checked separately by callers, per D5 — a
+   * single-line heading-anchored pattern isn't meaningful with today's
+   * fold logic).
+   */
+  heading_anchored?: boolean;
   /**
    * D11: optional cheap O(1) prefix check. If set, orchestrator runs
    * this FIRST per line; only tries `regex` if quick_reject matches.

--- a/test/conversation-parser/parse.test.ts
+++ b/test/conversation-parser/parse.test.ts
@@ -303,6 +303,92 @@ describe('parseConversation — markdown-heading-turn (gbrain transcript ingest)
   });
 });
 
+// ---------------------------------------------------------------------------
+// #4136 — suspect_heading_labels: out-of-set heading folded into the
+// previous turn under markdown-heading-turn. Reproducer from the issue:
+// same three-turn body, only the middle heading's label changes.
+// ---------------------------------------------------------------------------
+
+describe('parseConversation — suspect_heading_labels (#4136)', () => {
+  const mk = (label: string) =>
+    [
+      '## User',
+      '',
+      'What is the deploy command?',
+      '',
+      `## ${label}`,
+      '',
+      'Run the deploy script from the repo root.',
+      '',
+      '## User',
+      '',
+      'Thanks.',
+      '',
+    ].join('\n');
+
+  test('an in-set label (## Assistant) parses normally with no suspect labels', () => {
+    const r = parseConversation(mk('Assistant'), { fallbackDate: '2026-08-11' });
+    expect(r.matched_pattern_id).toBe('markdown-heading-turn');
+    expect(r.phase).toBe('regex_match');
+    expect(r.messages).toHaveLength(3);
+    expect(r.messages.map((m) => m.speaker)).toEqual(['User', 'Assistant', 'User']);
+    expect(r.suspect_heading_labels).toBeUndefined();
+  });
+
+  test('an out-of-set single-word label (## Claude) is folded AND surfaced', () => {
+    const r = parseConversation(mk('Claude'), { fallbackDate: '2026-08-11' });
+    expect(r.phase).toBe('regex_match');
+    // Folded: only 2 messages, both attributed to 'User' — the bug this
+    // field surfaces (attribution is still wrong; that's out of scope here).
+    expect(r.messages).toHaveLength(2);
+    expect(r.messages.map((m) => m.speaker)).toEqual(['User', 'User']);
+    expect(r.suspect_heading_labels).toEqual([{ label: 'Claude', count: 1 }]);
+  });
+
+  test('an out-of-set multi-word label (## Assistant Bot) is folded AND surfaced', () => {
+    const r = parseConversation(mk('Assistant Bot'), { fallbackDate: '2026-08-11' });
+    expect(r.phase).toBe('regex_match');
+    expect(r.messages).toHaveLength(2);
+    expect(r.messages.map((m) => m.speaker)).toEqual(['User', 'User']);
+    expect(r.suspect_heading_labels).toEqual([
+      { label: 'Assistant Bot', count: 1 },
+    ]);
+  });
+
+  test('a repeated out-of-set label increments count instead of duplicating entries', () => {
+    const body = [
+      '## User',
+      '',
+      'one',
+      '',
+      '## Claude',
+      '',
+      'two',
+      '',
+      '## Claude',
+      '',
+      'three',
+      '',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-08-11' });
+    expect(r.suspect_heading_labels).toEqual([{ label: 'Claude', count: 2 }]);
+  });
+
+  test('does not fire for non-heading-anchored multi_line patterns (bold-time-dash)', () => {
+    // A bold-time-dash body whose continuation text happens to contain a
+    // markdown-heading-shaped line must NOT be reported as a suspect
+    // heading label — that pattern has no closed speaker set to violate.
+    const body = [
+      '**Alice Example** 09:15 — hello world',
+      '## Not a speaker turn, just body content',
+      'more body',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-08-11' });
+    expect(r.matched_pattern_id).toBe('bold-time-dash');
+    expect(r.suspect_heading_labels).toBeUndefined();
+  });
+});
+
 describe('parseConversation — multi-line continuation (D5)', () => {
   test('iMessage continuation absorbs orphan lines', () => {
     const body = [

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -1347,6 +1347,71 @@ describe('runExtractConversationFactsCore', () => {
     });
     expect(result.pages_processed).toBe(1);
   });
+
+  test('#4136: warns to stderr when suspect_heading_labels is populated', async () => {
+    await engine.putPage('conversations/suspect-heading-example', {
+      type: 'conversation',
+      title: 'Out-of-set heading label example',
+      compiled_truth: [
+        '## User',
+        '',
+        'What is the deploy command?',
+        '',
+        '## Claude',
+        '',
+        'Run the deploy script from the repo root.',
+        '',
+        '## User',
+        '',
+        'Thanks.',
+        '',
+      ].join('\n'),
+      timeline: '',
+      frontmatter: { date: '2026-08-11' },
+    });
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const lines: string[] = [];
+    (process.stderr as unknown as { write: unknown }).write = ((chunk: unknown) => {
+      lines.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    }) as unknown as typeof process.stderr.write;
+    try {
+      const result = await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'conversations/suspect-heading-example',
+        dryRun: true,
+        sleepMs: 0,
+      });
+      expect(result.pages_considered).toBe(1);
+    } finally {
+      (process.stderr as unknown as { write: unknown }).write = origWrite;
+    }
+    const warnLine = lines.find(
+      (l) => l.includes('conversations/suspect-heading-example') && l.includes('Claude'),
+    );
+    expect(warnLine).toBeDefined();
+    expect(warnLine).toContain('markdown-heading-turn');
+  });
+
+  test('#4136: no stderr warning when suspect_heading_labels is absent', async () => {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const lines: string[] = [];
+    (process.stderr as unknown as { write: unknown }).write = ((chunk: unknown) => {
+      lines.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    }) as unknown as typeof process.stderr.write;
+    try {
+      await runExtractConversationFactsCore(engine, {
+        sourceId: 'default',
+        slug: 'conversations/imessage/alice-example',
+        dryRun: true,
+        sleepMs: 0,
+      });
+    } finally {
+      (process.stderr as unknown as { write: unknown }).write = origWrite;
+    }
+    expect(lines.some((l) => l.includes('heading-shaped line'))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (#4136)

`markdown-heading-turn` (added in #4005) anchors turns on a closed speaker set
(`User|Assistant|Human|System`). A `## <label>`/`### <label>` continuation
line whose label falls outside that set is not rejected — because the
pattern is `multi_line: true` with `score_continuations_as_body: true`, the
line is silently folded into the **body of the previous turn**, heading text
and all. The parse still returns `phase: 'regex_match'`, so nothing
downstream declines it. A speaker's turn (and its heading) gets absorbed
into another speaker's text with no observable trace.

## What this does

Per the maintainer's green-light on #4136 (comment 2026-08-16T14:42:35Z):

- Adds an optional `ParseResult.suspect_heading_labels?: { label: string; count: number }[]`
  field, populated when a heading-shaped continuation line is folded outside
  a heading-anchored pattern's closed speaker set. Does **not** change `phase`
  or `messages`/acceptance — pure observability.
- Gates this on a new explicit `PatternEntry.heading_anchored?: boolean`
  metadata flag (set `true` only on `markdown-heading-turn`), rather than
  sniffing `quick_reject`/`regex` source text for a `^#{` prefix. A prior
  review round on this branch flagged the source-sniffing heuristic as
  fragile (misses equivalent regex shapes, doesn't prove a closed speaker
  set exists); the explicit flag is the single source of truth and any
  future heading-anchored builtin declares it directly.
- `extract-conversation-facts` warns to stderr when the field is populated
  (same style as the existing `timezone_warning` surfacing). No decline
  threshold — the issue explicitly calls that a follow-on decision, not in
  scope here.
- Label text is recorded verbatim (trimmed only, no trailing-colon
  normalization) so it matches the "one entry per distinct out-of-set label
  text" contract documented on the field — `## Claude` and `## Claude:`
  are recorded as distinct labels.

## What this explicitly does not do

Per the issue's own scope note: no new pattern family, no widened/config-key
speaker set, no support for any particular agent's naming, no decline
threshold.

## Tests

`test/conversation-parser/parse.test.ts` — the issue's exact three-label
reproducer (`Assistant` in-set / `Claude` and `Assistant Bot` out-of-set),
a repeat-count case, and a negative case confirming a non-heading-anchored
`multi_line` pattern (`bold-time-dash`) never false-positives on
heading-shaped body content.

`test/extract-conversation-facts.test.ts` — the stderr warning fires when
`suspect_heading_labels` is populated and stays silent otherwise.

## Verification

- `bun run typecheck` — clean
- `bun test test/conversation-parser/ test/extract-conversation-facts.test.ts` — 205 pass, 0 fail
- `bun run scripts/check-module-size.sh` — OK (ratchet ceiling for
  `extract-conversation-facts.ts` bumped 1968→1982 in `scripts/module-size-limits.tsv`
  per the repo's documented convention, exact new line count)
- Manual reproduction of the issue's exact script confirms the three-row
  table in the issue: `Assistant`→3 messages/no suspect labels,
  `Claude`→2 messages/`[{"label":"Claude","count":1}]`,
  `Assistant Bot`→2 messages/`[{"label":"Assistant Bot","count":1}]`, all
  `phase: 'regex_match'`.
