### PR TITLE
fix(migrate): embedding column rebuild silently discards the embedding-IS-NULL partial indexes (#4252)

### DIFF
--- a/src/core/embedding-migration.ts
+++ b/src/core/embedding-migration.ts
@@ -136,6 +136,14 @@ export function formatEnvOverrideWarning(w: EnvOverrideWarning): string {
  *   src/schema.sql:169  -> idx_chunks_embedding_image
  *   src/core/pglite-schema.ts:130 -> idx_chunks_embedding_image
  *
+ * #4252: DROP COLUMN cascades away EVERY index depending on the column, not
+ * only the ones named here — it silently discarded the partial btree indexes
+ * on `embedding IS NULL` (idx_chunks_embedding_null from migration v66,
+ * content_chunks_stale_idx from v103) that `embed --stale` needs. So the
+ * transition captures every dependent index def via pg_depend (the exact set
+ * the cascade drops) before the drop and replays it after the rebuild;
+ * hard-coded names would just recreate this bug on the next index addition.
+ *
  * IF NOT EXISTS on CREATE INDEX makes the operation safe to re-run during
  * `--resume`.
  */
@@ -160,6 +168,25 @@ export async function runSchemaTransition(engine: BrainEngine, targetDim: number
   // 1280d, making voyage-multimodal-3 unable to write to it. The same
   // class of bug applies to embedding_multimodal — leave both untouched.
   await engine.transaction(async (tx) => {
+    // #4252: capture every index the DROP COLUMN below will cascade-drop.
+    // pg_depend holds the exact column→index dependency edges the cascade
+    // follows, so this also catches indexes that reference the column only
+    // in a partial WHERE predicate (which a pg_indexes.indexdef text match
+    // could not do without false-matching embedding_image/_multimodal).
+    const dependentIndexes = await tx.executeRaw<{ name: string; def: string }>(
+      `SELECT DISTINCT c.relname AS name, pg_get_indexdef(d.objid) AS def
+         FROM pg_depend d
+         JOIN pg_class c ON c.oid = d.objid AND c.relkind = 'i'
+        WHERE d.classid = 'pg_class'::regclass
+          AND d.refclassid = 'pg_class'::regclass
+          AND d.deptype = 'a'
+          AND d.refobjid = to_regclass('content_chunks')
+          AND d.refobjsubid = (
+            SELECT attnum FROM pg_attribute
+             WHERE attrelid = to_regclass('content_chunks')
+               AND attname = 'embedding' AND NOT attisdropped)`,
+    );
+
     // Text embedding column — transition to target dim.
     await tx.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding`);
     await tx.executeRaw(`ALTER TABLE content_chunks DROP COLUMN IF EXISTS embedding`);
@@ -170,6 +197,17 @@ export async function runSchemaTransition(engine: BrainEngine, targetDim: number
     if (hnswIndexExpected('vector', targetDim)) {
       await tx.executeRaw(
         `CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops)`,
+      );
+    }
+    // #4252: replay the captured dependent indexes the cascade dropped.
+    // idx_chunks_embedding is skipped (recreated above under the cap policy);
+    // any other HNSW def on the column obeys the same cap. Btree/partial defs
+    // are dim-agnostic and replay unconditionally.
+    for (const idx of dependentIndexes) {
+      if (idx.name === 'idx_chunks_embedding') continue;
+      if (/USING hnsw/i.test(idx.def) && !hnswIndexExpected('vector', targetDim)) continue;
+      await tx.executeRaw(
+        idx.def.replace(/^CREATE (UNIQUE )?INDEX /, 'CREATE $1INDEX IF NOT EXISTS '),
       );
     }
 

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5905,6 +5905,41 @@ export const MIGRATIONS: Migration[] = [
       ALTER TABLE session_context_state ADD COLUMN IF NOT EXISTS checkpoint_manifest JSONB NOT NULL DEFAULT '[]'::jsonb;
     `,
   },
+  {
+    version: 133,
+    name: 'restore_chunks_embedding_null_partial_indexes',
+    // #4252 heal: `migrate embeddings` rebuilt content_chunks.embedding via
+    // DROP COLUMN, which cascade-dropped the `embedding IS NULL` partial
+    // indexes (v66 idx_chunks_embedding_null, v103 content_chunks_stale_idx)
+    // without recreating them. runSchemaTransition now captures + replays
+    // dependent indexes, but brains that already ran a transition lost both
+    // permanently — v66/v103 are recorded as applied, so their IF NOT EXISTS
+    // never re-runs. Re-issue both defs; a no-op everywhere else.
+    // Engine-aware split mirrors v103: Postgres uses CREATE INDEX
+    // CONCURRENTLY + invalid-remnant pre-drop; PGLite plain CREATE INDEX.
+    transaction: false,
+    sql: '',
+    handler: async (engine) => {
+      const defs: Array<[string, string]> = [
+        ['idx_chunks_embedding_null', `ON content_chunks (page_id, chunk_index) WHERE embedding IS NULL;`],
+        ['content_chunks_stale_idx', `ON content_chunks (page_id, chunk_index) WHERE embedding IS NULL;`],
+      ];
+      for (const [name, tail] of defs) {
+        if (engine.kind === 'postgres') {
+          await dropInvalidConcurrentIndex(engine, 133, name);
+          await engine.runMigration(
+            133,
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${name} ${tail}`
+          );
+        } else {
+          await engine.runMigration(
+            133,
+            `CREATE INDEX IF NOT EXISTS ${name} ${tail}`
+          );
+        }
+      }
+    },
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -2327,3 +2327,37 @@ describe('v117 — context_volunteer_events_table', () => {
     expect(left.map(r => r.slug)).toEqual(['people/alice-example']);
   });
 });
+
+// #4252 — v133 heal: brains whose `migrate embeddings` run predates the
+// runSchemaTransition capture/replay fix lost both `embedding IS NULL`
+// partial indexes to the DROP COLUMN cascade. v66/v103 are recorded as
+// applied on those brains, so their IF NOT EXISTS never re-runs; v133
+// re-issues both defs. No-op on healthy brains.
+describe('v133 — restore_chunks_embedding_null_partial_indexes', () => {
+  test('recreates both partial indexes lost to a pre-fix embedding transition', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      // Simulate the pre-fix damage: both partial indexes gone.
+      await engine.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding_null`);
+      await engine.executeRaw(`DROP INDEX IF EXISTS content_chunks_stale_idx`);
+      // Rewind so v133 re-runs.
+      await engine.setConfig('version', '132');
+      await runMigrations(engine);
+
+      const rows = await engine.executeRaw<{ indexname: string; indexdef: string }>(
+        `SELECT indexname, indexdef FROM pg_indexes
+          WHERE tablename = 'content_chunks'
+            AND indexname IN ('idx_chunks_embedding_null', 'content_chunks_stale_idx')
+          ORDER BY indexname`,
+      );
+      expect(rows.map(r => r.indexname)).toEqual(['content_chunks_stale_idx', 'idx_chunks_embedding_null']);
+      for (const r of rows) {
+        expect(r.indexdef).toMatch(/WHERE\s+\(?embedding IS NULL\)?/i);
+      }
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
+});

--- a/test/retrieval-upgrade-planner.test.ts
+++ b/test/retrieval-upgrade-planner.test.ts
@@ -306,6 +306,42 @@ describe('applyRetrievalUpgrade — state machine + atomicity (D12, D18)', () =>
     expect(rows[0].indexdef).toMatch(/WHERE\s+\(?embedding_image IS NOT NULL\)?/i);
   });
 
+  // #4252 — DROP COLUMN embedding cascades away every index depending on the
+  // column, including the two partial btree indexes on `embedding IS NULL`
+  // (idx_chunks_embedding_null from migration v66, content_chunks_stale_idx
+  // from v103 / fresh schema). They are exactly what `embed --stale` — the
+  // migration's own recommended next step — needs. The transition must
+  // capture and replay every dependent index, not just the ones it names.
+  test('runSchemaTransition preserves partial stale indexes on content_chunks.embedding (#4252)', async () => {
+    await setLegacyDefaultConfig();
+    await seedPages(150);
+
+    // Fresh PGLite schema only carries content_chunks_stale_idx
+    // (pglite-schema.ts). Brains upgraded through migration v66 also have
+    // idx_chunks_embedding_null — create it to cover both index names.
+    await engine.executeRaw(
+      `CREATE INDEX IF NOT EXISTS idx_chunks_embedding_null
+         ON content_chunks (page_id, chunk_index)
+         WHERE embedding IS NULL`,
+    );
+
+    const plan = await planRetrievalUpgrade(engine);
+    await applyRetrievalUpgrade(engine, plan);
+
+    const rows = await engine.executeRaw<{ indexname: string; indexdef: string }>(
+      `SELECT indexname, indexdef FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'content_chunks'
+          AND indexname IN ('idx_chunks_embedding_null', 'content_chunks_stale_idx')
+        ORDER BY indexname`,
+    );
+    const byName = new Map(rows.map(r => [r.indexname, r.indexdef]));
+    expect([...byName.keys()]).toEqual(['content_chunks_stale_idx', 'idx_chunks_embedding_null']);
+    // The replayed definitions must keep the partial predicate.
+    expect(byName.get('content_chunks_stale_idx')).toMatch(/WHERE\s+\(?embedding IS NULL\)?/i);
+    expect(byName.get('idx_chunks_embedding_null')).toMatch(/WHERE\s+\(?embedding IS NULL\)?/i);
+  });
+
   test('runSchemaTransition EXISTS guard short-circuits cleanly when embedding_image column is absent', async () => {
     // Simulate a (hypothetical) pre-v0.27.1 brain with no embedding_image
     // column. The fix's EXISTS probe must skip the image branch without


### PR DESCRIPTION
Fixes #4252.

## Root cause

`runSchemaTransition` (src/core/embedding-migration.ts:162-174 on master) rebuilds `content_chunks.embedding` with `DROP COLUMN` + `ADD COLUMN` inside one transaction. `DROP COLUMN` cascade-drops **every** index that depends on the column, but the function only recreates the ones it names: `idx_chunks_embedding` (HNSW, under the dim-cap policy) and, in its own arm, `idx_chunks_embedding_image`. The two partial btree indexes on `WHERE embedding IS NULL` —

- `idx_chunks_embedding_null` (migration v66, src/core/migrate.ts:3314)
- `content_chunks_stale_idx` (migration v103, src/core/migrate.ts:4698)

— depend on the column only through their WHERE predicate, so the cascade takes them and nothing puts them back. They serve exactly the query the migration's final message tells the user to run next (`gbrain embed --stale`). v66/v103 are recorded as applied, so their `IF NOT EXISTS` never re-runs: the loss is permanent, silent, and largest on the biggest brains.

## Fix (commit 1)

Capture every dependent index def before the drop, replay after the rebuild — the issue's option 2. The capture uses `pg_depend`, which holds the exact column→index edges the cascade follows, so predicate-only dependencies are caught and `embedding_image`/`embedding_multimodal` indexes are structurally excluded (no `indexdef` text-matching). Replay skips `idx_chunks_embedding` (already recreated under the HNSW cap policy), gates any other HNSW def on the same cap, and inserts `IF NOT EXISTS` for `--resume` safety. Hard-coding the two missing names would just recreate this bug on the next index addition.

Runs on the existing `tx` handle inside the existing transaction; no engine method added, identical SQL on both engines.

## Heal (commit 2 — separable if unwanted)

Brains that already ran a transition lost both indexes permanently; the fixed transition never re-runs for them. Migration v133 re-issues both defs, mirroring v103's engine split (`CREATE INDEX CONCURRENTLY` + invalid-remnant pre-drop on Postgres, plain `CREATE INDEX` on PGLite). No-op everywhere else.

## Proof

New test in test/retrieval-upgrade-planner.test.ts drives the real `planRetrievalUpgrade` → `applyRetrievalUpgrade` path on a PGLite engine (with `idx_chunks_embedding_null` added to simulate a v66-upgraded brain) and asserts both indexes survive with their predicate. Red on unfixed master:

```
error: expect(received).toEqual(expected)   # both index names missing after transition
(fail) runSchemaTransition preserves partial stale indexes on content_chunks.embedding (#4252)
```

Green with the fix: 28/28 in the file. The v133 test in test/migrate.test.ts drops both indexes, rewinds `version` to 132, runs `runMigrations`, and asserts both come back (also red-verified against unfixed sources).

Blast radius run: 706 tests across 27 migration/schema/doctor files + the 6 serial migration suites, all green; `bun run typecheck` and `bun run verify` clean.

## Limits

- The v133 `CONCURRENTLY` arm is Postgres-only and not exercised under PGLite; it is a verbatim copy of the v103 pattern. I did not run the `DATABASE_URL`-gated e2e lane locally.
- The issue also notes v103's index duplicates v66's byte-for-byte. Left alone — deduping live index names has its own CONCURRENTLY considerations and is a separate decision.

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara