### PR TITLE
fix(pages): follow slug aliases in get_page

### DIFF
--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -56,8 +56,18 @@ const get_page: Operation = {
     const sourceOpts = federatedSearchScope(ctx);
     const fuzzyScope = sourceOpts;
 
-    let page = await ctx.engine.getPage(slug, { includeDeleted, ...sourceOpts });
+    // Slug aliases are redirects, not fuzzy suggestions. Resolve them before
+    // the exact read so deleted migration shells cannot shadow their active
+    // canonical page. Keep the lookup inside the caller's visible sources;
+    // an unscoped local CLI read defaults to the default source, matching the
+    // write-path default and the historical single-source behavior.
+    const aliasSources = sourceOpts.sourceIds?.length
+      ? sourceOpts.sourceIds
+      : [sourceOpts.sourceId ?? ctx.sourceId ?? 'default'];
+    const canonicalSlug = await ctx.engine.resolveSlugWithAlias(slug, aliasSources);
+    let page = await ctx.engine.getPage(canonicalSlug, { includeDeleted, ...sourceOpts });
     let resolved_slug: string | undefined;
+    if (canonicalSlug !== slug) resolved_slug = canonicalSlug;
 
     if (!page && fuzzy) {
       const candidates = await ctx.engine.resolveSlugs(slug, fuzzyScope);

--- a/test/get-page-federated-scope.test.ts
+++ b/test/get-page-federated-scope.test.ts
@@ -69,6 +69,11 @@ beforeEach(async () => {
   await engine.putPage('shared/alpha-doc', {
     type: 'note', title: 'Alpha doc', compiled_truth: 'alpha content', frontmatter: {},
   }, { sourceId: 'alpha' });
+  await engine.executeRaw(
+    `INSERT INTO slug_aliases (source_id, alias_slug, canonical_slug, notes)
+     VALUES ('alpha', 'legacy/alpha-doc', 'shared/alpha-doc', 'test alias'),
+            ('beta', 'legacy/beta-doc', 'secret/beta-doc', 'test alias')`,
+  );
 
   // --- #2200 secondary-fetch fixtures ---
   // beta page's own tags.
@@ -164,6 +169,32 @@ describe('get_page handler closes the cross-source exact-read leak', () => {
     const ctx = ctxOf({ remote: true, auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['alpha'] } as any });
     const page: any = await get_page.handler(ctx, { slug: 'shared/alpha-doc' });
     expect(page.title).toBe('Alpha doc');
+  });
+});
+
+describe('get_page follows slug aliases inside the caller source scope', () => {
+  test('single-source read returns the active canonical page', async () => {
+    const page: any = await get_page.handler(ctxOf({ remote: false, sourceId: 'alpha' }), {
+      slug: 'legacy/alpha-doc',
+    });
+    expect(page.slug).toBe('shared/alpha-doc');
+    expect(page.resolved_slug).toBe('shared/alpha-doc');
+    expect(page.title).toBe('Alpha doc');
+  });
+
+  test('federated grant cannot resolve an alias outside its allowed sources', async () => {
+    await expect(
+      get_page.handler(remoteCtx(['alpha']), { slug: 'legacy/beta-doc' }),
+    ).rejects.toBeInstanceOf(OperationError);
+  });
+
+  test('federated grant resolves an in-scope alias', async () => {
+    const page: any = await get_page.handler(remoteCtx(['alpha', 'beta']), {
+      slug: 'legacy/beta-doc',
+    });
+    expect(page.slug).toBe('secret/beta-doc');
+    expect(page.resolved_slug).toBe('secret/beta-doc');
+    expect(page.title).toBe('Beta secret');
   });
 });
 


### PR DESCRIPTION
## Summary

- resolve `slug_aliases` before the exact `get_page` read
- keep alias resolution inside scalar and federated source grants
- return the active canonical page instead of failing on a retired/soft-deleted migration slug

## Why

`resolveSlugWithAlias` documents `get_page` as a consumer, but the operation never called it. Search and wikilinks followed redirects while direct page reads returned `page_not_found`, which made old entity/project links look broken after safe deduplication.

## Verification

- `bun test test/get-page-federated-scope.test.ts test/engine-resolve-slug-with-alias.test.ts` (46 pass)
- `bun run typecheck`

The new tests include an out-of-grant alias to prove the redirect cannot become a cross-source read.