### PR TITLE
fix(search): demote chunkless synthetic results

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -81,6 +81,17 @@ const COMPILED_TRUTH_BOOST = 2.0;
 export function shouldBoostCompiledTruth(detail: string | null | undefined): boolean {
   return detail === 'low';
 }
+
+/** Synthetic title-arm rows have no real chunk and must not gain chunk authority. */
+function compiledTruthBoost(result: SearchResult, applyBoost: boolean): number {
+  const syntheticTitleRow = result.chunk_id === 0 && result.chunk_text.trim().length === 0;
+  return applyBoost
+    && result.chunk_source === 'compiled_truth'
+    && result.unverified !== true
+    && !syntheticTitleRow
+    ? COMPILED_TRUTH_BOOST
+    : 1.0;
+}
 const pendingCacheWrites = new Set<Promise<unknown>>();
 
 /**
@@ -2358,7 +2369,7 @@ export function rrfFusionWeighted(
       e.score = e.score / maxScore;
       // issue #160: unverified auto-extracted stubs (stamped pre-fusion by
       // stampUnverifiedExtractions) never get the compiled-truth authority boost.
-      const boost = applyBoost && e.result.chunk_source === 'compiled_truth' && e.result.unverified !== true ? COMPILED_TRUTH_BOOST : 1.0;
+      const boost = compiledTruthBoost(e.result, applyBoost);
       e.score *= boost;
     }
   }
@@ -2403,7 +2414,7 @@ export function rrfFusion(lists: SearchResult[][], k: number, applyBoost = true)
 
       // Apply compiled truth boost after normalization (skip for detail=high;
       // skip for unverified auto-extracted stubs — issue #160)
-      const boost = applyBoost && e.result.chunk_source === 'compiled_truth' && e.result.unverified !== true ? COMPILED_TRUTH_BOOST : 1.0;
+      const boost = compiledTruthBoost(e.result, applyBoost);
       e.score *= boost;
 
       if (DEBUG) {
@@ -2453,11 +2464,9 @@ async function cosineReScore(
 
   return results.map(r => {
     const chunkEmb = r.chunk_id != null ? embeddingMap.get(r.chunk_id) : undefined;
-    if (!chunkEmb) return r;
-
-    const cosine = cosineSimilarity(queryEmbedding, chunkEmb);
+    const cosine = chunkEmb ? cosineSimilarity(queryEmbedding, chunkEmb) : 0;
+    const blended = blendCosineScore(r.score, maxRrf, cosine);
     const normRrf = maxRrf > 0 ? r.score / maxRrf : 0;
-    const blended = 0.7 * normRrf + 0.3 * cosine;
 
     if (DEBUG) {
       console.error(`[search-debug] ${r.slug}:${r.chunk_id} cosine=${cosine.toFixed(4)} norm_rrf=${normRrf.toFixed(4)} blended=${blended.toFixed(4)}`);
@@ -2465,6 +2474,12 @@ async function cosineReScore(
 
     return { ...r, score: blended };
   }).sort((a, b) => b.score - a.score);
+}
+
+/** Keep every candidate on the same score scale, including chunkless rows. */
+export function blendCosineScore(rrfScore: number, maxRrf: number, cosine = 0): number {
+  const normRrf = maxRrf > 0 ? rrfScore / maxRrf : 0;
+  return 0.7 * normRrf + 0.3 * cosine;
 }
 
 export function cosineSimilarity(a: Float32Array, b: Float32Array): number {

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -7,6 +7,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   rrfFusion,
   cosineSimilarity,
+  blendCosineScore,
   applyBacklinkBoost,
   applySalienceBoost,
   applyRecencyBoost,
@@ -72,6 +73,21 @@ describe('rrfFusion', () => {
     const results = rrfFusion([list], 60);
     // Top result: normalized to 1.0, no boost (timeline = 1.0x)
     expect(results[0].score).toBe(1.0);
+  });
+
+  test('synthetic chunkless title rows do not receive compiled-truth authority boost', () => {
+    const synthetic = makeResult({
+      slug: 'title-only',
+      chunk_id: 0,
+      chunk_text: '',
+      chunk_source: 'compiled_truth',
+    });
+    const real = makeResult({ slug: 'real-page', chunk_id: 42, chunk_text: 'real content' });
+
+    const results = rrfFusion([[synthetic, real]], 60);
+
+    expect(results[0].slug).toBe('real-page');
+    expect(results.find((r) => r.slug === 'title-only')?.score).toBe(1);
   });
 
   test('returns empty for empty lists', () => {
@@ -162,6 +178,13 @@ describe('cosineSimilarity', () => {
     a[0] = 1.0;
     b[5] = 1.0;
     expect(cosineSimilarity(a, b)).toBe(0);
+  });
+});
+
+describe('blendCosineScore', () => {
+  test('puts an unembedded chunkless row on the same blended scale', () => {
+    expect(blendCosineScore(2, 2)).toBeCloseTo(0.7, 8);
+    expect(blendCosineScore(1, 2, 1)).toBeCloseTo(0.65, 8);
   });
 });
 


### PR DESCRIPTION
## Summary

- prevent chunkless synthetic title rows from receiving compiled-truth authority boost
- keep unembedded chunkless rows on the same blended score scale instead of letting a sentinel score escape
- pin both the RRF and cosine-blend regressions

Fixes #3695.

## Verification

- `bun test test/search.test.ts test/search-compiled-truth-boost-scope.test.ts` (58 pass)

