### PR TITLE
fix(probes): make standalone nightly adapters use configured routes

### DIFF
--- a/src/core/cycle/nightly-probe-adapters.ts
+++ b/src/core/cycle/nightly-probe-adapters.ts
@@ -16,6 +16,26 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
+import { loadConfig } from '../config.ts';
+import { buildGatewayConfig } from '../ai/build-gateway-config.ts';
+import { configureGateway, requireConfig } from '../ai/gateway.ts';
+
+/**
+ * The adapter is normally called from autopilot after connectEngine has
+ * configured the gateway. Direct in-process callers (including recovery
+ * probes) do not pass through cli.ts's no-DB LongMemEval bootstrap, however.
+ * Initialize only when absent so an autopilot process keeps its richer merged
+ * DB+file configuration.
+ */
+function ensureProbeGatewayConfigured(): void {
+  try {
+    requireConfig();
+    return;
+  } catch {
+    const config = loadConfig() ?? ({} as NonNullable<ReturnType<typeof loadConfig>>);
+    configureGateway(buildGatewayConfig(config));
+  }
+}
 
 /** Arguments accepted by the longmemeval adapter. */
 export interface LongMemEvalProbeArgs {
@@ -28,6 +48,8 @@ export interface CrossModalProbeArgs {
   batchPath: string;
   summaryPath: string;
   maxUsd: number;
+  /** Optional explicit judge route; defaults to the configured chat model. */
+  judgeModel?: string;
 }
 
 /** Cross-modal batch summary shape (matches `runEvalCrossModal --batch --json`'s envelope). */
@@ -53,8 +75,19 @@ export interface CrossModalBatchSummary {
  * autopilot.
  */
 export async function runLongMemEvalForProbe(args: LongMemEvalProbeArgs): Promise<void> {
+  ensureProbeGatewayConfigured();
   const { runEvalLongMemEval } = await import('../../commands/eval-longmemeval.ts');
-  await runEvalLongMemEval([args.fixturePath, '--output', args.outputPath]);
+  // Match the production max-recall posture while honoring the installation's
+  // explicit lack of a reranker credential. Without --no-reranker the
+  // ephemeral benchmark brain falls back to tokenmax's ZeroEntropy default,
+  // creating auth failures unrelated to retrieval quality.
+  await runEvalLongMemEval([
+    args.fixturePath,
+    '--output', args.outputPath,
+    '--mode', 'tokenmax',
+    '--no-reranker',
+    '--by-type',
+  ]);
 }
 
 /**
@@ -96,6 +129,20 @@ export async function runCrossModalBatchForProbe(
   args: CrossModalProbeArgs,
 ): Promise<{ exitCode: number; summary: CrossModalBatchSummary }> {
   const { runEvalCrossModal } = await import('../../commands/eval-cross-modal.ts');
+  // The general cross-modal command intentionally defaults to three frontier
+  // providers. A nightly installation probe must instead use a route this
+  // installation actually configured; otherwise missing OpenAI/Google keys
+  // make every run inconclusive even when the active provider is healthy.
+  // Repeating the configured model across three slots preserves the runner's
+  // parse/aggregation checks while making provider reachability truthful.
+  const judgeModel = args.judgeModel ?? loadConfig()?.chat_model;
+  const slotArgs = judgeModel
+    ? [
+        '--slot-a-model', judgeModel,
+        '--slot-b-model', judgeModel,
+        '--slot-c-model', judgeModel,
+      ]
+    : [];
   const exitCode = await runEvalCrossModal([
     '--batch',
     args.batchPath,
@@ -105,6 +152,7 @@ export async function runCrossModalBatchForProbe(
     String(args.maxUsd),
     '--dimensions',
     PROBE_QA_DIMENSIONS.join(','),
+    ...slotArgs,
     '--yes',
     '--json',
   ]);

--- a/src/core/cycle/nightly-probe-adapters.ts
+++ b/src/core/cycle/nightly-probe-adapters.ts
@@ -77,6 +77,13 @@ export interface CrossModalBatchSummary {
 export async function runLongMemEvalForProbe(args: LongMemEvalProbeArgs): Promise<void> {
   ensureProbeGatewayConfigured();
   const { runEvalLongMemEval } = await import('../../commands/eval-longmemeval.ts');
+  // LongMemEval has two independent chat lanes: answer generation and the
+  // trajectory claim extractor. Its generic CLI defaults intentionally target
+  // the benchmark's historical Sonnet/Haiku pair, but a nightly installation
+  // probe must exercise the provider this installation actually configured.
+  // Route BOTH lanes explicitly; otherwise a MiniMax/OpenAI-only installation
+  // still fails in the hidden extractor with "Anthropic chat requires...".
+  const probeModel = loadConfig()?.chat_model;
   // Match the production max-recall posture while honoring the installation's
   // explicit lack of a reranker credential. Without --no-reranker the
   // ephemeral benchmark brain falls back to tokenmax's ZeroEntropy default,
@@ -87,7 +94,8 @@ export async function runLongMemEvalForProbe(args: LongMemEvalProbeArgs): Promis
     '--mode', 'tokenmax',
     '--no-reranker',
     '--by-type',
-  ]);
+    ...(probeModel ? ['--model', probeModel] : []),
+  ], probeModel ? { extractorModel: probeModel } : {});
 }
 
 /**

--- a/test/cycle/nightly-probe-adapters.test.ts
+++ b/test/cycle/nightly-probe-adapters.test.ts
@@ -121,6 +121,8 @@ describe('nightly-probe-adapters: argv shape regression (codex round-2 #1)', () 
     expect(source).toContain(`'--mode', 'tokenmax'`);
     expect(source).toContain(`'--no-reranker'`);
     expect(source).toContain(`'--by-type'`);
+    expect(source).toContain(`'--model', probeModel`);
+    expect(source).toContain(`{ extractorModel: probeModel }`);
     expect(source).toContain(`ensureProbeGatewayConfigured()`);
     expect(source).toContain(`requireConfig()`);
   });

--- a/test/cycle/nightly-probe-adapters.test.ts
+++ b/test/cycle/nightly-probe-adapters.test.ts
@@ -107,6 +107,9 @@ describe('nightly-probe-adapters: argv shape regression (codex round-2 #1)', () 
     expect(source).toContain(`'--max-usd'`);
     expect(source).toContain(`'--yes'`);
     expect(source).toContain(`'--json'`); // cross-modal needs --json for the summary envelope
+    expect(source).toContain(`'--slot-a-model'`);
+    expect(source).toContain(`'--slot-b-model'`);
+    expect(source).toContain(`'--slot-c-model'`);
   });
 
   test('runLongMemEvalForProbe builds argv with --output for output path', () => {
@@ -114,7 +117,12 @@ describe('nightly-probe-adapters: argv shape regression (codex round-2 #1)', () 
     const fs = require('node:fs');
     const source = fs.readFileSync(path, 'utf-8');
     // longmemeval adapter: first positional arg is fixturePath, then --output outputPath.
-    expect(source).toMatch(/runEvalLongMemEval\(\[args\.fixturePath, '--output', args\.outputPath\]\)/);
+    expect(source).toContain(`args.fixturePath`);
+    expect(source).toContain(`'--mode', 'tokenmax'`);
+    expect(source).toContain(`'--no-reranker'`);
+    expect(source).toContain(`'--by-type'`);
+    expect(source).toContain(`ensureProbeGatewayConfigured()`);
+    expect(source).toContain(`requireConfig()`);
   });
 });
 


### PR DESCRIPTION
## Summary

- bootstrap the AI gateway only when a standalone adapter has no existing config
- preserve autopilot's richer merged DB/file configuration when already initialized
- run LongMemEval in tokenmax/by-type mode without an unavailable default reranker
- route cross-modal slots through the installation's configured judge model instead of hard-coded missing providers

## Why

Direct recovery/nightly adapter calls could fail with “gateway not configured.” After that was fixed, otherwise healthy installations still produced false ERROR/INCONCLUSIVE receipts because the probes selected ZeroEntropy or frontier provider keys that the installation never configured.

## Verification

- `bun test test/cycle/nightly-probe-adapters.test.ts` (6 pass)
- `bun run typecheck`

The gateway bootstrap is deliberately conditional: an already-configured autopilot process is never overwritten.