### PR TITLE
fix(chronicle): preserve source id in backfill jobs

### DIFF
--- a/src/core/ops/chronicle.ts
+++ b/src/core/ops/chronicle.ts
@@ -265,7 +265,7 @@ const chronicle_backfill: Operation = {
         eligible++;
         if (dryRun || !queue) continue;
         try {
-          await queue.add('chronicle_extract', { slug: page.slug, sourceId: ctx.sourceId ?? 'default' });
+          await queue.add('chronicle_extract', { slug: page.slug, sourceId: page.source_id });
           enqueued++;
         } catch (e) {
           // Never swallow — surface per-page failures (the #2057 no-swallow pattern).

--- a/test/chronicle-backfill.test.ts
+++ b/test/chronicle-backfill.test.ts
@@ -43,4 +43,24 @@ describe('chronicle_backfill op', () => {
     const jobs = await engine.executeRaw<{ n: number }>(`SELECT count(*)::int AS n FROM minion_jobs WHERE name='chronicle_extract'`);
     expect(Number(jobs[0].n)).toBe(2);
   });
+
+  test('unscoped backfill enqueues each page under its own source', async () => {
+    await engine.executeRaw(`INSERT INTO sources (id, name) VALUES ('other-src', 'other-src') ON CONFLICT (id) DO NOTHING`);
+    await engine.putPage('meetings/default-src', { type: 'meeting', title: 'default', compiled_truth: LONG });
+    await engine.putPage('meetings/other-src', { type: 'meeting', title: 'other', compiled_truth: LONG }, { sourceId: 'other-src' });
+    const ctx = { engine, remote: false } as unknown as OperationContext;
+
+    const r = await operationsByName.chronicle_backfill.handler(ctx, {}) as { eligible: number; enqueued: number; errors: unknown[] };
+
+    expect(r.eligible).toBe(2);
+    expect(r.enqueued).toBe(2);
+    expect(r.errors).toHaveLength(0);
+    const jobs = await engine.executeRaw<{ data: { slug: string; sourceId: string } }>(
+      `SELECT data FROM minion_jobs WHERE name='chronicle_extract' ORDER BY data->>'slug'`
+    );
+    expect(jobs.map((j) => j.data)).toEqual([
+      { slug: 'meetings/default-src', sourceId: 'default' },
+      { slug: 'meetings/other-src', sourceId: 'other-src' },
+    ]);
+  });
 });


### PR DESCRIPTION
Summary

- Fixes the Chronicle backfill source routing bug split out from #3478.
- `chronicle_backfill` may scan pages across sources, so each `chronicle_extract` job now carries the owning `page.source_id` instead of falling back to `ctx.sourceId ?? 'default'`.
- Adds regression coverage for an unscoped sweep that enqueues one default-source page and one non-default-source page.

Scope

- This intentionally does not include the already-landed `backfill` CLI_ONLY fix.
- This intentionally does not include the doctor image source-root fix or the Chronicle judge retry changes; those belong in separate PRs per maintainer feedback on #3478.
- No release metadata is included so this stays as the small, reviewable split requested by the maintainer.

Test plan

- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun test test/chronicle-backfill.test.ts`
- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun run typecheck`
- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun run verify`
- ATTEMPTED: `GBRAIN_HOME=/tmp/gbrain-dev-verify bash scripts/ci-local.sh --diff --no-pull`
  - gitleaks passed and postgres shards started.
  - The runner did not complete on this macOS host because `/bin/bash` 3.2 hit `scripts/ci-local.sh: line 357: EXTRA_MOUNTS[@]: unbound variable`.
- ATTEMPTED: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun test`
- Interrupted after unrelated local/full-suite failures, including Bun server startup failures on port 0 / fixed ports, sandbox denial writing `~/.gbrain/cycle.lock`, real launchd E2E timeouts, and an existing embedding-default assertion in `test/v0_37_fix_wave.serial.test.ts`.
