### PR TITLE
fix(facts): fence writes and forget resolve the page's real file via shared write-through target resolution (#4204)

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -508,9 +508,11 @@ async function runPipelineWithBody(
       // would write rows to a DB index whose fence is broken.
       continue;
     }
-    if (result.stubGuardBlocked) {
+    if (result.stubGuardBlocked || result.targetUnresolvable) {
       // v0.34.5: writeFactsToFence refused to spawn a phantom
       // unprefixed entity page (e.g. `jared.md` at brain root).
+      // #4204: or the shared page-target resolver found the source
+      // tree unusable (deleted dir / hostile source_path row).
       // Route these facts to the legacy DB-only path so they
       // aren't dropped — the slug stays attached but no markdown
       // file is created.
@@ -526,7 +528,7 @@ async function runPipelineWithBody(
           confidence: f.confidence,
           embedding: f.embedding ?? null,
         };
-        const legacyResult = await ctx.engine.insertFact(newFact, { source_id: ctx.sourceId }); // gbrain-allow-direct-insert: stub-guard fallback for unprefixed entity slugs (no fenceable page)
+        const legacyResult = await ctx.engine.insertFact(newFact, { source_id: ctx.sourceId }); // gbrain-allow-direct-insert: stub-guard / unresolvable-target fallback (no fenceable page or usable tree)
         fact_ids.push(legacyResult.id);
         if (legacyResult.status === 'inserted') inserted += 1;
         else if ((legacyResult.status as FactInsertStatus) === 'duplicate') duplicate += 1;

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -37,7 +37,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, appendF
 import { dirname } from 'node:path';
 
 import type { BrainEngine, NewFact, FactVisibility } from '../engine.ts';
-import { resolvePageFilePath } from '../markdown.ts';
+import { resolvePageWriteTarget } from '../write-through.ts';
 import { withPageLock } from '../page-lock.ts';
 import { gbrainPath } from '../config.ts';
 import { upsertFactRow, parseFactsFence } from '../facts-fence.ts';
@@ -94,6 +94,16 @@ export interface FenceWriteResult {
    * fell through resolution and produced a top-level `jared.md` stub.
    */
   stubGuardBlocked?: true;
+  /**
+   * True when the shared page-target resolver could not produce a usable
+   * fence file path (source tree missing / not a directory, or a hostile
+   * recorded `source_path` escaping the tree). Rows were NOT inserted; the
+   * caller is expected to route the facts to the legacy DB-only path so
+   * they aren't silently dropped. Unlike the old blind `mkdir -p`, we do
+   * NOT resurrect a deleted source tree just to hold a fence — the same
+   * refusal writePageThrough applies (#2018 `repo_not_found`).
+   */
+  targetUnresolvable?: true;
 }
 
 const FAILURE_LOG_PATH = (): string => gbrainPath('facts.write_failures.jsonl');
@@ -173,12 +183,26 @@ export async function writeFactsToFence(
     return { inserted: 0, ids: [] };
   }
 
-  // Local patch 2026-06-11: route through resolvePageFilePath so non-default
-  // sources fence into `<local_path>/.sources/<id>/<slug>.md` — the same path
-  // the put_page write-through and dream-cycle reverse-render compute. The
-  // bare join wrote main-source fences to the repo ROOT (the default source's
-  // tree), polluting ~/brain with stray root-level fence files.
-  const filePath = resolvePageFilePath(target.localPath, target.slug, target.sourceId);
+  // #4204: compute the SAME path writePageThrough computes for this
+  // (source, slug) — the fence appends to the page's file, so the two writers
+  // must agree. The previous resolvePageFilePath routing nested any
+  // non-default source under `<local_path>/.sources/<id>/` — but every
+  // non-default source that reaches this line has its OWN `local_path`
+  // (callers fall back to the legacy DB-only path when `sources.local_path`
+  // is NULL), and write-through/scanOneSource put that topology's pages at
+  // the tree ROOT. Sync's walker skips dot-directories, so a `.sources/`
+  // fence was invisible to sync and the next extract_facts reconcile deleted
+  // the fence-owned DB rows. The shared resolver also prefers the page's
+  // recorded `source_path`, so the fence lands in the file of record instead
+  // of minting a slug-derived twin beside a human-named vault file.
+  const resolved = await resolvePageWriteTarget(engine, target.slug, target.sourceId);
+  if (!resolved.ok) {
+    // Target tree unusable (deleted dir, hostile source_path row, …) — the
+    // caller routes the facts to the legacy DB-only path so they are
+    // recorded, not dropped.
+    return { inserted: 0, ids: [], targetUnresolvable: true };
+  }
+  const filePath = resolved.filePath;
   const tmpPath = `${filePath}.tmp`;
 
   return withPageLock(

--- a/src/core/facts/forget.ts
+++ b/src/core/facts/forget.ts
@@ -33,10 +33,10 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs';
-import { join } from 'node:path';
 
 import type { BrainEngine } from '../engine.ts';
 import { withPageLock } from '../page-lock.ts';
+import { resolvePageWriteTarget } from '../write-through.ts';
 import { parseFactsFence, renderFactsTable, type ParsedFact } from '../facts-fence.ts';
 
 export interface ForgetFactResult {
@@ -155,7 +155,17 @@ export async function forgetFactInFence(
 
   const slug = row.source_markdown_slug!;
   const targetRowNum = row.row_num!;
-  const filePath = join(localPath, `${slug}.md`);
+  // #4204: resolve the fence file the same way writeFactsToFence /
+  // writePageThrough do (recorded source_path preference, own-local_path
+  // root). A bare `join(localPath, slug.md)` misses fences that live in a
+  // human-named vault file, degrading forget to a DB-only expire while the
+  // fence keeps the live row for the next absorb to resurrect.
+  const resolved = await resolvePageWriteTarget(engine, slug, row.source_id);
+  if (!resolved.ok) {
+    const ok = await engine.expireFact(factId); // gbrain-allow-direct-insert: legacy fallback path inside forgetFactInFence — fence rewrite not possible (pre-v51 row / missing local_path / file deleted / row_num drift)
+    return { ok, path: 'legacy_db', reason };
+  }
+  const filePath = resolved.filePath;
   const tmpPath = `${filePath}.tmp`;
 
   if (!existsSync(filePath)) {

--- a/src/core/facts/write-single.ts
+++ b/src/core/facts/write-single.ts
@@ -164,7 +164,7 @@ export async function writeSingleFact(
         `facts fence write failed for ${resolvedSlug} — .tmp quarantined; see the facts write-failure JSONL log`,
       );
     }
-    if (!result.stubGuardBlocked && !result.legacyFallback) {
+    if (!result.stubGuardBlocked && !result.legacyFallback && !result.targetUnresolvable) {
       const newId = result.ids[0];
       if (supersedeId !== null && newId !== undefined) {
         await expireSuperseded(engine, supersedeId, newId);

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -145,6 +145,111 @@ function recordedPathFromFileUri(sourceUri: string | null | undefined, pageRoot:
   return rel;
 }
 
+/** Resolved disk target for a page's canonical markdown artifact. */
+export type PageWriteTarget =
+  | { ok: true; filePath: string; writeRoot: string }
+  | { ok: false; skipped: 'no_repo_configured' | 'repo_not_found' | 'source_repo_belongs_to_other_source' | 'path_escapes_source_root' };
+
+/**
+ * Compute the ONE file a (source, slug) pair lives in on disk.
+ *
+ * #2018: pick the disk target so a page is NEVER written into a different
+ * source's working tree. Two legitimate topologies, plus the leak guard:
+ *   1. The assigned source has its OWN `local_path` (a separate working
+ *      tree) → write at that tree's root (matches how `scanOneSource` reads
+ *      it back; never nested under `.sources/`).
+ *   2. No per-source `local_path` → nest under the host repo
+ *      (`sync.repo_path`): default at the root, non-default under
+ *      `.sources/<id>/` (the established multi-source layout).
+ *   3. LEAK GUARD: if `sync.repo_path` is literally ANOTHER source's own
+ *      `local_path`, nesting this page there would pollute that sibling's
+ *      git repo (the reported bug). Skip instead.
+ *
+ * Prefer the page's recorded `source_path` — the ACTUAL file this row was
+ * imported from — over a slug-derived name. Deriving `<slug>.md` mints a
+ * SECOND file beside the original whenever the on-disk name isn't the slug,
+ * which is the common case for a human-authored vault: `Library/People/
+ * Steve Jobs.md` has slug `library/people/steve-jobs`, so a later put_page
+ * dropped a lowercase `steve-jobs.md` twin next to it. Two artifacts, one
+ * row, and the newer content in whichever the caller didn't expect.
+ *
+ * It also desyncs `gbrain sync`, which keys delete-reconcile on
+ * `source_path` (see collectMissingSourcePaths): the twin is invisible to
+ * reconcile, so deleting the ORIGINAL file deletes the page even though a
+ * file for it is still on disk.
+ *
+ * A NULL `source_path` means the page was born via put/capture and has no
+ * file of record yet — the slug-derived path stays correct for those.
+ *
+ * Shared by `writePageThrough` AND the facts fence writer (#4204): the fence
+ * appends to the page's file, so both writers MUST compute the identical
+ * path or the fence lands in a file sync never reads back and the next
+ * extract_facts reconcile deletes the fence-owned DB rows.
+ */
+export async function resolvePageWriteTarget(
+  engine: BrainEngine,
+  slug: string,
+  sourceId: string,
+): Promise<PageWriteTarget> {
+  let filePath: string;
+  let writeRoot: string;
+  const srcRows = await engine.executeRaw<{ local_path: string | null }>(
+    `SELECT local_path FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  const sourceLocalPath = srcRows[0]?.local_path ?? null;
+
+  const pathRows = await engine.executeRaw<{ source_path: string | null; source_uri: string | null }>(
+    `SELECT source_path, source_uri FROM pages WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL LIMIT 1`,
+    [sourceId, slug],
+  );
+  const recordedPath = sanitizeRecordedSourcePath(pathRows[0]?.source_path);
+  const recordedUri = pathRows[0]?.source_uri ?? null;
+
+  if (sourceLocalPath) {
+    if (!existsSync(sourceLocalPath) || !statSync(sourceLocalPath).isDirectory()) {
+      return { ok: false, skipped: 'repo_not_found' };
+    }
+    filePath = join(
+      sourceLocalPath,
+      recordedPath ?? recordedPathFromFileUri(recordedUri, sourceLocalPath) ?? `${slug}.md`,
+    );
+    writeRoot = sourceLocalPath;
+  } else {
+    const repoPath = await engine.getConfig('sync.repo_path');
+    if (!repoPath) {
+      return { ok: false, skipped: 'no_repo_configured' };
+    }
+    if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
+      return { ok: false, skipped: 'repo_not_found' };
+    }
+    // Leak guard: refuse to write into a path that is some OTHER source's
+    // own working tree (#2018).
+    const collide = await engine.executeRaw<{ one: number }>(
+      `SELECT 1 AS one FROM sources WHERE id <> $1 AND local_path = $2 LIMIT 1`,
+      [sourceId, repoPath],
+    );
+    if (collide.length > 0) {
+      return { ok: false, skipped: 'source_repo_belongs_to_other_source' };
+    }
+    const pageRoot = sourceId === 'default' ? repoPath : join(repoPath, '.sources', sourceId);
+    const knownPath = recordedPath ?? recordedPathFromFileUri(recordedUri, pageRoot);
+    filePath = knownPath ? join(pageRoot, knownPath) : resolvePageFilePath(repoPath, slug, sourceId);
+    writeRoot = repoPath;
+  }
+
+  // Defense-in-depth (#1647-slug / codex #6): confirm the computed file path
+  // stays within the source's working tree before any mkdir/write. validateSlug
+  // already rejects `..`/backslash/control/%2e in the slug at write time, so
+  // this guards a pre-existing hostile row or a symlinked intermediate dir
+  // under the source tree from escaping to an arbitrary filesystem location.
+  if (!isWriteTargetContained(filePath, writeRoot)) {
+    return { ok: false, skipped: 'path_escapes_source_root' };
+  }
+
+  return { ok: true, filePath, writeRoot };
+}
+
 /**
  * Render the DB row for `slug` to markdown and atomically write it under
  * `sync.repo_path`. Never throws — failures are reported via the result's
@@ -158,87 +263,11 @@ export async function writePageThrough(
 ): Promise<WriteThroughResult> {
   const sourceId = opts.sourceId ?? 'default';
   try {
-    // #2018: pick the disk target so a page is NEVER written into a different
-    // source's working tree. Two legitimate topologies, plus the leak guard:
-    //   1. The assigned source has its OWN `local_path` (a separate working
-    //      tree) → write at that tree's root (matches how `scanOneSource` reads
-    //      it back; never nested under `.sources/`).
-    //   2. No per-source `local_path` → nest under the host repo
-    //      (`sync.repo_path`): default at the root, non-default under
-    //      `.sources/<id>/` (the established multi-source layout).
-    //   3. LEAK GUARD: if `sync.repo_path` is literally ANOTHER source's own
-    //      `local_path`, nesting this page there would pollute that sibling's
-    //      git repo (the reported bug). Skip instead.
-    let filePath: string;
-    let writeRoot: string;
-    const srcRows = await engine.executeRaw<{ local_path: string | null }>(
-      `SELECT local_path FROM sources WHERE id = $1`,
-      [sourceId],
-    );
-    const sourceLocalPath = srcRows[0]?.local_path ?? null;
-
-    // Prefer the page's recorded `source_path` — the ACTUAL file this row was
-    // imported from — over a slug-derived name. Deriving `<slug>.md` mints a
-    // SECOND file beside the original whenever the on-disk name isn't the slug,
-    // which is the common case for a human-authored vault: `Library/People/
-    // Steve Jobs.md` has slug `library/people/steve-jobs`, so a later put_page
-    // dropped a lowercase `steve-jobs.md` twin next to it. Two artifacts, one
-    // row, and the newer content in whichever the caller didn't expect.
-    //
-    // It also desyncs `gbrain sync`, which keys delete-reconcile on
-    // `source_path` (see collectMissingSourcePaths): the twin is invisible to
-    // reconcile, so deleting the ORIGINAL file deletes the page even though a
-    // file for it is still on disk.
-    //
-    // A NULL `source_path` means the page was born via put/capture and has no
-    // file of record yet — the slug-derived path stays correct for those.
-    const pathRows = await engine.executeRaw<{ source_path: string | null; source_uri: string | null }>(
-      `SELECT source_path, source_uri FROM pages WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL LIMIT 1`,
-      [sourceId, slug],
-    );
-    const recordedPath = sanitizeRecordedSourcePath(pathRows[0]?.source_path);
-    const recordedUri = pathRows[0]?.source_uri ?? null;
-
-    if (sourceLocalPath) {
-      if (!existsSync(sourceLocalPath) || !statSync(sourceLocalPath).isDirectory()) {
-        return { written: false, skipped: 'repo_not_found' };
-      }
-      filePath = join(
-        sourceLocalPath,
-        recordedPath ?? recordedPathFromFileUri(recordedUri, sourceLocalPath) ?? `${slug}.md`,
-      );
-      writeRoot = sourceLocalPath;
-    } else {
-      const repoPath = await engine.getConfig('sync.repo_path');
-      if (!repoPath) {
-        return { written: false, skipped: 'no_repo_configured' };
-      }
-      if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
-        return { written: false, skipped: 'repo_not_found' };
-      }
-      // Leak guard: refuse to write into a path that is some OTHER source's
-      // own working tree (#2018).
-      const collide = await engine.executeRaw<{ one: number }>(
-        `SELECT 1 AS one FROM sources WHERE id <> $1 AND local_path = $2 LIMIT 1`,
-        [sourceId, repoPath],
-      );
-      if (collide.length > 0) {
-        return { written: false, skipped: 'source_repo_belongs_to_other_source' };
-      }
-      const pageRoot = sourceId === 'default' ? repoPath : join(repoPath, '.sources', sourceId);
-      const knownPath = recordedPath ?? recordedPathFromFileUri(recordedUri, pageRoot);
-      filePath = knownPath ? join(pageRoot, knownPath) : resolvePageFilePath(repoPath, slug, sourceId);
-      writeRoot = repoPath;
+    const target = await resolvePageWriteTarget(engine, slug, sourceId);
+    if (!target.ok) {
+      return { written: false, skipped: target.skipped };
     }
-
-    // Defense-in-depth (#1647-slug / codex #6): confirm the computed file path
-    // stays within the source's working tree before any mkdir/write. validateSlug
-    // already rejects `..`/backslash/control/%2e in the slug at write time, so
-    // this guards a pre-existing hostile row or a symlinked intermediate dir
-    // under the source tree from escaping to an arbitrary filesystem location.
-    if (!isWriteTargetContained(filePath, writeRoot)) {
-      return { written: false, skipped: 'path_escapes_source_root' };
-    }
+    const { filePath, writeRoot } = target;
 
     const writtenPage = await engine.getPage(slug, { sourceId });
     if (!writtenPage) {

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { writeFactsToFence, lookupSourceLocalPath } from '../src/core/facts/fence-write.ts';
+import { forgetFactInFence } from '../src/core/facts/forget.ts';
 import type { FenceInputFact } from '../src/core/facts/fence-write.ts';
 
 let engine: PGLiteEngine;
@@ -360,6 +361,100 @@ describe('writeFactsToFence — row_num survives a fence-less rewrite', () => {
     );
     expect(result.inserted).toBe(1);
     expect(result.fenceWriteFailed).toBeUndefined();
+  });
+});
+
+describe('writeFactsToFence — path matches writePageThrough (#4204)', () => {
+  test('non-default source with its own local_path fences at the tree ROOT, not .sources/<id>/', async () => {
+    const projDir = mkdtempSync(join(tmpdir(), 'fence-write-proj-'));
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `INSERT INTO sources (id, name, local_path) VALUES ('proj', 'proj-test', $1)
+         ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+        [projDir],
+      );
+
+      const result = await writeFactsToFence(
+        engine,
+        { sourceId: 'proj', localPath: projDir, slug: 'people/alice' },
+        [baseInput()],
+      );
+
+      expect(result.inserted).toBe(1);
+      // writePageThrough (#2018) writes a source that has its OWN local_path at
+      // that tree's root, never nested under `.sources/` — and sync's walker
+      // skips dot-directories, so a `.sources/` fence would be invisible to
+      // sync and its DB rows wiped by the next extract_facts reconcile.
+      expect(existsSync(join(projDir, 'people/alice.md'))).toBe(true);
+      expect(existsSync(join(projDir, '.sources/proj/people/alice.md'))).toBe(false);
+    } finally {
+      rmSync(projDir, { recursive: true, force: true });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`DELETE FROM facts WHERE source_id = 'proj'`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`DELETE FROM pages WHERE source_id = 'proj'`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`DELETE FROM sources WHERE id = 'proj'`);
+    }
+  });
+
+  test('fence appends into the page\'s recorded source_path file, not a slug-derived twin', async () => {
+    // A human-authored vault file whose on-disk name is not the slug.
+    const recordedRel = 'People/Alice Smith.md';
+    const recordedAbs = join(brainDir, recordedRel);
+    mkdirSync(join(brainDir, 'People'), { recursive: true });
+    writeFileSync(
+      recordedAbs,
+      '---\ntype: person\ntitle: Alice Smith\nslug: people/alice-smith\n---\n\n# Alice Smith\n',
+      'utf-8',
+    );
+    await engine.putPage('people/alice-smith', {
+      type: 'person',
+      title: 'Alice Smith',
+      compiled_truth: '# Alice Smith',
+      source_path: recordedRel,
+    }, { sourceId: 'default' });
+
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'people/alice-smith' },
+      [baseInput()],
+    );
+
+    expect(result.inserted).toBe(1);
+    // The fence must land in the file of record (same preference
+    // writePageThrough applies), or sync round-trips two divergent files.
+    expect(readFileSync(recordedAbs, 'utf-8')).toContain('Founded Acme in 2017');
+    expect(existsSync(join(brainDir, 'people/alice-smith.md'))).toBe(false);
+
+    // Round-trip: forget must find the fence in the SAME file the write
+    // targeted, or it degrades to a DB-only expire and leaves a live fence
+    // row for the next absorb to resurrect.
+    const forgot = await forgetFactInFence(engine, result.ids[0], { reason: 'test' });
+    expect(forgot.ok).toBe(true);
+    expect(forgot.path).toBe('fence');
+    expect(readFileSync(recordedAbs, 'utf-8')).toContain('~~');
+  });
+
+  test('unusable source tree returns targetUnresolvable so callers route to DB-only, not drop', async () => {
+    // Point the source at a directory that no longer exists — the resolver
+    // must refuse (same repo_not_found refusal as writePageThrough) instead
+    // of blindly resurrecting the deleted tree with mkdir -p.
+    const goneDir = mkdtempSync(join(tmpdir(), 'fence-write-gone-'));
+    rmSync(goneDir, { recursive: true, force: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [goneDir]);
+
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: goneDir, slug: 'people/erin' },
+      [baseInput()],
+    );
+
+    expect(result.inserted).toBe(0);
+    expect(result.targetUnresolvable).toBe(true);
+    expect(existsSync(goneDir)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Root cause

`writeFactsToFence` and `writePageThrough` compute different files for the same (source, slug).

- `writePageThrough` (src/core/write-through.ts, the #2018 comment) writes a source that has its own `local_path` at that tree's **root**, preferring the page's recorded `pages.source_path` — "never nested under `.sources/`".
- `writeFactsToFence` (src/core/facts/fence-write.ts:181) routed through `resolvePageFilePath` (src/core/markdown.ts:804), which maps any non-default source to `<local_path>/.sources/<id>/<slug>.md`.

The `.sources/` arm is never right at this call site: both callers (src/core/facts/backstop.ts:437, src/core/facts/write-single.ts:136) fall back to the legacy DB-only path when `sources.local_path` is NULL, so every non-default source that reaches the fence write owns its tree — the topology write-through fences at the root.

Why it compounds into data loss:
1. Sync prunes dot-directories (`pruneDir`, src/core/sync.ts:365-367), so the `.sources/` fence file is invisible to sync and never reaches `pages.compiled_truth`.
2. The extract_facts cycle parses the fence from the DB body; finding none, it calls `engine.deleteFactsForPage` (src/core/cycle/extract-facts.ts:387-403) and wipes the rows the fence write just inserted.

## Fix

Extract `writePageThrough`'s target resolution into a shared exported helper, `resolvePageWriteTarget(engine, slug, sourceId)` (src/core/write-through.ts), and use it from the fence writer — so the fence always lands in the exact file the page lives in. This also carries over the recorded-`source_path` preference: a fence for a page imported from `People/Alice Smith.md` appends there instead of minting a slug-derived `people/alice-smith.md` twin, and the containment guard (`isWriteTargetContained`) now covers fence writes too.

Two consequences handled explicitly:

- `forgetFactInFence` (src/core/facts/forget.ts) resolved the fence as `join(localPath, slug + '.md')`. With fences in recorded-path files, that would miss the fence, degrade to a DB-only expire, and leave a live fence row for the next absorb to resurrect the forgotten fact. It now uses the same shared resolver. (This also fixes the pre-existing miss for `.sources/`-nested fences — forget never found those either.)
- When the resolver refuses (source tree deleted, hostile `source_path` row escaping the tree), the fence writer returns a new `targetUnresolvable` flag and both callers route the facts to the legacy DB-only insert — recorded, not dropped, and no `mkdir -p` resurrection of a deleted tree (matching write-through's `repo_not_found` refusal).

No engine methods, schema, or migrations touched. `resolvePageFilePath` itself is unchanged (still correct for the host-repo topology and its other callers).

## Proof

New tests in test/fence-write.test.ts, red on master, green with the fix:

```
# master
(fail) writeFactsToFence — path matches writePageThrough (#4204) > non-default source with its own
       local_path fences at the tree ROOT, not .sources/<id>/
(fail) writeFactsToFence — path matches writePageThrough (#4204) > fence appends into the page's
       recorded source_path file, not a slug-derived twin
 16 pass  2 fail

# with fix (fence-write + privacy-strip-and-forget + facts-backstop* + write-through* suites)
 74 pass  0 fail
```

Full unit suite (`bun run test`): 19,860 pass / 4 fail — the same 4 fail on unmodified master in this environment (git-exclude walker parity x2, reflex event logging x2; verified by rerunning those files with this diff stashed). `bun run verify`: 54 checks green. `bun run typecheck`: clean.

## Limits

- Existing brains already holding stray `.sources/<id>/*.md` fence files are not migrated; new fence writes go to the correct file, and `row_num` seeding from the DB (fence-write.ts) means re-fencing at the right path can't collide. A doctor surface for orphaned fence files would be a separate change.
- `resolveTakesFilePath` (src/core/takes-write.ts) still ignores `pages.source_path` — same bug class, left out to keep this diff reviewable.

Refs: #4204

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
