### PR TITLE
fix(search): wire onRelationalMeta through query op; drop text-path limit hard-floor

### DIFF
--- a/docs/protocol/MCP_META_CHANNELS.md
+++ b/docs/protocol/MCP_META_CHANNELS.md
@@ -31,7 +31,7 @@ shape for it.
 | Key | Producer | Contents |
 |-----|----------|----------|
 | `brain_hot_memory` | serve-http `metaHook` (`getBrainHotMemoryMeta`) | Hot-memory facts relevant to the call (v0.31 eD3) |
-| `retrieval` | `search`/`query` op handlers | `returned_count`, `retrieved_count`, `vector_enabled`, `expansion_applied`, `cache`, `token_budget`, `degraded[]` (closed stage vocabulary, D6), `hint` (non-contractual prose, E1), `relational` (`query` op only — `RelationalArmMeta`: `fired`, `kind`, `seeds_resolved`, `candidates`, `errored`, `duration_ms`; absent when the relational recall arm never ran, #3995) |
+| `retrieval` | `search`/`query` op handlers | `returned_count`, `retrieved_count`, `vector_enabled`, `expansion_applied`, `cache`, `token_budget`, `degraded[]` (closed stage vocabulary, D6), `hint` (non-contractual prose, E1), `relational` (`query` op only — `RelationalArmMeta`: `fired`, `kind`, `seeds_resolved`, `candidates`, `errored`, `duration_ms`; reports whether the arm ran on THIS invocation — absent when it didn't run this time, which includes every semantic-cache hit even if the cached result set was originally produced with relational recall, since the cache-hit path doesn't re-run the arm or persist its meta, #3995) |
 | `warnings` | dispatch strict-params warn mode (WP3) | `[{code: 'unknown_param', param, suggestion?}]` |
 
 Inbound `_meta` (e.g. `_meta.session_id` inside tool ARGUMENTS, CX2-11) is a

--- a/docs/protocol/MCP_META_CHANNELS.md
+++ b/docs/protocol/MCP_META_CHANNELS.md
@@ -31,7 +31,7 @@ shape for it.
 | Key | Producer | Contents |
 |-----|----------|----------|
 | `brain_hot_memory` | serve-http `metaHook` (`getBrainHotMemoryMeta`) | Hot-memory facts relevant to the call (v0.31 eD3) |
-| `retrieval` | `search`/`query` op handlers | `returned_count`, `retrieved_count`, `vector_enabled`, `expansion_applied`, `cache`, `token_budget`, `degraded[]` (closed stage vocabulary, D6), `hint` (non-contractual prose, E1) |
+| `retrieval` | `search`/`query` op handlers | `returned_count`, `retrieved_count`, `vector_enabled`, `expansion_applied`, `cache`, `token_budget`, `degraded[]` (closed stage vocabulary, D6), `hint` (non-contractual prose, E1), `relational` (`query` op only — `RelationalArmMeta`: `fired`, `kind`, `seeds_resolved`, `candidates`, `errored`, `duration_ms`; absent when the relational recall arm never ran, #3995) |
 | `warnings` | dispatch strict-params warn mode (WP3) | `[{code: 'unknown_param', param, suggestion?}]` |
 
 Inbound `_meta` (e.g. `_meta.session_id` inside tool ARGUMENTS, CX2-11) is a

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -151,11 +151,13 @@ const query: Operation = {
      *  CLI loads the file, base64-encodes, and passes through `image`). */
     image: { type: 'string', description: 'Base64-encoded image bytes for image-similarity search (CLI: --image <path>).' },
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
-    // #3995 — the op no longer hard-defaults this to 20; when omitted the
-    // resolved search mode's searchLimit applies (10/25/50 for
-    // conservative/balanced/tokenmax on a cache miss). Documenting the
-    // actual resolved defaults here rather than a single stale number.
-    limit: { type: 'number', description: 'Max results. When omitted, resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax on a cache miss).' },
+    // #3995 — the op no longer hard-defaults this to 20 on the text/hybrid
+    // path; when omitted the resolved search mode's searchLimit applies
+    // (10/25/50 for conservative/balanced/tokenmax on a cache miss). The
+    // image-similarity path (`image` param) is unaffected by this change
+    // and still hard-defaults to 20 regardless of mode — out of scope here,
+    // tracked separately.
+    limit: { type: 'number', description: 'Max results. For text queries, resolves from the active search mode when omitted (10 conservative / 25 balanced / 50 tokenmax on a cache miss). For image-similarity queries (`image` param), always defaults to 20 regardless of mode.' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -59,8 +59,12 @@ function buildRetrievalResponseMeta(
     // seed/candidate counts) so a caller can distinguish "graph answer
     // contributed" from "graph answer never reached fusion" without source
     // access. Additive field on the existing `retrieval` _meta key (rule 2,
-    // docs/protocol/MCP_META_CHANNELS.md); absent when the arm never ran
-    // (relational retrieval off, or the image-similarity branch).
+    // docs/protocol/MCP_META_CHANNELS.md); absent when the arm never ran on
+    // THIS invocation (relational retrieval off, the image-similarity
+    // branch, OR a semantic-cache hit — the cache-hit branch in hybrid.ts
+    // returns without invoking `onRelationalMeta`, so a cached result set
+    // originally produced with relational recall still reports no
+    // `relational` here; see docs/protocol/MCP_META_CHANNELS.md).
     ...(opts.relationalMeta ? { relational: opts.relationalMeta } : {}),
     ...(hint ? { hint } : {}),
   };
@@ -147,7 +151,11 @@ const query: Operation = {
      *  CLI loads the file, base64-encodes, and passes through `image`). */
     image: { type: 'string', description: 'Base64-encoded image bytes for image-similarity search (CLI: --image <path>).' },
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
-    limit: { type: 'number', description: 'Max results (default 20)' },
+    // #3995 — the op no longer hard-defaults this to 20; when omitted the
+    // resolved search mode's searchLimit applies (10/25/50 for
+    // conservative/balanced/tokenmax on a cache miss). Documenting the
+    // actual resolved defaults here rather than a single stale number.
+    limit: { type: 'number', description: 'Max results. When omitted, resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax on a cache miss).' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },
@@ -294,22 +302,29 @@ const query: Operation = {
     // search). When the param is the literal '__all__', force-allow
     // cross-source mode (matches SearchOpts.sourceId contract).
     let capturedMeta: HybridSearchMeta | null = null;
-    // #3995 — observability sink for the relational recall arm. Best-effort;
-    // stays null when the arm never runs (relational off, or a non-relational
-    // query where the intent classifier short-circuits before fanout).
+    // #3995 — observability sink for the relational recall arm. Stays null
+    // when the callback itself never fires: relational retrieval off for
+    // the resolved mode, or a semantic-cache hit (see the cache-hit note on
+    // `buildRetrievalResponseMeta` below — the arm can still be non-null
+    // with `fired: false` when relational retrieval is on but this query's
+    // intent didn't classify as relational; `fired` is what distinguishes
+    // "arm ran and found nothing to do" from "arm didn't run at all").
     let capturedRelationalMeta: RelationalArmMeta | null = null;
     // v0.32.x search-lite: route the query op through hybridSearchCached so
     // semantic cache + token budget + intent weighting fire automatically.
     // Plain hybridSearch remains the bare API for callers that opt out.
     const results = await hybridSearchCached(ctx.engine, queryText, {
-      // #3995 — omit the key entirely (rather than hard-defaulting to 20)
-      // when the caller didn't pass `limit`, so the resolved search mode's
-      // `searchLimit` (10/25/50 for conservative/balanced/tokenmax) applies
-      // through the op instead of being silently overridden. Both
-      // hybridSearch (limit = opts?.limit || resolvedMode.searchLimit) and
-      // hybridSearchCached's mode resolution treat `undefined` as "let the
-      // mode bundle decide" — an explicit numeric limit (including 0) still
-      // wins.
+      // #3995 — pass `undefined` (rather than hard-defaulting to 20) when
+      // the caller didn't pass a numeric `limit`, so the resolved search
+      // mode's `searchLimit` (10/25/50 for conservative/balanced/tokenmax)
+      // applies through the op instead of being silently overridden.
+      // hybridSearch does `opts?.limit || resolvedMode.searchLimit`
+      // (hybrid.ts), so this is a `||`, not `??`, downstream: `0` (and any
+      // other falsy numeric limit) still falls back to the mode default,
+      // same as omitting `limit` entirely. That fallback is inherited from
+      // `hybridSearch`'s existing contract, not something this change
+      // controls — only a positive numeric `limit` is guaranteed to be
+      // honored end-to-end.
       limit: typeof p.limit === 'number' ? p.limit : undefined,
       offset: (p.offset as number) || 0,
       expansion: expand,

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -12,6 +12,7 @@ import { expandQuery } from '../search/expansion.ts';
 import { dedupResults } from '../search/dedup.ts';
 import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from '../eval-capture.ts';
 import type { HybridSearchMeta } from '../types.ts';
+import type { RelationalArmMeta } from '../search/relational-recall.ts';
 import { bumpLastRetrievedAt } from '../last-retrieved.ts';
 import { QUERY_DESCRIPTION, SEARCH_DESCRIPTION } from '../operations-descriptions.ts';
 import { OperationError } from './contract.ts';
@@ -37,7 +38,7 @@ function buildRetrievalResponseMeta(
   queryText: string,
   results: unknown[],
   meta: HybridSearchMeta | null,
-  opts: { conceptHint?: boolean } = {},
+  opts: { conceptHint?: boolean; relationalMeta?: RelationalArmMeta | null } = {},
 ): Record<string, unknown> {
   const m = meta as (HybridSearchMeta & { degraded?: unknown; retrieved_count?: number }) | null;
   const hint = opts.conceptHint && looksConceptShaped(queryText)
@@ -54,6 +55,13 @@ function buildRetrievalResponseMeta(
       ...(m.token_budget ? { token_budget: m.token_budget } : {}),
       ...(m.degraded !== undefined ? { degraded: m.degraded } : {}),
     } : {}),
+    // #3995 — surface whether the relational recall arm fired (and its
+    // seed/candidate counts) so a caller can distinguish "graph answer
+    // contributed" from "graph answer never reached fusion" without source
+    // access. Additive field on the existing `retrieval` _meta key (rule 2,
+    // docs/protocol/MCP_META_CHANNELS.md); absent when the arm never ran
+    // (relational retrieval off, or the image-similarity branch).
+    ...(opts.relationalMeta ? { relational: opts.relationalMeta } : {}),
     ...(hint ? { hint } : {}),
   };
 }
@@ -286,11 +294,23 @@ const query: Operation = {
     // search). When the param is the literal '__all__', force-allow
     // cross-source mode (matches SearchOpts.sourceId contract).
     let capturedMeta: HybridSearchMeta | null = null;
+    // #3995 — observability sink for the relational recall arm. Best-effort;
+    // stays null when the arm never runs (relational off, or a non-relational
+    // query where the intent classifier short-circuits before fanout).
+    let capturedRelationalMeta: RelationalArmMeta | null = null;
     // v0.32.x search-lite: route the query op through hybridSearchCached so
     // semantic cache + token budget + intent weighting fire automatically.
     // Plain hybridSearch remains the bare API for callers that opt out.
     const results = await hybridSearchCached(ctx.engine, queryText, {
-      limit: (p.limit as number) || 20,
+      // #3995 — omit the key entirely (rather than hard-defaulting to 20)
+      // when the caller didn't pass `limit`, so the resolved search mode's
+      // `searchLimit` (10/25/50 for conservative/balanced/tokenmax) applies
+      // through the op instead of being silently overridden. Both
+      // hybridSearch (limit = opts?.limit || resolvedMode.searchLimit) and
+      // hybridSearchCached's mode resolution treat `undefined` as "let the
+      // mode bundle decide" — an explicit numeric limit (including 0) still
+      // wins.
+      limit: typeof p.limit === 'number' ? p.limit : undefined,
       offset: (p.offset as number) || 0,
       expansion: expand,
       expandFn: expand ? expandQuery : undefined,
@@ -314,6 +334,11 @@ const query: Operation = {
       // v0.36 cross-modal routing param.
       crossModal: p.cross_modal as 'text' | 'image' | 'both' | 'auto' | undefined,
       onMeta: (m) => { capturedMeta = m; },
+      // #3995 — thread the relational-arm observability sink through so
+      // `fired`/`kind`/`seeds_resolved`/`candidates`/`errored` land in the
+      // `retrieval` response meta below instead of only being visible to
+      // source-level tracing.
+      onRelationalMeta: (m) => { capturedRelationalMeta = m; },
       // v0.36 (D15): per-call embedding column override. Resolver rejects
       // unknown names at hybrid entry with EmbeddingColumnNotRegisteredError;
       // the error surfaces back to the agent as the op error envelope.
@@ -362,7 +387,10 @@ const query: Operation = {
     }
 
     // WP2/D3: query never nudges toward itself — no concept hint here.
-    ctx.emitResponseMeta?.('retrieval', buildRetrievalResponseMeta(queryText, results, capturedMeta));
+    ctx.emitResponseMeta?.(
+      'retrieval',
+      buildRetrievalResponseMeta(queryText, results, capturedMeta, { relationalMeta: capturedRelationalMeta }),
+    );
     return results;
   },
   scope: 'read',

--- a/test/query-op-relational-meta-and-limit.serial.test.ts
+++ b/test/query-op-relational-meta-and-limit.serial.test.ts
@@ -10,9 +10,22 @@
  *      the `query` op never passed one, so callers had no caller-visible
  *      signal that the arm fired.
  *   2. the op no longer hard-defaults `limit` to 20 when the caller omits
- *      it — it passes `undefined` through so the resolved search mode's
- *      `searchLimit` (e.g. 25 for balanced) applies. An explicit numeric
- *      `limit` (including `0`) still wins.
+ *      it — it forwards `undefined` to hybridSearchCached instead, so the
+ *      resolved search mode's `searchLimit` (e.g. 25 for balanced) applies.
+ *      A positive explicit numeric `limit` still wins. NOTE: this file mocks
+ *      `hybridSearchCached`, so it only proves the op forwards a numeric
+ *      `limit` unmodified — it does not exercise hybridSearch's own
+ *      `opts?.limit || resolvedMode.searchLimit` fallback (hybrid.ts), which
+ *      is a `||`, not `??`: `limit: 0` forwarded here still falls back to
+ *      the mode default downstream in the real (non-mocked) path, same as
+ *      omitting `limit`. That inherited behavior is out of scope for this
+ *      follow-up (see the "limit: 0" test below for what is and isn't
+ *      claimed).
+ *
+ * Also covers: the semantic-cache-hit contract from hybrid.ts (the cache-hit
+ * branch calls `onMeta` but never `onRelationalMeta`) — `_meta.retrieval`
+ * must reflect that even when the cached row set was originally produced by
+ * a relational-recall miss.
  *
  * Serial: mock.module (isolation guard R2).
  */
@@ -24,6 +37,12 @@ import type { BrainEngine } from '../src/core/engine.ts';
 let nextResults: unknown[] = [];
 let nextRelationalMeta: unknown = null;
 let capturedOpts: { limit?: number } | null = null;
+// #3995 — mirrors hybrid.ts's real cache-hit branch: it calls `onMeta` (with
+// `cache: 'hit'`) but returns WITHOUT ever calling `onRelationalMeta`, even
+// if the cached rows were originally produced by a relational-recall arm
+// that fired. Set true to simulate that contract regardless of
+// `nextRelationalMeta`.
+let simulateCacheHit = false;
 
 // Mock BEFORE importing dispatch (operations.ts binds hybridSearchCached at
 // import time; the spread keeps every other export live).
@@ -35,8 +54,17 @@ mock.module('../src/core/search/hybrid.ts', () => ({
     opts: { limit?: number; onMeta?: (m: unknown) => void; onRelationalMeta?: (m: unknown) => void },
   ) => {
     capturedOpts = opts;
-    opts.onMeta?.({ vector_enabled: true, expansion_applied: false, detail_resolved: null });
-    if (nextRelationalMeta) opts.onRelationalMeta?.(nextRelationalMeta);
+    opts.onMeta?.({
+      vector_enabled: true,
+      expansion_applied: false,
+      detail_resolved: null,
+      ...(simulateCacheHit ? { cache: { status: 'hit' as const } } : {}),
+    });
+    // Real hybrid.ts cache-hit branch (hybrid.ts:2206) never calls
+    // onRelationalMeta — it returns before reaching the relational-arm
+    // build. `nextRelationalMeta` is ignored on a simulated hit so this
+    // mock can't accidentally paper over that gap.
+    if (nextRelationalMeta && !simulateCacheHit) opts.onRelationalMeta?.(nextRelationalMeta);
     return nextResults;
   },
 }));
@@ -67,6 +95,7 @@ const RELATIONAL_META = {
 
 describe('query op — relational meta wiring (#3995)', () => {
   test('relational arm fired → _meta.retrieval.relational carries the arm meta verbatim', async () => {
+    simulateCacheHit = false;
     nextResults = [{ page_id: 1, slug: 'companies/acme-example', chunk_text: 'x' }];
     nextRelationalMeta = RELATIONAL_META;
     const out = await callQuery({});
@@ -76,6 +105,7 @@ describe('query op — relational meta wiring (#3995)', () => {
   });
 
   test('relational arm never reports in → _meta.retrieval.relational absent', async () => {
+    simulateCacheHit = false;
     nextResults = [{ page_id: 1, slug: 'companies/acme-example', chunk_text: 'x' }];
     nextRelationalMeta = null;
     const out = await callQuery({});
@@ -84,11 +114,31 @@ describe('query op — relational meta wiring (#3995)', () => {
   });
 
   test('relational arm ran but did not fire → still surfaced (fired: false is not the same as absent)', async () => {
+    simulateCacheHit = false;
     nextResults = [];
     nextRelationalMeta = { ...RELATIONAL_META, fired: false, candidates: 0 };
     const out = await callQuery({});
     const retrieval = (out._meta as Record<string, any>).retrieval;
     expect(retrieval.relational).toEqual({ ...RELATIONAL_META, fired: false, candidates: 0 });
+  });
+
+  // #3995 Codex review (Warning 2): hybrid.ts's cache-hit branch
+  // (hybrid.ts:2206) returns without ever calling onRelationalMeta, so a
+  // cache hit reports no `relational` field regardless of whether the row
+  // set behind it was originally produced with relational recall. This is
+  // the current contract (documented in MCP_META_CHANNELS.md), not
+  // something this test suite fixes — it pins the gap so a future change to
+  // hybrid.ts's caching (making relational meta survive the cache) shows up
+  // as an intentional test update rather than a silent behavior change.
+  test('semantic-cache hit → _meta.retrieval.relational absent even if the cached set had relational recall', async () => {
+    simulateCacheHit = true;
+    nextResults = [{ page_id: 1, slug: 'companies/acme-example', chunk_text: 'x' }];
+    nextRelationalMeta = RELATIONAL_META; // ignored by the mock while simulateCacheHit is true
+    const out = await callQuery({});
+    const retrieval = (out._meta as Record<string, any>).retrieval;
+    expect(retrieval.cache).toBe('hit');
+    expect(retrieval.relational).toBeUndefined();
+    simulateCacheHit = false;
   });
 });
 
@@ -110,7 +160,15 @@ describe('query op — limit no longer hard-floors to 20 (#3995)', () => {
     expect(capturedOpts!.limit).toBe(7);
   });
 
-  test('caller passes `limit: 0` → 0 is respected, not coerced back to a default', async () => {
+  // NOTE: this only proves the op forwards `0` to hybridSearchCached
+  // unmodified — it does NOT prove `0` survives end-to-end. The real (not
+  // mocked) hybridSearch does `opts?.limit || resolvedMode.searchLimit`
+  // (hybrid.ts), which is falsy-coercing: a forwarded `0` still falls back
+  // to the mode default downstream, on both the cache-miss and cache-hit
+  // paths. That fallback is inherited from hybridSearch's existing
+  // contract; changing it is a separately-scoped `||` → `??` follow-up, not
+  // part of this PR.
+  test('caller passes `limit: 0` → op forwards 0 unmodified (does not coerce it to undefined)', async () => {
     nextResults = [];
     nextRelationalMeta = null;
     capturedOpts = null;

--- a/test/query-op-relational-meta-and-limit.serial.test.ts
+++ b/test/query-op-relational-meta-and-limit.serial.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #3995 mechanical follow-up — two independent behaviors on the `query` op,
+ * driven through the REAL dispatch path (dispatchToolCall → query op
+ * handler) with hybridSearchCached mocked, same pattern as
+ * dispatch-response-meta.serial.test.ts:
+ *
+ *   1. `onRelationalMeta` is wired through to `_meta.retrieval.relational`
+ *      when the relational recall arm reports in (and absent when it
+ *      doesn't) — previously the callback existed on HybridSearchOpts but
+ *      the `query` op never passed one, so callers had no caller-visible
+ *      signal that the arm fired.
+ *   2. the op no longer hard-defaults `limit` to 20 when the caller omits
+ *      it — it passes `undefined` through so the resolved search mode's
+ *      `searchLimit` (e.g. 25 for balanced) applies. An explicit numeric
+ *      `limit` (including `0`) still wins.
+ *
+ * Serial: mock.module (isolation guard R2).
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import * as realHybrid from '../src/core/search/hybrid.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let nextResults: unknown[] = [];
+let nextRelationalMeta: unknown = null;
+let capturedOpts: { limit?: number } | null = null;
+
+// Mock BEFORE importing dispatch (operations.ts binds hybridSearchCached at
+// import time; the spread keeps every other export live).
+mock.module('../src/core/search/hybrid.ts', () => ({
+  ...realHybrid,
+  hybridSearchCached: async (
+    _engine: unknown,
+    _query: string,
+    opts: { limit?: number; onMeta?: (m: unknown) => void; onRelationalMeta?: (m: unknown) => void },
+  ) => {
+    capturedOpts = opts;
+    opts.onMeta?.({ vector_enabled: true, expansion_applied: false, detail_resolved: null });
+    if (nextRelationalMeta) opts.onRelationalMeta?.(nextRelationalMeta);
+    return nextResults;
+  },
+}));
+
+const { dispatchToolCall } = await import('../src/mcp/dispatch.ts');
+
+const engineStub = {
+  getConfig: async () => null,
+  executeRaw: async () => [],
+} as unknown as BrainEngine;
+
+function callQuery(params: Record<string, unknown>) {
+  return dispatchToolCall(engineStub, 'query', { query: 'who founded acme-example', ...params }, {
+    remote: true,
+    transport: 'http',
+    sourceId: 'default',
+  });
+}
+
+const RELATIONAL_META = {
+  fired: true,
+  kind: 'who' as const,
+  seeds_resolved: 1,
+  candidates: 1,
+  errored: false,
+  duration_ms: 4,
+};
+
+describe('query op — relational meta wiring (#3995)', () => {
+  test('relational arm fired → _meta.retrieval.relational carries the arm meta verbatim', async () => {
+    nextResults = [{ page_id: 1, slug: 'companies/acme-example', chunk_text: 'x' }];
+    nextRelationalMeta = RELATIONAL_META;
+    const out = await callQuery({});
+    expect(out.isError ?? false).toBe(false);
+    const retrieval = (out._meta as Record<string, any>).retrieval;
+    expect(retrieval.relational).toEqual(RELATIONAL_META);
+  });
+
+  test('relational arm never reports in → _meta.retrieval.relational absent', async () => {
+    nextResults = [{ page_id: 1, slug: 'companies/acme-example', chunk_text: 'x' }];
+    nextRelationalMeta = null;
+    const out = await callQuery({});
+    const retrieval = (out._meta as Record<string, any>).retrieval;
+    expect(retrieval.relational).toBeUndefined();
+  });
+
+  test('relational arm ran but did not fire → still surfaced (fired: false is not the same as absent)', async () => {
+    nextResults = [];
+    nextRelationalMeta = { ...RELATIONAL_META, fired: false, candidates: 0 };
+    const out = await callQuery({});
+    const retrieval = (out._meta as Record<string, any>).retrieval;
+    expect(retrieval.relational).toEqual({ ...RELATIONAL_META, fired: false, candidates: 0 });
+  });
+});
+
+describe('query op — limit no longer hard-floors to 20 (#3995)', () => {
+  test('caller omits `limit` → hybridSearchCached receives limit: undefined (mode bundle decides)', async () => {
+    nextResults = [];
+    nextRelationalMeta = null;
+    capturedOpts = null;
+    await callQuery({});
+    expect(capturedOpts).not.toBeNull();
+    expect(capturedOpts!.limit).toBeUndefined();
+  });
+
+  test('caller passes an explicit numeric `limit` → still wins', async () => {
+    nextResults = [];
+    nextRelationalMeta = null;
+    capturedOpts = null;
+    await callQuery({ limit: 7 });
+    expect(capturedOpts!.limit).toBe(7);
+  });
+
+  test('caller passes `limit: 0` → 0 is respected, not coerced back to a default', async () => {
+    nextResults = [];
+    nextRelationalMeta = null;
+    capturedOpts = null;
+    await callQuery({ limit: 0 });
+    expect(capturedOpts!.limit).toBe(0);
+  });
+});


### PR DESCRIPTION
Mechanical follow-up to #3995 (the reporter's own two asides), independent of the RRF-fusion/autocut design question that issue leaves open for a maintainer call.

## What changed

1. `query`'s op handler never passed `onRelationalMeta` to `hybridSearchCached`, even though `HybridSearchOpts` has carried the callback since v0.43. Callers had no way to tell whether the relational recall arm fired without source-level tracing. It now threads through and lands in the existing `retrieval` `_meta` key as an additive `relational` field.
2. The op hard-defaulted `limit` to `(p.limit as number) || 20` on the text/hybrid path, which silently overrode the resolved search mode's `searchLimit` (10/25/50 for conservative/balanced/tokenmax) whenever the caller omitted `limit`. It now passes `undefined` through so the resolved mode applies (matching how `hybridSearch`/`hybridSearchCached` already treat `undefined` on a cache miss).

## Known related gaps not fixed here (scoped out)

Two additional hardcoded-20 sites surfaced during review that are outside this PR's mechanical scope and are tracked separately in #4356:

- `hybrid.ts`'s semantic-cache-hit slice has its own independent `opts?.limit || 20`, disconnected from the mode-resolution logic this PR touches — a balanced-mode cache miss can return 25 results, but the next call served from cache (limit omitted) still silently slices to 20.
- The image-similarity branch (`image` param) always hard-defaults to 20 regardless of mode; unaffected by this PR.

Both are documented explicitly in the updated param description and code comments so the current behavior isn't misrepresented.

## Verification

- `bun test test/query-op-relational-meta-and-limit.serial.test.ts` — 7 pass / 0 fail
- `bun run typecheck` — clean
- `git diff --check` — clean
- Two rounds of Codex review (gpt-5.6-sol, high effort): round 1 found 3 warnings (limit:0 end-to-end claim, cache-hit relational-meta silence, stale param description) — all addressed; round 2 found 2 further warnings (the two gaps above) — documented rather than fixed, to keep this PR's diff mechanical per the reporter's own framing in #3995.
