### PR TITLE
v0.46.19.1 fix(search): bound oversized title FTS queries (#4091)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -93,7 +93,7 @@ import { sanitizeForJsonb, buildLinkRows, buildTimelineRows } from './batch-rows
 import { PAGE_SORT_SQL, MIN_ENTITY_PAGES_FOR_COVERAGE } from './types.ts';
 import { finalizeLastSeen } from './chronicle/last-seen.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery, boundWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';
 import { shouldExcludeFromOrphanReporting, loadOrphanPolicyOverrides } from './orphan-policy.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from './link-extraction.ts';
@@ -2244,8 +2244,8 @@ export class PGLiteEngine implements BrainEngine {
    * construction) with the same page-grain filters the keyword arm applies
    * (type/types/excludeSlugs/date/source scoping, hard-excludes,
    * visibility), joined to one representative chunk per page. Applies the
-   * same AND→OR recall fallback as searchKeyword. NO query-length gate —
-   * long exact-title queries are the case this arm exists for.
+   * same AND→OR recall fallback as searchKeyword. Ordinary long titles are
+   * preserved; oversized pasted context is bounded before websearch FTS.
    *
    * CJK queries fall through to websearch FTS here (a single-token CJK
    * query CAN exact-match a single-token CJK title); the richer CJK ILIKE
@@ -2273,7 +2273,7 @@ export class PGLiteEngine implements BrainEngine {
     // — safe to interpolate into raw SQL.
     const ftsLang = getFtsLanguage();
 
-    const params: unknown[] = [query, limit, offset];
+    const params: unknown[] = [boundWebsearchQuery(query), limit, offset];
     let extraFilter = '';
     if (opts?.type) {
       params.push(opts.type);
@@ -2342,10 +2342,10 @@ export class PGLiteEngine implements BrainEngine {
 
     let { rows } = await this.db.query(titlesSql, params);
     if (rows.length === 0) {
-      const orQuery = buildOrFallbackWebsearchQuery(query);
+      const orQuery = buildOrFallbackWebsearchQuery(params[0] as string);
       if (orQuery) {
         const fallbackParams = [...params];
-        fallbackParams[0] = orQuery;
+        fallbackParams[0] = boundWebsearchQuery(orQuery);
         ({ rows } = await this.db.query(titlesSql, fallbackParams));
       }
     }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -81,7 +81,7 @@ import { logConnectionEvent } from './connection-audit.ts';
 import { drainBackgroundWorkBeforeDisconnect } from './background-work.ts';
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery, boundWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
@@ -2049,8 +2049,8 @@ export class PostgresEngine implements BrainEngine {
    * construction) with the same page-grain filters the keyword arm applies
    * (type/types/excludeSlugs/date/source scoping, hard-excludes,
    * visibility), joined to one representative chunk per page. Applies the
-   * same AND→OR recall fallback as searchKeyword. NO query-length gate —
-   * long exact-title queries are the case this arm exists for.
+   * same AND→OR recall fallback as searchKeyword. Ordinary long titles are
+   * preserved; oversized pasted context is bounded before websearch FTS.
    */
   async searchTitles(query: string, opts?: SearchOpts): Promise<SearchResult[]> {
     // language/symbolKind are chunk-grain code filters with no page-grain
@@ -2074,7 +2074,7 @@ export class PostgresEngine implements BrainEngine {
     // — safe to interpolate into raw SQL.
     const ftsLang = getFtsLanguage();
 
-    const params: unknown[] = [query];
+    const params: unknown[] = [boundWebsearchQuery(query)];
     let typeClause = '';
     if (opts?.type) {
       params.push(opts.type);
@@ -2171,10 +2171,10 @@ export class PostgresEngine implements BrainEngine {
         boundParams[0] = queryText;
         return await tx.unsafe(rawQuery, boundParams as Parameters<typeof tx.unsafe>[1]);
       }, { alwaysTransaction: true });
-    let rows = await runTitles(query);
+    let rows = await runTitles(params[0] as string);
     if (rows.length === 0) {
-      const orQuery = buildOrFallbackWebsearchQuery(query);
-      if (orQuery) rows = await runTitles(orQuery);
+      const orQuery = buildOrFallbackWebsearchQuery(params[0] as string);
+      if (orQuery) rows = await runTitles(boundWebsearchQuery(orQuery));
     }
     return rows.map(rowToSearchResult);
   }

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -228,6 +228,48 @@ export function buildBestPerPagePoolCte(candidateCte: string): string {
 }
 
 // ============================================================
+// websearch_to_tsquery input bounds
+// ============================================================
+
+export const MAX_WEBSEARCH_QUERY_CHARS = 64_000;
+export const MAX_WEBSEARCH_QUERY_TERMS = 256;
+
+/**
+ * Bound caller text before feeding it to `websearch_to_tsquery`.
+ *
+ * Postgres can hit `stack depth limit exceeded` when websearch parses very
+ * large, high-term-count strings. Keep ordinary exact-title/body searches
+ * untouched, but cap pasted grounding blobs before they reach SQL.
+ */
+export function boundWebsearchQuery(query: string): string {
+  if (query.length <= MAX_WEBSEARCH_QUERY_CHARS) {
+    let terms = 0;
+    for (const _ of query.matchAll(/[\p{L}\p{N}]+/gu)) {
+      terms++;
+      if (terms > MAX_WEBSEARCH_QUERY_TERMS) break;
+    }
+    if (terms <= MAX_WEBSEARCH_QUERY_TERMS) return query;
+  }
+
+  let end = Math.min(query.length, MAX_WEBSEARCH_QUERY_CHARS);
+  let terms = 0;
+  for (const match of query.matchAll(/[\p{L}\p{N}]+/gu)) {
+    if (match.index >= MAX_WEBSEARCH_QUERY_CHARS) {
+      end = Math.min(end, match.index);
+      break;
+    }
+    terms++;
+    if (terms > MAX_WEBSEARCH_QUERY_TERMS) {
+      end = Math.min(end, match.index);
+      break;
+    }
+  }
+
+  const bounded = query.slice(0, end).trim();
+  return bounded.length > 0 ? bounded : query.slice(0, MAX_WEBSEARCH_QUERY_CHARS).trim();
+}
+
+// ============================================================
 // AND→OR keyword-recall fallback (fix/title-retrieval-arm, D2)
 // ============================================================
 

--- a/test/search/title-retrieval-arm.test.ts
+++ b/test/search/title-retrieval-arm.test.ts
@@ -13,7 +13,8 @@
  * Fixes under test:
  *   C1 — engine.searchTitles: page-grain candidates from pages.search_vector
  *        (title weight 'A'), joined to one representative chunk, fused into
- *        hybridSearch as a keyword-class RRF list. No query-length gate.
+ *        hybridSearch as a keyword-class RRF list. Human-sized long title
+ *        queries stay intact; oversized pasted context is bounded.
  *   C2 — searchKeyword retries ONCE with OR-of-terms when strict AND
  *        returns zero rows; strict results always win when non-empty.
  *
@@ -26,7 +27,12 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import { hybridSearch } from '../../src/core/search/hybrid.ts';
-import { buildOrFallbackWebsearchQuery } from '../../src/core/search/sql-ranking.ts';
+import {
+  MAX_WEBSEARCH_QUERY_CHARS,
+  MAX_WEBSEARCH_QUERY_TERMS,
+  boundWebsearchQuery,
+  buildOrFallbackWebsearchQuery,
+} from '../../src/core/search/sql-ranking.ts';
 import { configureGateway } from '../../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
@@ -109,6 +115,16 @@ describe('searchTitles — D1 title candidate arm', () => {
 
     const hits = await engine.searchTitles(longTitle, { limit: 10 });
     expect(hits.map(r => r.slug)).toContain('reports/emerald-falcon');
+  });
+
+  test('oversized pasted context is bounded before title FTS while preserving early terms', async () => {
+    await seedTitleOnlyPage();
+    const filler = Array.from({ length: 5000 }, (_, i) => `oversizedtoken${i}`).join(' ');
+    const hugeQuery = `Chronomancer Codex Ledger ${filler}`;
+    expect(hugeQuery.length).toBeGreaterThan(MAX_WEBSEARCH_QUERY_CHARS);
+
+    const hits = await engine.searchTitles(hugeQuery, { limit: 10 });
+    expect(hits.map(r => r.slug)).toContain('projects/chronomancer');
   });
 
   test('representative chunk prefers compiled_truth, else lowest chunk_index', async () => {
@@ -254,6 +270,26 @@ describe('buildOrFallbackWebsearchQuery — pure', () => {
     expect(buildOrFallbackWebsearchQuery('alpha AND beta')).toBe('alpha OR beta');
     // Only operator words survive tokenization → nothing left to relax.
     expect(buildOrFallbackWebsearchQuery('or and')).toBeNull();
+  });
+});
+
+describe('boundWebsearchQuery — pure', () => {
+  test('leaves ordinary title-sized queries unchanged', () => {
+    const q = 'Chronomancer Codex Ledger';
+    expect(boundWebsearchQuery(q)).toBe(q);
+  });
+
+  test('caps by term count without dropping the early useful prefix', () => {
+    const q = Array.from({ length: MAX_WEBSEARCH_QUERY_TERMS + 10 }, (_, i) => `term${i}`).join(' ');
+    const bounded = boundWebsearchQuery(q);
+    expect(bounded).toContain('term0');
+    expect(bounded).toContain(`term${MAX_WEBSEARCH_QUERY_TERMS - 1}`);
+    expect(bounded).not.toContain(`term${MAX_WEBSEARCH_QUERY_TERMS + 1}`);
+  });
+
+  test('caps very long single-token input by character length', () => {
+    const q = 'x'.repeat(MAX_WEBSEARCH_QUERY_CHARS + 100);
+    expect(boundWebsearchQuery(q).length).toBe(MAX_WEBSEARCH_QUERY_CHARS);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #4091.

Large pasted grounding blobs can make the `searchTitles` title arm send hundreds or thousands of terms directly into `websearch_to_tsquery`, which can trip PostgreSQL `stack depth limit exceeded` and silently drop title candidates from hybrid search.

This change:

- adds a shared defensive bound for websearch FTS input (`64k` chars / `256` terms)
- applies it to the Postgres and PGLite `searchTitles` strict query and OR fallback paths
- preserves normal long-title behavior while preventing oversized context from reaching title FTS unbounded
- extends the title-arm tests with helper coverage and an oversized pasted-context regression

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/search/title-retrieval-arm.test.ts` - 22 pass
- `GBRAIN_TEST_ALLOW_DATABASE_URL=1 bash scripts/gbrain-gate.sh <worktree> test/search/title-retrieval-arm.test.ts` - RESULT: GREEN; verify green, focused unit test 22 pass, mapped E2E 92 pass across 9 files
