### PR TITLE
feat(budget): declare static canonical rates for router-prefixed OpenRouter ids

### DIFF
--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -102,6 +102,29 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   // DeepSeek v4 (verified 2026-07-27 at api-docs.deepseek.com): cache-miss rates.
   'deepseek:deepseek-v4-flash':           { input:  0.14, output:  0.28 },
   'deepseek:deepseek-v4-pro':             { input:  0.435, output: 0.87 },
+
+  // ── OpenRouter (router-prefixed, own catalogue rate) ────────────────────
+  // Static entries pulled from OpenRouter's published `/api/v1/models`
+  // catalogue (verified 2026-08-17), NOT aliased to the inner vendor's
+  // direct rate — a router bills its own spread, and canonicalLookup's
+  // nested-id miss (see doc comment below) exists precisely to stop a
+  // router-prefixed id from silently matching the vendor's key instead.
+  // These are exact-key entries for the router id itself, so that miss
+  // path is untouched; only ids listed here resolve, everything else still
+  // returns undefined and the caller's no-pricing refusal still applies.
+  //
+  // Scoped to the three models this fork's OpenRouter fallback tier
+  // actually routes through (model-fallback-probe.ts's FALLBACK map) —
+  // add more entries here as needed rather than fetching the catalogue
+  // live; see PR discussion on gbrain#3848 for why a dynamic fetch/cache
+  // didn't merge (default-on network behavior, new pricing-source surface).
+  //
+  // deepseek/deepseek-v4-flash-0731 matches deepseek:deepseek-v4-flash
+  // above to the cent — OpenRouter passing DeepSeek through at vendor
+  // rate, not a coincidence worth losing to an alias shortcut.
+  'openrouter:deepseek/deepseek-v4-flash-0731': { input: 0.14,  output: 0.28 },
+  'openrouter:qwen/qwen3.7-flash':              { input: 0.03,  output: 0.13 },
+  'openrouter:qwen/qwen3.6-plus':               { input: 0.325, output: 1.95 },
 };
 
 /**

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -80,8 +80,27 @@ describe('canonicalLookup — id normalization', () => {
     expect(canonicalLookup('gpt-5')).toBeUndefined();
   });
 
-  test('nested OpenRouter id → MISS (markup ≠ native pricing)', () => {
+  test('nested OpenRouter id with NO declared entry → MISS (markup ≠ native pricing)', () => {
     expect(canonicalLookup('openrouter:anthropic/claude-sonnet-4-6')).toBeUndefined();
+  });
+
+  test('OpenRouter id WITH a declared static entry → hit on its own rate, not the vendor alias', () => {
+    // deepseek/deepseek-v4-flash-0731 happens to match deepseek:deepseek-v4-flash
+    // to the cent, but this must resolve via its OWN canonical key, not by
+    // falling through to the bare vendor tail — that fallthrough is exactly
+    // what canonicalLookup's nested-id miss (case above) exists to prevent.
+    expect(canonicalLookup('openrouter:deepseek/deepseek-v4-flash-0731')).toEqual({
+      input: 0.14,
+      output: 0.28,
+    });
+    expect(canonicalLookup('openrouter:qwen/qwen3.7-flash')).toEqual({
+      input: 0.03,
+      output: 0.13,
+    });
+    expect(canonicalLookup('openrouter:qwen/qwen3.6-plus')).toEqual({
+      input: 0.325,
+      output: 1.95,
+    });
   });
 
   test('slash-bearing model tail kept as exact key (together Llama)', () => {


### PR DESCRIPTION
Narrow re-cut of #3848, per the review comment on that PR:
https://github.com/garrytan/gbrain/pull/3848#issuecomment-5273840300

## What changed vs. #3848

#3848's dynamic fetch/cache module (`openrouter-rates.ts`) didn't merge — it
introduced a new pricing-source surface and default-on network behavior
(a recurring outbound catalogue fetch from every install's housekeeping
cycle). The review comment named the accepted shape explicitly:

> declare the router-prefixed model rates as static entries against the
> existing canonical table ... Small diff, no fetch, no new module — send
> that alone and it goes in the normal lane

This PR is that cut. No new module, no fetch, no config surface — same
shape as prior merged edits to `CANONICAL_PRICING`.

## The change

Three exact-key entries in `model-pricing.ts`'s `CANONICAL_PRICING`:

```
openrouter:deepseek/deepseek-v4-flash-0731  $0.14 / $0.28
openrouter:qwen/qwen3.7-flash               $0.03 / $0.13
openrouter:qwen/qwen3.6-plus                $0.325 / $1.95
```

Rates pulled from OpenRouter's published `/api/v1/models` catalogue
(verified 2026-08-17). These are declared as the router id's own key, not
aliased to the inner vendor's direct rate — `canonicalLookup`'s existing
nested-id miss (`openrouter:anthropic/claude-...` stays undefined,
preventing a silent reprice at Anthropic's direct rate) is untouched.
Only the three ids listed above resolve; every other router-prefixed id
still returns `undefined` and the caller's no-pricing refusal still
applies.

`deepseek/deepseek-v4-flash-0731` matches `deepseek:deepseek-v4-flash`
to the cent — consistent with the pattern surfaced in #3833's discussion,
where every overlapping OpenRouter/vendor rate checked (DeepSeek and
embedding models) matched exactly. Declared as its own entry anyway
rather than reusing the vendor key, per the no-alias invariant.

## Why these three

Scoped to the models actually reachable in practice: these are the ids
this fork's OpenRouter fallback tier routes through when the primary
provider is unavailable. Rather than fetching the full catalogue, this
adds entries as they're needed — a few more lines, no new surface.

## Verification

- `bun run typecheck`: clean
- `bun test test/model-pricing.test.ts`: 20/20 pass (includes 2 new
  assertions: a declared router id hits its own rate, not a vendor alias)
- `bun test test/anthropic-pricing.test.ts test/batch-projection.test.ts`:
  26/26 pass — existing `openrouter:anthropic/claude-sonnet-4-6` miss
  assertions in both files are untouched and still pass
- `bun test test/budget-tracker.test.ts test/budget-meter.test.ts`: 12/13
  pass; the 1 failure is a `beforeEach`/`afterEach` hook timeout that
  reproduces identically on the unmodified base commit with this diff
  stashed — confirmed pre-existing, not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)