### PR TITLE
fix(enrichment): respect canonical slug aliases

### DIFF
--- a/src/core/enrichment-service.ts
+++ b/src/core/enrichment-service.ts
@@ -98,7 +98,9 @@ export async function enrichEntity(
   request: EnrichmentRequest,
   opts?: EnrichmentTrustOptions,
 ): Promise<EnrichmentResult> {
-  const slug = slugifyEntity(request.entityName, request.entityType);
+  const candidateSlug = slugifyEntity(request.entityName, request.entityType);
+  const sourceId = opts?.sourceId ?? 'default';
+  const slug = await engine.resolveSlugWithAlias(candidateSlug, sourceId);
   // Fail-closed: only an explicit `trusted: true` writes authoritative pages.
   const trusted = opts?.trusted === true;
   const scope = opts?.sourceId ? { sourceId: opts.sourceId } : undefined;

--- a/test/extraction-review.test.ts
+++ b/test/extraction-review.test.ts
@@ -72,6 +72,7 @@ beforeEach(async () => {
   await engine.executeRaw('DELETE FROM links');
   await engine.executeRaw('DELETE FROM timeline_entries');
   await engine.executeRaw('DELETE FROM pages');
+  await engine.executeRaw('DELETE FROM slug_aliases');
 });
 
 function ctx(over: Partial<OperationContext> = {}): OperationContext {
@@ -175,6 +176,32 @@ describe('rrfFusion compiled-truth boost skip', () => {
 // ---------------------------------------------------------------------------
 
 describe('enrichEntity trust lane', () => {
+  test('resolves slug aliases before checking or writing entity pages', async () => {
+    await engine.putPage('people/aditya-vikram-singh', {
+      title: 'Aditya Vikram Singh',
+      type: 'person',
+      compiled_truth: '# Aditya Vikram Singh',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.executeRaw(
+      `INSERT INTO slug_aliases (source_id, alias_slug, canonical_slug)
+       VALUES ('default', 'people/avsingh', 'people/aditya-vikram-singh')`,
+    );
+
+    const result = await enrichEntity(engine, {
+      entityName: 'Avsingh',
+      entityType: 'person',
+      context: 'canonical identity mention',
+      sourceSlug: 'notes/daily',
+    }, { trusted: true });
+
+    expect(result.slug).toBe('people/aditya-vikram-singh');
+    expect(result.action).toBe('updated');
+    expect(await engine.getPage('people/avsingh')).toBeNull();
+    expect(await engine.getPage('people/aditya-vikram-singh')).not.toBeNull();
+  });
+
   test('default (opts omitted) → fail-closed quarantine markers', async () => {
     const r = await enrichEntity(engine, {
       entityName: 'Mallory Fake',


### PR DESCRIPTION
## Summary

- resolve slug aliases before enrichment existence checks and writes
- route timeline and backlink updates to the canonical page
- prevent alias mentions from reminting duplicate entity pages

## Production regression

A known alias (`people/avsingh` -> `people/aditya-vikram-singh`) was recreated as a standalone enriched person page because `enrichEntity` slugified and wrote directly without consulting `slug_aliases`.

## Validation

- `bun test test/extraction-review.test.ts test/enrichment-service.test.ts test/engine-resolve-slug-with-alias.test.ts` (56 pass)
- `bun run typecheck`
- `bun run check:module-size`
- `bun run check:structural-manifest`