### PR TITLE
fix(search): match CJK keyword queries term-by-term, not as one substring

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -6,7 +6,7 @@
 src/commands/doctor.ts	4270	ratchet	peel target: containment sprint C8-C13; grown v0.46.11.0 five-issue wave
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5816	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
-src/core/pglite-engine.ts	5744	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave
+src/core/pglite-engine.ts	5650	ratchet	peel target: containment sprint C15; grown v0.46.11.0 five-issue wave + retrieval wave; peeled cjk-search
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4300	ratchet	peel target: containment sprint C13-C14; grown v0.46.11.0 five-issue wave
 src/core/ai/gateway.ts	4364	ratchet	watchlist; merged: master waves + dream-wave C1-C3+C7 (thinking predicate, length, providerMetadata, turn permits) + TurnPermit signal form

--- a/src/core/cjk.ts
+++ b/src/core/cjk.ts
@@ -96,3 +96,19 @@ export function countCJKAwareWords(s: string): number {
 export function escapeLikePattern(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
+
+/**
+ * Splits a CJK query into distinct, non-empty whitespace-delimited terms.
+ *
+ * In Korean and Japanese, word order is flexible and particles attach to nouns,
+ * so the same fact or search intent frequently appears in varying token sequences
+ * (e.g. "김대리 미팅" vs "미팅 김대리"). Splitting into individual terms allows
+ * multi-term conjunction (AND matching) across chunk text regardless of word order.
+ *
+ * Returns deduplicated terms preserving the original order of appearance.
+ */
+export function splitCJKQueryTerms(query: string): string[] {
+  const terms = query.split(/\s+/).filter(t => t.length > 0);
+  return Array.from(new Set(terms));
+}
+

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -106,7 +106,7 @@ import {
   COLUMN_NAME_REGEX,
   EmbeddingColumnNotRegisteredError,
 } from './search/embedding-column.ts';
-import { hasCJK, escapeLikePattern } from './cjk.ts';
+import { hasCJK } from './cjk.ts';
 import * as factsImpl from './pglite-engine/facts.ts';
 import type { PgliteFactsDeps } from './pglite-engine/facts.ts';
 import * as takesImpl from './pglite-engine/takes.ts';
@@ -115,6 +115,7 @@ import * as codeEdgesImpl from './pglite-engine/code-edges.ts';
 import type { PgliteCodeEdgesDeps } from './pglite-engine/code-edges.ts';
 import * as salienceImpl from './pglite-engine/salience.ts';
 import type { PgliteSalienceDeps } from './pglite-engine/salience.ts';
+import { searchKeywordCJK } from './pglite-engine/cjk-search.ts';
 
 type PGLiteDB = PGlite;
 
@@ -2136,7 +2137,7 @@ export class PGLiteEngine implements BrainEngine {
 
     // v0.32.7: CJK query branch. PGLite uses websearch_to_tsquery('english')
     // which can't tokenize CJK; queries return empty. Switch to ILIKE on
-    // chunk_text with bigram-frequency-count ranking when the query contains
+    // chunk_text with term-frequency-count ranking when the query contains
     // CJK characters. ASCII path stays exactly the same below.
     if (hasCJK(query)) {
       return this._searchKeywordCJK(query, {
@@ -2356,15 +2357,23 @@ export class PGLiteEngine implements BrainEngine {
    * v0.32.7 CJK keyword fallback. PGLite's `websearch_to_tsquery('english')`
    * can't tokenize CJK so the FTS path returns empty for Chinese / Japanese /
    * Korean queries. This routes to an ILIKE substring scan with
-   * bigram-frequency-count ranking as a ts_rank substitute.
+   * term-frequency-count ranking as a ts_rank substitute.
    *
-   * Codex outside-voice C8 corrections in place:
-   *   - Two distinct parameter bindings: $qLike (LIKE-escaped, for ILIKE) and
-   *     $qRaw (un-escaped, for ranking arithmetic via position/replace).
-   *     Escaped chars cannot be reused as ranking substrings.
-   *   - Explicit `ESCAPE '\'` on the ILIKE clause.
-   *   - Symmetric: no asymmetric whitespace strip (caller's query and
-   *     chunk_text are compared as-stored).
+   * Multi-term CJK queries are split via splitCJKQueryTerms and matched
+   * conjunctively (AND) so that documents containing all terms match
+   * regardless of token order (e.g. Korean / Japanese free word order and particles).
+   *
+   * Ranking rules:
+   *   - Individual term occurrences are summed via replace/length arithmetic.
+   *   - Contiguous match of the full raw query receives bonus weight.
+   *   - POSITION()-tiebreaker ensures earlier hits outrank later hits.
+   *   - Single-term queries preserve identical ranking to the single-token path.
+   *
+   * Parameter bindings:
+   *   - LIKE parameters are individually escaped with escapeLikePattern and wrapped with %.
+   *   - Raw terms and raw query are bound unescaped for ranking arithmetic.
+   *   - Explicit `ESCAPE '\'` on ILIKE clauses.
+   *   - Symmetric: no asymmetric whitespace strip on chunk_text.
    *   - Empty-query guard returns no results without binding SQL.
    *
    * Postgres engine is intentionally untouched (multi-tenant deployments
@@ -2384,110 +2393,7 @@ export class PGLiteEngine implements BrainEngine {
       dedup: boolean;
     },
   ): Promise<SearchResult[]> {
-    const { limit, offset, innerLimit, sourceFactorCase, hardExcludeClause, visibilityClause, detailFilter, opts, dedup } = ctx;
-    const qRaw = query;
-    if (qRaw.length === 0) return [];
-    const qLike = escapeLikePattern(qRaw);
-
-    // $1 = qLike (escaped for ILIKE)
-    // $2 = qRaw  (raw for position()/replace() ranking arithmetic)
-    // $3 = inner limit (dedup path) OR final limit (chunk-grain path)
-    // $4 = final limit (dedup path only) — see callers
-    // $5 = offset (dedup path)  /  $4 = offset (chunk-grain path)
-    const params: unknown[] = dedup
-      ? [qLike, qRaw, innerLimit, limit, offset]
-      : [qLike, qRaw, limit, offset];
-
-    let extraFilter = '';
-    if (opts?.language) {
-      params.push(opts.language);
-      extraFilter += ` AND cc.language = $${params.length}`;
-    }
-    if (opts?.symbolKind) {
-      params.push(opts.symbolKind);
-      extraFilter += ` AND cc.symbol_type = $${params.length}`;
-    }
-    if (opts?.afterDate) {
-      params.push(opts.afterDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
-    }
-    if (opts?.beforeDate) {
-      params.push(opts.beforeDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
-    }
-    // v0.34.1 (#861 — P0 leak seal): source-isolation on the CJK fallback path.
-    if (opts?.sourceIds && opts.sourceIds.length > 0) {
-      params.push(opts.sourceIds);
-      extraFilter += ` AND p.source_id = ANY($${params.length}::text[])`;
-    } else if (opts?.sourceId) {
-      params.push(opts.sourceId);
-      extraFilter += ` AND p.source_id = $${params.length}`;
-    }
-
-    // Bigram-frequency count: count occurrences of $qRaw in chunk_text via
-    // (length(chunk) - length(replace(chunk, q, ''))) / length(q). Acts as
-    // a ts_rank substitute. position()-tiebreaker so earlier-in-chunk hits
-    // outrank later ones at the same occurrence count.
-    const scoreExpr = `
-      ((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $2, ''))) / NULLIF(LENGTH($2), 0)::real
-        + 1.0 / NULLIF(POSITION($2 IN cc.chunk_text), 0)::real)
-      * ${sourceFactorCase}
-    `;
-
-    if (dedup) {
-      const { rows } = await this.db.query(
-        `WITH ranked AS (
-           SELECT
-             p.slug, p.id as page_id, p.title, p.type, p.source_id,
-             p.effective_date, p.effective_date_source,
-             CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
-               THEN p.frontmatter->>'message_id' END AS message_id, p.frontmatter->>'thread_id' AS thread_id,
-             CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
-               THEN NULLIF(p.frontmatter->>'subject', '') END AS source_subject,
-             cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-             ${scoreExpr} AS score,
-             CASE WHEN p.updated_at < (
-               SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
-             ) THEN true ELSE false END AS stale
-           FROM content_chunks cc
-           JOIN pages p ON p.id = cc.page_id
-           JOIN sources s ON s.id = p.source_id
-           WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\' ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
-             AND cc.modality = 'text'
-           ORDER BY score DESC
-           LIMIT $3
-         ),
-         ${buildBestPerPagePoolCte('ranked')}
-         SELECT * FROM best_per_page
-         ORDER BY score DESC, page_id ASC, chunk_id ASC
-         LIMIT $4 OFFSET $5`,
-        params,
-      );
-      return (rows as Record<string, unknown>[]).map(rowToSearchResult);
-    } else {
-      const { rows } = await this.db.query(
-        `SELECT
-           p.slug, p.id as page_id, p.title, p.type, p.source_id,
-           p.effective_date, p.effective_date_source,
-           CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
-             THEN p.frontmatter->>'message_id' END AS message_id, p.frontmatter->>'thread_id' AS thread_id,
-           CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
-             THEN NULLIF(p.frontmatter->>'subject', '') END AS source_subject,
-           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-           ${scoreExpr} AS score,
-           CASE WHEN p.updated_at < (
-             SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
-           ) THEN true ELSE false END AS stale
-         FROM content_chunks cc
-         JOIN pages p ON p.id = cc.page_id
-         JOIN sources s ON s.id = p.source_id
-         WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\' ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
-         ORDER BY score DESC
-         LIMIT $3 OFFSET $4`,
-        params,
-      );
-      return (rows as Record<string, unknown>[]).map(rowToSearchResult);
-    }
+    return searchKeywordCJK({ db: this.db }, query, ctx);
   }
 
   /**

--- a/src/core/pglite-engine/cjk-search.ts
+++ b/src/core/pglite-engine/cjk-search.ts
@@ -1,0 +1,183 @@
+/**
+ * v0.32.7: CJK keyword fallback search, peeled out of PGLiteEngine
+ * (containment sprint C15). Free functions over a NARROW deps surface — the
+ * live PGLite handle only. Never the whole engine class.
+ */
+import type { PGlite } from '@electric-sql/pglite';
+import type { SearchOpts, SearchResult } from '../types.ts';
+import { rowToSearchResult } from '../utils.ts';
+import { buildBestPerPagePoolCte } from '../search/sql-ranking.ts';
+import { escapeLikePattern, splitCJKQueryTerms } from '../cjk.ts';
+
+/** Narrow slice of PGLiteEngine the CJK search operations use. */
+export interface PgliteCjkSearchDeps {
+  /** Live PGLite handle. Getter-backed at the call site so the
+   *  connect() check fires exactly when the original engine `db` read did. */
+  readonly db: PGlite;
+}
+
+export async function searchKeywordCJK(
+  deps: PgliteCjkSearchDeps,
+  query: string,
+  ctx: {
+    limit: number;
+    offset: number;
+    innerLimit: number;
+    sourceFactorCase: string;
+    hardExcludeClause: string;
+    visibilityClause: string;
+    detailFilter: string;
+    opts: SearchOpts | undefined;
+    dedup: boolean;
+  },
+): Promise<SearchResult[]> {
+  const { limit, offset, innerLimit, sourceFactorCase, hardExcludeClause, visibilityClause, detailFilter, opts, dedup } = ctx;
+  const qRaw = query;
+  if (qRaw.length === 0) return [];
+  const terms = splitCJKQueryTerms(qRaw);
+  if (terms.length === 0) return [];
+
+  const params: unknown[] = [];
+
+  // LIKE parameters: $1 .. $N (each escaped and wrapped with %)
+  const likeParamIndices: number[] = [];
+  for (const term of terms) {
+    params.push(`%${escapeLikePattern(term)}%`);
+    likeParamIndices.push(params.length);
+  }
+
+  // Raw term parameters for term-frequency scoring: $N+1 .. $2N
+  const rawTermIndices: number[] = [];
+  for (const term of terms) {
+    params.push(term);
+    rawTermIndices.push(params.length);
+  }
+
+  // Raw full query parameter for contiguous match bonus and tiebreaker: $2N+1
+  params.push(qRaw);
+  const qRawIndex = params.length;
+
+  // Pagination limits & offset
+  let innerLimitIndex = 0;
+  let limitIndex = 0;
+  let offsetIndex = 0;
+
+  if (dedup) {
+    params.push(innerLimit);
+    innerLimitIndex = params.length;
+    params.push(limit);
+    limitIndex = params.length;
+    params.push(offset);
+    offsetIndex = params.length;
+  } else {
+    params.push(limit);
+    limitIndex = params.length;
+    params.push(offset);
+    offsetIndex = params.length;
+  }
+
+  let extraFilter = '';
+  if (opts?.language) {
+    params.push(opts.language);
+    extraFilter += ` AND cc.language = $${params.length}`;
+  }
+  if (opts?.symbolKind) {
+    params.push(opts.symbolKind);
+    extraFilter += ` AND cc.symbol_type = $${params.length}`;
+  }
+  if (opts?.afterDate) {
+    params.push(opts.afterDate);
+    extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+  }
+  if (opts?.beforeDate) {
+    params.push(opts.beforeDate);
+    extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+  }
+  // v0.34.1 (#861 — P0 leak seal): source-isolation on the CJK fallback path.
+  if (opts?.sourceIds && opts.sourceIds.length > 0) {
+    params.push(opts.sourceIds);
+    extraFilter += ` AND p.source_id = ANY($${params.length}::text[])`;
+  } else if (opts?.sourceId) {
+    params.push(opts.sourceId);
+    extraFilter += ` AND p.source_id = $${params.length}`;
+  }
+
+  const whereLikeClause = likeParamIndices
+    .map(idx => `cc.chunk_text ILIKE $${idx} ESCAPE '\\'`)
+    .join(' AND ');
+
+  const termFreqExpr = rawTermIndices
+    .map(idx => `((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $${idx}, ''))) / NULLIF(LENGTH($${idx}), 0)::real)`)
+    .join(' + ');
+
+  const qRawBonusExpr = terms.length > 1
+    ? ` + ((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $${qRawIndex}, ''))) / NULLIF(LENGTH($${qRawIndex}), 0)::real)`
+    : '';
+
+  const positionExpr = `COALESCE(1.0 / NULLIF(POSITION($${qRawIndex} IN cc.chunk_text), 0)::real, 0.0)`;
+
+  // Term-frequency count: count occurrences of each term in chunk_text via
+  // (length(chunk) - length(replace(chunk, term, ''))) / length(term),
+  // plus bonus for contiguous raw query occurrences when multi-term, and
+  // position()-tiebreaker so earlier-in-chunk hits outrank later ones.
+  const scoreExpr = `
+      ((${termFreqExpr}${qRawBonusExpr}
+        + ${positionExpr})
+      * ${sourceFactorCase})
+    `;
+
+  if (dedup) {
+    const { rows } = await deps.db.query(
+      `WITH ranked AS (
+           SELECT
+             p.slug, p.id as page_id, p.title, p.type, p.source_id,
+             p.effective_date, p.effective_date_source,
+             CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
+               THEN p.frontmatter->>'message_id' END AS message_id, p.frontmatter->>'thread_id' AS thread_id,
+             CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
+               THEN NULLIF(p.frontmatter->>'subject', '') END AS source_subject,
+             cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+             ${scoreExpr} AS score,
+             CASE WHEN p.updated_at < (
+               SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
+             ) THEN true ELSE false END AS stale
+           FROM content_chunks cc
+           JOIN pages p ON p.id = cc.page_id
+           JOIN sources s ON s.id = p.source_id
+           WHERE ${whereLikeClause} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+             AND cc.modality = 'text'
+           ORDER BY score DESC
+           LIMIT $${innerLimitIndex}
+         ),
+         ${buildBestPerPagePoolCte('ranked')}
+         SELECT * FROM best_per_page
+         ORDER BY score DESC, page_id ASC, chunk_id ASC
+         LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
+      params,
+    );
+    return (rows as Record<string, unknown>[]).map(rowToSearchResult);
+  } else {
+    const { rows } = await deps.db.query(
+      `SELECT
+           p.slug, p.id as page_id, p.title, p.type, p.source_id,
+           p.effective_date, p.effective_date_source,
+           CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
+             THEN p.frontmatter->>'message_id' END AS message_id, p.frontmatter->>'thread_id' AS thread_id,
+           CASE WHEN NULLIF(regexp_replace(p.frontmatter->>'message_id', '^[[:space:]]+|[[:space:]]+$', '', 'g'), '') IS NOT NULL
+             THEN NULLIF(p.frontmatter->>'subject', '') END AS source_subject,
+           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+           ${scoreExpr} AS score,
+           CASE WHEN p.updated_at < (
+             SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
+           ) THEN true ELSE false END AS stale
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         JOIN sources s ON s.id = p.source_id
+         WHERE ${whereLikeClause} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         ORDER BY score DESC
+         LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
+      params,
+    );
+    return (rows as Record<string, unknown>[]).map(rowToSearchResult);
+  }
+}

--- a/test/cjk.test.ts
+++ b/test/cjk.test.ts
@@ -8,6 +8,7 @@ import {
   CJK_SENTENCE_DELIMITERS,
   CJK_CLAUSE_DELIMITERS,
   escapeLikePattern,
+  splitCJKQueryTerms,
 } from '../src/core/cjk.ts';
 
 describe('hasCJK', () => {
@@ -128,3 +129,43 @@ describe('escapeLikePattern', () => {
     expect(escapeLikePattern('测试')).toBe('测试');
   });
 });
+
+describe('splitCJKQueryTerms', () => {
+  test('splits query by whitespace into terms', () => {
+    expect(splitCJKQueryTerms('김대리 미팅')).toEqual(['김대리', '미팅']);
+    expect(splitCJKQueryTerms('미팅 김대리')).toEqual(['미팅', '김대리']);
+  });
+
+  test('deduplicates terms while preserving original order', () => {
+    expect(splitCJKQueryTerms('김대리 미팅 김대리')).toEqual(['김대리', '미팅']);
+    expect(splitCJKQueryTerms('미팅 김대리 미팅')).toEqual(['미팅', '김대리']);
+    expect(splitCJKQueryTerms('a b a c b')).toEqual(['a', 'b', 'c']);
+  });
+
+  test('handles consecutive whitespace, tabs, and newlines', () => {
+    expect(splitCJKQueryTerms('김대리   미팅 \t\n 2026')).toEqual(['김대리', '미팅', '2026']);
+    expect(splitCJKQueryTerms('  \t  주간   보고서  \n ')).toEqual(['주간', '보고서']);
+  });
+
+  test('returns single term for single-word queries', () => {
+    expect(splitCJKQueryTerms('김대리')).toEqual(['김대리']);
+    expect(splitCJKQueryTerms(' 한글 ')).toEqual(['한글']);
+  });
+
+  test('returns empty array on empty or whitespace-only input', () => {
+    expect(splitCJKQueryTerms('')).toEqual([]);
+    expect(splitCJKQueryTerms('   ')).toEqual([]);
+    expect(splitCJKQueryTerms('\t\n\r ')).toEqual([]);
+  });
+
+  test('handles mixed CJK and alphanumeric queries', () => {
+    expect(splitCJKQueryTerms('한국어 日本語 中文 English 123')).toEqual([
+      '한국어',
+      '日本語',
+      '中文',
+      'English',
+      '123',
+    ]);
+  });
+});
+


### PR DESCRIPTION
### Problem

The CJK keyword fallback matches the whole query as one contiguous substring, so a multi-word query only hits documents that happen to store those words adjacently, in that exact order.

Korean and Japanese allow free word order and attach particles to nouns, so the same fact is routinely written both ways. One of the two orders silently returns nothing.

Reproduced on PGLite with a 20k-row Korean corpus, half written as `<person> <noun>` and half as `<noun> ... <person>` — the same fact, both orders, as Korean is actually written:

```
current — whole query as one contiguous substring:
  "김대리 미팅"  -> 2000
  "미팅 김대리"  -> 0        ← the other half, same fact

proposed — split on whitespace, AND the terms:
  "김대리 미팅"  -> 2000
  "미팅 김대리"  -> 2000
```

<details>
<summary>Repro script (<code>npm i @electric-sql/pglite@0.4.3 && node repro.mjs</code>)</summary>

```js
import { PGlite } from '@electric-sql/pglite';

const db = await PGlite.create();
await db.exec(`CREATE TABLE content_chunks (id serial PRIMARY KEY, chunk_text text NOT NULL);`);

const nouns  = ['미팅','회의','보고서','일정','계약','검토','승인','예산','설계','배포'];
const people = ['김대리','박과장','이팀장','최부장','정사원'];
const verbs  = ['진행했다','완료했다','검토중이다','보류했다','확정했다'];
const filler = '이 문서는 내부 기록이며 관련 담당자가 후속 조치를 맡는다.';

const rows = [];
for (let i = 0; i < 20000; i++) {
  const p = people[i % people.length];
  const n = nouns[(i * 7) % nouns.length];
  const v = verbs[(i * 3) % verbs.length];
  const core = i % 2 === 0
    ? `${p} ${n}을 ${v}`           // "김대리 미팅을 진행했다"
    : `${n} 담당은 ${p}이고 ${v}`;  // "미팅 담당은 김대리이고 진행했다"
  rows.push(`('${core}. ${filler} seq-${i}')`);
}
for (let i = 0; i < rows.length; i += 2000) {
  await db.exec(`INSERT INTO content_chunks (chunk_text) VALUES ${rows.slice(i, i + 2000).join(',')};`);
}

const count = async (sql, params) => (await db.query(sql, params)).rows[0].count;

console.log('current — whole query as one contiguous substring:');
for (const q of ['김대리 미팅', '미팅 김대리']) {
  const c = await count(`SELECT count(*) FROM content_chunks WHERE chunk_text ILIKE $1 ESCAPE '\\'`, [`%${q}%`]);
  console.log(`  "${q}"  -> ${c}`);
}

console.log('\nproposed — split on whitespace, AND the terms:');
for (const q of ['김대리 미팅', '미팅 김대리']) {
  const terms = [...new Set(q.split(/\s+/).filter(Boolean))];
  const where = terms.map((_, i) => `chunk_text ILIKE $${i + 1} ESCAPE '\\'`).join(' AND ');
  const c = await count(`SELECT count(*) FROM content_chunks WHERE ${where}`, terms.map(t => `%${t}%`));
  console.log(`  "${q}"  -> ${c}`);
}

await db.close();
```
</details>

### Fix

Split the query on whitespace and AND the terms together — word order stops mattering while every term is still required.

**Ranking still prefers the original order.** Per-term occurrence counts are summed, and a contiguous match of the full raw query adds a bonus on top, so a document that spells the query out verbatim outranks one that merely contains the same terms scattered. Single-term queries keep their previous ranking exactly — the bonus expression is only emitted when there is more than one term. Duplicate terms are dropped before binding so repeating a word cannot multiply its weight.

Two smaller fixes ride along:

- The `POSITION()` tiebreaker is now `COALESCE`'d to 0. `ILIKE` is case-insensitive but `POSITION` is not, so a mixed-script query could match in `WHERE` and then yield NULL from `POSITION`, propagating NULL through the whole score expression.
- The comment called the ranking `bigram-frequency-count`, which never matched the implementation — it counts occurrences of the query string, not bigrams. Renamed to `term-frequency-count`.

### Module move

The method moved to `src/core/pglite-engine/cjk-search.ts`, following the existing peel pattern of `facts.ts` / `takes.ts` / `code-edges.ts` / `salience.ts` — narrow deps, the live PGLite handle only.

That keeps `pglite-engine.ts` under its module-size ratchet: it drops from 5797 to 5650 lines, and the ceiling in `scripts/module-size-limits.tsv` is **lowered** to match rather than raised. The move is behaviour-preserving — the SQL is unchanged apart from the term handling above.

Postgres engine intentionally untouched, per the existing note that multi-tenant deployments can install pgroonga / zhparser instead.

### Verification

- `bun run verify` — 54/54
- `bun test test/cjk.test.ts` — 32 pass
- Both `dedup=true` and `dedup=false` paths executed against a real PGLite instance with the real schema, covering reversed word order, single terms, repeated terms, LIKE metacharacters (`100%`, `할인_코드`) and the empty-query guard.

### Not covered

Terms shorter than 3 characters still fall back to a sequential scan — `pg_trgm` cannot index them, and many Korean nouns are two syllables. A trigram GIN index on `chunk_text` would accelerate the 3-character-and-longer terms this change now produces, but that is a separate trade-off (index size) and belongs in its own PR.
