### PR TITLE
fix(dream): bound summaries and preserve source dates

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -20,7 +20,7 @@ src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2000	ratchet	grown v0.46.11.0 five-issue wave
-src/core/cycle/synthesize.ts	2702	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches
+src/core/cycle/synthesize.ts	2649	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + summary-page peel
 src/commands/embed.ts	1963	ratchet
 src/core/types.ts	1863	ratchet
 src/commands/skillpack.ts	1360	ratchet

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -20,7 +20,7 @@ src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2000	ratchet	grown v0.46.11.0 five-issue wave
-src/core/cycle/synthesize.ts	2649	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + summary-page peel
+src/core/cycle/synthesize.ts	2591	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + summary/provenance peels
 src/commands/embed.ts	1963	ratchet
 src/core/types.ts	1863	ratchet
 src/commands/skillpack.ts	1360	ratchet

--- a/src/core/cycle/dream-provenance.ts
+++ b/src/core/cycle/dream-provenance.ts
@@ -1,0 +1,82 @@
+import { basename } from 'node:path';
+import type { BrainEngine } from '../engine.ts';
+import { executeRawJsonb } from '../sql-query.ts';
+
+export interface DreamPageRef {
+  slug: string;
+  source_id: string;
+  raw_source?: string;
+}
+
+/**
+ * Persist stable cycle provenance plus evidence-backed `created` metadata.
+ * Existing creation metadata and the first dream cycle both win over reruns.
+ */
+export async function stampDreamProvenance(
+  engine: BrainEngine,
+  refs: DreamPageRef[],
+  cycleDate: string,
+): Promise<void> {
+  for (const { slug, source_id, raw_source } of refs) {
+    try {
+      await executeRawJsonb(
+        engine,
+        `UPDATE pages
+            SET frontmatter = COALESCE(frontmatter, '{}'::jsonb)
+                              || $5::jsonb
+                              || jsonb_build_object(
+                                   'dream_cycle_date',
+                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''), NULLIF(frontmatter->>'dream_cycle_date', ''), $3),
+                                   'dream_created_cycle_date',
+                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''), NULLIF(frontmatter->>'dream_cycle_date', ''), $3)
+                                 )
+                              || CASE WHEN $4::text IS NULL THEN '{}'::jsonb ELSE jsonb_build_object('created', COALESCE(NULLIF(frontmatter->>'created', ''), $4::text)) END
+          WHERE slug = $1 AND source_id = $2`,
+        [slug, source_id, cycleDate, dreamChildCreatedDate(slug, raw_source, cycleDate) ?? null],
+        [{ dream_generated: true, dream_cycle_date: cycleDate, ...(raw_source ? { raw_source } : {}) }],
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`[dream] provenance stamp ${slug}@${source_id} failed: ${msg}\n`);
+    }
+  }
+}
+
+/**
+ * Resolve honest `created` metadata for a dream child page.
+ *
+ * A date-prefixed raw-source basename is first-party evidence and wins. A
+ * dated slug is only a fallback when it differs from the cycle date: the
+ * synthesis prompt injects the cycle date into names for undated sources, so
+ * an equal date is ambiguous and must not be promoted to provenance.
+ */
+export function dreamChildCreatedDate(
+  slug: string,
+  rawSource: string | undefined,
+  cycleDate: string,
+): string | undefined {
+  const sourceDate = rawSource ? datePrefixedBasename(rawSource) : undefined;
+  if (sourceDate) return sourceDate;
+  const slugDate = datePrefixedSlugSegment(slug);
+  return slugDate && slugDate !== cycleDate ? slugDate : undefined;
+}
+
+function datePrefixedBasename(path: string): string | undefined {
+  const match = /^(\d{4}-\d{2}-\d{2})(?:\D|$)/.exec(basename(path));
+  return match ? validIsoDate(match[1]) : undefined;
+}
+
+function datePrefixedSlugSegment(slug: string): string | undefined {
+  const match = /(?:^|\/)(\d{4}-\d{2}-\d{2})(?:-|\/|$)/.exec(slug);
+  return match ? validIsoDate(match[1]) : undefined;
+}
+
+function validIsoDate(value: string): string | undefined {
+  const [year, month, day] = value.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day
+    ? value
+    : undefined;
+}

--- a/src/core/cycle/synthesize-summary.ts
+++ b/src/core/cycle/synthesize-summary.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { BrainEngine } from '../engine.ts';
+import { parseMarkdown, serializeMarkdown } from '../markdown.ts';
+
+const SUMMARY_LINK_SAMPLE_LIMIT = 20;
+
+/**
+ * Persist the source-scoped dream-cycle index without turning it into a graph
+ * hub. Small cycles remain fully linked; large cycles expose a deterministic
+ * sorted sample while immutable per-page provenance remains authoritative.
+ */
+export async function writeSummaryPage(
+  engine: BrainEngine,
+  brainDir: string,
+  summarySlug: string,
+  summaryDate: string,
+  writtenSlugs: string[],
+  childOutcomes: Array<{ jobId: number; status: string }>,
+  sourceId = 'default',
+): Promise<void> {
+  const completed = childOutcomes.filter(c => c.status === 'completed').length;
+  const failed = childOutcomes.length - completed;
+  const lines: string[] = [
+    `# Dream cycle ${summaryDate}`,
+    '',
+    `**Children:** ${completed} completed, ${failed} failed/timeout.`,
+    `**Pages written:** ${writtenSlugs.length}.`,
+    '',
+  ];
+  if (writtenSlugs.length > 0) {
+    const sampledSlugs = [...writtenSlugs].sort().slice(0, SUMMARY_LINK_SAMPLE_LIMIT);
+    lines.push(
+      writtenSlugs.length > SUMMARY_LINK_SAMPLE_LIMIT
+        ? `## Page sample (${sampledSlugs.length} of ${writtenSlugs.length})`
+        : '## Pages',
+      '',
+      ...sampledSlugs.map(slug => `- [[${slug}]]`),
+      '',
+    );
+    if (writtenSlugs.length > SUMMARY_LINK_SAMPLE_LIMIT) {
+      lines.push(
+        '## Full output provenance',
+        '',
+        `The complete ${writtenSlugs.length}-page set is recoverable in this source by querying page frontmatter for ` +
+          `\`dream_generated: true\` and \`dream_cycle_date: ${summaryDate}\`, excluding \`${summarySlug}\`. ` +
+          'Every child page carries those provenance fields; this summary intentionally links only the deterministic sample above.',
+        '',
+      );
+    }
+  }
+
+  const fullMarkdown = serializeMarkdown(
+    {
+      dream_generated: true,
+      dream_cycle_date: summaryDate,
+      dream_created_cycle_date: summaryDate,
+      // Deterministic index page: source traces live on its child pages.
+      raw_trace_exempt: true,
+      raw_trace_exempt_reason: 'deterministic dream-cycle index; raw traces live on listed pages',
+    } as Record<string, unknown>,
+    lines.join('\n'),
+    '',
+    { type: 'note' as string, title: `Dream cycle ${summaryDate}`, tags: ['dream-cycle'] },
+  );
+  const parsed = parseMarkdown(fullMarkdown);
+  await engine.putPage(summarySlug, {
+    type: parsed.type,
+    title: parsed.title,
+    compiled_truth: parsed.compiled_truth,
+    timeline: parsed.timeline,
+    frontmatter: parsed.frontmatter,
+  }, { sourceId });
+
+  try {
+    const filePath = join(brainDir, `${summarySlug}.md`);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, fullMarkdown, 'utf8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`[dream] summary file-write failed: ${msg}\n`);
+  }
+}

--- a/src/core/cycle/synthesize-summary.ts
+++ b/src/core/cycle/synthesize-summary.ts
@@ -53,6 +53,7 @@ export async function writeSummaryPage(
   const fullMarkdown = serializeMarkdown(
     {
       dream_generated: true,
+      created: summaryDate,
       dream_cycle_date: summaryDate,
       dream_created_cycle_date: summaryDate,
       // Deterministic index page: source traces live on its child pages.

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -59,9 +59,9 @@ import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { runSubagentsInline, runDrainRenewalTick, percentile, INLINE_LOCK_MS } from './inline-drain.ts';
 import { buildManifestContext, buildLinkManifest, type ManifestContext } from './link-manifest.ts';
 import { writeSummaryPage } from './synthesize-summary.ts';
+import { stampDreamProvenance } from './dream-provenance.ts';
 
-// Re-exports: the drain was peeled to inline-drain.ts (dream-wave C7);
-// patterns.ts and the __testing surface import from here unchanged.
+// Re-export the peeled drain while preserving the existing import surface.
 export { runSubagentsInline, runDrainRenewalTick };
 import { discoverTranscripts, DEFAULT_EXCLUDE_PATTERNS, type DiscoveredTranscript } from './transcript-discovery.ts';
 import { serializePageToMarkdown } from '../markdown.ts';
@@ -2460,64 +2460,6 @@ function findLegacyCompletion(
     if (seen.size === n) return 'chunked';
   }
   return null;
-}
-
-// ── Dream-provenance DB stamp (#2569) ────────────────────────────────
-
-/**
- * Persist the dream-output identity marker plus its first-cycle provenance
- * into the `pages.frontmatter` JSONB row for every page a synthesize child
- * wrote. `dream_cycle_date` remains the compatible query key and
- * `dream_created_cycle_date` makes its immutable meaning explicit. Reruns
- * preserve the first non-empty value instead of dating old content as new.
- * Render-time `frontmatterOverrides` alone only
- * reach the markdown FILE — the DB row stayed unstamped, so DB consumers
- * couldn't enumerate generated pages and a later put_page write-through
- * (which re-renders from the DB row) silently erased the marker.
- *
- * Plain UPDATE through executeRawJsonb (raw object bound to $3::jsonb —
- * never JSON.stringify into a ::jsonb cast; engine-parity safe, no new
- * engine method). Best-effort per row: a stamp failure never kills the
- * phase (the render-time override still covers the file).
- */
-async function stampDreamProvenance(
-  engine: BrainEngine,
-  refs: Array<{ slug: string; source_id: string; raw_source?: string }>,
-  cycleDate: string,
-): Promise<void> {
-  if (refs.length === 0) return;
-  const { executeRawJsonb } = await import('../sql-query.ts');
-  for (const { slug, source_id, raw_source } of refs) {
-    try {
-      await executeRawJsonb(
-        engine,
-        `UPDATE pages
-            SET frontmatter = COALESCE(frontmatter, '{}'::jsonb)
-                              || $4::jsonb
-                              || jsonb_build_object(
-                                   'dream_cycle_date',
-                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''),
-                                            NULLIF(frontmatter->>'dream_cycle_date', ''), $3),
-                                   'dream_created_cycle_date',
-                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''),
-                                            NULLIF(frontmatter->>'dream_cycle_date', ''), $3)
-                                 )
-          WHERE slug = $1 AND source_id = $2`,
-        [slug, source_id, cycleDate],
-        // #1978 raw-source persistence: record the transcript path the
-        // synthesis was derived from, so `gbrain doctor` (raw_provenance
-        // check) can verify every generated page carries a raw trace.
-        [{
-          dream_generated: true,
-          dream_cycle_date: cycleDate,
-          ...(raw_source ? { raw_source } : {}),
-        }],
-      );
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      process.stderr.write(`[dream] provenance stamp ${slug}@${source_id} failed: ${msg}\n`);
-    }
-  }
 }
 
 // ── Reverse-write DB rows → markdown files ───────────────────────────

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -58,12 +58,13 @@ import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { runSubagentsInline, runDrainRenewalTick, percentile, INLINE_LOCK_MS } from './inline-drain.ts';
 import { buildManifestContext, buildLinkManifest, type ManifestContext } from './link-manifest.ts';
+import { writeSummaryPage } from './synthesize-summary.ts';
 
 // Re-exports: the drain was peeled to inline-drain.ts (dream-wave C7);
 // patterns.ts and the __testing surface import from here unchanged.
 export { runSubagentsInline, runDrainRenewalTick };
 import { discoverTranscripts, DEFAULT_EXCLUDE_PATTERNS, type DiscoveredTranscript } from './transcript-discovery.ts';
-import { serializeMarkdown, serializePageToMarkdown } from '../markdown.ts';
+import { serializePageToMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
 import { validateSourceId } from '../utils.ts';
 import { safeSplitIndex } from '../text-safe.ts';
@@ -2464,9 +2465,12 @@ function findLegacyCompletion(
 // ── Dream-provenance DB stamp (#2569) ────────────────────────────────
 
 /**
- * Persist the dream-output identity marker (`dream_generated: true` +
- * `dream_cycle_date`) into the `pages.frontmatter` JSONB row for every page
- * a synthesize child wrote. Render-time `frontmatterOverrides` alone only
+ * Persist the dream-output identity marker plus its first-cycle provenance
+ * into the `pages.frontmatter` JSONB row for every page a synthesize child
+ * wrote. `dream_cycle_date` remains the compatible query key and
+ * `dream_created_cycle_date` makes its immutable meaning explicit. Reruns
+ * preserve the first non-empty value instead of dating old content as new.
+ * Render-time `frontmatterOverrides` alone only
  * reach the markdown FILE — the DB row stayed unstamped, so DB consumers
  * couldn't enumerate generated pages and a later put_page write-through
  * (which re-renders from the DB row) silently erased the marker.
@@ -2488,9 +2492,18 @@ async function stampDreamProvenance(
       await executeRawJsonb(
         engine,
         `UPDATE pages
-            SET frontmatter = COALESCE(frontmatter, '{}'::jsonb) || $3::jsonb
+            SET frontmatter = COALESCE(frontmatter, '{}'::jsonb)
+                              || $4::jsonb
+                              || jsonb_build_object(
+                                   'dream_cycle_date',
+                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''),
+                                            NULLIF(frontmatter->>'dream_cycle_date', ''), $3),
+                                   'dream_created_cycle_date',
+                                   COALESCE(NULLIF(frontmatter->>'dream_created_cycle_date', ''),
+                                            NULLIF(frontmatter->>'dream_cycle_date', ''), $3)
+                                 )
           WHERE slug = $1 AND source_id = $2`,
-        [slug, source_id],
+        [slug, source_id, cycleDate],
         // #1978 raw-source persistence: record the transcript path the
         // synthesis was derived from, so `gbrain doctor` (raw_provenance
         // check) can verify every generated page carries a raw trace.
@@ -2552,94 +2565,27 @@ async function reverseWriteRefs(
  * `serializeMarkdown` does not embed the page slug in the body.
  */
 export function renderPageToMarkdown(page: Page, tags: string[]): string {
-  // v0.38 DRY: the dream-output identity stamp (dream_generated +
-  // dream_cycle_date) is the ONLY thing that differs from the v0.38
+  // v0.38 DRY: the dream-output identity stamp is the ONLY thing that differs
+  // from the v0.38
   // put_page write-through renderer. Both call the shared
   // serializePageToMarkdown helper in markdown.ts; this wrapper passes
-  // the dream-specific overrides. Future markdown-shape changes happen
-  // in one place.
+  // the dream-specific overrides. Preserve the DB-stamped first cycle date;
+  // falling back to today() is only for legacy callers rendering an unstamped
+  // page for the first time. Future markdown-shape changes happen in one place.
+  const createdCycleDate = page.frontmatter?.dream_created_cycle_date;
+  const legacyCycleDate = page.frontmatter?.dream_cycle_date;
+  const stableCycleDate = typeof createdCycleDate === 'string' && createdCycleDate
+    ? createdCycleDate
+    : typeof legacyCycleDate === 'string' && legacyCycleDate
+      ? legacyCycleDate
+      : today();
   return serializePageToMarkdown(page, tags, {
     frontmatterOverrides: {
       dream_generated: true,
-      dream_cycle_date: today(),
+      dream_cycle_date: stableCycleDate,
+      dream_created_cycle_date: stableCycleDate,
     },
   });
-}
-
-// ── Summary index page ───────────────────────────────────────────────
-
-async function writeSummaryPage(
-  engine: BrainEngine,
-  brainDir: string,
-  summarySlug: string,
-  summaryDate: string,
-  writtenSlugs: string[],
-  childOutcomes: Array<{ jobId: number; status: string }>,
-  sourceId = 'default',
-): Promise<void> {
-  const completed = childOutcomes.filter(c => c.status === 'completed').length;
-  const failed = childOutcomes.length - completed;
-
-  const lines: string[] = [];
-  lines.push(`# Dream cycle ${summaryDate}`);
-  lines.push('');
-  lines.push(`**Children:** ${completed} completed, ${failed} failed/timeout.`);
-  lines.push(`**Pages written:** ${writtenSlugs.length}.`);
-  lines.push('');
-  if (writtenSlugs.length > 0) {
-    lines.push('## Pages');
-    lines.push('');
-    for (const s of writtenSlugs) {
-      lines.push(`- [[${s}]]`);
-    }
-    lines.push('');
-  }
-
-  const body = lines.join('\n');
-  // Stamp the dream-output identity marker into the summary's frontmatter.
-  // parseMarkdown below round-trips it into the DB-stored frontmatter, so the
-  // marker survives any later reverse-render of the summary page.
-  const fullMarkdown = serializeMarkdown(
-    {
-      dream_generated: true,
-      dream_cycle_date: summaryDate,
-      // #1978: deterministic index page — no source document of its own;
-      // raw traces live on the listed pages. Explicit exemption keeps the
-      // doctor raw_provenance check quiet.
-      raw_trace_exempt: true,
-      raw_trace_exempt_reason: 'deterministic dream-cycle index; raw traces live on listed pages',
-    } as Record<string, unknown>,
-    body,
-    '',
-    { type: 'note' as string, title: `Dream cycle ${summaryDate}`, tags: ['dream-cycle'] },
-  );
-
-  // Direct engine.putPage — orchestrator write, no subagent context, no
-  // allow-list check (server-side viaSubagent=false). The summary slug is
-  // pre-validated against SUMMARY_SLUG_RE in the caller.
-  // Importing put_page via operations.ts would re-run namespace logic
-  // unnecessarily; we go straight to the engine.
-  const { parseMarkdown } = await import('../markdown.ts');
-  const parsed = parseMarkdown(fullMarkdown);
-  // #1586: summary lands in the cycle's resolved source too — otherwise the
-  // children live in the named source while the index drifts to 'default'.
-  await engine.putPage(summarySlug, {
-    type: parsed.type,
-    title: parsed.title,
-    compiled_truth: parsed.compiled_truth,
-    timeline: parsed.timeline,
-    frontmatter: parsed.frontmatter,
-  }, { sourceId });
-
-  // Also write to disk (orchestrator dual-write).
-  try {
-    const filePath = join(brainDir, `${summarySlug}.md`);
-    mkdirSync(dirname(filePath), { recursive: true });
-    writeFileSync(filePath, fullMarkdown, 'utf8');
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    process.stderr.write(`[dream] summary file-write failed: ${msg}\n`);
-  }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -2697,6 +2643,7 @@ export const __testing = {
   buildSynthesisPrompt,
   stampDreamProvenance,
   reverseWriteRefs,
+  writeSummaryPage,
   runSubagentsInline,
   loadSynthConfig,
 };

--- a/test/cycle-synthesize-slug-collection.test.ts
+++ b/test/cycle-synthesize-slug-collection.test.ts
@@ -249,4 +249,115 @@ describe('#2569: stampDreamProvenance persists the marker into DB frontmatter', 
     expect(fm.dream_generated).toBe(true);
     expect(fm.raw_source).toBe('/transcripts/2026-07-17-standup.md');
   });
+
+  test('sets created from a date-prefixed raw source, not the later dream run date', async () => {
+    // A conflicting dated slug proves source evidence wins over generated
+    // naming hints; the cycle date is later than both.
+    const slug = 'wiki/originals/ideas/2026-08-19-source-dated-idea-abc123';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Source-dated idea',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: {},
+    });
+
+    await stampDreamProvenance(
+      engine as any,
+      [{
+        slug,
+        source_id: 'default',
+        raw_source: '/transcripts/2026-07-17-standup.md',
+      }],
+      '2026-08-20',
+    );
+
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`,
+      [slug],
+    );
+    expect(rows[0].fm.created).toBe('2026-07-17');
+    expect(rows[0].fm.created).not.toBe('2026-08-20');
+    const page = await engine.getPage(slug);
+    expect(page).not.toBeNull();
+    expect(renderPageToMarkdown(page!, [])).toMatch(/created:\s*['"]?2026-07-17/);
+  });
+
+  test('preserves an existing created value instead of replacing it from provenance', async () => {
+    const slug = 'wiki/personal/reflections/2026-07-17-existing-created-def456';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Existing creation metadata',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: { created: '2026-06-25' },
+    });
+
+    await stampDreamProvenance(
+      engine as any,
+      [{
+        slug,
+        source_id: 'default',
+        raw_source: '/transcripts/2026-07-17-standup.md',
+      }],
+      '2026-08-20',
+    );
+
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`,
+      [slug],
+    );
+    expect(rows[0].fm.created).toBe('2026-06-25');
+  });
+
+  test('falls back to a stable dated slug when raw-source evidence is unavailable', async () => {
+    const slug = 'wiki/originals/ideas/2026-07-04-dated-slug-evidence-fed789';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Dated slug evidence',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: {},
+    });
+
+    await stampDreamProvenance(
+      engine as any,
+      [{ slug, source_id: 'default' }],
+      '2026-08-20',
+    );
+
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`,
+      [slug],
+    );
+    expect(rows[0].fm.created).toBe('2026-07-04');
+  });
+
+  test('does not mislabel an undated source with the maintenance cycle date', async () => {
+    const slug = 'wiki/personal/reflections/2026-08-20-undated-source-abc999';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Undated source',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: {},
+    });
+
+    await stampDreamProvenance(
+      engine as any,
+      [{
+        slug,
+        source_id: 'default',
+        raw_source: '/archive/2026-07-01/claude-session-without-date.md',
+      }],
+      '2026-08-20',
+    );
+
+    const rows = await engine.executeRaw<{ fm: Record<string, unknown> }>(
+      `SELECT frontmatter AS fm FROM pages WHERE slug = $1`,
+      [slug],
+    );
+    expect(rows[0].fm.created).toBeUndefined();
+    expect(rows[0].fm.dream_cycle_date).toBe('2026-08-20');
+  });
 });

--- a/test/cycle-synthesize-slug-collection.test.ts
+++ b/test/cycle-synthesize-slug-collection.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
-import { __testing } from '../src/core/cycle/synthesize.ts';
+import { __testing, renderPageToMarkdown } from '../src/core/cycle/synthesize.ts';
 
 const { collectChildPutPageSlugs, stampDreamProvenance } = __testing;
 
@@ -183,6 +183,7 @@ describe('#2569: stampDreamProvenance persists the marker into DB frontmatter', 
     // double-encoded string scalar.
     expect(fm.dream_generated).toBe(true);
     expect(fm.dream_cycle_date).toBe('2026-07-17');
+    expect(fm.dream_created_cycle_date).toBe('2026-07-17');
     // Merge, not replace: pre-existing frontmatter keys survive.
     expect(fm.keep_me).toBe('yes');
   });
@@ -191,6 +192,35 @@ describe('#2569: stampDreamProvenance persists the marker into DB frontmatter', 
     const refs = [{ slug: 'wiki/originals/ideas/does-not-exist', source_id: 'default' }];
     await stampDreamProvenance(engine as any, refs, '2026-07-17'); // no throw
     await stampDreamProvenance(engine as any, refs, '2026-07-17'); // idempotent
+  });
+
+  test('a rerun preserves the first dream cycle date in DB and reverse-rendered markdown', async () => {
+    const slug = 'wiki/originals/ideas/2026-08-18-stable-cycle-date-abc123';
+    await engine.putPage(slug, {
+      type: 'note',
+      title: 'Stable dream provenance',
+      compiled_truth: 'body',
+      timeline: '',
+      frontmatter: {
+        dream_generated: true,
+        dream_cycle_date: '2026-08-18',
+      },
+    });
+
+    await stampDreamProvenance(
+      engine as any,
+      [{ slug, source_id: 'default' }],
+      '2026-08-19',
+    );
+
+    const page = await engine.getPage(slug);
+    expect(page).not.toBeNull();
+    expect(page!.frontmatter.dream_cycle_date).toBe('2026-08-18');
+    expect(page!.frontmatter.dream_created_cycle_date).toBe('2026-08-18');
+    const markdown = renderPageToMarkdown(page!, []);
+    expect(markdown).toMatch(/dream_cycle_date:\s*['"]?2026-08-18/);
+    expect(markdown).toMatch(/dream_created_cycle_date:\s*['"]?2026-08-18/);
+    expect(markdown).not.toContain('dream_cycle_date: 2026-08-19');
   });
 
   // #1978: raw-source persistence — the stamp carries the transcript path

--- a/test/cycle-synthesize-summary-page.test.ts
+++ b/test/cycle-synthesize-summary-page.test.ts
@@ -78,6 +78,7 @@ describe('dream-cycle summary graph bounds', () => {
     expect(forward.body).not.toContain(`[[${slugs[20]}]]`);
     expect(forward.body).toContain('dream_generated: true');
     expect(forward.body).toContain('dream_cycle_date: 2026-08-20');
+    expect(forward.markdown).toMatch(/created:\s*['"]?2026-08-20/);
     expect(forward.body).toContain('excluding `dream-cycle-summaries/2026-08-20`');
     expect(Buffer.byteLength(forward.markdown, 'utf8')).toBeLessThan(8_192);
   });

--- a/test/cycle-synthesize-summary-page.test.ts
+++ b/test/cycle-synthesize-summary-page.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { __testing } from '../src/core/cycle/synthesize.ts';
+import type { PageInput } from '../src/core/types.ts';
+
+type SummaryWriter = (
+  engine: BrainEngine,
+  brainDir: string,
+  summarySlug: string,
+  summaryDate: string,
+  writtenSlugs: string[],
+  childOutcomes: Array<{ jobId: number; status: string }>,
+  sourceId?: string,
+) => Promise<void>;
+
+const writeSummaryPage = (
+  __testing as unknown as { writeSummaryPage: SummaryWriter }
+).writeSummaryPage;
+
+async function renderSummary(writtenSlugs: string[]): Promise<{ body: string; markdown: string }> {
+  const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-dream-summary-'));
+  let stored: PageInput | undefined;
+  const engine = {
+    putPage: async (_slug: string, page: PageInput) => {
+      stored = page;
+      return {};
+    },
+  } as unknown as BrainEngine;
+  try {
+    await writeSummaryPage(
+      engine,
+      brainDir,
+      'dream-cycle-summaries/2026-08-20',
+      '2026-08-20',
+      writtenSlugs,
+      [
+        { jobId: 1, status: 'completed' },
+        { jobId: 2, status: 'completed' },
+        { jobId: 3, status: 'failed' },
+      ],
+    );
+    if (!stored) throw new Error('summary page was not persisted');
+    return {
+      body: stored.compiled_truth,
+      markdown: readFileSync(
+        join(brainDir, 'dream-cycle-summaries/2026-08-20.md'),
+        'utf8',
+      ),
+    };
+  } finally {
+    rmSync(brainDir, { recursive: true, force: true });
+  }
+}
+
+describe('dream-cycle summary graph bounds', () => {
+  test('more than 2,000 outputs produce one deterministic bounded sample with recoverable provenance', async () => {
+    const slugs = Array.from(
+      { length: 2_105 },
+      (_, index) => {
+        const prefix = `wiki/originals/ideas/output-${String(index).padStart(4, '0')}-`;
+        return prefix + 'x'.repeat(255 - prefix.length);
+      },
+    );
+    const forward = await renderSummary(slugs);
+    const reverse = await renderSummary([...slugs].reverse());
+
+    expect(forward.body).toBe(reverse.body);
+    expect(forward.markdown).toBe(reverse.markdown);
+    expect(forward.body).toContain('**Children:** 2 completed, 1 failed/timeout.');
+    expect(forward.body).toContain('**Pages written:** 2105.');
+    expect(forward.body.match(/\[\[/g)).toHaveLength(20);
+    expect(slugs.every(slug => slug.length === 255)).toBe(true);
+    expect(forward.body).toContain(`[[${slugs[0]}]]`);
+    expect(forward.body).toContain(`[[${slugs[19]}]]`);
+    expect(forward.body).not.toContain(`[[${slugs[20]}]]`);
+    expect(forward.body).toContain('dream_generated: true');
+    expect(forward.body).toContain('dream_cycle_date: 2026-08-20');
+    expect(forward.body).toContain('excluding `dream-cycle-summaries/2026-08-20`');
+    expect(Buffer.byteLength(forward.markdown, 'utf8')).toBeLessThan(8_192);
+  });
+
+  test('small runs retain a complete page list', async () => {
+    const slugs = [
+      'wiki/originals/ideas/output-charlie',
+      'wiki/originals/ideas/output-alpha',
+      'wiki/originals/ideas/output-bravo',
+    ];
+    const { body } = await renderSummary(slugs);
+
+    expect(body).toContain('**Pages written:** 3.');
+    expect(body).toContain('## Pages');
+    expect(body).not.toContain('## Page sample');
+    expect(body).not.toContain('## Full output provenance');
+    expect(body.match(/\[\[/g)).toHaveLength(3);
+    for (const slug of slugs) expect(body).toContain(`[[${slug}]]`);
+  });
+});


### PR DESCRIPTION
## What changed

- Cap large dream-cycle summary indexes at a deterministic, lexicographically sorted sample of 20 wikilinks.
- Preserve exact child and page totals, and explain how to recover the complete set through per-page dream provenance.
- Preserve the first dream cycle date across reruns, with `dream_created_cycle_date` as an explicit immutable mirror of the compatible `dream_cycle_date` query key.
- Give newly synthesized child pages an honest `created` value when evidence exists:
  - a valid date-prefixed raw-source basename wins;
  - a valid dated slug is a fallback only when it differs from the cycle date;
  - existing `created` metadata is never overwritten;
  - an undated source whose generated slug merely repeats the maintenance date remains unstamped rather than receiving false provenance.
- Peel summary and provenance logic into focused sibling modules, reducing `synthesize.ts` from 2,702 to 2,591 lines and lowering the size ratchet accordingly.

## Why

`writeSummaryPage` linked every generated page. A large cycle could therefore create a thousands-edge graph hub and an oversized summary file even though every child already carries queryable provenance.

Reruns also overwrote `dream_cycle_date` with the maintenance date in both the DB stamp and reverse renderer. Separately, child pages omitted the required `created` frontmatter. Naively filling it from the cycle date would be incorrect because the synthesis prompt injects that date into slugs for undated sources. This change distinguishes source evidence from generated naming hints.

## Behavior

- Runs with 20 or fewer outputs continue to list every page.
- Larger runs list exactly 20 deterministic links while retaining exact totals.
- The summary names the source-scoped frontmatter query needed to recover the complete child set and excludes its own summary slug.
- Existing first-cycle dates win over later rerun dates in both DB JSONB and rendered Markdown.
- Source-dated children carry the source date through the DB stamp into rendered Markdown.
- Ambiguous undated children do not get mislabeled with the maintenance run date.

## Verification

- TDD regressions for 2,105 maximum-length summary slugs, deterministic bounds, first-cycle preservation, raw-source precedence, existing-created preservation, dated-slug fallback, ambiguous-date abstention, and rendered Markdown.
- 19 direct summary/provenance tests passed on the combined branch.
- 194 broader synthesis and serializer tests passed during the child-date implementation.
- `bun run typecheck` passed.
- Module-size and structural guards passed with the lower 2,591-line ceiling.
- Full `bun run verify`: 54/54 checks passed on the final combined branch.
