### PR TITLE
fix(facts): resolve stub entity-page type from the active pack (#4322)

### DIFF
--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -37,7 +37,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, appendF
 import { dirname } from 'node:path';
 
 import type { BrainEngine, NewFact, FactVisibility } from '../engine.ts';
-import { resolvePageFilePath } from '../markdown.ts';
+import { resolvePageFilePath, inferTypeFromPack } from '../markdown.ts';
+import { loadActivePackBestEffort } from '../schema-pack/best-effort.ts';
 import { withPageLock } from '../page-lock.ts';
 import { gbrainPath } from '../config.ts';
 import { upsertFactRow, parseFactsFence } from '../facts-fence.ts';
@@ -126,14 +127,24 @@ function recordWriteFailure(slug: string, sourceId: string, warnings: string[], 
  * (e.g. `people/alice` → 'person'); unknown prefixes fall back to
  * 'concept' which is the most permissive PageType.
  */
-function stubEntityPage(slug: string): string {
-  const prefix = slug.split('/')[0];
-  const type =
-    prefix === 'people'    ? 'person' :
-    prefix === 'companies' ? 'company' :
-    prefix === 'deals'     ? 'deal' :
-    prefix === 'topics'    ? 'concept' :
-    /* fallback */           'concept';
+function stubEntityPage(
+  slug: string,
+  pack: Parameters<typeof inferTypeFromPack>[1] | null,
+): string {
+  // #4322: resolve the type through the ACTIVE PACK, not a hardcoded table.
+  // The previous people/companies/deals/topics ternary shadowed every other
+  // pack-declared prefix, so a stub under a declared prefix such as
+  // `products/` was written as `concept` even though the pack maps that
+  // prefix to `company` — manufacturing prefix/type mismatches in brains
+  // that were otherwise fully pack-conformant, and (because `concept` skips
+  // the facts backstop) silently opting those pages out of the very
+  // subsystem that created them.
+  //
+  // A null pack means the load failed. Per best-effort.ts's contract we do
+  // NOT substitute an ad-hoc table here; passing an empty pack routes
+  // inferTypeFromPack to its own documented GBRAIN_BASE_PATH_PREFIXES
+  // fallback, the same base behaviour every other ingest path degrades to.
+  const type = inferTypeFromPack(slug, pack ?? { page_types: [] });
   const tail = slug.split('/').slice(1).join('/');
   const title = tail
     .replace(/[-_/]+/g, ' ')
@@ -220,7 +231,8 @@ export async function writeFactsToFence(
         }
         // Stub-create the parent directory if it doesn't exist.
         mkdirSync(dirname(filePath), { recursive: true });
-        body = stubEntityPage(target.slug);
+        const activePack = await loadActivePackBestEffort({ engine } as never);
+        body = stubEntityPage(target.slug, activePack?.manifest ?? null);
       }
 
       // 2. Upsert each fact onto the fence in input order. row_num

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -96,6 +96,27 @@ describe('writeFactsToFence — happy path', () => {
     });
   });
 
+  // #4322 regression. stubEntityPage used to pick the type from a hardcoded
+  // people/companies/deals/topics ternary, so a stub under ANY other declared
+  // prefix silently became `concept`. `projects/` is in the gbrain-base prefix
+  // table (→ `project`) but was absent from that ternary, so it is the minimal
+  // case that fails on the old code and passes on the pack-aware one. No custom
+  // pack needed: with no pack configured the loader returns null and
+  // inferTypeFromPack falls back to GBRAIN_BASE_PATH_PREFIXES.
+  test('types a stub from the prefix table, not a hardcoded 4-entry list', async () => {
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'projects/apollo' },
+      [baseInput({ fact: 'Apollo shipped in 2017' })],
+    );
+
+    expect(result.inserted).toBe(1);
+    const body = readFileSync(join(brainDir, 'projects/apollo.md'), 'utf-8');
+    expect(body).toContain('type: project');
+    expect(body).not.toContain('type: concept');
+    expect(body).toContain('slug: projects/apollo');
+  });
+
   test('appends to existing entity page without overwriting body', async () => {
     // Pre-create the entity page with custom content.
     const filePath = join(brainDir, 'people/bob.md');


### PR DESCRIPTION
Fixes #4322.

## What

`stubEntityPage()` (`src/core/facts/fence-write.ts`) picked the `type:` for a
newly stub-created entity page from a hardcoded four-entry ternary
(`people` / `companies` / `deals` / `topics`), never from the active schema
pack. Every stub under any other prefix was written as `concept` — including
prefixes the pack explicitly declares.

Observed on 0.45.18.0 with a custom pack: a stub at `products/<x>` came out
`concept` even though the pack maps `products/` to `company`, and stubs at
`papers/`, `arxiv/`, `education/` and `organizations/` were all `concept`.

## Why it matters beyond cosmetics

- **Type gates behavior.** Correctly-typed pages queue the facts backstop;
  `concept` skips it (`skipped: kind:concept`). Mistyped stubs silently opt out
  of the subsystem that created them.
- **It manufactures mismatches.** A brain that was otherwise 100%
  pack-conformant acquires prefix/type mismatches from this path alone.

## How

Resolve through the existing `inferTypeFromPack()`, loading the pack with
`loadActivePackBestEffort()`.

A null pack (load failure) degrades to `inferTypeFromPack`'s own documented
`GBRAIN_BASE_PATH_PREFIXES` fallback rather than to an ad-hoc table — the
contract in `schema-pack/best-effort.ts`, whose header predicts precisely this
drift:

> Without this helper, the four sites would each open-code their own
> `try { load pack } catch { ... }` block, and one of them WILL drift to
> silently use hardcoded defaults.

`stubEntityPage` was such a site and was not among the four it lists.

`writeFactsToFence` is already `async` and already holds `engine`, so no
call-site signature changes.

## Test

`projects/` is in the `gbrain-base` prefix table (→ `project`) but was absent
from the old ternary, making it the minimal case that fails on the old code and
passes on the new one — and it needs no custom-pack fixture, since with no pack
configured the loader returns null and the base table applies.

Verified the test is a real regression test: with the `src/` change reverted it
fails (16 pass / 1 fail); with it applied the file is green (17 pass / 0 fail).

- `tsc --noEmit`: clean
- `bun test test/fence-write*.test.ts test/facts*.test.ts`: 350 pass / 0 fail

## Scope

Deliberately type-only. `inferTypeAndSubtypeFromPack()` could also stamp
`subtype:`, but subtype is not currently written as a frontmatter field on any
other path, so that belongs in a separate change.

Not addressed here: #4108 governs **whether** an unresolved `fallback_slugify`
entity should be materialized as a canonical page at all. That is independent —
fixing it reduces how often this path fires but leaves legitimately-created
stubs mistyped. Also worth a follow-up audit: the other ~17 `inferTypeFromPack`
call sites for the same drift, and adding `stubEntityPage` to the wiring-site
list documented in `best-effort.ts`.
