### PR TITLE
fix(dream): keep summaries under configured output root

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -942,7 +942,7 @@ export async function runPhaseSynthesize(
 
     // Summary index page (deterministic; orchestrator-written via direct
     // engine.putPage so no allow-list path needed).
-    const summarySlug = `dream-cycle-summaries/${summaryDate}`;
+    const summarySlug = buildDreamSummarySlug(config.outputRoot, summaryDate);
     // Back-compat: writeSummaryPage takes string[] for display; map refs back to slugs.
     const writtenSlugs = writtenRefs.map(r => r.slug);
     if (SUMMARY_SLUG_RE.test(summarySlug)) {
@@ -1213,6 +1213,13 @@ export interface SynthConfig {
   mode: 'agentic' | 'oneshot';
 }
 
+/** Keep orchestrator summaries inside a configured non-default namespace. */
+export function buildDreamSummarySlug(outputRoot: string, summaryDate: string): string {
+  return outputRoot === 'wiki'
+    ? `dream-cycle-summaries/${summaryDate}`
+    : `${outputRoot}/dream-cycle-summaries/${summaryDate}`;
+}
+
 /** #2415: shared output-root resolution (synthesize + patterns phases). */
 export async function loadOutputRoot(engine: BrainEngine): Promise<string> {
   const raw = await engine.getConfig('dream.synthesize.output_root');
@@ -1425,9 +1432,11 @@ export async function loadAllowedSlugPrefixes(outputRoot = 'wiki'): Promise<stri
       const globs = parsed?.dream_synthesize_paths?.globs;
       if (Array.isArray(globs) && globs.every(g => typeof g === 'string')) {
         if (outputRoot === 'wiki') return globs as string[];
-        return (globs as string[]).map(g =>
-          g.startsWith('wiki/') ? `${outputRoot}/${g.slice('wiki/'.length)}` : g,
-        );
+        return (globs as string[]).map(g => {
+          if (g.startsWith('wiki/')) return `${outputRoot}/${g.slice('wiki/'.length)}`;
+          if (g.startsWith('dream-cycle-summaries/')) return `${outputRoot}/${g}`;
+          return g;
+        });
       }
     } catch { /* try next */ }
   }
@@ -2695,6 +2704,7 @@ function makeError(cls: string, code: string, message: string, hint?: string): P
 export const __testing = {
   collectChildPutPageSlugs,
   buildSynthesisPrompt,
+  buildDreamSummarySlug,
   stampDreamProvenance,
   reverseWriteRefs,
   runSubagentsInline,

--- a/test/cycle-dream-output-root.test.ts
+++ b/test/cycle-dream-output-root.test.ts
@@ -18,7 +18,7 @@ import { __testing, loadAllowedSlugPrefixes, loadOutputRoot } from '../src/core/
 import { runPhasePatterns } from '../src/core/cycle/patterns.ts';
 import type { DiscoveredTranscript } from '../src/core/cycle/transcript-discovery.ts';
 
-const { buildSynthesisPrompt } = __testing;
+const { buildSynthesisPrompt, buildDreamSummarySlug } = __testing;
 
 const transcript: DiscoveredTranscript = {
   filePath: '/tmp/t.txt',
@@ -52,14 +52,44 @@ describe('#2415: loadAllowedSlugPrefixes remap', () => {
     expect(globs).toContain('dream-cycle-summaries/*');
   });
 
-  test('custom root remaps only wiki/-rooted globs', async () => {
+  test('custom root remaps wiki globs and the legacy summary glob', async () => {
     const globs = await loadAllowedSlugPrefixes('notes');
     expect(globs).toContain('notes/personal/reflections/*');
     expect(globs).toContain('notes/originals/*');
     expect(globs).toContain('notes/personal/patterns/*');
-    // Non-wiki globs pass through untouched.
-    expect(globs).toContain('dream-cycle-summaries/*');
+    expect(globs).toContain('notes/dream-cycle-summaries/*');
+    expect(globs).not.toContain('dream-cycle-summaries/*');
     expect(globs.some(g => g.startsWith('wiki/'))).toBe(false);
+  });
+
+  test('custom root brain authorizes nothing outside brain/**', async () => {
+    const globs = await loadAllowedSlugPrefixes('brain');
+    expect(globs.length).toBeGreaterThan(0);
+    expect(globs.every(g => g.startsWith('brain/'))).toBe(true);
+  });
+
+  test('default root remains byte-identical to the canonical globs', async () => {
+    expect(await loadAllowedSlugPrefixes()).toEqual([
+      'wiki/personal/reflections/*',
+      'wiki/originals/*',
+      'wiki/personal/patterns/*',
+      'wiki/people/*',
+      'dream-cycle-summaries/*',
+    ]);
+  });
+});
+
+describe('orchestrator summary slug follows the output root', () => {
+  test('default wiki root preserves the legacy unrooted slug', () => {
+    expect(buildDreamSummarySlug('wiki', '2026-08-20')).toBe(
+      'dream-cycle-summaries/2026-08-20',
+    );
+  });
+
+  test('custom roots contain the summary page', () => {
+    expect(buildDreamSummarySlug('brain', '2026-08-20')).toBe(
+      'brain/dream-cycle-summaries/2026-08-20',
+    );
   });
 });
 


### PR DESCRIPTION
Follow up to merged PR #2939 and closed issue #2415.

Custom output roots were added, but the orchestrator summary page and the legacy allow list glob could still remain outside the configured namespace. This makes both follow the configured output root while preserving the existing wiki default.

Focused regression coverage exercises the default root and a custom root.