### PR TITLE
fix(facts): record-only budget tracker at the pipeline choke point — extract_facts spend reaches the audit (#4210)

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -348,6 +348,29 @@ async function runPipelineWithBody(
   ctx: FactsBackstopCtx,
   abortSignal?: AbortSignal,
 ): Promise<{ inserted: number; duplicate: number; superseded: number; fact_ids: number[]; entity_slugs: string[] }> {
+  // #4210: outside a withBudgetTracker scope (extract_facts op, sweep,
+  // put_page backstop, checkpoint harvest, file/code import) the gateway's
+  // chat/embed calls were budget no-ops — real spend, zero audit rows.
+  // Install a record-only fallback tracker labeled by the entry point so
+  // every pipeline invocation is visible to accounting. Uncapped, so it can
+  // never throw BudgetExhausted (cost/runtime gates need a cap); the
+  // pipeline's failure surface is unchanged. An ambient tracker (cycle
+  // phases, transcripts ingest) wins — no double scope, labels preserved.
+  const { getCurrentBudgetTracker, withBudgetTracker } = await import('../ai/gateway.ts');
+  if (!getCurrentBudgetTracker()) {
+    const { BudgetTracker } = await import('../budget/budget-tracker.ts');
+    const fallback = new BudgetTracker({ label: `facts:${ctx.source}` });
+    return withBudgetTracker(fallback, () => runPipelineBodyInner(input, ctx, abortSignal));
+  }
+  return runPipelineBodyInner(input, ctx, abortSignal);
+}
+
+/** The actual pipeline body — always runs inside a BudgetTracker scope (#4210). */
+async function runPipelineBodyInner(
+  input: { turnText: string; isDreamGenerated: boolean },
+  ctx: FactsBackstopCtx,
+  abortSignal?: AbortSignal,
+): Promise<{ inserted: number; duplicate: number; superseded: number; fact_ids: number[]; entity_slugs: string[] }> {
   const { extractFactsFromTurn } = await import('./extract.ts');
   const { resolveEntitySlug } = await import('../entities/resolve.ts');
   const { cosineSimilarity } = await import('./classify.ts');

--- a/test/facts-pipeline-budget-accounting.test.ts
+++ b/test/facts-pipeline-budget-accounting.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #4210 — extract_facts op (and every other runFactsPipeline entry point
+ * outside a cycle) ran with no ambient BudgetTracker, so the Haiku
+ * extraction spend was a budget no-op: real money spent, zero rows in the
+ * budget audit.
+ *
+ * Pins the fix's contract at the pipeline choke point (backstop.ts):
+ *   - With NO ambient tracker, the pipeline installs a record-only
+ *     fallback tracker labeled `facts:<ctx.source>` — the chat spend lands
+ *     in the budget audit JSONL.
+ *   - With an ambient tracker (the cycle case), the fallback does NOT
+ *     engage: rows keep the ambient label and are recorded exactly once.
+ *   - The fallback is uncapped, so it can never throw BudgetExhausted —
+ *     the pipeline's failure surface is unchanged.
+ *
+ * Hermetic: PGLite engine + __setChatTransportForTests (which keeps
+ * chat()'s real reserve/record wiring active) + GBRAIN_AUDIT_DIR pointed
+ * at a temp dir. Env-mutating → serial-safe file (no test.concurrent).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withEnv } from './helpers/with-env.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runFactsPipeline } from '../src/core/facts/backstop.ts';
+import { operations } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/ops/contract.ts';
+import {
+  __setChatTransportForTests,
+  resetGateway,
+  withBudgetTracker,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
+import { BudgetTracker } from '../src/core/budget/budget-tracker.ts';
+
+let engine: PGLiteEngine;
+let auditDir: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+}, 60_000);
+
+beforeEach(() => {
+  auditDir = mkdtempSync(join(tmpdir(), 'gbrain-facts-budget-'));
+});
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+  resetGateway();
+  rmSync(auditDir, { recursive: true, force: true });
+});
+
+/** Stub the extractor's chat call. Priced model id → real cost math runs. */
+function chatStub(): void {
+  __setChatTransportForTests(async (): Promise<ChatResult> => ({
+    text: JSON.stringify({
+      facts: [
+        { fact: 'budget-accounting-probe fact', kind: 'fact', entity: null, confidence: 1.0, notability: 'medium' },
+      ],
+    }),
+    blocks: [],
+    stopReason: 'end',
+    usage: { input_tokens: 321, output_tokens: 45, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'anthropic:claude-haiku-4-5-20251001',
+    providerId: 'anthropic',
+  }));
+}
+
+/** Every parsed row from every budget-*.jsonl in the temp audit dir. */
+function readAuditRows(): any[] {
+  const rows: any[] = [];
+  for (const f of readdirSync(auditDir)) {
+    if (!f.startsWith('budget')) continue;
+    for (const line of readFileSync(join(auditDir, f), 'utf-8').split('\n')) {
+      if (line.trim()) rows.push(JSON.parse(line));
+    }
+  }
+  return rows;
+}
+
+describe('facts pipeline budget accounting (#4210)', () => {
+  test('runFactsPipeline with no ambient tracker records chat spend in the budget audit', async () => {
+    chatStub();
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      const r = await runFactsPipeline('a turn worth extracting', {
+        engine,
+        sourceId: 'default',
+        sessionId: null,
+        source: 'mcp:extract_facts',
+      });
+      expect(r.inserted).toBe(1);
+    });
+
+    const records = readAuditRows().filter(r => r.event === 'record');
+    // The core of #4210: pre-fix this is [] — the Haiku call happened,
+    // the money was spent, and no audit row exists anywhere.
+    expect(records.length).toBe(1);
+    expect(records[0].label).toBe('facts:mcp:extract_facts');
+    expect(records[0].sub_label).toBe('gateway.chat');
+    expect(records[0].model).toBe('anthropic:claude-haiku-4-5-20251001');
+    expect(records[0].input_tokens).toBe(321);
+    expect(records[0].output_tokens).toBe(45);
+    expect(records[0].actual_cost_usd).toBeGreaterThan(0);
+  });
+
+  test('extract_facts op handler end-to-end: spend is audited, response envelope unchanged', async () => {
+    chatStub();
+    const op = operations.find(o => o.name === 'extract_facts')!;
+    const ctx = {
+      engine,
+      config: {},
+      logger: console,
+      dryRun: false,
+      remote: true,
+    } as unknown as OperationContext;
+
+    let result: any;
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      result = await op.handler(ctx, { turn_text: 'another turn worth extracting' });
+    });
+
+    // Response contract untouched by the fix.
+    expect(typeof result.inserted).toBe('number');
+    expect(Array.isArray(result.fact_ids)).toBe(true);
+
+    const records = readAuditRows().filter(r => r.event === 'record');
+    expect(records.length).toBe(1);
+    expect(records[0].label).toBe('facts:mcp:extract_facts');
+  });
+
+  test('the fallback label carries the entry point: hook:compact audits as facts:hook:compact', async () => {
+    chatStub();
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      await runFactsPipeline('a compaction-boundary turn', {
+        engine,
+        sourceId: 'default',
+        sessionId: null,
+        source: 'hook:compact',
+      });
+    });
+    const records = readAuditRows().filter(r => r.event === 'record');
+    expect(records.length).toBe(1);
+    expect(records[0].label).toBe('facts:hook:compact');
+  });
+
+  test('an ambient tracker (cycle case) wins: rows keep the ambient label, recorded exactly once', async () => {
+    chatStub();
+    const ambient = new BudgetTracker({ label: 'cycle-phase-test', auditPath: join(auditDir, 'budget-ambient.jsonl') });
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      await withBudgetTracker(ambient, () =>
+        runFactsPipeline('a cycle-scoped turn', {
+          engine,
+          sourceId: 'default',
+          sessionId: null,
+          source: 'sync:import',
+        }),
+      );
+    });
+
+    const records = readAuditRows().filter(r => r.event === 'record');
+    // Exactly one record, under the ambient label — the fallback must not
+    // double-wrap an already-scoped call.
+    expect(records.length).toBe(1);
+    expect(records[0].label).toBe('cycle-phase-test');
+    expect(ambient.snapshot().callsRecorded).toBe(1);
+    expect(ambient.totalSpent).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #4210.

## Root cause

`chat()` and `embed()` only account spend when a `BudgetTracker` is on the gateway's AsyncLocalStorage (`src/core/ai/gateway.ts:2832`, `getCurrentBudgetTracker` — "Outside the scope, the gateway functions are budget no-ops"). The `extract_facts` op handler ([src/core/ops/facts.ts:71](../blob/master/src/core/ops/facts.ts#L71)) calls `runFactsPipeline` with no scope installed, so its Haiku call spends real money and writes nothing to `budget-*.jsonl`.

The gap is wider than the op. `runFactsPipeline`/`runFactsBackstop` is the declared choke point for five write surfaces (`src/core/facts/backstop.ts:15`), and **none** of the non-cycle entry points install a tracker:

- `extract_facts` op — `src/core/ops/facts.ts:71`
- sweep pass 3 — `src/core/sweep.ts:554`
- `put_page` backstop / file_upload / code_import — via `runFactsBackstop`
- checkpoint harvest (Cathedral 5, new in v0.46.17.0) — `src/core/context/checkpoint-harvest.ts:245`
- compaction context engine — `src/core/context-engine.ts:936`

The cycle phases and transcripts ingest are fine (they wrap with `withBudgetTracker`), which is why cycle runs appear in the audit and direct op calls don't. Same class as #4121, one layer up: there the gateway's own `expand()`/OCR calls bypassed `chat()`'s recording; here the recording works but no scope exists.

## Fix

`runPipelineWithBody` (the single body both entry points share) installs a fallback record-only `BudgetTracker` labeled `facts:<ctx.source>` when no ambient tracker exists — so every entry point becomes visible at once, with per-entry-point provenance (`facts:mcp:extract_facts`, `facts:sweep:corpus`, `facts:hook:compact`, …) instead of a per-caller patch.

- **Uncapped, so it can never throw `BudgetExhausted`** — both throw sites (`reserve` TX2/runtime, `record` TX1) require a cap. The pipeline's failure surface is unchanged.
- **An ambient tracker wins** — cycle/ingest scopes keep their own labels, recorded exactly once, no double scope.
- Embed spend (per-fact `embedOne`) lands too, not just the chat call.

Two files: the fix in `src/core/facts/backstop.ts` (+24 lines), the pin in `test/facts-pipeline-budget-accounting.test.ts`.

## Proof

Red on master (the fallback tests; the ambient-scope guard passes pre-fix as expected):

```
(fail) runFactsPipeline with no ambient tracker records chat spend in the budget audit
       expect(records.length).toBe(1) — Received: 0
(fail) extract_facts op handler end-to-end: spend is audited, response envelope unchanged
(fail) the fallback label carries the entry point: hook:compact audits as facts:hook:compact
 1 pass, 3 fail
```

Green with the fix:

```
 4 pass, 0 fail, 18 expect() calls
```

Hermetic: PGLite + `__setChatTransportForTests` (which keeps `chat()`'s real reserve/record wiring active) + `GBRAIN_AUDIT_DIR` at a temp dir. Blast radius: all 29 test files referencing `runFactsPipeline`/`runFactsBackstop`/`extract_facts` pass (540 parallel + serial + PGLite e2e, 0 fail), budget cluster passes, `bun run typecheck` clean, `bun run verify` 54/54.

## Honest limits

- Brains configured with an unpriced local chat model now hit the tracker's pre-existing warn-once `BUDGET_TRACKER_NO_PRICING` stderr line on the first facts extraction — that's the documented legacy path for uncapped trackers, not new machinery, but it is a new place it can fire from.
- This is record-only visibility, as the issue asked. Whether `extract_facts` should also accept a caller-supplied cap is a separate product question, untouched here.

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
