### PR TITLE
fix(facts): retry malformed extractor output once

### DIFF
--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -307,10 +307,43 @@ export async function extractFactsFromTurnWithOutcome(
     return { ok: false, reason: 'non_terminal_stop' };
   }
 
-  const parsedShape = parseExtractorJsonDetailed(result.text);
+  let parsedShape = parseExtractorJsonDetailed(result.text);
   if (!parsedShape ||
       (parsedShape.invalidCandidates > 0 && parsedShape.facts.length === 0)) {
-    return { ok: false, reason: 'malformed_output' };
+    process.stderr.write(
+      `[facts-extract] WARN: extractor returned malformed output (model=${model}); ` +
+      'retrying once with an explicit JSON-only reminder\n',
+    );
+    try {
+      result = await chat({
+        model,
+        system: `${EXTRACTOR_SYSTEM}\nThe previous attempt returned invalid JSON or an invalid facts schema. ` +
+          'Return exactly one valid JSON object and no prose.',
+        messages: [{ role: 'user', content: userContent }],
+        maxTokens,
+        abortSignal: input.abortSignal,
+      });
+    } catch (err) {
+      if (isAbort(err)) throw err;
+      return { ok: false, reason: 'provider_error', error: err };
+    }
+
+    if (result.stopReason === 'refusal') return { ok: false, reason: 'refusal' };
+    if (result.stopReason === 'content_filter') {
+      return { ok: false, reason: 'content_filter' };
+    }
+    if (result.stopReason === 'length') {
+      return { ok: false, reason: 'truncated_output' };
+    }
+    if (result.stopReason !== 'end') {
+      return { ok: false, reason: 'non_terminal_stop' };
+    }
+
+    parsedShape = parseExtractorJsonDetailed(result.text);
+    if (!parsedShape ||
+        (parsedShape.invalidCandidates > 0 && parsedShape.facts.length === 0)) {
+      return { ok: false, reason: 'malformed_output' };
+    }
   }
   if (parsedShape.invalidCandidates > 0) {
     process.stderr.write(

--- a/test/facts-extract-truncation.test.ts
+++ b/test/facts-extract-truncation.test.ts
@@ -130,3 +130,42 @@ describe('extractFactsFromTurn truncation handling (#2113)', () => {
     expect(facts).toEqual([]);
   });
 });
+
+describe('extractFactsFromTurn malformed-output retry', () => {
+  test('completed malformed JSON retries once and recovers the facts', async () => {
+    const seen: ChatOpts[] = [];
+    __setChatTransportForTests(async (opts) => {
+      seen.push(opts);
+      return seen.length === 1
+        ? chatResult('not json', 'end')
+        : chatResult(GOOD_JSON, 'end');
+    });
+
+    const facts = await extractFactsFromTurn({
+      turnText: 'I gave up alcohol.',
+      source: 'test:malformed-retry',
+    });
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.maxTokens).toBe(seen[0]!.maxTokens);
+    expect(String(seen[1]!.system)).toContain('invalid JSON or an invalid facts schema');
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.fact).toContain('alcohol');
+  });
+
+  test('second malformed response is still fail-closed', async () => {
+    let calls = 0;
+    __setChatTransportForTests(async () => {
+      calls++;
+      return chatResult('{"facts":[{"kind":"fact"}]}', 'end');
+    });
+
+    const facts = await extractFactsFromTurn({
+      turnText: 'I gave up alcohol.',
+      source: 'test:malformed-retry',
+    });
+
+    expect(calls).toBe(2);
+    expect(facts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- retry a completed-but-malformed facts extractor response once with an explicit JSON-only reminder
- keep the retry fail-closed: a second malformed response still returns `malformed_output`
- leave the existing salvage behavior unchanged when at least one valid candidate is present

## Why

Scheduled facts extraction can receive a normal `stopReason: 'end'` response that is not parseable JSON, or has no valid facts after schema validation. The current truncation path already retries once, but this completed malformed-output path fails immediately and causes the caller to mark the page unfinished.

This PR uses only synthetic fixtures. No production transcript content, slugs, names, paths, timestamps, or logs are included.

## Validation

```bash
bun test test/facts-extract-truncation.test.ts
```

Result: 8 pass, 0 fail.
