### PR TITLE
fix(search): keyword arm fails open — a keyword-arm timeout no longer kills the whole hybrid search

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -1184,7 +1184,14 @@ export async function hybridSearch(
     earlyModality === 'image'
       ? [[], []]
       : await Promise.all([
-          engine.searchKeyword(query, searchOpts),
+          engine.searchKeyword(query, searchOpts).catch((err: unknown) => {
+            warnOncePerProcess(
+              'search-keyword-arm-failed',
+              `[gbrain] searchKeyword arm failed (fail-open, keyword candidates skipped): ` +
+                `${err instanceof Error ? err.message : String(err)}`,
+            );
+            return [] as SearchResult[];
+          }),
           engine.searchTitles(query, searchOpts).catch((err: unknown) => {
             warnOncePerProcess(
               'search-titles-arm-failed',


### PR DESCRIPTION
## What

`hybridSearch` runs the keyword and title arms in one `Promise.all`. The title arm has a `.catch` (fail-open with a once-per-process warning, Reviewer F2), the keyword arm does not. A keyword-arm rejection therefore fails the entire search and discards healthy vector + title results.

## Repro (real brain, Postgres engine)

On a 430k-chunk brain, a multi-term query with no strict-AND match (e.g. six tokens including common ones) triggers the D2 AND→OR zero-recall fallback. The OR-joined rerun matches ~83k chunks; `ts_rank` over that set measured 12.5s, past the 8s `SET LOCAL statement_timeout`. Result: every such query returns `canceling statement due to statement timeout` instead of the vector arm's results. Warm cache does not help; the cost is CPU-bound in rank/recheck.

## Fix

Mirror the `searchTitles` catch on `engine.searchKeyword`: degrade to no keyword candidates, warn once per process (`search-keyword-arm-failed`). One code path changed; strict-AND behavior, orFallback semantics, and all other arms untouched.

Verified on the brain above: the failing query now completes with vector-arm results and logs the fail-open warning.