### PR TITLE
v0.46.24.1 fix(bootstrap): honor Claude config dir for transcripts (#4324)

### DIFF
--- a/src/core/bootstrap/host-specs.ts
+++ b/src/core/bootstrap/host-specs.ts
@@ -278,9 +278,13 @@ export function claudeUserMcpConfigPath(): string {
   return join(home || homedir(), '.claude.json');
 }
 
-/** Where Claude Code stores session transcripts — the confinement root [S3#8]. */
+/**
+ * Where Claude Code stores session transcripts — the confinement root [S3#8].
+ * Uses the same config-dir base as settings/skills so custom config dirs keep
+ * legitimate transcript paths inside the allowed root.
+ */
 export function claudeProjectsDir(): string {
-  return join(homedir(), '.claude', 'projects');
+  return join(claudeConfigBase(), 'projects');
 }
 
 /**

--- a/test/bootstrap-harness-writers.test.ts
+++ b/test/bootstrap-harness-writers.test.ts
@@ -24,6 +24,7 @@ import {
   GBRAIN_HARNESS_MARKER_VALUE,
   GBRAIN_HOOK_MARKER_KEY,
   GBRAIN_HOOK_MARKER_VALUE,
+  claudeProjectsDir,
   codexConfigPath,
   mcpPermissionEntry,
 } from '../src/core/bootstrap/host-specs.ts';
@@ -349,6 +350,15 @@ describe('codexConfigPath honors CODEX_HOME', () => {
     });
     await withEnv({ CODEX_HOME: '   ' }, async () => {
       expect(codexConfigPath()).toContain(join('.codex', 'config.toml')); // blank trims to falsy
+    });
+  });
+});
+
+describe('claudeProjectsDir honors CLAUDE_CONFIG_DIR', () => {
+  test('transcript confinement root follows the configured Claude Code base', async () => {
+    const configDir = tmp();
+    await withEnv({ CLAUDE_CONFIG_DIR: configDir, HOME: tmp() }, async () => {
+      expect(claudeProjectsDir()).toBe(join(configDir, 'projects'));
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4324.

When Claude Code runs with CLAUDE_CONFIG_DIR set, transcript files live under that configured base. The harness confinement root still pointed at the default home-derived projects directory, so legitimate hook transcript paths were rejected as transcript_outside_projects_dir and context injection/session capture silently degraded.

This change routes claudeProjectsDir() through the existing claudeConfigBase() helper, matching the settings and skills path behavior that already honors CLAUDE_CONFIG_DIR.

## Changes

- Resolve the Claude Code transcript projects directory from claudeConfigBase().
- Add a focused host-spec test proving CLAUDE_CONFIG_DIR controls the transcript confinement root.

## Verification

- env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/bootstrap-harness-writers.test.ts
- bash scripts/gbrain-gate.sh <worktree> test/bootstrap-harness-writers.test.ts
