### PR TITLE
v0.46.22.0 fix(doctor): bound sampled entity coverage

### DIFF
--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -18,6 +18,7 @@
 import type { BrainEngine } from '../engine.ts';
 import type { RemediationStep } from '../remediation-step.ts';
 import { makeRemediationStep } from '../remediation-step.ts';
+import { QUARANTINE_FILTER_FRAGMENT } from '../quarantine.ts';
 
 /** Shared shape returned by all four checks. */
 export interface OnboardCheckResult {
@@ -43,6 +44,77 @@ async function safeCount(engine: BrainEngine, sql: string, params: unknown[] = [
   } catch {
     return 0;
   }
+}
+
+const VISIBLE_ENTITY_PREDICATE = `p.type IN ('person', 'company', 'organization', 'entity')
+  AND p.deleted_at IS NULL
+  AND ${QUARANTINE_FILTER_FRAGMENT}`;
+
+type CoverageFeature =
+  | { table: 'links'; pageIdColumn: 'to_page_id' }
+  | { table: 'timeline_entries'; pageIdColumn: 'page_id' };
+
+interface EntityCoverageSample {
+  matched: number;
+  sampleSize: number;
+}
+
+/** Parse a SQL count defensively: coverage is an operator-facing health metric,
+ * so a malformed driver value must not escape as NaN or a negative count. */
+function finiteCount(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+}
+
+/**
+ * Count the feature numerator and denominator from the SAME sampled CTE.
+ * TABLESAMPLE BERNOULLI returns a random number of rows; deriving its
+ * denominator from `total * requestedPercent` can make coverage exceed 100%.
+ */
+async function sampleVisibleEntityCoverage(
+  engine: BrainEngine,
+  sampleClause: string,
+  feature: CoverageFeature,
+): Promise<EntityCoverageSample> {
+  try {
+    const result = await engine.executeRaw(
+      `WITH sampled_entities AS (
+         SELECT p.id
+           FROM pages p ${sampleClause}
+          WHERE ${VISIBLE_ENTITY_PREDICATE}
+       )
+       SELECT
+         COUNT(*)::int AS sample_size,
+         COUNT(*) FILTER (
+           WHERE EXISTS (
+             SELECT 1
+               FROM ${feature.table} f
+              WHERE f.${feature.pageIdColumn} = s.id
+           )
+         )::int AS matched
+         FROM sampled_entities s`,
+    );
+    const rows = (result as { rows?: Array<Record<string, unknown>> } | undefined)?.rows
+      ?? (result as Array<Record<string, unknown>> | undefined)
+      ?? [];
+    const row = rows[0] ?? {};
+    const sampleSize = finiteCount(row.sample_size);
+    // The SQL shape guarantees matched <= sample_size. Keep a defensive clamp
+    // at the rendering boundary so a driver/fixture anomaly still cannot emit
+    // impossible percentages or feed a negative value into sqrt().
+    const matched = Math.min(sampleSize, finiteCount(row.matched));
+    return { matched, sampleSize };
+  } catch {
+    return { matched: 0, sampleSize: 0 };
+  }
+}
+
+function coverageWithConfidence(sample: EntityCoverageSample): { coverage: number; ci: number } {
+  const rawCoverage = sample.sampleSize > 0 ? sample.matched / sample.sampleSize : 0;
+  const coverage = Math.min(1, Math.max(0, rawCoverage));
+  const variance = Math.max(0, coverage * (1 - coverage));
+  const ci = Math.sqrt(variance / Math.max(1, sample.sampleSize));
+  return { coverage, ci };
 }
 
 /**
@@ -115,12 +187,12 @@ export async function checkEmbedStaleness(
 export async function checkEntityLinkCoverage(
   engine: BrainEngine,
 ): Promise<OnboardCheckResult> {
-  // Total entity pages
+  // Total visible entity pages. Quarantined pages are hidden from the brain,
+  // so they are outside both the coverage numerator and denominator.
   const totalEntities = await safeCount(
     engine,
-    `SELECT COUNT(*) AS count FROM pages
-       WHERE type IN ('person', 'company', 'organization', 'entity')
-         AND deleted_at IS NULL`,
+    `SELECT COUNT(*) AS count FROM pages p
+       WHERE ${VISIBLE_ENTITY_PREDICATE}`,
   );
 
   if (totalEntities === 0) {
@@ -137,23 +209,12 @@ export async function checkEntityLinkCoverage(
     : 100;
   const sampleClause = useSample ? `TABLESAMPLE BERNOULLI (${samplePct.toFixed(2)})` : '';
 
-  // Sample query: counts entities with inbound links
-  const linkedCount = await safeCount(
+  const sample = await sampleVisibleEntityCoverage(
     engine,
-    `SELECT COUNT(*) AS count FROM (
-       SELECT p.id FROM pages p ${sampleClause}
-       WHERE p.type IN ('person', 'company', 'organization', 'entity')
-         AND p.deleted_at IS NULL
-         AND EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
-     ) sub`,
+    sampleClause,
+    { table: 'links', pageIdColumn: 'to_page_id' },
   );
-  const sampleSize = useSample
-    ? Math.max(1, Math.round(totalEntities * (samplePct / 100)))
-    : totalEntities;
-
-  const coverage = sampleSize > 0 ? linkedCount / sampleSize : 0;
-  // Wilson-ish confidence interval (1σ; ±sqrt(p(1-p)/n))
-  const ci = Math.sqrt((coverage * (1 - coverage)) / Math.max(1, sampleSize));
+  const { coverage, ci } = coverageWithConfidence(sample);
 
   const pct = Math.round(coverage * 100);
   const ciPct = (ci * 100).toFixed(1);
@@ -213,9 +274,8 @@ export async function checkTimelineCoverage(
 ): Promise<OnboardCheckResult> {
   const totalEntities = await safeCount(
     engine,
-    `SELECT COUNT(*) AS count FROM pages
-       WHERE type IN ('person', 'company', 'organization', 'entity')
-         AND deleted_at IS NULL`,
+    `SELECT COUNT(*) AS count FROM pages p
+       WHERE ${VISIBLE_ENTITY_PREDICATE}`,
   );
 
   if (totalEntities === 0) {
@@ -231,21 +291,12 @@ export async function checkTimelineCoverage(
     : 100;
   const sampleClause = useSample ? `TABLESAMPLE BERNOULLI (${samplePct.toFixed(2)})` : '';
 
-  const withTimelineCount = await safeCount(
+  const sample = await sampleVisibleEntityCoverage(
     engine,
-    `SELECT COUNT(*) AS count FROM (
-       SELECT p.id FROM pages p ${sampleClause}
-       WHERE p.type IN ('person', 'company', 'organization', 'entity')
-         AND p.deleted_at IS NULL
-         AND EXISTS (SELECT 1 FROM timeline_entries t WHERE t.page_id = p.id)
-     ) sub`,
+    sampleClause,
+    { table: 'timeline_entries', pageIdColumn: 'page_id' },
   );
-  const sampleSize = useSample
-    ? Math.max(1, Math.round(totalEntities * (samplePct / 100)))
-    : totalEntities;
-
-  const coverage = sampleSize > 0 ? withTimelineCount / sampleSize : 0;
-  const ci = Math.sqrt((coverage * (1 - coverage)) / Math.max(1, sampleSize));
+  const { coverage, ci } = coverageWithConfidence(sample);
   const pct = Math.round(coverage * 100);
   const ciPct = (ci * 100).toFixed(1);
   const sampleNote = useSample ? ` (sampled ${samplePct.toFixed(1)}%)` : '';

--- a/test/onboard-coverage-invariants.test.ts
+++ b/test/onboard-coverage-invariants.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Coverage checks must derive numerator and denominator from the same visible
+ * entity sample. An estimated Bernoulli denominator can be smaller than the
+ * actual sample, producing impossible values above 100% and a NaN confidence
+ * interval. Quarantined pages are hidden from the brain and must be excluded
+ * from both sides of every coverage ratio.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  checkEntityLinkCoverage,
+  checkTimelineCoverage,
+} from '../src/core/onboard/checks.ts';
+import { buildQuarantineMarker } from '../src/core/quarantine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function seedVisibleAndQuarantinedEntities(): Promise<void> {
+  await engine.putPage('people/visible-example', {
+    type: 'person',
+    title: 'Visible Example',
+    compiled_truth: 'A visible synthetic entity.',
+    timeline: '',
+  });
+  await engine.putPage('people/quarantined-example', {
+    type: 'person',
+    title: 'Quarantined Example',
+    compiled_truth: 'A quarantined synthetic entity.',
+    timeline: '',
+    frontmatter: {
+      quarantine: buildQuarantineMarker('junk_pattern', 'synthetic fixture'),
+    },
+  });
+  await engine.putPage('notes/source-example', {
+    type: 'note',
+    title: 'Source Example',
+    compiled_truth: 'A synthetic source page.',
+    timeline: '',
+  });
+}
+
+describe('onboard entity coverage invariants', () => {
+  test('uses the actual Bernoulli sample size and never emits >100% or NaN', async () => {
+    const queries: string[] = [];
+    let call = 0;
+    const postgres = {
+      kind: 'postgres',
+      async executeRaw(sql: string) {
+        queries.push(sql);
+        call++;
+        if (call === 1) return [{ count: 100_000 }];
+        // The old implementation reads count=7,050 but divides by the
+        // estimated 5,000 rows, yielding "Coverage 141% ± NaN%". The actual
+        // sampled denominator is 10,000, so the truthful result is 71%.
+        return [{ count: 7_050, matched: 7_050, sample_size: 10_000 }];
+      },
+    } as unknown as BrainEngine;
+
+    const result = await checkEntityLinkCoverage(postgres);
+
+    expect(result.check.message).toMatch(/^Coverage 71% ± \d+\.\d%/);
+    expect(result.check.message).not.toMatch(/NaN|Infinity/);
+    expect(result.check.message).not.toMatch(/Coverage 1\d\d%/);
+    expect(queries).toHaveLength(2);
+  });
+
+  test('defensively clamps malformed sampled counts to the 0-100% invariant', async () => {
+    let call = 0;
+    const postgres = {
+      kind: 'postgres',
+      async executeRaw() {
+        call++;
+        if (call === 1) return [{ count: 100_000 }];
+        return [{ matched: 12_000, sample_size: 10_000 }];
+      },
+    } as unknown as BrainEngine;
+
+    const result = await checkEntityLinkCoverage(postgres);
+
+    expect(result.check.message).toMatch(/^Coverage 100% ± 0\.0%/);
+    expect(result.check.message).not.toMatch(/NaN|Infinity/);
+  });
+
+  test('entity-link coverage excludes quarantined entities from numerator and denominator', async () => {
+    await seedVisibleAndQuarantinedEntities();
+    await engine.addLink(
+      'notes/source-example',
+      'people/quarantined-example',
+      '',
+      'mentions',
+      'manual',
+    );
+
+    const result = await checkEntityLinkCoverage(engine);
+
+    expect(result.check.message).toMatch(/^Coverage 0% ± 0\.0%/);
+    expect(result.check.message).not.toContain('50%');
+  });
+
+  test('timeline coverage applies the same visible-sample invariant', async () => {
+    await seedVisibleAndQuarantinedEntities();
+    await engine.addTimelineEntry('people/quarantined-example', {
+      date: '2026-01-01',
+      source: 'synthetic fixture',
+      summary: 'Synthetic event',
+    });
+
+    const result = await checkTimelineCoverage(engine);
+
+    expect(result.check.message).toMatch(/^Coverage 0% ± 0\.0%/);
+    expect(result.check.message).not.toContain('50%');
+  });
+});


### PR DESCRIPTION
## Summary

The doctor/onboard `entity_link_coverage` check estimated the denominator of a Postgres Bernoulli sample as `totalEntities * requestedPercent`, but Bernoulli sampling returns a variable number of rows. When the actual sample (or its eligibility predicates) exceeded that estimate, the check could report more than 100%; `sqrt(p * (1 - p) / n)` then received a negative value and rendered `NaN`.

This patch:

- counts the numerator and actual denominator from the same sampled CTE
- applies the canonical quarantine visibility predicate to both the total and sampled entity sets
- reuses the same invariant for `timeline_coverage`, which had the identical sampling path
- normalizes SQL counts and defensively clamps `matched <= sample_size` and coverage to `[0, 1]`
- preserves the existing thresholds, remediation policy, sampling rate, and message schema

## TDD evidence

The new public-seam regression reproduced the production failure before the fix:

```text
Expected: Coverage 71% ± ...
Received: Coverage 141% ± NaN% (sampled 5.0%)
```

Two PGLite integration cases also failed before the visibility predicates were aligned: a linked/timelined quarantined entity inflated both metrics from the truthful 0% to 50%.

The final cases cover:

- actual Bernoulli sample size as denominator
- finite coverage bounded to 0–100%
- defensive clamping of malformed driver counts
- quarantine exclusion for entity-link coverage
- the same quarantine/sample invariant for timeline coverage

## Verification

- `bun test test/onboard-coverage-invariants.test.ts test/e2e/onboard-full-flow.test.ts test/init-nudge.test.ts test/onboard-pack-upgrade-checks.test.ts test/doctor-graph-coverage-soft-deleted.test.ts` — 33 pass, 0 fail
- `bun run typecheck` — pass
- `bun run check:module-size` — pass
- `bun run verify` — 54/54 pass

The repository-wide unit run reached 18,644 pass / 8 fail / 22 skip. The eight failures are the same unrelated stock failures already reproduced on a detached clean `origin/master` worktree: doctor parser-probe shape, check-resolvable environment fixtures, reflex event logging, worker registry, and brain-repo durability. The changed onboard/doctor coverage surfaces are green.
