### PR TITLE
fix(skillpack-check): resolve real binary path before bunfs argv[1]

### DIFF
--- a/src/commands/skillpack-check.ts
+++ b/src/commands/skillpack-check.ts
@@ -23,21 +23,27 @@ import { getCliOptions } from '../core/cli-options.ts';
 /**
  * Resolve the gbrain binary + args for spawning subcommands from
  * within skillpack-check. Handles three install cases:
- *   - Running the compiled binary (argv[1] ends in /gbrain): re-exec it.
+ *   - Running the compiled binary: process.execPath IS the real on-disk
+ *     binary — re-exec it. Checked before argv[1] (#4094): in a Bun
+ *     single-file compiled binary, argv[1] is the virtual bunfs path
+ *     `/$bunfs/root/gbrain`, which also ends in `/gbrain` but is not
+ *     spawnable (ENOENT). execPath never has this problem.
+ *   - argv[1] ends in /gbrain (e.g. a `gbrain` shim script on $PATH,
+ *     where execPath points at the bun runtime instead): re-exec argv[1].
  *   - Running via `bun run src/cli.ts` (argv[1] is a .ts file): prefix with `bun run`.
  *   - Anything else: fall back to `which gbrain` on $PATH.
  */
 function gbrainSpawn(): { cmd: string; prefix: string[] } {
+  const execPath = process.execPath ?? '';
+  if (execPath.endsWith('/gbrain') || execPath.endsWith('\\gbrain.exe')) {
+    return { cmd: execPath, prefix: [] };
+  }
   const arg1 = process.argv[1] ?? '';
   if (arg1.endsWith('/gbrain') || arg1.endsWith('\\gbrain.exe')) {
     return { cmd: arg1, prefix: [] };
   }
   if (arg1.endsWith('.ts') || arg1.endsWith('.mjs') || arg1.endsWith('.js')) {
     return { cmd: 'bun', prefix: ['run', arg1] };
-  }
-  const execPath = process.execPath ?? '';
-  if (execPath.endsWith('/gbrain') || execPath.endsWith('\\gbrain.exe')) {
-    return { cmd: execPath, prefix: [] };
   }
   return { cmd: 'gbrain', prefix: [] };
 }
@@ -262,4 +268,4 @@ function isSkillpackCheckSubcommand(): boolean {
 }
 
 /** Exported for unit tests. */
-export const __testing = { buildReport, runDoctor, runMigrationsList };
+export const __testing = { buildReport, runDoctor, runMigrationsList, gbrainSpawn };

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -19,6 +19,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
+import { __testing } from '../src/commands/skillpack-check.ts';
 
 const CLI = join(__dirname, '..', 'src', 'cli.ts');
 
@@ -133,5 +134,58 @@ describe('gbrain skillpack-check', () => {
     const report = JSON.parse(result.stdout);
     expect(report.summary).toMatch(/\d+ action\(s\)/);
     expect(report.summary).toContain(report.actions[0]);
+  });
+});
+
+describe('gbrainSpawn — argv[1] vs execPath resolution (#4094)', () => {
+  const originalArgv1 = process.argv[1];
+  const originalExecPath = process.execPath;
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+    process.execPath = originalExecPath;
+  });
+
+  test('compiled-binary bunfs argv[1]: execPath (the real on-disk binary) wins, not the unusable virtual path', () => {
+    // Bun single-file compiled binary: argv[1] is a virtual bunfs path that
+    // ends in '/gbrain' but is not spawnable (ENOENT). execPath correctly
+    // points at the real on-disk binary in this exact scenario.
+    process.argv[1] = '/$bunfs/root/gbrain';
+    process.execPath = '/usr/local/bin/gbrain';
+    const { cmd, prefix } = __testing.gbrainSpawn();
+    expect(cmd).toBe('/usr/local/bin/gbrain');
+    expect(prefix).toEqual([]);
+  });
+
+  test('gbrain shim script on PATH: argv[1] is used when execPath is the bun runtime, not gbrain', () => {
+    process.argv[1] = '/usr/local/bin/gbrain';
+    process.execPath = '/opt/homebrew/Cellar/bun/1.2.15/bin/bun';
+    const { cmd, prefix } = __testing.gbrainSpawn();
+    expect(cmd).toBe('/usr/local/bin/gbrain');
+    expect(prefix).toEqual([]);
+  });
+
+  test('dev mode: `bun run src/cli.ts` prefixes with `bun run`', () => {
+    process.argv[1] = '/repo/src/cli.ts';
+    process.execPath = '/opt/homebrew/Cellar/bun/1.2.15/bin/bun';
+    const { cmd, prefix } = __testing.gbrainSpawn();
+    expect(cmd).toBe('bun');
+    expect(prefix).toEqual(['run', '/repo/src/cli.ts']);
+  });
+
+  test('neither argv[1] nor execPath resolves to gbrain: falls back to $PATH', () => {
+    process.argv[1] = '/some/unrelated/entrypoint';
+    process.execPath = '/opt/homebrew/Cellar/bun/1.2.15/bin/bun';
+    const { cmd, prefix } = __testing.gbrainSpawn();
+    expect(cmd).toBe('gbrain');
+    expect(prefix).toEqual([]);
+  });
+
+  test('Windows compiled binary: execPath ending in gbrain.exe wins over bunfs argv[1]', () => {
+    process.argv[1] = 'B:\\~BUN\\root\\gbrain.exe';
+    process.execPath = 'C:\\Program Files\\gbrain\\gbrain.exe';
+    const { cmd, prefix } = __testing.gbrainSpawn();
+    expect(cmd).toBe('C:\\Program Files\\gbrain\\gbrain.exe');
+    expect(prefix).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`gbrain skillpack-check` silently reports false-healthy on a compiled Bun binary install. `doctor` and `apply-migrations --list` both fail internally, but the failure gets caught and folded into an `error` field rather than surfacing cleanly — hiding real health/migration state from the exact automation (cron, agent briefings) the command exists to serve.

## Root cause

`gbrainSpawn()` in `src/commands/skillpack-check.ts` resolves the command to re-exec by checking `process.argv[1]` before `process.execPath`:

```ts
const arg1 = process.argv[1] ?? '';
if (arg1.endsWith('/gbrain') || arg1.endsWith('\\gbrain.exe')) {
  return { cmd: arg1, prefix: [] };
}
```

In a Bun single-file compiled binary, `argv[1]` is the virtual bunfs path `/$bunfs/root/gbrain` — it ends in `/gbrain` so this branch fires, but the path isn't spawnable. `process.execPath`, checked further down, correctly points at the real on-disk binary in this exact scenario, but the function never reaches it.

Confirmed live: built the real compiled binary (`bun build --compile`), symlinked it onto `$PATH` as `gbrain` (the issue's exact repro shape), ran `gbrain skillpack-check` — `doctor.error: "doctor failed: ENOENT: no such file or directory, posix_spawn '/$bunfs/root/gbrain'"`.

## Fix

Swap the check order: `execPath` first, then `argv[1]`. This only changes behavior for the compiled-binary case — `execPath` only ends in `/gbrain` when it genuinely is the binary, so a `gbrain` shim-script install (where `execPath` is the bun runtime, not `gbrain`) still falls through to the `argv[1]` branch unchanged.

Considered reusing `resolveGbrainCliPath()` from `src/commands/autopilot.ts`, which already prioritizes `execPath` over `argv[1]` — but it also shells out to `which gbrain` and throws on failure, a different contract than `gbrainSpawn()`'s return-a-fallback shape. Reordering two existing checks is the smaller, more contained fix.

## Tests

Exported `gbrainSpawn` via the file's existing `__testing` object and added 5 unit tests in `test/skillpack-check.test.ts`, each mocking `process.argv[1]`/`process.execPath` for one resolution branch (compiled binary, shim script, dev `bun run`, no match → `$PATH` fallback, Windows compiled binary).

Verified red→green twice:
- Reverted the whole file: new tests failed on missing export (proves the export matters).
- Kept the export, reverted only the check order: exactly the two compiled-binary tests failed with the wrong `cmd` value, the other three still passed (proves the tests target the ordering bug specifically, not just the export).

Also verified against the real compiled binary end to end: pre-fix binary reproduces the exact ENOENT from the issue; same binary rebuilt with the fix reports `doctor.exit_code: 0` and real migration data, no ENOENT.

Commands run:
```
bun test test/skillpack-check.test.ts   # 10 pass, 0 fail (5 new)
bun run verify                          # 54/54 checks green (incl. typecheck)
bun run test                            # 18621 pass, 28 fail
```

The 28 `bun run test` failures are pre-existing — 16 of them (`runExtractConversationFactsCore`, `#4136 folded speaker headings`) reproduce identically on a clean, unmodified `upstream/master` worktree with none of this branch's changes applied (all `chat_unavailable` — no chat-provider key configured in this environment). The rest match the same PGLite-engine flake class (`oom-rescue ... confirmed real`) already traced across every prior PR in this session. None touch `skillpack-check.ts` or its test file.

## Limitations

There's prior art here: PR #607 attempted a very similar fix back in June and was closed in a mass backlog cleanup, not on technical grounds — the underlying bug it targeted is still live on current master, confirmed by this investigation. Didn't reuse #607's diff directly (the surrounding file has changed since), but the fix direction is the same.

Fixes #4094.