### PR TITLE
v0.46.24.1 fix(timeline): scan legacy meeting notes after unify-types (#2109)

### DIFF
--- a/src/core/extract-timeline-from-meetings.ts
+++ b/src/core/extract-timeline-from-meetings.ts
@@ -57,6 +57,12 @@ interface AttendedEdgeRow {
 }
 
 const BATCH_SIZE = 200;
+// gbrain-base-v2 catch-all retypes old meeting pages to note while
+// preserving legacy_type, so this extractor treats those rows as meetings.
+const MEETING_PAGE_PREDICATE =
+  `(type = 'meeting' OR (type = 'note' AND frontmatter ->> 'legacy_type' = 'meeting'))`;
+const MEETING_EDGE_PREDICATE =
+  `(pf.type = 'meeting' OR (pf.type = 'note' AND pf.frontmatter ->> 'legacy_type' = 'meeting'))`;
 
 export async function extractTimelineFromMeetings(
   engine: BrainEngine,
@@ -72,7 +78,7 @@ export async function extractTimelineFromMeetings(
     `SELECT slug, source_id, title, effective_date, updated_at,
             compiled_truth, COALESCE(timeline, '') AS timeline
        FROM pages
-      WHERE type = 'meeting'
+      WHERE ${MEETING_PAGE_PREDICATE}
         AND deleted_at IS NULL
         ${sourceFilter}
       ORDER BY effective_date DESC NULLS LAST, slug`,
@@ -94,7 +100,7 @@ export async function extractTimelineFromMeetings(
        JOIN pages pf ON pf.id = l.from_page_id
        JOIN pages pt ON pt.id = l.to_page_id
       WHERE l.link_type = 'attended'
-        AND pf.type = 'meeting'
+        AND ${MEETING_EDGE_PREDICATE}
         AND pf.deleted_at IS NULL
         AND pt.deleted_at IS NULL`,
   );

--- a/test/extract-timeline-from-meetings.test.ts
+++ b/test/extract-timeline-from-meetings.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { extractTimelineFromMeetings } from '../src/core/extract-timeline-from-meetings.ts';
+import type { Gazetteer } from '../src/core/by-mention.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function seedEntity(slug: string, title: string): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'person',
+    title,
+    compiled_truth: `${title} profile`,
+    timeline: '',
+    frontmatter: {},
+  });
+}
+
+async function seedNote(
+  slug: string,
+  opts: { title: string; legacyType?: string },
+): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'note',
+    title: opts.title,
+    compiled_truth: 'Meeting discussion notes.',
+    timeline: '',
+    frontmatter: opts.legacyType ? { legacy_type: opts.legacyType } : {},
+    effective_date: new Date('2026-04-20T00:00:00.000Z'),
+  });
+}
+
+async function addAttended(fromSlug: string, toSlug: string): Promise<void> {
+  await engine.addLinksBatch([{
+    from_slug: fromSlug,
+    to_slug: toSlug,
+    link_type: 'attended',
+    link_source: 'manual',
+  }]);
+}
+
+describe('extractTimelineFromMeetings', () => {
+  it('scans post-unify legacy meeting notes and follows their attended links', async () => {
+    await seedEntity('people/alice-example', 'Alice Example');
+    await seedNote('meetings/team-sync', {
+      title: 'Team Sync',
+      legacyType: 'meeting',
+    });
+    await addAttended('meetings/team-sync', 'people/alice-example');
+
+    const emptyGazetteer: Gazetteer = new Map();
+    const result = await extractTimelineFromMeetings(engine, { gazetteer: emptyGazetteer });
+
+    expect(result).toMatchObject({
+      meetings_scanned: 1,
+      entries_created: 1,
+      entities_touched: 1,
+      batch_errors: 0,
+    });
+    const timeline = await engine.getTimeline('people/alice-example', { sourceId: 'default' });
+    expect(timeline).toHaveLength(1);
+    expect(new Date(timeline[0]!.date).toISOString().slice(0, 10)).toBe('2026-04-20');
+    expect(timeline[0]).toMatchObject({
+      source: 'extract-timeline-from-meetings:meetings/team-sync',
+      summary: 'Discussed in Team Sync',
+    });
+  });
+
+  it('does not scan ordinary note pages as meetings', async () => {
+    await seedEntity('people/alice-example', 'Alice Example');
+    await seedNote('notes/team-sync', { title: 'Team Sync' });
+    await addAttended('notes/team-sync', 'people/alice-example');
+
+    const emptyGazetteer: Gazetteer = new Map();
+    const result = await extractTimelineFromMeetings(engine, { gazetteer: emptyGazetteer });
+
+    expect(result).toMatchObject({
+      meetings_scanned: 0,
+      entries_created: 0,
+      entities_touched: 0,
+      batch_errors: 0,
+    });
+    const timeline = await engine.getTimeline('people/alice-example', { sourceId: 'default' });
+    expect(timeline).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Treat post-unify `note` rows with `frontmatter.legacy_type = "meeting"` as meeting pages in `extractTimelineFromMeetings`.
- Apply the same meeting predicate to the `attended` edge scan so attendee-linked legacy meeting notes still propagate timeline entries.
- Add a PGLite regression covering legacy meeting notes plus a plain-note exclusion case.

Fixes #2109.

## Verification

- `bash scripts/gbrain-gate.sh <worktree> test/extract-timeline-from-meetings.test.ts` -> RESULT: GREEN
- Focused unit test: `test/extract-timeline-from-meetings.test.ts` -> 2 pass, 0 fail
- Diff-selected E2E: selector returned the full suite, so local gate skipped unrelated E2E; CI runs the full suite.
