### PR TITLE
fix(think): enforce temporal windows during retrieval

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1959,6 +1959,14 @@ export class PGLiteEngine implements BrainEngine {
     if (filters?.includeDeleted !== true) {
       where.push('p.deleted_at IS NULL');
     }
+    if (filters?.effective_after) {
+      params.push(filters.effective_after);
+      where.push(`p.effective_date >= $${params.length}::timestamptz`);
+    }
+    if (filters?.effective_before) {
+      params.push(filters.effective_before);
+      where.push(`p.effective_date <= $${params.length}::timestamptz`);
+    }
 
     const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
     params.push(limit, offset);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1563,6 +1563,12 @@ export class PostgresEngine implements BrainEngine {
     const deletedCondition = filters?.includeDeleted === true
       ? sql``
       : sql`AND p.deleted_at IS NULL`;
+    const effectiveAfterCondition = filters?.effective_after
+      ? sql`AND p.effective_date >= ${filters.effective_after}::timestamptz`
+      : sql``;
+    const effectiveBeforeCondition = filters?.effective_before
+      ? sql`AND p.effective_date <= ${filters.effective_before}::timestamptz`
+      : sql``;
 
     // v0.29: ORDER BY threading via PAGE_SORT_SQL whitelist (no SQL injection).
     // postgres.js sql.unsafe lets us splice the literal fragment safely.
@@ -1576,7 +1582,7 @@ export class PostgresEngine implements BrainEngine {
       const rows = await tx`
         SELECT p.* FROM pages p
         ${tagJoin}
-        WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${sourceCondition} ${deletedCondition}
+        WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${sourceCondition} ${deletedCondition} ${effectiveAfterCondition} ${effectiveBeforeCondition}
         ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}
       `;
       return rows.map(rowToPage);

--- a/src/core/think/gather.ts
+++ b/src/core/think/gather.ts
@@ -17,7 +17,8 @@
 
 import type { BrainEngine, TakeHit, Take } from '../engine.ts';
 import { hybridSearch } from '../search/hybrid.ts';
-import type { SearchResult } from '../types.ts';
+import type { Page, SearchResult } from '../types.ts';
+import { filterPagesToWindow, type TemporalWindow } from './temporal-window.ts';
 import { sanitizeQueryForPrompt } from '../search/expansion.ts';
 import { ensureWellFormed } from '../text-safe.ts';
 import { CJK_SLUG_CHARS } from '../cjk.ts';
@@ -34,6 +35,7 @@ export interface ThinkGatherOpts {
   graphDepth?: number;
   /** Optional pre-computed embedding for the question. Lets the caller share embedding cost. */
   questionEmbedding?: Float32Array;
+  window?: TemporalWindow;
   /** When set, MCP-bound calls forward this allow-list to takes_search. Local CLI leaves unset. */
   takesHoldersAllowList?: string[];
   /** Source scope inherited from the caller. Federated array wins over scalar. */
@@ -62,6 +64,7 @@ export interface ThinkGatherResult {
     takesFromVector: number;
     graphHits: number;
     questionSanitizedFor: 'expansion' | 'none';
+    window?: { dropped: number; undatedKept: number };
   };
 }
 
@@ -124,13 +127,46 @@ export async function runGather(
   const sanitizedQuestion = sanitizeQueryForPrompt(opts.question);
 
   const warnings: string[] = [];
+  const window = opts.window;
+
+  const toSearchResult = (page: Page, rank: number): SearchResult => ({
+    slug: page.slug, page_id: page.id, title: page.title, type: page.type,
+    chunk_text: page.compiled_truth ?? '', chunk_source: 'compiled_truth',
+    chunk_id: 0, chunk_index: 0, score: 1 / (51 + rank), stale: false,
+    source_id: page.source_id ?? 'default',
+    effective_date: page.effective_date instanceof Date ? page.effective_date.toISOString() : null,
+    effective_date_source: page.effective_date_source ?? null,
+  });
+
+  let windowDiagnostic: ThinkGatherResult['diagnostics']['window'];
 
   // Stream 1: hybrid page search (existing primitive).
-  const pagesPromise = hybridSearch(engine, opts.question, {
+  const pagesPromise = (window ? Promise.all([
+    hybridSearch(engine, opts.question, {
+      limit: Math.min(gatherLimit * 4, 200),
+      expansion: false,
+      ...sourceScope,
+    }),
+    engine.listPages({
+      ...(window.startMs !== null ? { effective_after: new Date(window.startMs).toISOString() } : {}),
+      ...(window.endMs !== null ? { effective_before: new Date(window.endMs).toISOString() } : {}),
+      limit: 50, ...sourceScope,
+    }).then(pages => pages.map(toSearchResult)).catch((e) => {
+      warnings.push('GATHER_WINDOW_FLOOR_FAILED');
+      process.stderr.write(`[think.gather] window floor failed: ${(e as Error).message}\n`);
+      return [] as SearchResult[];
+    }),
+  ]).then(([hybrid, floor]) => {
+    const seen = new Set<string>();
+    const combined = [...hybrid, ...floor].filter(page => !seen.has(page.slug) && !!seen.add(page.slug));
+    const filtered = filterPagesToWindow(combined, window);
+    windowDiagnostic = { dropped: filtered.droppedOutOfWindow, undatedKept: filtered.undatedKept };
+    return filtered.kept.slice(0, gatherLimit);
+  }) : hybridSearch(engine, opts.question, {
     limit: gatherLimit,
-    expansion: false,  // think provides its own anchor + graph context; no need for re-expansion
+    expansion: false,
     ...sourceScope,
-  }).catch((e) => {
+  })).catch((e) => {
     warnings.push('GATHER_HYBRID_FAILED');
     process.stderr.write(`[think.gather] hybrid stream failed: ${(e as Error).message}\n`);
     return [] as SearchResult[];
@@ -199,6 +235,7 @@ export async function runGather(
       takesFromVector: takesVec.length,
       graphHits: graphSlugs.length,
       questionSanitizedFor: sanitizedQuestion === opts.question ? 'none' : 'expansion',
+      ...(windowDiagnostic ? { window: windowDiagnostic } : {}),
     },
   };
 }

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -31,6 +31,7 @@ import { getProviderCapabilities } from '../ai/capabilities.ts';
 import { AIConfigError } from '../ai/errors.ts';
 import { normalizeModelId } from '../model-id.ts';
 import { hasAnthropicKey } from '../ai/anthropic-key.ts';
+import { parseTemporalWindow } from './temporal-window.ts';
 
 /** Anthropic Messages client interface — same shape used by subagent.ts so test stubs can be shared. */
 export interface ThinkLLMClient {
@@ -374,6 +375,7 @@ export async function runThink(
 ): Promise<ThinkResult> {
   const rounds = Math.max(1, opts.rounds ?? 1);
   const warnings: string[] = [];
+  const window = parseTemporalWindow(opts.since, opts.until);
 
   // Resolve the model through the 6-tier chain.
   const modelUsed = await resolveModel(engine, {
@@ -416,6 +418,7 @@ export async function runThink(
     question: opts.question,
     anchor: opts.anchor,
     questionEmbedding,
+    ...(window ? { window } : {}),
     takesHoldersAllowList: opts.takesHoldersAllowList,
     ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
     ...(opts.allowedSources !== undefined ? { sourceIds: opts.allowedSources } : {}),
@@ -424,6 +427,9 @@ export async function runThink(
   // raw error text stays on stderr. Distinguishes an errored stream from a
   // legitimately-empty one for MCP/remote callers.
   for (const w of gather.warnings) warnings.push(w);
+  if (gather.diagnostics.window?.dropped) {
+    warnings.push(`WINDOW_EXCLUDED_${gather.diagnostics.window.dropped}_PAGES`);
+  }
 
   // Render evidence blocks for the prompt
   const pagesBlock = renderPagesBlock(gather.pages, 600, opts.question);
@@ -474,6 +480,7 @@ export async function runThink(
   // `other` intent short-circuits before any SQL fires.
   let trajectoryBlock = '';
   let trajectoryPointsCount = 0;
+  let trajectoryExcludedCount = 0;
   const trajectoryEnabledConfig = await readThinkTrajectoryEnabled(engine);
   const trajectoryEnabledOpt = opts.withTrajectory !== false; // default true
   if (trajectoryEnabledConfig && trajectoryEnabledOpt) {
@@ -520,8 +527,15 @@ export async function runThink(
                     setTimeout(() => resolve([]), 5000);
                   }),
                 ]);
-                if (points.length === 0) return null;
-                const fmt = formatTrajectoryBlock(points, resolved.slug, {
+                const boundedPoints = window ? points.filter(point => {
+                  const ms = point.valid_from.getTime();
+                  const outside = (window.startMs !== null && ms < window.startMs)
+                    || (window.endMs !== null && ms > window.endMs);
+                  if (outside) trajectoryExcludedCount++;
+                  return !outside;
+                }) : points;
+                if (boundedPoints.length === 0) return null;
+                const fmt = formatTrajectoryBlock(boundedPoints, resolved.slug, {
                   intent: trajIntent,
                 });
                 if (fmt.rendered.length === 0) return null;
@@ -552,6 +566,7 @@ export async function runThink(
   if (trajectoryPointsCount > 0) {
     warnings.push(`TRAJECTORY_INJECTED_${trajectoryPointsCount}_POINTS`);
   }
+  if (trajectoryExcludedCount > 0) warnings.push(`WINDOW_EXCLUDED_${trajectoryExcludedCount}_TRAJECTORY_POINTS`);
 
   // SYNTHESIZE
   const intent = inferIntent(opts.question, opts.anchor);

--- a/src/core/think/temporal-window.ts
+++ b/src/core/think/temporal-window.ts
@@ -1,0 +1,88 @@
+export interface TemporalWindow {
+  startMs: number | null;
+  endMs: number | null;
+}
+
+export class TemporalWindowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TemporalWindowError';
+  }
+}
+
+const DAY = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTH = /^(\d{4})-(\d{2})$/;
+
+function parseBound(raw: string, end: boolean, label: string): number {
+  const value = raw.trim();
+  const day = DAY.exec(value);
+  if (day) {
+    const [, year, month, date] = day;
+    const ms = Date.UTC(+year, +month - 1, +date, end ? 23 : 0, end ? 59 : 0, end ? 59 : 0, end ? 999 : 0);
+    const parsed = new Date(ms);
+    if (parsed.getUTCFullYear() !== +year || parsed.getUTCMonth() !== +month - 1 || parsed.getUTCDate() !== +date) {
+      throw new TemporalWindowError(`THINK_INVALID_WINDOW: ${label} is not a real calendar date: "${raw}"`);
+    }
+    return ms;
+  }
+  const month = MONTH.exec(value);
+  if (month) {
+    const [, year, number] = month;
+    if (+number < 1 || +number > 12) {
+      throw new TemporalWindowError(`THINK_INVALID_WINDOW: ${label} has an invalid month: "${raw}"`);
+    }
+    return end
+      ? Date.UTC(+year, +number, 0, 23, 59, 59, 999)
+      : Date.UTC(+year, +number - 1, 1);
+  }
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) {
+    throw new TemporalWindowError(`THINK_INVALID_WINDOW: ${label} is not a parseable date: "${raw}"`);
+  }
+  return ms;
+}
+
+export function parseTemporalWindow(since?: string | null, until?: string | null): TemporalWindow | null {
+  const lower = since?.trim();
+  const upper = until?.trim();
+  if (!lower && !upper) return null;
+  const startMs = lower ? parseBound(lower, false, 'since') : null;
+  const endMs = upper ? parseBound(upper, true, 'until') : null;
+  if (startMs !== null && endMs !== null && startMs > endMs) {
+    throw new TemporalWindowError(`THINK_INVALID_WINDOW: since (${since}) is after until (${until})`);
+  }
+  return { startMs, endMs };
+}
+
+export interface DatedPage { slug?: string; effective_date?: string | Date | null }
+
+export function resolvePageDateMs(page: DatedPage): number | null {
+  const value = page.effective_date;
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  if (typeof value === 'string' && value.trim()) {
+    const day = DAY.exec(value.trim());
+    if (day) return Date.UTC(+day[1], +day[2] - 1, +day[3], 12);
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return ms;
+  }
+  const match = page.slug?.match(/(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+  const ms = Date.UTC(+match[1], +match[2] - 1, +match[3], 12);
+  const parsed = new Date(ms);
+  return parsed.getUTCFullYear() === +match[1] && parsed.getUTCMonth() === +match[2] - 1 && parsed.getUTCDate() === +match[3]
+    ? ms : null;
+}
+
+export function filterPagesToWindow<T extends DatedPage>(pages: T[], window: TemporalWindow) {
+  const kept: T[] = [];
+  let droppedOutOfWindow = 0;
+  let undatedKept = 0;
+  for (const page of pages) {
+    const ms = resolvePageDateMs(page);
+    if (ms === null) { undatedKept++; kept.push(page); continue; }
+    if ((window.startMs !== null && ms < window.startMs) || (window.endMs !== null && ms > window.endMs)) {
+      droppedOutOfWindow++;
+    } else kept.push(page);
+  }
+  return { kept, droppedOutOfWindow, undatedKept };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -339,6 +339,9 @@ export interface PageFilters {
    * pre-v0.34 unscoped behavior is preserved for local CLI callers.
    */
   sourceIds?: string[];
+  /** Inclusive bounds on semantic page time. NULL effective dates do not match. */
+  effective_after?: string;
+  effective_before?: string;
 }
 
 /** v0.26.5 — opts for getPage / softDeletePage / restorePage. */

--- a/test/think-temporal-window.serial.test.ts
+++ b/test/think-temporal-window.serial.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runGather } from '../src/core/think/gather.ts';
+import {
+  filterPagesToWindow,
+  parseTemporalWindow,
+  resolvePageDateMs,
+  TemporalWindowError,
+} from '../src/core/think/temporal-window.ts';
+import { __setEmbedTransportForTests } from '../src/core/ai/gateway.ts';
+import type { ChunkInput, SearchResult } from '../src/core/types.ts';
+
+let engine: PGLiteEngine;
+
+async function seed(slug: string, body: string, effective?: string, type = 'note') {
+  await engine.putPage(slug, {
+    title: slug,
+    type,
+    compiled_truth: body,
+    ...(effective ? { effective_date: new Date(effective), effective_date_source: 'date' as const } : {}),
+  });
+  const chunks: ChunkInput[] = [{
+    chunk_index: 0,
+    chunk_text: body,
+    chunk_source: 'compiled_truth',
+    token_count: 10,
+  }];
+  await engine.upsertChunks(slug, chunks);
+}
+
+beforeAll(async () => {
+  __setEmbedTransportForTests(() => { throw new Error('keyword-only test'); });
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await seed('brain/ops/2026-07-18', 'operations update release green', '2026-07-18T09:00:00Z');
+  await seed('brain/ops/2026-06-01', 'operations update old rollback', '2026-06-01T09:00:00Z', 'meeting');
+  await seed('brain/ops/2026-07-17', 'xyzzy vocabulary absent from query', '2026-07-17T12:00:00Z', 'idea');
+  await seed('brain/ops/undated', 'operations update timeless guidance');
+});
+
+afterAll(async () => {
+  __setEmbedTransportForTests(null);
+  await engine.disconnect();
+});
+
+describe('temporal-window parsing', () => {
+  test('date bounds are inclusive UTC days', () => {
+    const window = parseTemporalWindow('2026-07-17', '2026-07-18')!;
+    expect(new Date(window.startMs!).toISOString()).toBe('2026-07-17T00:00:00.000Z');
+    expect(new Date(window.endMs!).toISOString()).toBe('2026-07-18T23:59:59.999Z');
+  });
+
+  test('month bounds expand to the whole month', () => {
+    const window = parseTemporalWindow('2026-02', '2026-02')!;
+    expect(new Date(window.endMs!).toISOString()).toBe('2026-02-28T23:59:59.999Z');
+  });
+
+  test('open and absent bounds remain distinct', () => {
+    expect(parseTemporalWindow('2026-07-17')!.endMs).toBeNull();
+    expect(parseTemporalWindow(undefined, '2026-07-18')!.startMs).toBeNull();
+    expect(parseTemporalWindow()).toBeNull();
+  });
+
+  test('invalid and inverted ranges fail clearly', () => {
+    expect(() => parseTemporalWindow('2026-02-30')).toThrow(TemporalWindowError);
+    expect(() => parseTemporalWindow('2026-07-18', '2026-07-17')).toThrow(/since.*after.*until/);
+  });
+});
+
+describe('effective-date policy', () => {
+  const result = (slug: string, effective_date: string | null): SearchResult => ({
+    slug, effective_date, page_id: 1, title: slug, type: 'note', chunk_text: '',
+    chunk_source: 'compiled_truth', chunk_id: 1, chunk_index: 0, score: 1, stale: false,
+  });
+
+  test('effective date wins, then slug date; truly undated evidence is counted and kept', () => {
+    const window = parseTemporalWindow('2026-07-17', '2026-07-18')!;
+    const filtered = filterPagesToWindow([
+      result('in', '2026-07-18'),
+      result('brain/ops/2026-06-01', null),
+      result('undated', null),
+    ], window);
+    expect(filtered.kept.map(page => page.slug)).toEqual(['in', 'undated']);
+    expect(filtered.droppedOutOfWindow).toBe(1);
+    expect(filtered.undatedKept).toBe(1);
+    expect(resolvePageDateMs({ slug: 'brain/ops/2026-07-17' })).not.toBeNull();
+  });
+});
+
+describe('engine and gather enforcement', () => {
+  const window = parseTemporalWindow('2026-07-17', '2026-07-18')!;
+
+  test('bounded listPages is inclusive and excludes NULL effective dates', async () => {
+    const pages = await engine.listPages({
+      effective_after: new Date(window.startMs!).toISOString(),
+      effective_before: new Date(window.endMs!).toISOString(),
+      slugPrefix: 'brain/ops/',
+    });
+    expect(pages.map(page => page.slug).sort()).toEqual([
+      'brain/ops/2026-07-17',
+      'brain/ops/2026-07-18',
+    ]);
+  });
+
+  test('bounded gather excludes old relevance and supplies a nonmatching in-window page', async () => {
+    const gathered = await runGather(engine, { question: 'operations update', window });
+    const slugs = gathered.pages.map(page => page.slug);
+    expect(slugs).toContain('brain/ops/2026-07-18');
+    expect(slugs).toContain('brain/ops/2026-07-17');
+    expect(slugs).not.toContain('brain/ops/2026-06-01');
+    expect(gathered.diagnostics.window?.dropped).toBeGreaterThan(0);
+  });
+
+  test('no bounds preserves ordinary relevance behavior', async () => {
+    const gathered = await runGather(engine, { question: 'operations update' });
+    expect(gathered.pages.map(page => page.slug)).toContain('brain/ops/2026-06-01');
+    expect(gathered.diagnostics.window).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #4074

`since` and `until` were accepted by think requests but did not constrain retrieved page evidence. This parses and validates the bounds, filters dated retrieval and trajectory evidence, and reports excluded items in diagnostics.

Undated pages remain eligible and are reported separately, avoiding a silent loss of potentially relevant material. The serial regression suite covers bounded windows, invalid bounds, out of window evidence, and the unbounded control.