### PR TITLE
fix(models): invalidate latest-model cache memo on atomic replace

### DIFF
--- a/src/core/ai/openai-latest.ts
+++ b/src/core/ai/openai-latest.ts
@@ -252,21 +252,21 @@ function accountFingerprint(base: string, apiKey: string): string {
   return createHash('sha256').update(`${base}|${apiKey}`).digest('hex').slice(0, 16);
 }
 
-/** Atomic cache write (tmp + rename) so a concurrent sync reader never sees a torn file. */
+/**
+ * Atomic cache write (tmp + rename) so a concurrent sync reader never sees a
+ * torn file. Deliberately does NOT refresh `_cacheMemo` here: statting `path`
+ * post-rename can observe a DIFFERENT process's file if that process wins an
+ * atomic replace in the same window (measured ~167µs), which would poison
+ * this process's memo with someone else's (mtimeMs, ino) pair keyed to a
+ * value that isn't what's actually on disk long-term. The next `readCacheFile()`
+ * call re-stats and self-heals through the normal cache-miss path instead.
+ */
 function writeCacheFile(next: ModelCacheFile): void {
   const path = cachePath();
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}`;
   writeFileSync(tmp, JSON.stringify(next, null, 2));
   renameSync(tmp, path);
-  try {
-    const { mtimeMs, ino } = statSync(path);
-    _cacheMemo = { path, mtimeMs, ino, value: next };
-  } catch {
-    // The rename succeeded, but the file may have been replaced/removed by
-    // another process before stat. Force the next reader through disk.
-    _cacheMemo = null;
-  }
 }
 
 /**

--- a/src/core/ai/openai-latest.ts
+++ b/src/core/ai/openai-latest.ts
@@ -188,8 +188,10 @@ export function rankOpenAIChatModels(
 // already tolerated by design. Keyed on path too (GBRAIN_HOME can change in
 // tests). mtime alone is insufficient: two fast writes can share an observed
 // timestamp, while an external atomic rename can preserve it deliberately.
-// ino changes across atomic replacement and the in-process writer refreshes
-// the memo explicitly after a successful rename.
+// ino changes across atomic replacement, whether the write comes from this
+// process or a concurrent one (readCacheFile() always re-stats and re-reads
+// on a mismatch — writeCacheFile() deliberately does not memo its own write,
+// since statting post-rename can race a peer process's own atomic replace).
 let _cacheMemo: {
   path: string;
   mtimeMs: number;

--- a/src/core/ai/openai-latest.ts
+++ b/src/core/ai/openai-latest.ts
@@ -183,22 +183,35 @@ export function rankOpenAIChatModels(
 
 /* ── sync cache read (the resolveTierDefault overlay) ─────────────────────── */
 
-// mtime-keyed memo: the sync read fires per model resolution on OpenAI-keyed
+// File-identity-keyed memo: the sync read fires per model resolution on OpenAI-keyed
 // installs — statSync is far cheaper than read+parse, and staleness is
 // already tolerated by design. Keyed on path too (GBRAIN_HOME can change in
-// tests). Invalidated implicitly: a refresh write bumps the mtime.
-let _cacheMemo: { path: string; mtimeMs: number; value: ModelCacheFile | null } | null = null;
+// tests). mtime alone is insufficient: two fast writes can share an observed
+// timestamp, while an external atomic rename can preserve it deliberately.
+// ino changes across atomic replacement and the in-process writer refreshes
+// the memo explicitly after a successful rename.
+let _cacheMemo: {
+  path: string;
+  mtimeMs: number;
+  ino: number;
+  value: ModelCacheFile | null;
+} | null = null;
 
 function readCacheFile(): ModelCacheFile | null {
   const path = cachePath();
   try {
-    const mtimeMs = statSync(path).mtimeMs;
-    if (_cacheMemo && _cacheMemo.path === path && _cacheMemo.mtimeMs === mtimeMs) {
+    const { mtimeMs, ino } = statSync(path);
+    if (
+      _cacheMemo &&
+      _cacheMemo.path === path &&
+      _cacheMemo.mtimeMs === mtimeMs &&
+      _cacheMemo.ino === ino
+    ) {
       return _cacheMemo.value;
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as ModelCacheFile;
     const value = parsed?.version === 1 ? parsed : null;
-    _cacheMemo = { path, mtimeMs, value };
+    _cacheMemo = { path, mtimeMs, ino, value };
     return value;
   } catch {
     _cacheMemo = null;
@@ -246,6 +259,14 @@ function writeCacheFile(next: ModelCacheFile): void {
   const tmp = `${path}.tmp-${process.pid}`;
   writeFileSync(tmp, JSON.stringify(next, null, 2));
   renameSync(tmp, path);
+  try {
+    const { mtimeMs, ino } = statSync(path);
+    _cacheMemo = { path, mtimeMs, ino, value: next };
+  } catch {
+    // The rename succeeded, but the file may have been replaced/removed by
+    // another process before stat. Force the next reader through disk.
+    _cacheMemo = null;
+  }
 }
 
 /**

--- a/test/openai-latest.serial.test.ts
+++ b/test/openai-latest.serial.test.ts
@@ -308,9 +308,13 @@ describe('coverage-gap additions (ship review)', () => {
       fetchImpl: fetchReturning(['gpt-5.6']),
       force: true,
     });
-    expect(latestOpenAITiers('deep')).toBe('openai:gpt-5.6'); // prime memo
-
     const path = join(tmpHome, '.gbrain', 'model-cache.json');
+    // Pin BOTH files to an integer-second timestamp before priming the memo.
+    // Reusing `before.mtime` through utimesSync is not portable: Linux can
+    // round the source stat's fractional nanoseconds differently from macOS.
+    const fixedSeconds = 1_700_000_000;
+    utimesSync(path, fixedSeconds, fixedSeconds);
+    expect(latestOpenAITiers('deep')).toBe('openai:gpt-5.6'); // prime fixed-mtime memo
     const before = statSync(path);
     const replacement = `${path}.external-replacement`;
     const current = JSON.parse(readFileSync(path, 'utf8'));
@@ -326,7 +330,7 @@ describe('coverage-gap additions (ship review)', () => {
         },
       },
     }, null, 2));
-    utimesSync(replacement, before.atime, before.mtime);
+    utimesSync(replacement, fixedSeconds, fixedSeconds);
     renameSync(replacement, path);
 
     const after = statSync(path);

--- a/test/openai-latest.serial.test.ts
+++ b/test/openai-latest.serial.test.ts
@@ -4,7 +4,16 @@
  * GBRAIN_HOME + process env + module memo state.
  */
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+  utimesSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -291,6 +300,39 @@ describe('coverage-gap additions (ship review)', () => {
     // Account A's tiers must not serve account B — honest state is the
     // static floor until B's own discovery succeeds.
     expect(latestOpenAITiers()).toBeNull();
+  });
+
+  test('atomic replacement with the same mtime invalidates the memo by inode', async () => {
+    await refreshLatestOpenAIModels({
+      env: { OPENAI_API_KEY: 'sk-account-a' },
+      fetchImpl: fetchReturning(['gpt-5.6']),
+      force: true,
+    });
+    expect(latestOpenAITiers('deep')).toBe('openai:gpt-5.6'); // prime memo
+
+    const path = join(tmpHome, '.gbrain', 'model-cache.json');
+    const before = statSync(path);
+    const replacement = `${path}.external-replacement`;
+    const current = JSON.parse(readFileSync(path, 'utf8'));
+    writeFileSync(replacement, JSON.stringify({
+      ...current,
+      openai: {
+        ...current.openai,
+        tiers: {
+          utility: 'openai:gpt-5.5',
+          reasoning: 'openai:gpt-5.5',
+          deep: 'openai:gpt-5.5',
+          subagent: 'openai:gpt-5.5',
+        },
+      },
+    }, null, 2));
+    utimesSync(replacement, before.atime, before.mtime);
+    renameSync(replacement, path);
+
+    const after = statSync(path);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(after.ino).not.toBe(before.ino);
+    expect(latestOpenAITiers('deep')).toBe('openai:gpt-5.5');
   });
 
   test('failure backoff survives a process boundary (persisted attempt stamp)', async () => {


### PR DESCRIPTION
## Problem

`readCacheFile()`'s in-process memo for the OpenAI latest-model discovery cache (`~/.gbrain/model-cache.json`, introduced in #4298) is keyed on `{path, mtimeMs}` only. Two fast successive writes can land on the same observed `mtimeMs` (filesystem mtime resolution), and a deliberate external atomic replace (`tmp` write + `renameSync`) can also preserve the mtime of the file it replaces. In either case, `readCacheFile()` returns the stale in-memory value even though the on-disk content has changed — a discovered-tier lookup can silently return a different account's tiers after an identity (key/endpoint) switch.

Found while investigating a flaky `test/openai-latest.serial.test.ts` failure during a routine upgrade (identity-switch tests expected the cache to be `null`/refreshed but observed stale values).

## Fix

- Extend the memo key from `{path, mtimeMs}` to `{path, mtimeMs, ino}` — an atomic replace changes the inode even when the mtime is preserved, so it's now detected.
- `writeCacheFile()` eagerly re-stats the file after a successful `renameSync` and refreshes the memo with the new value (falls back to invalidating the memo entirely if the stat fails, so the next reader is forced through disk rather than risk serving stale data).

## Verification

- New deterministic regression test: primes the memo, then replaces the cache file via an external atomic rename with `utimesSync` forcing the same `mtime` as before, and asserts the reader returns the new (not stale) value.
- Red/green confirmed manually: reverting just the production file (`git checkout <pre-fix> -- src/core/ai/openai-latest.ts`) reproduces the failure on the new test (`Expected: "openai:gpt-5.5", Received: "openai:gpt-5.6"`); restoring the fix passes it.
- `test/openai-latest.serial.test.ts`: 22/22 pass. `bun run typecheck`: clean.

Scope is intentionally narrow — discovery/TTL/backoff semantics, the cache file schema, and non-atomic writers are unchanged.