### PR TITLE
fix(cycle): mirror search reranker config in nightly probe

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -1359,7 +1359,10 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     // loop. Probe runs even when cycleOk=false (probe may surface signal
     // explaining why the cycle is failing).
     try {
-      const { resolveProbeEnabled, resolveProbeMaxUsd, runNightlyQualityProbe } = await import('../core/cycle/nightly-quality-probe.ts');
+      const { resolveProbeEnabled, resolveProbeMaxUsd, runNightlyQualityProbe } =
+        await import('../core/cycle/nightly-quality-probe.ts');
+      const { resolveNightlyProbeSearchConfigSnapshot } =
+        await import('../core/cycle/nightly-probe-search-config.ts');
       // Dual-plane read: `gbrain config set` (what the doctor enable hint
       // prints) writes the DB plane; ~/.gbrain/config.json is the fallback.
       let dbEnabled: string | null = null;
@@ -1376,12 +1379,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const { fileURLToPath } = await import('node:url');
         const { join } = await import('node:path');
         const maxUsd = resolveProbeMaxUsd(dbMaxUsd, cfg?.autopilot?.nightly_quality_probe?.max_usd);
-        // The committed fixture (test/fixtures/longmemeval-nightly.jsonl)
-        // lives in the gbrain PACKAGE, not the brain repo — repoPath is
-        // sync.repo_path (the user's brain), where the fixture never
-        // exists, so the probe error'd on every real install. Resolve the
-        // package root from the module location; keep repoPath as the
-        // fallback for setups that vendor the fixture into the brain repo.
+        // The fixture lives in the package, not usually in the user's brain repo.
         const pkgRoot = fileURLToPath(new URL('../..', import.meta.url));
         const fixtureAtPkgRoot = existsSync(join(pkgRoot, 'test', 'fixtures', 'longmemeval-nightly.jsonl'));
         await runNightlyQualityProbe({
@@ -1389,6 +1387,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           hasEmbeddingProvider: () => isAvailable('embedding'),
           resolveMaxUsd: () => maxUsd,
           resolveRepoRoot: () => (fixtureAtPkgRoot ? pkgRoot : repoPath ?? gbrainHomePath('.')),
+          resolveSearchConfigSnapshot: () => resolveNightlyProbeSearchConfigSnapshot(engine),
           runLongMemEval: runLongMemEvalForProbe,
           runCrossModalBatch: runCrossModalBatchForProbe,
           now: () => new Date(),

--- a/src/commands/eval-longmemeval.ts
+++ b/src/commands/eval-longmemeval.ts
@@ -393,6 +393,12 @@ export interface RunOpts {
    * a production engine with real data would clobber it via resetTables.
    */
   engine?: PGLiteEngine;
+  /**
+   * v0.45.0+ (#3676): live nightly-probe search-mode/reranker settings copied
+   * into the isolated benchmark brain. This preserves benchmark data isolation
+   * while keeping the probe on the operator-selected retrieval pipeline.
+   */
+  searchConfigSnapshot?: Record<string, string>;
 }
 
 export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}): Promise<void> {
@@ -526,7 +532,15 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
   // already calls resetTables() as its first line so the prior caller's
   // pages are cleared on the first question of this run.
   const work = async (engine: PGLiteEngine): Promise<void> => {
-    // v0.32.3 search-lite: thread --mode into the in-memory brain's config.
+    // v0.45.0+ (#3676): nightly probe callers may copy audited live search
+    // config into this isolated engine. Data tables stay hermetic, but the
+    // benchmark no longer silently evaluates a different reranker/mode.
+    for (const [key, value] of Object.entries(runOpts.searchConfigSnapshot ?? {})) {
+      if (key.trim().length > 0) {
+        await engine.setConfig(key, value);
+      }
+    }
+    // v0.32.3 search-lite: explicit --mode wins over any injected snapshot.
     // resetTables preserves `config` between questions, so this fires once
     // for the run. hybridSearch resolves it through the standard chain.
     if (opts.mode) {

--- a/src/core/cycle/nightly-probe-adapters.ts
+++ b/src/core/cycle/nightly-probe-adapters.ts
@@ -21,6 +21,7 @@ import { readFileSync, existsSync } from 'node:fs';
 export interface LongMemEvalProbeArgs {
   fixturePath: string;
   outputPath: string;
+  searchConfigSnapshot?: Record<string, string>;
 }
 
 /** Arguments accepted by the cross-modal adapter. */
@@ -54,7 +55,10 @@ export interface CrossModalBatchSummary {
  */
 export async function runLongMemEvalForProbe(args: LongMemEvalProbeArgs): Promise<void> {
   const { runEvalLongMemEval } = await import('../../commands/eval-longmemeval.ts');
-  await runEvalLongMemEval([args.fixturePath, '--output', args.outputPath]);
+  await runEvalLongMemEval(
+    [args.fixturePath, '--output', args.outputPath],
+    { searchConfigSnapshot: args.searchConfigSnapshot },
+  );
 }
 
 /**

--- a/src/core/cycle/nightly-probe-search-config.ts
+++ b/src/core/cycle/nightly-probe-search-config.ts
@@ -1,0 +1,20 @@
+import type { BrainEngine } from '../engine.ts';
+import { NIGHTLY_PROBE_SEARCH_CONFIG_KEYS } from './nightly-quality-probe.ts';
+
+export async function resolveNightlyProbeSearchConfigSnapshot(
+  engine: BrainEngine,
+): Promise<Record<string, string>> {
+  try {
+    const snapshot: Record<string, string> = {};
+    for (const key of NIGHTLY_PROBE_SEARCH_CONFIG_KEYS) {
+      const value = await engine.getConfig(key);
+      if (value != null) snapshot[key] = value;
+    }
+    return snapshot;
+  } catch (err) {
+    throw new Error(
+      `nightly-quality-probe: could not read live search config snapshot: ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/core/cycle/nightly-quality-probe.ts
+++ b/src/core/cycle/nightly-quality-probe.ts
@@ -34,6 +34,15 @@ const DEFAULT_MAX_USD = 5.0;
 /** Committed fixture used as the probe's input dataset. */
 const NIGHTLY_FIXTURE_REL_PATH = 'test/fixtures/longmemeval-nightly.jsonl';
 
+export const NIGHTLY_PROBE_SEARCH_CONFIG_KEYS: ReadonlyArray<string> = Object.freeze([
+  'search.mode',
+  'search.reranker.enabled',
+  'search.reranker.model',
+  'search.reranker.top_n_in',
+  'search.reranker.top_n_out',
+  'search.reranker.timeout_ms',
+]);
+
 /** Result reported back to the cycle dispatcher / Minion handler. */
 export interface NightlyProbeResult {
   outcome: 'pass' | 'fail' | 'inconclusive' | 'error' | 'budget_exceeded' | 'rate_limited' | 'no_embedding_key' | 'disabled';
@@ -50,8 +59,10 @@ export interface NightlyProbeDeps {
   resolveMaxUsd: () => number | Promise<number>;
   /** Resolves the repo root so we can find the committed fixture. */
   resolveRepoRoot: () => string | Promise<string>;
+  /** Resolves live search-mode/reranker overrides copied into the isolated benchmark brain. */
+  resolveSearchConfigSnapshot?: () => Record<string, string> | Promise<Record<string, string>>;
   /** Runs the longmemeval command; returns the path to the JSONL output. */
-  runLongMemEval: (args: { fixturePath: string; outputPath: string }) => Promise<void>;
+  runLongMemEval: (args: { fixturePath: string; outputPath: string; searchConfigSnapshot?: Record<string, string> }) => Promise<void>;
   /** Runs the cross-modal batch; returns exit code (0/1/2). */
   runCrossModalBatch: (args: {
     batchPath: string;
@@ -198,7 +209,10 @@ export async function runNightlyQualityProbe(deps: NightlyProbeDeps): Promise<Ni
   const summaryPath = path.join(workDir, 'summary.json');
 
   try {
-    await deps.runLongMemEval({ fixturePath, outputPath: lmeOutPath });
+    const searchConfigSnapshot = deps.resolveSearchConfigSnapshot
+      ? await deps.resolveSearchConfigSnapshot()
+      : undefined;
+    await deps.runLongMemEval({ fixturePath, outputPath: lmeOutPath, searchConfigSnapshot });
     const { exitCode, summary } = await deps.runCrossModalBatch({
       batchPath: lmeOutPath,
       summaryPath,

--- a/test/cycle/nightly-probe-adapters.test.ts
+++ b/test/cycle/nightly-probe-adapters.test.ts
@@ -114,7 +114,15 @@ describe('nightly-probe-adapters: argv shape regression (codex round-2 #1)', () 
     const fs = require('node:fs');
     const source = fs.readFileSync(path, 'utf-8');
     // longmemeval adapter: first positional arg is fixturePath, then --output outputPath.
-    expect(source).toMatch(/runEvalLongMemEval\(\[args\.fixturePath, '--output', args\.outputPath\]\)/);
+    expect(source).toContain("[args.fixturePath, '--output', args.outputPath]");
+  });
+
+  test('runLongMemEvalForProbe passes the live search config snapshot via RunOpts', () => {
+    const path = require('node:path').resolve('src/core/cycle/nightly-probe-adapters.ts');
+    const fs = require('node:fs');
+    const source = fs.readFileSync(path, 'utf-8');
+
+    expect(source).toContain('searchConfigSnapshot: args.searchConfigSnapshot');
   });
 });
 

--- a/test/eval-longmemeval-search-config.test.ts
+++ b/test/eval-longmemeval-search-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { runEvalLongMemEval } from '../src/commands/eval-longmemeval.ts';
+import { createBenchmarkBrain } from '../src/eval/longmemeval/harness.ts';
+
+const FIXTURE_PATH = join(import.meta.dir, 'fixtures', 'longmemeval-mini.jsonl');
+
+describe('runEvalLongMemEval — injected search config snapshot', () => {
+  test('copies live search-mode/reranker config into the isolated benchmark brain', async () => {
+    const engine = await createBenchmarkBrain();
+    const tmp = mkdtempSync(join(tmpdir(), 'lme-search-config-'));
+    try {
+      await runEvalLongMemEval(
+        [
+          FIXTURE_PATH,
+          '--keyword-only',
+          '--retrieval-only',
+          '--no-trajectory',
+          '--limit',
+          '1',
+          '--output',
+          join(tmp, 'out.jsonl'),
+          '--mode',
+          'tokenmax',
+        ],
+        {
+          engine,
+          searchConfigSnapshot: {
+            'search.mode': 'balanced',
+            'search.reranker.enabled': 'false',
+            'search.reranker.model': 'llama-server-reranker:qwen3-reranker-4b',
+            'search.reranker.timeout_ms': '30000',
+          },
+        },
+      );
+
+      expect(await engine.getConfig('search.mode')).toBe('tokenmax');
+      expect(await engine.getConfig('search.reranker.enabled')).toBe('false');
+      expect(await engine.getConfig('search.reranker.model'))
+        .toBe('llama-server-reranker:qwen3-reranker-4b');
+      expect(await engine.getConfig('search.reranker.timeout_ms')).toBe('30000');
+    } finally {
+      await engine.disconnect();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/test/nightly-quality-probe.test.ts
+++ b/test/nightly-quality-probe.test.ts
@@ -162,6 +162,31 @@ describe('runNightlyQualityProbe (DI stub harness)', () => {
     });
   });
 
+  test('threads live search-mode/reranker snapshot into LongMemEval', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditTmp }, async () => {
+      let seenSnapshot: Record<string, string> | undefined;
+      const r = await runNightlyQualityProbe(makeDeps({
+        resolveSearchConfigSnapshot: async () => ({
+          'search.mode': 'balanced',
+          'search.reranker.enabled': 'true',
+          'search.reranker.model': 'llama-server-reranker:qwen3-reranker-4b',
+          'search.reranker.timeout_ms': '30000',
+        }),
+        runLongMemEval: async (args) => {
+          seenSnapshot = args.searchConfigSnapshot;
+        },
+      }));
+
+      expect(r.outcome).toBe('pass');
+      expect(seenSnapshot).toEqual({
+        'search.mode': 'balanced',
+        'search.reranker.enabled': 'true',
+        'search.reranker.model': 'llama-server-reranker:qwen3-reranker-4b',
+        'search.reranker.timeout_ms': '30000',
+      });
+    });
+  });
+
   test('enabled + FAIL summary → outcome: fail', async () => {
     await withEnv({ GBRAIN_AUDIT_DIR: auditTmp }, async () => {
       const r = await runNightlyQualityProbe(makeDeps({


### PR DESCRIPTION
## Summary
- snapshot the live search mode and reranker config used by the nightly quality probe
- inject that audited snapshot into the isolated LongMemEval PGLite brain before benchmark questions run
- keep explicit --mode overrides higher precedence than the injected snapshot
- keep the autopilot entrypoint under the upstream module-size ratchet by moving snapshot resolution into a cycle helper

Fixes #3676.

## Why
The nightly quality probe runs LongMemEval in an isolated PGLite brain, which is correct for benchmark data isolation. But the isolated engine previously started with an empty config table, so a configured search.reranker.model could be ignored and the probe could evaluate a different reranker pipeline than production search.

This keeps the data isolation boundary intact while copying only the search-mode/reranker keys needed for the probe path. It deliberately does not mirror every search.* key.

## Validation
- GBRAIN_HOME=/tmp/gbrain-nightly-probe-test-rebase2 bun test test/nightly-quality-probe.test.ts test/cycle/nightly-probe-adapters.test.ts test/eval-longmemeval-search-config.test.ts
- bun run typecheck
- GBRAIN_HOME=/tmp/gbrain-nightly-reranker-verify-rebase2 bun run verify (54/54 checks passed)