### PR TITLE
fix(cycle): honor propose_takes off switch

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -11,7 +11,7 @@ src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely;
 src/commands/sync.ts	4300	ratchet	peel target: containment sprint C13-C14; grown v0.46.11.0 five-issue wave
 src/core/ai/gateway.ts	4364	ratchet	watchlist; merged: master waves + dream-wave C1-C3+C7 (thinking predicate, length, providerMetadata, turn permits) + TurnPermit signal form
 src/cli.ts	3482	ratchet	watchlist; merged unions: cathedral-5 compile-context wiring + gap-closure thin-client routing + cathedral-6 register guards + sources self-help
-src/core/cycle.ts	3030	ratchet
+src/core/cycle.ts	3043	ratchet
 src/commands/serve-http.ts	2978	ratchet	grown cathedral-6 multi-agent wave (admin register route composes registerScopedClient in one tx under the name advisory lock; ttl validation + brain_too_old preflight) + chennai no-grant federated scope
 src/commands/jobs.ts	2950	ratchet	grown v0.46.11.0 five-issue wave
 src/core/search/hybrid.ts	2500	ratchet

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2484,17 +2484,30 @@ export async function runCycle(
 
         if (phases.includes('propose_takes')) {
           checkAborted(cycleSignal);
-          progress.start('cycle.propose_takes');
-          const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
-          // gbrain#4168: thread the job's absolute deadline so the phase's
-          // clean partial-exit fires before the worker's kill switch (same
-          // literal shape as the patterns call above so the structural guard
-          // matches both).
-          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined, deadlineAtMs: opts.deadlineAtMs ?? null }) as Promise<PhaseResult>);
-          result.duration_ms = duration_ms;
-          phaseResults.push(result);
-          progress.finish();
-          await safeYield(opts.yieldBetweenPhases);
+          const enabledRaw = await engine.getConfig('cycle.propose_takes.enabled');
+          const explicitlyDisabled = typeof enabledRaw === 'string' &&
+            ['false', '0', 'no', 'off'].includes(enabledRaw.trim().toLowerCase());
+          if (explicitlyDisabled) {
+            phaseResults.push({
+              phase: 'propose_takes',
+              status: 'skipped',
+              duration_ms: 0,
+              summary: 'propose_takes disabled by cycle.propose_takes.enabled',
+              details: { reason: 'disabled_by_config' },
+            });
+          } else {
+            progress.start('cycle.propose_takes');
+            const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
+            // gbrain#4168: thread the job's absolute deadline so the phase's
+            // clean partial-exit fires before the worker's kill switch (same
+            // literal shape as the patterns call above so the structural guard
+            // matches both).
+            const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined, deadlineAtMs: opts.deadlineAtMs ?? null }) as Promise<PhaseResult>);
+            result.duration_ms = duration_ms;
+            phaseResults.push(result);
+            progress.finish();
+            await safeYield(opts.yieldBetweenPhases);
+          }
         }
 
         if (phases.includes('grade_takes')) {

--- a/test/cycle-enabled-phase-completeness.test.ts
+++ b/test/cycle-enabled-phase-completeness.test.ts
@@ -176,3 +176,20 @@ describe('#2540 — ALL_PHASES still includes the pack-gated phases', () => {
     expect(ALL_PHASES).toContain('synthesize_concepts');
   });
 });
+
+describe('cycle phase config gates', () => {
+  test('cycle.propose_takes.enabled=false skips the phase before provider work', async () => {
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      await seedSource('propose-disabled');
+      await engine.setConfig('cycle.propose_takes.enabled', 'false');
+      const report = await runCycle(engine, {
+        brainDir,
+        sourceId: 'propose-disabled',
+        phases: ['propose_takes'],
+      });
+      const phase = report.phases.find(p => p.phase === 'propose_takes');
+      expect(phase?.status).toBe('skipped');
+      expect(phase?.details?.reason).toBe('disabled_by_config');
+    });
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- honor `cycle.propose_takes.enabled=false` in the stock cycle dispatcher
- emit an explicit skipped phase result instead of invoking the provider
- preserve enabled/default behavior and add a structural regression test

Fixes #4102.

## Verification

- `bun test test/cycle-enabled-phase-completeness.test.ts test/propose-takes.test.ts`
- `bun run typecheck`

This was reproduced in a production backlog drain where an explicitly disabled `propose_takes` phase still entered the provider path.