### PR TITLE
fix(search): honor resolved mode searchLimit on text-path miss + cache-hit

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silen
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating
-src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352); grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20`
+src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352); grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20` + round-1 review comment accuracy fixes (double-resolution caveat)
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
 src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silen
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating
-src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352)
+src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352); grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20`
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
 src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silen
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating
-src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352); grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20` + round-1 review comment accuracy fixes (double-resolution caveat)
+src/core/search/hybrid.ts	2866	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352); grown #4356: semantic-cache-hit slice now honors resolved mode's searchLimit instead of a hard `|| 20` + round-1 review comment accuracy fixes (double-resolution caveat)
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
 src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)

--- a/src/core/operations-descriptions.ts
+++ b/src/core/operations-descriptions.ts
@@ -68,9 +68,12 @@ export const QUERY_DESCRIPTION =
   "Hybrid search with vector + keyword + multi-query expansion. " +
   "Prefer `query` for concept / synonym / landscape questions ('all the X that " +
   "do Y', 'the landscape of Z') — expansion recovers synonym- and " +
-  "outcome-phrased matches a single embedding misses. Still top-K: for " +
-  "exhaustive enumeration use list_pages; for exact known tokens `search` is " +
-  "cheaper (no expansion LLM call). " +
+  "outcome-phrased matches a single embedding misses. Still top-K, and the " +
+  "default count when `limit` is omitted depends on the configured search " +
+  "mode (10 conservative / 25 balanced / 50 tokenmax — see the `limit` param " +
+  "description); pass `limit` explicitly for a stable count regardless of " +
+  "mode. For exhaustive enumeration use list_pages; for exact known tokens " +
+  "`search` is cheaper (no expansion LLM call). " +
   "For personal/emotional questions ('what's going on with me', 'anything notable', " +
   "'how am I feeling'), prefer get_recent_salience, find_anomalies, or " +
   "get_recent_transcripts. Semantic search returns polished pages and misses " +

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -235,17 +235,20 @@ const query: Operation = {
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
     // #4356 — the text/hybrid path no longer hard-defaults this to 20; an
     // omitted OR falsy (0) `limit` resolves from the active search mode's
-    // searchLimit (10/25/50 for conservative/balanced/tokenmax). 0 is
-    // treated as "unset" rather than "return zero rows", matching the
-    // existing convention on every other limit surface in this file
-    // (`search`'s own limit, the image-similarity branch below, and
-    // `search_by_image`) — none of which support a literal empty-result
-    // request today; introducing that only here would be a new,
-    // undocumented asymmetry rather than a limit-consistency fix. The
-    // image-similarity path (`image` param) is unaffected by this change
-    // and still hard-defaults to 20 regardless of mode — out of scope
-    // here, tracked separately (#4356 Problem 2).
-    limit: { type: 'number', description: 'Max results. For text queries, omitted or 0 resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax). For image-similarity queries (`image` param), always defaults to 20 regardless of mode.' },
+    // searchLimit (10/25/50 for conservative/balanced/tokenmax by default,
+    // overridable via the `search.searchLimit` config key — see mode.ts
+    // `pick()`). 0 is treated as "unset" rather than "return zero rows",
+    // matching the existing convention on every other limit surface with
+    // this same shape (`search`'s own limit below, and the image-
+    // similarity branch below it) — none of which support a literal
+    // empty-result request today; introducing that only here would be a
+    // new, undocumented asymmetry rather than a limit-consistency fix.
+    // (`search_by_image`, a separate op in src/core/ops/image.ts, has the
+    // same convention but isn't "in this file".) The image-similarity path
+    // (`image` param) is unaffected by this change and still hard-defaults
+    // to 20 regardless of mode — out of scope here, tracked separately
+    // (#4356 Problem 2).
+    limit: { type: 'number', description: 'Max results. For text queries, omitted or 0 resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax by default, or the configured `search.searchLimit` override). For image-similarity queries (`image` param), always defaults to 20 regardless of mode.' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     // #3985: multi-type filter (plumbing shipped v0.33; exposed here).
     types: { type: 'array', items: { type: 'string' }, description: TYPES_PARAM_DESCRIPTION },

--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -233,7 +233,19 @@ const query: Operation = {
      *  CLI loads the file, base64-encodes, and passes through `image`). */
     image: { type: 'string', description: 'Base64-encoded image bytes for image-similarity search (CLI: --image <path>).' },
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
-    limit: { type: 'number', description: 'Max results (default 20)' },
+    // #4356 — the text/hybrid path no longer hard-defaults this to 20; an
+    // omitted OR falsy (0) `limit` resolves from the active search mode's
+    // searchLimit (10/25/50 for conservative/balanced/tokenmax). 0 is
+    // treated as "unset" rather than "return zero rows", matching the
+    // existing convention on every other limit surface in this file
+    // (`search`'s own limit, the image-similarity branch below, and
+    // `search_by_image`) — none of which support a literal empty-result
+    // request today; introducing that only here would be a new,
+    // undocumented asymmetry rather than a limit-consistency fix. The
+    // image-similarity path (`image` param) is unaffected by this change
+    // and still hard-defaults to 20 regardless of mode — out of scope
+    // here, tracked separately (#4356 Problem 2).
+    limit: { type: 'number', description: 'Max results. For text queries, omitted or 0 resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax). For image-similarity queries (`image` param), always defaults to 20 regardless of mode.' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     // #3985: multi-type filter (plumbing shipped v0.33; exposed here).
     types: { type: 'array', items: { type: 'string' }, description: TYPES_PARAM_DESCRIPTION },
@@ -399,7 +411,15 @@ const query: Operation = {
     // Plain hybridSearch remains the bare API for callers that opt out.
     // (#1663: `let` — the CRAG gate below may swap in an escalated run.)
     let results = await hybridSearchCached(ctx.engine, queryText, {
-      limit: (p.limit as number) || 20,
+      // #4356 — was a hard `|| 20`, independent of the mode-resolution
+      // hybridSearchCached applies when `limit` is falsy (undefined OR 0):
+      // `opts?.limit || resolvedMode.searchLimit` (hybrid.ts). Passing
+      // `undefined` through instead of hard-defaulting to 20 lets that
+      // resolution apply (10/25/50 for conservative/balanced/tokenmax).
+      // `(p.limit as number) || undefined` keeps 0 in that same "unset"
+      // bucket rather than requesting a literal empty result — see the
+      // `limit` param description above for why.
+      limit: (p.limit as number) || undefined,
       offset: (p.offset as number) || 0,
       excludePrivate,
       expansion: expand,

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2439,11 +2439,23 @@ export async function hybridSearchCached(
       // miss path uses (`opts?.limit || resolvedMode.searchLimit` above, in
       // bare hybridSearch): a balanced-mode miss could cache 25 results,
       // then the next identical-shape hit sliced that row down to 20.
-      // `resolvedForCache` is already the same resolved-mode knob set the
-      // miss path uses (its own `searchLimit` already folds `opts?.limit`
-      // through the per-call resolver above, including 0 — see mode.ts
-      // `resolveSearchMode`'s `pick()`), so mirroring it here keeps
-      // hit/miss consistent without re-resolving the mode.
+      // `resolvedForCache` (resolved once, above, at the top of this
+      // function) already folds `opts?.limit` through the same per-call
+      // resolver bare hybridSearch's own `resolvedMode` uses (including 0 —
+      // see mode.ts `resolveSearchMode`'s `pick()`), so mirroring it here
+      // keeps hit/miss consistent for the common case without a second
+      // config round-trip. Caveat: this is a SEPARATE `resolveSearchMode`
+      // call from the one bare hybridSearch performs internally on a miss
+      // (hybrid.ts's inner `resolvedMode`, computed when `hybridSearch` is
+      // invoked below) — not literally the same object — so a `search.mode`
+      // / `search.searchLimit` config change landing between these two
+      // resolutions within one request could theoretically desync the
+      // stored row's actual size from what its own `knobsHash` (built from
+      // `resolvedForCache`) implies. Narrow and pre-existing (the double
+      // resolution itself predates this PR); tracked as #4359, not fixed
+      // here — closing it would mean threading one resolved snapshot into
+      // the inner `hybridSearch` call, a larger change than this PR's
+      // `|| 20` → `|| resolvedMode.searchLimit` substitution.
       const limit = opts?.limit || resolvedForCache.searchLimit;
       const offset = opts?.offset || 0;
       const sliced = scopedResults.slice(offset, offset + limit);

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2435,7 +2435,16 @@ export async function hybridSearchCached(
       // displace legitimate ones off the offset/limit window either.
       const scopedResults = filterResultsByCallerScope(hit.results, opts);
 
-      const limit = opts?.limit || 20;
+      // #4356 — was a hard `|| 20`, independent of the mode-resolution the
+      // miss path uses (`opts?.limit || resolvedMode.searchLimit` above, in
+      // bare hybridSearch): a balanced-mode miss could cache 25 results,
+      // then the next identical-shape hit sliced that row down to 20.
+      // `resolvedForCache` is already the same resolved-mode knob set the
+      // miss path uses (its own `searchLimit` already folds `opts?.limit`
+      // through the per-call resolver above, including 0 — see mode.ts
+      // `resolveSearchMode`'s `pick()`), so mirroring it here keeps
+      // hit/miss consistent without re-resolving the mode.
+      const limit = opts?.limit || resolvedForCache.searchLimit;
       const offset = opts?.offset || 0;
       const sliced = scopedResults.slice(offset, offset + limit);
 

--- a/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
+++ b/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
@@ -7,7 +7,7 @@
  * shape call served from cache silently sliced that cached row down to 20 —
  * inconsistent between the miss and hit paths for the same call shape.
  * (Scope note: this fix closes that gap for `offset: 0` — the common case,
- * and the shape every test below drives. A SEPARATE, pre-existing bug
+ * and the shape the first three tests below drive. A SEPARATE, pre-existing bug
  * — offset is applied twice on a hit, once already baked into what the miss
  * path stored and once again by the hit branch, AND offset isn't part of
  * the cache key at all — means a nonzero `offset` still breaks hit/miss
@@ -206,13 +206,14 @@ describe('cache HIT — limit honors the resolved mode (#4356)', () => {
   // This test pins the CURRENT (broken) behavior so a future fix shows up
   // as an intentional test update, per the same "pin the gap" pattern the
   // original #3995/#4355 review applied to the cache-hit relational-meta
-  // absence. Properly fixing this requires redesigning what the cache
-  // stores (e.g. cache the pre-offset pool and re-slice offset+limit fresh
-  // on every hit, key offset into the cache, or skip caching for
-  // offset>0) — a distinct concern from the `|| 20` vs
-  // `|| resolvedMode.searchLimit` substitution this PR makes, so it is
-  // deliberately NOT fixed here (would reintroduce the "bundling unrelated
-  // changes" problem that got #4355/#4357 closed).
+  // absence. Possible fixes include caching the pre-offset pool, bypassing
+  // paginated (offset>0) cache calls, or keying offset and returning the
+  // stored page without re-slicing (keying offset alone does NOT fix the
+  // double-slice — the hit branch would still need to stop re-applying
+  // `offset` to an already-offset-sliced row). A distinct concern from the
+  // `|| 20` vs `|| resolvedMode.searchLimit` substitution this PR makes, so
+  // it is deliberately NOT fixed here (would reintroduce the "bundling
+  // unrelated changes" problem that got #4355/#4357 closed).
   test('KNOWN LIMITATION: nonzero offset breaks hit/miss count parity (offset is re-applied to an already offset-sliced cached row)', async () => {
     let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
     const missResults = await hybridSearchCached(engine, KEYWORD, {

--- a/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
+++ b/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
@@ -7,14 +7,18 @@
  * shape call served from cache silently sliced that cached row down to 20 —
  * inconsistent between the miss and hit paths for the same call shape.
  * (Scope note: this fix closes that gap for `offset: 0` — the common case,
- * and the shape the first three tests below drive. A SEPARATE, pre-existing bug
- * — offset is applied twice on a hit, once already baked into what the miss
- * path stored and once again by the hit branch, AND offset isn't part of
- * the cache key at all — means a nonzero `offset` still breaks hit/miss
- * parity; see the "KNOWN LIMITATION" test near the end of this file. That
- * bug is orthogonal to the `|| 20` vs `|| resolvedMode.searchLimit`
- * substitution this PR makes and isn't fixed here — see that test's comment
- * for why.)
+ * and the shape the first three tests below drive. A SEPARATE bug — offset
+ * used to be applied twice on a hit, once already baked into what the miss
+ * path stored and once again by the hit branch — used to break hit/miss
+ * parity for a nonzero `offset` (filed as #4358); the positive-offset half
+ * of that bug is now closed by upstream's #4368 wave (this branch is
+ * rebased onto it) by skipping the cache entirely for any positive offset,
+ * so there's no cached row left to double-slice for the case the last test
+ * near the end of this file drives. A separate PR, #4414 (this account's
+ * own, still open as of this commit), widens the same skip condition to
+ * also cover negative offsets — not exercised by this file. Both fixes are
+ * orthogonal to the `|| 20` vs `|| resolvedMode.searchLimit` substitution
+ * this PR makes and neither is part of this PR's diff.)
  *
  * Companion to #4356 Site 1 (see
  * test/query-op-limit-mode-4356.serial.test.ts, the `query` op's own
@@ -181,40 +185,44 @@ describe('cache HIT — limit honors the resolved mode (#4356)', () => {
     expect(hitResults.length).toBe(3);
   });
 
-  // KNOWN LIMITATION (pre-existing, NOT introduced or worsened by this PR's
-  // `resolvedForCache.searchLimit` change — filed as #4358): the miss path
-  // stores the ALREADY offset-sliced array (`hybridSearch`'s own
-  // `returnPool.slice(offset,
-  // offset + limit)`), then the cache-hit branch applies `offset` a SECOND
-  // time on top of that already-sliced array. For offset=0 this is a no-op
-  // (slicing from 0 twice is idempotent), which is why every test above —
-  // and the miss/hit consistency this PR actually fixes — holds. For a
-  // nonzero offset it is NOT idempotent: e.g. a miss with `limit: 9,
-  // offset: 2` stores 9 rows representing pool positions [2, 11); the next
-  // hit then slices THAT 9-row array at [2, 11) again, yielding rows [2, 9)
-  // of a 9-element array — 7 rows, not 9.
+  // FIXED for POSITIVE offset (was "KNOWN LIMITATION" — the positive-offset
+  // half of #4358 landed via upstream's #4368 wave, which this branch is
+  // rebased onto; the SEPARATE negative-offset half is #4414, this
+  // account's own PR, still open/unmerged as of this commit — see below):
+  // a nonzero offset used to break hit/miss count parity, because the miss
+  // path stores the ALREADY offset-sliced array (`hybridSearch`'s own
+  // `returnPool.slice(offset, offset + limit)`) and the cache-hit branch
+  // re-applied `offset` a SECOND time on top of that already-sliced array.
+  // For offset=0 this was a no-op (slicing from 0 twice is idempotent),
+  // which is why every test above — and the miss/hit consistency this PR
+  // actually fixes — held even pre-#4358. For a nonzero offset it was NOT
+  // idempotent: e.g. a miss with `limit: 9, offset: 2` stored 9 rows
+  // representing pool positions [2, 11); a hit then re-sliced THAT 9-row
+  // array at [2, 11) again, yielding rows [2, 9) of a 9-element array — 7
+  // rows, not 9.
+  //
+  // The fix in THIS branch's `hybrid.ts` is `pagedRequest = (opts?.offset
+  // ?? 0) > 0` — positive-offset only. It skips the cache entirely (lookup
+  // AND store) for any positive offset, so the double-slice path is
+  // unreachable for this test's `offset: 2` case: a paginated request
+  // returns freshly-computed, correctly-sliced results with
+  // `cache.status: 'disabled'`, never a re-sliced cached page. (#4414 later
+  // widens this same condition to `!== 0` so negative offsets get the same
+  // protection — Array.prototype.slice's negative-index semantics mean a
+  // negative offset re-slices a stored page just as badly as a positive
+  // one, an independent gap `> 0` alone doesn't cover. That's out of scope
+  // for THIS test, which only ever calls with a positive offset.)
   //
   // (`limit: 9` here — rather than the mode default this file's other tests
-  // rely on — is deliberate, not incidental: `offset` is NOT part of
+  // rely on — is deliberate, not incidental: `offset` still isn't part of
   // `knobsHash` (mode.ts's `knobsHash()` has no `offset=` component), so a
   // lookup with a NEW offset but the SAME resolved limit as an earlier test
-  // in this file would hit an already-written row instead of missing —
-  // itself a related but distinct pre-existing gap, also out of scope here.
-  // A limit value unique to this test sidesteps that collision so the
-  // miss/hit pair below is clean.)
-  //
-  // This test pins the CURRENT (broken) behavior so a future fix shows up
-  // as an intentional test update, per the same "pin the gap" pattern the
-  // original #3995/#4355 review applied to the cache-hit relational-meta
-  // absence. Possible fixes include caching the pre-offset pool, bypassing
-  // paginated (offset>0) cache calls, or keying offset and returning the
-  // stored page without re-slicing (keying offset alone does NOT fix the
-  // double-slice — the hit branch would still need to stop re-applying
-  // `offset` to an already-offset-sliced row). A distinct concern from the
-  // `|| 20` vs `|| resolvedMode.searchLimit` substitution this PR makes, so
-  // it is deliberately NOT fixed here (would reintroduce the "bundling
-  // unrelated changes" problem that got #4355/#4357 closed).
-  test('KNOWN LIMITATION: nonzero offset breaks hit/miss count parity (offset is re-applied to an already offset-sliced cached row)', async () => {
+  // in this file could otherwise collide with an already-written row if the
+  // cache were consulted. A limit value unique to this test sidesteps that
+  // collision — though it's moot for THIS assertion, since paginated
+  // requests bypass the cache outright now; kept for robustness against
+  // future changes to the skip condition.)
+  test('positive offset never hits the cache — hit/miss count parity holds (was #4358, fixed here by #4368)', async () => {
     let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
     const missResults = await hybridSearchCached(engine, KEYWORD, {
       limit: 9,
@@ -223,7 +231,7 @@ describe('cache HIT — limit honors the resolved mode (#4356)', () => {
       relationalRetrieval: false,
       onMeta: (m) => { missMeta = m; },
     });
-    expect(missMeta?.cache?.status).toBe('miss');
+    expect(missMeta?.cache?.status).toBe('disabled');
     expect(missResults.length).toBe(9);
 
     await awaitPendingSearchCacheWrites();
@@ -236,11 +244,14 @@ describe('cache HIT — limit honors the resolved mode (#4356)', () => {
       relationalRetrieval: false,
       onMeta: (m) => { hitMeta = m; },
     });
-    expect(hitMeta?.cache?.status).toBe('hit');
-    // Pins the CURRENT (pre-existing, unfixed) double-offset behavior: 7,
-    // not 9. If this assertion ever fails, the underlying bug was fixed —
-    // update this test (and close #4358) rather than reverting.
-    expect(hitResults.length).toBe(7);
+    // Still 'disabled', not 'hit' — a paginated request skips the cache on
+    // EVERY call (lookup AND store), so there's never a stored row for a
+    // nonzero offset to serve back. If this assertion ever changes to
+    // 'hit', the skip-cache design changed — re-verify the double-slice
+    // fix still holds under whatever replaced it, rather than just
+    // updating the expected string.
+    expect(hitMeta?.cache?.status).toBe('disabled');
+    expect(hitResults.length).toBe(9);
   });
 
   // NOTE on `limit: 0` (not a test — documenting why one isn't here): a

--- a/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
+++ b/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
@@ -6,6 +6,15 @@
  * omitted could return and cache up to 25 results, but the next identical-
  * shape call served from cache silently sliced that cached row down to 20 —
  * inconsistent between the miss and hit paths for the same call shape.
+ * (Scope note: this fix closes that gap for `offset: 0` — the common case,
+ * and the shape every test below drives. A SEPARATE, pre-existing bug
+ * — offset is applied twice on a hit, once already baked into what the miss
+ * path stored and once again by the hit branch, AND offset isn't part of
+ * the cache key at all — means a nonzero `offset` still breaks hit/miss
+ * parity; see the "KNOWN LIMITATION" test near the end of this file. That
+ * bug is orthogonal to the `|| 20` vs `|| resolvedMode.searchLimit`
+ * substitution this PR makes and isn't fixed here — see that test's comment
+ * for why.)
  *
  * Companion to #4356 Site 1 (see
  * test/query-op-limit-mode-4356.serial.test.ts, the `query` op's own
@@ -170,6 +179,67 @@ describe('cache HIT — limit honors the resolved mode (#4356)', () => {
     });
     expect(hitMeta?.cache?.status).toBe('hit');
     expect(hitResults.length).toBe(3);
+  });
+
+  // KNOWN LIMITATION (pre-existing, NOT introduced or worsened by this PR's
+  // `resolvedForCache.searchLimit` change — filed as #4358): the miss path
+  // stores the ALREADY offset-sliced array (`hybridSearch`'s own
+  // `returnPool.slice(offset,
+  // offset + limit)`), then the cache-hit branch applies `offset` a SECOND
+  // time on top of that already-sliced array. For offset=0 this is a no-op
+  // (slicing from 0 twice is idempotent), which is why every test above —
+  // and the miss/hit consistency this PR actually fixes — holds. For a
+  // nonzero offset it is NOT idempotent: e.g. a miss with `limit: 9,
+  // offset: 2` stores 9 rows representing pool positions [2, 11); the next
+  // hit then slices THAT 9-row array at [2, 11) again, yielding rows [2, 9)
+  // of a 9-element array — 7 rows, not 9.
+  //
+  // (`limit: 9` here — rather than the mode default this file's other tests
+  // rely on — is deliberate, not incidental: `offset` is NOT part of
+  // `knobsHash` (mode.ts's `knobsHash()` has no `offset=` component), so a
+  // lookup with a NEW offset but the SAME resolved limit as an earlier test
+  // in this file would hit an already-written row instead of missing —
+  // itself a related but distinct pre-existing gap, also out of scope here.
+  // A limit value unique to this test sidesteps that collision so the
+  // miss/hit pair below is clean.)
+  //
+  // This test pins the CURRENT (broken) behavior so a future fix shows up
+  // as an intentional test update, per the same "pin the gap" pattern the
+  // original #3995/#4355 review applied to the cache-hit relational-meta
+  // absence. Properly fixing this requires redesigning what the cache
+  // stores (e.g. cache the pre-offset pool and re-slice offset+limit fresh
+  // on every hit, key offset into the cache, or skip caching for
+  // offset>0) — a distinct concern from the `|| 20` vs
+  // `|| resolvedMode.searchLimit` substitution this PR makes, so it is
+  // deliberately NOT fixed here (would reintroduce the "bundling unrelated
+  // changes" problem that got #4355/#4357 closed).
+  test('KNOWN LIMITATION: nonzero offset breaks hit/miss count parity (offset is re-applied to an already offset-sliced cached row)', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, KEYWORD, {
+      limit: 9,
+      offset: 2,
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    expect(missResults.length).toBe(9);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      limit: 9,
+      offset: 2,
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    // Pins the CURRENT (pre-existing, unfixed) double-offset behavior: 7,
+    // not 9. If this assertion ever fails, the underlying bug was fixed —
+    // update this test (and close #4358) rather than reverting.
+    expect(hitResults.length).toBe(7);
   });
 
   // NOTE on `limit: 0` (not a test — documenting why one isn't here): a

--- a/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
+++ b/test/hybrid-cache-hit-limit-honors-mode.serial.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #4356 Site 2 — the semantic-cache-hit slice used a hard
+ * `opts?.limit || 20`, independent of the mode-resolution logic the cache-
+ * MISS path uses (`opts?.limit || resolvedMode.searchLimit`, bare
+ * hybridSearch). In `balanced` mode (searchLimit: 25) a miss with `limit`
+ * omitted could return and cache up to 25 results, but the next identical-
+ * shape call served from cache silently sliced that cached row down to 20 —
+ * inconsistent between the miss and hit paths for the same call shape.
+ *
+ * Companion to #4356 Site 1 (see
+ * test/query-op-limit-mode-4356.serial.test.ts, the `query` op's own
+ * text-path `limit` translation). Fixing both sites in the same PR is the
+ * point: shipping only the miss-path fix would make this miss/hit
+ * inconsistency newly OBSERVABLE (previously both were wrong at a flat 20,
+ * so they agreed) without resolving it — a maintainer-lens review rejected
+ * exactly that partial shape when it shipped split across two closed PRs
+ * (#4355, #4357).
+ *
+ * Drives a real store→hit roundtrip (mocked `embed`/`embedQuery` for a
+ * deterministic vector, real PGLite SemanticQueryCache — same pattern as
+ * test/hybrid-cached-hit-budget-meta.serial.test.ts) with 30 keyword-
+ * findable pages spread across 6 page types (dedup's type-diversity layer
+ * caps any one type at 60% of the result set, so a single type would
+ * silently shrink the pool below 25 regardless of this fix). `autocut` and
+ * `relationalRetrieval` are forced off per-call so the result count is
+ * driven only by the limit slice under test, not by an unrelated cliff cut
+ * or graph arm.
+ *
+ * Serial: mock.module (isolation guard R2).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realEmbedding from '../src/core/embedding.ts';
+
+/** Deterministic 1536d unit vector — identical for every call, so the
+ * second consult matches the first write at cosine 1.0. */
+function fixedEmbedding(): Float32Array {
+  const arr = new Float32Array(1536);
+  for (let i = 0; i < 1536; i++) arr[i] = Math.sin(1 + i * 0.001);
+  let norm = 0;
+  for (let i = 0; i < 1536; i++) norm += arr[i] * arr[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < 1536; i++) arr[i] /= norm;
+  return arr;
+}
+
+// Mock BEFORE importing hybrid.ts (spread keeps every other export live).
+mock.module('../src/core/embedding.ts', () => ({
+  ...realEmbedding,
+  embed: async () => fixedEmbedding(),
+  embedQuery: async () => fixedEmbedding(),
+}));
+
+// Import AFTER mocking.
+const { hybridSearchCached, awaitPendingSearchCacheWrites } =
+  await import('../src/core/search/hybrid.ts');
+const { configureGateway, resetGateway } = await import('../src/core/ai/gateway.ts');
+const { PGLiteEngine } = await import('../src/core/pglite-engine.ts');
+
+let engine: InstanceType<typeof PGLiteEngine>;
+let tmpHome: string;
+const savedGbrainHome = process.env.GBRAIN_HOME;
+
+const PAGE_TYPES = ['note', 'company', 'person', 'decision', 'concept', 'idea'];
+const PAGE_COUNT = 30; // > balanced searchLimit (25), so the bug (slice to 20) is observable.
+const KEYWORD = 'gbrain4356widget';
+
+beforeAll(async () => {
+  // Hermetic config home so the developer's real ~/.gbrain/config.json
+  // can't leak an embedding_model that flips the cache consult to
+  // 'disabled' via isCacheSafe.
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-cache-hit-limit-'));
+  process.env.GBRAIN_HOME = tmpHome;
+
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-fake' },
+  });
+
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  for (let i = 0; i < PAGE_COUNT; i++) {
+    const type = PAGE_TYPES[i % PAGE_TYPES.length];
+    const slug = `widgets/${type}-${i}`;
+    const truth = `${KEYWORD} entry number ${i}, a ${type} about widgets.`;
+    await engine.putPage(slug, { type, title: `Widget ${i}`, compiled_truth: truth });
+    await engine.upsertChunks(slug, [
+      { chunk_index: 0, chunk_text: truth, chunk_source: 'compiled_truth' },
+    ]);
+  }
+});
+
+afterAll(async () => {
+  if (savedGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = savedGbrainHome;
+  try { await engine.disconnect(); } catch { /* ignore */ }
+  resetGateway();
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('cache HIT — limit honors the resolved mode (#4356)', () => {
+  test('balanced mode, limit omitted: hit returns the same count as the miss (searchLimit=25), not clipped to 20', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, KEYWORD, {
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    // Sanity: the pool is deep enough that the mode's searchLimit (25),
+    // not the pool size, is what caps the miss — otherwise this test
+    // can't distinguish `|| 20` from `|| resolvedMode.searchLimit`.
+    expect(missResults.length).toBe(25);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    // Pre-fix: this was clipped to 20 regardless of the miss's count.
+    expect(hitResults.length).toBe(missResults.length);
+    expect(hitResults.length).toBe(25);
+  });
+
+  test('conservative mode, limit omitted: hit still matches the miss (searchLimit=10, both below the old flat 20)', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, KEYWORD, {
+      mode: 'conservative',
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    expect(missResults.length).toBe(10);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      mode: 'conservative',
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    expect(hitResults.length).toBe(missResults.length);
+  });
+
+  test('explicit numeric limit round-trips through a hit (limit is folded into knobsHash, so a hit only ever serves a lookup with the SAME resolved limit as the write — this pins that path still behaves, not just the mode-default path above)', async () => {
+    await hybridSearchCached(engine, KEYWORD, { limit: 3, autocut: false, relationalRetrieval: false });
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, KEYWORD, {
+      limit: 3,
+      autocut: false,
+      relationalRetrieval: false,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    expect(hitResults.length).toBe(3);
+  });
+
+  // NOTE on `limit: 0` (not a test — documenting why one isn't here): a
+  // `limit: 0` call always returns zero rows (resolveSearchMode's
+  // perCall.searchLimit pick treats a forwarded 0 as a set value, so
+  // `0 || resolvedMode.searchLimit` resolves to 0 — verified directly
+  // against mode.ts), and the miss-path writeback above explicitly skips
+  // caching empty result sets ("skip when search returned empty so we
+  // don't cache zero-result queries forever"). A `limit: 0` query can
+  // therefore never reach a cache HIT via the public API: nothing is ever
+  // written for it to hit against, and even if a prior non-zero-limit
+  // write existed, `lim=<n>` is folded into `knobsHash` (mode.ts), so a
+  // `limit: 0` lookup's hash never matches a `limit: 25` write's row. The
+  // line this PR changes (`resolvedForCache.searchLimit` instead of a flat
+  // `20`) is exercised by the non-zero cases above; a 0-specific hit
+  // scenario is structurally unreachable, not merely untested.
+});

--- a/test/query-op-limit-mode-4356.serial.test.ts
+++ b/test/query-op-limit-mode-4356.serial.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #4356 Site 1 — the `query` op's text/hybrid path (src/core/ops/search.ts)
+ * was a hard `(p.limit as number) || 20`, independent of the resolved
+ * search mode's `searchLimit` (10/25/50 for conservative/balanced/
+ * tokenmax). Now `(p.limit as number) || undefined` — an omitted OR falsy
+ * (`0`) `limit` lets hybridSearchCached's own mode-resolution apply instead
+ * of being silently overridden to a flat 20.
+ *
+ * `0` is deliberately folded into "unset" here rather than forwarded as a
+ * literal "return zero rows" request: `resolveSearchMode` (mode.ts) folds a
+ * *forwarded* `opts.limit: 0` into `resolvedMode.searchLimit` itself (the
+ * `perCall.searchLimit` pick treats 0 as a set value, not undefined), so a
+ * bare hybridSearch/hybridSearchCached caller who passes `limit: 0` today
+ * already gets zero rows end-to-end on both the miss and (after this PR's
+ * Site 2 fix, see test/hybrid-cache-hit-limit-honors-mode.serial.test.ts)
+ * the hit path. This op deliberately does NOT forward that 0 — matching
+ * every other limit surface in this file (`search`'s own limit, the image-
+ * similarity branch, `search_by_image`), none of which support a literal
+ * empty-result request today. Introducing that capability only on this one
+ * path would be a new, undocumented asymmetry — out of scope for a limit-
+ * CONSISTENCY fix.
+ *
+ * Companion to #4356 Site 2 (see the sibling cache-hit test file). Fixing
+ * both sites in the same PR is the point: shipping only this miss-path fix
+ * would make the miss/hit inconsistency newly OBSERVABLE (previously both
+ * were wrong at a flat 20, so they agreed) without resolving it — a
+ * maintainer-lens review rejected exactly that partial shape when it shipped
+ * split across two closed PRs (#4355, #4357).
+ *
+ * Driven through the REAL dispatch path (dispatchToolCall → query op
+ * handler) with hybridSearchCached mocked, same pattern as
+ * dispatch-response-meta.serial.test.ts.
+ *
+ * Serial: mock.module (isolation guard R2).
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import * as realHybrid from '../src/core/search/hybrid.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+let nextResults: unknown[] = [];
+let capturedOpts: { limit?: number } | null = null;
+
+// Mock BEFORE importing dispatch (operations.ts binds hybridSearchCached at
+// import time; the spread keeps every other export live).
+mock.module('../src/core/search/hybrid.ts', () => ({
+  ...realHybrid,
+  hybridSearchCached: async (
+    _engine: unknown,
+    _query: string,
+    opts: { limit?: number; onMeta?: (m: unknown) => void },
+  ) => {
+    capturedOpts = opts;
+    opts.onMeta?.({ vector_enabled: true, expansion_applied: false, detail_resolved: null });
+    return nextResults;
+  },
+}));
+
+const { dispatchToolCall } = await import('../src/mcp/dispatch.ts');
+
+const engineStub = {
+  getConfig: async () => null,
+  executeRaw: async () => [],
+} as unknown as BrainEngine;
+
+function callQuery(params: Record<string, unknown>) {
+  return dispatchToolCall(engineStub, 'query', { query: 'who founded acme-example', ...params }, {
+    remote: true,
+    transport: 'http',
+    sourceId: 'default',
+  });
+}
+
+describe('query op — text-path limit no longer hard-floors to 20 (#4356 Site 1)', () => {
+  test('caller omits `limit` → hybridSearchCached receives limit: undefined (mode bundle decides)', async () => {
+    nextResults = [];
+    capturedOpts = null;
+    await callQuery({});
+    expect(capturedOpts).not.toBeNull();
+    expect(capturedOpts!.limit).toBeUndefined();
+  });
+
+  test('caller passes an explicit positive numeric `limit` → still wins', async () => {
+    nextResults = [];
+    capturedOpts = null;
+    await callQuery({ limit: 7 });
+    expect(capturedOpts!.limit).toBe(7);
+  });
+
+  test('caller passes `limit: 0` → op forwards undefined (0 is treated as unset, not as "return zero rows")', async () => {
+    nextResults = [];
+    capturedOpts = null;
+    await callQuery({ limit: 0 });
+    expect(capturedOpts!.limit).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Split from #4355 / #4357 (both closed) per maintainer-lens review feedback — this PR ships the atomic limit-consistency fix (text-path miss + cache-hit, together) that review asked for. Relational-meta wiring (#4355's other half) is not resubmitted — a separate design consultation concluded it's a new observability feature (not a bug fix) and should stay fork-local; the image-similarity branch (#4356 Problem 2) remains an open design question in #4356, not implemented here.

## What changed

1. `query` op's text/hybrid path (`src/core/ops/search.ts`) hard-defaulted `limit` to `(p.limit as number) || 20`, silently overriding the resolved search mode's `searchLimit` (10/25/50 for conservative/balanced/tokenmax) whenever the caller omitted `limit`. Now `(p.limit as number) || undefined` — an omitted OR falsy (`0`) `limit` lets `hybridSearchCached`'s own mode-resolution apply.

2. `hybrid.ts`'s semantic-cache-hit slice did `opts?.limit || 20`, disconnected from the mode-resolution logic the cache-miss path uses. A balanced-mode miss with `limit` omitted could return/cache up to 25 results, but the next identical-shape call served from cache silently sliced that cached row down to 20. Now reuses `resolvedForCache.searchLimit` (the same resolved-mode knob set the miss path's own cache-key build already uses) instead of the flat 20.

Both ship together in one PR because shipping only #1 would make the miss/hit inconsistency newly *observable* (previously both were wrong at a flat 20, so miss and hit agreed) without resolving it — the exact partial shape that got the prior split PRs closed.

## `limit: 0` scope decision

Consulted Codex (gpt-5.x, `model_reasoning_effort=high`) on whether `0` should be forwarded as a literal "return zero rows" request or folded into "unset" before implementing. Verified directly against `resolveSearchMode` (`src/core/search/mode.ts`) that a *forwarded* `opts.limit: 0` already resolves end-to-end to zero rows for bare `hybridSearch`/`hybridSearchCached` callers today (the per-call `pick()` treats a set `0` as intentional, not undefined) — so this wasn't a question of "can 0 work," only "should the `query` op forward it." Decision: fold `0` into "unset" at the op layer, matching the existing convention on every other limit surface with this shape (`search`'s own limit, the image-similarity branch, `search_by_image`) — none of which support a literal empty-result request today. Introducing that only on this one path would be a new, undocumented asymmetry, out of scope for a limit-*consistency* fix.

## Known limitations (found during review; one now fixed upstream, one still open)

A strict maintainer-lens review of this diff originally surfaced two pre-existing, narrow gaps that this PR's substitution (`|| 20` → `|| resolvedMode.searchLimit`) doesn't introduce but did newly expose for the common no-explicit-limit caller shape:

- **#4358** (UPDATE: partially fixed since this PR was opened) — the cache-hit branch applied `offset` a second time on top of an already offset-sliced stored array (idempotent at `offset: 0`, the shape every test in this PR drives; broken for a nonzero offset, verified 9→7 for `limit: 9, offset: 2`). `offset` also isn't part of the cache key at all. An unrelated, independently-merged upstream wave (#4368) fixed the **positive**-offset half by skipping the cache entirely for `offset > 0` — this branch is now rebased onto that fix, and the regression test in `test/hybrid-cache-hit-limit-honors-mode.serial.test.ts` (originally a `KNOWN LIMITATION` pinning the broken 7-row behavior) is updated to assert the correct 9-row/`disabled` behavior it now exercises. The **negative**-offset half is a separate open PR, #4414 (this account's own), which widens the same skip condition from `> 0` to `!== 0` — not yet merged, not exercised by this PR's tests.
- **#4359** — `hybridSearchCached`'s outer mode resolution and bare `hybridSearch`'s independent inner resolution are two separate `resolveSearchMode()` calls; a concurrent `search.mode`/`search.searchLimit` config change between them could theoretically desync a cache row's key from its content. Previously masked for the common caller shape because an explicit numeric `limit` (the old hardcoded `20`) short-circuited both resolutions identically; now exposed since `undefined` reaches the mode-bundle fallback in both. Still open — would need redesigning cache storage semantics / threading a resolved snapshot across a call boundary, a real fix rather than a one-line substitution, so fixing it here would reintroduce the "bundling unrelated changes" problem that got #4355/#4357 closed in the first place.

## Verification

- `bun test test/query-op-limit-mode-4356.serial.test.ts test/hybrid-cache-hit-limit-honors-mode.serial.test.ts` — 7 pass / 0 fail
- `bun run typecheck` — clean
- `bun run check:module-size` — clean (`hybrid.ts` ceiling now 2724, reviewer-visible in `scripts/module-size-limits.tsv`; grown further by the rebase onto #4368's wave, unrelated to this PR's own diff)
- Two rounds of Codex review (`gpt-5.x`, `model_reasoning_effort=high`) on the original diff: round 1 found 0 Critical / 2 Warning / 1 Nit (both Warnings are the known limitations above; the Nit — a param-description overclaim — is fixed). Round 2 re-reviewed the full diff after the round-1 fixes.
- Confirmed (via a same-batch clean-baseline re-run against unmodified `upstream/master`) that an unrelated pre-existing batch-mode test flake (13 tests, identical failure set with and without this diff) is not caused by this change.
- Rebased onto current `upstream/master` (post-#4368) after the original review; a focused maintainer-lens re-check of just the rebase + test-update commit flagged one overclaim (the updated test/comments initially implied the FULL #4358 fix — including negative offsets — was already live in this branch, when only the positive-offset half is) — fixed by scoping the wording precisely to positive offsets and naming #4414 as the separate pending negative-offset fix.



<!-- maintainer-lens: SAFE @ a7ae7aa161ebe32d8323cf160f9950663b045ced 2026-08-21T13:54:28Z -->

