### PR TITLE
v0.46.12.4 fix(doctor): make extract_atoms backlog drain hints source-aware (#4097)

### DIFF
--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -394,6 +394,42 @@ export async function checkDbOnlyCollectorCollision(
   }
 }
 
+type ExtractAtomsBacklogCounter = (engine: BrainEngine, sourceId?: string) => Promise<number | null>;
+
+async function countExtractAtomsBacklogBySource(
+  engine: BrainEngine,
+  countBacklog: ExtractAtomsBacklogCounter,
+): Promise<Array<{ source_id: string; backlog: number }> | null> {
+  try {
+    const sources = await engine.executeRaw<{ source_id: string }>(
+      `SELECT DISTINCT source_id FROM pages WHERE deleted_at IS NULL ORDER BY source_id`,
+    );
+    const rows: Array<{ source_id: string; backlog: number }> = [];
+    for (const src of sources) {
+      const backlog = await countBacklog(engine, src.source_id);
+      if (backlog === null) return null;
+      if (backlog > 0) rows.push({ source_id: src.source_id, backlog });
+    }
+    return rows;
+  } catch {
+    return null;
+  }
+}
+
+function buildExtractAtomsBacklogFixHint(
+  bySource: Array<{ source_id: string; backlog: number }> | null,
+): string {
+  const suffix = '(or declare extract_atoms in your active schema pack)';
+  if (!bySource || bySource.length === 0) {
+    return `gbrain dream --phase extract_atoms --drain --source <source-id> --window 120 ${suffix}`;
+  }
+  if (bySource.length === 1) {
+    return `gbrain dream --phase extract_atoms --drain --source ${bySource[0]!.source_id} --window 120 ${suffix}`;
+  }
+  const sources = bySource.map((row) => row.source_id).join(', ');
+  return `gbrain dream --phase extract_atoms --drain --source ${bySource[0]!.source_id} --window 120 (repeat for backlog source(s): ${sources}; or declare extract_atoms in your active schema pack)`;
+}
+
 /**
  * issue #1678 — extract_atoms_backlog doctor check.
  *
@@ -436,11 +472,12 @@ export async function computeExtractAtomsBacklogCheck(
     // The incident: pack does NOT run the phase but a real backlog exists →
     // it will grow forever without a signal. WARN with the drain command.
     if (!declared && backlog > 10) {
-      const fix = 'gbrain dream --phase extract_atoms --drain --window 120 (or declare extract_atoms in your active schema pack)';
+      const backlogBySource = await countExtractAtomsBacklogBySource(engine, countExtractAtomsBacklog);
+      const fix = buildExtractAtomsBacklogFixHint(backlogBySource);
       return {
         name, status: 'warn',
         message: `${backlog} pages eligible for atom extraction but the active pack does not run extract_atoms — backlog growing. Fix: ${fix}`,
-        details: { backlog, pack_declares_phase: false, fix_hint: fix, known_approximation: approx },
+        details: { backlog, backlog_by_source: backlogBySource ?? undefined, pack_declares_phase: false, fix_hint: fix, known_approximation: approx },
       };
     }
 

--- a/test/doctor-extract-atoms-backlog.test.ts
+++ b/test/doctor-extract-atoms-backlog.test.ts
@@ -22,6 +22,7 @@ import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { withEnv } from './helpers/with-env.ts';
 import { countExtractAtomsBacklog } from '../src/core/cycle/extract-atoms.ts';
 import { computeExtractAtomsBacklogCheck } from '../src/commands/doctor.ts';
+import { addSource } from '../src/core/sources-ops.ts';
 
 let engine: PGLiteEngine;
 const EMPTY_HOME = mkdtempSync(join(tmpdir(), 'gbrain-xa-backlog-home-'));
@@ -42,8 +43,8 @@ beforeEach(async () => {
 
 const BODY = 'x'.repeat(600); // >= MIN_PAGE_CHARS_FOR_EXTRACTION (500)
 
-async function seedArticle(slug: string) {
-  return engine.putPage(slug, { type: 'article', title: slug, compiled_truth: BODY });
+async function seedArticle(slug: string, sourceId = 'default') {
+  return engine.putPage(slug, { type: 'article', title: slug, compiled_truth: BODY }, { sourceId });
 }
 
 describe('countExtractAtomsBacklog (issue #1678)', () => {
@@ -105,5 +106,22 @@ describe('computeExtractAtomsBacklogCheck (issue #1678)', () => {
     expect(check.message).toContain('--drain');
     expect((check.details as { pack_declares_phase: boolean }).pack_declares_phase).toBe(false);
     expect((check.details as { known_approximation: string }).known_approximation).toContain('page backlog only');
+  });
+
+  it('includes the source in the drain hint when backlog lives outside default', async () => {
+    await addSource(engine, { id: 'gbrain-raw' });
+    for (let i = 0; i < 11; i++) await seedArticle(`raw-article-${i}`, 'gbrain-raw');
+
+    expect(await countExtractAtomsBacklog(engine)).toBe(11);
+    expect(await countExtractAtomsBacklog(engine, 'default')).toBe(0);
+    expect(await countExtractAtomsBacklog(engine, 'gbrain-raw')).toBe(11);
+
+    const check = await withEnv({ GBRAIN_HOME: EMPTY_HOME }, () =>
+      computeExtractAtomsBacklogCheck(engine));
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('gbrain dream --phase extract_atoms --drain --source gbrain-raw --window 120');
+    expect((check.details as { fix_hint: string }).fix_hint).toContain('--source gbrain-raw');
+    expect((check.details as { backlog_by_source: Array<{ source_id: string; backlog: number }> }).backlog_by_source)
+      .toEqual([{ source_id: 'gbrain-raw', backlog: 11 }]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4097.

`gbrain doctor` counted `extract_atoms_backlog` across the whole brain, but its remediation hint omitted `--source`. On a DB-only brain whose backlog lives in a non-default source, the suggested drain could exit successfully while targeting empty `default` scope and clearing nothing.

This change:

- resolves backlog counts per source before rendering the warning
- includes the backlog source in the suggested `gbrain dream --phase extract_atoms --drain --source <id> --window 120` command
- keeps a fallback placeholder when source breakdown cannot be computed, instead of suggesting a silently wrong default drain
- adds a regression test for a non-default DB-only source with `default` empty

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/doctor-extract-atoms-backlog.test.ts` - 7 pass
- `GBRAIN_TEST_ALLOW_DATABASE_URL=1 bash scripts/gbrain-gate.sh <worktree> test/doctor-extract-atoms-backlog.test.ts` - RESULT: GREEN; verify green, focused unit test 7 pass, mapped E2E `test/e2e/doctor-progress.test.ts` 3 pass
