### PR TITLE
v0.46.22.0 fix(skills): honor trigger-only GBRAIN_SKILLS_DIR (#3381)

### DIFF
--- a/src/core/repo-root.ts
+++ b/src/core/repo-root.ts
@@ -1,8 +1,9 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, type Dirent } from 'fs';
 import { fileURLToPath } from 'url';
 import { isAbsolute, join, resolve as resolvePath } from 'path';
 import { RESOLVER_FILENAMES, hasResolverFile } from './resolver-filenames.ts';
 import { isPathContained } from './path-confine.ts';
+import { parseSkillFrontmatter } from './skill-frontmatter.ts';
 
 /**
  * Walk up from `startDir` looking for a `skills/` directory that
@@ -22,6 +23,40 @@ export function findRepoRoot(startDir: string = process.cwd()): string | null {
     dir = parent;
   }
   return null;
+}
+
+/**
+ * True when `dir` is a usable trigger-only skills catalog. Frontmatter
+ * `triggers:` are the canonical routing surface for modern skillpacks, so an
+ * explicit operator override must not require RESOLVER.md / AGENTS.md.
+ */
+function hasFrontmatterTriggerSkill(dir: string): boolean {
+  if (!existsSync(dir)) return false;
+
+  let dirents: Dirent[];
+  try {
+    dirents = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const dirent of dirents) {
+    if (!dirent.isDirectory()) continue;
+    const name = dirent.name;
+    if (name.startsWith('_') || name.startsWith('.')) continue;
+
+    const skillPath = join(dir, name, 'SKILL.md');
+    if (!existsSync(skillPath)) continue;
+
+    try {
+      const parsed = parseSkillFrontmatter(readFileSync(skillPath, 'utf-8'));
+      if (parsed?.triggers && parsed.triggers.length > 0) return true;
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -239,8 +274,19 @@ export function autoDetectSkillsDirReadOnly(
   startDir: string = process.cwd(),
   env: NodeJS.ProcessEnv = process.env,
 ): SkillsDirDetection {
+  if (env.GBRAIN_SKILLS_DIR) {
+    const explicit = isAbsolute(env.GBRAIN_SKILLS_DIR)
+      ? env.GBRAIN_SKILLS_DIR
+      : resolvePath(startDir, env.GBRAIN_SKILLS_DIR);
+    if (hasResolverFile(explicit) || hasFrontmatterTriggerSkill(explicit)) {
+      return { dir: explicit, source: 'env_explicit' };
+    }
+    return { dir: null, source: 'env_explicit' };
+  }
+
   const primary = autoDetectSkillsDir(startDir, env);
   if (primary.dir) return primary;
+  if (primary.source === 'env_explicit') return primary;
 
   // Tier-5 install-path fallback: walk up from this module's install
   // location. Gate with isGbrainRepoRoot so we don't false-positive when

--- a/src/core/repo-root.ts
+++ b/src/core/repo-root.ts
@@ -44,8 +44,11 @@ function hasFrontmatterTriggerSkill(dir: string): boolean {
     if (!dirent.isDirectory()) continue;
     const name = dirent.name;
     if (name.startsWith('_') || name.startsWith('.')) continue;
+    if (name.includes('/') || name.includes('\\')) continue;
 
-    const skillPath = join(dir, name, 'SKILL.md');
+    // Directory names come from readdirSync(dir), are separator-checked above,
+    // and are confined to explicit operator-selected skills catalogs.
+    const skillPath = join(dir, name, 'SKILL.md'); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     if (!existsSync(skillPath)) continue;
 
     try {
@@ -161,7 +164,8 @@ export function autoDetectSkillsDir(
   if (env.GBRAIN_SKILLS_DIR) {
     const explicit = isAbsolute(env.GBRAIN_SKILLS_DIR)
       ? env.GBRAIN_SKILLS_DIR
-      : resolvePath(startDir, env.GBRAIN_SKILLS_DIR);
+      // GBRAIN_SKILLS_DIR is an explicit operator override for local skills discovery.
+      : resolvePath(startDir, env.GBRAIN_SKILLS_DIR); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     if (hasResolverFile(explicit)) {
       return { dir: explicit, source: 'env_explicit' };
     }
@@ -277,7 +281,8 @@ export function autoDetectSkillsDirReadOnly(
   if (env.GBRAIN_SKILLS_DIR) {
     const explicit = isAbsolute(env.GBRAIN_SKILLS_DIR)
       ? env.GBRAIN_SKILLS_DIR
-      : resolvePath(startDir, env.GBRAIN_SKILLS_DIR);
+      // GBRAIN_SKILLS_DIR is an explicit operator override for local skills discovery.
+      : resolvePath(startDir, env.GBRAIN_SKILLS_DIR); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     if (hasResolverFile(explicit) || hasFrontmatterTriggerSkill(explicit)) {
       return { dir: explicit, source: 'env_explicit' };
     }

--- a/src/core/repo-root.ts
+++ b/src/core/repo-root.ts
@@ -286,6 +286,24 @@ export function autoDetectSkillsDirReadOnly(
     if (hasResolverFile(explicit) || hasFrontmatterTriggerSkill(explicit)) {
       return { dir: explicit, source: 'env_explicit' };
     }
+
+    if (env.OPENCLAW_WORKSPACE) {
+      const workspace = isAbsolute(env.OPENCLAW_WORKSPACE)
+        ? env.OPENCLAW_WORKSPACE
+        : resolvePath(startDir, env.OPENCLAW_WORKSPACE);
+      const workspaceResolved = resolveWorkspaceSkillsDir(
+        workspace,
+        'openclaw_workspace_env',
+        'openclaw_workspace_env_root',
+      );
+      if (
+        workspaceResolved?.dir &&
+        resolvePath(workspaceResolved.dir) === resolvePath(explicit)
+      ) {
+        return workspaceResolved;
+      }
+    }
+
     return { dir: null, source: 'env_explicit' };
   }
 

--- a/src/core/repo-root.ts
+++ b/src/core/repo-root.ts
@@ -290,7 +290,9 @@ export function autoDetectSkillsDirReadOnly(
     if (env.OPENCLAW_WORKSPACE) {
       const workspace = isAbsolute(env.OPENCLAW_WORKSPACE)
         ? env.OPENCLAW_WORKSPACE
-        : resolvePath(startDir, env.OPENCLAW_WORKSPACE);
+        // OPENCLAW_WORKSPACE is an explicit operator override; the resolved
+        // skills dir is still validated by resolver markers and confinement.
+        : resolvePath(startDir, env.OPENCLAW_WORKSPACE); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
       const workspaceResolved = resolveWorkspaceSkillsDir(
         workspace,
         'openclaw_workspace_env',
@@ -298,7 +300,9 @@ export function autoDetectSkillsDirReadOnly(
       );
       if (
         workspaceResolved?.dir &&
-        resolvePath(workspaceResolved.dir) === resolvePath(explicit)
+        // Normalize both absolute candidates before comparing the explicit
+        // skills-dir override with the workspace-derived skills sibling.
+        resolvePath(workspaceResolved.dir) === resolvePath(explicit) // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
       ) {
         return workspaceResolved;
       }

--- a/test/explicit-skills-dir-readonly.test.ts
+++ b/test/explicit-skills-dir-readonly.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { autoDetectSkillsDirReadOnly } from '../src/core/repo-root.ts';
+
+const CLI = resolve(import.meta.dir, '..', 'src', 'cli.ts');
+const REPO_ROOT = resolve(import.meta.dir, '..');
+
+const created: string[] = [];
+
+function scratch(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+
+function writeResolverSkillsDir(skillsDir: string): void {
+  mkdirSync(skillsDir, { recursive: true });
+  writeFileSync(join(skillsDir, 'RESOLVER.md'), '# Resolver\n');
+}
+
+function writeTriggerOnlySkillsDir(skillsDir: string): void {
+  mkdirSync(join(skillsDir, 'query'), { recursive: true });
+  writeFileSync(
+    join(skillsDir, 'query', 'SKILL.md'),
+    [
+      '---',
+      'name: query',
+      'triggers:',
+      '  - "what do we know"',
+      '---',
+      '',
+      '# Query',
+      '',
+      'A trigger-only skill.',
+      '',
+    ].join('\n'),
+  );
+}
+
+afterEach(() => {
+  while (created.length) {
+    const dir = created.pop()!;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe('read-only GBRAIN_SKILLS_DIR detection', () => {
+  test('honors an explicit trigger-only catalog over cwd fallback', () => {
+    const explicit = scratch('explicit-skills-');
+    writeTriggerOnlySkillsDir(explicit);
+    const host = scratch('host-with-skills-');
+    writeResolverSkillsDir(join(host, 'skills'));
+
+    const found = autoDetectSkillsDirReadOnly(host, { GBRAIN_SKILLS_DIR: explicit });
+
+    expect(found.dir).toBe(explicit);
+    expect(found.source).toBe('env_explicit');
+  });
+
+  test('fails closed on an invalid explicit catalog instead of checking cwd fallback', () => {
+    const invalid = scratch('invalid-skills-');
+    const host = scratch('host-with-skills-');
+    writeResolverSkillsDir(join(host, 'skills'));
+
+    const found = autoDetectSkillsDirReadOnly(host, { GBRAIN_SKILLS_DIR: invalid });
+
+    expect(found.dir).toBeNull();
+    expect(found.source).toBe('env_explicit');
+  });
+
+  test('check-resolvable --json reports the trigger-only explicit catalog', () => {
+    const explicit = scratch('cli-trigger-only-skills-');
+    writeTriggerOnlySkillsDir(explicit);
+
+    const res = spawnSync('bun', [CLI, 'check-resolvable', '--json'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, GBRAIN_SKILLS_DIR: explicit },
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    const json = JSON.parse(res.stdout);
+    expect(res.status).toBe(0);
+    expect(json.ok).toBe(true);
+    expect(json.skillsDir).toBe(explicit);
+  });
+
+  test('check-resolvable --json fails invalid explicit catalog without repo fallback', () => {
+    const invalid = scratch('cli-invalid-skills-');
+
+    const res = spawnSync('bun', [CLI, 'check-resolvable', '--json'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, GBRAIN_SKILLS_DIR: invalid },
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    const json = JSON.parse(res.stdout);
+    expect(res.status).toBe(1);
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('no_skills_dir');
+    expect(json.skillsDir).toBeNull();
+  });
+});

--- a/test/explicit-skills-dir-readonly.test.ts
+++ b/test/explicit-skills-dir-readonly.test.ts
@@ -21,6 +21,11 @@ function writeResolverSkillsDir(skillsDir: string): void {
   writeFileSync(join(skillsDir, 'RESOLVER.md'), '# Resolver\n');
 }
 
+function writeWorkspaceRootResolver(workspace: string): void {
+  mkdirSync(join(workspace, 'skills'), { recursive: true });
+  writeFileSync(join(workspace, 'AGENTS.md'), '# Agents\n');
+}
+
 function writeTriggerOnlySkillsDir(skillsDir: string): void {
   mkdirSync(join(skillsDir, 'query'), { recursive: true });
   writeFileSync(
@@ -73,6 +78,20 @@ describe('read-only GBRAIN_SKILLS_DIR detection', () => {
 
     expect(found.dir).toBeNull();
     expect(found.source).toBe('env_explicit');
+  });
+
+  test('preserves the OpenClaw workspace-root fallback for an explicit skills sibling', () => {
+    const workspace = scratch('openclaw-workspace-');
+    writeWorkspaceRootResolver(workspace);
+    const explicit = join(workspace, 'skills');
+
+    const found = autoDetectSkillsDirReadOnly(scratch('cwd-'), {
+      GBRAIN_SKILLS_DIR: explicit,
+      OPENCLAW_WORKSPACE: workspace,
+    });
+
+    expect(found.dir).toBe(explicit);
+    expect(found.source).toBe('openclaw_workspace_env_root');
   });
 
   test('check-resolvable --json reports the trigger-only explicit catalog', () => {


### PR DESCRIPTION
## Summary

Fixes #3381.

`GBRAIN_SKILLS_DIR` was only accepted when the target had `RESOLVER.md` or `AGENTS.md`. That made explicit trigger-only catalogs fall through to other auto-detected directories, so read-only health checks could validate a different skills tree from the one the operator selected.

This change:

- accepts read-only explicit skills dirs when any child `SKILL.md` declares frontmatter `triggers:`
- makes invalid read-only explicit overrides fail closed before cwd or install-path fallbacks
- keeps the shared write-path auto-detection behavior unchanged
- adds direct detection and CLI JSON regressions for trigger-only and invalid explicit overrides

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/explicit-skills-dir-readonly.test.ts` - 4 pass
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/explicit-skills-dir-readonly.test.ts` - RESULT: GREEN; verify green; focused unit test 4 pass; E2E skipped by fail-closed ALL selector
