### PR TITLE
v0.46.22.0 fix(doctor): detect dangling free-text aliases

### DIFF
--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -517,9 +517,9 @@ export async function checkTypeProliferation(
 }
 
 /**
- * dangling_aliases (F12): surfaces slug_aliases rows whose canonical page
- * no longer exists in the pages table. Source-scoped JOIN prevents
- * cross-source false-positive deletion.
+ * dangling_aliases (F12): surfaces both slug_aliases redirects and
+ * page_aliases free-text names whose target page no longer exists.
+ * Source-scoped JOINs prevent cross-source false-positive deletion.
  *
  * v0.42 ships surface-only (no auto-GC RemediationStep). v0.43+ may add
  * `cleanup-dangling-aliases` as an auto_apply handler once detection is
@@ -532,7 +532,7 @@ export async function checkTypeProliferation(
 export async function checkDanglingAliases(
   engine: BrainEngine,
 ): Promise<OnboardCheckResult> {
-  const n = await safeCount(
+  const slugAliases = await safeCount(
     engine,
     `SELECT COUNT(*) AS count FROM slug_aliases sa
      LEFT JOIN pages p
@@ -541,16 +541,30 @@ export async function checkDanglingAliases(
       AND p.deleted_at IS NULL
      WHERE p.id IS NULL`,
   );
+  const pageAliases = await safeCount(
+    engine,
+    `SELECT COUNT(*) AS count FROM page_aliases pa
+     LEFT JOIN pages p
+       ON p.slug = pa.slug
+      AND p.source_id = pa.source_id
+      AND p.deleted_at IS NULL
+     WHERE p.id IS NULL`,
+  );
+  const n = slugAliases + pageAliases;
   if (n > 0) {
     return {
       check: {
         name: 'dangling_aliases',
         status: 'warn',
         message:
-          `${n} alias rows point at deleted canonicals. Safe GC (source-scoped): ` +
+          `${n} alias rows point at missing/deleted pages ` +
+          `(${slugAliases} slug redirects; ${pageAliases} free-text page aliases). ` +
+          `Safe GC (source-scoped): ` +
           `\`DELETE FROM slug_aliases sa WHERE NOT EXISTS (SELECT 1 FROM pages p ` +
           `WHERE p.slug = sa.canonical_slug AND p.source_id = sa.source_id ` +
-          `AND p.deleted_at IS NULL);\``,
+          `AND p.deleted_at IS NULL); DELETE FROM page_aliases pa WHERE NOT EXISTS ` +
+          `(SELECT 1 FROM pages p WHERE p.slug = pa.slug ` +
+          `AND p.source_id = pa.source_id AND p.deleted_at IS NULL);\``,
       },
       remediations: [],  // v0.42: surface-only; auto-GC v0.43+
     };

--- a/test/onboard-pack-upgrade-checks.test.ts
+++ b/test/onboard-pack-upgrade-checks.test.ts
@@ -156,6 +156,60 @@ describe('checkDanglingAliases (F12 source-scoped JOIN)', () => {
     const result = await checkDanglingAliases(engine);
     expect(result.check.status).toBe('warn');
     expect(result.check.message).toContain('1 alias rows');
+    expect(result.check.message).toContain('1 slug redirects');
+    expect(result.check.message).toContain('0 free-text page aliases');
+  });
+
+  it('warns when a free-text alias points at a missing page', async () => {
+    await engine.executeRaw(
+      `INSERT INTO page_aliases (source_id, alias_norm, slug)
+       VALUES ('default', 'alice example', 'people/alice-example')`,
+    );
+    const result = await checkDanglingAliases(engine);
+    expect(result.check.status).toBe('warn');
+    expect(result.check.message).toContain('1 alias rows');
+    expect(result.check.message).toContain('0 slug redirects');
+    expect(result.check.message).toContain('1 free-text page aliases');
+  });
+
+  it('returns ok when a free-text alias points at an active page', async () => {
+    await seedPages(['note']);
+    await engine.executeRaw(
+      `INSERT INTO page_aliases (source_id, alias_norm, slug)
+       VALUES ('default', 'page zero', 'p0')`,
+    );
+    const result = await checkDanglingAliases(engine);
+    expect(result.check.status).toBe('ok');
+  });
+
+  it('warns when a free-text alias points at a soft-deleted page', async () => {
+    await seedPages(['note']);
+    await engine.executeRaw(
+      `INSERT INTO page_aliases (source_id, alias_norm, slug)
+       VALUES ('default', 'old page', 'p0')`,
+    );
+    await engine.softDeletePage('p0', { sourceId: 'default' });
+    const result = await checkDanglingAliases(engine);
+    expect(result.check.status).toBe('warn');
+    expect(result.check.message).toContain('1 free-text page aliases');
+  });
+
+  it('does not let another source satisfy a free-text alias target', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('alt', 'alt') ON CONFLICT DO NOTHING`,
+    );
+    await engine.putPage('shared-page', {
+      title: 'shared', type: 'note' as never,
+      compiled_truth: 'body that is long enough to pass any min-length guards in the codebase',
+      timeline: '', frontmatter: {}, source_path: 'shared-page.md',
+    }, { sourceId: 'alt' });
+    await engine.executeRaw(
+      `INSERT INTO page_aliases (source_id, alias_norm, slug)
+       VALUES ('default', 'shared', 'shared-page')`,
+    );
+    const result = await checkDanglingAliases(engine);
+    expect(result.check.status).toBe('warn');
+    expect(result.check.message).toContain('1 free-text page aliases');
   });
 
   it('does NOT false-positive across sources (F12 regression)', async () => {


### PR DESCRIPTION
## Root cause

The dangling-alias doctor check only inspected slug redirects. Free-text page aliases have no foreign key to pages, so missing or soft-deleted targets could accumulate while doctor reported the alias layer clean.

## Change

- Count missing or soft-deleted page_alias targets alongside slug_alias targets.
- Keep both joins source-scoped so a same-slug page in another source cannot hide the defect.
- Report the two counts separately and include source-scoped cleanup SQL.
- Cover missing, active, soft-deleted, and cross-source page-alias targets.

## Validation

- bun test test/onboard-pack-upgrade-checks.test.ts (13 pass)
- bun run typecheck
- bun run check:module-size
- bun run check:structural-manifest
- bun run check:test-names
- bun run check:fixture-privacy
- git diff --check

The full local diff CI entrypoint could not start its E2E phase because Docker/Colima is not running on this machine; the focused unit and static gates above pass.