### PR TITLE
fix(consolidate): fetch pending facts in large buckets

### DIFF
--- a/src/core/cycle/phases/consolidate.ts
+++ b/src/core/cycle/phases/consolidate.ts
@@ -101,10 +101,13 @@ export async function runPhaseConsolidate(
 
     const facts = await engine.listFactsByEntity(b.source_id, b.entity_slug, {
       activeOnly: true,
+      unconsolidatedOnly: true,
       limit: 100,
     });
-    // Re-filter to unconsolidated since listFactsByEntity returns all active.
-    const unconsolidated = facts.filter(f => f.consolidated_at == null);
+    // The engine predicate matches the bucket scan. This keeps already-
+    // consolidated rows from occupying the bounded 100-row window and
+    // starving older pending facts in large entity buckets.
+    const unconsolidated = facts;
     if (unconsolidated.length < minPerBucket) {
       bucketsSkipped += 1;
       continue;

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -566,6 +566,8 @@ export interface NewFact {
 export interface FactListOpts {
   /** Hide expired_at IS NOT NULL rows. Default true. */
   activeOnly?: boolean;
+  /** Restrict to facts not yet promoted into a take. Default false. */
+  unconsolidatedOnly?: boolean;
   limit?: number;
   offset?: number;
   /** Restrict to specific kinds. Default: all kinds. */

--- a/src/core/pglite-engine/facts.ts
+++ b/src/core/pglite-engine/facts.ts
@@ -522,6 +522,9 @@ async function _listFacts(
     if (opts.activeOnly !== false) {
       whereParts.push(`expired_at IS NULL`);
     }
+    if (opts.unconsolidatedOnly === true) {
+      whereParts.push(`consolidated_at IS NULL`);
+    }
     if (opts.kinds && opts.kinds.length > 0) {
       whereParts.push(`kind = ANY($kinds)`);
       params.kinds = opts.kinds;

--- a/src/core/postgres-engine/facts.ts
+++ b/src/core/postgres-engine/facts.ts
@@ -229,6 +229,7 @@ export async function listFactsByEntity(
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -236,6 +237,7 @@ export async function listFactsByEntity(
       WHERE source_id = ${source_id}
         AND entity_slug = ${entitySlug}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY valid_from DESC, id DESC
@@ -254,6 +256,7 @@ export async function listFactsSince(
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const entitySlug = opts?.entitySlug ?? null;
@@ -263,6 +266,7 @@ export async function listFactsSince(
         AND created_at >= ${since}
         ${entitySlug ? sql`AND entity_slug = ${entitySlug}` : sql``}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC
@@ -281,6 +285,7 @@ export async function listFactsBySession(
     const limit = clampSearchLimit(opts?.limit, 50, MAX_SEARCH_LIMIT);
     const offset = Math.max(0, opts?.offset ?? 0);
     const activeOnly = opts?.activeOnly !== false;
+    const unconsolidatedOnly = opts?.unconsolidatedOnly === true;
     const kinds = (opts?.kinds && opts.kinds.length > 0) ? opts.kinds : null;
     const visibility = (opts?.visibility && opts.visibility.length > 0) ? opts.visibility : null;
     const rows = await sql<FactRowSqlShape[]>`
@@ -288,6 +293,7 @@ export async function listFactsBySession(
       WHERE source_id = ${source_id}
         AND source_session = ${sessionId}
         ${activeOnly ? sql`AND expired_at IS NULL` : sql``}
+        ${unconsolidatedOnly ? sql`AND consolidated_at IS NULL` : sql``}
         ${kinds ? sql`AND kind = ANY(${kinds}::text[])` : sql``}
         ${visibility ? sql`AND visibility = ANY(${visibility}::text[])` : sql``}
       ORDER BY created_at DESC, id DESC

--- a/test/cycle-consolidate.test.ts
+++ b/test/cycle-consolidate.test.ts
@@ -129,6 +129,38 @@ describe('runPhaseConsolidate', () => {
     }
   });
 
+  test('large bucket fetches pending facts instead of starving behind 100 consolidated rows', async () => {
+    const slug = 'people/large-bucket-example';
+    await seedPage(slug);
+    const newer = new Date(Date.now() - 30 * 60 * 60 * 1000);
+    for (let i = 0; i < 100; i++) {
+      await engine.executeRaw(
+        `INSERT INTO facts
+           (source_id, entity_slug, fact, kind, source, valid_from, embedding, embedded_at, consolidated_at)
+         VALUES ('default', $1, $2, 'fact', 'test', $3::timestamptz, $4::vector, $3::timestamptz, now())`,
+        [slug, `already consolidated ${i}`, new Date(newer.getTime() + i * 1000).toISOString(), unitVec()],
+      );
+    }
+    const older = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+    for (let i = 0; i < 3; i++) {
+      await engine.executeRaw(
+        `INSERT INTO facts
+           (source_id, entity_slug, fact, kind, source, valid_from, embedding, embedded_at)
+         VALUES ('default', $1, $2, 'fact', 'test', $3::timestamptz, $4::vector, $3::timestamptz)`,
+        [slug, `pending ${i}`, older, unitVec()],
+      );
+    }
+
+    const result = await runPhaseConsolidate(engine, {});
+
+    expect(result.details.facts_consolidated).toBe(3);
+    const pending = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM facts WHERE entity_slug = $1 AND consolidated_at IS NULL`,
+      [slug],
+    );
+    expect(Number(pending[0]?.n ?? -1)).toBe(0);
+  });
+
   test('dryRun honored: counters tick but no rows written', async () => {
     await seedPage('cons-dryrun');
     for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
## Summary

- fetch unconsolidated facts directly instead of taking the first 100 historical rows and filtering afterward
- preserve the existing per-entity batch bound
- add a regression fixture where 100 already-consolidated rows precede pending facts

Fixes #4057.

## Verification

- `bun test test/cycle-consolidate.test.ts` (6 pass)

