### PR TITLE
fix(schema): keep conversations in base-v2 source closure

### DIFF
--- a/src/core/schema-pack/base/gbrain-base-v2.yaml
+++ b/src/core/schema-pack/base/gbrain-base-v2.yaml
@@ -232,6 +232,7 @@ page_types:
       - sources/article
       - source/article
       - transcript
+      - conversation
       - ref
     extractable: true
     expert_routing: false

--- a/test/schema-pack-find-pack-successors.serial.test.ts
+++ b/test/schema-pack-find-pack-successors.serial.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
+  loadActivePack,
   findPackSuccessors,
   _versionRangeMatches,
   _versionDescCompare,
@@ -61,6 +62,16 @@ describe('_versionDescCompare', () => {
 });
 
 describe('findPackSuccessors (against bundled packs)', () => {
+  it('keeps legacy conversation pages inside the v2 source closure', async () => {
+    const pack = await loadActivePack({
+      cfg: null,
+      remote: false,
+      perCall: 'gbrain-base-v2',
+    });
+    const source = pack.manifest.page_types.find(type => type.name === 'source');
+    expect(source?.aliases).toContain('conversation');
+  });
+
   it('finds gbrain-base-v2 as successor of gbrain-base@1.0.0', async () => {
     const successors = await findPackSuccessors('gbrain-base', '1.0.0');
     expect(successors.length).toBe(1);


### PR DESCRIPTION
## Summary

- add legacy `conversation` to the canonical `source` alias closure in `gbrain-base-v2`
- retain the v2 DRY taxonomy instead of introducing another canonical type
- add a bundled-pack regression test

## Why

`gbrain-base` explicitly supports `conversation`, but its v2 successor omitted both the type and an alias mapping. Existing transcript collectors therefore emitted a warning on every sync (`type conversation is not declared`) even though conversation facts extraction supports those pages.

## Verification

- `bun test test/schema-pack-find-pack-successors.serial.test.ts test/schema-pack-loader.test.ts test/schema-pack-lint-rules.test.ts` (86 pass)
- `bun run typecheck`