### PR TITLE
fix(facts): commit durable fence writes

### DIFF
--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -33,13 +33,15 @@
  * sees the constraint.
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, appendFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, isAbsolute, relative } from 'node:path';
 
 import type { BrainEngine, NewFact, FactVisibility } from '../engine.ts';
 import { resolvePageFilePath } from '../markdown.ts';
 import { withPageLock } from '../page-lock.ts';
 import { gbrainPath } from '../config.ts';
+import { isDurabilityHardened, commitWriteThroughFile } from '../brain-repo-durability.ts';
 import { upsertFactRow, parseFactsFence } from '../facts-fence.ts';
 import { extractFactsFromFenceText } from './extract-from-fence.ts';
 import { logStubGuardEvent } from './stub-guard-audit.ts';
@@ -119,6 +121,54 @@ function recordWriteFailure(slug: string, sourceId: string, warnings: string[], 
   }
 }
 
+type FactFenceGitPathState = 'clean' | 'dirty' | 'unknown';
+
+function gitPathState(repoPath: string, filePath: string): FactFenceGitPathState {
+  try {
+    const rel = relative(repoPath, filePath);
+    if (!rel || rel.startsWith('..') || isAbsolute(rel)) return 'unknown';
+    const status = execFileSync(
+      'git',
+      ['-C', repoPath, 'status', '--porcelain=v1', '--untracked-files=all', '--', rel],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000, env: process.env },
+    );
+    return status.trim().length === 0 ? 'clean' : 'dirty';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function commitFactFenceFile(
+  repoPath: string,
+  filePath: string,
+  slug: string,
+  sourceId: string,
+  prewriteState: FactFenceGitPathState,
+): Promise<void> {
+  if (prewriteState !== 'clean') {
+    recordWriteFailure(
+      slug,
+      sourceId,
+      [prewriteState === 'dirty'
+        ? 'git_durability_preexisting_dirty'
+        : 'git_durability_prewrite_state_unknown'],
+      filePath,
+    );
+    return;
+  }
+
+  for (const delayMs of [0, 50, 200] as const) {
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    if (commitWriteThroughFile(repoPath, filePath, slug) && gitPathState(repoPath, filePath) === 'clean') {
+      return;
+    }
+  }
+
+  recordWriteFailure(slug, sourceId, ['git_durability_commit_failed'], filePath);
+}
+
 /**
  * Stub-create body for a new entity page. Minimum frontmatter so the
  * page validates as gbrain-canonical markdown and survives an
@@ -180,6 +230,10 @@ export async function writeFactsToFence(
   // tree), polluting ~/brain with stray root-level fence files.
   const filePath = resolvePageFilePath(target.localPath, target.slug, target.sourceId);
   const tmpPath = `${filePath}.tmp`;
+  const durabilityEnabled = isDurabilityHardened(target.localPath);
+  const durabilityPrewriteState = durabilityEnabled
+    ? gitPathState(target.localPath, filePath)
+    : 'clean';
 
   return withPageLock(
     target.slug,
@@ -325,6 +379,15 @@ export async function writeFactsToFence(
       }));
 
       const result = await engine.insertFacts(enriched, { source_id: target.sourceId }); // gbrain-allow-direct-insert: writeFactsToFence is the markdown-first reconcile path; runs only after the atomic fence write commits
+      if (durabilityEnabled) {
+        await commitFactFenceFile(
+          target.localPath!,
+          filePath,
+          target.slug,
+          target.sourceId,
+          durabilityPrewriteState,
+        );
+      }
       return { inserted: result.inserted, ids: result.ids };
     },
     { timeoutMs: 5_000 },

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -14,7 +14,8 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -60,6 +61,35 @@ const baseInput = (overrides: Partial<FenceInputFact> = {}): FenceInputFact => (
   sessionId: null,
   ...overrides,
 });
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', ['-C', cwd, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  }).trim();
+}
+
+function initGitRepo(repoPath: string): void {
+  git(repoPath, 'init');
+  git(repoPath, 'config', 'user.email', 't@t.t');
+  git(repoPath, 'config', 'user.name', 'T');
+  writeFileSync(join(repoPath, 'seed.md'), 'seed\n');
+  git(repoPath, 'add', 'seed.md');
+  git(repoPath, 'commit', '-m', 'init');
+}
+
+function installFakeDurabilityHook(repoPath: string): void {
+  const hooksDir = join(repoPath, '.git', 'hooks');
+  mkdirSync(hooksDir, { recursive: true });
+  const hookPath = join(hooksDir, 'post-commit');
+  writeFileSync(hookPath, [
+    '#!/usr/bin/env bash',
+    '# gbrain brain-durability post-commit hook (v0.42.44+)',
+    'exit 0',
+    '',
+  ].join('\n'));
+  chmodSync(hookPath, 0o755);
+}
 
 describe('writeFactsToFence — happy path', () => {
   test('stub-creates entity page when none exists, writes fence, stamps DB', async () => {
@@ -178,6 +208,24 @@ describe('writeFactsToFence — happy path', () => {
     const body = readFileSync(join(brainDir, 'companies/acme.md'), 'utf-8');
     expect(body).toContain('type: company');  // type inferred from slug prefix
   });
+
+  test('commits the fence file on a durability-hardened repo without sweeping unrelated dirt', async () => {
+    initGitRepo(brainDir);
+    installFakeDurabilityHook(brainDir);
+    writeFileSync(join(brainDir, 'seed.md'), 'dirty unrelated edit\n');
+
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'people/durable' },
+      [baseInput({ fact: 'Durable fence fact' })],
+    );
+
+    expect(result.inserted).toBe(1);
+    expect(git(brainDir, 'log', '-1', '--format=%s')).toBe('gbrain: write-through people/durable');
+    expect(git(brainDir, 'log', '-1', '--name-only', '--format=')).toBe('people/durable.md');
+    expect(git(brainDir, 'status', '--porcelain', 'people/durable.md')).toBe('');
+    expect(git(brainDir, 'status', '--porcelain', 'seed.md')).not.toBe('');
+  }, 60_000);
 });
 
 describe('writeFactsToFence — legacy fallback', () => {


### PR DESCRIPTION
## Summary

- commit facts fence markdown files on durability-hardened repos using the existing exact-path write-through helper
- keep the commit best-effort and path-limited
- skip auto-commit when the target fence path was already dirty before the generated write, so human edits are not swept into a generated commit

Fixes #4243.

## Why

`writePageThrough` already commits the exact markdown artifact when a source repo is durability-hardened. `writeFactsToFence` writes the markdown fence and mirrors rows into the database, but did not trigger the same exact-path durability path. That can leave the fence file dirty while the DB has already been stamped.

This PR uses only synthetic fixtures. No production slugs, page names, local paths, timestamps, user names, or log excerpts are included.

## Validation

```bash
bun test test/fence-write.test.ts
```

Result: 17 pass, 0 fail.
