### PR TITLE
v0.46.24.1 fix(autopilot): exit non-zero after crash cap (#2234)

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -18,7 +18,7 @@ test/autopilot-install.test.ts	autopilot wrapper script — bun PATH export (v0.
 test/autopilot-install.test.ts	autopilot wrapper script — env source order (v0.36.1.x #966)	1	readFileSync
 test/autopilot-pause-marker.test.ts	pause marker fences minion job pickup	1	readFileSync
 test/autopilot-self-upgrade.test.ts	autopilot self-upgrade static-shape regressions	4	readFileSync
-test/autopilot-shutdown-engine-close.test.ts	autopilot.ts graceful engine shutdown (#1872)	4	readFileSync
+test/autopilot-shutdown-engine-close.test.ts	autopilot.ts graceful engine shutdown (#1872)	6	readFileSync
 test/autopilot-supervisor-wiring.test.ts	autopilot.ts ↔ ChildWorkerSupervisor wiring	6	readFileSync
 test/backlinks-job-default.test.ts	backlinks Minion handler — empty payload defaults to check, not fix	3	readFileSync
 test/book-mirror.test.ts	gbrain book-mirror — source file invariants	7	readFileSync

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -686,7 +686,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     await closeEngine();
     deregisterEngineClose();
     try { unlinkSync(lockPath); } catch { /* already gone */ }
-    process.exit(0);
+    process.exit(sig === 'max_crashes' || sig === 'cycle-failure-cap' ? 1 : 0);
   };
   process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
   process.on('SIGINT',  () => { void shutdown('SIGINT'); });

--- a/test/autopilot-shutdown-engine-close.test.ts
+++ b/test/autopilot-shutdown-engine-close.test.ts
@@ -55,9 +55,27 @@ describe('autopilot.ts graceful engine shutdown (#1872)', () => {
     expect(AUTOPILOT_SRC).toMatch(/inflightInlineCycle\s*=\s*cyclePromise/);
   });
 
-  it('shutdown() awaits closeEngine() before process.exit(0) (SIGINT + internal-stop path)', () => {
+  it('shutdown() awaits closeEngine() before process.exit (SIGINT + internal-stop path)', () => {
     expect(AUTOPILOT_SRC).toMatch(
-      /await closeEngine\(\);[\s\S]{0,400}process\.exit\(0\)/,
+      /await closeEngine\(\);[\s\S]{0,400}process\.exit\(/,
+    );
+  });
+
+  it('exits non-zero when the daemon gives up after repeated failures (#2234)', () => {
+    expect(AUTOPILOT_SRC).toContain(
+      "process.exit(sig === 'max_crashes' || sig === 'cycle-failure-cap' ? 1 : 0);",
+    );
+  });
+
+  it('keeps operator stops and intentional relaunch stops clean', () => {
+    expect(AUTOPILOT_SRC).toMatch(
+      /process\.on\('SIGTERM', \(\) => \{ void shutdown\('SIGTERM'\); \}\);/,
+    );
+    expect(AUTOPILOT_SRC).toMatch(
+      /process\.on\('SIGINT',\s+\(\) => \{ void shutdown\('SIGINT'\);\s+\}\);/,
+    );
+    expect(AUTOPILOT_SRC).toContain(
+      "await shutdown('engine-config-changed');",
     );
   });
 });


### PR DESCRIPTION
## Summary

Addresses #2234 (the daemon exit-code slice).

When autopilot gave up after repeated worker crashes or repeated inline cycle failures, the shared shutdown path always exited `0`. Supervisors configured with restart-on-failure treated that as a clean stop and left maintenance down.

This change:

- returns exit code `1` for `max_crashes` and `cycle-failure-cap`
- keeps operator stops and intentional relaunch stops on the clean exit path
- expands the existing autopilot shutdown static-shape coverage and refreshes the structural test manifest

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/autopilot-shutdown-engine-close.test.ts` - 6 pass
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/autopilot-shutdown-engine-close.test.ts test/autopilot-supervisor-wiring.test.ts test/autopilot-cycle-failure-classification.test.ts` - 17 pass
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/autopilot-shutdown-engine-close.test.ts` - RESULT: GREEN; verify green; focused unit test 6 pass; E2E skipped by fail-closed ALL selector
