### PR TITLE
fix(search): stop double-applying offset on a semantic-cache hit (#4358)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3499	ratchet	grown v0.46.24.0: serve-delegated sync preflight hook
 src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyclePhases + normalizeQueuedSourcePhases + deriveStatus exclusion filter)
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match
 src/commands/jobs.ts	3027	ratchet	grown v0.46.22.0 phone wave: github source sync job (#4104)
-src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: supersede scoping + edge-existence gate
+src/core/search/hybrid.ts	2641	ratchet	grown #4358: skip the semantic cache for offset!=0 requests (fixes hit-path double-slicing an already offset-sliced stored page)
 src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2211,13 +2211,25 @@ export async function hybridSearchCached(
   // now-relative timestamp, which a persisted cache row can't express.
   const dateFiltered =
     Boolean(opts?.since ?? opts?.afterDate) || Boolean(opts?.until ?? opts?.beforeDate);
+  // #4358: paginated (offset!=0) requests skip the cache. The write side
+  // (bare hybridSearch) stores `returnPool.slice(offset, offset + limit)` —
+  // already offset-sliced — so the hit path below re-slicing that stored
+  // page with the SAME offset double-applies it and returns too few (or the
+  // wrong) rows. offset is also not part of knobsHash, so two different
+  // offsets could collide on one cache row. Skipping any nonzero offset
+  // (negative included — Array.prototype.slice treats a negative offset as
+  // "from the end", which the same double-apply bug still corrupts)
+  // sidesteps both bugs until the cache can store the pre-offset pool and
+  // key on offset too.
+  const offsetPaginated = (opts?.offset ?? 0) !== 0;
   const skipCache =
     !cache.isEnabled() ||
     (opts?.walkDepth ?? 0) > 0 ||
     Boolean(opts?.nearSymbol) ||
     isNonDefaultColumn ||
     adaptiveReturnOn ||
-    dateFiltered;
+    dateFiltered ||
+    offsetPaginated;
 
   let cacheStatus: 'hit' | 'miss' | 'disabled' = skipCache ? 'disabled' : 'miss';
   let cacheSimilarity: number | undefined;

--- a/src/core/search/mode.ts
+++ b/src/core/search/mode.ts
@@ -859,7 +859,18 @@ export function attributeKnob<K extends keyof ModeBundle>(
 // expects the floor) — same contamination class as ac=/acj=. The PR
 // authored this as v=16; master had already reached 18, so it sequences
 // here per the D8 convention. Same one-time global cold-miss pattern.
-export const KNOBS_HASH_VERSION = 19;
+//
+// bump 19→20 (#4358): pure invalidation bump, no new key part. `offset`
+// isn't folded into the hash (see hybrid.ts's `hybridSearchCached`
+// skipCache), so pre-fix rows written for an offset>0 request keyed
+// identically to an offset=0 request on the same (source_id, knobsHash,
+// embedding) — and stored an already offset-sliced page. Post-fix,
+// offset>0 requests always skip the cache, but a stale pre-fix row could
+// still be looked up by a NEW offset=0 request and silently serve the
+// wrong page (the old offset>0 slice). Bumping makes every pre-fix row
+// unreachable (one-time global cold-miss, refills within
+// cache.ttl_seconds).
+export const KNOBS_HASH_VERSION = 20;
 
 /**
  * v0.36 (D8 / CDX-2) — second-arg context for the cache key. The

--- a/test/cross-modal-phase1.test.ts
+++ b/test/cross-modal-phase1.test.ts
@@ -136,7 +136,7 @@ describe('D2 — knobsHash differs across cross-modal knob values', () => {
     return resolveSearchMode({ mode: 'balanced' });
   }
 
-  test('KNOBS_HASH_VERSION is 19 (cross-modal still appended; 16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621)', () => {
+  test('KNOBS_HASH_VERSION is 20 (cross-modal still appended; 16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621; 19→20 offset double-slice fix #4358)', () => {
     // v0.35 ladder: 1→2 reranker, 2→3 floor_ratio. v0.36 piggybacks on v=3
     // with 7 cross-modal knobs + column/provider context. v0.40.4 (salem) +
     // v0.39 T21 (master) bump to v=4 for graph_signals + schema-pack fields.
@@ -153,7 +153,8 @@ describe('D2 — knobsHash differs across cross-modal knob values', () => {
     // WP2/T3: 16→17 degradation-stamp epoch — pre-stamp cache rows must not
     // claim a clean (undegraded) run they can't prove.
     // #3621: 18→19 ack= autocut minKeep floor.
-    expect(KNOBS_HASH_VERSION).toBe(19);
+    // #4358: 19→20 pure invalidation bump for the offset double-slice fix.
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 
   test('flipping unified_multimodal changes the hash', () => {

--- a/test/hybrid-cache-offset-skip-4358.serial.test.ts
+++ b/test/hybrid-cache-offset-skip-4358.serial.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #4358 — semantic-cache hit path double-applies `offset`.
+ *
+ * The miss path (bare `hybridSearch`, in hybrid.ts) stores
+ * `returnPool.slice(offset, offset + limit)` — an ALREADY offset-sliced
+ * page. The hit path (`hybridSearchCached`) then re-applies
+ * `hit.results.slice(offset, offset + limit)` to that already-sliced page,
+ * double-applying offset. At offset=0 this is a no-op (slicing from 0
+ * twice is harmless); at offset>0 it silently drops rows: for
+ * `{ limit: 9, offset: 2 }`, the write stores a 9-row page
+ * (`pool[2..11)`), and a hit re-slices `[2, 11)` of THAT 9-row array,
+ * returning only 7. Compounding factor: `offset` is not folded into
+ * `knobsHash`, so two different offsets can collide on the same cache row.
+ *
+ * The fix (`skipCache` in `hybridSearchCached`) skips the cache entirely
+ * for any offset>0 request, so the double-slice path is unreachable and a
+ * stale pre-fix row can never satisfy a post-fix lookup (KNOBS_HASH_VERSION
+ * bump 19→20 invalidates any pre-fix rows that were written before the
+ * skip existed). This file drives a real store→hit roundtrip (mocked
+ * `embedQuery`/`embed` for a deterministic vector, real PGLite
+ * SemanticQueryCache) — same harness shape as
+ * `hybrid-cached-hit-budget-meta.serial.test.ts`.
+ *
+ * Serial: mock.module + gateway/global-env mutation (isolation guard R2).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realEmbedding from '../src/core/embedding.ts';
+
+/** Deterministic 1536d unit vector — identical for every call, so the
+ * second consult matches the first write at cosine 1.0. */
+function fixedEmbedding(): Float32Array {
+  const arr = new Float32Array(1536);
+  for (let i = 0; i < 1536; i++) arr[i] = Math.sin(1 + i * 0.001);
+  let norm = 0;
+  for (let i = 0; i < 1536; i++) norm += arr[i] * arr[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < 1536; i++) arr[i] /= norm;
+  return arr;
+}
+
+// Mock BEFORE importing hybrid.ts (spread keeps every other export live).
+mock.module('../src/core/embedding.ts', () => ({
+  ...realEmbedding,
+  embed: async () => fixedEmbedding(),
+  embedQuery: async () => fixedEmbedding(),
+}));
+
+// Import AFTER mocking.
+const { hybridSearchCached, awaitPendingSearchCacheWrites } =
+  await import('../src/core/search/hybrid.ts');
+const { configureGateway, resetGateway } = await import('../src/core/ai/gateway.ts');
+const { PGLiteEngine } = await import('../src/core/pglite-engine.ts');
+
+let engine: InstanceType<typeof PGLiteEngine>;
+let tmpHome: string;
+const savedGbrainHome = process.env.GBRAIN_HOME;
+
+// 15 keyword-findable pages on a distinctive, collision-free term, spread
+// across 5 types (3 each) so dedup's type-diversity layer (no type >60% of
+// results) never trims below what's needed for an offset=2/limit=9 slice
+// (needs a pool of >=11 survivors). dedup's text-similarity layer is scoped
+// PER PAGE (dedup.ts:dedupByTextSimilarity), so reusing identical filler
+// text across DIFFERENT pages — same pattern as the sibling
+// hybrid-cached-hit-budget-meta test — is safe.
+const TYPES = ['person', 'company', 'note', 'idea', 'project'];
+const FIXTURE_COUNT = 15;
+const QUERY_TERM = 'wobblesnark';
+
+beforeAll(async () => {
+  // Hermetic config home so the developer's real ~/.gbrain/config.json
+  // can't leak an embedding_model that flips the cache consult to
+  // 'disabled' via isCacheSafe.
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-offset-skip-4358-'));
+  process.env.GBRAIN_HOME = tmpHome;
+
+  // Pin the gateway to a 1536d provider BEFORE initSchema so the
+  // query_cache.embedding column is sized for the mock vectors. The fake
+  // key is never used — embedQuery is mocked above.
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-fake' },
+  });
+
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  const longText = 'x'.repeat(800);
+  for (let i = 0; i < FIXTURE_COUNT; i++) {
+    const type = TYPES[i % TYPES.length];
+    const slug = `${QUERY_TERM}-fixture-${i}`;
+    const title = `${QUERY_TERM} fixture ${i}`;
+    const truth = `${title} is a ${QUERY_TERM} record. ${longText}`;
+    await engine.putPage(slug, { type, title, compiled_truth: truth });
+    await engine.upsertChunks(slug, [
+      { chunk_index: 0, chunk_text: truth, chunk_source: 'compiled_truth' },
+    ]);
+  }
+});
+
+afterAll(async () => {
+  if (savedGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = savedGbrainHome;
+  try { await engine.disconnect(); } catch { /* ignore */ }
+  resetGateway();
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('#4358 — offset>0 skips the semantic cache', () => {
+  test('offset=0 (baseline) still caches normally: miss then hit, same page both times', async () => {
+    let missMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const missResults = await hybridSearchCached(engine, QUERY_TERM, {
+      limit: 9,
+      onMeta: (m) => { missMeta = m; },
+    });
+    expect(missMeta?.cache?.status).toBe('miss');
+    expect(missResults.length).toBe(9);
+
+    await awaitPendingSearchCacheWrites();
+
+    let hitMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const hitResults = await hybridSearchCached(engine, QUERY_TERM, {
+      limit: 9,
+      onMeta: (m) => { hitMeta = m; },
+    });
+    expect(hitMeta?.cache?.status).toBe('hit');
+    // offset=0 double-slicing a 9-row page with slice(0, 9) is a no-op —
+    // the pre-#4358 bug only manifests at offset>0. This pins the baseline
+    // stays correct (both page identity and count).
+    expect(hitResults.length).toBe(9);
+    expect(hitResults.map((r) => r.slug)).toEqual(missResults.map((r) => r.slug));
+  });
+
+  test('offset=2/limit=9 never becomes a cache hit and always returns 9 rows (not 7)', async () => {
+    // First call: cache is skipped for offset>0 (skipCache = ... ||
+    // offsetPaginated), so this is never a 'hit' — it's 'disabled', the
+    // same status the sibling skip-cache dimensions (dateFiltered,
+    // nearSymbol, adaptiveReturnOn, isNonDefaultColumn) already use.
+    let firstMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const firstResults = await hybridSearchCached(engine, QUERY_TERM, {
+      limit: 9,
+      offset: 2,
+      onMeta: (m) => { firstMeta = m; },
+    });
+    expect(firstMeta?.cache?.status).not.toBe('hit');
+    expect(firstMeta?.cache?.status).toBe('disabled');
+    // Pre-#4358 this FIRST call already double-sliced down to 7 (verified by
+    // temporarily reverting the fix): the preceding test in this file
+    // already wrote a cache row for the same query at the same knobsHash
+    // (offset isn't hashed), so THIS call's offset=2 lookup collided with
+    // that offset=0 row and re-sliced its already-offset-sliced 9-row page.
+    // Asserting 9 here pins that the fix makes this call bypass the cache
+    // entirely (not just "eventually self-heal").
+    expect(firstResults.length).toBe(9);
+
+    await awaitPendingSearchCacheWrites();
+
+    // Second call, identical params: if the cache were consulted (pre-fix
+    // behavior) this would become a 'hit' and double-slice the already
+    // offset-sliced 9-row stored page down to 7. Post-fix it must still be
+    // fully bypassed.
+    let secondMeta: import('../src/core/types.ts').HybridSearchMeta | undefined;
+    const secondResults = await hybridSearchCached(engine, QUERY_TERM, {
+      limit: 9,
+      offset: 2,
+      onMeta: (m) => { secondMeta = m; },
+    });
+    expect(secondMeta?.cache?.status).not.toBe('hit');
+    expect(secondMeta?.cache?.status).toBe('disabled');
+    expect(secondResults.length).toBe(9);
+    expect(secondResults.map((r) => r.slug)).toEqual(firstResults.map((r) => r.slug));
+  });
+});

--- a/test/hybrid-degraded-cache-meta.serial.test.ts
+++ b/test/hybrid-degraded-cache-meta.serial.test.ts
@@ -8,7 +8,10 @@
  *     on BOTH the miss and the hit path (the spread-carry rebuild can
  *     never silently drop a key again — the adaptive_return drop class)
  *   - cache-hit stamping: `cache.status === 'hit'`, degraded carried from
- *     the stored row; hit-with-offset stays labeled 'hit'
+ *     the stored row
+ *   - #4358: offset>0 requests never consult the cache (`cache.status ===
+ *     'disabled'`), so an offset-paginated lookup can never double-slice an
+ *     already offset-sliced stored page — see hybrid.ts's `skipCache`
  *   - cache_prestamp: a row whose stored meta lacks the degradation stamp
  *     surfaces degraded:[{stage:'cache_prestamp'}], never a clean claim
  *   - D14.2 short TTL: a degraded (but embeddable) result set is written
@@ -157,14 +160,19 @@ describe('cache-hit stamping', () => {
     expect(typeof hitMeta.retrieved_count).toBe('number');
   });
 
-  test('hit-with-offset stays labeled hit (never a clean-miss mislabel)', async () => {
+  test('#4358: offset>0 always skips the cache — never labeled hit', async () => {
+    // Pre-#4358 this asserted the OPPOSITE: an offset>0 lookup was served
+    // from the offset=0 stored row and stayed labeled 'hit'. That's exactly
+    // the double-slice bug (offset isn't part of knobsHash, and the hit
+    // path re-sliced an already offset-sliced stored page). The fix skips
+    // the cache entirely for offset>0, so this now asserts 'disabled'.
     const { results: missResults } = await cachedRun('builder', { limit: 5 });
     expect(missResults.length).toBeGreaterThan(0);
     await awaitPendingSearchCacheWrites();
 
     const { results, meta } = await cachedRun('builder', { limit: 5, offset: 50 });
-    expect(results).toHaveLength(0); // offset past the stored set
-    expect(meta.cache?.status).toBe('hit');
+    expect(results).toHaveLength(0); // offset past the small fixture set
+    expect(meta.cache?.status).toBe('disabled');
     expect(meta.retrieved_count).toBe(0); // pre-budget count for THIS page
   });
 });

--- a/test/search-alias-resolved-boost.test.ts
+++ b/test/search-alias-resolved-boost.test.ts
@@ -89,7 +89,7 @@ describe('alias_resolved boost stage', () => {
 });
 
 describe('KNOBS_HASH_VERSION', () => {
-  it('is 19 (16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 adds the ack= autocut minKeep floor — a minKeep=1 write must not serve a raised-floor lookup)', () => {
-    expect(KNOBS_HASH_VERSION).toBe(19);
+  it('is 20 (16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 adds the ack= autocut minKeep floor — a minKeep=1 write must not serve a raised-floor lookup; 19→20 pure invalidation bump for the offset double-slice fix #4358)', () => {
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 });

--- a/test/search-mode.test.ts
+++ b/test/search-mode.test.ts
@@ -433,7 +433,12 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // detail=low write must not be served to a detail=medium lookup.
     // v0.46.15 (#1863): bumped 17→18 to fold the autocut weak-top floor (acm=).
     // #3621: bumped 18→19 to fold the autocut minKeep floor (ack=).
-    expect(KNOBS_HASH_VERSION).toBe(19);
+    // #4358: bumped 19→20 — pure invalidation bump (no new key part). Fixes
+    // the semantic-cache hit path double-applying `offset`; since offset was
+    // never folded into the hash, pre-fix rows written for an offset>0
+    // request could be served to a NEW offset=0 lookup and silently return
+    // the wrong page.
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 
   test('#3515: detail set vs unset produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -452,7 +457,8 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // carry degraded[]/retrieved_count; pre-stamp rows must not claim clean.
     // v0.46.15 (#1863): 17→18 — autocut weak-top floor folds in (acm=).
     // #3621: 18→19 — autocut minKeep floor folds in (ack=).
-    expect(KNOBS_HASH_VERSION).toBe(19);
+    // #4358: 19→20 — pure invalidation bump for the offset double-slice fix.
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 
   test('T1 (codex): floor_ratio set vs unset produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -617,8 +623,8 @@ describe('v0.40.4 — graph_signals knob', () => {
 });
 
 describe('v0.42.3.0 — autocut knobs', () => {
-  test('KNOBS_HASH_VERSION is 19 (16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621)', () => {
-    expect(KNOBS_HASH_VERSION).toBe(19);
+  test('KNOBS_HASH_VERSION is 20 (16→17 degradation-stamp epoch; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621; 19→20 offset double-slice fix #4358)', () => {
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 
   test('bundle defaults: conservative off, balanced/tokenmax on @0.20', () => {

--- a/test/search/knobs-hash-reranker.test.ts
+++ b/test/search/knobs-hash-reranker.test.ts
@@ -44,7 +44,7 @@ function baseKnobs(): ResolvedSearchKnobs {
 }
 
 describe('KNOBS_HASH_VERSION + version invariants', () => {
-  test('version is 19 (…; 15→16 detail fold #3515; 16→17 degradation stamp; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621)', () => {
+  test('version is 20 (…; 15→16 detail fold #3515; 16→17 degradation stamp; 17→18 autocut weak-top floor #1863; 18→19 autocut minKeep floor #3621; 19→20 offset double-slice fix #4358)', () => {
     // v0.35.0.0: 1→2 to fold reranker fields. v0.35.6.0: 2→3 to fold
     // floor_ratio. v0.36 wave: piggybacks on v=3 with 7 cross-modal knobs
     // (D2) PLUS column + provider context (D8/CDX-2 cross-column isolation).
@@ -77,7 +77,10 @@ describe('KNOBS_HASH_VERSION + version invariants', () => {
     // degraded[]/retrieved_count; pre-stamp rows must not claim clean.
     // #3621: 18→19 ack= (autocut minKeep floor) — the floor changes how many
     // rows survive the cut, so writes and lookups must agree on it.
-    expect(KNOBS_HASH_VERSION).toBe(19);
+    // #4358: 19→20 — pure invalidation bump for the offset double-slice fix
+    // (offset isn't part of the hash; the bump clears pre-fix rows that could
+    // otherwise serve a stale offset-shifted page to an offset=0 lookup).
+    expect(KNOBS_HASH_VERSION).toBe(20);
   });
 
   test('hash is 16 hex chars regardless of reranker config', () => {


### PR DESCRIPTION
Fixes #4358

## What's broken

`hybridSearchCached`'s semantic-cache **hit** path re-applies pagination to a page that was already paginated once at write time:

- **Miss path** (bare `hybridSearch`, `src/core/search/hybrid.ts`): stores `returnPool.slice(offset, offset + limit)` into the cache — an already offset-sliced page.
- **Hit path** (`hybridSearchCached`): does `hit.results.slice(offset, offset + limit)` on that same already-sliced page.

At `offset=0` this is a no-op (slicing `[0, n)` twice is harmless), which is why it went unnoticed. At `offset>0` it silently drops rows. For `{ limit: 9, offset: 2 }`: the write stores `pool[2..11)` (9 rows), and a hit re-slices `[2, 11)` of *that* 9-row array — returning only 7.

Compounding factor: `offset` is not folded into `knobsHash` (`src/core/search/mode.ts`), so requests at different offsets can collide on the same cache row. In the worst case an `offset=2` write can be served to an `offset=50` lookup (or vice versa), independent of the double-slice bug.

## The fix

`skipCache` in `hybridSearchCached` already has 5 existing conditions that bypass the cache for structural reasons it can't safely express (`dateFiltered`, `nearSymbol`, `walkDepth`, `isNonDefaultColumn`, `adaptiveReturnOn`). This adds a 6th, following the same pattern:

```ts
const offsetPaginated = (opts?.offset ?? 0) !== 0;
const skipCache =
  !cache.isEnabled() ||
  (opts?.walkDepth ?? 0) > 0 ||
  Boolean(opts?.nearSymbol) ||
  isNonDefaultColumn ||
  adaptiveReturnOn ||
  dateFiltered ||
  offsetPaginated;
```

Any nonzero offset (including negative — `Array.prototype.slice`'s negative-index semantics mean the double-apply bug can still corrupt results for some offset/pool-size combinations, e.g. `offset=-21, limit=9` on a 21-row pool silently drops all 9 rows on re-slice, verified directly in a Node REPL; many other negative-offset shapes happen to no-op instead, but distinguishing "safe" from "unsafe" negative offsets isn't worth the complexity) skips the cache entirely, so the double-slice path is unreachable. This is the smaller of two possible fixes; a larger cacheable-offset redesign (fold `offset` into the hash and store the pre-offset pool so paginated requests stay cacheable) is deliberately out of scope here — it's the same tradeoff the existing `adaptiveReturnOn` skip already made (its comment notes folding those params into the hash as a future TODO).

**`KNOBS_HASH_VERSION` bump (19→20, `src/core/search/mode.ts`)**: pure invalidation, no new key part. Since `offset` was never part of the hash, a pre-fix row written for an `offset>0` request is keyed identically to an `offset=0` request on the same `(source_id, knobsHash, embedding)`. Post-fix, `offset>0` requests always skip the cache — but a *stale pre-fix* row could still be looked up by a **new** `offset=0` request and silently serve the wrong (offset-shifted) page. Bumping the version makes every pre-fix row unreachable, so the next otherwise cache-eligible `offset=0` search cold-misses and writes a fresh row, following the same pattern documented by every prior bump in the comment ladder above the constant.

## Other changes in this diff

- `test/hybrid-cache-offset-skip-4358.serial.test.ts` (new): a real PGLite store→hit roundtrip (mocked `embed`/`embedQuery` for a deterministic vector, same harness shape as `hybrid-cached-hit-budget-meta.serial.test.ts`) proving:
  1. `offset=0` caching is unaffected (miss then hit, same page).
  2. `offset=2/limit=9` never becomes a cache hit (`cache.status` is `'disabled'`, matching the sibling skip-cache dimensions — never `'hit'`).
  3. `offset=2/limit=9` always returns 9 rows, not 7 — on both calls, including the *first* one (the preceding test already wrote a same-knobsHash `offset=0` row, so pre-fix even the first `offset=2` call collided with it and double-sliced down to 7 — verified directly by temporarily reverting the fix locally).
- `test/hybrid-degraded-cache-meta.serial.test.ts`: this file had an existing test literally named `'hit-with-offset stays labeled hit (never a clean-miss mislabel)'` that asserted `cache.status === 'hit'` for an `offset: 50` lookup — i.e. it had encoded the pre-fix buggy collision as intended behavior. Updated to assert `'disabled'` with an explanatory comment; the surrounding assertions (0 results, `retrieved_count: 0`) are unchanged.
- `test/search-mode.test.ts`, `test/cross-modal-phase1.test.ts`, `test/search-alias-resolved-boost.test.ts`, `test/search/knobs-hash-reranker.test.ts`: mechanical updates to the hardcoded `KNOBS_HASH_VERSION` pin (19→20), each following that file's existing bump-comment convention.
- `scripts/module-size-limits.tsv`: `hybrid.ts`'s ceiling raised 2629→2641 (the new code's line count) with a reviewer-visible reason, per this repo's documented module-size-ratchet convention.

No new config knobs, no new CLI flags, no new public API surface. Two operational effects worth calling out plainly: the `KNOBS_HASH_VERSION` bump is a global cache-invalidation event — every pre-fix row becomes unreachable, so the next otherwise cache-eligible `offset=0` search cold-misses and writes a fresh row (this repo's existing convention for this class of bump, per the comment ladder above the constant in `mode.ts`) — and every `offset !== 0` (nonzero, negative included) search request now permanently skips the semantic cache going forward, a deliberate correctness-over-speed tradeoff (see "The fix" above).

## Verification

```
$ bun test test/hybrid-cache-offset-skip-4358.serial.test.ts test/hybrid-degraded-cache-meta.serial.test.ts \
    test/search-mode.test.ts test/cross-modal-phase1.test.ts test/search-alias-resolved-boost.test.ts \
    test/search/knobs-hash-reranker.test.ts test/search-compiled-truth-boost-scope.test.ts
 166 pass
 0 fail
 384 expect() calls

$ bun run typecheck
$ tsc --noEmit   # clean

$ bun run check:module-size
OK: module sizes within committed ceilings (scripts/module-size-limits.tsv; new-file cap 1500).
```

Also ran the broader hybrid/cache-adjacent test set (~40 files); all pass individually (a pre-existing cross-file test-isolation flake appears only when several `.serial.test.ts` files are batched into one `bun test` invocation, unrelated to this change).

**Red/green check on the new test**: temporarily reverted the `hybrid.ts` fix (keeping the `KNOBS_HASH_VERSION` bump) and re-ran `test/hybrid-cache-offset-skip-4358.serial.test.ts` — it failed exactly as expected, with the *first* `offset=2/limit=9` call reporting `cache.status: 'hit'` and `length: 7` (confirming both the cross-offset collision and the double-slice). Restored the fix and confirmed green again.

<!-- maintainer-lens: SAFE @ d1e4e68a45d54176ca952d5bfd16a5d9d34c8897 2026-08-21T00:57:53Z -->
