### PR TITLE
fix(ai): enable keyless Ollama chat routing

### DIFF
--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -109,7 +109,7 @@ export function assertTouchpoint(
       `Provider "${recipe.id}" does not support touchpoint "${touchpoint}".`,
       touchpoint === 'embedding' && recipe.id === 'anthropic'
         ? 'Anthropic has no embedding model. Use openai or google for embeddings.'
-        : touchpoint === 'chat' && (recipe.id === 'voyage' || recipe.id === 'ollama')
+        : touchpoint === 'chat' && recipe.id === 'voyage'
           ? `${recipe.name} is configured here only for embeddings. Use openai/anthropic/google/deepseek/groq/together for chat.`
           : undefined,
     );

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -54,6 +54,8 @@ export const ollama: Recipe = {
       supports_tools: false,
       supports_subagent_loop: false,
       supports_prompt_cache: false,
+      // Provider-wide routing ceiling only; Ollama still enforces each loaded
+      // model's actual context window at request time.
       max_context_tokens: 128_000,
       cost_per_1m_input_usd: 0,
       cost_per_1m_output_usd: 0,
@@ -62,5 +64,5 @@ export const ollama: Recipe = {
       default_timeout_ms: 180_000,
     },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` for embeddings, `ollama pull qwen3:8b` for local chat, and `ollama serve`. Custom local model tags are accepted.',
 };

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -45,6 +45,22 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      // Model ids are user-managed; this informational default makes the chat
+      // capability visible in provider discovery without constraining custom tags.
+      models: ['qwen3:8b'],
+      // Chat completion is provider-wide, but tool support varies by loaded
+      // model. Keep the subagent capability gate conservative.
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 128_000,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-08-18',
+      // Local cold starts can exceed the generic 5-second provider probe.
+      default_timeout_ms: 180_000,
+    },
   },
   setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
 };

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -17,6 +17,13 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(1_050_000); // gpt-5.6 family window (recipe-driven)
   });
 
+  it('returns local chat capabilities for Ollama without tool-loop support', () => {
+    const caps = getProviderCapabilities('ollama:qwen3:8b');
+    expect(caps.supportsToolCalling).toBe(false);
+    expect(caps.supportsPromptCaching).toBe(false);
+    expect(caps.supportsParallelTools).toBe(false);
+  });
+
   it('returns capabilities for Google Gemini', () => {
     const caps = getProviderCapabilities('google:gemini-1.5-pro');
     expect(caps.supportsToolCalling).toBe(true);
@@ -68,6 +75,10 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
 
   it('returns degraded:no_caching for OpenAI (tools yes, caching no)', () => {
     expect(classifyCapabilities('openai:gpt-5.2')).toBe('degraded:no_caching');
+  });
+
+  it('returns unusable:no_tools for Ollama subagent loops', () => {
+    expect(classifyCapabilities('ollama:qwen3:8b')).toBe('unusable:no_tools');
   });
 
   it('returns degraded:no_caching for Google Gemini', () => {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -61,12 +61,23 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('Voyage remains embedding-only', () => {
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
+  });
+
+  test('Ollama declares local chat without subagent tool-loop support', () => {
+    const chat = getRecipe('ollama')!.touchpoints.chat;
+    expect(chat).toBeDefined();
+    expect(chat!.models).toContain('qwen3:8b');
+    expect(chat!.supports_tools).toBe(false);
+    expect(chat!.supports_subagent_loop).toBe(false);
+    expect(chat!.supports_prompt_cache).toBe(false);
+    expect(chat!.cost_per_1m_input_usd).toBe(0);
+    expect(chat!.cost_per_1m_output_usd).toBe(0);
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
+    expect(getRecipe('ollama')!.base_url_default).toBe('http://localhost:11434/v1');
     expect(getRecipe('deepseek')!.base_url_default).toBe('https://api.deepseek.com/v1');
     expect(getRecipe('groq')!.base_url_default).toBe('https://api.groq.com/openai/v1');
     expect(getRecipe('together')!.base_url_default).toBe('https://api.together.xyz/v1');
@@ -173,8 +184,6 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
       .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
-      .toThrow(AIConfigError);
   });
 
   test('assertTouchpoint accepts unlisted models on native recipes (no runtime allowlist)', () => {
@@ -191,6 +200,7 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint accepts arbitrary model on openai-compat tier', () => {
     // openai-compat lets users pass models not declared in the recipe (provider may host more)
     expect(() => assertTouchpoint(getRecipe('groq')!, 'chat', 'some-future-model')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'locally-installed-model')).not.toThrow();
   });
 });
 

--- a/test/model-config.serial.test.ts
+++ b/test/model-config.serial.test.ts
@@ -391,13 +391,9 @@ describe('providerKeyReady + resolveEffectiveChatModel (shared runtime/report re
     expect(providerKeyReady('not-a-provider:x', { OPENAI_API_KEY: 'sk-test' })).toBe(false);
     // No required keys + a chat touchpoint (the CLI owns auth) → ready.
     expect(providerKeyReady('claude-cli:claude-sonnet-4-6', {})).toBe(true);
-    // A keyed/keyless but CHAT-LESS recipe is NOT ready: honoring an
-    // embedding-only pin as chat_model would install a model
-    // isAvailable('chat') rejects instead of falling back to the key-aware
-    // default. (ollama is embedding-only in this repo's recipe, hence false
-    // despite requiring no keys.)
+    // Keyless Ollama exposes a local OpenAI-compatible chat endpoint.
     expect(providerKeyReady('voyage:voyage-4-large', { VOYAGE_API_KEY: 'x' })).toBe(false);
-    expect(providerKeyReady('ollama:llama3', {})).toBe(false);
+    expect(providerKeyReady('ollama:llama3', {})).toBe(true);
   });
 
   test('servable file pin wins (init-era openai pin + live key)', () => {

--- a/test/models-doctor-chat-probe-timeout.test.ts
+++ b/test/models-doctor-chat-probe-timeout.test.ts
@@ -31,6 +31,11 @@ describe('resolveChatProbeTimeoutMs', () => {
     expect(ms).toBe(30_000);
   });
 
+  test('Ollama chat allows a local cold start', async () => {
+    const ms = await resolveChatProbeTimeoutMs('ollama:qwen3:8b', 'chat');
+    expect(ms).toBe(180_000);
+  });
+
   test('a provider without a declared default_timeout_ms keeps the historical 5000ms', async () => {
     const ms = await resolveChatProbeTimeoutMs('anthropic:claude-sonnet-4-6', 'chat');
     expect(ms).toBe(5000);

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -63,6 +63,13 @@ describe('formatRecipeTable', () => {
     expect(openaiLine).toContain('✗ missing OPENAI_API_KEY');
   });
 
+  test('shows keyless Ollama chat as available', () => {
+    const out = formatRecipeTable(listRecipes(), {});
+    const ollamaLine = out.split('\n').find(line => line.startsWith('ollama'));
+    expect(ollamaLine).toBeDefined();
+    expect(ollamaLine).toMatch(/ollama\s+openai-compat\s+yes\s+—\s+yes\s+✓ ready/);
+  });
+
   test('each recipe appears at most once', () => {
     const out = formatRecipeTable(listRecipes(), {});
     const recipes = listRecipes();


### PR DESCRIPTION
## Summary

- add a zero-cost Ollama chat touchpoint through the existing OpenAI-compatible gateway
- keep tool calling and Minions subagent loops conservatively disabled because capabilities vary by locally loaded model
- advertise `qwen3:8b` as an informational default while continuing to accept arbitrary Ollama tags
- give local cold starts up to 180 seconds in provider probes
- update model resolution and capability tests for keyless Ollama chat

## Why

GBrain already recognizes `ollama:*` chat inference as free in its budget layer, and Ollama serves an OpenAI-compatible `/v1/chat/completions` endpoint. However, the Ollama recipe currently declares embeddings only, so explicit routes such as `models.dream.triage` and `models.dream.synthesize` are rejected before reaching the local server.

This was reproduced on GBrain 0.46.21.0 with a local `qwen38-27b:latest` model. After this change:

- `gbrain providers list` reports Ollama chat as available
- `gbrain providers test --touchpoint chat --model ollama:qwen38-27b:latest` completes successfully
- dream triage and one-shot synthesis resolve to the local model with zero token cost

## Validation

- `bun test test/ai/gateway-chat.test.ts test/ai/capabilities.test.ts test/model-config.serial.test.ts test/budget/free-local-chat-pricing.test.ts test/ai/recipe-ollama-dims.test.ts test/models-doctor-chat-probe-timeout.test.ts test/providers.test.ts` — 128 pass
- `bun run verify` — 54/54 checks pass
- `bun run typecheck` — pass
- `bun run wave-security-scan master..HEAD` — pass, including gitleaks
- live provider probe against Ollama/Qwen3.8 — pass

The full unit suite has unrelated baseline failures in bootstrap/plugin-state and volunteer-event tests. The same failing files reproduce with this patch stashed; directly affected tests are green.

## Relationship to #4073

This overlaps #4073, which proposes broader Ollama chat plus expansion support. This PR is a narrower current-master implementation focused on chat routing needed by dream synthesis, with a longer local cold-start probe timeout and live Qwen3.8 validation. I am happy for maintainers to close this in favor of #4073 or use whichever pieces fit the release wave.

No VERSION or CHANGELOG bump; release-time maintainer lane, consistent with current community PR practice.
