### PR TITLE
fix(sweep): links/timeline pass honors its own watermark and reconciles removed links (#4196)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -96,7 +96,7 @@ export const STALE_TIME_BUDGET_MS = Math.max(1000, Number(process.env.GBRAIN_EXT
  */
 export async function stampExtracted(
   engine: BrainEngine,
-  refs: Array<{ slug: string; source_id: string }>,
+  refs: Array<{ slug: string; source_id: string; extractedAt?: string }>,
   at: string = new Date().toISOString(),
 ): Promise<void> {
   if (refs.length === 0) return;

--- a/src/commands/sweep.ts
+++ b/src/commands/sweep.ts
@@ -109,6 +109,7 @@ export async function runSweep(engine: BrainEngine, args: string[]): Promise<voi
     console.log(`Sweep complete (${report.durationMs}ms, source=${sourceId}):`);
     console.log(`  facts reconciled:   ${report.factsReconciled}`);
     console.log(`  links extracted:    ${report.linksExtracted}`);
+    console.log(`  links removed:      ${report.linksRemoved}`);
     console.log(`  timeline extracted: ${report.timelineExtracted}`);
     console.log(`  corpus ingested:    ${report.corpusIngested}`);
     if (report.skipped.length > 0) {

--- a/src/core/sweep.ts
+++ b/src/core/sweep.ts
@@ -105,6 +105,8 @@ export interface SweepReport {
   corpusIngested: number;
   factsReconciled: number;
   linksExtracted: number;
+  /** Stale sweep-owned edges reconciled away (#4196). */
+  linksRemoved: number;
   timelineExtracted: number;
   skipped: SweepSkip[];
   durationMs: number;
@@ -130,6 +132,7 @@ export async function runMaintenanceSweep(
     corpusIngested: 0,
     factsReconciled: 0,
     linksExtracted: 0,
+    linksRemoved: 0,
     timelineExtracted: 0,
     skipped: [],
     durationMs: 0,
@@ -288,11 +291,21 @@ async function runLinksTimelinePass(
   if (!timelineEnabled) skip('auto_timeline_disabled');
   if (!linksEnabled && !timelineEnabled) return;
 
-  const recent = await engine.executeRaw<{ slug: string }>(
-    `SELECT slug FROM pages
+  // #4196: honor the watermark this pass stamps, or repeated bounded sweeps
+  // re-select the same newest batchLimit rows forever and page batchLimit+1
+  // is never reached. Same predicate as the engines' buildStalePagesWhere
+  // (no versionTs branch — extractor-version catch-up is `extract --stale`'s
+  // job; the sweep is a recency back-stop). The µs to_char projection is the
+  // #1768 stamp discipline: stamp the row's READ updated_at, not now(), so an
+  // edit between SELECT and stamp stays stale and re-sweeps.
+  const recent = await engine.executeRaw<{ slug: string; updated_at_iso: string }>(
+    `SELECT slug,
+            to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at_iso
+       FROM pages
       WHERE source_id = $1
         AND deleted_at IS NULL
         AND updated_at >= $2::timestamptz
+        AND (links_extracted_at IS NULL OR updated_at > links_extracted_at)
       ORDER BY updated_at DESC
       LIMIT $3`,
     [sourceId, cutoffIso, batchLimit],
@@ -310,7 +323,7 @@ async function runLinksTimelinePass(
   type Extracted = Awaited<ReturnType<typeof extractPageLinks>>;
 
   const tlBatch: TimelineBatchInput[] = [];
-  const processedRefs: Array<{ slug: string; source_id: string }> = [];
+  const processedRefs: Array<{ slug: string; source_id: string; extractedAt: string }> = [];
   const pageCandidates: Array<{ slug: string; candidates: Extracted['candidates'] }> = [];
 
   // Phase 1: per-page extraction. The per-slug getPage loop stays a loop —
@@ -353,7 +366,7 @@ async function runLinksTimelinePass(
       }
     }
 
-    processedRefs.push({ slug, source_id: sourceId });
+    processedRefs.push({ slug, source_id: sourceId, extractedAt: recent[i].updated_at_iso });
   }
 
   // Phase 2: endpoint validation is scoped to the slugs the candidates
@@ -402,10 +415,75 @@ async function runLinksTimelinePass(
   if (tlBatch.length > 0) {
     report.timelineExtracted += await engine.addTimelineEntriesBatch(tlBatch); // gbrain-allow-direct-insert: same extract-path rationale as addLinksBatch above [CX-P0.3]
   }
+
+  // #4196: reconcile removals. The sweep is the ONLY link extraction remote
+  // put_page pages ever get (runAutoLink is skipped by design), so add-only
+  // inserts leave a phantom edge forever once a page drops a reference.
+  // Mirror runAutoLink's provenance-scoped removal (ops/pages.ts) — markdown /
+  // NULL-legacy / wikilink-resolved only — minus its own-frontmatter clause:
+  // the sweep extracts with skipFrontmatter, so its desired set can never
+  // contain frontmatter candidates and deleting them would clobber valid
+  // edges. 'manual' and 'mentions' are never touched. A page whose reconcile
+  // fails (or is cut by budget) is left unstamped so the next sweep retries.
+  const stampable = new Set(processedRefs.map(r => r.slug));
+  if (linksEnabled) {
+    const { autoLinkLockKey } = await import('./ops/pages.ts');
+    const desiredBySlug = new Map<string, Set<string>>(
+      processedRefs.map(r => [r.slug, new Set<string>()]),
+    );
+    for (const b of linkBatch) {
+      // runAutoLink's exact key shape (ops/pages.ts outKeys).
+      desiredBySlug.get(b.from_slug)?.add(
+        `${b.to_slug}\u0000${b.link_type}\u0000${b.link_source ?? 'markdown'}`,
+      );
+    }
+    for (const ref of processedRefs) {
+      if (overBudget()) {
+        skip('budget_exhausted:link_reconcile');
+        stampable.delete(ref.slug);
+        continue;
+      }
+      const desired = desiredBySlug.get(ref.slug)!;
+      try {
+        report.linksRemoved += await engine.transaction(async (tx) => {
+          try {
+            // Same advisory lock runAutoLink takes, so sweep reconciliation
+            // serializes against a concurrent local put_page on the slug.
+            await tx.executeRaw(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [
+              autoLinkLockKey(sourceId, ref.slug),
+            ]);
+          } catch { /* engine without advisory locks — PGLite is single-process */ }
+          const existing = await tx.getLinks(ref.slug, { sourceId });
+          let removed = 0;
+          for (const l of existing) {
+            const reconcilable =
+              l.link_source === 'markdown' || l.link_source == null ||
+              l.link_source === 'wikilink-resolved';
+            if (!reconcilable) continue;
+            const key = `${l.to_slug}\u0000${l.link_type}\u0000${l.link_source ?? 'markdown'}`;
+            if (desired.has(key)) continue;
+            await tx.removeLink(ref.slug, l.to_slug, l.link_type, l.link_source ?? undefined, {
+              fromSourceId: sourceId,
+              toSourceId: l.to_source_id,
+            });
+            removed++;
+          }
+          return removed;
+        });
+      } catch {
+        skip('link_reconcile_failed');
+        stampable.delete(ref.slug);
+      }
+    }
+  }
+
   // Stamp only when BOTH kinds ran for these pages (extract.ts C3/D6:
-  // links_extracted_at covers links AND timeline).
-  if (linksEnabled && timelineEnabled && processedRefs.length > 0) {
-    await stampExtracted(engine, processedRefs);
+  // links_extracted_at covers links AND timeline). Per-ref extractedAt is the
+  // page's read updated_at (#1768 µs discipline; D4 — an edit between SELECT
+  // and stamp stays stale).
+  if (linksEnabled && timelineEnabled) {
+    const toStamp = processedRefs.filter(r => stampable.has(r.slug));
+    if (toStamp.length > 0) await stampExtracted(engine, toStamp);
   }
 }
 

--- a/test/sweep.test.ts
+++ b/test/sweep.test.ts
@@ -21,6 +21,7 @@ import {
   type SweepReport,
 } from '../src/core/sweep.ts';
 import { isTotalFailure, runSweep, SWEEP_HELP } from '../src/commands/sweep.ts';
+import { importFromContent } from '../src/core/import-file.ts';
 import { currentExitCode, _resetCliExitVerdictForTests } from '../src/core/cli-force-exit.ts';
 import { _resetStdoutRedirectForTests } from '../src/core/console-prefix.ts';
 import type { CapabilityReport } from '../src/core/capability.ts';
@@ -208,6 +209,98 @@ describe('runMaintenanceSweep — link/timeline extraction [CX-P0.3]', () => {
       await engine.setConfig('auto_link', 'true');
       await engine.setConfig('auto_timeline', 'true');
     }
+  });
+});
+
+describe('runMaintenanceSweep — watermark progress + link reconciliation (#4196)', () => {
+  // Seed with an explicit updated_at so batch-selection order is deterministic.
+  async function seedPageAt(slug: string, body: string, updatedAtIso: string) {
+    await engine.executeRaw(
+      `INSERT INTO pages (slug, source_id, type, title, compiled_truth, updated_at)
+       VALUES ($1, 'default', 'note', $1, $2, $3::timestamptz)`,
+      [slug, body, updatedAtIso],
+    );
+  }
+  const minsAgo = (n: number) => new Date(Date.now() - n * 60_000).toISOString();
+
+  test('repeated bounded sweeps make forward progress past batchLimit', async () => {
+    // Newest two pages fill a batchLimit=2 selection; the oldest writer is
+    // starved unless the selection honors links_extracted_at.
+    await seedPageAt('prog/target', 'Target page.', minsAgo(1));
+    await seedPageAt('prog/w-new', 'See [T](prog/target).', minsAgo(2));
+    await seedPageAt('prog/w-old', 'Also see [T](prog/target).', minsAgo(3));
+
+    const sweep = () => runMaintenanceSweep(engine, {
+      sourceId: 'default', capabilities: KEYLESS, batchLimit: 2, budgetMs: 30_000,
+    });
+    await sweep();
+    await sweep();
+
+    const oldEdge = await engine.executeRaw<{ n: string }>(
+      `SELECT COUNT(*) AS n FROM links l
+         JOIN pages pf ON pf.id = l.from_page_id
+        WHERE pf.slug = 'prog/w-old'`,
+    );
+    expect(parseInt(oldEdge[0].n, 10)).toBeGreaterThanOrEqual(1);
+
+    // Every swept page is stamped at its own updated_at (extract.ts D4/#1768
+    // discipline), so the engines' shared stale predicate clears fully.
+    const stale = await engine.countStalePagesForExtraction({ sourceId: 'default' });
+    expect(stale).toBe(0);
+  });
+
+  test('a link removed via the remote put_page path is reconciled away', async () => {
+    const page = (t: string, b: string) => `---\ntitle: ${t}\ntype: note\n---\n\n${b}\n`;
+    const write = (slug: string, c: string) =>
+      importFromContent(engine, slug, c, { noEmbed: true, sourceId: 'default' });
+    const sweep = () => runMaintenanceSweep(engine, {
+      sourceId: 'default', capabilities: KEYLESS, budgetMs: 30_000,
+    });
+    const edges = async (slug: string) => engine.executeRaw<{ to_slug: string; link_source: string | null }>(
+      `SELECT pt.slug AS to_slug, l.link_source FROM links l
+         JOIN pages pf ON pf.id = l.from_page_id
+         JOIN pages pt ON pt.id = l.to_page_id
+        WHERE pf.slug = $1 ORDER BY pt.slug`,
+      [slug],
+    );
+
+    await write('concepts/target-a', page('Target A', 'Target page.'));
+    await write('concepts/writer-a', page('Writer A', 'References [Target A](concepts/target-a).'));
+    await sweep();
+    expect((await edges('concepts/writer-a')).map(e => e.to_slug)).toEqual(['concepts/target-a']);
+
+    // Non-sweep-owned provenances on the same page must survive reconciliation.
+    await engine.addLink('concepts/writer-a', 'concepts/target-a', '', 'manual-ref', 'manual');
+    await engine.addLink('concepts/writer-a', 'concepts/target-a', '', 'mention', 'mentions');
+
+    await write('concepts/writer-a', page('Writer A', 'The reference is gone.'));
+    await sweep();
+
+    const after = await edges('concepts/writer-a');
+    expect(after.map(e => e.link_source).sort()).toEqual(['manual', 'mentions']);
+  });
+
+  test('reconciliation never touches pages outside the sweep batch', async () => {
+    // A page last updated outside the recentDays window keeps its edges even
+    // though the sweep runs over the same source.
+    await seedPageAt('cold/target', 'Cold target.', minsAgo(1));
+    await seedPageAt('cold/writer', 'See [T](cold/target).', minsAgo(2));
+    await runMaintenanceSweep(engine, { sourceId: 'default', capabilities: KEYLESS, budgetMs: 30_000 });
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = now() - interval '30 days',
+                        links_extracted_at = now() - interval '30 days'
+        WHERE slug = 'cold/writer'`,
+    );
+    // Rewrite the page body so the edge would be stale IF the page were swept.
+    await engine.executeRaw(
+      `UPDATE pages SET compiled_truth = 'Reference removed.' WHERE slug = 'cold/writer'`,
+    );
+    await runMaintenanceSweep(engine, { sourceId: 'default', capabilities: KEYLESS, budgetMs: 30_000 });
+    const n = await engine.executeRaw<{ n: string }>(
+      `SELECT COUNT(*) AS n FROM links l JOIN pages pf ON pf.id = l.from_page_id
+        WHERE pf.slug = 'cold/writer'`,
+    );
+    expect(parseInt(n[0].n, 10)).toBe(1);
   });
 });
 
@@ -512,6 +605,7 @@ describe('runMaintenanceSweep — budget + never-throw', () => {
       corpusIngested: 0,
       factsReconciled: 3,
       linksExtracted: 1,
+      linksRemoved: 0,
       timelineExtracted: 0,
       skipped: [{ reason: 'budget_exhausted:corpus', count: 2 }],
       durationMs: 10,


### PR DESCRIPTION
Fixes both defects reported in #4196 — the maintenance sweep is the designated backstop for remote `put_page` (which skips inline extraction by design, `autoLinks: { skipped: 'remote' }`), but it could neither make forward progress nor remove anything.

## Root cause

**1. The watermark is stamped but never read.** Selection in `runLinksTimelinePass` (`src/core/sweep.ts:294`) filtered only on `updated_at >= cutoff`, ordered `updated_at DESC`, `LIMIT batchLimit` (default 20). After processing, `stampExtracted` advances `links_extracted_at` — but nothing read it, and processing never touches `updated_at`, so every sweep re-selected the same newest 20 rows. Page 21 was unreachable forever.

**2. Add-only edges.** The pass inserted via `engine.addLinksBatch` with no removal step. Local writes reconcile through `runAutoLink` (`src/core/ops/pages.ts`), but remote `put_page` skips that hook — so for exactly the pages the sweep exists to serve, a dropped `[[link]]` left a phantom edge forever. Fixing (1) alone would make (2) worse: the page gets swept once additively, stamped fresh, and the phantom edge becomes permanently invisible.

## Fix

- Selection now adds the engines' shared stale predicate (`buildStalePagesWhere`): `AND (links_extracted_at IS NULL OR updated_at > links_extracted_at)`. No `versionTs` branch — extractor-version catch-up stays `extract --stale`'s job; the sweep is a recency backstop.
- Each page is stamped at its **read** `updated_at`, projected with the µs `to_char` idiom from the #1768 fix — not `now()` — so an edit between SELECT and stamp stays stale and re-sweeps.
- After inserts, the pass reconciles each processed page inside the same advisory-locked transaction shape as `runAutoLink` (same `autoLinkLockKey`, so it serializes against a concurrent local `put_page` on the slug). Removal is scoped to sweep-owned provenances only: `markdown`, NULL-legacy, `wikilink-resolved`. `frontmatter` is deliberately excluded — the sweep extracts with `skipFrontmatter: true`, so its desired set can never contain frontmatter candidates and deleting them would clobber valid edges. `manual` and `mentions` are never touched (pinned by test).
- A page whose reconcile fails or is cut by budget is left unstamped, so the next sweep retries it.
- `SweepReport` gains an additive `linksRemoved` counter (printed by `gbrain sweep`); `stampExtracted` refs accept the per-ref `extractedAt` that `markPagesExtractedBatch` already supports. No engine changes — all SQL stays in sweep.ts.

## Proof

New tests in `test/sweep.test.ts` drive `runMaintenanceSweep` through the real production paths (`importFromContent` is what remote `put_page` calls). Red on master, green with the fix:

```
(fail) … repeated bounded sweeps make forward progress past batchLimit
(fail) … a link removed via the remote put_page path is reconciled away
 32 pass / 2 fail        # master
 34 pass / 0 fail        # with fix
```

- Forward progress: 3 pages, `batchLimit: 2` — the starved oldest page gets its link on sweep 2, and `countStalePagesForExtraction` returns 0 afterwards (the stamp really clears the engines' shared predicate at µs precision).
- Reconciliation: write → sweep → edge exists; rewrite without the reference → sweep → edge gone, while `manual` and `mentions` edges on the same page survive.
- Blast radius guard: pages outside the `recentDays` window keep their edges untouched.

`bun run typecheck` clean; `bun run verify` 54/54 (including the system-of-record and jsonb guards); `test/extract-stale.test.ts`, `test/public-exports.test.ts`, both sync stamp serial suites, and `test/e2e/bootstrap-magic-moment.serial.test.ts` all pass.

## Honest limits

- Timeline entries remain additive on every path (including `runAutoLink`) — pre-existing, out of #4196's scope; links-only reconcile keeps the sweep at exact parity with what local writers get.
- `extractStaleFromDB` is also additive-only; same class, left for a separate decision.
- Pages last updated outside the sweep's `recentDays` window (default 7d) are still never revisited — that bound is existing design; this PR makes sweeps converge *within* it.

Refs: #4196

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
