### PR TITLE
fix(timeline): ignore generated backlink receipts

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1293,6 +1293,12 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
       summary = cm[4].trim();
     }
     if (!isValidDate(date) || summary.length === 0) { i++; continue; }
+    // Backlink materialization writes navigation receipts such as
+    // `- **2026-06-13** | Referenced in [Acme](../companies/acme.md)`.
+    // The date belongs to the backlink write, not to an event involving this
+    // entity. Treating it as timeline evidence both invents event dates and
+    // lets graph-maintenance noise satisfy timeline coverage.
+    if (/^Referenced in\s+\[/i.test(summary)) { i++; continue; }
     // Collect optional detail lines (indented, until next date or heading).
     const detailLines: string[] = [];
     let j = i + 1;

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -925,6 +925,13 @@ describe('parseTimelineEntries', () => {
     expect(parseTimelineEntries('Just some plain text.')).toEqual([]);
   });
 
+  test('skips generated backlink receipts because their dates are not entity events', () => {
+    const entries = parseTimelineEntries(
+      '- **2026-06-13** | Referenced in [Acme](../companies/acme.md)',
+    );
+    expect(entries).toEqual([]);
+  });
+
   test('handles mixed content (timeline lines interspersed with prose)', () => {
     const content = `Some intro paragraph.
 


### PR DESCRIPTION
## Summary

- exclude generated `Referenced in [...]` backlink receipts from timeline parsing
- add a regression test beside the timeline parser tests

## Why

Backlink maintenance emits dated receipt text using the synthesis/page creation date. The generic timeline parser treated those maintenance receipts as real entity events, inflating timeline coverage with fabricated chronology.

## Verification

- `bun test test/link-extraction.test.ts` (172 pass)
- `bun run typecheck`