### PR TITLE
fix(search): honor resolved mode searchLimit on cache-hit and image-similarity limit defaults

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3486	ratchet	grown v0.46.23.0: awaited stdout delivery (#3423)
 src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyclePhases + normalizeQueuedSourcePhases + deriveStatus exclusion filter)
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match
 src/commands/jobs.ts	3027	ratchet	grown v0.46.22.0 phone wave: github source sync job (#4104)
-src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: supersede scoping + edge-existence gate
+src/core/search/hybrid.ts	2640	ratchet	grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20`
 src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -139,7 +139,12 @@ const query: Operation = {
      *  CLI loads the file, base64-encodes, and passes through `image`). */
     image: { type: 'string', description: 'Base64-encoded image bytes for image-similarity search (CLI: --image <path>).' },
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
-    limit: { type: 'number', description: 'Max results (default 20)' },
+    // #4356 — the image-similarity branch (`image` param) no longer hard-
+    // defaults this to 20; when omitted it now resolves from the active
+    // search mode's searchLimit, same convention as hybridSearch. The text
+    // path is a separate hardcoded-20 site tracked in #4355 (not touched
+    // here, to keep this fix's diff scoped to the image branch).
+    limit: { type: 'number', description: 'Max results. For image-similarity queries (`image` param), resolves from the active search mode when omitted (10 conservative / 25 balanced / 50 tokenmax). For text queries, currently still hard-defaults to 20 regardless of mode (tracked separately in #4355).' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },
@@ -253,12 +258,28 @@ const query: Operation = {
       const [vec] = await embedMultimodal([
         { kind: 'image_base64', data: imageData, mime: imageMime },
       ]);
+      // #4356 — this branch bypasses hybridSearch entirely, so it never
+      // saw the resolved search mode's `searchLimit` and always hard-
+      // defaulted to 20 regardless of mode (10/25/50 for conservative/
+      // balanced/tokenmax). Resolve the same mode + per-key overrides
+      // hybridSearch/hybridSearchCached use (mode.ts:resolveSearchMode) so
+      // an omitted `limit` follows the active mode here too, mirroring the
+      // `opts?.limit || resolvedMode.searchLimit` pattern those call sites
+      // already use. `p.mode` is honored the same way the text path honors
+      // it (resolvePerCallMode — local/trusted callers only; remote falls
+      // through to the server-configured mode).
+      const { loadSearchModeConfig, resolveSearchMode } = await import('../search/mode.ts');
+      const imageModeInput = await loadSearchModeConfig(ctx.engine);
+      const imageResolvedMode = resolveSearchMode({
+        mode: resolvePerCallMode(ctx, p.mode) ?? imageModeInput.mode,
+        overrides: imageModeInput.overrides,
+      });
       // v0.34.1 (#861 F2 — 6th leak surface): the image path bypasses
       // hybridSearch and calls searchVector directly, so it needs its
       // own thread of the source scope. Pre-fix, this branch leaked
       // image pages across sources independent of the text path's fix.
       const results = await ctx.engine.searchVector(vec, {
-        limit: (p.limit as number) || 20,
+        limit: (p.limit as number) || imageResolvedMode.searchLimit,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
         ...querySourceScope,

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2267,7 +2267,14 @@ export async function hybridSearchCached(
       cacheSimilarity = hit.similarity;
       cacheAge = hit.ageSeconds;
 
-      const limit = opts?.limit || 20;
+      // #4356 — was a hard `|| 20`, independent of the mode-resolution the
+      // miss path uses (`opts?.limit || resolvedMode.searchLimit` above, in
+      // bare hybridSearch): a balanced-mode miss could cache 25 results,
+      // then the next identical-shape hit sliced that row down to 20.
+      // `resolvedForCache` is already the same resolved-mode knob set the
+      // miss path uses, so mirroring its `searchLimit` keeps hit/miss
+      // consistent without re-resolving the mode.
+      const limit = opts?.limit || resolvedForCache.searchLimit;
       const offset = opts?.offset || 0;
       const sliced = hit.results.slice(offset, offset + limit);
 

--- a/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
+++ b/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #4356 — the semantic-cache-hit slice used a hard `opts?.limit || 20`,
+ * independent of the mode-resolution logic the cache-MISS path uses
+ * (`opts?.limit || resolvedMode.searchLimit`, bare hybridSearch). In
+ * `balanced` mode (searchLimit: 25) a miss with `limit` omitted could
+ * return and cache up to 25 results, but the next identical-shape call
+ * served from cache silently sliced that cached row down to 20 —
+ * inconsistent between the miss and hit paths for the same call shape.
+ *
+ * Drives a real store→hit roundtrip (mocked `embed`/`embedQuery` for a
+ * deterministic vector, real PGLite SemanticQueryCache — same pattern as
+ * test/hybrid-cached-hit-budget-meta.serial.test.ts) with 30 keyword-
+ * findable pages spread across 6 page types (dedup's type-diversity layer
+ * caps any one type at 60% of the result set, so a single type would
+ * silently shrink the pool below 25 regardless of this fix). `autocut` and
+ * `relationalRetrieval` are forced off per-call so the result count is
+ * driven only by the limit slice under test, not by an unrelated cliff cut
+ * or graph arm.
+ *
+ * Serial: mock.module (isolation guard R2).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realEmbedding from '../src/core/embedding.ts';
+
+/** Deterministic 1536d unit vector — identical for every call, so the
+ * second consult matches the first write at cosine 1.0. */
+function fixedEmbedding(): Float32Array {
+  const arr = new Float32Array(1536);
+  for (let i = 0; i < 1536; i++) arr[i] = Math.sin(1 + i * 0.001);
+  let norm = 0;
+  for (let i = 0; i < 1536; i++) norm += arr[i] * arr[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < 1536; i++) arr[i] /= norm;
+  return arr;
+}
+
+// Mock BEFORE importing hybrid.ts (spread keeps every other export live).
+mock.module('../src/core/embedding.ts', () => ({
+  ...realEmbedding,
+  embed: async () => fixedEmbedding(),
+  embedQuery: async () => fixedEmbedding(),
+}));
+
+// Import AFTER mocking.
+const { hybridSearchCached, awaitPendingSearchCacheWrites } =
+  await import('../src/core/search/hybrid.ts');
+const { configureGateway, resetGateway } = await import('../src/core/ai/gateway.ts');
+const { PGLiteEngine } = await import('../src/core/pglite-engine.ts');
+
+let engine: InstanceType<typeof PGLiteEngine>;
+let tmpHome: string;
+const savedGbrainHome = process.env.GBRAIN_HOME;
+
+const PAGE_TYPES = ['note', 'company', 'person', 'decision', 'concept', 'idea'];
+const PAGE_COUNT = 30; // > balanced searchLimit (25), so the bug (slice to 20) is observable.
+const KEYWORD = 'gbrain4356widget';
+
+beforeAll(async () => {
+  // Hermetic config home so the developer's real ~/.gbrain/config.json
+  // can't leak an embedding_model that flips the cache consult to
+  // 'disabled' via isCacheSafe.
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-cache-hit-limit-'));
+  process.env.GBRAIN_HOME = tmpHome;
+
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-fake' },
+  });
+
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  for (let i = 0; i < PAGE_COUNT; i++) {
+    const type = PAGE_TYPES[i % PAGE_TYPES.length];
+    const slug = `widgets/${type}-${i}`;
+    const truth = `${KEYWORD} entry number ${i}, a ${type} about widgets.`;
+    await engine.putPage(slug, { type, title: `Widget ${i}`, compiled_truth: truth });
+    await engine.upsertChunks(slug, [
+      { chunk_index: 0, chunk_text: truth, chunk_source: 'compiled_truth' },
+    ]);
+  }
+});
+
+afterAll(async () => {
+  if (savedGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = savedGbrainHome;
+  try { await engine.disconnect(); } catch { /* ignore */ }
+  resetGateway();
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('cache HIT — limit honors the resolved mode (#4356)', () => {
+  test('balanced mode, limit omitted: hit returns the same count as the miss (searchLimit=25), not clipped to 20', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, KEYWORD, {
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    // Sanity: the pool is deep enough that the mode's searchLimit (25),
+    // not the pool size, is what caps the miss — otherwise this test
+    // can't distinguish `|| 20` from `|| resolvedMode.searchLimit`.
+    expect(missResults.length).toBe(25);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    // Pre-fix: this was clipped to 20 regardless of the miss's count.
+    expect(hitResults.length).toBe(missResults.length);
+    expect(hitResults.length).toBe(25);
+  });
+
+  test('conservative mode, limit omitted: hit still matches the miss (searchLimit=10, both below the old flat 20)', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, KEYWORD, {
+      mode: 'conservative',
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    expect(missResults.length).toBe(10);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      mode: 'conservative',
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    expect(hitResults.length).toBe(missResults.length);
+  });
+
+  test('explicit numeric limit round-trips through a hit (limit is folded into knobsHash, so a hit only ever serves a lookup with the SAME resolved limit as the write — this pins that path still behaves, not just the mode-default path above)', async () => {
+    await hybridSearchCached(engine, KEYWORD, { limit: 3, autocut: false, relationalRetrieval: false });
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      limit: 3,
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    expect(hitResults.length).toBe(3);
+  });
+});

--- a/test/query-op-image-limit-honors-mode.serial.test.ts
+++ b/test/query-op-image-limit-honors-mode.serial.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #4356 — the `query` op's image-similarity branch (`image` param) bypasses
+ * hybridSearch entirely (it calls `engine.searchVector` directly), so it
+ * never saw the resolved search mode's `searchLimit` and always hard-
+ * defaulted `limit` to 20 regardless of mode. This pins that the branch now
+ * resolves the same mode + per-key overrides hybridSearch uses
+ * (mode.ts:resolveSearchMode) and forwards that mode's `searchLimit` to
+ * `searchVector` when the caller omits `limit` — mirroring the
+ * `opts?.limit || resolvedMode.searchLimit` convention already used
+ * elsewhere, instead of the flat `|| 20`.
+ *
+ * Drives the REAL dispatch path (dispatchToolCall → query op handler) with
+ * `embedMultimodal` (ai/gateway.ts) and `engine.searchVector` stubbed, same
+ * pattern as test/query-op-relational-meta-and-limit.serial.test.ts.
+ *
+ * Serial: mock.module (isolation guard R2).
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import * as realGateway from '../src/core/ai/gateway.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let capturedSearchVectorOpts: { limit?: number } | null = null;
+
+// Mock BEFORE importing dispatch (operations.ts binds embedMultimodal at
+// call time via dynamic import, but mock.module still needs to be
+// registered before the module graph resolves it).
+mock.module('../src/core/ai/gateway.ts', () => ({
+  ...realGateway,
+  embedMultimodal: async () => [new Float32Array(8).fill(0.1)],
+}));
+
+const { dispatchToolCall } = await import('../src/mcp/dispatch.ts');
+
+function makeEngineStub(configOverrides: Record<string, string> = {}): BrainEngine {
+  return {
+    getConfig: async (key: string) => configOverrides[key] ?? null,
+    executeRaw: async () => [],
+    searchVector: async (_vec: Float32Array, opts: { limit?: number }) => {
+      capturedSearchVectorOpts = opts;
+      return [];
+    },
+  } as unknown as BrainEngine;
+}
+
+function callImageQuery(params: Record<string, unknown>, ctxOverrides: Record<string, unknown> = {}) {
+  return dispatchToolCall(
+    makeEngineStub(),
+    'query',
+    { image: Buffer.from('fake-image-bytes').toString('base64'), image_mime: 'image/png', ...params },
+    { remote: false, transport: 'stdio', sourceId: 'default', ...ctxOverrides },
+  );
+}
+
+describe('query op — image-similarity limit honors the resolved mode (#4356)', () => {
+  test('limit omitted, default mode (balanced) → searchVector receives searchLimit 25, not the old flat 20', async () => {
+    capturedSearchVectorOpts = null;
+    const out = await callImageQuery({});
+    expect(out.isError ?? false).toBe(false);
+    expect(capturedSearchVectorOpts).not.toBeNull();
+    expect(capturedSearchVectorOpts!.limit).toBe(25);
+  });
+
+  test('limit omitted, mode: conservative (local caller) → searchVector receives searchLimit 10', async () => {
+    capturedSearchVectorOpts = null;
+    const out = await callImageQuery({ mode: 'conservative' });
+    expect(out.isError ?? false).toBe(false);
+    expect(capturedSearchVectorOpts!.limit).toBe(10);
+  });
+
+  test('explicit numeric limit still wins over the mode default', async () => {
+    capturedSearchVectorOpts = null;
+    const out = await callImageQuery({ limit: 3, mode: 'tokenmax' });
+    expect(out.isError ?? false).toBe(false);
+    expect(capturedSearchVectorOpts!.limit).toBe(3);
+  });
+
+  test('remote caller: per-call mode is ignored (D5), falls through to server-configured mode default (balanced)', async () => {
+    capturedSearchVectorOpts = null;
+    const out = await callImageQuery({ mode: 'conservative' }, { remote: true });
+    expect(out.isError ?? false).toBe(false);
+    // Remote callers can't select a per-call mode — server config (unset
+    // here) falls through to DEFAULT_SEARCH_MODE (balanced, searchLimit 25),
+    // not the requested conservative (10).
+    expect(capturedSearchVectorOpts!.limit).toBe(25);
+  });
+});


### PR DESCRIPTION
Addresses #4356 — the two independent hardcoded `|| 20` sites that #4355's mechanical op-layer fix explicitly scoped out.

## What changed

1. `hybrid.ts`'s semantic-cache-hit slice did `opts?.limit || 20`, disconnected from the mode-resolution logic the cache-miss path uses (`opts?.limit || resolvedMode.searchLimit`, bare `hybridSearch`). In `balanced` mode (`searchLimit: 25`), a cache-miss call with `limit` omitted could return and cache up to 25 results, but the next identical-shape call served from cache silently sliced that cached row down to 20 — inconsistent between the miss and hit paths for the same call shape. Fixed by reusing `resolvedForCache.searchLimit` (already computed in scope at cache-key-build time, same resolved-mode knob set the miss path uses) instead of the flat 20.

2. The `query` op's image-similarity branch (`image` param) bypasses `hybridSearch` entirely (it calls `engine.searchVector` directly), so it never saw the resolved search mode's `searchLimit` and always hard-defaulted to 20 regardless of mode (10/25/50 for conservative/balanced/tokenmax). It now resolves the same mode + per-key overrides `hybridSearch`/`hybridSearchCached` use (`mode.ts:resolveSearchMode`) and forwards that mode's `searchLimit` when the caller omits `limit`, mirroring the `opts?.limit || resolvedMode.searchLimit` convention already used elsewhere. The `query` op's `limit` param description is updated to describe this for the image path (the text path's description is #4355's territory — not touched here, to keep this PR's diff scoped to the image branch).

Both changes replace the hardcoded `20` with the resolved mode's `searchLimit`, the same shape of fix #4355 already established at the op layer.

## Scope notes

- Does not touch the `query` op's text/hybrid path (`(p.limit as number) || 20` in `src/core/ops/search.ts`) — that's #4355's PR, still in flight.
- Does not touch the plain `search` op's own `limit` default, or the separate `search_by_image` op (`src/core/ops/image.ts`) — neither is mentioned in #4356, so left out to keep this PR's diff mechanical and scoped to exactly the two sites the issue names.
- `scripts/module-size-limits.tsv`: raised `src/core/search/hybrid.ts`'s ratchet ceiling 2629→2640 (reviewer-visible note in the same commit) since the fix's explanatory comment pushed the file over its prior ceiling.

## Verification

- `bun test test/hybrid-cache-hit-limit-honors-mode.serial.test.ts test/query-op-image-limit-honors-mode.serial.test.ts` — 7 pass / 0 fail
- `bun run typecheck` — clean
- `git diff --check` — clean
- `bun run check:module-size` — clean

New test coverage:
- `test/hybrid-cache-hit-limit-honors-mode.serial.test.ts` — real PGLite store→hit roundtrip (30 keyword-findable pages across 6 page types, so dedup's type-diversity cap doesn't shrink the pool below the mode's searchLimit) pinning that a cache hit with `limit` omitted returns the same count as the miss for both `balanced` (25) and `conservative` (10) modes, plus that an explicit numeric limit still round-trips correctly through a hit.
- `test/query-op-image-limit-honors-mode.serial.test.ts` — drives the real `query` op dispatch path with `embedMultimodal` + `engine.searchVector` stubbed, pinning that the image-similarity branch forwards the resolved mode's `searchLimit` (default balanced=25, per-call `mode: conservative`=10, explicit `limit` still wins, remote callers can't override mode per D5).