### PR TITLE
fix(windows): resolve-ipc client existsSync gate always false on win32

### DIFF
--- a/src/core/context/resolve-ipc.ts
+++ b/src/core/context/resolve-ipc.ts
@@ -427,7 +427,20 @@ function roundTrip(
   requestLine: string,
   timeoutMs: number,
 ): Promise<unknown | typeof IPC_UNAVAILABLE> {
-  if (!existsSync(socketPath)) return Promise.resolve(IPC_UNAVAILABLE);
+  // POSIX fast-path only: a Unix domain socket is a real filesystem entry, so
+  // existsSync() lets the common "no server running" case skip a syscall.
+  // On win32, net.createServer()/createConnection() silently translate a
+  // plain path into \\.\pipe\<name> — no file is ever created on disk, so
+  // existsSync() is always false here even while a live server is listening
+  // and a real connection would succeed. Gating on it on Windows made every
+  // IPC call fail closed unconditionally (verified: a listen()+connect()
+  // round trip against the same plain path succeeds on Bun 1.3.14 / Windows
+  // 11, while existsSync() on that path returns false throughout). Skip the
+  // pre-check there and let the connection-level error/timeout handlers
+  // below do the real "no server" detection.
+  if (process.platform !== 'win32' && !existsSync(socketPath)) {
+    return Promise.resolve(IPC_UNAVAILABLE);
+  }
   return new Promise((resolve) => {
     let settled = false;
     let buf = '';

--- a/src/core/context/resolve-ipc.ts
+++ b/src/core/context/resolve-ipc.ts
@@ -521,6 +521,34 @@ export async function startResolveIpcServer(
   // Remove a stale socket file if present (a previous serve that didn't clean up).
   cleanupStaleSocket(socketPath);
 
+  return listenWithRetry(socketPath, handlers, opts);
+}
+
+/**
+ * win32 EADDRINUSE recovery (2026-08-20 field report): `cleanupStaleSocket`
+ * below is a POSIX-only op — it unlinks a real socket FILE, but on win32
+ * `server.listen(socketPath)` binds a named pipe (`\\.\pipe\<name>`) and no
+ * filesystem entry is ever created, so `existsSync(socketPath)` is always
+ * false there (same root cause as the client-side existsSync gap fixed
+ * 2026-08-19, PR #4330 — this is its server-side sibling). A `gbrain serve`
+ * killed ungracefully (app force-closed, repeated quick close/reopen cycles)
+ * can leave the pipe name held by the OS for a short window before the
+ * kernel reclaims it; the next serve's listen() hits EADDRINUSE against a
+ * name nothing is actually listening on anymore. There is no file to clean
+ * up — the fix is a short bounded retry, which is how Windows itself expects
+ * pipe-name contention to be handled. POSIX gets the existing cleanup path
+ * and never needs a retry (a live listener on a POSIX path is real
+ * contention, not staleness), so the retry loop only engages on win32.
+ */
+const WIN32_LISTEN_RETRY_ATTEMPTS = 5;
+const WIN32_LISTEN_RETRY_DELAY_MS = 300;
+
+function listenWithRetry(
+  socketPath: string,
+  handlers: IpcHandlers,
+  opts: IpcServerOpts,
+  attempt = 0,
+): Promise<net.Server | null> {
   return new Promise((resolve) => {
     const server = net.createServer((conn) => {
       let buf = '';
@@ -594,7 +622,20 @@ export async function startResolveIpcServer(
       });
       conn.on('error', () => { try { conn.destroy(); } catch { /* noop */ } });
     });
-    server.on('error', () => resolve(null));
+    server.on('error', (err: NodeJS.ErrnoException) => {
+      if (
+        process.platform === 'win32' &&
+        err.code === 'EADDRINUSE' &&
+        attempt < WIN32_LISTEN_RETRY_ATTEMPTS
+      ) {
+        try { server.close(); } catch { /* noop — never bound, best effort */ }
+        setTimeout(() => {
+          listenWithRetry(socketPath, handlers, opts, attempt + 1).then(resolve);
+        }, WIN32_LISTEN_RETRY_DELAY_MS).unref?.();
+        return;
+      }
+      resolve(null);
+    });
     server.listen(socketPath, () => {
       // Mode set BEFORE readiness is announced (the resolve() below) [S3#6].
       try { chmodSync(socketPath, 0o600); } catch { /* best effort */ }

--- a/test/context/resolve-ipc.test.ts
+++ b/test/context/resolve-ipc.test.ts
@@ -50,6 +50,54 @@ describe('resolve IPC', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // Windows regression (community #1294-cluster follow-up). On win32,
+  // net.createServer()/createConnection() silently translate a plain path
+  // into \\.\pipe\<name> — no file is ever created on disk, so a client-side
+  // existsSync(socketPath) pre-check is always false there even while a live
+  // server is listening and a real connection would succeed. Verified
+  // manually against Bun 1.3.14 / Windows 11 (listen()+connect() round trip
+  // on the same plain path succeeds while existsSync() on that path stays
+  // false throughout) — CI here is Ubuntu-only so that positive path can't
+  // run in this suite. What CAN run cross-platform: the win32 branch must
+  // still degrade to IPC_UNAVAILABLE (not throw, not hang) when there is
+  // truly no server — this proves it delegates to the connection-level
+  // error/timeout handlers instead of silently short-circuiting.
+  test('win32: absent server still degrades to IPC_UNAVAILABLE without the existsSync fast-path', async () => {
+    const dir = tmpDir();
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const got = await resolveViaIpc(resolveSocketPath(dir), { candidates: [{ display: 'A', query: 'A' }] });
+      expect(got).toBe(IPC_UNAVAILABLE);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('win32: a real listening server is still reachable when existsSync would say false (POSIX fixture proxy)', async () => {
+    const dir = tmpDir();
+    const sock = resolveSocketPath(dir);
+    const block: PointerBlock = { pointers: [], text: 'WIN32-OK' };
+    const server = await startResolveIpcServer(sock, async () => block);
+    servers.push(server!);
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      // On this (POSIX) CI box the socket file genuinely exists, so this
+      // does not reproduce the Windows bug end-to-end — it only proves the
+      // win32 branch does not regress the case where a server IS reachable
+      // (no new false-negative introduced by skipping the pre-check there).
+      const got = await resolveViaIpc(sock, { candidates: [{ display: 'A', query: 'A' }] });
+      expect(got).not.toBe(IPC_UNAVAILABLE);
+      expect((got as PointerBlock).text).toBe('WIN32-OK');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test('server returning null relays as null (resolved, nothing found)', async () => {
     const dir = tmpDir();
     const sock = resolveSocketPath(dir);
@@ -70,7 +118,13 @@ describe('resolve IPC', () => {
     const s2 = await startResolveIpcServer(sock, async () => null);
     expect(s2).not.toBeNull();
     servers.push(s2!);
-    expect(existsSync(sock)).toBe(true);
+    // win32: the rebind itself is the real assertion — s2 must be non-null,
+    // i.e. listen() didn't fail with an "address in use" equivalent against
+    // the stale pipe. existsSync() can't observe a named pipe on Windows
+    // (see the round-trip fix above), so the file-presence check is POSIX-only.
+    if (process.platform !== 'win32') {
+      expect(existsSync(sock)).toBe(true);
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/test/context/resolve-ipc.test.ts
+++ b/test/context/resolve-ipc.test.ts
@@ -98,6 +98,60 @@ describe('resolve IPC', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // Server-side sibling of the client existsSync gap above (2026-08-20 field
+  // report): cleanupStaleSocket() unlinks a real socket FILE, which on win32
+  // never exists for a named pipe, so a serve killed ungracefully can leave
+  // the pipe name held by the OS long enough for the next serve's listen()
+  // to hit EADDRINUSE against a name nothing is really listening on anymore.
+  // The fix is a short bounded retry on win32 only. This test reproduces
+  // genuine EADDRINUSE (two real listeners racing the same path — true
+  // contention on every platform, not simulated), gates the win32 branch via
+  // the platform override, and proves the retry both (a) eventually succeeds
+  // once the blocking listener releases and (b) degrades to null instead of
+  // hanging when contention never clears.
+  test('win32: EADDRINUSE retries and succeeds once the blocking listener releases', async () => {
+    const dir = tmpDir();
+    const sock = resolveSocketPath(dir);
+    const blocker = await startResolveIpcServer(sock, async () => null);
+    expect(blocker).not.toBeNull();
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const secondAttempt = startResolveIpcServer(sock, async () => ({ pointers: [], text: 'RETRIED-OK' }));
+      // Release the "stale" pipe mid-retry-window (retries run every 300ms).
+      setTimeout(() => { try { blocker!.close(); } catch { /* noop */ } }, 150);
+      const server = await secondAttempt;
+      expect(server).not.toBeNull();
+      servers.push(server!);
+      const got = await resolveViaIpc(sock, { candidates: [{ display: 'A', query: 'A' }] });
+      expect(got).not.toBe(IPC_UNAVAILABLE);
+      expect((got as PointerBlock).text).toBe('RETRIED-OK');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }, 10_000);
+
+  test('win32: EADDRINUSE exhausts retries and degrades to null instead of hanging', async () => {
+    const dir = tmpDir();
+    const sock = resolveSocketPath(dir);
+    const blocker = await startResolveIpcServer(sock, async () => null);
+    expect(blocker).not.toBeNull();
+    servers.push(blocker!);
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      // blocker never closes — contention never clears, retries must exhaust.
+      const server = await startResolveIpcServer(sock, async () => null);
+      expect(server).toBeNull();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }, 10_000);
+
   test('server returning null relays as null (resolved, nothing found)', async () => {
     const dir = tmpDir();
     const sock = resolveSocketPath(dir);

--- a/test/resolve-ipc-v2.test.ts
+++ b/test/resolve-ipc-v2.test.ts
@@ -345,9 +345,22 @@ describe('socket + secret hardening [S3#6]', () => {
       { secret, boundSourceId: 'default' },
     );
     servers.push(server!);
-    expect(statSync(sock).mode & 0o777).toBe(0o600);
-    expect(statSync(ipcSecretPath(dir)).mode & 0o777).toBe(0o600);
-    expect(statSync(dir).mode & 0o777).toBe(0o700);
+    // win32: none of these three assertions hold there, for two distinct
+    // reasons — neither fixable by this PR's scope (the round-trip bug):
+    //   - the socket path: net maps it to \\.\pipe\<name>, no filesystem
+    //     entry is ever created, so statSync() throws rather than returning
+    //     a fake mode.
+    //   - the secret file and parent dir: chmodSync() on win32 can only
+    //     toggle the FILE_ATTRIBUTE_READONLY flag, not the full POSIX
+    //     owner/group/other bit pattern — Node's fs.stat().mode synthesizes
+    //     0o666/0o777-ish values there regardless of the 0600/0700 the code
+    //     requested. Real hardening on Windows needs the ACL APIs
+    //     (icacls-equivalent), a separate piece of work.
+    if (process.platform !== 'win32') {
+      expect(statSync(sock).mode & 0o777).toBe(0o600);
+      expect(statSync(ipcSecretPath(dir)).mode & 0o777).toBe(0o600);
+      expect(statSync(dir).mode & 0o777).toBe(0o700);
+    }
   });
 
   test('ensureIpcSecret is stable across calls; readIpcSecret round-trips', async () => {


### PR DESCRIPTION
## Summary

- Fixes retrieval-reflex / turn_context / context_pack IPC (the mechanism behind per-turn hook context injection) failing closed unconditionally on Windows.
- Root cause: `roundTrip()` in `src/core/context/resolve-ipc.ts` gates every client call on `existsSync(socketPath)`. On win32, `net.createServer()`/`createConnection()` silently map a plain path to `\\.\pipe\` — no filesystem entry is ever created there, so `existsSync()` is always `false`, even against a live, reachable server.
- Verified against Bun 1.3.14 / Windows 11: a `listen()` + `connect()` round trip on the *same plain path* succeeds while `existsSync()` on that path stays `false` throughout the whole test.
- Fix: skip the `existsSync` fast-path on `win32` and fall through to the connection-level `error`/`timeout` handlers already in place — those correctly detect &#34;no server&#34; via the real connection attempt.

Found this while bootstrapping GBrain as a personal agent on Windows (`gbrain doctor` reported `retrieval_reflex_health` degraded and the hook heartbeat showed `user_prompt_degraded: 8, user_prompt_ok: 0`). Traced it to source, wrote a standalone spike to confirm the `net` module behavior empirically before touching anything.

## What's changed

- `src/core/context/resolve-ipc.ts` — one guarded early-return on the client side (POSIX behavior unchanged), plus a server-side win32 EADDRINUSE retry (see &#34;Second fix&#34; below).
- `test/context/resolve-ipc.test.ts` — 2 new regression tests (simulated win32: absent-server still degrades safely; a real listening server stays reachable when the win32 branch is taken), plus 2 more for the retry (see below). Also gates 1 pre-existing assertion (`existsSync(sock) === true` after stale-socket cleanup) that's POSIX-only — Windows named pipes leave no filesystem entry to check.
- `test/resolve-ipc-v2.test.ts` — gates 3 pre-existing assertions (socket/secret/dir `chmod` 0600/0700 checks) that assume POSIX permission bits. `chmodSync` on win32 can only toggle the read-only attribute, not the full owner/group/other pattern, so these never held on Windows regardless of this fix — real hardening there needs the Windows ACL APIs, out of scope here.

I deliberately did **not** try to fix the chmod/permission-hardening gaps in this PR — different root cause (Windows has no POSIX permission bits at all vs. this PR's actual functional round-trip bug), and conflating them would make the diff harder to review.

## Test plan

- [x] `bun test test/context/resolve-ipc.test.ts test/resolve-ipc-v2.test.ts` — 8/28 pass → 32/32 pass on Windows (confirmed the pre-fix failures by stashing the change and re-running).
- [x] `bun test test/context-engine.test.ts test/ambient-recall-hooks.serial.test.ts test/hook-command.serial.test.ts` — no regressions (119/120 pass; the 1 remaining failure is the same pre-existing chmod-on-Windows gap, in a file I didn't touch, confirmed pre-existing by stash-and-rerun).
- [ ] CI is Ubuntu-only per `docs/designs/COMMUNITY_IDEAS.md` §8, so the positive Windows round-trip can't be exercised there — the manual verification above is the evidence for that half. The new tests that *can* run cross-platform (safe-degrade under simulated `win32`, no regression on POSIX) are included and pass in this environment too.

## Second fix (2026-08-20): server-side win32 EADDRINUSE retry — read the caveat below before trusting this fully

While diagnosing a live Windows session where the entire gbrain MCP tool surface (not just the passive hook) disappeared mid-conversation, `~/.gbrain/ipc-debug.log` showed the serve process cycling through new PIDs over several hours, every attempt hitting `EADDRINUSE` on `listen()`. Root-caused by inspection: `cleanupStaleSocket()` unlinks a real socket FILE to recover from a serve that died without releasing its listener, but on win32 that file never exists (same POSIX-only assumption as the client-side gap above, just on the server this time) — so the cleanup path never runs there. Fix: a short bounded retry (5 attempts, 300ms apart) on `EADDRINUSE`, gated to win32 only.

Live-reproduced trigger for the staleness this targets: closing the desktop host app and reopening it (including doing that several times in quick succession while investigating) visibly kills and respawns the gbrain child process; a kill mid-startup can plausibly leave the pipe name held by the OS for a beat before the next attempt binds.

**Important caveat, disclosed rather than glossed over:** this repo already has a documented, *abandoned* retry-with-backoff attempt for what may be a related-but-distinct failure mode — see &#34;Known limitation&#34; below, first written 2026-08-19. That attempt (up to ~5s backoff) reportedly did not reliably resolve a case where the MCP host spawns two `gbrain serve` processes within a couple of seconds of each other, with the losing process staying unbound for over a minute in some runs — far outside any bounded retry window, mine included. My tests below prove this new retry works for genuine transient staleness (a since-closed listener) and fails safe (returns `null`, never hangs) when contention doesn't clear — but I have **not** re-run the specific duplicate-spawn repro from the note below against this change, so I can't claim it fixes that case. Treat this as &#34;fixes one confirmed cause of the symptom&#34; not &#34;closes the known limitation.&#34;

Tests: two new cases in `test/context/resolve-ipc.test.ts` reproduce genuine `EADDRINUSE` (two real listeners racing the same path — true contention on every platform, not simulated) and gate the win32 retry branch via the platform override: the retry (a) succeeds once the blocking listener releases mid-window, and (b) degrades to `null` instead of hanging when contention never clears. 32/32 resolve-ipc tests pass.

## Known limitation this PR does NOT fully fix (disclosed, not silently left out) — 2026-08-19, re-evaluated 2026-08-20

While validating the client-side fix end-to-end against a real Claude Code session on Windows, I found a **second, separate** issue: the MCP host (Claude Code) sometimes spawns two `gbrain serve` processes within a couple of seconds of each other on reconnect. Both race to bind the same named-pipe path; the loser gets `EADDRINUSE` and runs for its entire lifetime with no resolve-ipc listener, even though the client-side fix is in place and correct in isolation. Confirmed via a `Win32_Process` creation-time watcher (two `gbrain.exe` spawned ~2-3s apart, same parent) and a system-wide named-pipe listing (zero gbrain pipes present while the &#34;losing&#34; process was demonstrably alive and healthy).

I attempted a retry-with-backoff mitigation (up to ~5s) in `startResolveIpcServer()` at the time, but it did **not** reliably resolve the symptom in repeated live testing — the losing process still had no listener over a minute later in some runs, which means either the winner doesn't reliably die within that window, or there's a third factor I hadn't isolated yet. Rather than ship an unverified mitigation, I left that part out of the PR at the time and flagged it here for visibility.

2026-08-20 update: a *different* live incident (full MCP tool surface disappearing, not just the passive hook) turned out to have a distinct, confirmable trigger — a serve killed ungracefully leaving a stale pipe name — and got its own bounded retry fix (see &#34;Second fix&#34; above), verified with tests. Whether that also explains some or all of the duplicate-spawn cases described in this note, or whether the duplicate-spawn race is a genuinely separate host-side bug, is still open. Opening a dedicated issue with both repros (this one and the ungraceful-kill one) is probably the right next step rather than continuing to grow this PR's scope.

Relates to the tracked Windows-portability effort (§8 Developer experience &amp; platform reach in `docs/designs/COMMUNITY_IDEAS.md`, issue cluster #1294/#1149/#1554/#1396) — this is a new, previously unreported instance in that same class, not a duplicate.

## Update (2026-08-21): rebased onto v0.46.24.0, cross-machine confirmation of the duplicate-spawn race, still open

Independent confirmation of the "known limitation" above on a **second physical machine**, not just a second session: replicated this whole install on a separate Windows PC, and the exact same duplicate-`gbrain serve`-spawn race showed up there too, captured with a standalone process watcher (`Win32_Process` creation-time polling) with millisecond precision — two `gbrain.exe` spawning ~4s apart from the same parent, one dying at the exact instant the other is born in one capture. Across two controlled 3-cycle restart experiments (one per machine) the race resolved in the surviving process's favor in 5/6 cycles total, failing to resolve (all attempts died, no survivor) in 1/6. Small sample, but consistent across two independent machines — this really does look like host-side behavior (Claude Code's own MCP reconnect timeout racing the child's boot), not something specific to one install.

Also re-confirmed the original diagnosis from the "Second fix" section above (host kills the loser via its own MCP handshake timeout, not anything internal to `pglite-lock.ts`/`serve.ts`) by re-reading those files end to end — no internal gbrain code path produces a process death in the observed 3-8s range.

Separately: this branch's tip (`718c1fc4`) was only 3 commits behind `v0.46.24.0`. Rebased cleanly (`git cherry-pick 8b0675d6 718c1fc4` on top of `v0.46.24.0`, no conflicts, 32/32 resolve-ipc tests still pass) — pushed to `oscampo/gbrain#fix/windows-resolve-ipc-v0.46.24` (new branch name; didn't force-push over this PR's head branch, my own tooling correctly refused a force-push as a destructive operation without explicit human confirmation). Happy to update this PR's head to that commit if a maintainer wants it force-pushed, or to re-open against `v0.46.24.0` as a fresh PR — whichever is less friction on your end. Notably, `v0.46.24.0` itself ships `7e3ce95b fix(sync): delegate sync through a live serve over resolve-IPC (#4362)`, which looks like it's aimed at a related class of "CLI vs. live serve" lock contention, though not the specific duplicate-spawn race described here (that one already has a live serve running, the contention is serve-vs-serve, not CLI-vs-serve).