### PR TITLE
fix(doctor): fail on forward schema skew

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { resolveEnvNumber, resolveHoursEnv } from '../core/env-number.ts';
 import { hnswIndexExpected, hnswMaxDimsForType } from '../core/vector-index.ts';
 import { VERSION as GBRAIN_BINARY_VERSION } from '../version.ts';
+import { schemaVersionHealth } from '../core/schema-version-health.ts';
 // Peeled doctor modules (containment sprint): each is a verbatim move out of
 // this file. doctor.ts re-exports every moved public symbol under its
 // original name so existing importers (tests, scripts/live-brain-first-check.ts,
@@ -1874,22 +1875,7 @@ export async function buildChecks(
   try {
     const version = await engine.getConfig('version');
     schemaVersion = parseInt(version || '0', 10);
-    if (schemaVersion >= LATEST_VERSION) {
-      checks.push({ name: 'schema_version', status: 'ok', message: `Version ${schemaVersion} (latest: ${LATEST_VERSION})` });
-    } else if (schemaVersion === 0) {
-      checks.push({
-        name: 'schema_version',
-        status: 'fail',
-        message: `No schema version recorded. Migrations never ran. Fix: gbrain apply-migrations --yes. ` +
-                 `If you installed via 'bun install -g github:...', see https://github.com/garrytan/gbrain/issues/218.`,
-      });
-    } else {
-      checks.push({
-        name: 'schema_version',
-        status: 'warn',
-        message: `Version ${schemaVersion}, latest is ${LATEST_VERSION}. Fix: gbrain apply-migrations --yes`,
-      });
-    }
+    checks.push({ name: 'schema_version', ...schemaVersionHealth(schemaVersion, LATEST_VERSION) });
   } catch {
     checks.push({ name: 'schema_version', status: 'warn', message: 'Could not check schema version' });
   }

--- a/src/commands/doctor/report-remote.ts
+++ b/src/commands/doctor/report-remote.ts
@@ -15,6 +15,7 @@ import { loadConfig } from '../../core/config.ts';
 import { loadCompletedMigrations } from '../../core/preferences.ts';
 import { compareVersions } from '../migrations/index.ts';
 import { resolveHoursEnv } from '../../core/env-number.ts';
+import { schemaVersionHealth } from '../../core/schema-version-health.ts';
 import {
   type Check,
   type DoctorReport,
@@ -107,21 +108,10 @@ export async function doctorReportRemote(
   try {
     const versionStr = await engine.getConfig('version');
     const version = parseInt(versionStr || '0', 10);
-    if (version >= LATEST_VERSION) {
-      checks.push({ name: 'schema_version', status: 'ok', message: `Version ${version} (latest: ${LATEST_VERSION})` });
-    } else if (version === 0) {
-      checks.push({
-        name: 'schema_version',
-        status: 'fail',
-        message: `No schema version recorded. Migrations never ran. Run \`gbrain apply-migrations --yes\` on the host.`,
-      });
-    } else {
-      checks.push({
-        name: 'schema_version',
-        status: 'warn',
-        message: `Version ${version}, latest is ${LATEST_VERSION}. Run \`gbrain apply-migrations --yes\` on the host.`,
-      });
-    }
+    checks.push({
+      name: 'schema_version',
+      ...schemaVersionHealth(version, LATEST_VERSION, { remote: true }),
+    });
   } catch {
     checks.push({ name: 'schema_version', status: 'warn', message: 'Could not check schema version' });
   }

--- a/src/core/schema-version-health.ts
+++ b/src/core/schema-version-health.ts
@@ -1,0 +1,43 @@
+export interface SchemaVersionHealth {
+  status: 'ok' | 'warn' | 'fail';
+  message: string;
+}
+
+/** Compare the database schema with the schema understood by this client. */
+export function schemaVersionHealth(
+  version: number,
+  latestVersion: number,
+  opts: { remote?: boolean } = {},
+): SchemaVersionHealth {
+  const migrationFix = opts.remote
+    ? 'Run `gbrain apply-migrations --yes` on the host.'
+    : 'Fix: gbrain apply-migrations --yes';
+
+  if (version === latestVersion) {
+    return { status: 'ok', message: `Version ${version} (latest: ${latestVersion})` };
+  }
+
+  if (version === 0) {
+    return {
+      status: 'fail',
+      message: opts.remote
+        ? `No schema version recorded. Migrations never ran. ${migrationFix}`
+        : `No schema version recorded. Migrations never ran. ${migrationFix}. ` +
+          `If you installed via 'bun install -g github:...', see https://github.com/garrytan/gbrain/issues/218.`,
+    };
+  }
+
+  if (version > latestVersion) {
+    return {
+      status: 'fail',
+      message:
+        `Database schema version ${version} is newer than this client's latest ${latestVersion}. ` +
+        'Upgrade gbrain before performing writes; do not run migrations with this client.',
+    };
+  }
+
+  return {
+    status: 'warn',
+    message: `Version ${version}, latest is ${latestVersion}. ${migrationFix}`,
+  };
+}

--- a/test/schema-version-health.test.ts
+++ b/test/schema-version-health.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { schemaVersionHealth } from '../src/core/schema-version-health.ts';
+
+describe('schemaVersionHealth', () => {
+  test('accepts only an exact schema match', () => {
+    expect(schemaVersionHealth(130, 130)).toEqual({
+      status: 'ok',
+      message: 'Version 130 (latest: 130)',
+    });
+  });
+
+  test('flags a database newer than the client as unsafe', () => {
+    expect(schemaVersionHealth(130, 125)).toEqual({
+      status: 'fail',
+      message:
+        "Database schema version 130 is newer than this client's latest 125. " +
+        'Upgrade gbrain before performing writes; do not run migrations with this client.',
+    });
+  });
+
+  test('retains the existing missing and behind guidance', () => {
+    expect(schemaVersionHealth(0, 130).status).toBe('fail');
+    expect(schemaVersionHealth(125, 130)).toEqual({
+      status: 'warn',
+      message: 'Version 125, latest is 130. Fix: gbrain apply-migrations --yes',
+    });
+    expect(schemaVersionHealth(125, 130, { remote: true })).toEqual({
+      status: 'warn',
+      message: 'Version 125, latest is 130. Run `gbrain apply-migrations --yes` on the host.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- centralize schema-version health classification
- treat a database schema newer than the client as an unsafe failure rather than healthy
- retain the existing missing-schema and pending-migration guidance

Fixes #2036.

## Verification

- `bun test test/schema-version-health.test.ts` (3 pass)

