### PR TITLE
fix(skills): accept populated default source preconditions

### DIFF
--- a/src/commands/doctor/skill-checks.ts
+++ b/src/commands/doctor/skill-checks.ts
@@ -240,7 +240,16 @@ export async function skillPreconditionsCheck(
     },
     async listSourceIds() {
       try {
-        const rows = await engine.executeRaw<{ id: string }>(`SELECT id FROM sources WHERE id <> 'default'`);
+        const rows = await engine.executeRaw<{ id: string }>(
+          `SELECT s.id
+             FROM sources s
+            WHERE EXISTS (
+              SELECT 1 FROM pages p
+               WHERE p.source_id = s.id
+                 AND p.deleted_at IS NULL
+            )
+            ORDER BY s.id`,
+        );
         return rows.map(r => r.id);
       } catch { return []; }
     },

--- a/src/core/skillpack/preconditions.ts
+++ b/src/core/skillpack/preconditions.ts
@@ -9,8 +9,8 @@
  * empty corpus.
  *
  * Vocabulary:
- *   - `source`        — the brain has at least one non-default source with
- *                       >=1 page (a corpus exists).
+ *   - `source`        — the brain has at least one source with >=1 page
+ *                       (the default source is a valid corpus).
  *   - `source:<id>`   — a source with that id exists.
  *   - `dir:<path>`    — a brain page-directory (e.g. `conversations/`) has
  *                       >=1 page.
@@ -56,7 +56,7 @@ export interface PreconditionContext {
   countPages(): Promise<number>;
   /** Pages filed under a given brain directory prefix (e.g. `conversations/`). */
   countPagesInDir(dir: string): Promise<number>;
-  /** Non-default source ids that hold at least one page. */
+  /** Source ids that hold at least one page, including `default`. */
   listSourceIds(): Promise<string[]>;
   /** Optional: pages for a specific source id. */
   countPagesForSource?(id: string): Promise<number>;
@@ -139,7 +139,7 @@ async function checkAnySource(req: Precondition, ctx: PreconditionContext): Prom
     met,
     detail: met
       ? `found ${ids.length} source(s) with content: ${ids.join(', ')}`
-      : `no non-default source holds any pages`,
+      : `no source holds any pages`,
     hint: met
       ? `corpus present (${ids.length} source(s))`
       : `ingest a corpus first (gbrain sync / gbrain import), then re-run`,

--- a/test/skill-preconditions.test.ts
+++ b/test/skill-preconditions.test.ts
@@ -99,6 +99,12 @@ describe('checkPreconditions — source', () => {
     expect(r.hint.length).toBeGreaterThan(0);
   });
 
+  test('bare source accepts a populated default corpus', async () => {
+    const [r] = await checkPreconditions(['source'], fakeCtx({ listSourceIds: async () => ['default'] }));
+    expect(r.met).toBe(true);
+    expect(r.detail).toContain('default');
+  });
+
   test('bare source unmet on empty brain, with remediation hint', async () => {
     const [r] = await checkPreconditions(['source'], fakeCtx({ listSourceIds: async () => [] }));
     expect(r.met).toBe(false);


### PR DESCRIPTION
## Summary

- treat any populated source, including `default`, as satisfying bare `requires: source`
- keep `requires: source:<id>` for callers that need a specific source
- make doctor enumerate sources with live pages instead of excluding the default corpus

## Why

A healthy single-source brain stores its corpus under source id `default`. Bare `requires: source` incorrectly treated that as “no source,” so valid skills produced a persistent doctor warning despite tens of thousands of pages.

## Verification

- `bun test test/skill-preconditions.test.ts` (24 pass)
- `bun run typecheck`