### PR TITLE
fix(engine): refuse to overwrite a non-empty page body with an empty one

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -720,7 +720,13 @@ export interface BrainEngine {
    * DO UPDATE actually targets the intended row instead of fabricating a
    * duplicate at (default, slug). Multi-source brains MUST pass sourceId.
    */
-  putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page>;
+  /**
+   * `allowEmptyOverwrite` (default false) opts out of the data-loss guard that
+   * refuses to overwrite an existing non-empty page body with a blank one (see
+   * `isBlankBody`). Pass it only when clearing a body is the deliberate intent;
+   * deleting a page goes through `deletePage`/`softDeletePage`, not this path.
+   */
+  putPage(slug: string, page: PageInput, opts?: { sourceId?: string; allowEmptyOverwrite?: boolean }): Promise<Page>;
   /**
    * v0.41.13 (#1309) — identity-based dedup pre-check for the import pipeline.
    *

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -86,7 +86,7 @@ import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
   EnrichCandidatesOpts, EnrichCandidate,
 } from './types.ts';
-import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { validateSlug, contentHash, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { executeRawJsonb, type SqlValue } from './sql-query.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows } from './batch-rows.ts';
 import { PAGE_SORT_SQL, MIN_ENTITY_PAGES_FOR_COVERAGE } from './types.ts';
@@ -1655,11 +1655,33 @@ export class PGLiteEngine implements BrainEngine {
     return { slug: r.slug, id: Number(r.id) };
   }
 
-  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string; allowEmptyOverwrite?: boolean }): Promise<Page> {
     slug = validateSlug(slug);
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
     const sourceId = opts?.sourceId ?? 'default';
+
+    // Data-loss guard (mirrors postgres-engine.ts): a page edit is a
+    // read-modify-write; if the read returned empty, the modify lands on
+    // nothing and this upsert would blank the body over real content. Only
+    // fires when the incoming body is itself blank. Deletes use deletePage; a
+    // deliberate clear passes allowEmptyOverwrite. See isBlankBody.
+    if (isBlankBody(page.compiled_truth) && !opts?.allowEmptyOverwrite) {
+      const { rows: prior } = await this.db.query<{ compiled_truth: string | null }>(
+        `SELECT compiled_truth FROM pages
+         WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL
+         LIMIT 1`,
+        [sourceId, slug],
+      );
+      if (prior[0] && !isBlankBody(prior[0].compiled_truth)) {
+        throw new Error(
+          `putPage: refusing to overwrite non-empty page '${slug}' ` +
+            `(${prior[0].compiled_truth!.length} chars) with an empty body — ` +
+            `likely a read-modify-write that read empty. Pass ` +
+            `{ allowEmptyOverwrite: true } to force, or deletePage to remove it.`,
+        );
+      }
+    }
 
     // v0.18.0 Step 5+: source_id is now in the INSERT column list so multi-
     // source callers land on the intended (source_id, slug) row. Omitting it

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -79,7 +79,7 @@ import * as db from './db.ts';
 import { ConnectionManager, DEFAULT_DIRECT_POOL_SIZE } from './connection-manager.ts';
 import { logConnectionEvent } from './connection-audit.ts';
 import { drainBackgroundWorkBeforeDisconnect } from './background-work.ts';
-import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { validateSlug, contentHash, isBlankBody, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildBestPerPagePoolCte, buildOrFallbackWebsearchQuery } from './search/sql-ranking.ts';
 import { unverifiedExtractionFragment } from './extraction-review.ts';
@@ -1275,12 +1275,33 @@ export class PostgresEngine implements BrainEngine {
     });
   }
 
-  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string; allowEmptyOverwrite?: boolean }): Promise<Page> {
     slug = validateSlug(slug);
     const sql = this.sql;
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
     const sourceId = opts?.sourceId ?? 'default';
+
+    // Data-loss guard: a page edit is a read-modify-write; if the read returned
+    // empty, the modify lands on nothing and this upsert would blank the body
+    // over real content (ON CONFLICT sets compiled_truth = EXCLUDED.* flat).
+    // Only fires when the incoming body is itself blank, so the common
+    // non-empty write pays no extra query. Deletes use deletePage; a deliberate
+    // clear passes allowEmptyOverwrite. See isBlankBody.
+    if (isBlankBody(page.compiled_truth) && !opts?.allowEmptyOverwrite) {
+      const prior = await sql<{ compiled_truth: string | null }[]>`
+        SELECT compiled_truth FROM pages
+        WHERE source_id = ${sourceId} AND slug = ${slug} AND deleted_at IS NULL
+        LIMIT 1`;
+      if (prior[0] && !isBlankBody(prior[0].compiled_truth)) {
+        throw new Error(
+          `putPage: refusing to overwrite non-empty page '${slug}' ` +
+            `(${prior[0].compiled_truth!.length} chars) with an empty body — ` +
+            `likely a read-modify-write that read empty. Pass ` +
+            `{ allowEmptyOverwrite: true } to force, or deletePage to remove it.`,
+        );
+      }
+    }
 
     // v0.18.0 Step 5+: source_id is now in the INSERT column list so multi-
     // source callers actually land on the (source_id, slug) row they intend.

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -69,6 +69,23 @@ export function contentHash(page: PageInput): string {
 }
 
 /**
+ * True when a page body carries no real content (null/undefined/whitespace).
+ *
+ * A routine page edit is a read-modify-write: read the page, change it, put
+ * it back. If the read intermittently returns empty (a store/consistency
+ * hiccup, or a caller that assembled content from a failed read), the "edit"
+ * is applied to nothing and `putPage` persists a blank body OVER real content
+ * — `putPage`'s ON CONFLICT sets `compiled_truth = EXCLUDED.compiled_truth`
+ * unconditionally, so the page is silently destroyed. Observed in production:
+ * a live task/notes page wiped down to just its frontmatter, caught only
+ * because the agent re-read the page and rebuilt it by hand. `isBlankBody`
+ * is the predicate `putPage` uses to refuse that destructive overwrite.
+ */
+export function isBlankBody(body: string | null | undefined): boolean {
+  return body == null || body.trim() === '';
+}
+
+/**
  * Validate a `source_id` is safe for use as a filesystem path segment AND
  * as a SQL identifier value. Used by the per-source disk-layout code in
  * patterns.ts/synthesize.ts before any `join(brainDir, source_id, ...)`

--- a/test/put-page-empty-overwrite-guard.test.ts
+++ b/test/put-page-empty-overwrite-guard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * putPage empty-overwrite data-loss guard.
+ *
+ * A page edit is a read-modify-write (read the page, change it, put it back).
+ * When the read intermittently returns empty, the modify lands on nothing and
+ * putPage's `ON CONFLICT ... SET compiled_truth = EXCLUDED.compiled_truth`
+ * blanks the body over real content — silent data loss. Observed in
+ * production: a live task/notes page wiped down to just its frontmatter,
+ * caught only because the agent re-read and rebuilt it by hand.
+ *
+ * putPage now refuses to overwrite a non-empty page body with a blank one.
+ * These pin the four cases: it blocks the destructive overwrite, still allows
+ * a genuinely new empty page, still allows a deliberate clear via
+ * allowEmptyOverwrite, and never false-positives on a normal non-empty edit.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+const SLUG = 'projects/suzanne-tasks';
+
+function body(text: string) {
+  return { type: 'note' as any, title: SLUG, compiled_truth: text, timeline: '', frontmatter: {} };
+}
+
+async function storedBody(engine: PGLiteEngine, slug: string): Promise<string | null> {
+  const rows = await engine.executeRaw<{ compiled_truth: string | null }>(
+    `SELECT compiled_truth FROM pages WHERE slug = $1 AND source_id = 'default' AND deleted_at IS NULL`,
+    [slug],
+  );
+  return rows[0]?.compiled_truth ?? null;
+}
+
+describe('putPage empty-overwrite guard', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('refuses to blank a non-empty page body', async () => {
+    await engine.putPage(SLUG, body('- [ ] real task one\n- [ ] real task two'));
+
+    await expect(engine.putPage(SLUG, body(''))).rejects.toThrow(/refusing to overwrite non-empty page/);
+    await expect(engine.putPage(SLUG, body('   \n  '))).rejects.toThrow(/refusing to overwrite non-empty page/);
+
+    // The real content survived the rejected writes.
+    expect(await storedBody(engine, SLUG)).toContain('real task one');
+  });
+
+  test('allows a genuinely new empty page (no existing content to lose)', async () => {
+    const fresh = 'projects/brand-new-empty';
+    await expect(engine.putPage(fresh, body(''))).resolves.toBeDefined();
+    expect(await storedBody(engine, fresh)).toBe('');
+  });
+
+  test('allows a deliberate clear via allowEmptyOverwrite', async () => {
+    const slug = 'projects/intentional-clear';
+    await engine.putPage(slug, body('content to be cleared'));
+    await expect(engine.putPage(slug, body(''), { allowEmptyOverwrite: true })).resolves.toBeDefined();
+    expect(await storedBody(engine, slug)).toBe('');
+  });
+
+  test('never blocks a normal non-empty edit', async () => {
+    const slug = 'projects/normal-edit';
+    await engine.putPage(slug, body('first version'));
+    await expect(engine.putPage(slug, body('second version'))).resolves.toBeDefined();
+    expect(await storedBody(engine, slug)).toBe('second version');
+  });
+});


### PR DESCRIPTION
## The bug: a save can silently blank a page

A page edit is a **read-modify-write** — read the page, change it, `putPage` it back. If that read intermittently returns empty, the modify lands on nothing and `putPage`'s upsert (`ON CONFLICT ... SET compiled_truth = EXCLUDED.compiled_truth`) blanks the body **over real content**. No error is raised; the page is just gone.

### Seen in production
On a live task/notes brain, over ~11 days:
- Saves repeatedly "didn't stick" on the first attempt (the agent's verify-read came back without the change), and
- Once, an actively-edited page was **wiped down to just its frontmatter** — the finalized content was lost.

It was only caught because the agent had started re-reading every page after writing it and rebuilding lost content by hand. A caller that trusts `putPage` would have silently lost data. (The markdown write-through file confirmed it too: the page's own nightly pass logged it as an "empty stub.")

## The fix

Guard both engines' `putPage`: when the incoming `compiled_truth` is blank, look up the existing row first and **refuse the write if it would blank a non-empty body**.

- The extra lookup runs **only when the incoming body is itself blank**, so normal non-empty writes are untouched (zero added cost on the hot path).
- **Escape hatches preserved:**
  - a genuinely new empty page is fine (nothing to lose),
  - a deliberate clear passes `{ allowEmptyOverwrite: true }`,
  - deleting a page still goes through `deletePage` / `softDeletePage`, not this path.

This is defense-in-depth at the durable sink: even if an upstream read hiccups, the store won't destroy content — it turns silent data loss into a clear, catchable error.

## Tests
- New `test/put-page-empty-overwrite-guard.test.ts` — 4 cases (blocks the destructive overwrite; allows new empty page; allows deliberate clear; never blocks a normal edit). Green against PGLite.
- Adjacent `put-page` / page suites green (41 tests), `tsc --noEmit` clean.

## Notes for review
- Placement is at the engine `putPage` (the single durable write path) so every caller benefits. Happy to move it up into the operation layer instead if you'd prefer to keep the engine unconditional.
- Applied identically to `postgres-engine.ts` and `pglite-engine.ts` for parity.

_AI-assisted (Claude Code); reviewed and validated locally before opening._