### PR TITLE
fix(cli): route thin-client think before connectEngine

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2517,6 +2517,21 @@ async function handleCliOnly(command: string, args: string[]) {
     return;
   }
 
+  // Thin-client `think` dispatch: runThinkCli already routes through
+  // callRemoteTool when isThinClient(cfg) (v0.31.1). Falling through to
+  // connectEngine() below fails with `database_url is missing` on
+  // Topology-2 installs and never reaches that branch. Official invariant:
+  // detect isThinClient BEFORE connectEngine (docs/architecture/thin-client.md).
+  // --save/--take stay server-gated; runThinkCli already warns.
+  if (command === 'think') {
+    const cfgThink = loadConfig();
+    if (cfgThink && isThinClient(cfgThink)) {
+      const { runThinkCli } = await import('./commands/think.ts');
+      await runThinkCli(null as never, args);
+      return;
+    }
+  }
+
   // All remaining CLI-only commands need a DB connection
   const engine = await connectEngine();
   try {

--- a/test/cli-dispatch-thin-client.test.ts
+++ b/test/cli-dispatch-thin-client.test.ts
@@ -221,4 +221,27 @@ describe('thin-client scratch-DB guard — jobs partial dispatch + config refusa
     expect(r.stdout + r.stderr).not.toContain('Schema version');
     expect(r.stdout + r.stderr).not.toContain('Setting up brain schema');
   });
+
+  test('`gbrain think` never fabricates a scratch local engine', async () => {
+    // Same class as jobs get: pglite-keyed thin client must not open a
+    // scratch store / replay migrations before the remote think call.
+    seedThinClientConfig({ engine: 'pglite' });
+    const r = await run(['think', 'What do we know?']);
+    const { existsSync } = await import('fs');
+    expect(existsSync(join(tmp, '.gbrain', 'brain.pglite'))).toBe(false);
+    expect(r.stdout + r.stderr).not.toContain('Schema version');
+    expect(r.stdout + r.stderr).not.toContain('Setting up brain schema');
+    expect(r.stdout + r.stderr).not.toContain('database_url is missing');
+  });
+
+  test('`gbrain think` on postgres-keyed thin client never demands database_url', async () => {
+    // Topology 2 as shipped: engine postgres, remote_mcp set, no database_url.
+    // Today's connectEngine() throws `database_url is missing` before
+    // runThinkCli's isThinClient branch. Remote call to brain-host.example
+    // will fail (unreachable) — irrelevant. Pin that connectEngine did not run.
+    seedThinClientConfig({ engine: 'postgres' });
+    const r = await run(['think', 'What do we know?']);
+    expect(r.stdout + r.stderr).not.toContain('database_url is missing');
+    expect(r.stdout + r.stderr).not.toContain('No brain configured');
+  });
 });


### PR DESCRIPTION
## Summary

On a Topology-2 thin client (`gbrain init --mcp-only`, no local `database_url`), `gbrain think "…"` dies with `database_url is missing` before the official MCP route runs.

`runThinkCli` already has the v0.31.1 `isThinClient` + `callRemoteTool(..., 'think', ...)` branch (`src/commands/think.ts`). `think` is `CLI_ONLY`, so `handleCliOnly` called `connectEngine()` first and never reached that branch.

This copies the existing pre-connect bypass used by `status` and `jobs list|get`. Official invariant: detect `isThinClient` **before** `connectEngine` (`docs/architecture/thin-client.md`, `docs/architecture/topologies.md` Topology 2). `--save` / `--take` stay server-gated; `runThinkCli` already warns.

Two regression tests in `test/cli-dispatch-thin-client.test.ts`:
- pglite-keyed thin client must not fabricate a scratch store (same class as `jobs get`)
- postgres-keyed thin client (the shipped Topology-2 shape) must not throw `database_url is missing`

`bun test test/cli-dispatch-thin-client.test.ts` — 20 pass, including both new cases.

## Not in this PR

- `gbrain call think` also dies at `connectEngine`. `runCall` has no remote branch; the same one-liner does not apply and would null-deref. Left alone.
- `salience`, `anomalies`, and `graph-query` are the same CLI_ONLY + in-command `isThinClient` class. Mentioning only; not sweeping.

No VERSION / CHANGELOG bump (release-time maintainer lane).