### PR TITLE
fix(doctor): summary-only meeting/slack pages are not conversation-parser coverage debt (#4193)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4270	ratchet	peel target: containment sprint C8-C13; grown v0.46.11.0 five-issue wave
+src/commands/doctor.ts	4220	ratchet	peel target: containment sprint C8-C13; grown v0.46.11.0 five-issue wave; conversation_format_coverage peeled (#4193)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5816	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
 src/core/pglite-engine.ts	5744	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -54,7 +54,7 @@ test/compile-view.test.ts	compileView — source isolation + read errors	3	readF
 test/config.test.ts	config source correctness	2	readFileSync
 test/connection-resilience.test.ts	Eng-review D3 — executeRaw has no per-call retry wrapper	3	readFileSync
 test/contextual-retrieval-service-pure.test.ts	inline import contextual synopsis containment	1	readFileSync
-test/conversation-facts-type-allowlist-drift.test.ts	(file-level)	17	readFileSync
+test/conversation-facts-type-allowlist-drift.test.ts	(file-level)	18	readFileSync
 test/cycle-abort.test.ts	#1972 — complete cooperative-abort coverage	3	readFileSync
 test/cycle-abort.test.ts	CycleOpts.signal contract (v0.20.5)	4	readFileSync
 test/cycle-abort.test.ts	autopilot-cycle handler contract (v0.20.5)	3	readFileSync

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,4 @@
 import type { BrainEngine } from '../core/engine.ts';
-// Leaf module (no flag surface of its own) — see that file for why this
-// isn't imported from extract-conversation-facts.ts directly (#4135).
-import { ALLOWED_TYPES } from '../core/facts/conversation-types.ts';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION, getIdleBlockers } from '../core/migrate.ts';
@@ -119,6 +116,7 @@ export {
   computeExtractHealthCheck,
   checkSyncFreshness,
 } from './doctor/checks/extraction-sync.ts';
+export { computeConversationFormatCoverageCheck } from './doctor/checks/conversation-coverage.ts';
 export {
   checkSyncConsolidation,
   computePoolBudgetCheck,
@@ -195,6 +193,7 @@ import {
   computeExtractHealthCheck,
   checkSyncFreshness,
 } from './doctor/checks/extraction-sync.ts';
+import { computeConversationFormatCoverageCheck } from './doctor/checks/conversation-coverage.ts';
 import {
   checkSyncConsolidation,
   checkCycleFreshness,
@@ -1261,70 +1260,12 @@ export async function buildChecks(
     }
   }
 
-  // 3d.3 v0.41.13.0 — conversation_format_coverage. Scans up to 200
-  // most-recent conversation-type pages, runs parseConversation in
-  // dry mode, reports per-pattern hit counts + unmatched count. Warn
-  // at >10% unmatched with paste-ready hint pointing at
-  // `gbrain conversation-parser scan <slug>` so the operator can
-  // triage the misses interactively.
+  // 3d.3 v0.41.13.0 — conversation_format_coverage. Peeled to
+  // doctor/checks/conversation-coverage.ts (#4193) so it is unit-testable;
+  // summary-only conversation pages report separately instead of counting
+  // as parser misses. Error handling lives inside the compute function.
   if (engine) {
-    try {
-      const { readConversationBodyForParsing } = await import('../core/conversation-parser/body.ts');
-      const { parseConversation } = await import('../core/conversation-parser/parse.ts');
-      // Single source of truth for the conversation-facts type allowlist (#4135).
-      const allowedTypes = ALLOWED_TYPES;
-      // PageFilters supports singular `type` only; iterate the allowed types
-      // and cap at ~50/each to land at ~200 total max.
-      const sample: import('../core/types.ts').Page[] = [];
-      for (const t of allowedTypes) {
-        const slice = await engine.listPages({ limit: 50, type: t as import('../core/types.ts').PageType });
-        sample.push(...slice);
-      }
-      if (sample.length === 0) {
-        checks.push({
-          name: 'conversation_format_coverage',
-          status: 'ok',
-          message: 'No conversation-type pages — coverage check not applicable',
-        });
-      } else {
-        const hitsByPattern: Record<string, number> = {};
-        let unmatched = 0;
-        for (const page of sample) {
-          const body = await readConversationBodyForParsing(engine, page);
-          const result = parseConversation(body, { page, noPolish: true, noFallback: true });
-          const id = result.matched_pattern_id ?? '_no_match';
-          hitsByPattern[id] = (hitsByPattern[id] ?? 0) + 1;
-          if (result.phase === 'no_match') unmatched++;
-        }
-        const unmatchedPct = (unmatched / sample.length) * 100;
-        const breakdown = Object.entries(hitsByPattern)
-          .sort(([, a], [, b]) => b - a)
-          .map(([k, v]) => `${k}=${v}`)
-          .join(', ');
-        if (unmatchedPct > 10) {
-          checks.push({
-            name: 'conversation_format_coverage',
-            status: 'warn',
-            message:
-              `${unmatched}/${sample.length} conversation pages (${unmatchedPct.toFixed(1)}%) match NO built-in pattern. ` +
-              `Breakdown: ${breakdown}. ` +
-              `Investigate: gbrain conversation-parser scan <slug>`,
-          });
-        } else {
-          checks.push({
-            name: 'conversation_format_coverage',
-            status: 'ok',
-            message: `${sample.length} pages: ${breakdown}`,
-          });
-        }
-      }
-    } catch (err) {
-      checks.push({
-        name: 'conversation_format_coverage',
-        status: 'warn',
-        message: `Could not check conversation format coverage: ${(err as Error)?.message ?? String(err)}`,
-      });
-    }
+    checks.push(await computeConversationFormatCoverageCheck(engine));
   }
 
   // 3d.4 v0.41.13.0 — progressive_batch_audit_health. Reads last 7

--- a/src/commands/doctor/checks/conversation-coverage.ts
+++ b/src/commands/doctor/checks/conversation-coverage.ts
@@ -1,0 +1,87 @@
+/**
+ * conversation_format_coverage check — peeled verbatim from src/commands/doctor.ts
+ * (3d.3 v0.41.13.0) so it is unit-testable against PGLite, following the
+ * computeExtractAtomsBacklogCheck pattern. doctor.ts re-exports it under the
+ * facade rule.
+ *
+ * Scans up to 200 most-recent conversation-type pages (50 per allowed type),
+ * runs parseConversation in dry mode, reports per-pattern hit counts +
+ * unmatched count. Warn at >10% unmatched with paste-ready hint pointing at
+ * `gbrain conversation-parser scan <slug>`.
+ */
+import type { BrainEngine } from '../../../core/engine.ts';
+import { ALLOWED_TYPES } from '../../../core/facts/conversation-types.ts';
+import type { Check } from '../../doctor.ts';
+
+export async function computeConversationFormatCoverageCheck(
+  engine: BrainEngine,
+): Promise<Check> {
+  const name = 'conversation_format_coverage';
+  try {
+    const { readConversationBodyForParsing } = await import('../../../core/conversation-parser/body.ts');
+    const { parseConversation } = await import('../../../core/conversation-parser/parse.ts');
+    // Single source of truth for the conversation-facts type allowlist (#4135).
+    const allowedTypes = ALLOWED_TYPES;
+    // PageFilters supports singular `type` only; iterate the allowed types
+    // and cap at ~50/each to land at ~200 total max.
+    const sample: import('../../../core/types.ts').Page[] = [];
+    for (const t of allowedTypes) {
+      const slice = await engine.listPages({ limit: 50, type: t as import('../../../core/types.ts').PageType });
+      sample.push(...slice);
+    }
+    if (sample.length === 0) {
+      return {
+        name,
+        status: 'ok',
+        message: 'No conversation-type pages — coverage check not applicable',
+      };
+    }
+    const { isTranscriptClaiming } = await import('../../../core/conversation-parser/transcript-signals.ts');
+    const hitsByPattern: Record<string, number> = {};
+    let unmatched = 0;
+    let summaryOnly = 0;
+    for (const page of sample) {
+      const body = await readConversationBodyForParsing(engine, page);
+      const result = parseConversation(body, { page, noPolish: true, noFallback: true });
+      // #4193: a no_match on a page that never claimed a transcript
+      // (summary-only meeting/slack page) is not parser debt. Report it
+      // separately and keep it out of the coverage denominator. Matched
+      // pages and transcript-claiming misses keep today's behavior.
+      if (result.phase === 'no_match' && !isTranscriptClaiming(page, body)) {
+        hitsByPattern['_summary_only'] = (hitsByPattern['_summary_only'] ?? 0) + 1;
+        summaryOnly++;
+        continue;
+      }
+      const id = result.matched_pattern_id ?? '_no_match';
+      hitsByPattern[id] = (hitsByPattern[id] ?? 0) + 1;
+      if (result.phase === 'no_match') unmatched++;
+    }
+    const candidates = sample.length - summaryOnly;
+    const unmatchedPct = candidates > 0 ? (unmatched / candidates) * 100 : 0;
+    const breakdown = Object.entries(hitsByPattern)
+      .sort(([, a], [, b]) => b - a)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ');
+    if (unmatchedPct > 10) {
+      return {
+        name,
+        status: 'warn',
+        message:
+          `${unmatched}/${candidates} transcript-bearing conversation pages (${unmatchedPct.toFixed(1)}%) match NO built-in pattern. ` +
+          `Breakdown: ${breakdown}. ` +
+          `Investigate: gbrain conversation-parser scan <slug>`,
+      };
+    }
+    return {
+      name,
+      status: 'ok',
+      message: `${sample.length} pages: ${breakdown}`,
+    };
+  } catch (err) {
+    return {
+      name,
+      status: 'warn',
+      message: `Could not check conversation format coverage: ${(err as Error)?.message ?? String(err)}`,
+    };
+  }
+}

--- a/src/core/conversation-parser/transcript-signals.ts
+++ b/src/core/conversation-parser/transcript-signals.ts
@@ -1,0 +1,65 @@
+/**
+ * Transcript-likeness signals (#4193).
+ *
+ * `conversation_format_coverage` used to treat every page whose type is in
+ * the conversation allowlist as a transcript-parsing candidate, so summary
+ * documents that legitimately use `meeting`/`slack` types counted as parser
+ * failures even though they contain no conversation turns. This helper is
+ * the single definition of "this page claims to contain a transcript" so a
+ * `no_match` on a summary page can be reported as summary-only rather than
+ * as coverage debt.
+ *
+ * Deliberately conservative: it never constructs messages and never treats
+ * `Name: text` labels as a signal (builtins.ts's own test_negative shows
+ * that shape is ambiguous in real summaries). A false positive only means
+ * the page keeps today's behavior (counted as a miss).
+ */
+import type { Page } from '../types.ts';
+
+/**
+ * A `## Transcript` / `### Raw transcript` style section heading. Grounded
+ * in the real meeting-page shape (`## Summary` + `## Transcript`,
+ * see parse.ts's SCORING_HEAD_TRIGGER_THRESHOLD rationale).
+ */
+const TRANSCRIPT_HEADING_RX = /^#{1,6}\s*(?:raw\s+)?transcript\b/im;
+
+/**
+ * A time-of-day token near the start of a line — the anchor shape every
+ * time-based builtin uses (`[10:12]`, `(Mon 11:18 AM)`, `18:37 <alice>`,
+ * `**Name** (2024-03-15 9:00 AM):`). Checked against the first 24 chars of
+ * each line so a stray "standup at 3:00" deep in a bullet doesn't count.
+ */
+const TIME_TOKEN_RX = /[[(]?\b\d{1,2}:\d{2}(?::\d{2})?\b\s*(?:[APap]\.?[Mm]\.?)?[\])]?/;
+
+/** Min timestamped lines + min share of non-blank lines for the density
+ *  signal. Mirrors the parser's own density-floor philosophy
+ *  (SCORING_MIN_ACCEPTANCE): a couple of times in an agenda list is not a
+ *  transcript; a page where 10%+ of lines open with a clock time is. */
+const TIME_DENSITY_MIN_LINES = 3;
+const TIME_DENSITY_MIN_SHARE = 0.1;
+
+/**
+ * Does this page claim to contain conversation turns?
+ *
+ * True when ANY of:
+ *  1. `frontmatter.raw_transcript` is a non-empty string — even if the file
+ *     did not resolve, the page claims a transcript, so an unparseable body
+ *     is genuine coverage debt;
+ *  2. the body has a transcript section heading;
+ *  3. enough lines open with a time-of-day token (>=3 lines and >=10% of
+ *     non-blank lines).
+ */
+export function isTranscriptClaiming(page: Page | undefined, body: string): boolean {
+  const raw = page?.frontmatter?.raw_transcript;
+  if (typeof raw === 'string' && raw.trim().length > 0) return true;
+
+  if (TRANSCRIPT_HEADING_RX.test(body)) return true;
+
+  const nonBlank = body.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (nonBlank.length === 0) return false;
+  let timed = 0;
+  for (const line of nonBlank) {
+    if (TIME_TOKEN_RX.test(line.slice(0, 24))) timed++;
+  }
+  return timed >= TIME_DENSITY_MIN_LINES && timed / nonBlank.length >= TIME_DENSITY_MIN_SHARE;
+}

--- a/test/conversation-facts-type-allowlist-drift.test.ts
+++ b/test/conversation-facts-type-allowlist-drift.test.ts
@@ -183,6 +183,7 @@ describe('ALLOWED_TYPES — canonical source of truth (leaf module)', () => {
 describe('DRIFT GUARD — consumer sites derive from the leaf module (re-hardcode + wrong-import trip-wire)', () => {
   for (const [label, relPath] of [
     ['doctor.ts', 'commands/doctor.ts'],
+    ['conversation-coverage.ts', 'commands/doctor/checks/conversation-coverage.ts'],
     ['jobs.ts', 'commands/jobs.ts'],
     ['sources.ts', 'commands/sources.ts'],
     ['conversation-facts-backfill.ts', 'core/cycle/conversation-facts-backfill.ts'],
@@ -209,12 +210,18 @@ describe('DRIFT GUARD — consumer sites derive from the leaf module (re-hardcod
     expect(countAllowedTypesImportsFrom(src, '\\.\\./facts/conversation-types\\.ts')).toBe(1);
   });
 
-  test('doctor.ts: imports ALLOWED_TYPES from the leaf exactly once', () => {
-    // Post-peel (v0.46.9.1 containment sprint) doctor.ts keeps ONE call site
-    // (the buildChecks parser sample); the backlog check moved to
-    // doctor/checks/search-eval.ts and is guarded separately below.
+  test('doctor.ts: no longer imports ALLOWED_TYPES (all call sites peeled)', () => {
+    // The backlog check moved to doctor/checks/search-eval.ts and the
+    // parser-sample scan (conversation_format_coverage, #4193) moved to
+    // doctor/checks/conversation-coverage.ts; each is guarded separately.
     const src = readSrc('commands/doctor.ts');
-    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./core/facts/conversation-types\\.ts')).toBe(0);
+    expect((src.match(/\bALLOWED_TYPES\b/g) ?? []).length).toBe(0);
+  });
+
+  test('doctor/checks/conversation-coverage.ts: the peeled coverage check derives from the leaf', () => {
+    const src = readSrc('commands/doctor/checks/conversation-coverage.ts');
+    expect(countAllowedTypesImportsFrom(src, '\\.\\./\\.\\./\\.\\./core/facts/conversation-types\\.ts')).toBe(1);
     expect((src.match(/\bALLOWED_TYPES\b/g) ?? []).length).toBeGreaterThanOrEqual(2); // import + 1 usage
   });
 

--- a/test/conversation-parser-transcript-signals.test.ts
+++ b/test/conversation-parser-transcript-signals.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { isTranscriptClaiming } from '../src/core/conversation-parser/transcript-signals.ts';
+import type { Page } from '../src/core/types.ts';
+
+function pageWith(frontmatter: Record<string, unknown>): Page {
+  return { frontmatter } as unknown as Page;
+}
+
+const SUMMARY = [
+  '## Highlights',
+  '- Shipped the new onboarding flow',
+  '- Reviewed the quarterly metrics doc',
+  '## Decisions',
+  '- Move the launch to next week',
+  '- Alice owns the follow-up doc',
+].join('\n');
+
+describe('isTranscriptClaiming (#4193)', () => {
+  test('summary-only headings + bullets: false', () => {
+    expect(isTranscriptClaiming(undefined, SUMMARY)).toBe(false);
+  });
+
+  test('empty body: false', () => {
+    expect(isTranscriptClaiming(undefined, '')).toBe(false);
+  });
+
+  test('raw_transcript frontmatter claims a transcript even when unresolvable', () => {
+    expect(isTranscriptClaiming(pageWith({ raw_transcript: 'transcripts/x.txt' }), SUMMARY)).toBe(true);
+  });
+
+  test('blank raw_transcript is not a claim', () => {
+    expect(isTranscriptClaiming(pageWith({ raw_transcript: '  ' }), SUMMARY)).toBe(false);
+  });
+
+  test('## Transcript section heading: true', () => {
+    expect(isTranscriptClaiming(undefined, '## Summary\n- notes\n\n## Transcript\nweird turn shape')).toBe(true);
+    expect(isTranscriptClaiming(undefined, '### Raw Transcript\nstuff')).toBe(true);
+  });
+
+  test('timestamp-dense lines: true (telegram/irc style anchors)', () => {
+    const body = ['[10:12] alice: hi', '[10:13] bob: hello', '[10:15] alice: bye'].join('\n');
+    expect(isTranscriptClaiming(undefined, body)).toBe(true);
+  });
+
+  test('a single time mention in an agenda does not trip the density signal', () => {
+    const body = [
+      '## Agenda',
+      '- standup at 3:00',
+      '- retro planning',
+      '- metrics review',
+      '- launch checklist',
+      '- follow-ups',
+      '- docs pass',
+      '- close out',
+    ].join('\n');
+    expect(isTranscriptClaiming(undefined, body)).toBe(false);
+  });
+
+  test('prose label lines (builtins test_negative shape) are not a signal', () => {
+    expect(
+      isTranscriptClaiming(undefined, 'Owner: this is a prose label, not a transcript line\nNext: more prose'),
+    ).toBe(false);
+  });
+});

--- a/test/doctor-conversation-format-coverage.test.ts
+++ b/test/doctor-conversation-format-coverage.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { computeConversationFormatCoverageCheck } from '../src/commands/doctor.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+/** A summary-only page: headings + short bullets, no transcript shape.
+ *  Mirrors the seven pages observed in #4193 (5-30 nonblank lines). */
+const SLACK_SUMMARY_BODY = [
+  '## Highlights',
+  '',
+  '- Shipped the new onboarding flow',
+  '- Reviewed the quarterly metrics doc',
+  '',
+  '## Decisions',
+  '',
+  '- Move the launch to next week',
+  '- Alice owns the follow-up doc',
+].join('\n');
+
+/** Transcript-claiming page (explicit `## Transcript` section) whose turn
+ *  shape no builtin matches — must STILL count as a parser miss. */
+const UNSUPPORTED_TRANSCRIPT_BODY = [
+  '## Transcript',
+  '',
+  '9.03.12 -- Alice -- kicking off',
+  '9.04.55 -- Bob -- sounds good',
+  '9.06.20 -- Alice -- shipping it',
+].join('\n');
+
+/** Body matching the builtin `imessage-slack` pattern (its own test_positive shape). */
+const SUPPORTED_TRANSCRIPT_BODY = [
+  '**Alice Example** (2024-03-15 9:00 AM): hello',
+  '**Bob Example** (2024-03-15 9:02 AM): hi there',
+  '**Alice Example** (2024-03-15 9:05 AM): shipping it',
+].join('\n');
+
+async function seedPage(slug: string, type: string, body: string): Promise<void> {
+  await engine.putPage(slug, {
+    type,
+    title: slug,
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: {},
+  });
+}
+
+describe('conversation_format_coverage summary-only handling (#4193)', () => {
+  test('a slack/meeting summary page (headings + bullets) is not _no_match coverage debt', async () => {
+    await seedPage('slack-weekly-summary', 'slack', SLACK_SUMMARY_BODY);
+    await seedPage('meeting-standup-notes', 'meeting', SLACK_SUMMARY_BODY);
+
+    const check = await computeConversationFormatCoverageCheck(engine);
+    expect(check.name).toBe('conversation_format_coverage');
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('_summary_only=2');
+    expect(check.message).not.toContain('_no_match');
+  });
+
+  test('a transcript-claiming page with an unsupported turn shape still counts as a miss', async () => {
+    await seedPage('meeting-odd-transcript', 'meeting', UNSUPPORTED_TRANSCRIPT_BODY);
+
+    const check = await computeConversationFormatCoverageCheck(engine);
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('_no_match=1');
+  });
+
+  test('supported transcript patterns keep their current results in the denominator', async () => {
+    await seedPage('slack-real-transcript', 'slack', SUPPORTED_TRANSCRIPT_BODY);
+    await seedPage('slack-weekly-summary', 'slack', SLACK_SUMMARY_BODY);
+
+    const check = await computeConversationFormatCoverageCheck(engine);
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('imessage-slack=1');
+    expect(check.message).toContain('_summary_only=1');
+  });
+
+  test('mixed brain: summaries excluded from the denominator, real misses still warn', async () => {
+    // 1 supported + 1 unsupported transcript + 2 summaries.
+    // Old math: 3/4 unmatched = 75% -> warn either way, but with summaries
+    // wrongly in the numerator. New math: 1/2 transcript-claiming unmatched
+    // = 50% -> warn, with the summaries reported separately.
+    await seedPage('slack-real-transcript', 'slack', SUPPORTED_TRANSCRIPT_BODY);
+    await seedPage('meeting-odd-transcript', 'meeting', UNSUPPORTED_TRANSCRIPT_BODY);
+    await seedPage('slack-weekly-summary', 'slack', SLACK_SUMMARY_BODY);
+    await seedPage('meeting-standup-notes', 'meeting', SLACK_SUMMARY_BODY);
+
+    const check = await computeConversationFormatCoverageCheck(engine);
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('1/2');
+    expect(check.message).toContain('_summary_only=2');
+  });
+
+  test('no conversation pages -> not-applicable ok', async () => {
+    const check = await computeConversationFormatCoverageCheck(engine);
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('No conversation-type pages');
+  });
+});


### PR DESCRIPTION
Closes #4193

## Root cause

`conversation_format_coverage` (previously inline at `src/commands/doctor.ts:1264-1328`) samples up to 50 pages per type in the conversation allowlist and counts every `parseConversation` `phase === 'no_match'` as coverage debt. But `readConversationBodyForParsing` (`src/core/conversation-parser/body.ts:21-39`) falls back to the summary body (`compiled_truth` + `timeline`) whenever there is no resolvable `raw_transcript` — so a `meeting`/`slack` summary page feeds prose into the parser, the parser correctly refuses to invent turns (the `SCORING_MIN_ACCEPTANCE` floor exists for exactly that), and doctor books that correct refusal as a parser miss. Seven summary pages in a 58-page cohort is 12.1% — over the 10% warn threshold, as observed in the issue.

## Fix

1. **`src/core/conversation-parser/transcript-signals.ts`** (new) — `isTranscriptClaiming(page, body)`: true when the page has non-empty `raw_transcript` frontmatter (even unresolvable — the page still claims a transcript, so an unparseable body is genuine debt), a `## Transcript` / `### Raw Transcript` heading (the documented meeting-page shape in `parse.ts`), or timestamp-dense lines (>=3 lines and >=10% of non-blank lines opening with a clock-time token — the anchor shape every time-based builtin uses). Deliberately conservative: `Name: text` labels are never a signal (`builtins.ts`'s own `test_negative` shows that shape is ambiguous in summaries), and a false positive only preserves today's behavior.
2. **`src/commands/doctor/checks/conversation-coverage.ts`** (new) — the check, peeled verbatim from doctor.ts (the `computeExtractAtomsBacklogCheck` pattern; doctor.ts re-exports under the facade rule) plus one behavior change: a `no_match` page that never claimed a transcript counts as `_summary_only` in the breakdown and leaves the coverage denominator. The warn message denominator is now transcript-claiming pages only.
3. doctor.ts module-size ceiling lowered 4270 → 4220 (peel shrank it 57 lines; the ratchet fails on >50 lines of stale slack), and the ALLOWED_TYPES drift guard now tracks the check's new home.

## Acceptance (from the issue) → tests

`test/doctor-conversation-format-coverage.test.ts` (PGLite, real `computeConversationFormatCoverageCheck`) + `test/conversation-parser-transcript-signals.test.ts` (pure):

- slack/meeting fixture with only headings + bullets → `ok`, `_summary_only=2`, no `_no_match` ✓
- transcript-claiming page (`## Transcript` + unsupported `9.03.12 -- Alice` turn shape) → still `warn`, `_no_match=1` ✓
- supported pattern (`imessage-slack` body) keeps its result in the denominator ✓
- no new patterns added; the summary fixture still parses to zero messages ✓

Red (verbatim-peeled check, before the gate):

```
(fail) a slack/meeting summary page (headings + bullets) is not _no_match coverage debt
       Expected: "ok"  Received: "warn"   # 2/2 pages counted as _no_match
(fail) mixed brain: ... Received: "3/4 conversation pages (75.0%) match NO built-in pattern"
 2 pass, 3 fail
```

Green (with the gate): `13 pass, 0 fail` across both files. Full sweep: `bun run typecheck` clean, `bun run verify` 54/54 green, and 812 pass / 0 fail across `test/conversation-parser/` + all non-serial `doctor-*` tests + `test/extract-conversation-facts.test.ts` (serial doctor tests green individually).

## Honest limits

- The three signals are heuristics; the thresholds (>=3 timestamped lines, >=10% density, first-24-chars window) are the one place a maintainer may want to tune. A summary that trips them is counted as a miss — i.e. today's behavior, never worse.
- **Sibling exposure left alone:** `extract-conversation-facts` has the adjacent problem — summary-only pages hit `no_match` there too, are never marked non-extractable (so they re-parse every run), and the opt-in LLM fallback would run on summary prose. Wiring `isTranscriptClaiming` into the extractor is a behavior change beyond this issue's acceptance; the helper lives in `core/conversation-parser/` so that follow-up can share the same definition.
- One pre-existing structural test updated: the drift guard's "doctor.ts imports ALLOWED_TYPES exactly once" encoded the check's old location; it now asserts zero in doctor.ts and exactly one in the peeled check, mirroring its own `search-eval.ts` precedent.


P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
