### PR TITLE
fix(doctor): distinguish "no worker" from "worker stuck" in wedged_queue message (#3063)

### DIFF
--- a/src/commands/doctor/checks/queue-jobs.ts
+++ b/src/commands/doctor/checks/queue-jobs.ts
@@ -308,7 +308,10 @@ export async function computeQueueHealthCheck(
  * Exported so `test/doctor.test.ts` drives it directly. Reads
  * GBRAIN_WEDGED_QUEUE_WARN_MINUTES (default 15).
  */
-export async function computeWedgedQueueCheck(engine: BrainEngine): Promise<Check> {
+export async function computeWedgedQueueCheck(
+  engine: BrainEngine,
+  opts: { readWorkers?: () => Array<{ queue: string }> } = {},
+): Promise<Check> {
   if (engine.kind !== 'postgres') {
     return { name: 'wedged_queue', status: 'ok', message: 'PGLite — no queue to check' };
   }
@@ -329,8 +332,7 @@ export async function computeWedgedQueueCheck(engine: BrainEngine): Promise<Chec
        WHERE queue NOT LIKE 'dream-inline-%'
        GROUP BY queue`,
     );
-    const wedged: string[] = [];
-    const wedgedQueueNames: string[] = [];
+    const wedged: { queue: string; label: string }[] = [];
     for (const r of rows) {
       const activeHealthy = Number(r.active_healthy ?? 0);
       const waiting = Number(r.waiting ?? 0);
@@ -338,36 +340,99 @@ export async function computeWedgedQueueCheck(engine: BrainEngine): Promise<Chec
       // Conservative: only flag stale-after-progress (non-null mins past
       // threshold). The null-completions case is the supervisor's job.
       if (activeHealthy === 0 && waiting > 0 && mins !== null && mins > thresholdMin) {
-        wedged.push(`'${r.queue}' (${waiting} waiting, 0 active, ${Math.round(mins)}m since last completion)`);
-        wedgedQueueNames.push(r.queue);
+        wedged.push({
+          queue: r.queue,
+          label: `'${r.queue}' (${waiting} waiting, 0 active, ${Math.round(mins)}m since last completion)`,
+        });
       }
     }
     if (wedged.length === 0) {
       return { name: 'wedged_queue', status: 'ok', message: 'No wedged queues' };
     }
-    // Queue-aware restart hint: the bare stop/start pair bounces the DEFAULT
-    // worker — for a non-default wedged queue that advice restarts the wrong
-    // process. Name the queue in the start command. Queue names are
-    // producer-controlled and this hint gets copy-pasted (by operators AND
-    // remediation agents), so embedded quotes are escaped for the shell.
-    const shellQuote = (q: string) => `'${q.replace(/'/g, String.raw`'\''`)}'`;
-    const nonDefault = wedgedQueueNames.filter(q => q !== 'default');
-    const hints: string[] = [];
-    if (nonDefault.length < wedgedQueueNames.length || nonDefault.length === 0) {
-      hints.push('`gbrain jobs supervisor stop && gbrain jobs supervisor start`');
+    // #3063: "worker alive but not claiming work" would be a false claim
+    // for a queue no worker process was ever subscribed to. Split the
+    // wedged set by whether a registered live worker actually exists for
+    // that queue (getLiveWorkers() self-cleans dead entries), so the
+    // advisory repair matches the real fault instead of misdirecting the
+    // operator toward restarting a worker that was never there — a queue
+    // with no worker needs `start`, not `stop && start`.
+    let liveWorkers: Array<{ queue: string }> = [];
+    let registryReadable = true;
+    try {
+      // Lazy import mirrors computeQueueHealthCheck's own registry access
+      // above — the registry module stays off this file's eager import
+      // graph and only loads once a wedge actually needs the signal.
+      const getLiveWorkers = opts.readWorkers
+        ?? (await import('../../../core/minions/worker-registry.ts')).readWorkers;
+      liveWorkers = getLiveWorkers();
+    } catch {
+      // A registry read error must not turn this check green (the queue is
+      // demonstrably wedged) — but it also must not fabricate a liveness
+      // verdict either way. Fall through to the liveness-unknown wording.
+      registryReadable = false;
     }
-    for (const q of nonDefault) {
-      hints.push(`\`gbrain jobs supervisor stop && gbrain jobs supervisor start --queue ${shellQuote(q)}\``);
+    if (!registryReadable) {
+      return {
+        name: 'wedged_queue',
+        status: 'fail',
+        message:
+          `Wedged queue(s) — worker registry unreadable, worker liveness unknown: ` +
+          `${wedged.map((w) => w.label).join('; ')}. ` +
+          `If a worker is running for the queue, restart it: ` +
+          '`gbrain jobs supervisor stop && gbrain jobs supervisor start [--queue <name>]`; ' +
+          'if none is, start one: `gbrain jobs supervisor start --queue <name> --detach`.',
+        details: {
+          wedged_queues: wedged.length,
+          worker_registry_unreadable: true,
+          threshold_minutes: thresholdMin,
+        },
+      };
     }
-    const restartHint = hints.join(', ');
+    const liveQueues = new Set(liveWorkers.map((w) => w.queue));
+    const stuck = wedged.filter((w) => liveQueues.has(w.queue));
+    const noWorker = wedged.filter((w) => !liveQueues.has(w.queue));
+
+    const messageParts: string[] = [];
+    if (stuck.length > 0) {
+      // Queue-aware restart hint (upstream v0.46.26.0): the bare stop/start
+      // pair bounces the DEFAULT worker — for a non-default wedged queue
+      // that advice restarts the wrong process. Name the queue in the
+      // start command. Queue names are producer-controlled and this hint
+      // gets copy-pasted (by operators AND remediation agents), so
+      // embedded quotes are escaped for the shell.
+      const shellQuote = (q: string) => `'${q.replace(/'/g, String.raw`'\''`)}'`;
+      const stuckQueueNames = stuck.map((w) => w.queue);
+      const nonDefault = stuckQueueNames.filter((q) => q !== 'default');
+      const hints: string[] = [];
+      if (nonDefault.length < stuckQueueNames.length || nonDefault.length === 0) {
+        hints.push('`gbrain jobs supervisor stop && gbrain jobs supervisor start`');
+      }
+      for (const q of nonDefault) {
+        hints.push(`\`gbrain jobs supervisor stop && gbrain jobs supervisor start --queue ${shellQuote(q)}\``);
+      }
+      messageParts.push(
+        `Wedged queue(s) — worker alive but not claiming work: ${stuck.map((w) => w.label).join('; ')}. ` +
+          `Restart the worker so it rebuilds a fresh DB pool: ${hints.join(', ')}, ` +
+          `then \`gbrain jobs retry <id>\` on any dead-lettered jobs.`,
+      );
+    }
+    if (noWorker.length > 0) {
+      messageParts.push(
+        `No worker subscribed to queue(s): ${noWorker.map((w) => w.label).join('; ')}. ` +
+          `Start one: \`gbrain jobs supervisor start --queue <name> --detach\` ` +
+          `or \`gbrain jobs work --queue <name>\`.`,
+      );
+    }
     return {
       name: 'wedged_queue',
       status: 'fail',
-      message:
-        `Wedged queue(s) — worker alive but not claiming work: ${wedged.join('; ')}. ` +
-        `Restart the worker so it rebuilds a fresh DB pool: ${restartHint}, ` +
-        `then \`gbrain jobs retry <id>\` on any dead-lettered jobs.`,
-      details: { wedged_queues: wedged.length, threshold_minutes: thresholdMin },
+      message: messageParts.join(' '),
+      details: {
+        wedged_queues: wedged.length,
+        stuck_worker_queues: stuck.length,
+        no_worker_queues: noWorker.length,
+        threshold_minutes: thresholdMin,
+      },
     };
   } catch (e) {
     // Pre-migration brains / transient errors: advisory check stays ok.

--- a/test/doctor-wedged-queue.test.ts
+++ b/test/doctor-wedged-queue.test.ts
@@ -94,6 +94,56 @@ describe('issue #1801 fix #3 — computeWedgedQueueCheck', () => {
     expect(check.message).toContain("'default'");
   });
 
+  // #3063: the check must not claim "worker alive" when no worker is
+  // registered for the wedged queue, and must keep the original "worker
+  // alive but stuck" wording when one genuinely is.
+  it('says "No worker subscribed" (not "worker alive") when no live worker is registered for the wedged queue', async () => {
+    await seed('default', 'cycle', 'waiting');
+    await seed('default', 'cycle', 'completed', { updatedAtSql: "now() - interval '20 min'" });
+    const check = await computeWedgedQueueCheck(pgLike, { readWorkers: () => [] });
+    expect(check.status).toBe('fail');
+    expect(check.message).toContain('No worker subscribed');
+    expect(check.message).not.toContain('worker alive but not claiming work');
+  });
+
+  it('keeps "worker alive but not claiming work" when a live worker IS registered for the wedged queue', async () => {
+    await seed('default', 'cycle', 'waiting');
+    await seed('default', 'cycle', 'completed', { updatedAtSql: "now() - interval '20 min'" });
+    const check = await computeWedgedQueueCheck(pgLike, { readWorkers: () => [{ queue: 'default' }] });
+    expect(check.status).toBe('fail');
+    expect(check.message).toContain('worker alive but not claiming work');
+    expect(check.message).not.toContain('No worker subscribed');
+  });
+
+  it('a throwing registry read → still fail, but liveness-unknown wording (no fabricated verdict)', async () => {
+    await seed('default', 'cycle', 'waiting');
+    await seed('default', 'cycle', 'completed', { updatedAtSql: "now() - interval '20 min'" });
+    const check = await computeWedgedQueueCheck(pgLike, {
+      readWorkers: () => { throw new Error('registry dir unreadable'); },
+    });
+    expect(check.status).toBe('fail');
+    expect(check.message).toContain('worker registry unreadable');
+    expect(check.message).not.toContain('worker alive but not claiming work');
+    expect(check.message).not.toContain('No worker subscribed');
+    expect(check.details?.worker_registry_unreadable).toBe(true);
+  });
+
+  it('mixed stuck + no-worker queues → both messages, details count each subset', async () => {
+    await seed('default', 'cycle', 'waiting');
+    await seed('default', 'cycle', 'completed', { updatedAtSql: "now() - interval '20 min'" });
+    await seed('q-orphan', 'cycle', 'waiting');
+    await seed('q-orphan', 'cycle', 'completed', { updatedAtSql: "now() - interval '20 min'" });
+    const check = await computeWedgedQueueCheck(pgLike, { readWorkers: () => [{ queue: 'default' }] });
+    expect(check.status).toBe('fail');
+    expect(check.message).toContain('worker alive but not claiming work');
+    expect(check.message).toContain("'default'");
+    expect(check.message).toContain('No worker subscribed');
+    expect(check.message).toContain("'q-orphan'");
+    expect(check.details?.stuck_worker_queues).toBe(1);
+    expect(check.details?.no_worker_queues).toBe(1);
+    expect(check.details?.wedged_queues).toBe(2);
+  });
+
   it('does NOT flag when a job holds a live lock (active_healthy > 0)', async () => {
     await seed('default', 'cycle', 'waiting');
     await seed('default', 'cycle', 'active', { lockUntilSql: "now() + interval '5 min'" });
@@ -132,9 +182,12 @@ describe('issue #1801 fix #3 — computeWedgedQueueCheck', () => {
   it('shell-escapes an embedded single quote in the restart hint (producer-controlled queue names)', async () => {
     // The hint is copy-pasted by operators AND remediation agents, so a
     // queue named q-wedge'd must arrive POSIX-escaped, never raw.
+    // A live worker must be registered for the queue, or the #3063
+    // liveness split routes this to the "no worker" branch instead,
+    // which never builds the restart-hint string at all.
     await seed("q-wedge'd", 'cycle', 'waiting');
     await seed("q-wedge'd", 'cycle', 'completed', { updatedAtSql: "now() - interval '30 min'" });
-    const check = await computeWedgedQueueCheck(pgLike);
+    const check = await computeWedgedQueueCheck(pgLike, { readWorkers: () => [{ queue: "q-wedge'd" }] });
     expect(check.status).toBe('fail');
     expect(check.message).toContain(String.raw`--queue 'q-wedge'\''d'`);
   });
@@ -144,7 +197,12 @@ describe('issue #1801 fix #3 — computeWedgedQueueCheck', () => {
     await seed('default', 'cycle', 'completed', { updatedAtSql: "now() - interval '30 min'" });
     await seed('q-side', 'cycle', 'waiting');
     await seed('q-side', 'cycle', 'completed', { updatedAtSql: "now() - interval '30 min'" });
-    const check = await computeWedgedQueueCheck(pgLike);
+    // Both queues need a live worker registered so the #3063 liveness
+    // split routes them into the "stuck" branch that builds this
+    // restart-hint union, not the "no worker" branch.
+    const check = await computeWedgedQueueCheck(pgLike, {
+      readWorkers: () => [{ queue: 'default' }, { queue: 'q-side' }],
+    });
     expect(check.status).toBe('fail');
     // The bare pair (for 'default') terminates with a backtick — no --queue —
     // and the comma-join carries the per-queue variant right behind it.


### PR DESCRIPTION
## Summary

Fixes #3063.

`computeWedgedQueueCheck` always said "worker alive but not claiming work" for any wedged queue, even when no worker was ever subscribed to it. That misdirects the operator toward `gbrain jobs supervisor stop && gbrain jobs supervisor start` — restarting a worker that was never there — instead of starting one.

The fix threads the existing local worker-registry liveness signal (`readWorkers()` from `core/minions/worker-registry.ts`, already used by `computeQueueHealthCheck` and the `jobs stats` "Scheduling priority" line) into `computeWedgedQueueCheck`, and splits wedged queues into two buckets:

- **worker registered for that queue, but not draining it** → keeps the original "worker alive but not claiming work" message + `supervisor stop && start` repair (dead DB pool / stuck handler).
- **no worker registered for that queue at all** → new "No worker subscribed to queue(s): ..." message pointing at `jobs supervisor start --queue <name> --detach` or `jobs work --queue <name>`.

`opts.readWorkers` is injectable (mirrors `computeQueueHealthCheck`'s existing pattern) for testability; defaults to the real registry read, wrapped in try/catch so a registry read failure can't turn this advisory check red.

## Real-world repro

Hit this on a personal single-user brain: a `local.gbrain-cron-worker` supervisor was scoped to `--queue cron` only, nothing was ever subscribed to `default`, and a `facts-absorb` job sat `waiting` on `default` for ~23h. `doctor` reported "worker alive but not claiming work" — following the advertised fix (restart the worker) does nothing, since there was never a worker on that queue. Verified live that the message correctly switches to "No worker subscribed to queue(s): 'default' ..." with this fix applied. Full writeup in the linked issue comment.

## Test plan
- [x] Two new test cases in `test/doctor-wedged-queue.test.ts`: message says "No worker subscribed" (not "worker alive") when `readWorkers()` returns no match for the wedged queue; keeps "worker alive but not claiming work" when a worker IS registered for it.
- [x] `bun test test/doctor-wedged-queue.test.ts` — 28/28 pass (26 existing + 2 new).
- [x] `bun run typecheck` — clean.