### PR TITLE
fix(source): preserve established default routing

### DIFF
--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -229,8 +229,21 @@ async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | n
       `SELECT id FROM sources WHERE local_path IS NOT NULL AND id != 'default'`,
     );
   }
-  if (rows.length === 1) return rows[0].id;
-  return null;
+  if (rows.length !== 1) return null;
+
+  // The sole-source tier is a rescue for an empty seeded default. Once the
+  // default contains live pages it is established operator state and must not
+  // be silently bypassed merely because a side source was later registered.
+  try {
+    const defaultPages = await engine.executeRaw<{ n: string | number }>(
+      `SELECT COUNT(*) AS n FROM pages WHERE source_id = 'default' AND deleted_at IS NULL`,
+    );
+    if (Number(defaultPages[0]?.n ?? 0) > 0) return null;
+  } catch {
+    // A failed establishment check must not route writes away from default.
+    return null;
+  }
+  return rows[0].id;
 }
 
 /**

--- a/test/source-resolver-sole-default.serial.test.ts
+++ b/test/source-resolver-sole-default.serial.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resolveSourceId } from '../src/core/source-resolver.ts';
+
+let engine: PGLiteEngine;
+
+async function freshEngine(): Promise<PGLiteEngine> {
+  const next = new PGLiteEngine();
+  await next.connect({});
+  await next.initSchema();
+  return next;
+}
+
+async function addSideSource(id = 'side'): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path) VALUES ($1, $1, $2)
+     ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+    [id, `/tmp/${id}`],
+  );
+}
+
+afterAll(async () => {
+  await engine?.disconnect();
+});
+
+beforeEach(async () => {
+  await engine?.disconnect();
+  engine = await freshEngine();
+  delete process.env.GBRAIN_SOURCE;
+});
+
+describe('sole non-default routing preserves established default state', () => {
+  test('an established default is not bypassed by a side source', async () => {
+    await engine.putPage('wiki/established', {
+      type: 'note',
+      title: 'Established',
+      compiled_truth: 'live default corpus',
+    });
+    await addSideSource();
+
+    expect(await resolveSourceId(engine, null, '/')).toBe('default');
+  });
+
+  test('an empty seeded default still rescues to the sole side source', async () => {
+    await addSideSource('vault');
+
+    expect(await resolveSourceId(engine, null, '/')).toBe('vault');
+  });
+
+  test('soft-deleted default pages do not establish the default', async () => {
+    await engine.putPage('wiki/deleted', {
+      type: 'note',
+      title: 'Deleted',
+      compiled_truth: 'no longer live',
+    });
+    await engine.executeRaw(
+      `UPDATE pages SET deleted_at = now() WHERE slug = 'wiki/deleted'`,
+    );
+    await addSideSource('vault');
+
+    expect(await resolveSourceId(engine, null, '/')).toBe('vault');
+  });
+
+  test('a failed default-page check fails conservatively to default', async () => {
+    const failingEngine = {
+      kind: 'pglite',
+      async executeRaw<T>(sql: string): Promise<T[]> {
+        if (sql.includes('SELECT id, local_path')) return [] as T[];
+        if (sql.includes('archived = false')) return [{ id: 'side' }] as T[];
+        if (sql.includes('COUNT(*)')) throw new Error('page count unavailable');
+        return [] as T[];
+      },
+      async getConfig(): Promise<null> {
+        return null;
+      },
+    } as unknown as BrainEngine;
+
+    expect(await resolveSourceId(failingEngine, null, '/')).toBe('default');
+  });
+});


### PR DESCRIPTION
Fixes #3070

When a default source already contains live pages, adding exactly one nondefault source should not silently redirect unscoped operations away from that established default.

This keeps the sole source fallback for an empty seeded default, and fails closed to default routing if the establishment check cannot run.

Regression coverage includes 29 focused passing cases. Typecheck is clean. A prior refresh attempt was PR #4036, which is now closed and conflicted with current master.