### PR TITLE
fix(dream): reconcile private queues on phase exit

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -11,21 +11,21 @@ src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely;
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)
 src/core/ai/gateway.ts	4441	ratchet	grown v0.46.25.0 D2: env-key snapshot stash (#2119)
 src/cli.ts	3628	ratchet	grown v0.46.25.0 D2: stdout interposer install (#4383)
-src/core/cycle.ts	3099	ratchet	grown v0.46.25.0 fix waves: refresher abort gating + keyless honesty (#4309 #2821) | signal feature-detect (#4309 handler shape)
+src/core/cycle.ts	3103	ratchet	grown v0.46.25.0 fix waves: refresher abort gating + keyless honesty (#4309 #2821) | signal feature-detect (#4309 handler shape); private queue owner id threading (#4332)
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
-src/commands/jobs.ts	3041	ratchet	grown v0.46.25.0 fix waves: jobs list/get --json (#3685)
+src/commands/jobs.ts	3043	ratchet	grown v0.46.25.0 fix waves: jobs list/get --json (#3685); private queue owner id threading (#4332)
 src/core/search/hybrid.ts	2703	ratchet	grown v0.46.25.0 fix waves: cache scope isolation + pool floor + offset bypass (#3871 #3002)
 src/core/engine.ts	2415	ratchet	grown v0.46.25.0 fix waves: timeline dedup contract + registry write contract (#3827 #1262)
 src/commands/autopilot.ts	2349	ratchet	grown v0.46.25.0 fix waves: positional validation (#1525) + liveness takeover (#4300)
 src/commands/extract.ts	2066	ratchet	lowered: timeline extractor hoisted to core/timeline-extract.ts (module-cycle fix)
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2016	ratchet	grown v0.46.24.0 overnight wave: embedding_plane_split named error (#4287)
-src/core/cycle/synthesize.ts	2702	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches
+src/core/cycle/synthesize.ts	2719	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches; private queue lease renewal + finally-path reconcile (#4332)
 src/commands/embed.ts	2046	ratchet	grown v0.46.25.0 delegated wave (#3971)
 src/core/types.ts	1882	ratchet	grown v0.46.22.0 phone wave: supersession rerank result fields + effective-date page filters (#4056 #4389)
 src/commands/skillpack.ts	1360	ratchet
-src/core/minions/queue.ts	2138	ratchet	grown by #4078 subagent-loop capability fix
-src/core/schema-embedded.ts	1501	ratchet	generated schema bundle grew for private queue metadata
+src/core/minions/queue.ts	2468	ratchet	grown by #4078 subagent-loop capability fix; private-queue owner/lease/pid metadata + orphan startup recovery + legacy adoption (#4332)
+src/core/schema-embedded.ts	1506	ratchet	generated schema bundle grew for private queue owner metadata (#4332)
 src/commands/init.ts	1950	ratchet	grown v0.46.x keyless capability notices
 src/commands/integrations.ts	1733	ratchet	grown v0.46.24.0 overnight wave (#3588)
 src/core/minions/handlers/subagent.ts	1825	ratchet	merged: master v131 settle rework + dream-wave C5 peel + C6 accounting + C7 lease heartbeats/lost-lease aborts + C9 oneshot dispatch + adversarial fix batches; grown by #4078 subagent-loop capability fix

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -5,7 +5,7 @@
 # Columns: path	max_lines	policy	note
 src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
-src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
+src/core/postgres-engine.ts	6011	ratchet	grown v0.46.26.0: private-queue forward-reference bootstrap prevents pre-v136 upgrade wedge (#4332)
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -25,6 +25,7 @@ src/commands/embed.ts	2046	ratchet	grown v0.46.25.0 delegated wave (#3971)
 src/core/types.ts	1882	ratchet	grown v0.46.22.0 phone wave: supersession rerank result fields + effective-date page filters (#4056 #4389)
 src/commands/skillpack.ts	1360	ratchet
 src/core/minions/queue.ts	2138	ratchet	grown by #4078 subagent-loop capability fix
+src/core/schema-embedded.ts	1501	ratchet	generated schema bundle grew for private queue metadata
 src/commands/init.ts	1950	ratchet	grown v0.46.x keyless capability notices
 src/commands/integrations.ts	1733	ratchet	grown v0.46.24.0 overnight wave (#3588)
 src/core/minions/handlers/subagent.ts	1825	ratchet	merged: master v131 settle rework + dream-wave C5 peel + C6 accounting + C7 lease heartbeats/lost-lease aborts + C9 oneshot dispatch + adversarial fix batches; grown by #4078 subagent-loop capability fix

--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -10,7 +10,8 @@ import type { BrainEngine } from '../../../core/engine.ts';
 import { probeSourceGitState } from '../../../core/git-head.ts';
 // v0.41.32.0: remote staleness reads the stored newest_content_at column via
 // this pure comparator (no git subprocess on the HTTP MCP doctor path).
-import { lagFromContentMs, resolveStalenessCeilingSeconds } from '../../../core/source-health.ts';
+import { lagFromContentMs, resolveStalenessCeilingSeconds, isImmutableSourceConfig } from '../../../core/source-health.ts';
+import { parseSourceConfig } from '../../../core/sources-load.ts';
 import { resolveEnvNumber, resolveHoursEnv, warnOnceForEnv } from '../../../core/env-number.ts';
 import { CHUNKER_VERSION } from '../../../core/chunkers/code.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from '../../../core/link-extraction.ts';
@@ -696,10 +697,12 @@ export async function checkSyncFreshness(
       last_commit: string | null;
       chunker_version: string | null;
       newest_content_at: Date | null;
+      config: Record<string, unknown> | string | null;
     }>(
       // v0.41.32.0: newest_content_at feeds the REMOTE (non-localOnly) lag so
       // doctorReportRemote never shells out to git on a DB-supplied local_path.
-      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at FROM sources WHERE local_path IS NOT NULL`,
+      // config carries the #4332 `immutable` declaration (no new column).
+      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at, config FROM sources WHERE local_path IS NOT NULL`,
     );
 
     if (sources.length === 0) {
@@ -915,6 +918,9 @@ export async function checkSyncFreshness(
           lastSync,
           now,
           stalenessCeilingSeconds,
+          // #4332 follow-up: an immutable dated snapshot (camera-roll-2026-08-13)
+          // is permanently caught up by construction; suppress only the ramp.
+          { immutable: isImmutableSourceConfig(parseSourceConfig(source.config)) },
         );
         thresholdAgeMs = lagSec === null ? ageMs : lagSec * 1000;
       }

--- a/src/commands/doctor/checks/queue-jobs.ts
+++ b/src/commands/doctor/checks/queue-jobs.ts
@@ -493,11 +493,13 @@ export async function computeOrphanedPrivateQueueCheck(engine: BrainEngine): Pro
     return {
       name: 'orphaned_private_queue',
       status: 'fail',
-      message:
+     message:
         `Orphaned private dream queue(s): ${orphaned.join('; ')}. ` +
         `A supervisor restart cannot consume these parent-owned queues. ` +
-        `Run \`gbrain dream retriage --help\` and use its queue-reconciliation dry run; ` +
-        `apply cancellation only after reviewing that preview.`,
+        `Current binaries run metadata-backed private-queue startup recovery when ` +
+        `\`gbrain jobs supervisor start\` begins. For legacy unowned queues, run ` +
+        `\`gbrain dream retriage --help\` and use its queue-reconciliation dry run; ` +
+        `apply manual cancellation only after reviewing that preview.`,
       details: {
         orphaned_private_queues: orphaned.length,
         waiting_jobs: waitingTotal,

--- a/src/commands/doctor/checks/queue-jobs.ts
+++ b/src/commands/doctor/checks/queue-jobs.ts
@@ -493,7 +493,7 @@ export async function computeOrphanedPrivateQueueCheck(engine: BrainEngine): Pro
     return {
       name: 'orphaned_private_queue',
       status: 'fail',
-     message:
+      message:
         `Orphaned private dream queue(s): ${orphaned.join('; ')}. ` +
         `A supervisor restart cannot consume these parent-owned queues. ` +
         `Current binaries run metadata-backed private-queue startup recovery when ` +

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -2609,6 +2609,7 @@ export async function registerBuiltinHandlers(
       pull,
       signal: job.signal, // propagate abort so cycle bails on timeout/cancel
       deadlineAtMs: job.deadlineAtMs, // #2781: phases budget sub-work from remaining time
+      privateQueueOwnerJobId: job.id,
       ...(sourceId ? { sourceId } : {}),
       ...(effectivePhases !== undefined ? { phases: effectivePhases as any } : {}),
       yieldBetweenPhases: async () => {
@@ -2805,6 +2806,7 @@ export async function registerBuiltinHandlers(
       phases: [phase as any],
       signal: job.signal,
       deadlineAtMs: job.deadlineAtMs, // #2781: phases budget sub-work from remaining time
+      privateQueueOwnerJobId: job.id,
     });
     return { phase, status: report.status, report };
   };

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -560,6 +560,8 @@ export interface CycleOpts {
    * phases then use their configured timeouts unchanged.
    */
   deadlineAtMs?: number | null;
+  /** Internal: minion job id that owns any phase-created private dream-inline queues. */
+  privateQueueOwnerJobId?: number | null;
 }
 
 // ─── Lock primitives ───────────────────────────────────────────────
@@ -2172,6 +2174,7 @@ export async function runCycle(
           // job budget (same collision shape as propose_takes, cross-process
           // timeout domain — clamped via the patterns.ts childBudget template).
           deadlineAtMs: opts.deadlineAtMs ?? null,
+          privateQueueOwnerJobId: opts.privateQueueOwnerJobId ?? null,
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
@@ -2380,6 +2383,7 @@ export async function runCycle(
           yieldDuringPhase: buildYieldDuringPhase(lock, opts.yieldDuringPhase, onStolen),
           once: opts.onceForPhase === 'patterns',
           deadlineAtMs: opts.deadlineAtMs ?? null,
+          privateQueueOwnerJobId: opts.privateQueueOwnerJobId ?? null,
           // #1586: scope pattern writes to the cycle's resolved source, same as
           // synthesize above. Without it the child's put_page rows land in
           // 'default' while the reverse-write drops the file into the named

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -68,6 +68,8 @@ export interface PatternsPhaseOpts {
    * row. Unset → legacy 'default'. Mirrors synthesize.ts's `sourceId`.
    */
   sourceId?: string;
+  /** Internal: minion owner job id for private dream-inline queue recovery. */
+  privateQueueOwnerJobId?: number | null;
 }
 
 /**
@@ -206,6 +208,11 @@ export async function runPhasePatterns(
     // synthesize.ts's childQueueName derivation exactly.
     const childQueueName = `dream-inline-${Date.now()}-${randomUUID().slice(0, 8)}`;
     ownedPrivateQueue = { queue, name: childQueueName };
+    const privateQueueOwnerToken = randomUUID();
+    const renewPrivateQueueLease = async () => {
+      await queue.renewPrivateQueueLease(childQueueName, privateQueueOwnerToken);
+      if (opts.yieldDuringPhase) await opts.yieldDuringPhase();
+    };
     const data: SubagentHandlerData = {
       prompt: buildPatternsPrompt(reflections, config.minEvidence, config.sourceSlugPrefix, config.outputSlugPrefix),
       model: config.model,
@@ -223,6 +230,9 @@ export async function runPhasePatterns(
       max_stalled: 3,
       timeout_ms: budgets.timeoutMs,
       queue: childQueueName,
+      private_queue_owner_job_id: opts.privateQueueOwnerJobId ?? null,
+      private_queue_owner_token: privateQueueOwnerToken,
+      private_queue_lease_ms: Math.max(600_000, budgets.waitTimeoutMs),
     };
     let job: Awaited<ReturnType<typeof queue.add>>;
     try {
@@ -243,7 +253,7 @@ export async function runPhasePatterns(
     // the terminal state instead of polling waitForCompletion until
     // subagentWaitTimeoutMs expires. Runs on BOTH engines — on Postgres the
     // parent job otherwise deadlocks a fully-occupied worker (#2050).
-    await runSubagentsInline(engine, queue, childQueueName, opts.yieldDuringPhase);
+    await runSubagentsInline(engine, queue, childQueueName, renewPrivateQueueLease);
 
     let outcome: MinionJobStatus | 'timeout';
     try {

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -122,6 +122,7 @@ export async function runPhasePatterns(
   opts: PatternsPhaseOpts,
 ): Promise<PhaseResult> {
   const start = Date.now();
+  let ownedPrivateQueue: { queue: MinionQueue; name: string } | null = null;
   try {
     const config = await loadPatternsConfig(engine);
 
@@ -204,6 +205,7 @@ export async function runPhasePatterns(
     // never claim a child this parent is about to run itself. Mirrors
     // synthesize.ts's childQueueName derivation exactly.
     const childQueueName = `dream-inline-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    ownedPrivateQueue = { queue, name: childQueueName };
     const data: SubagentHandlerData = {
       prompt: buildPatternsPrompt(reflections, config.minEvidence, config.sourceSlugPrefix, config.outputSlugPrefix),
       model: config.model,
@@ -326,6 +328,24 @@ export async function runPhasePatterns(
     return failed(makeError('InternalError', 'PATTERNS_PHASE_FAIL',
       e instanceof Error ? (e.message || 'patterns phase threw') : String(e)));
   } finally {
+    if (ownedPrivateQueue) {
+      try {
+        const cancelled = await ownedPrivateQueue.queue.reconcilePrivateQueue(
+          ownedPrivateQueue.name,
+          'private queue owner terminalized: patterns phase ended',
+        );
+        if (cancelled.length > 0) {
+          process.stderr.write(
+            `[dream] patterns reconciled ${cancelled.length} non-terminal child job(s) from ${ownedPrivateQueue.name}\n`,
+          );
+        }
+      } catch (cleanupError) {
+        process.stderr.write(
+          `[dream] patterns private-queue cleanup failed for ${ownedPrivateQueue.name}: ` +
+          `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}\n`,
+        );
+      }
+    }
     void start;
   }
 }

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -330,6 +330,8 @@ export interface SynthesizePhaseOpts {
    * correct (source_id, slug) row. Unset → legacy 'default'.
    */
   sourceId?: string;
+  /** Internal: minion owner job id for private dream-inline queue recovery. */
+  privateQueueOwnerJobId?: number | null;
   /**
    * issue #2860 — `gbrain dream --phase synthesize --once`. Bypasses the
    * `dream.synthesize.enabled` gate for THIS call only (does NOT bypass
@@ -548,6 +550,11 @@ export async function runPhaseSynthesize(
     // claim a child this parent is about to run itself.
     const childQueueName = `dream-inline-${Date.now()}-${randomUUID().slice(0, 8)}`;
     ownedPrivateQueue = { queue, name: childQueueName };
+    const privateQueueOwnerToken = randomUUID();
+    const renewPrivateQueueLease = async () => {
+      await queue.renewPrivateQueueLease(childQueueName, privateQueueOwnerToken);
+      if (opts.yieldDuringPhase) await opts.yieldDuringPhase();
+    };
     const childIds: number[] = [];
     /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
     const chunkInfo = new Map<number, { idx: number; hash6: string }>();
@@ -758,6 +765,9 @@ export async function runPhaseSynthesize(
           idempotency_key,
           timeout_ms: perChild.timeoutMs,
           queue: childQueueName,
+          private_queue_owner_job_id: opts.privateQueueOwnerJobId ?? null,
+          private_queue_owner_token: privateQueueOwnerToken,
+          private_queue_lease_ms: Math.max(600_000, perChild.waitTimeoutMs),
         };
         let child: Awaited<ReturnType<typeof queue.add>>;
         try {
@@ -858,7 +868,7 @@ export async function runPhaseSynthesize(
     }
     const drainStartedAt = Date.now();
     await runSubagentsInline(
-      engine, queue, childQueueName, opts.yieldDuringPhase,
+      engine, queue, childQueueName, renewPrivateQueueLease,
       undefined, undefined, effectiveConcurrency, opts.deadlineAtMs ?? null,
     );
     // Captured HERE: everything after this line (waiters, collection,

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -344,6 +344,7 @@ export async function runPhaseSynthesize(
   opts: SynthesizePhaseOpts,
 ): Promise<PhaseResult> {
   const start = Date.now();
+  let ownedPrivateQueue: { queue: MinionQueue; name: string } | null = null;
   // Normalize brainDir to an absolute path BEFORE any reverse-write. Without
   // this, a relative or empty brainDir flows down to writeReversePages →
   // `join(brainDir, '${slug}.md')` → relative path → resolves against cwd at
@@ -546,6 +547,7 @@ export async function runPhaseSynthesize(
     // unrelated 'default'-queue jobs, and a 'default'-queue worker must never
     // claim a child this parent is about to run itself.
     const childQueueName = `dream-inline-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    ownedPrivateQueue = { queue, name: childQueueName };
     const childIds: number[] = [];
     /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
     const chunkInfo = new Map<number, { idx: number; hash6: string }>();
@@ -1135,6 +1137,27 @@ export async function runPhaseSynthesize(
   } catch (e) {
     return failed(makeError('InternalError', 'SYNTH_PHASE_FAIL',
       e instanceof Error ? (e.message || 'synthesize phase threw') : String(e)));
+  } finally {
+    if (ownedPrivateQueue) {
+      try {
+        const cancelled = await ownedPrivateQueue.queue.reconcilePrivateQueue(
+          ownedPrivateQueue.name,
+          'private queue owner terminalized: synthesize phase ended',
+        );
+        if (cancelled.length > 0) {
+          process.stderr.write(
+            `[dream] synthesize reconciled ${cancelled.length} non-terminal child job(s) from ${ownedPrivateQueue.name}\n`,
+          );
+        }
+      } catch (cleanupError) {
+        // The phase result must survive a transient cleanup failure; Doctor
+        // and waiting-TTL remain delayed backstops and will surface/reap it.
+        process.stderr.write(
+          `[dream] synthesize private-queue cleanup failed for ${ownedPrivateQueue.name}: ` +
+          `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}\n`,
+        );
+      }
+    }
   }
 }
 

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -6015,11 +6015,21 @@ export const MIGRATIONS: Migration[] = [
     // dream-inline queues. Startup recovery uses these columns to cancel only
     // orphaned private queues (terminal/missing owner or expired lease), never
     // live queues and never legacy unowned rows.
+    //
+    // owner_host/owner_pid exist because owner_job_id is NULL for every
+    // non-minion dream run (`gbrain dream` from a CLI/cron shell threads no
+    // owner job). Without a process identity those queues would be defended
+    // only by a lease that stops renewing between children, so a slow drain
+    // could look "orphaned" while the owner is very much alive. Recovery
+    // probes the recorded process via classifyHolderLiveness (PID-reuse-safe,
+    // cross-host-safe) before it is ever allowed to cancel.
     idempotent: true,
     sql: `
       ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL;
       ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_token TEXT;
       ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_lease_until TIMESTAMPTZ;
+      ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_host TEXT;
+      ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_pid INTEGER;
       CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_recovery
         ON minion_jobs (queue, private_queue_lease_until)
         WHERE queue LIKE 'dream-inline-%'

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -6008,6 +6008,27 @@ export const MIGRATIONS: Migration[] = [
         WHERE expired_at IS NULL;
     `,
   },
+  {
+    version: 136,
+    name: 'minion_private_queue_owner_metadata',
+    // issue #4332: durable ownership/liveness metadata for parent-owned
+    // dream-inline queues. Startup recovery uses these columns to cancel only
+    // orphaned private queues (terminal/missing owner or expired lease), never
+    // live queues and never legacy unowned rows.
+    idempotent: true,
+    sql: `
+      ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL;
+      ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_token TEXT;
+      ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_lease_until TIMESTAMPTZ;
+      CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_recovery
+        ON minion_jobs (queue, private_queue_lease_until)
+        WHERE queue LIKE 'dream-inline-%'
+          AND status IN ('waiting','active','delayed','waiting-children','paused');
+      CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_owner
+        ON minion_jobs (private_queue_owner_job_id)
+        WHERE private_queue_owner_job_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/minions/child-worker-supervisor.ts
+++ b/src/core/minions/child-worker-supervisor.ts
@@ -145,6 +145,14 @@ export interface ChildWorkerSupervisorOpts {
   /** Accessor for the composer's stopping flag; loop exits when this returns true. */
   isStopping: () => boolean;
 
+  /**
+   * Optional fenced maintenance hook run immediately before EVERY child spawn,
+   * including crash/watchdog respawns. The composer owns error handling: a
+   * rejected hook aborts the supervise loop instead of spawning past a failed
+   * safety precondition.
+   */
+  beforeSpawn?: () => Promise<void>;
+
   /** Test seed for the clean-restart window. Defaults to Date.now. @internal */
   _now?: () => number;
 }
@@ -328,6 +336,8 @@ export class ChildWorkerSupervisor {
       this.opts.maxCrashes * HARD_STOP_CRASH_MULTIPLIER;
     let degradedAnnounced = false;
     while (!this.opts.isStopping()) {
+      await this.opts.beforeSpawn?.();
+      if (this.opts.isStopping()) return;
       await this.spawnOnce();
 
       if (this.opts.isStopping()) return;

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -8,7 +8,10 @@
  *   await queue.prune({ olderThan: new Date(Date.now() - 30 * 86400000) });
  */
 
+import { hostname } from 'os';
+import { randomUUID } from 'crypto';
 import type { BrainEngine } from '../engine.ts';
+import { classifyHolderLiveness } from '../db-lock.ts';
 import type {
   MinionJob, MinionJobInput, MinionJobStatus, InboxMessage, TokenUpdate,
   MinionQueueOpts, ChildDoneMessage, ChildOutcome, Attachment, AttachmentInput,
@@ -123,7 +126,17 @@ export interface PrivateQueueRecoveryResult {
   skipped_live_queues: number;
   skipped_unowned_queues: number;
   skipped_non_orphan_queues: number;
+  /** Legacy unowned queues stamped with adoption metadata this pass. */
+  adopted_legacy_queues: number;
 }
+
+/**
+ * Minimum age before a legacy (pre-#4332) unowned `dream-inline-*` queue may be
+ * ADOPTED into the metadata regime. Generous by construction: adoption is a
+ * one-way stamp that starts a lease clock, and a queue younger than this could
+ * still belong to an owner that simply predates the owner-stamping build.
+ */
+export const LEGACY_PRIVATE_QUEUE_ADOPTION_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** Audit payload deferred from inside the submission transaction. */
 type CoalesceAuditEvent = {
@@ -572,11 +585,12 @@ export class MinionQueue {
       const baseCols = `name, queue, status, priority, data, max_attempts, backoff_type,
             backoff_delay, backoff_jitter, delay_until, parent_job_id, on_child_fail,
             depth, max_children, timeout_ms, lock_duration_ms, remove_on_complete, remove_on_fail, idempotency_key,
-            quiet_hours, stagger_key, private_queue_owner_job_id, private_queue_owner_token, private_queue_lease_until`;
+            quiet_hours, stagger_key, private_queue_owner_job_id, private_queue_owner_token, private_queue_lease_until,
+            private_queue_owner_host, private_queue_owner_pid`;
       const baseVals = `$1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20::jsonb, $21`;
-      const baseValsWithOwner = `${baseVals}, $22, $23, $24`;
+      const baseValsWithOwner = `${baseVals}, $22, $23, $24, $25, $26`;
       const cols = hasMaxStalled ? `${baseCols}, max_stalled` : baseCols;
-      const vals = hasMaxStalled ? `${baseValsWithOwner}, $25` : baseValsWithOwner;
+      const vals = hasMaxStalled ? `${baseValsWithOwner}, $27` : baseValsWithOwner;
 
       const insertSql = opts?.idempotency_key
         ? `INSERT INTO minion_jobs (${cols})
@@ -622,6 +636,15 @@ export class MinionQueue {
         opts?.private_queue_owner_job_id ?? null,
         opts?.private_queue_owner_token ?? null,
         privateQueueLeaseUntil,
+        // Stamp the submitting process when this row carries private-queue
+        // ownership. owner_job_id is NULL for CLI dream runs, so this is the
+        // only liveness signal recovery can probe for that (common) shape.
+        opts?.private_queue_owner_token
+          ? (opts?.private_queue_owner_host ?? hostname())
+          : (opts?.private_queue_owner_host ?? null),
+        opts?.private_queue_owner_token
+          ? (opts?.private_queue_owner_pid ?? process.pid)
+          : (opts?.private_queue_owner_pid ?? null),
       ];
       if (hasMaxStalled) params.push(clampedMaxStalled);
 
@@ -815,6 +838,17 @@ export class MinionQueue {
   async reconcileOrphanedPrivateQueues(opts: {
     reason?: string;
     maxQueues?: number;
+    /**
+     * Opt-in migration for legacy pre-#4332 queues that carry NO owner
+     * metadata. When enabled, a sufficiently old unowned queue is *adopted* —
+     * stamped with an owner token and a fresh lease — instead of being
+     * cancelled. Adoption never terminalizes a job: the next pass evaluates it
+     * under the normal liveness rules, and a still-live owner keeps renewing.
+     * Default OFF so a plain supervisor start never mutates legacy rows.
+     */
+    adoptLegacyUnowned?: boolean;
+    /** @internal test seam for the adoption age gate. */
+    legacyAdoptionMinAgeMs?: number;
   } = {}): Promise<PrivateQueueRecoveryResult> {
     const result: PrivateQueueRecoveryResult = {
       scanned_queues: 0,
@@ -823,6 +857,7 @@ export class MinionQueue {
       skipped_live_queues: 0,
       skipped_unowned_queues: 0,
       skipped_non_orphan_queues: 0,
+      adopted_legacy_queues: 0,
     };
     const maxQueues = Math.max(1, Math.floor(opts.maxQueues ?? 100));
     const queues = await this.engine.executeRaw<{ queue: string }>(
@@ -843,6 +878,16 @@ export class MinionQueue {
         continue;
       }
       if (verdict === 'unowned') {
+        if (opts.adoptLegacyUnowned) {
+          const adopted = await this.adoptLegacyPrivateQueue(
+            q.queue,
+            opts.legacyAdoptionMinAgeMs ?? LEGACY_PRIVATE_QUEUE_ADOPTION_MIN_AGE_MS,
+          );
+          if (adopted) {
+            result.adopted_legacy_queues++;
+            continue;
+          }
+        }
         result.skipped_unowned_queues++;
         continue;
       }
@@ -862,6 +907,69 @@ export class MinionQueue {
     return result;
   }
 
+  /**
+   * Migration path for legacy pre-#4332 `dream-inline-*` queues that carry no
+   * owner metadata at all.
+   *
+   * Deliberately NOT a cancellation. Adoption only stamps an owner token plus
+   * a lease onto rows that are already old enough that no in-flight phase can
+   * plausibly own them, which brings them under the normal recovery rules
+   * without ever terminalizing work. Two guards keep a live queue safe:
+   *   - an age gate (default 24h) evaluated on the queue's newest row, so a
+   *     queue that is still being appended to is never adopted; and
+   *   - a healthy-active-lock check, so a queue with a running child is skipped
+   *     even if it is old.
+   *
+   * Returns true when rows were stamped.
+   */
+  async adoptLegacyPrivateQueue(
+    queueName: string,
+    minAgeMs = LEGACY_PRIVATE_QUEUE_ADOPTION_MIN_AGE_MS,
+  ): Promise<boolean> {
+    if (!isDreamInlinePrivateQueue(queueName)) {
+      throw new Error(`refusing to adopt non-private queue '${queueName}'`);
+    }
+    const rows = await this.engine.executeRaw<{ id: number }>(
+      `WITH q AS (
+         SELECT * FROM minion_jobs
+          WHERE queue = $1
+            AND status = ANY($2::text[])
+       ),
+       gate AS (
+         SELECT
+           count(*) FILTER (
+             WHERE private_queue_owner_job_id IS NOT NULL
+                OR private_queue_owner_token IS NOT NULL
+                OR private_queue_lease_until IS NOT NULL
+           ) AS owned_rows,
+           count(*) FILTER (WHERE status = 'active' AND lock_until > now()) AS active_healthy,
+           max(COALESCE(updated_at, created_at)) AS newest_at,
+           count(*) AS total_rows
+           FROM q
+       )
+       UPDATE minion_jobs m
+          SET private_queue_owner_token = $3,
+              private_queue_lease_until = now() + ($4::text::interval),
+              updated_at = now()
+         FROM gate
+        WHERE m.queue = $1
+          AND m.status = ANY($2::text[])
+          AND gate.total_rows > 0
+          AND gate.owned_rows = 0
+          AND gate.active_healthy = 0
+          AND gate.newest_at < now() - ($5::text::interval)
+        RETURNING m.id`,
+      [
+        queueName,
+        NON_TERMINAL_STATUSES,
+        `legacy-adopted-${randomUUID()}`,
+        `${Math.max(1, Math.floor(DEFAULT_PRIVATE_QUEUE_LEASE_MS))} milliseconds`,
+        `${Math.max(1, Math.floor(minAgeMs))} milliseconds`,
+      ],
+    );
+    return rows.length > 0;
+  }
+
   private async classifyPrivateQueueForRecovery(
     queueName: string,
   ): Promise<'orphan' | 'live' | 'unowned' | 'not_orphan'> {
@@ -873,6 +981,9 @@ export class MinionQueue {
       nonterminal_owner_rows: string | number;
       max_lease_until: string | null;
       future_lease_rows: string | number;
+      owner_host: string | null;
+      owner_pid: number | null;
+      owner_age_ms: string | number | null;
     }>(
       `WITH q AS (
          SELECT *
@@ -897,7 +1008,10 @@ export class MinionQueue {
          (SELECT count(*) FROM owners WHERE status = 'active' AND lock_until > now()) AS live_owner_rows,
          (SELECT count(*) FROM owners WHERE status IN ('waiting','active','delayed','waiting-children','paused')) AS nonterminal_owner_rows,
          max(q.private_queue_lease_until)::text AS max_lease_until,
-         count(*) FILTER (WHERE q.private_queue_lease_until > now()) AS future_lease_rows
+         count(*) FILTER (WHERE q.private_queue_lease_until > now()) AS future_lease_rows,
+         min(q.private_queue_owner_host) AS owner_host,
+         min(q.private_queue_owner_pid) AS owner_pid,
+         EXTRACT(EPOCH FROM (now() - min(q.created_at))) * 1000 AS owner_age_ms
        FROM q`,
       [queueName, NON_TERMINAL_STATUSES],
     );
@@ -914,7 +1028,27 @@ export class MinionQueue {
     if (ownerTerminal) return 'orphan';
     if (Number(r.future_lease_rows ?? 0) > 0) return 'live';
     const leaseExpired = r.max_lease_until !== null && new Date(r.max_lease_until).getTime() <= Date.now();
-    return leaseExpired ? 'orphan' : 'not_orphan';
+    if (!leaseExpired) return 'not_orphan';
+
+    // Lease lapsed — NOT sufficient on its own. The lease only renews while a
+    // child handler is executing (inline-drain's 60s keepalive), so a long
+    // gap between children, or a slow post-drain collection, can lapse the
+    // lease under a perfectly healthy owner. Probe the recorded process
+    // before cancelling: alive/cross-host/unknown all mean HANDS OFF, and a
+    // provably-dead PID must still age past the reuse grace.
+    const ownerHost = r.owner_host;
+    const ownerPid = r.owner_pid == null ? null : Number(r.owner_pid);
+    if (ownerHost && ownerPid != null && Number.isFinite(ownerPid) && ownerPid > 0) {
+      const ageMs = Number(r.owner_age_ms ?? 0);
+      const liveness = classifyHolderLiveness(ownerPid, ownerHost, Number.isFinite(ageMs) ? ageMs : 0);
+      // Only a same-host, provably-dead, past-grace owner may be reclaimed.
+      return liveness === 'dead_eligible' ? 'orphan' : 'live';
+    }
+
+    // Metadata-backed but no probe-able process identity (rows written by an
+    // older build of this same feature). Expired lease is all we have; keep
+    // the prior behaviour rather than inventing a stronger claim.
+    return 'orphan';
   }
 
   /**

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -722,6 +722,34 @@ export class MinionQueue {
   }
 
   /**
+   * Terminalize every non-terminal job in one private, parent-owned queue.
+   *
+   * Dream phases drain `dream-inline-*` queues themselves; the shared worker
+   * intentionally never claims them.  A phase therefore owns cleanup too:
+   * every return/throw/timeout path calls this from `finally`.  The method is
+   * idempotent and routes through cancelJobs() so child_done messages,
+   * descendant cancellation, active-job aborts, and aggregator unblocking all
+   * retain the queue's normal bookkeeping semantics.
+   */
+  async reconcilePrivateQueue(queueName: string, reason: string): Promise<MinionJob[]> {
+    if (!queueName.startsWith('dream-inline-')) {
+      throw new Error(`refusing to reconcile non-private queue '${queueName}'`);
+    }
+    const rows = await this.engine.executeRaw<{ id: number }>(
+      `SELECT id FROM minion_jobs
+        WHERE queue = $1
+          AND status IN ('waiting','active','delayed','waiting-children','paused')
+        ORDER BY id`,
+      [queueName],
+    );
+    if (rows.length === 0) return [];
+    return this.cancelJobs(rows.map(r => r.id), {
+      reason,
+      rootStatuses: ['waiting', 'active', 'delayed', 'waiting-children', 'paused'],
+    });
+  }
+
+  /**
    * Batch variant of cancelJob: cancels every root id AND its descendants in
    * ONE transaction, with the full bookkeeping the single-id path carries
    * (child_done inbox messages + aggregator-parent resolution). Callers that

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -49,6 +49,8 @@ export interface TrustedSubmitOpts {
 const MIGRATION_VERSION = 7;
 
 const DEFAULT_MAX_SPAWN_DEPTH = 5;
+export const DREAM_INLINE_PRIVATE_QUEUE_PREFIX = 'dream-inline-';
+export const DEFAULT_PRIVATE_QUEUE_LEASE_MS = 10 * 60 * 1000;
 
 /**
  * Stall-sweep reclaim grace (#4145, CDX-7): don't reclaim a row whose
@@ -108,6 +110,20 @@ export function resolveStallReclaimGraceMs(
 const DEFAULT_MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024; // 5 MiB
 
 const TERMINAL_STATUSES = ['completed', 'failed', 'dead', 'cancelled'] as const;
+const NON_TERMINAL_STATUSES: MinionJobStatus[] = ['waiting', 'active', 'delayed', 'waiting-children', 'paused'];
+
+export function isDreamInlinePrivateQueue(queueName: string): boolean {
+  return queueName.startsWith(DREAM_INLINE_PRIVATE_QUEUE_PREFIX);
+}
+
+export interface PrivateQueueRecoveryResult {
+  scanned_queues: number;
+  cancelled_queues: number;
+  cancelled_jobs: number;
+  skipped_live_queues: number;
+  skipped_unowned_queues: number;
+  skipped_non_orphan_queues: number;
+}
 
 /** Audit payload deferred from inside the submission transaction. */
 type CoalesceAuditEvent = {
@@ -549,13 +565,18 @@ export class MinionQueue {
         ? Math.max(1, Math.min(100, Math.floor(opts!.max_stalled as number)))
         : null;
 
+      const privateQueueLeaseUntil = opts?.private_queue_lease_ms != null
+        ? new Date(Date.now() + Math.max(1, Math.floor(opts.private_queue_lease_ms))).toISOString()
+        : null;
+
       const baseCols = `name, queue, status, priority, data, max_attempts, backoff_type,
             backoff_delay, backoff_jitter, delay_until, parent_job_id, on_child_fail,
             depth, max_children, timeout_ms, lock_duration_ms, remove_on_complete, remove_on_fail, idempotency_key,
-            quiet_hours, stagger_key`;
+            quiet_hours, stagger_key, private_queue_owner_job_id, private_queue_owner_token, private_queue_lease_until`;
       const baseVals = `$1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20::jsonb, $21`;
+      const baseValsWithOwner = `${baseVals}, $22, $23, $24`;
       const cols = hasMaxStalled ? `${baseCols}, max_stalled` : baseCols;
-      const vals = hasMaxStalled ? `${baseVals}, $22` : baseVals;
+      const vals = hasMaxStalled ? `${baseValsWithOwner}, $25` : baseValsWithOwner;
 
       const insertSql = opts?.idempotency_key
         ? `INSERT INTO minion_jobs (${cols})
@@ -598,6 +619,9 @@ export class MinionQueue {
         opts?.idempotency_key ?? null,
         opts?.quiet_hours ?? null,
         opts?.stagger_key ?? null,
+        opts?.private_queue_owner_job_id ?? null,
+        opts?.private_queue_owner_token ?? null,
+        privateQueueLeaseUntil,
       ];
       if (hasMaxStalled) params.push(clampedMaxStalled);
 
@@ -732,7 +756,7 @@ export class MinionQueue {
    * retain the queue's normal bookkeeping semantics.
    */
   async reconcilePrivateQueue(queueName: string, reason: string): Promise<MinionJob[]> {
-    if (!queueName.startsWith('dream-inline-')) {
+    if (!isDreamInlinePrivateQueue(queueName)) {
       throw new Error(`refusing to reconcile non-private queue '${queueName}'`);
     }
     const rows = await this.engine.executeRaw<{ id: number }>(
@@ -747,6 +771,150 @@ export class MinionQueue {
       reason,
       rootStatuses: ['waiting', 'active', 'delayed', 'waiting-children', 'paused'],
     });
+  }
+
+  /**
+   * Renew the owner lease on still-non-terminal jobs in one private queue.
+   * The owner token prevents a stale phase finally/keepalive from extending a
+   * successor queue that reused the same queue name in a test or fixture.
+   */
+  async renewPrivateQueueLease(
+    queueName: string,
+    ownerToken: string,
+    leaseMs = DEFAULT_PRIVATE_QUEUE_LEASE_MS,
+  ): Promise<number> {
+    if (!isDreamInlinePrivateQueue(queueName)) {
+      throw new Error(`refusing to renew non-private queue '${queueName}'`);
+    }
+    if (ownerToken.length === 0) {
+      throw new Error('private queue owner token cannot be empty');
+    }
+    const rows = await this.engine.executeRaw<{ id: number }>(
+      `UPDATE minion_jobs
+          SET private_queue_lease_until = now() + ($3::text::interval),
+              updated_at = now()
+        WHERE queue = $1
+          AND private_queue_owner_token = $2
+          AND status = ANY($4::text[])
+        RETURNING id`,
+      [queueName, ownerToken, `${Math.max(1, Math.floor(leaseMs))} milliseconds`, NON_TERMINAL_STATUSES],
+    );
+    return rows.length;
+  }
+
+  /**
+   * Startup/supervisor crash recovery for metadata-backed private dream queues.
+   * Cancels only queues that are provably orphaned:
+   *   - no live child lock in the private queue;
+   *   - explicit owner metadata exists; and
+   *   - the owner job is terminal/missing OR the renewable lease has expired.
+   *
+   * Legacy `dream-inline-*` rows with no owner metadata are left untouched and
+   * remain a Doctor/manual-retriage concern.
+   */
+  async reconcileOrphanedPrivateQueues(opts: {
+    reason?: string;
+    maxQueues?: number;
+  } = {}): Promise<PrivateQueueRecoveryResult> {
+    const result: PrivateQueueRecoveryResult = {
+      scanned_queues: 0,
+      cancelled_queues: 0,
+      cancelled_jobs: 0,
+      skipped_live_queues: 0,
+      skipped_unowned_queues: 0,
+      skipped_non_orphan_queues: 0,
+    };
+    const maxQueues = Math.max(1, Math.floor(opts.maxQueues ?? 100));
+    const queues = await this.engine.executeRaw<{ queue: string }>(
+      `SELECT queue
+         FROM minion_jobs
+        WHERE queue LIKE 'dream-inline-%'
+          AND status = ANY($1::text[])
+        GROUP BY queue
+        ORDER BY min(created_at), queue
+        LIMIT $2`,
+      [NON_TERMINAL_STATUSES, maxQueues],
+    );
+    result.scanned_queues = queues.length;
+    for (const q of queues) {
+      const verdict = await this.classifyPrivateQueueForRecovery(q.queue);
+      if (verdict === 'live') {
+        result.skipped_live_queues++;
+        continue;
+      }
+      if (verdict === 'unowned') {
+        result.skipped_unowned_queues++;
+        continue;
+      }
+      if (verdict === 'not_orphan') {
+        result.skipped_non_orphan_queues++;
+        continue;
+      }
+      const cancelled = await this.reconcilePrivateQueue(
+        q.queue,
+        opts.reason ?? 'startup recovery: orphaned dream-inline private queue',
+      );
+      if (cancelled.length > 0) {
+        result.cancelled_queues++;
+        result.cancelled_jobs += cancelled.length;
+      }
+    }
+    return result;
+  }
+
+  private async classifyPrivateQueueForRecovery(
+    queueName: string,
+  ): Promise<'orphan' | 'live' | 'unowned' | 'not_orphan'> {
+    const rows = await this.engine.executeRaw<{
+      active_healthy: string | number;
+      owner_ids: unknown;
+      metadata_rows: string | number;
+      live_owner_rows: string | number;
+      nonterminal_owner_rows: string | number;
+      max_lease_until: string | null;
+      future_lease_rows: string | number;
+    }>(
+      `WITH q AS (
+         SELECT *
+           FROM minion_jobs
+          WHERE queue = $1
+            AND status = ANY($2::text[])
+       ),
+       owner_ids AS (
+         SELECT DISTINCT private_queue_owner_job_id AS id
+           FROM q
+          WHERE private_queue_owner_job_id IS NOT NULL
+       ),
+       owners AS (
+         SELECT o.id, m.status, m.lock_until
+           FROM owner_ids o
+           LEFT JOIN minion_jobs m ON m.id = o.id
+       )
+       SELECT
+         count(*) FILTER (WHERE q.status = 'active' AND q.lock_until > now()) AS active_healthy,
+         COALESCE(jsonb_agg(DISTINCT q.private_queue_owner_job_id) FILTER (WHERE q.private_queue_owner_job_id IS NOT NULL), '[]'::jsonb) AS owner_ids,
+         count(*) FILTER (WHERE q.private_queue_owner_job_id IS NOT NULL OR q.private_queue_lease_until IS NOT NULL) AS metadata_rows,
+         (SELECT count(*) FROM owners WHERE status = 'active' AND lock_until > now()) AS live_owner_rows,
+         (SELECT count(*) FROM owners WHERE status IN ('waiting','active','delayed','waiting-children','paused')) AS nonterminal_owner_rows,
+         max(q.private_queue_lease_until)::text AS max_lease_until,
+         count(*) FILTER (WHERE q.private_queue_lease_until > now()) AS future_lease_rows
+       FROM q`,
+      [queueName, NON_TERMINAL_STATUSES],
+    );
+    const r = rows[0];
+    if (!r) return 'not_orphan';
+    if (Number(r.active_healthy ?? 0) > 0 || Number(r.live_owner_rows ?? 0) > 0) {
+      return 'live';
+    }
+    if (Number(r.metadata_rows ?? 0) === 0) return 'unowned';
+    const ownerIds = Array.isArray(r.owner_ids)
+      ? r.owner_ids
+      : (typeof r.owner_ids === 'string' ? JSON.parse(r.owner_ids) : []);
+    const ownerTerminal = ownerIds.length > 0 && Number(r.nonterminal_owner_rows ?? 0) === 0;
+    if (ownerTerminal) return 'orphan';
+    if (Number(r.future_lease_rows ?? 0) > 0) return 'live';
+    const leaseExpired = r.max_lease_until !== null && new Date(r.max_lease_until).getTime() <= Date.now();
+    return leaseExpired ? 'orphan' : 'not_orphan';
   }
 
   /**

--- a/src/core/minions/supervisor.ts
+++ b/src/core/minions/supervisor.ts
@@ -45,6 +45,7 @@ import {
 import { dirname, resolve } from 'path';
 import type { BrainEngine } from '../engine.ts';
 import { tryAcquireDbLock, inspectLock, isLockHolderLive, type DbLockHandle } from '../db-lock.ts';
+import { MinionQueue } from './queue.ts';
 import { currentBrainId, readWorkers } from './worker-registry.ts';
 import { autopilotPausedMarkerPath } from '../autopilot-paths.ts';
 import { resolveEnvNumber } from '../env-number.ts';
@@ -710,6 +711,8 @@ export class MinionSupervisor {
     // can be 0/disabled) so the TTL never lapses while we're alive.
     this.lockRefreshTimer = setInterval(() => { void this.refreshDbLock(); }, SUPERVISOR_LOCK_REFRESH_MS);
 
+    await this.reconcileOrphanedPrivateQueuesOnStartup();
+
     // 3. Signal handlers (tracked refs; removed on shutdown for test lifecycle hygiene).
     this.sigtermListener = () => { void this.shutdown('SIGTERM', ExitCodes.CLEAN); };
     this.sigintListener = () => { void this.shutdown('SIGINT', ExitCodes.CLEAN); };
@@ -785,6 +788,25 @@ export class MinionSupervisor {
         reason: 'wedge_watchdog_inert',
         error: e instanceof Error ? e.message : String(e),
         queue: this.opts.queue,
+      });
+    }
+  }
+
+  private async reconcileOrphanedPrivateQueuesOnStartup(): Promise<void> {
+    try {
+      const result = await new MinionQueue(this.engine).reconcileOrphanedPrivateQueues({
+        reason: 'supervisor startup recovery: orphaned dream-inline private queue',
+      });
+      if (result.cancelled_jobs > 0) {
+        this.emit('health_warn', {
+          reason: 'private_queue_startup_recovery',
+          ...result,
+        });
+      }
+    } catch (e) {
+      this.emit('health_warn', {
+        reason: 'private_queue_startup_recovery_failed',
+        error: e instanceof Error ? e.message : String(e),
       });
     }
   }

--- a/src/core/minions/supervisor.ts
+++ b/src/core/minions/supervisor.ts
@@ -468,6 +468,15 @@ export const ExitCodes = {
 // via the DB lock instead of the (possibly split-$HOME) pidfile.
 export const SUPERVISOR_LOCK_TTL_MIN = 5;
 const SUPERVISOR_LOCK_REFRESH_MS = 60_000;
+
+/**
+ * Floor between pre-spawn private-queue recovery scans (#4332). The first
+ * spawn after supervisor start always scans; a crash-loop respawning faster
+ * than this reuses the previous pass rather than re-scanning every dream-inline
+ * row. Orphan recovery is not latency-sensitive — the delayed backstops
+ * (waiting-TTL, Doctor) still cover anything this defers.
+ */
+const PRIVATE_QUEUE_RECOVERY_MIN_INTERVAL_MS = 60_000;
 const SUPERVISOR_LOCK_REFRESH_MAX_FAILURES = 3; // 3 × 60s = 180s < 5min TTL
 
 /**
@@ -524,6 +533,8 @@ export class MinionSupervisor {
   /** Path to tini binary for zombie reaping, or empty string when absent. */
   private readonly tiniPath: string;
   private stopping = false;
+  /** Throttle stamp for pre-spawn private-queue recovery; null = never run. */
+  private lastPrivateQueueRecoveryAtMs: number | null = null;
   private healthInFlight = false;
   private healthTimer: ReturnType<typeof setInterval> | null = null;
   private exitListener: (() => void) | null = null;
@@ -791,6 +802,19 @@ export class MinionSupervisor {
   }
 
   private async reconcileOrphanedPrivateQueuesBeforeWorkerSpawn(): Promise<void> {
+    // Runs before EVERY spawn (including crash/watchdog respawns) because those
+    // are exactly the exits that strand a parent-owned queue. A crash-loop can
+    // fire this many times per minute, though, and the scan touches every
+    // non-terminal dream-inline row — so throttle repeat passes while still
+    // guaranteeing one scan on the first spawn after supervisor start.
+    const now = Date.now();
+    if (
+      this.lastPrivateQueueRecoveryAtMs !== null &&
+      now - this.lastPrivateQueueRecoveryAtMs < PRIVATE_QUEUE_RECOVERY_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.lastPrivateQueueRecoveryAtMs = now;
     try {
       const result = await new MinionQueue(this.engine).reconcileOrphanedPrivateQueues({
         reason: 'supervisor startup recovery: orphaned dream-inline private queue',

--- a/src/core/minions/supervisor.ts
+++ b/src/core/minions/supervisor.ts
@@ -711,8 +711,6 @@ export class MinionSupervisor {
     // can be 0/disabled) so the TTL never lapses while we're alive.
     this.lockRefreshTimer = setInterval(() => { void this.refreshDbLock(); }, SUPERVISOR_LOCK_REFRESH_MS);
 
-    await this.reconcileOrphanedPrivateQueuesOnStartup();
-
     // 3. Signal handlers (tracked refs; removed on shutdown for test lifecycle hygiene).
     this.sigtermListener = () => { void this.shutdown('SIGTERM', ExitCodes.CLEAN); };
     this.sigintListener = () => { void this.shutdown('SIGINT', ExitCodes.CLEAN); };
@@ -792,7 +790,7 @@ export class MinionSupervisor {
     }
   }
 
-  private async reconcileOrphanedPrivateQueuesOnStartup(): Promise<void> {
+  private async reconcileOrphanedPrivateQueuesBeforeWorkerSpawn(): Promise<void> {
     try {
       const result = await new MinionQueue(this.engine).reconcileOrphanedPrivateQueues({
         reason: 'supervisor startup recovery: orphaned dream-inline private queue',
@@ -1046,6 +1044,11 @@ export class MinionSupervisor {
       hardStopMaxCrashes: resolveHardStopMaxCrashes(this.opts.maxCrashes),
       _backoffFloorMs: this.opts._backoffFloorMs,
       isStopping: () => this.stopping,
+      // Run under the supervisor's queue-scoped DB singleton lock before every
+      // child spawn, not merely once when the supervisor starts. The supervisor
+      // intentionally survives worker crashes/watchdog drains, and those are
+      // exactly the exits that can strand a parent-owned private queue.
+      beforeSpawn: () => this.reconcileOrphanedPrivateQueuesBeforeWorkerSpawn(),
       onMaxCrashesExceeded: (count, max) => {
         this.emit('max_crashes_exceeded', {
           crash_count: count,

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -76,6 +76,12 @@ export interface MinionJob {
   remove_on_complete: boolean;
   remove_on_fail: boolean;
   idempotency_key: string | null;
+  /** Private dream-inline queue owner job, when this job is owned by an inline parent. */
+  private_queue_owner_job_id: number | null;
+  /** Private dream-inline queue owner token; random per phase run. */
+  private_queue_owner_token: string | null;
+  /** Renewable private-queue lease. Startup recovery may cancel only after this expires. */
+  private_queue_lease_until: Date | null;
 
   // v12: scheduler polish — quiet-hours gate + deterministic stagger
   quiet_hours: Record<string, unknown> | null;
@@ -140,6 +146,13 @@ export interface MinionJobInput {
   max_spawn_depth?: number;
   /** Global dedup key. Same key returns the existing job, no second row created. */
   idempotency_key?: string;
+  /**
+   * Internal: owner metadata for parent-owned `dream-inline-*` queues. Used by
+   * startup recovery to distinguish crashed owners from live private queues.
+   */
+  private_queue_owner_job_id?: number | null;
+  private_queue_owner_token?: string | null;
+  private_queue_lease_ms?: number | null;
   /** Submission backpressure: cap waiting jobs with this name before inserting
    *  a new row. Scope is (name, queue, source), where source reads
    *  data.sourceId ?? data.source_id; a submission with NO source key counts
@@ -455,6 +468,9 @@ export function rowToMinionJob(row: Record<string, unknown>): MinionJob {
     remove_on_complete: row.remove_on_complete === true,
     remove_on_fail: row.remove_on_fail === true,
     idempotency_key: (row.idempotency_key as string) || null,
+    private_queue_owner_job_id: (row.private_queue_owner_job_id as number | null) ?? null,
+    private_queue_owner_token: (row.private_queue_owner_token as string) || null,
+    private_queue_lease_until: row.private_queue_lease_until ? new Date(row.private_queue_lease_until as string) : null,
     quiet_hours: row.quiet_hours ? (typeof row.quiet_hours === 'string' ? JSON.parse(row.quiet_hours) : row.quiet_hours) as Record<string, unknown> : null,
     stagger_key: (row.stagger_key as string) || null,
     result: row.result ? (typeof row.result === 'string' ? JSON.parse(row.result) : row.result) as Record<string, unknown> : null,

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -82,6 +82,10 @@ export interface MinionJob {
   private_queue_owner_token: string | null;
   /** Renewable private-queue lease. Startup recovery may cancel only after this expires. */
   private_queue_lease_until: Date | null;
+  /** Host of the process that owns this private queue (liveness probe scope). */
+  private_queue_owner_host: string | null;
+  /** PID of the process that owns this private queue; probed before any recovery. */
+  private_queue_owner_pid: number | null;
 
   // v12: scheduler polish — quiet-hours gate + deterministic stagger
   quiet_hours: Record<string, unknown> | null;
@@ -153,6 +157,13 @@ export interface MinionJobInput {
   private_queue_owner_job_id?: number | null;
   private_queue_owner_token?: string | null;
   private_queue_lease_ms?: number | null;
+  /**
+   * Owning process identity. Defaults to the submitting process when a private
+   * queue owner token is supplied, so a CLI dream run (which has no owner JOB)
+   * still carries a probe-able liveness signal.
+   */
+  private_queue_owner_host?: string | null;
+  private_queue_owner_pid?: number | null;
   /** Submission backpressure: cap waiting jobs with this name before inserting
    *  a new row. Scope is (name, queue, source), where source reads
    *  data.sourceId ?? data.source_id; a submission with NO source key counts
@@ -471,6 +482,8 @@ export function rowToMinionJob(row: Record<string, unknown>): MinionJob {
     private_queue_owner_job_id: (row.private_queue_owner_job_id as number | null) ?? null,
     private_queue_owner_token: (row.private_queue_owner_token as string) || null,
     private_queue_lease_until: row.private_queue_lease_until ? new Date(row.private_queue_lease_until as string) : null,
+    private_queue_owner_host: (row.private_queue_owner_host as string) || null,
+    private_queue_owner_pid: (row.private_queue_owner_pid as number | null) ?? null,
     quiet_hours: row.quiet_hours ? (typeof row.quiet_hours === 'string' ? JSON.parse(row.quiet_hours) : row.quiet_hours) as Record<string, unknown> : null,
     stagger_key: (row.stagger_key as string) || null,
     result: row.result ? (typeof row.result === 'string' ? JSON.parse(row.result) : row.result) as Record<string, unknown> : null,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1138,7 +1138,13 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='timeout_at') AS minion_jobs_timeout_at_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='idempotency_key') AS minion_jobs_idempotency_key_exists
+                WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='idempotency_key') AS minion_jobs_idempotency_key_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='private_queue_owner_job_id') AS minion_jobs_pq_owner_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='private_queue_owner_token') AS minion_jobs_pq_token_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='minion_jobs' AND column_name='private_queue_lease_until') AS minion_jobs_pq_lease_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -1188,6 +1194,9 @@ export class PGLiteEngine implements BrainEngine {
       minion_jobs_exists: boolean;
       minion_jobs_timeout_at_exists: boolean;
       minion_jobs_idempotency_key_exists: boolean;
+      minion_jobs_pq_owner_exists: boolean;
+      minion_jobs_pq_token_exists: boolean;
+      minion_jobs_pq_lease_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -1279,6 +1288,9 @@ export class PGLiteEngine implements BrainEngine {
     // exactly like the v121 incident.
     const needsMinionJobsTimeoutAt = probe.minion_jobs_exists && !probe.minion_jobs_timeout_at_exists;
     const needsMinionJobsIdempotencyKey = probe.minion_jobs_exists && !probe.minion_jobs_idempotency_key_exists;
+    const needsMinionJobsPrivateQueue = probe.minion_jobs_exists
+      && (!probe.minion_jobs_pq_owner_exists || !probe.minion_jobs_pq_token_exists
+          || !probe.minion_jobs_pq_lease_exists);
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
@@ -1293,7 +1305,8 @@ export class PGLiteEngine implements BrainEngine {
         && !needsPagesEmbeddingSignature
         && !needsPagesLinksExtractedAt
         && !needsTimelineEventPageId
-        && !needsMinionJobsTimeoutAt && !needsMinionJobsIdempotencyKey) return;
+        && !needsMinionJobsTimeoutAt && !needsMinionJobsIdempotencyKey
+        && !needsMinionJobsPrivateQueue) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -1572,6 +1585,15 @@ export class PGLiteEngine implements BrainEngine {
       // v7: blob index uniq_minion_jobs_idempotency references idempotency_key.
       await this.db.exec(`
         ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+      `);
+    }
+    if (needsMinionJobsPrivateQueue) {
+      // v136: schema-blob indexes reference these columns before migrations
+      // run on an old brain; add the full lifecycle shape before replay.
+      await this.db.exec(`
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL;
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_token TEXT;
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_lease_until TIMESTAMPTZ;
       `);
     }
   }

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -470,6 +470,9 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   remove_on_complete BOOLEAN   NOT NULL DEFAULT FALSE,
   remove_on_fail   BOOLEAN     NOT NULL DEFAULT FALSE,
   idempotency_key  TEXT,
+  private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
+  private_queue_owner_token TEXT,
+  private_queue_lease_until TIMESTAMPTZ,
   result           JSONB,
   progress         JSONB,
   error_text       TEXT,
@@ -504,6 +507,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uniq_minion_jobs_idempotency ON minion_jobs (i
 -- WP4/WP5 (v127, ENG-10): wedge-signal index — covers the queue-health count
 -- FILTERs and max(updated_at) reads in queryWedgeSignals (supervisor.ts).
 CREATE INDEX IF NOT EXISTS idx_minion_jobs_queue_status_updated ON minion_jobs (queue, status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_recovery
+  ON minion_jobs (queue, private_queue_lease_until)
+  WHERE queue LIKE 'dream-inline-%'
+    AND status IN ('waiting','active','delayed','waiting-children','paused');
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_owner
+  ON minion_jobs (private_queue_owner_job_id)
+  WHERE private_queue_owner_job_id IS NOT NULL;
 
 -- Inbox table for sidechannel messaging
 CREATE TABLE IF NOT EXISTS minion_inbox (

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -473,6 +473,8 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
   private_queue_owner_token TEXT,
   private_queue_lease_until TIMESTAMPTZ,
+  private_queue_owner_host TEXT,
+  private_queue_owner_pid INTEGER,
   result           JSONB,
   progress         JSONB,
   error_text       TEXT,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -662,7 +662,13 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'timeout_at') AS minion_jobs_timeout_at_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'idempotency_key') AS minion_jobs_idempotency_key_exists
+                WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'idempotency_key') AS minion_jobs_idempotency_key_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'private_queue_owner_job_id') AS minion_jobs_pq_owner_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'private_queue_owner_token') AS minion_jobs_pq_token_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'minion_jobs' AND column_name = 'private_queue_lease_until') AS minion_jobs_pq_lease_exists
     `;
     const probe = probeRows[0]!;
 
@@ -755,6 +761,9 @@ export class PostgresEngine implements BrainEngine {
       minion_jobs_exists?: boolean;
       minion_jobs_timeout_at_exists?: boolean;
       minion_jobs_idempotency_key_exists?: boolean;
+      minion_jobs_pq_owner_exists?: boolean;
+      minion_jobs_pq_token_exists?: boolean;
+      minion_jobs_pq_lease_exists?: boolean;
     };
     const needsContextualRetrievalColumns = (probe.pages_exists
         && (!probeCr.pages_cr_mode_exists || !probeCr.pages_corpus_generation_exists))
@@ -785,6 +794,9 @@ export class PostgresEngine implements BrainEngine {
       && !probeCr.minion_jobs_timeout_at_exists;
     const needsMinionJobsIdempotencyKey = probeCr.minion_jobs_exists === true
       && !probeCr.minion_jobs_idempotency_key_exists;
+    const needsMinionJobsPrivateQueue = probeCr.minion_jobs_exists === true
+      && (!probeCr.minion_jobs_pq_owner_exists || !probeCr.minion_jobs_pq_token_exists
+          || !probeCr.minion_jobs_pq_lease_exists);
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -798,7 +810,8 @@ export class PostgresEngine implements BrainEngine {
         && !needsPagesEmbeddingSignature
         && !needsPagesLinksExtractedAt
         && !needsTimelineEventPageId
-        && !needsMinionJobsTimeoutAt && !needsMinionJobsIdempotencyKey) return;
+        && !needsMinionJobsTimeoutAt && !needsMinionJobsIdempotencyKey
+        && !needsMinionJobsPrivateQueue) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -1077,6 +1090,15 @@ export class PostgresEngine implements BrainEngine {
       // v7: blob index uniq_minion_jobs_idempotency references idempotency_key.
       await conn.unsafe(`
         ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+      `);
+    }
+    if (needsMinionJobsPrivateQueue) {
+      // v136: schema-blob indexes reference these columns before migrations
+      // run on an old brain; add the full lifecycle shape before replay.
+      await conn.unsafe(`
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL;
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_owner_token TEXT;
+        ALTER TABLE minion_jobs ADD COLUMN IF NOT EXISTS private_queue_lease_until TIMESTAMPTZ;
       `);
     }
   }

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -935,6 +935,9 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   remove_on_complete BOOLEAN   NOT NULL DEFAULT FALSE,
   remove_on_fail   BOOLEAN     NOT NULL DEFAULT FALSE,
   idempotency_key  TEXT,
+  private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
+  private_queue_owner_token TEXT,
+  private_queue_lease_until TIMESTAMPTZ,
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   started_at       TIMESTAMPTZ,
   finished_at      TIMESTAMPTZ,
@@ -962,6 +965,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uniq_minion_jobs_idempotency ON minion_jobs (i
 -- WP4/WP5 (v127, ENG-10): wedge-signal index — covers the queue-health count
 -- FILTERs and max(updated_at) reads in queryWedgeSignals (supervisor.ts).
 CREATE INDEX IF NOT EXISTS idx_minion_jobs_queue_status_updated ON minion_jobs (queue, status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_recovery
+  ON minion_jobs (queue, private_queue_lease_until)
+  WHERE queue LIKE 'dream-inline-%'
+    AND status IN ('waiting','active','delayed','waiting-children','paused');
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_owner
+  ON minion_jobs (private_queue_owner_job_id)
+  WHERE private_queue_owner_job_id IS NOT NULL;
 
 -- Inbox table for sidechannel messaging
 CREATE TABLE IF NOT EXISTS minion_inbox (

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -938,6 +938,8 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
   private_queue_owner_token TEXT,
   private_queue_lease_until TIMESTAMPTZ,
+  private_queue_owner_host TEXT,
+  private_queue_owner_pid INTEGER,
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   started_at       TIMESTAMPTZ,
   finished_at      TIMESTAMPTZ,

--- a/src/core/source-health.ts
+++ b/src/core/source-health.ts
@@ -218,24 +218,51 @@ export function resolveStalenessCeilingSeconds(): number {
  * The LOCAL path does NOT use this — it keys off the live commit hash via
  * `isSourceUnchangedSinceSync` (robust against HEAD moving to an old-dated
  * commit, which a timestamp comparison would miss).
+ *
+ * IMMUTABLE SOURCES (#4332 follow-up, the camera-roll-2026-08-13 bug):
+ *
+ *   The ramp assumes "nobody has looked in a long time" is a defect worth
+ *   escalating. That is false for a dated, write-once snapshot
+ *   (`camera-roll-2026-08-13`, an archival import of one day's photos). Its
+ *   content can never change, so re-syncing it can never clear the alarm —
+ *   the ramp just re-fires forever and trains operators to ignore the check.
+ *   `opts.immutable` suppresses ONLY the caught-up ramp: the source still
+ *   reports full wall-clock lag the moment `newest_content_at` shows content
+ *   NEWER than the last sync, and a source with no content signal at all
+ *   still falls through to wall-clock. So a real regression is never hidden —
+ *   only "caught up and by definition staying that way" stops escalating.
  */
 export function lagFromContentMs(
   contentMs: number | null,
   lastSyncMs: number | null,
   nowMs: number,
   ceilingSeconds: number = resolveStalenessCeilingSeconds(),
+  opts: { immutable?: boolean } = {},
 ): number | null {
   if (lastSyncMs === null || !Number.isFinite(lastSyncMs)) return null;
   const wallClockSeconds = Math.floor((nowMs - lastSyncMs) / 1000);
   if (wallClockSeconds < 0) return wallClockSeconds; // clock skew passthrough
   if (contentMs !== null && Number.isFinite(contentMs)) {
     // Caught up: 0 while recently checked, then ramp once nobody has looked
-    // for longer than the ceiling.
-    return contentMs <= lastSyncMs
-      ? Math.max(0, wallClockSeconds - ceilingSeconds)
-      : wallClockSeconds;
+    // for longer than the ceiling — unless the source is declared immutable,
+    // in which case caught-up is the permanent, correct steady state.
+    if (contentMs <= lastSyncMs) {
+      return opts.immutable === true ? 0 : Math.max(0, wallClockSeconds - ceilingSeconds);
+    }
+    return wallClockSeconds;
   }
   return wallClockSeconds; // no stored content signal — wall-clock fallback
+}
+
+/**
+ * Read the per-source immutability declaration from `sources.config`.
+ *
+ * Stored in the existing free-form config JSON (`{"immutable": true}`) so this
+ * needs no migration and no new column. Deliberately strict `=== true`: a
+ * truthy string or 1 must NOT silently disable a staleness alarm.
+ */
+export function isImmutableSourceConfig(config: Record<string, unknown> | null | undefined): boolean {
+  return config?.immutable === true;
 }
 
 /**
@@ -319,7 +346,11 @@ export async function computeAllSourceMetrics(
       const contentMs = src.newest_content_at
         ? new Date(src.newest_content_at).getTime()
         : null;
-      lagSeconds = lagFromContentMs(contentMs, lastMs, now, stalenessCeilingSeconds);
+      lagSeconds = lagFromContentMs(contentMs, lastMs, now, stalenessCeilingSeconds, {
+        // #4332 follow-up: immutable dated snapshots stay caught-up forever by
+        // construction; only the time-based ramp is suppressed.
+        immutable: isImmutableSourceConfig(cfg),
+      });
     }
 
     return {

--- a/src/core/sync-status-report.ts
+++ b/src/core/sync-status-report.ts
@@ -8,7 +8,7 @@ import { loadConfig } from './config.ts';
 import { unacknowledgedSyncFailures } from './sync.ts';
 // lagFromContentMs is the remote/column comparator (buildSyncStatusReport
 // backs the get_status_snapshot MCP op — must NOT shell out to git).
-import { lagFromContentMs } from './source-health.ts';
+import { lagFromContentMs, isImmutableSourceConfig } from './source-health.ts';
 
 /**
  * v0.40.3.0 — read-only per-source dashboard for `gbrain sources status`.
@@ -207,6 +207,9 @@ export async function buildSyncStatusReport(
   const now = Date.now();
   const out: SyncStatusReportSource[] = sources.map((src) => {
     const cfgEntry = (src.config || {}) as { syncEnabled?: boolean };
+    // #4332 follow-up: a dated write-once snapshot never escalates on the
+    // caught-up ramp (see lagFromContentMs). Newer content still reports lag.
+    const immutable = isImmutableSourceConfig(src.config as Record<string, unknown> | undefined);
     const row = sourceMap.get(src.id) || { id: src.id, last_commit: null, last_sync_at: null, newest_content_at: null };
     const counts = countMap.get(src.id) || { pages: 0, chunks_total: 0, chunks_unembedded: 0 };
     const lastSyncMs = row.last_sync_at
@@ -223,6 +226,8 @@ export async function buildSyncStatusReport(
       Number.isFinite(contentMs as number) ? (contentMs as number) : null,
       lastSyncMs !== null && Number.isFinite(lastSyncMs) ? lastSyncMs : null,
       now,
+      undefined,
+      { immutable },
     );
     const stalenessHours = lagSeconds === null ? null : lagSeconds / 3600;
     const hoursSinceLastSync = lastSyncMs !== null && Number.isFinite(lastSyncMs)

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -934,6 +934,8 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
   private_queue_owner_token TEXT,
   private_queue_lease_until TIMESTAMPTZ,
+  private_queue_owner_host TEXT,
+  private_queue_owner_pid INTEGER,
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   started_at       TIMESTAMPTZ,
   finished_at      TIMESTAMPTZ,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -931,6 +931,9 @@ CREATE TABLE IF NOT EXISTS minion_jobs (
   remove_on_complete BOOLEAN   NOT NULL DEFAULT FALSE,
   remove_on_fail   BOOLEAN     NOT NULL DEFAULT FALSE,
   idempotency_key  TEXT,
+  private_queue_owner_job_id INTEGER REFERENCES minion_jobs(id) ON DELETE SET NULL,
+  private_queue_owner_token TEXT,
+  private_queue_lease_until TIMESTAMPTZ,
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   started_at       TIMESTAMPTZ,
   finished_at      TIMESTAMPTZ,
@@ -958,6 +961,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS uniq_minion_jobs_idempotency ON minion_jobs (i
 -- WP4/WP5 (v127, ENG-10): wedge-signal index — covers the queue-health count
 -- FILTERs and max(updated_at) reads in queryWedgeSignals (supervisor.ts).
 CREATE INDEX IF NOT EXISTS idx_minion_jobs_queue_status_updated ON minion_jobs (queue, status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_recovery
+  ON minion_jobs (queue, private_queue_lease_until)
+  WHERE queue LIKE 'dream-inline-%'
+    AND status IN ('waiting','active','delayed','waiting-children','paused');
+CREATE INDEX IF NOT EXISTS idx_minion_jobs_private_queue_owner
+  ON minion_jobs (private_queue_owner_job_id)
+  WHERE private_queue_owner_job_id IS NOT NULL;
 
 -- Inbox table for sidechannel messaging
 CREATE TABLE IF NOT EXISTS minion_inbox (

--- a/test/child-worker-supervisor.test.ts
+++ b/test/child-worker-supervisor.test.ts
@@ -140,6 +140,7 @@ async function runUntilTerminal(
     watchdogLoopBudget: number;
     watchdogLoopWindowMs: number;
     watchdogBackoffMs: number;
+    beforeSpawn: () => Promise<void>;
     _now: () => number;
     stopAfterEvents: number; // safety net so a buggy test can't hang
     deadlineMs: number; // wall-clock safety net (see below)
@@ -165,6 +166,7 @@ async function runUntilTerminal(
     watchdogLoopWindowMs: overrides.watchdogLoopWindowMs,
     watchdogBackoffMs: overrides.watchdogBackoffMs,
     _now: overrides._now,
+    beforeSpawn: overrides.beforeSpawn,
     isStopping: () => stopping,
     onMaxCrashesExceeded: (count, max) => {
       maxCrashesFired = { count, max };
@@ -231,6 +233,23 @@ afterEach(() => {
 });
 
 describe('ChildWorkerSupervisor', () => {
+  it('runs the maintenance hook before every crash respawn', async () => {
+    const h = makeConstantExitHarness(1);
+    let beforeSpawnCalls = 0;
+    try {
+      const res = await runUntilTerminal(h, {
+        maxCrashes: 2,
+        hardStopMaxCrashes: 3,
+        beforeSpawn: async () => { beforeSpawnCalls++; },
+      });
+      const spawns = res.events.filter((e) => e.kind === 'worker_spawned').length;
+      expect(spawns).toBeGreaterThanOrEqual(2);
+      expect(beforeSpawnCalls).toBe(spawns);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   describe('D1 — code=0 exit classifier', () => {
     it('code=0 worker exit does not count as crash; restarts immediately', async () => {
       const h = makeConstantExitHarness(0);

--- a/test/queue-child-done.test.ts
+++ b/test/queue-child-done.test.ts
@@ -254,6 +254,125 @@ describe('private queue terminal reconciliation', () => {
   test('refuses to reconcile a shared queue', async () => {
     await expect(queue.reconcilePrivateQueue('default', 'bad target')).rejects.toThrow('refusing to reconcile non-private queue');
   });
+
+  test('startup recovery cancels an ownerless private queue only after its lease expires', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-expired1`;
+    const token = 'ownerless-expired';
+    const job = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_token: token,
+      private_queue_lease_ms: 600_000,
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET private_queue_lease_until = now() - interval '1 second' WHERE id = $1`,
+      [job.id],
+    );
+
+    const first = await queue.reconcileOrphanedPrivateQueues({ reason: 'test startup recovery' });
+    expect(first.cancelled_jobs).toBe(1);
+    expect(first.cancelled_queues).toBe(1);
+    expect((await queue.getJob(job.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(job.id))?.error_text).toBe('test startup recovery');
+
+    const second = await queue.reconcileOrphanedPrivateQueues({ reason: 'second pass' });
+    expect(second.cancelled_jobs).toBe(0);
+    expect(second.cancelled_queues).toBe(0);
+  });
+
+  test('startup recovery never cancels a private queue with a future lease', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-future1`;
+    const job = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_token: 'ownerless-live',
+      private_queue_lease_ms: 600_000,
+    });
+
+    const result = await queue.reconcileOrphanedPrivateQueues();
+    expect(result.cancelled_jobs).toBe(0);
+    expect(result.skipped_live_queues).toBeGreaterThanOrEqual(1);
+    expect((await queue.getJob(job.id))?.status).toBe('waiting');
+  });
+
+  test('startup recovery never cancels a private queue whose owner job is live', async () => {
+    const owner = await queue.add('autopilot-cycle', {});
+    const ownerToken = nextToken();
+    const claimedOwner = await queue.claim(ownerToken, 30_000, 'default', ['autopilot-cycle']);
+    expect(claimedOwner?.id).toBe(owner.id);
+    const privateQueue = `dream-inline-${Date.now()}-liveown`;
+    const child = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_job_id: owner.id,
+      private_queue_owner_token: 'live-owner-token',
+      private_queue_lease_ms: 1,
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET private_queue_lease_until = now() - interval '1 second' WHERE id = $1`,
+      [child.id],
+    );
+
+    const result = await queue.reconcileOrphanedPrivateQueues();
+    expect(result.cancelled_jobs).toBe(0);
+    expect(result.skipped_live_queues).toBeGreaterThanOrEqual(1);
+    expect((await queue.getJob(child.id))?.status).toBe('waiting');
+  });
+
+  test('startup recovery cancels when the owner job is terminal even if the lease has not expired', async () => {
+    const owner = await queue.add('autopilot-cycle', {});
+    await claimAndComplete('autopilot-cycle', { ok: true });
+    const privateQueue = `dream-inline-${Date.now()}-termown`;
+    const child = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_job_id: owner.id,
+      private_queue_owner_token: 'terminal-owner-token',
+      private_queue_lease_ms: 600_000,
+    });
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ reason: 'owner terminal' });
+    expect(result.cancelled_jobs).toBe(1);
+    expect((await queue.getJob(child.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(child.id))?.error_text).toBe('owner terminal');
+  });
+
+  test('startup recovery preserves legacy unowned private queues for manual Doctor/retriage handling', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-legacy1`;
+    const job = await queue.add('legacy-private-waiting', {}, { queue: privateQueue });
+
+    const result = await queue.reconcileOrphanedPrivateQueues();
+    expect(result.cancelled_jobs).toBe(0);
+    expect(result.skipped_unowned_queues).toBeGreaterThanOrEqual(1);
+    expect((await queue.getJob(job.id))?.status).toBe('waiting');
+  });
+
+  test('startup recovery uses normal cancellation semantics for descendants and aggregators', async () => {
+    const owner = await queue.add('autopilot-cycle', {});
+    await claimAndComplete('autopilot-cycle', { ok: true });
+    const aggregator = await queue.add('aggregator', {});
+    const privateQueue = `dream-inline-${Date.now()}-tree001`;
+    const child = await queue.add('private-child', {}, {
+      queue: privateQueue,
+      parent_job_id: aggregator.id,
+      on_child_fail: 'continue',
+      private_queue_owner_job_id: owner.id,
+      private_queue_owner_token: 'tree-token',
+      private_queue_lease_ms: 600_000,
+    });
+    const grandchild = await queue.add('private-grandchild', {}, {
+      queue: privateQueue,
+      parent_job_id: child.id,
+      on_child_fail: 'continue',
+      private_queue_owner_job_id: owner.id,
+      private_queue_owner_token: 'tree-token',
+      private_queue_lease_ms: 600_000,
+    });
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ reason: 'owner terminal tree' });
+    expect(result.cancelled_jobs).toBeGreaterThanOrEqual(2);
+    expect((await queue.getJob(child.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(grandchild.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(aggregator.id))?.status).toBe('waiting');
+    const msgs = await readChildDoneInbox(aggregator.id);
+    expect(msgs.some(m => m.child_id === child.id && m.outcome === 'cancelled')).toBe(true);
+  });
 });
 
 describe('v0.16 MinionJobInput.max_stalled', () => {

--- a/test/queue-child-done.test.ts
+++ b/test/queue-child-done.test.ts
@@ -230,6 +230,32 @@ describe('v0.15 parent-resolution terminal set', () => {
   });
 });
 
+describe('private queue terminal reconciliation', () => {
+  test('cancels every non-terminal job in the owned queue and preserves unrelated work', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-deadbeef`;
+    const waiting = await queue.add('private-waiting', {}, { queue: privateQueue });
+    const active = await queue.add('private-active', {}, { queue: privateQueue });
+    const unrelated = await queue.add('unrelated', {}, { queue: 'default' });
+    const claimed = await queue.claim(nextToken(), 30_000, privateQueue, ['private-active']);
+    expect(claimed?.id).toBe(active.id);
+
+    const reconciled = await queue.reconcilePrivateQueue(privateQueue, 'owner terminalized');
+
+    expect(reconciled.map(j => j.id).sort((a, b) => a - b)).toEqual([waiting.id, active.id].sort((a, b) => a - b));
+    expect((await queue.getJob(waiting.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(active.id))?.status).toBe('cancelled');
+    expect((await queue.getJob(waiting.id))?.error_text).toBe('owner terminalized');
+    expect((await queue.getJob(unrelated.id))?.status).toBe('waiting');
+
+    // Idempotent: a second finally/recovery pass finds nothing to do.
+    expect(await queue.reconcilePrivateQueue(privateQueue, 'second pass')).toEqual([]);
+  });
+
+  test('refuses to reconcile a shared queue', async () => {
+    await expect(queue.reconcilePrivateQueue('default', 'bad target')).rejects.toThrow('refusing to reconcile non-private queue');
+  });
+});
+
 describe('v0.16 MinionJobInput.max_stalled', () => {
   test('default max_stalled picks up schema DEFAULT when omitted (regression)', async () => {
     // v0.14.3 bumped the schema column DEFAULT from 1 → 5 (max_stalled becomes

--- a/test/queue-child-done.test.ts
+++ b/test/queue-child-done.test.ts
@@ -13,8 +13,25 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { hostname } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { MinionQueue } from '../src/core/minions/queue.ts';
+
+/**
+ * A PID that is provably dead on this host. Probing upward from a high base
+ * keeps the search off live processes; the recovery path treats ESRCH (and
+ * only ESRCH, past the reuse grace) as reclaimable.
+ */
+const DEAD_PID = (() => {
+  for (let pid = 4_194_300; pid > 4_000_000; pid--) {
+    try {
+      process.kill(pid, 0);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ESRCH') return pid;
+    }
+  }
+  throw new Error('could not find a dead PID for the test');
+})();
 import type { ChildDoneMessage } from '../src/core/minions/types.ts';
 
 let engine: PGLiteEngine;
@@ -255,7 +272,7 @@ describe('private queue terminal reconciliation', () => {
     await expect(queue.reconcilePrivateQueue('default', 'bad target')).rejects.toThrow('refusing to reconcile non-private queue');
   });
 
-  test('startup recovery cancels an ownerless private queue only after its lease expires', async () => {
+  test('startup recovery cancels an ownerless private queue once its lease expires AND its owner process is gone', async () => {
     const privateQueue = `dream-inline-${Date.now()}-expired1`;
     const token = 'ownerless-expired';
     const job = await queue.add('private-waiting', {}, {
@@ -263,9 +280,17 @@ describe('private queue terminal reconciliation', () => {
       private_queue_owner_token: token,
       private_queue_lease_ms: 600_000,
     });
+    // Expire the lease AND point the owner identity at a dead PID on this
+    // host, aged past the PID-reuse grace. Both are required now: an expired
+    // lease alone must never be enough (see the test below).
     await engine.executeRaw(
-      `UPDATE minion_jobs SET private_queue_lease_until = now() - interval '1 second' WHERE id = $1`,
-      [job.id],
+      `UPDATE minion_jobs
+          SET private_queue_lease_until = now() - interval '1 second',
+              private_queue_owner_pid = $2,
+              private_queue_owner_host = $3,
+              created_at = now() - interval '2 hours'
+        WHERE id = $1`,
+      [job.id, DEAD_PID, hostname()],
     );
 
     const first = await queue.reconcileOrphanedPrivateQueues({ reason: 'test startup recovery' });
@@ -277,6 +302,120 @@ describe('private queue terminal reconciliation', () => {
     const second = await queue.reconcileOrphanedPrivateQueues({ reason: 'second pass' });
     expect(second.cancelled_jobs).toBe(0);
     expect(second.cancelled_queues).toBe(0);
+  });
+
+  // ── the live-cancellation regression this pass exists to prevent ────────
+  //
+  // The lease only renews while a child handler is executing (inline-drain's
+  // 60s keepalive). A slow gap between children, or a long post-drain
+  // collection, can lapse it under a perfectly healthy owner — and
+  // owner_job_id is NULL for every CLI `gbrain dream` run, so the lease was
+  // the ONLY guard. Recovery must probe the owning process before cancelling.
+  test('startup recovery does NOT cancel an expired-lease queue whose owner process is still alive', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-livepid`;
+    const job = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_token: 'live-process',
+      private_queue_lease_ms: 600_000,
+    });
+    // add() stamps this process's host/pid; expire only the lease.
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET private_queue_lease_until = now() - interval '1 hour' WHERE id = $1`,
+      [job.id],
+    );
+    const stamped = await queue.getJob(job.id);
+    expect(stamped?.private_queue_owner_pid).toBe(process.pid);
+    expect(stamped?.private_queue_owner_host).toBe(hostname());
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ reason: 'must not fire' });
+    expect(result.cancelled_jobs).toBe(0);
+    expect(result.skipped_live_queues).toBeGreaterThanOrEqual(1);
+    expect((await queue.getJob(job.id))?.status).toBe('waiting');
+  });
+
+  test('startup recovery does NOT cancel an expired-lease queue owned by another host', async () => {
+    // Cross-host PIDs are unprobeable; process.kill would be meaningless.
+    const privateQueue = `dream-inline-${Date.now()}-otherhost`;
+    const job = await queue.add('private-waiting', {}, {
+      queue: privateQueue,
+      private_queue_owner_token: 'remote-owner',
+      private_queue_lease_ms: 600_000,
+    });
+    await engine.executeRaw(
+      `UPDATE minion_jobs
+          SET private_queue_lease_until = now() - interval '1 hour',
+              private_queue_owner_pid = $2,
+              private_queue_owner_host = 'some-other-machine',
+              created_at = now() - interval '2 hours'
+        WHERE id = $1`,
+      [job.id, DEAD_PID],
+    );
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ reason: 'must not fire cross-host' });
+    expect(result.cancelled_jobs).toBe(0);
+    expect((await queue.getJob(job.id))?.status).toBe('waiting');
+  });
+
+  // ── legacy (pre-#4332) unowned queues: adopt, never cancel ──────────────
+  test('legacy adoption is OFF by default — unowned queues are left untouched', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-legacyoff`;
+    const job = await queue.add('private-waiting', {}, { queue: privateQueue });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = $1`,
+      [job.id],
+    );
+
+    const result = await queue.reconcileOrphanedPrivateQueues();
+    expect(result.adopted_legacy_queues).toBe(0);
+    expect(result.skipped_unowned_queues).toBeGreaterThanOrEqual(1);
+    expect((await queue.getJob(job.id))?.status).toBe('waiting');
+  });
+
+  test('legacy adoption stamps ownership instead of cancelling, and never terminalizes', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-legacyadopt`;
+    const job = await queue.add('private-waiting', {}, { queue: privateQueue });
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = $1`,
+      [job.id],
+    );
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ adoptLegacyUnowned: true });
+    expect(result.adopted_legacy_queues).toBeGreaterThanOrEqual(1);
+    expect(result.cancelled_jobs).toBe(0);
+
+    // Still live work, now carrying a token + lease so the normal rules apply.
+    const after = await queue.getJob(job.id);
+    expect(after?.status).toBe('waiting');
+    expect(after?.private_queue_owner_token).toStartWith('legacy-adopted-');
+    expect(after?.private_queue_lease_until).not.toBeNull();
+  });
+
+  test('legacy adoption refuses a queue that is younger than the age gate', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-legacyyoung`;
+    const job = await queue.add('private-waiting', {}, { queue: privateQueue });
+
+    const result = await queue.reconcileOrphanedPrivateQueues({ adoptLegacyUnowned: true });
+    expect(result.adopted_legacy_queues).toBe(0);
+    expect((await queue.getJob(job.id))?.private_queue_owner_token).toBeNull();
+  });
+
+  test('legacy adoption refuses a queue with a healthy active child lock', async () => {
+    const privateQueue = `dream-inline-${Date.now()}-legacybusy`;
+    const job = await queue.add('private-busy', {}, { queue: privateQueue });
+    const claimed = await queue.claim(nextToken(), 30_000, privateQueue, ['private-busy']);
+    expect(claimed?.id).toBe(job.id);
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET created_at = now() - interval '30 days', updated_at = now() - interval '30 days' WHERE id = $1`,
+      [job.id],
+    );
+
+    const adopted = await queue.adoptLegacyPrivateQueue(privateQueue);
+    expect(adopted).toBe(false);
+    expect((await queue.getJob(job.id))?.private_queue_owner_token).toBeNull();
+  });
+
+  test('refuses to adopt a shared queue', async () => {
+    await expect(queue.adoptLegacyPrivateQueue('default')).rejects.toThrow('refusing to adopt non-private queue');
   });
 
   test('startup recovery never cancels a private queue with a future lease', async () => {

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -183,6 +183,9 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // wedges the blob replay exactly like the v121 incident.
   { kind: 'column', table: 'minion_jobs', column: 'timeout_at' },
   { kind: 'column', table: 'minion_jobs', column: 'idempotency_key' },
+  { kind: 'column', table: 'minion_jobs', column: 'private_queue_owner_job_id' },
+  { kind: 'column', table: 'minion_jobs', column: 'private_queue_owner_token' },
+  { kind: 'column', table: 'minion_jobs', column: 'private_queue_lease_until' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -284,6 +287,12 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       DROP INDEX IF EXISTS uniq_minion_jobs_idempotency;
       ALTER TABLE minion_jobs DROP COLUMN IF EXISTS timeout_at;
       ALTER TABLE minion_jobs DROP COLUMN IF EXISTS idempotency_key;
+
+      DROP INDEX IF EXISTS idx_minion_jobs_private_queue_recovery;
+      DROP INDEX IF EXISTS idx_minion_jobs_private_queue_owner;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_owner_job_id;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_owner_token;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_lease_until;
     `);
 
     // Note: we don't strip sources.archived* here because they're inline in the
@@ -377,6 +386,12 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       DROP INDEX IF EXISTS uniq_minion_jobs_idempotency;
       ALTER TABLE minion_jobs DROP COLUMN IF EXISTS timeout_at;
       ALTER TABLE minion_jobs DROP COLUMN IF EXISTS idempotency_key;
+
+      DROP INDEX IF EXISTS idx_minion_jobs_private_queue_recovery;
+      DROP INDEX IF EXISTS idx_minion_jobs_private_queue_owner;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_owner_job_id;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_owner_token;
+      ALTER TABLE minion_jobs DROP COLUMN IF EXISTS private_queue_lease_until;
 
       -- WP4 (v127) strip: surface columns + the wedge-signal index; replay
       -- must succeed from the pre-v127 shape.

--- a/test/source-health.test.ts
+++ b/test/source-health.test.ts
@@ -23,6 +23,7 @@ import {
   resolvePriority,
   newestCommitMs,
   lagFromContentMs,
+  isImmutableSourceConfig,
   resolveStalenessCeilingSeconds,
   _resetPriorityWarningsForTest,
 } from '../src/core/source-health.ts';
@@ -195,6 +196,62 @@ describe('lagFromContentMs (pure remote/column comparator)', () => {
   });
   test('content after last sync → wall-clock since sync', () => {
     expect(lagFromContentMs(now - 10 * HOUR, now - 100 * HOUR, now)).toBe(360_000);
+  });
+
+  // ── #4332 follow-up: immutable dated snapshots (camera-roll-2026-08-13) ──
+  //
+  // The ramp treats "nobody looked recently" as a defect. For a write-once
+  // dated snapshot that is false: content can never change, so the alarm can
+  // never be cleared by syncing and just re-fires forever.
+  test('immutable source: caught-up past the ceiling does NOT ramp', () => {
+    const ceiling = 72 * 3600;
+    // Same inputs as the ramp test above, which returns 28h of lag.
+    expect(lagFromContentMs(now - 200 * HOUR, now - 100 * HOUR, now, ceiling)).toBe(28 * 3600);
+    // Declared immutable → permanently caught up, no escalation.
+    expect(
+      lagFromContentMs(now - 200 * HOUR, now - 100 * HOUR, now, ceiling, { immutable: true }),
+    ).toBe(0);
+  });
+  test('immutable source: stays 0 no matter how much time passes', () => {
+    const ceiling = 72 * 3600;
+    // Content must stay OLDER than last_sync for this to be the caught-up
+    // branch — a snapshot imported long before every sync of it. (If the
+    // content timestamp were newer than last_sync the source is genuinely
+    // behind, and the test below pins that it still reports wall-clock.)
+    const at = (h: number) =>
+      lagFromContentMs(now - (h + 1) * HOUR, now - h * HOUR, now, ceiling, { immutable: true });
+    expect(at(100)).toBe(0);
+    expect(at(1000)).toBe(0);
+    expect(at(10_000)).toBe(0);
+  });
+  test('immutable does NOT suppress genuinely newer content (no blanket mute)', () => {
+    // Content NEWER than last sync is real, actionable staleness even on a
+    // source someone mislabelled immutable. Must still report wall-clock.
+    expect(
+      lagFromContentMs(now - 10 * HOUR, now - 100 * HOUR, now, 72 * 3600, { immutable: true }),
+    ).toBe(360_000);
+  });
+  test('immutable does NOT suppress the never-synced / no-content-signal path', () => {
+    // No stored content signal → wall-clock fallback regardless of the flag,
+    // so a source with no evidence is never silently marked healthy.
+    expect(
+      lagFromContentMs(null, now - 100 * HOUR, now, 72 * 3600, { immutable: true }),
+    ).toBe(360_000);
+    // Unknown last sync is still null (caller reports "never synced").
+    expect(lagFromContentMs(now - HOUR, null, now, 72 * 3600, { immutable: true })).toBeNull();
+  });
+  test('immutable does NOT suppress clock-skew passthrough', () => {
+    expect(lagFromContentMs(now, now + 10_000, now, 72 * 3600, { immutable: true })).toBe(-10);
+  });
+  test('isImmutableSourceConfig is strict — only boolean true opts out', () => {
+    expect(isImmutableSourceConfig({ immutable: true })).toBe(true);
+    // A truthy string/number must NOT silently disable a staleness alarm.
+    expect(isImmutableSourceConfig({ immutable: 'true' })).toBe(false);
+    expect(isImmutableSourceConfig({ immutable: 1 })).toBe(false);
+    expect(isImmutableSourceConfig({ immutable: false })).toBe(false);
+    expect(isImmutableSourceConfig({})).toBe(false);
+    expect(isImmutableSourceConfig(null)).toBe(false);
+    expect(isImmutableSourceConfig(undefined)).toBe(false);
   });
   test('GBRAIN_STALENESS_CEILING_HOURS overrides GBRAIN_SYNC_FRESHNESS_FAIL_HOURS', async () => {
     await withEnv(


### PR DESCRIPTION
## What

Rebased onto current master (v0.46.25.0, `055ac6c7`) and hardened. Closes #4332.

Gives every dream-inline private queue explicit owner metadata, reconciles it on every phase exit, and recovers orphans before every worker spawn — **without ever cancelling a live queue.**

### The hole this pass closes

The first three commits protected an ownerless private queue with a renewable lease. Re-auditing that on top of master found it insufficient:

- the lease only renews while a **child handler is executing** (inline-drain's 60s keepalive, cleared between children), and
- `owner_job_id` is **NULL for every non-minion dream run** — `gbrain dream` from a CLI/cron shell threads no owner job.

So for the common shape, a slow gap between children or a long post-drain collection could lapse the lease under a perfectly healthy owner, and pre-spawn recovery would cancel live work — exactly the outcome this branch exists to prevent.

Private-queue rows now also record the **owning process (host + pid)**, and recovery probes it through the existing `classifyHolderLiveness` before it may cancel anything. `alive`, `EPERM`, `cross_host`, `unknown`, and "inside the PID-reuse grace" all mean hands off. Only a same-host, provably-dead, past-grace owner is reclaimable.

### Legacy unowned queues

Rather than leaving them a permanent Doctor backlog, opt-in `adoptLegacyUnowned` **stamps ownership** onto a legacy queue that is old enough (24h, measured on its newest row) and has no healthy active lock, bringing it under the normal rules. Adoption never terminalizes a job, and it is **off by default**, so a plain supervisor start cannot mutate legacy rows. No live queue is ever cancelled by this path.

### Respawn recovery

Still runs before **every** spawn including crash/watchdog respawns, but throttled to one scan per 60s so a crash-loop cannot re-scan every dream-inline row on each restart. The first spawn after supervisor start always scans.

## Also: `camera-roll-2026-08-13` staleness false positive

That source was flagged stale repeatedly despite being an immutable dated snapshot. Root cause is the caught-up ramp in `lagFromContentMs`: when content is at/before the last sync it returns `max(0, wallClock - ceiling)`, which grows without bound. The ramp is right for a quiet-but-live source (it fixed the 71-day bug), but it assumes "nobody looked recently" is a defect. For a write-once dated snapshot that is false — content can never change, so syncing can never clear the alarm.

Sources may now declare `{"immutable": true}` in the existing `sources.config` JSON (**no new column, no migration**). It suppresses **only** the caught-up ramp. Deliberately narrow — real staleness is never masked:

- content **newer** than last_sync still reports full wall-clock lag, even if mislabelled immutable;
- no stored content signal still falls through to wall-clock;
- never-synced and clock-skew paths untouched;
- strict `=== true`, so a truthy `"true"`/`1` cannot silently disable an alarm.

Applied at all three consumers of the comparator (doctor `sync_freshness`, doctor `federation_health` via `computeAllSourceMetrics`, `buildSyncStatusReport`) so they cannot disagree about one source.

## Rebase notes

- Migration renumbered **133 → 136** (master took 133–135).
- `scripts/module-size-limits.tsv`: took master's reflowed numbers, then re-derived ceilings for the files this branch actually grows.
- Schema parity verified: `src/schema.sql`, `pglite-schema.ts`, `migrate.ts`, and `schema-embedded.ts` all carry the new columns, and `bun run build:schema` regenerates the bundle byte-identical.

## Testing

- `queue-child-done`: **28 pass** — incl. 2 new liveness regressions (live local pid, cross-host) and 5 legacy-adoption cases
- `source-health`: **39 pass** — incl. 4 negative cases pinning that `immutable` does not mask real staleness
- `sync-status-report` + `child-worker-supervisor` + the above: **83 pass, 1 fail**
- The 1 failure is **pre-existing on unmodified master** — a Tini "not running as PID 1" container artifact in the missing-binary spawn-failure test. Verified by running that file on a clean `055ac6c7` worktree: same single failure.
- `tsc --noEmit` clean; `check:module-size` OK
- **BrainBench** `--harness all --suite all`: fixtures `509fd20d7cda`, **zero drift** — all 12 cells match `evals/brainbench/baselines/main.json` exactly
- Mutation-checked the two new guards: reverting the liveness probe fails both new regressions; weakening the adoption age gate fails its test

No production DB was touched and no service was restarted.
