### PR TITLE
fix(doctor): resolve image assets by source root

### DIFF
--- a/src/commands/doctor-asset-paths.ts
+++ b/src/commands/doctor-asset-paths.ts
@@ -63,6 +63,19 @@ export function resolveAssetPath(
 }
 
 /**
+ * Resolve an image asset against the source that owns the files row. The
+ * global sync.repo_path is only a legacy fallback for rows without source root
+ * metadata.
+ */
+export function resolveImageAssetPath(
+  storagePath: string,
+  sourceLocalPath: string | null,
+  fallbackRepoRoot: string,
+): AssetPathResolution {
+  return resolveAssetPath(storagePath, sourceLocalPath ?? fallbackRepoRoot);
+}
+
+/**
  * Extract the `[automount] root` value from /etc/wsl.conf content.
  * Defaults to `/mnt` (WSL's own default) when absent/unparseable.
  */

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3600,24 +3600,23 @@ export async function buildChecks(
   if (engine) {
     progress.heartbeat('image_assets');
     try {
-      const rows = await engine.executeRaw<{ storage_path: string }>(
-        `SELECT storage_path FROM files WHERE mime_type LIKE 'image/%' LIMIT 1000`
+      const rows = await engine.executeRaw<{ storage_path: string; source_local_path: string | null }>(
+        `SELECT f.storage_path, s.local_path AS source_local_path FROM files f LEFT JOIN sources s ON s.id = COALESCE(f.source_id, 'default') WHERE f.mime_type LIKE 'image/%' LIMIT 1000`
       );
       let vanished = 0;
       let foreign = 0;
       const vanishedPaths: string[] = [];
       const fs = await import('node:fs');
-      const { resolveAssetPath } = await import('./doctor-asset-paths.ts');
-      // storage_path is repo-relative for sync-ingested assets. Resolving
-      // against cwd made this check a false-positive WARN whenever doctor
-      // ran outside the brain repo.
+      const { resolveImageAssetPath } = await import('./doctor-asset-paths.ts');
+      // storage_path is repo-relative for sync-ingested assets. Prefer the
+      // owning source's root; sync.repo_path is only a legacy fallback.
       const repoRoot = (await engine.getConfig('sync.repo_path')) ?? process.cwd();
       for (const r of rows) {
         // #1835: Windows drive paths (D:/…) translate to the WSL automount
         // (/mnt/d/…) under WSL, and are SKIPPED (not "missing") on hosts
         // where they cannot exist (macOS / plain Linux) — never joined onto
         // repoRoot, which produced a false "restore from git" WARN.
-        const resolved = resolveAssetPath(r.storage_path, repoRoot);
+        const resolved = resolveImageAssetPath(r.storage_path, r.source_local_path, repoRoot);
         if (resolved.abs === null) {
           foreign++;
           continue;

--- a/test/doctor-image-assets.test.ts
+++ b/test/doctor-image-assets.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveImageAssetPath } from '../src/commands/doctor-asset-paths.ts';
+
+describe('doctor image asset path resolution', () => {
+  test('uses the owning source local_path before the global sync fallback', () => {
+    expect(resolveImageAssetPath(
+      'images/example.jpg',
+      '/brains/default-source',
+      '/brains/other-source',
+    ).abs).toBe('/brains/default-source/images/example.jpg');
+  });
+
+  test('falls back to sync.repo_path for legacy rows without a source root', () => {
+    expect(resolveImageAssetPath(
+      'images/example.jpg',
+      null,
+      '/brains/fallback',
+    ).abs).toBe('/brains/fallback/images/example.jpg');
+  });
+
+  test('keeps absolute storage paths unchanged', () => {
+    expect(resolveImageAssetPath(
+      '/var/lib/gbrain/example.jpg',
+      '/brains/default-source',
+      '/brains/fallback',
+    ).abs).toBe('/var/lib/gbrain/example.jpg');
+  });
+});


### PR DESCRIPTION
Summary

- Fixes the doctor `image_assets` source-root bug split out from #3478.
- Image asset rows now resolve repo-relative `storage_path` values against the owning source `local_path` before falling back to global `sync.repo_path`.
- Keeps the existing Windows-drive / WSL foreign-path handling by routing through the shared doctor asset path helper.

Scope

- This is intentionally only the doctor image source-root fix requested by the maintainer on #3478.
- It does not include the Chronicle backfill source-id fix, which is split separately in #4320.
- It does not include the already-landed `backfill` CLI_ONLY fix, Chronicle covered-query changes, or segmented judge retry work.

Test plan

- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun test test/doctor-image-assets.test.ts`
- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun run typecheck`
- PASS: `GBRAIN_HOME=/tmp/gbrain-dev-verify bun run verify`
