### PR TITLE
v0.46.22.0 fix(search): honor query filters across hybrid retrieval

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import type { CliOptions } from './core/cli-options.ts';
 import { callRemoteTool, RemoteMcpError, unpackToolResult, extractResponseMeta } from './core/mcp-client.ts';
 import { maybePromptForUpgrade } from './core/thin-client-upgrade-prompt.ts';
 import { CLI_FLAG_REGISTRY } from './core/cli-flag-registry.generated.ts';
+import { assignOpArgValue } from './core/cli-op-args.ts';
 import { VERSION } from './version.ts';
 
 // Build CLI name -> operation lookup
@@ -1035,9 +1036,7 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
         const def = op.params[key];
         if (def) {
           const raw = arg.slice(eq + 1);
-          params[key] = def.type === 'boolean' ? raw !== 'false'
-            : def.type === 'number' ? Number(raw)
-            : raw;
+          assignOpArgValue(params, key, def, raw);
           continue;
         }
       }
@@ -1062,8 +1061,7 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
         // rehearsal request (the resurrected #2185 class the red team caught).
         params[key] = true;
       } else if (i + 1 < args.length) {
-        params[key] = args[++i];
-        if (paramDef?.type === 'number') params[key] = Number(params[key]);
+        assignOpArgValue(params, key, paramDef, args[++i]);
       }
     } else if (posIdx < positional.length) {
       const key = positional[posIdx++];

--- a/src/core/cli-op-args.ts
+++ b/src/core/cli-op-args.ts
@@ -1,0 +1,19 @@
+import type { ParamDef } from './ops/contract.ts';
+
+/** Parse and assign one operation CLI value, accumulating array flags. */
+export function assignOpArgValue(
+  params: Record<string, unknown>,
+  key: string,
+  def: ParamDef | undefined,
+  raw: string,
+): void {
+  if (def?.type === 'array' && def.items?.type === 'string') {
+    const values = raw.split(',').map(value => value.trim()).filter(Boolean);
+    const prior = Array.isArray(params[key]) ? params[key] as unknown[] : [];
+    params[key] = [...prior, ...values];
+    return;
+  }
+  params[key] = def?.type === 'boolean' ? raw !== 'false'
+    : def?.type === 'number' ? Number(raw)
+    : raw;
+}

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -141,6 +141,21 @@ const query: Operation = {
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
+    types: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Filter results to these page types (CLI: comma-separated or repeat the flag).',
+    },
+    exclude_slug_prefixes: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Add slug prefixes to the search-policy hard-exclude list (CLI: comma-separated or repeat the flag).',
+    },
+    include_slug_prefixes: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Opt slug prefixes back in when search policy excludes them (CLI: comma-separated or repeat the flag).',
+    },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },
     mode: { type: 'string', description: 'Search mode (conservative|balanced|tokenmax). Local callers only; remote uses configured mode.' },
@@ -244,6 +259,17 @@ const query: Operation = {
     // #2561: unqualified trusted-local query spans federated sources (per-call
     // source_id / remote grants still resolve through resolveRequestedScope).
     const querySourceScope = federatedSearchScope(ctx, sourceIdParam);
+    const stringList = (value: unknown): string[] | undefined => {
+      if (!Array.isArray(value)) return undefined;
+      const items = value
+        .filter((item): item is string => typeof item === 'string')
+        .map(item => item.trim())
+        .filter(Boolean);
+      return items.length > 0 ? [...new Set(items)] : undefined;
+    };
+    const types = stringList(p.types);
+    const excludeSlugPrefixes = stringList(p.exclude_slug_prefixes);
+    const includeSlugPrefixes = stringList(p.include_slug_prefixes);
 
     // v0.27.1: image-similarity branch. Bypasses hybridSearch (which is
     // text-only); embeds the image via embedMultimodal and runs a direct
@@ -261,6 +287,9 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
+        types,
+        exclude_slug_prefixes: excludeSlugPrefixes,
+        include_slug_prefixes: includeSlugPrefixes,
         ...querySourceScope,
       });
       return results;
@@ -301,6 +330,9 @@ const query: Operation = {
       symbolKind: (p.symbol_kind as string) || undefined,
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
+      types,
+      exclude_slug_prefixes: excludeSlugPrefixes,
+      include_slug_prefixes: includeSlugPrefixes,
       ...querySourceScope,
       // v0.29.1 — agent-explicit recency + salience. Omitted = heuristic defaults.
       salience: p.salience as 'off' | 'on' | 'strong' | undefined,

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -23,6 +23,8 @@ import { embed, embedQuery } from '../embedding.ts';
 import { registerBackgroundWorkDrainer } from '../background-work.ts';
 import { resolveEmbeddingColumn, isCacheSafe } from './embedding-column.ts';
 import { resolveHardExcludes } from './source-boost.ts';
+import { applyResultFilters, shouldBoostCompiledTruth } from './result-filters.ts';
+export { shouldBoostCompiledTruth } from './result-filters.ts';
 import {
   resolveAdaptiveReturn,
   applyAdaptiveReturn,
@@ -56,31 +58,6 @@ import {
 export const RRF_K = 60;
 const COMPILED_TRUTH_BOOST = 2.0;
 
-/**
- * Which detail levels get the compiled_truth boost (#3430).
- *
- * ONLY `low`. The documented contract (`src/core/operations.ts`) is
- * "low (compiled truth only), medium (default, all with dedup), high (all
- * chunks)" — so `low` is the level that privileges compiled truth, and both
- * `medium` and `high` are supposed to see everything on equal footing.
- *
- * This was previously spelled `detail !== 'high'`, i.e. written as though
- * `high` were the special case. Because COMPILED_TRUTH_BOOST is applied AFTER
- * RRF normalization, and RRF's whole range over a 100-deep pool is 1/60 → 1/160,
- * a 2.0x multiplier is not a tilt — break-even is `2/(60+r) >= 1/60`, so any
- * boosted chunk inside the first 60 ranks outranks an unboosted rank-1 chunk.
- * At the default detail that made search categorically compiled-truth-only:
- * a page whose answer lived in a `fenced_code` chunk returned the prose chunk,
- * and the code chunk fell out of the window entirely.
- *
- * Extracted as a named predicate rather than left inline at three call sites so
- * the detail→boost mapping is directly testable. An inline expression can only
- * be covered through a full `hybridSearch` round trip, which is why the
- * original inversion went unnoticed.
- */
-export function shouldBoostCompiledTruth(detail: string | null | undefined): boolean {
-  return detail === 'low';
-}
 const pendingCacheWrites = new Set<Promise<unknown>>();
 
 /**
@@ -1069,7 +1046,11 @@ export async function hybridSearch(
     // v0.33: multi-type filter for whoknows ('person','company'). Pushes
     // type filter to SQL level so the limit budget goes to candidate-typed
     // pages instead of being eaten by note/transcript/article pages.
+    type: opts?.type,
     types: opts?.types,
+    exclude_slugs: opts?.exclude_slugs,
+    exclude_slug_prefixes: opts?.exclude_slug_prefixes,
+    include_slug_prefixes: opts?.include_slug_prefixes,
     // v0.29.1: since/until take precedence over deprecated afterDate/beforeDate.
     // The engine still consumes the legacy field names; this aliasing keeps
     // PR #618 callers compiling while the new names are the public surface.
@@ -1316,10 +1297,10 @@ export async function hybridSearch(
     }
     // T3/T4 — alias hop + evidence stamp even without an embedding provider
     // (the named-thing fix is most valuable exactly when vector is unavailable).
-    const noEmbedHopped = await applyAliasHop(engine, dedupResults(noEmbedResults), query, {
+    const noEmbedHopped = applyResultFilters(await applyAliasHop(engine, dedupResults(noEmbedResults), query, {
       sourceId: opts?.sourceId,
       sourceIds: opts?.sourceIds,
-    });
+    }), opts);
     stampEvidence(noEmbedHopped, { cosineFloor: resolvedMode.evidence_cosine_floor });
     const noEmbedSliced = noEmbedHopped.slice(offset, offset + limit);
     // v0.32.3 search-lite: budget enforcement on the no-embedding-provider path.
@@ -1665,10 +1646,10 @@ export async function hybridSearch(
       await runPostFusionStages(engine, fallbackResults, postFusionOpts);
       fallbackResults.sort((a, b) => b.score - a.score);
     }
-    const kwHopped = await applyAliasHop(engine, dedupResults(fallbackResults), query, {
+    const kwHopped = applyResultFilters(await applyAliasHop(engine, dedupResults(fallbackResults), query, {
       sourceId: opts?.sourceId,
       sourceIds: opts?.sourceIds,
-    });
+    }), opts);
     stampEvidence(kwHopped, { cosineFloor: resolvedMode.evidence_cosine_floor });
     const kwSliced = kwHopped.slice(offset, offset + limit);
     // v0.32.3 search-lite: budget enforcement on the keyword-fallback path too.
@@ -1860,10 +1841,10 @@ export async function hybridSearch(
   // T3 — free-text alias hop. Runs AFTER rerank so a query that is a page's
   // declared chosen name reliably surfaces that page regardless of how the
   // reranker scored body chunks. Fail-open on pre-v110 brains.
-  const aliasHopped = await applyAliasHop(engine, reranked, query, {
+  const aliasHopped = applyResultFilters(await applyAliasHop(engine, reranked, query, {
     sourceId: opts?.sourceId,
     sourceIds: opts?.sourceIds,
-  });
+  }), opts);
 
   // T4 — stamp evidence + create_safety so the agent's don't-duplicate
   // decision keys off WHY a page matched, not a raw blended score. Stamp on
@@ -2082,13 +2063,19 @@ export async function hybridSearchCached(
   // now-relative timestamp, which a persisted cache row can't express.
   const dateFiltered =
     Boolean(opts?.since ?? opts?.afterDate) || Boolean(opts?.until ?? opts?.beforeDate);
+  // Page-type filters are not represented in the persisted query-cache key.
+  // Bypass the cache rather than serving an untyped row to a typed request (or
+  // caching a narrow typed result for a later untyped lookup). Prefix filters
+  // are cache-safe because their resolved list is already folded into hx=.
+  const typeFiltered = Boolean(opts?.type) || Boolean(opts?.types?.length);
   const skipCache =
     !cache.isEnabled() ||
     (opts?.walkDepth ?? 0) > 0 ||
     Boolean(opts?.nearSymbol) ||
     isNonDefaultColumn ||
     adaptiveReturnOn ||
-    dateFiltered;
+    dateFiltered ||
+    typeFiltered;
 
   let cacheStatus: 'hit' | 'miss' | 'disabled' = skipCache ? 'disabled' : 'miss';
   let cacheSimilarity: number | undefined;

--- a/src/core/search/result-filters.ts
+++ b/src/core/search/result-filters.ts
@@ -1,0 +1,50 @@
+import type { SearchOpts, SearchResult } from '../types.ts';
+import { resolveHardExcludes } from './source-boost.ts';
+
+/**
+ * Which detail levels get the compiled_truth boost (#3430).
+ *
+ * ONLY `low`. The documented contract (`src/core/operations.ts`) is
+ * "low (compiled truth only), medium (default, all with dedup), high (all
+ * chunks)" — so `low` is the level that privileges compiled truth, and both
+ * `medium` and `high` are supposed to see everything on equal footing.
+ *
+ * This was previously spelled `detail !== 'high'`, i.e. written as though
+ * `high` were the special case. Because COMPILED_TRUTH_BOOST is applied AFTER
+ * RRF normalization, and RRF's whole range over a 100-deep pool is 1/60 → 1/160,
+ * a 2.0x multiplier is not a tilt — break-even is `2/(60+r) >= 1/60`, so any
+ * boosted chunk inside the first 60 ranks outranks an unboosted rank-1 chunk.
+ * At the default detail that made search categorically compiled-truth-only:
+ * a page whose answer lived in a `fenced_code` chunk returned the prose chunk,
+ * and the code chunk fell out of the window entirely.
+ *
+ * Extracted as a named predicate rather than left inline at three call sites so
+ * the detail→boost mapping is directly testable. An inline expression can only
+ * be covered through a full `hybridSearch` round trip, which is why the
+ * original inversion went unnoticed.
+ */
+export function shouldBoostCompiledTruth(detail: string | null | undefined): boolean {
+  return detail === 'low';
+}
+
+/**
+ * Defense-in-depth for candidate generators that do not query through the
+ * engine SearchOpts surface (alias, relational, and structural-walk arms).
+ * SQL-level filtering still happens first so excluded rows do not consume the
+ * candidate budget; this final fence prevents a later arm from reintroducing
+ * them after fusion.
+ */
+export function applyResultFilters(results: SearchResult[], opts?: SearchOpts): SearchResult[] {
+  const hardExcludes = resolveHardExcludes(
+    opts?.exclude_slug_prefixes,
+    opts?.include_slug_prefixes,
+  );
+  const exactExcludes = new Set(opts?.exclude_slugs ?? []);
+  const types = opts?.types?.length ? new Set(opts.types) : null;
+  return results.filter((result) => {
+    if (opts?.type && result.type !== opts.type) return false;
+    if (types && !types.has(result.type)) return false;
+    if (exactExcludes.has(result.slug)) return false;
+    return !hardExcludes.some(prefix => result.slug.startsWith(prefix));
+  });
+}

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -20,5 +20,23 @@ describe('parseOpArgs', () => {
       source_id: 'gstack-code-repo-0e4763c9',
     });
   });
-});
 
+  test('array params accept comma-separated, repeated, and inline flag forms', () => {
+    const params = parseOpArgs(operationsByName.query, [
+      'acme-example',
+      '--types',
+      'person, company',
+      '--types=note',
+      '--exclude-slug-prefixes',
+      'private/,scratch/',
+      '--include-slug-prefixes=test/',
+    ]);
+
+    expect(params).toMatchObject({
+      query: 'acme-example',
+      types: ['person', 'company', 'note'],
+      exclude_slug_prefixes: ['private/', 'scratch/'],
+      include_slug_prefixes: ['test/'],
+    });
+  });
+});

--- a/test/e2e/search-exclude.test.ts
+++ b/test/e2e/search-exclude.test.ts
@@ -216,6 +216,31 @@ describe('hybridSearch (the real user/MCP surface)', () => {
     expect(slugs).not.toContain('test/fixtures/widget');
     expect(slugs).not.toContain('.raw/widget-dump');
   });
+
+  test('include_slug_prefixes reaches the engine arms through hybridSearch', async () => {
+    const results = await hybridSearch(engine, 'widget test fixture', {
+      limit: 20,
+      include_slug_prefixes: ['test/'],
+    });
+    expect(results.map(r => r.slug)).toContain('test/fixtures/widget');
+  });
+
+  test('exclude_slug_prefixes reaches the engine arms through hybridSearch', async () => {
+    const results = await hybridSearch(engine, 'widget design pattern', {
+      limit: 20,
+      exclude_slug_prefixes: ['concepts/'],
+    });
+    expect(results.map(r => r.slug)).not.toContain('concepts/widget-pattern');
+  });
+
+  test('types reaches the engine arms through hybridSearch', async () => {
+    const results = await hybridSearch(engine, 'widget', {
+      limit: 20,
+      types: ['concept'],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.type === 'concept')).toBe(true);
+  });
 });
 
 describe('caller-supplied exclude_slug_prefixes (additive)', () => {

--- a/test/hybrid-cached-hit-budget-meta.serial.test.ts
+++ b/test/hybrid-cached-hit-budget-meta.serial.test.ts
@@ -130,4 +130,27 @@ describe('cache HIT — token_budget provenance', () => {
     expect(hitMeta?.token_budget?.dropped).toBe(missDropped);
     expect(hitMeta?.token_budget?.kept).toBe(missMeta?.token_budget?.kept);
   });
+
+  test('typed requests bypass untyped cache rows', async () => {
+    const query = 'builder cache isolation';
+    let broadMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const broad = await hybridSearchCached(engine, query, {
+      limit: 10,
+      onMeta: (m) => { broadMeta = m; },
+    });
+    expect(broadMeta?.cache?.status).toBe('miss');
+    expect(new Set(broad.map(r => r.type)).size).toBeGreaterThan(1);
+    await awaitPendingSearchCacheWrites();
+
+    let typedMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const typed = await hybridSearchCached(engine, query, {
+      limit: 10,
+      types: ['company'],
+      onMeta: (m) => { typedMeta = m; },
+    });
+
+    expect(typedMeta?.cache?.status).toBe('disabled');
+    expect(typed.length).toBeGreaterThan(0);
+    expect(typed.every(r => r.type === 'company')).toBe(true);
+  });
 });

--- a/test/query-filter-threading.serial.test.ts
+++ b/test/query-filter-threading.serial.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Query operation filter threading.
+ *
+ * Serial: mock.module must bind before operations.ts imports hybridSearchCached.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realHybrid from '../src/core/search/hybrid.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { HybridSearchOpts } from '../src/core/search/hybrid.ts';
+
+let capturedOpts: HybridSearchOpts | undefined;
+
+mock.module('../src/core/search/hybrid.ts', () => ({
+  ...realHybrid,
+  hybridSearchCached: async (
+    _engine: BrainEngine,
+    _query: string,
+    opts?: HybridSearchOpts,
+  ) => {
+    capturedOpts = opts;
+    return [];
+  },
+}));
+
+const { operationsByName } = await import('../src/core/operations.ts');
+
+const engine = {
+  getConfig: async () => null,
+} as unknown as BrainEngine;
+
+const ctx = {
+  engine,
+  config: { engine: 'pglite' as const },
+  logger: { info: () => {}, warn: () => {}, error: () => {} },
+  dryRun: false,
+  remote: true,
+  sourceId: 'default',
+};
+
+beforeEach(() => {
+  capturedOpts = undefined;
+});
+
+describe('query operation filters', () => {
+  test('declares all three filters on the public operation contract', () => {
+    expect(operationsByName.query.params.types?.type).toBe('array');
+    expect(operationsByName.query.params.exclude_slug_prefixes?.type).toBe('array');
+    expect(operationsByName.query.params.include_slug_prefixes?.type).toBe('array');
+  });
+
+  test('threads page types to the ordinary cached-hybrid path', async () => {
+    await operationsByName.query.handler(ctx, {
+      query: 'acme-example',
+      expand: false,
+      types: ['company', '', 17, ' company '],
+    });
+
+    expect(capturedOpts?.types).toEqual(['company']);
+  });
+
+  test('threads additive hard-exclude prefixes to the ordinary cached-hybrid path', async () => {
+    await operationsByName.query.handler(ctx, {
+      query: 'acme-example',
+      expand: false,
+      exclude_slug_prefixes: ['private/', '', ' private/ '],
+    });
+
+    expect(capturedOpts?.exclude_slug_prefixes).toEqual(['private/']);
+  });
+
+  test('threads search-policy opt-back-in prefixes to the ordinary cached-hybrid path', async () => {
+    await operationsByName.query.handler(ctx, {
+      query: 'acme-example',
+      expand: false,
+      include_slug_prefixes: ['test/', '', ' test/ '],
+    });
+
+    expect(capturedOpts?.include_slug_prefixes).toEqual(['test/']);
+  });
+});

--- a/test/search/alias-hop.test.ts
+++ b/test/search/alias-hop.test.ts
@@ -7,7 +7,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
-import { applyAliasHop } from '../../src/core/search/hybrid.ts';
+import { applyAliasHop, hybridSearch } from '../../src/core/search/hybrid.ts';
 import { importFromContent } from '../../src/core/import-file.ts';
 import type { SearchResult } from '../../src/core/types.ts';
 
@@ -95,6 +95,32 @@ describe('applyAliasHop', () => {
     await engine.setPageAliases('b/hall', 'default', ['the hall']);
     const out = await applyAliasHop(engine, [], 'the hall', { sourceId: 'default' });
     expect(out.map(r => r.slug).sort()).toEqual(['a/hall', 'b/hall']);
+  });
+
+  test('hybrid filters fence alias-injected pages after candidate generation', async () => {
+    await engine.putPage('notes/hidden-canonical', {
+      type: 'note',
+      title: 'Hidden canonical',
+      compiled_truth: 'Only reachable through its chosen alias.',
+    });
+    await engine.setPageAliases('notes/hidden-canonical', 'default', ['chosen name']);
+
+    const typed = await hybridSearch(engine, 'chosen name', { types: ['company'] });
+    expect(typed.map(r => r.slug)).not.toContain('notes/hidden-canonical');
+
+    await engine.putPage('test/hidden-canonical', {
+      type: 'note',
+      title: 'Test canonical',
+      compiled_truth: 'Only reachable through its test alias.',
+    });
+    await engine.setPageAliases('test/hidden-canonical', 'default', ['test chosen name']);
+
+    const excluded = await hybridSearch(engine, 'test chosen name');
+    expect(excluded.map(r => r.slug)).not.toContain('test/hidden-canonical');
+    const included = await hybridSearch(engine, 'test chosen name', {
+      include_slug_prefixes: ['test/'],
+    });
+    expect(included.map(r => r.slug)).toContain('test/hidden-canonical');
   });
 });
 


### PR DESCRIPTION
## Summary

- expose types, exclude_slug_prefixes, and include_slug_prefixes on the query operation
- parse string-array CLI flags as comma-separated or repeatable values, including thin-client calls
- thread filters through image, keyword, title, and vector candidates, then enforce a final fence after alias, relational, and structural arms
- bypass semantic-cache lookup for typed requests so untyped cached rows cannot violate or starve the filter

## Validation

- bun test test/query-filter-threading.serial.test.ts
- bun test test/cli-args.test.ts
- bun test test/e2e/search-exclude.test.ts
- bun test test/search/alias-hop.test.ts
- bun test test/hybrid-cached-hit-budget-meta.serial.test.ts
- bun test test/cli-flag-validation.test.ts test/search-compiled-truth-boost-scope.test.ts test/parity.test.ts
- bun run typecheck
- bun run check:module-size
- bun run check:test-isolation
- bun run check:operations-filter-bypass
- bun run verify (54/54 checks green)

## Non-goal

This does not change exact-title or entity-ranking weights; it makes requested filters reliable across every retrieval arm.