### PR TITLE
fix(import): quote YAML titles by allowlist, not denylist

### DIFF
--- a/src/core/frontmatter-inference.ts
+++ b/src/core/frontmatter-inference.ts
@@ -337,6 +337,35 @@ export function inferFrontmatter(relativePath: string, content: string): Inferre
 }
 
 /**
+ * Is `title` safe to emit as an UNQUOTED YAML plain scalar?
+ *
+ * This is an allowlist on purpose. The previous denylist of "special" chars
+ * (`/[:"\'#\[\]{}|>&*!?,]/`) could never be complete, and every gap corrupted
+ * a page at import time:
+ *   - a leading backtick or `@` (YAML c-reserved) threw a parse error — the
+ *     failure that blocked `docs/guides/skillopt.md` and two siblings, since
+ *     gbrain doc H1s are routinely `` `gbrain <cmd>` ``;
+ *   - a leading `%` (directive indicator) threw the same way;
+ *   - a leading `- ` parsed as a sequence entry, so `title` came back
+ *     `undefined` — silent, and worse than the throw;
+ *   - `true` / `2026` coerced to a boolean / number (the #1948/#1939 class).
+ *
+ * Inverting to an allowlist makes the worst case a redundant pair of quotes
+ * instead of a broken or silently-wrong import. Non-ASCII titles (em dashes,
+ * CJK) are quoted rather than enumerated — harmless, and it keeps the safe
+ * set small enough to reason about.
+ */
+export function isSafePlainYamlScalar(title: string): boolean {
+  // Must start with an ASCII letter: excludes every YAML indicator, plus the
+  // digit-leading titles that would coerce to a number.
+  if (!/^[A-Za-z][A-Za-z0-9 _.()/-]*$/.test(title)) return false;
+  // Trailing whitespace does not survive a round trip.
+  if (/\s$/.test(title)) return false;
+  // YAML 1.1 boolean/null keywords js-yaml still coerces.
+  return !/^(y|yes|n|no|true|false|on|off|null)$/i.test(title);
+}
+
+/**
  * Generate a YAML frontmatter block from inferred fields.
  * Returns the `---\n...\n---\n` string to prepend to content.
  */
@@ -345,9 +374,11 @@ export function serializeFrontmatter(fm: InferredFrontmatter): string {
 
   const lines: string[] = ['---'];
 
-  // Title — quote if it contains special YAML chars
-  const needsQuote = /[:"'#\[\]{}|>&*!?,]/.test(fm.title);
-  lines.push(`title: ${needsQuote ? JSON.stringify(fm.title) : fm.title}`);
+  // Title — emit as a plain scalar ONLY when provably safe (see
+  // isSafePlainYamlScalar). Everything else is quoted.
+  lines.push(
+    `title: ${isSafePlainYamlScalar(fm.title) ? fm.title : JSON.stringify(fm.title)}`,
+  );
 
   lines.push(`type: ${fm.type}`);
 

--- a/test/frontmatter-inference.test.ts
+++ b/test/frontmatter-inference.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import matter from 'gray-matter';
 import {
   compileExcludePatterns,
   DEFAULT_EXCLUDE_PATTERNS,
@@ -261,6 +262,36 @@ describe('serializeFrontmatter', () => {
       type: 'note',
     });
     expect(fm).toContain('title: "What\'s the deal: a \\"primer\\""');
+  });
+
+  // Regression: the title quoting rule was a denylist of "special" chars and
+  // every gap corrupted a page at import. A round trip through gray-matter is
+  // the assertion that matters — `toContain` on the emitted string cannot tell
+  // a throw from a silent coercion.
+  describe('title quoting round-trips through the YAML parser', () => {
+    const cases: Array<[string, string]> = [
+      ['leading backtick (blocked docs/guides/skillopt.md)', '`gbrain skillopt` — Self-evolving skills'],
+      ['leading @ (YAML c-reserved)', '@mentions and you'],
+      ['leading % (directive indicator)', '% completion tracking'],
+      ['leading dash (parsed as a sequence — title went undefined)', '- dash leading title'],
+      ['bare true (coerced to boolean)', 'true'],
+      ['bare year (coerced to number)', '2026'],
+      ['plain safe title', 'Search Modes'],
+      ['colon and quotes', 'What\'s the deal: a "primer"'],
+    ];
+    for (const [label, title] of cases) {
+      test(label, () => {
+        const parsed = matter(serializeFrontmatter({ title, type: 'guide' }));
+        expect(parsed.data.title).toBe(title);
+        expect(typeof parsed.data.title).toBe('string');
+      });
+    }
+  });
+
+  test('leaves a provably-safe title unquoted', () => {
+    expect(serializeFrontmatter({ title: 'Alice Smith', type: 'note' })).toContain(
+      'title: Alice Smith',
+    );
   });
 
   test('returns empty string for skipped files', () => {


### PR DESCRIPTION
## The bug

Frontmatter synthesis emits the inferred title as a plain YAML scalar unless it
matches a denylist of "special" characters (`src/core/frontmatter-inference.ts`).
The denylist is incomplete, and each gap corrupts a page at import time.

Hit while syncing gbrain's own `docs/` into a brain — three files failed:

```
docs/guides/skillopt.md
docs/eval-takes-quality.md
docs/architecture/serve-sync-concurrency.md
```

All three have an H1 of the form `` # `gbrain <cmd>` — ... ``. A leading backtick
is YAML c-reserved, so the emitted scalar cannot parse. Any doc whose title
starts with a backtick fails to sync, which is a common shape in technical
documentation.

## Failure modes found

Round-tripping the serializer output through gray-matter:

| Title | Current | Result |
|---|---|---|
| `` `gbrain skillopt` — … `` | unquoted | **throws** |
| `@mentions and you` | unquoted | **throws** |
| `% completion tracking` | unquoted | **throws** |
| `- dash leading title` | unquoted | **silently `undefined`** |
| `true` | unquoted | **coerced to boolean** |
| `2026` | unquoted | **coerced to number** |

The last three are silent — worse than the throw, since the page imports with a
missing or wrong-typed title and nothing reports it. (`true` / `2026` are the
#1948/#1939 class.)

## The fix

Invert the denylist to an allowlist (`isSafePlainYamlScalar`). A title is emitted
bare only when it is ASCII-letter-led and contains nothing but letters, digits,
spaces and `_ . ( ) / -`; it is also rejected on trailing whitespace and on the
YAML 1.1 boolean/null keywords. Everything else is quoted.

A denylist can never be complete — that incompleteness is the bug. With an
allowlist the worst case is a redundant pair of quotes rather than a broken or
silently-wrong import.

## Tests

Added round-trip tests through gray-matter rather than `toContain` assertions on
the emitted string — `toContain` cannot distinguish a throw from a silent
coercion. **Verified failing 6/6 against the unfixed serializer**, passing after.

Both existing assertions on unquoted output (`title: Apr 13 founders mtg`,
`title: Alice Smith`) still pass untouched — the allowlist was chosen so they
would.

`bun run typecheck` clean. `test/frontmatter-inference.test.ts` and
`test/brain-writer.test.ts`: 78 pass, 0 fail.