### PR TITLE
fix(health): measure orphans over served memory

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -5,8 +5,8 @@
 # Columns: path	max_lines	policy	note
 src/commands/doctor.ts	4270	ratchet	peel target: containment sprint C8-C13; grown v0.46.11.0 five-issue wave
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
-src/core/postgres-engine.ts	5816	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
-src/core/pglite-engine.ts	5744	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
+src/core/postgres-engine.ts	5826	ratchet	peel target: containment sprint C15; retrieval wave + orphan metadata
+src/core/pglite-engine.ts	5752	ratchet	peel target: containment sprint C15; retrieval wave + orphan metadata
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4300	ratchet	peel target: containment sprint C13-C14; grown v0.46.11.0 five-issue wave
 src/core/ai/gateway.ts	4364	ratchet	watchlist; merged: master waves + dream-wave C1-C3+C7 (thinking predicate, length, providerMetadata, turn permits) + TurnPermit signal form
@@ -15,7 +15,7 @@ src/core/cycle.ts	3030	ratchet
 src/commands/serve-http.ts	2978	ratchet	grown cathedral-6 multi-agent wave (admin register route composes registerScopedClient in one tx under the name advisory lock; ttl validation + brain_too_old preflight) + chennai no-grant federated scope
 src/commands/jobs.ts	2950	ratchet	grown v0.46.11.0 five-issue wave
 src/core/search/hybrid.ts	2500	ratchet
-src/core/engine.ts	2345	ratchet
+src/core/engine.ts	2351	ratchet	metadata-aware orphan candidates
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
 src/commands/extract-conversation-facts.ts	2032	ratchet

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2348,7 +2348,7 @@ export async function buildChecks(
       // warn about coverage on pages the rest of the system treats as gone.
       // buildGazetteer (src/core/by-mention.ts) already filters this way, so
       // without it the two disagree about whether entity pages exist at all.
-      "SELECT COUNT(*)::int AS count FROM pages WHERE deleted_at IS NULL AND type IN ('entity', 'person', 'company', 'organization')",
+      "SELECT COUNT(*)::int AS count FROM pages WHERE deleted_at IS NULL AND type IN ('entity', 'person', 'company', 'organization') AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')",
     ))[0]?.count ?? 0;
 
     // Compute coverage against eligible entities only — exclude test fixtures
@@ -2361,6 +2361,7 @@ export async function buildChecks(
         SELECT id FROM pages
         WHERE deleted_at IS NULL
           AND type IN ('entity','person','company','organization')
+          AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')
           AND slug NOT LIKE 'tools/gbrain/test/%'
           AND slug <> 'templates/new-person'
       )

--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -43,8 +43,12 @@ export interface OrphanResult {
  * Returns true if a slug should be excluded from orphan reporting by default.
  * These are pages where having no inbound links is expected / not a content problem.
  */
-export function shouldExclude(slug: string, overrides?: OrphanPolicyOverrides): boolean {
-  return shouldExcludeFromOrphanReporting(slug, overrides);
+export function shouldExclude(
+  slug: string,
+  overrides?: OrphanPolicyOverrides,
+  meta?: { type?: string | null; quarantined?: boolean },
+): boolean {
+  return shouldExcludeFromOrphanReporting(slug, overrides, meta);
 }
 
 /**
@@ -69,7 +73,7 @@ export function deriveDomain(frontmatterDomain: string | null | undefined, slug:
  */
 export async function queryOrphanPages(
   engine: BrainEngine,
-): Promise<{ slug: string; title: string; domain: string | null }[]> {
+): Promise<{ slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }[]> {
   return engine.findOrphanPages();
 }
 
@@ -107,7 +111,7 @@ export async function findOrphans(
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
   progress.start('orphans.scan');
   const stopHb = startHeartbeat(progress, 'scanning pages for missing inbound links…');
-  let allOrphans: { slug: string; title: string; domain: string | null }[];
+  let allOrphans: { slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }[];
   let total: number;
   let excludedAll: number;
   const overrides = includePseudo ? undefined : await loadOrphanPolicyOverrides(engine);
@@ -132,14 +136,16 @@ export async function findOrphans(
       liveParams.push(sourceId);
       scopeClause = ` AND source_id = $${liveParams.length}`;
     }
-    const liveRows = await engine.executeRaw<{ slug: string }>(
-      `SELECT slug FROM pages WHERE deleted_at IS NULL${scopeClause}`,
+    const liveRows = await engine.executeRaw<{ slug: string; type: string; quarantined: boolean }>(
+      `SELECT slug, type,
+              jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine') AS quarantined
+         FROM pages WHERE deleted_at IS NULL${scopeClause}`,
       liveParams,
     );
     total = liveRows.length;
     excludedAll = includePseudo
       ? 0
-      : liveRows.reduce((n, r) => n + (shouldExclude(r.slug, overrides) ? 1 : 0), 0);
+      : liveRows.reduce((n, r) => n + (shouldExclude(r.slug, overrides, r) ? 1 : 0), 0);
   } finally {
     stopHb();
     progress.finish();
@@ -147,7 +153,7 @@ export async function findOrphans(
 
   const filtered = includePseudo
     ? allOrphans
-    : allOrphans.filter(row => !shouldExclude(row.slug, overrides));
+    : allOrphans.filter(row => !shouldExclude(row.slug, overrides, row));
 
   const orphans: OrphanPage[] = filtered.map(row => ({
     slug: row.slug,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1452,7 +1452,13 @@ export interface BrainEngine {
   findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
+  }): Promise<Array<{
+    slug: string;
+    title: string;
+    domain: string | null;
+    type?: string | null;
+    quarantined?: boolean;
+  }>>;
 
   // Tags
   /**

--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -120,7 +120,8 @@ export async function checkEntityLinkCoverage(
     engine,
     `SELECT COUNT(*) AS count FROM pages
        WHERE type IN ('person', 'company', 'organization', 'entity')
-         AND deleted_at IS NULL`,
+         AND deleted_at IS NULL
+         AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')`,
   );
 
   if (totalEntities === 0) {
@@ -215,7 +216,8 @@ export async function checkTimelineCoverage(
     engine,
     `SELECT COUNT(*) AS count FROM pages
        WHERE type IN ('person', 'company', 'organization', 'entity')
-         AND deleted_at IS NULL`,
+         AND deleted_at IS NULL
+         AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')`,
   );
 
   if (totalEntities === 0) {
@@ -237,6 +239,7 @@ export async function checkTimelineCoverage(
        SELECT p.id FROM pages p ${sampleClause}
        WHERE p.type IN ('person', 'company', 'organization', 'entity')
          AND p.deleted_at IS NULL
+         AND NOT jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine')
          AND EXISTS (SELECT 1 FROM timeline_entries t WHERE t.page_id = p.id)
      ) sub`,
   );

--- a/src/core/orphan-policy.ts
+++ b/src/core/orphan-policy.ts
@@ -69,6 +69,14 @@ export interface OrphanPolicyOverrides {
   excludeSlugs?: string[];
 }
 
+/** Optional page metadata for conventions that cannot be inferred from slug. */
+export interface OrphanPageMeta {
+  type?: string | null;
+  quarantined?: boolean;
+}
+
+const NON_LINKABLE_PAGE_TYPES = new Set(['atom', 'conversation', 'source']);
+
 /** Config keys for per-brain orphan exclusions (comma-separated values). */
 export const ORPHAN_EXCLUDE_PREFIXES_KEY = 'orphans.exclude_prefixes';
 export const ORPHAN_EXCLUDE_SLUGS_KEY = 'orphans.exclude_slugs';
@@ -96,7 +104,10 @@ export async function loadOrphanPolicyOverrides(
 export function shouldExcludeFromOrphanReporting(
   slug: string,
   overrides?: OrphanPolicyOverrides,
+  meta?: OrphanPageMeta,
 ): boolean {
+  if (meta?.quarantined === true) return true;
+  if (meta?.type && NON_LINKABLE_PAGE_TYPES.has(meta.type)) return true;
   if (PSEUDO_SLUGS.has(slug)) return true;
 
   for (const suffix of AUTO_SUFFIX_PATTERNS) {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4197,7 +4197,7 @@ export class PGLiteEngine implements BrainEngine {
   async findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+  }): Promise<Array<{ slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }>> {
     // Soft-delete filter on BOTH sides:
     //   - candidate: p.deleted_at IS NULL — soft-deleted pages aren't orphan candidates
     //   - link source: src.deleted_at IS NULL — links FROM soft-deleted pages don't count as inbound
@@ -4222,7 +4222,9 @@ export class PGLiteEngine implements BrainEngine {
       `SELECT
          p.slug,
          COALESCE(p.title, p.slug) AS title,
-         p.frontmatter->>'domain' AS domain
+         p.frontmatter->>'domain' AS domain,
+         p.type,
+         jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine') AS quarantined
        FROM pages p
        WHERE p.deleted_at IS NULL
          ${sourceFilter}
@@ -4236,7 +4238,7 @@ export class PGLiteEngine implements BrainEngine {
        ORDER BY p.slug`,
       params
     );
-    return rows as Array<{ slug: string; title: string; domain: string | null }>;
+    return rows as Array<{ slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }>;
   }
 
   // Tags
@@ -5208,7 +5210,10 @@ export class PGLiteEngine implements BrainEngine {
     // getStats, and destructive-removal counts elsewhere deliberately stay raw.
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company') AND deleted_at IS NULL
+        SELECT id, slug FROM pages
+         WHERE type IN ('entity', 'person', 'company')
+           AND deleted_at IS NULL
+           AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')
       )
       SELECT
         (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
@@ -5263,7 +5268,9 @@ export class PGLiteEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('entity', 'person', 'company') AND p.deleted_at IS NULL
+      WHERE p.type IN ('entity', 'person', 'company')
+        AND p.deleted_at IS NULL
+        AND NOT jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine')
       ORDER BY link_count DESC
       LIMIT 5
     `);
@@ -5283,7 +5290,7 @@ export class PGLiteEngine implements BrainEngine {
     // `gbrain orphans` whenever a soft-deleted page still linked to (or was
     // linked from) a live one.
     const { rows: pageScopeRows } = await this.db.query(`
-      SELECT p.slug,
+      SELECT p.slug, p.type,
              (NOT EXISTS (SELECT 1 FROM links l
                           JOIN pages src ON src.id = l.from_page_id
                           WHERE l.to_page_id = p.id AND src.deleted_at IS NULL)
@@ -5293,6 +5300,7 @@ export class PGLiteEngine implements BrainEngine {
              EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = p.id) as has_timeline
       FROM pages p
       WHERE p.deleted_at IS NULL
+        AND NOT jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine')
     `);
 
     const r = h as Record<string, unknown>;
@@ -5300,8 +5308,8 @@ export class PGLiteEngine implements BrainEngine {
     const embedCoverage = Number(r.embed_coverage);
     const stalePages = await this.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS });
     const orphanOverrides = await loadOrphanPolicyOverrides(this);
-    const linkablePages = (pageScopeRows as { slug: string; islanded: boolean; has_timeline: boolean }[])
-      .filter(row => !shouldExcludeFromOrphanReporting(row.slug, orphanOverrides));
+    const linkablePages = (pageScopeRows as { slug: string; type: string; islanded: boolean; has_timeline: boolean }[])
+      .filter(row => !shouldExcludeFromOrphanReporting(row.slug, orphanOverrides, { type: row.type }));
     const linkablePageCount = linkablePages.length;
     const orphanPages = linkablePages.filter(row => row.islanded).length;
     const linkableTimelinePages = linkablePages.filter(row => row.has_timeline).length;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4050,7 +4050,7 @@ export class PostgresEngine implements BrainEngine {
   async findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+  }): Promise<Array<{ slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }>> {
     const sql = this.sql;
     // Soft-delete filter on BOTH sides:
     //   - candidate: p.deleted_at IS NULL — soft-deleted pages aren't orphan candidates
@@ -4073,7 +4073,9 @@ export class PostgresEngine implements BrainEngine {
       SELECT
         p.slug,
         COALESCE(p.title, p.slug) AS title,
-        p.frontmatter->>'domain' AS domain
+        p.frontmatter->>'domain' AS domain,
+        p.type,
+        jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine') AS quarantined
       FROM pages p
       WHERE p.deleted_at IS NULL
         ${sourceFilter}
@@ -4086,7 +4088,7 @@ export class PostgresEngine implements BrainEngine {
         )
       ORDER BY p.slug
     `;
-    return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
+    return rows as unknown as Array<{ slug: string; title: string; domain: string | null; type?: string | null; quarantined?: boolean }>;
   }
 
   // Tags
@@ -5076,7 +5078,10 @@ export class PostgresEngine implements BrainEngine {
     // getStats, and destructive-removal counts elsewhere deliberately stay raw.
     const [h] = await sql`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company') AND deleted_at IS NULL
+        SELECT id, slug FROM pages
+         WHERE type IN ('entity', 'person', 'company')
+           AND deleted_at IS NULL
+           AND NOT jsonb_exists(COALESCE(frontmatter, '{}'::jsonb), 'quarantine')
       )
       SELECT
         (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
@@ -5139,7 +5144,9 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('entity', 'person', 'company') AND p.deleted_at IS NULL
+      WHERE p.type IN ('entity', 'person', 'company')
+        AND p.deleted_at IS NULL
+        AND NOT jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine')
       ORDER BY link_count DESC
       LIMIT 5
     `;
@@ -5158,8 +5165,8 @@ export class PostgresEngine implements BrainEngine {
     // TARGET is live. Without this, get_health's orphan_pages disagreed with
     // `gbrain orphans` whenever a soft-deleted page still linked to (or was
     // linked from) a live one.
-    const pageScopeRows = await sql<{ slug: string; islanded: boolean; has_timeline: boolean }[]>`
-      SELECT p.slug,
+    const pageScopeRows = await sql<{ slug: string; type: string; islanded: boolean; has_timeline: boolean }[]>`
+      SELECT p.slug, p.type,
              (NOT EXISTS (SELECT 1 FROM links l
                           JOIN pages src ON src.id = l.from_page_id
                           WHERE l.to_page_id = p.id AND src.deleted_at IS NULL)
@@ -5169,13 +5176,16 @@ export class PostgresEngine implements BrainEngine {
              EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = p.id) as has_timeline
       FROM pages p
       WHERE p.deleted_at IS NULL
+        AND NOT jsonb_exists(COALESCE(p.frontmatter, '{}'::jsonb), 'quarantine')
     `;
 
     const pageCount = Number(h.page_count);
     const embedCoverage = Number(h.embed_coverage);
     const stalePages = await this.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS });
     const orphanOverrides = await loadOrphanPolicyOverrides(this);
-    const linkablePages = pageScopeRows.filter(row => !shouldExcludeFromOrphanReporting(row.slug, orphanOverrides));
+    const linkablePages = pageScopeRows.filter(row =>
+      !shouldExcludeFromOrphanReporting(row.slug, orphanOverrides, { type: row.type }),
+    );
     const linkablePageCount = linkablePages.length;
     const orphanPages = linkablePages.filter(row => row.islanded).length;
     const linkableTimelinePages = linkablePages.filter(row => row.has_timeline).length;

--- a/test/doctor-timeline-metric-labels-2298.test.ts
+++ b/test/doctor-timeline-metric-labels-2298.test.ts
@@ -34,7 +34,9 @@ async function seedFourPages(eng: PGLiteEngine): Promise<void> {
   const sql = sqlQueryForEngine(eng);
   // 6 eligible entity pages (>= the gbrain#4147 small-N floor of 5, so the
   // entity ratio is a real percentage rather than the below-floor null),
-  // 2 technical/non-entity pages. THREE entity pages carry timeline entries:
+  // 2 technical/non-entity pages and one quarantined entity shell. THREE
+  // served entity pages carry timeline entries; the quarantined shell is not
+  // part of the served-memory denominator:
   //   Metric A (entity-scoped):   3/6 = 50%  (same 50% the contract pins)
   //   Metric B (whole-brain):     3/8 -> round(15 * 0.375) = 6/15
   // The two stay provably distinct (50% vs 40%).
@@ -47,6 +49,7 @@ async function seedFourPages(eng: PGLiteEngine): Promise<void> {
       ('carol-example', 'default', 'person', 'Carol', '', '{}', 'h6', now(), now()),
       ('widget-co-example', 'default', 'company', 'Widget Co', '', '{}', 'h7', now(), now()),
       ('dana-example', 'default', 'person', 'Dana', '', '{}', 'h8', now(), now()),
+      ('quarantined-example', 'default', 'company', 'Quarantined', '', '{"quarantine":{"reason":"test"}}', 'hq', now(), now()),
       ('technical-a', 'default', 'note', 'Tech A', '', '{}', 'h3', now(), now()),
       ('technical-b', 'default', 'note', 'Tech B', '', '{}', 'h4', now(), now())
   `;
@@ -106,6 +109,8 @@ describe('issue #2298 — doctor rendered-message contract', () => {
     // ambiguous old label must NOT be present
     expect(graph!.message).not.toMatch(/timeline 50%/);
     expect(graph!.message).not.toMatch(/timeline \(entity, brain score\)/);
+    const timeline = checks.find((c) => c.name === 'timeline_coverage');
+    expect(timeline?.message).toContain('Coverage 50%');
   });
 
   test('brain_score renders whole-brain density label 6/15', async () => {

--- a/test/orphans-pure-fn.test.ts
+++ b/test/orphans-pure-fn.test.ts
@@ -254,6 +254,14 @@ describe('shouldExclude — orphan filter regression (preserve curation)', () =>
     // #2264 — only life/events/ is excluded; human-authored life/diary/ stays counted.
     expect(shouldExclude('life/diary/2026-08-01-xyz')).toBe(false);
   });
+
+  test('machine leaf types and quarantined pages are excluded regardless of slug', () => {
+    expect(shouldExclude('legacy-root-atom', undefined, { type: 'atom' })).toBe(true);
+    expect(shouldExclude('legacy-root-chat', undefined, { type: 'conversation' })).toBe(true);
+    expect(shouldExclude('legacy-root-source', undefined, { type: 'source' })).toBe(true);
+    expect(shouldExclude('legacy-rescue', undefined, { type: 'synthesis', quarantined: true })).toBe(true);
+    expect(shouldExclude('concepts/real-topic', undefined, { type: 'concept' })).toBe(false);
+  });
 });
 
 describe('getHealth orphan_pages uses shared exclusion policy', () => {


### PR DESCRIPTION
## Summary

- carry page type and quarantine metadata through orphan enumeration
- exclude machine leaf types (`atom`, `conversation`, `source`) and quarantined pages from actionable orphan counts
- apply the same policy to CLI output, denominator math, and engine health
- exclude quarantined entity shells from served entity link/timeline denominators

## Why

A source, transcript, atom, or quarantined shell can be intentionally leaf-shaped without being a broken knowledge node. Counting those pages made `gbrain orphans` and doctor report large failures that did not describe the graph users can actually retrieve. It also incentivized junk links or fabricated dates merely to turn the dashboard green.

## Verification

- `bun test test/orphans-pure-fn.test.ts test/doctor-orphan-ratio.test.ts test/doctor-timeline-metric-labels-2298.test.ts test/e2e/orphan-reduction.test.ts` (46 pass)
- `bun run typecheck`
- `bun run check:module-size`
- `bun scripts/classify-tests.ts --check`

The raw corpus is still counted in total-pages/excluded reporting; only the actionable served-memory numerator and denominator change.