### PR TITLE
fix(search): searchKeyword arm fails open in hybridSearch, matching searchTitles (#4091)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3499	ratchet	grown v0.46.24.0: serve-delegated sync preflight hook
 src/core/cycle.ts	3080	ratchet	grown v0.46.20.0 phase-boundary split (resolveCyclePhases + normalizeQueuedSourcePhases + deriveStatus exclusion filter)
 src/commands/serve-http.ts	3194	ratchet	grown v0.46.23.0 review fix wave: github-kind webhook gating + case-insensitive repo match
 src/commands/jobs.ts	3027	ratchet	grown v0.46.22.0 phone wave: github source sync job (#4104)
-src/core/search/hybrid.ts	2629	ratchet	grown v0.46.23.0 review fix wave: supersede scoping + edge-existence gate
+src/core/search/hybrid.ts	2640	ratchet	grown #4091: add fail-open .catch() to the searchKeyword arm in hybridSearch (mirrors the existing searchTitles fail-open)
 src/core/engine.ts	2351	ratchet	grown v0.46.23.0: putPage allowEmptyOverwrite contract (#4335)
 src/commands/autopilot.ts	2301	ratchet
 src/commands/extract.ts	2161	ratchet

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -1304,7 +1304,18 @@ export async function hybridSearch(
     earlyModality === 'image'
       ? [[], []]
       : await Promise.all([
-          engine.searchKeyword(query, searchOpts),
+          // #4091: keyword arm shares searchTitles' failure mode (a very long
+          // query overflows Postgres's websearch_to_tsquery parser — "stack
+          // depth limit exceeded") but had no fail-open, so it crashed direct
+          // hybridSearch callers instead of degrading like its sibling arm.
+          engine.searchKeyword(query, searchOpts).catch((err: unknown) => {
+            warnOncePerProcess(
+              'search-keyword-arm-failed',
+              `[gbrain] searchKeyword arm failed (fail-open, keyword candidates skipped): ` +
+                `${err instanceof Error ? err.message : String(err)}`,
+            );
+            return [] as SearchResult[];
+          }),
           engine.searchTitles(query, searchOpts).catch((err: unknown) => {
             warnOncePerProcess(
               'search-titles-arm-failed',

--- a/test/search/hybrid-keyword-arm-failopen-4091.serial.test.ts
+++ b/test/search/hybrid-keyword-arm-failopen-4091.serial.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #4091 — hybridSearch's keyword arm (`engine.searchKeyword`) had no fail-open,
+ * unlike its sibling title arm (`engine.searchTitles`, added under
+ * fix/title-retrieval-arm with an explicit `.catch()`). Both arms build their
+ * SQL around `websearch_to_tsquery` with no query-length gate; a sufficiently
+ * long/complex query can overflow Postgres's internal parser and raise "stack
+ * depth limit exceeded" (Postgres error 54001) — verified against a live
+ * Postgres brain (not reproducible against PGLite at the tested scale, hence
+ * the mock-based approach here: PGLite's embedded Postgres apparently applies
+ * a different/higher stack-depth ceiling, or none, for the same input size).
+ *
+ * Before the fix, `searchTitles` failing this way degraded gracefully (its
+ * error was caught and logged), but the IDENTICAL error from `searchKeyword`
+ * propagated uncaught through the `Promise.all` in `hybridSearch`, crashing
+ * direct callers instead of returning degraded-but-successful results.
+ *
+ * This test doesn't attempt to reproduce the real Postgres stack-depth error
+ * (unreproducible on PGLite, and reproducing it for real requires a live
+ * Postgres connection + a ~300KB query — see the issue for that repro). It
+ * spies on `engine.searchKeyword` to inject an arbitrary rejection and
+ * confirms `hybridSearch` still returns a result (title/other arms) instead
+ * of rejecting — i.e. it tests the fail-open CONTRACT this PR adds, not the
+ * specific Postgres failure mode that motivated it.
+ *
+ * Serial: spyOn engine methods (isolation guard R2).
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import { hybridSearch } from '../../src/core/search/hybrid.ts';
+import { configureGateway } from '../../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+const DIM = 1536;
+
+beforeAll(async () => {
+  // Empty env so isAvailable('embedding') is false -> hybridSearch takes the
+  // keyword(+title)-only no-embed path, same hermetic setup as the sibling
+  // title-retrieval-arm.test.ts file.
+  configureGateway({ embedding_model: 'openai:text-embedding-3-large', embedding_dimensions: DIM, env: {} });
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  configureGateway({ embedding_model: 'openai:text-embedding-3-large', embedding_dimensions: DIM, env: { ...process.env } });
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.putPage('notes/widget', {
+    type: 'note',
+    title: 'Widget gbrain4091test Notes',
+    compiled_truth: 'A page about widgets for the gbrain4091test keyword arm fail-open test.',
+  });
+  await engine.upsertChunks('notes/widget', [
+    { chunk_index: 0, chunk_text: 'A page about widgets for the gbrain4091test keyword arm fail-open test.', chunk_source: 'compiled_truth' },
+  ]);
+});
+
+afterEach(() => {
+  // Restore engine.searchKeyword unconditionally, even if a test's own
+  // hybridSearch call or assertion throws before reaching an explicit
+  // spy.mockRestore() — otherwise a failure in the first test leaves the
+  // spy in place and silently contaminates the control test that follows.
+  const maybeSpy = engine.searchKeyword as unknown as { mockRestore?: () => void };
+  maybeSpy.mockRestore?.();
+});
+
+describe('#4091 — hybridSearch keyword arm fails open on a searchKeyword rejection', () => {
+  test('searchKeyword rejecting does not crash hybridSearch — it degrades like searchTitles already does', async () => {
+    spyOn(engine, 'searchKeyword').mockRejectedValue(new Error('stack depth limit exceeded'));
+
+    // Before the fix, this await would reject (the uncaught Promise.all
+    // rejection). After the fix, it resolves with whatever the title arm
+    // (and other RRF inputs) still found.
+    const results = await hybridSearch(engine, 'gbrain4091test', {
+      limit: 5,
+      expansion: false,
+    });
+
+    // The title arm should still have found the seeded page by its title
+    // tokens — proving the OTHER arm's results survive a keyword-arm crash,
+    // not just that the call didn't throw.
+    expect(results.some((r) => r.slug === 'notes/widget')).toBe(true);
+  });
+
+  test('control: searchKeyword succeeding normally still returns results (regression guard)', async () => {
+    // No spy here — this pins that the fix doesn't accidentally suppress
+    // real keyword-arm results in the non-error path.
+    const results = await hybridSearch(engine, 'widgets gbrain4091test', {
+      limit: 5,
+      expansion: false,
+    });
+    expect(results.some((r) => r.slug === 'notes/widget')).toBe(true);
+  });
+});

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, spyOn } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { operationsByName } from '../src/core/operations.ts';
 import { runThink, persistSynthesis, type ThinkLLMClient } from '../src/core/think/index.ts';
 import { sanitizeTakeForPrompt, renderTakesBlock } from '../src/core/think/sanitize.ts';
 import { resolveCitations, parseInlineCitations, normalizeStructuredCitations } from '../src/core/think/cite-render.ts';
 import { runGather } from '../src/core/think/gather.ts';
+import * as hybridModule from '../src/core/search/hybrid.ts';
 import { withoutAnthropicKey } from './helpers/no-anthropic-key.ts';
 
 let engine: PGLiteEngine;
@@ -161,31 +162,44 @@ describe('runGather — per-stream typed warnings (GATHER_*_FAILED)', () => {
   });
 
   test('a throwing hybrid stream surfaces GATHER_HYBRID_FAILED and stays fail-open', async () => {
-    const r = await runGather(withFailing(['searchKeyword']), { question: 'technical founder' });
-    expect(r.warnings).toContain('GATHER_HYBRID_FAILED');
-    expect(r.pages).toEqual([]);
-    // Fail-open: the takes stream keeps working.
-    expect(r.takes.length).toBeGreaterThan(0);
+    // hybridSearch itself now fails open internally on a searchKeyword rejection
+    // (#4091), so forcing GATHER_HYBRID_FAILED here means failing the whole
+    // hybridSearch call, not just one of its internal arms.
+    const spy = spyOn(hybridModule, 'hybridSearch').mockRejectedValue(new Error('hybrid boom'));
+    try {
+      const r = await runGather(engine, { question: 'technical founder' });
+      expect(r.warnings).toContain('GATHER_HYBRID_FAILED');
+      expect(r.pages).toEqual([]);
+      // Fail-open: the takes stream keeps working.
+      expect(r.takes.length).toBeGreaterThan(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test('each failing stream maps to its own code', async () => {
-    const r = await runGather(
-      withFailing(['searchKeyword', 'searchTakes', 'searchTakesVector', 'traversePaths']),
-      {
-        question: 'technical founder',
-        anchor: 'people/alice-example',
-        questionEmbedding: new Float32Array(8),
-      },
-    );
-    expect([...r.warnings].sort()).toEqual([
-      'GATHER_GRAPH_FAILED',
-      'GATHER_HYBRID_FAILED',
-      'GATHER_TAKES_KEYWORD_FAILED',
-      'GATHER_TAKES_VECTOR_FAILED',
-    ]);
-    expect(r.pages).toEqual([]);
-    expect(r.takes).toEqual([]);
-    expect(r.graphSlugs).toEqual([]);
+    const spy = spyOn(hybridModule, 'hybridSearch').mockRejectedValue(new Error('hybrid boom'));
+    try {
+      const r = await runGather(
+        withFailing(['searchTakes', 'searchTakesVector', 'traversePaths']),
+        {
+          question: 'technical founder',
+          anchor: 'people/alice-example',
+          questionEmbedding: new Float32Array(8),
+        },
+      );
+      expect([...r.warnings].sort()).toEqual([
+        'GATHER_GRAPH_FAILED',
+        'GATHER_HYBRID_FAILED',
+        'GATHER_TAKES_KEYWORD_FAILED',
+        'GATHER_TAKES_VECTOR_FAILED',
+      ]);
+      expect(r.pages).toEqual([]);
+      expect(r.takes).toEqual([]);
+      expect(r.graphSlugs).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test('runThink folds gather warnings into ThinkResult.warnings', async () => {


### PR DESCRIPTION
Fixes #4091

## What's broken

`hybridSearch` runs `searchKeyword` and `searchTitles` in parallel via `Promise.all`. `searchTitles` already fails open on error (added under fix/title-retrieval-arm — its docstring explicitly notes it has no query-length gate). `searchKeyword` did not have the same protection.

Both build their SQL around `websearch_to_tsquery('${ftsLang}', $1)` with the caller's query text as a bind parameter and no length gate — the same vulnerable pattern. #4091 documents `searchTitles` hitting Postgres's "stack depth limit exceeded" error message, reproduced there against a live Postgres 16 brain with a ~208KB query (I haven't independently confirmed the underlying SQLSTATE code). I haven't independently reproduced `searchKeyword` hitting the identical error in isolation — what I have is this: running `gbrain query` with an oversized query (live Postgres macmini install) produces two stderr lines, `stack depth limit exceeded` and `[gbrain] searchTitles arm failed (fail-open, title candidates skipped): stack depth limit exceeded`, followed by process exit 1. The first line has no `searchTitles`-specific prefix, which is consistent with it being a *second*, uncaught error surfacing through the CLI's top-level `console.error(e.message || e)` handler — i.e. `searchKeyword` hitting the same failure mode, uncaught. Circumstantial, not proven by isolated reproduction, but it's what motivates this fix: regardless of whether `searchKeyword` shares this *specific* Postgres failure mode, it unquestionably has the same missing-catch gap `searchTitles` already had, on the same category of input.

## The fix

Mirrors the existing `searchTitles` `.catch()` pattern exactly: catch, warn once per process (distinct warning key), return an empty result set.

```ts
engine.searchKeyword(query, searchOpts).catch((err: unknown) => {
  warnOncePerProcess(
    'search-keyword-arm-failed',
    `[gbrain] searchKeyword arm failed (fail-open, keyword candidates skipped): ` +
      `${err instanceof Error ? err.message : String(err)}`,
  );
  return [] as SearchResult[];
}),
```

Placed at the `hybridSearch` call site, not inside the `searchKeyword` engine method itself. `searchKeyword` has at least 11 other direct call sites in the codebase (enrichment-service.ts, link-extraction.ts, cycle/link-manifest.ts, search/keyword.ts, search/eval.ts, ops/search.ts, ops/facts.ts, verbs/entity-card.ts, commands/search-diagnose.ts, commands/eval-longmemeval.ts, commands/eval-replay.ts) — none of them are touched by this change (the diff below is scoped to `hybrid.ts`/the test file/the size-ratchet TSV only), so they keep their normal rejection semantics unchanged. Only the parallel-arm race in `hybridSearch` gets the fail-open.

## Verification

```
$ bun test test/search/hybrid-keyword-arm-failopen-4091.serial.test.ts test/search/title-retrieval-arm.test.ts
 20 pass
 0 fail

$ bun run typecheck
$ tsc --noEmit   # clean

$ bun run check:module-size
OK: module sizes within committed ceilings (hybrid.ts ceiling raised 2629→2640, reviewer-visible in scripts/module-size-limits.tsv)
```

**Red/green check**: temporarily reverted the fix and re-ran the new test — it failed as expected (an uncaught rejection from the mocked `searchKeyword` failure propagated instead of degrading). Restored the fix and confirmed green.

New test spies on `engine.searchKeyword` to inject a rejection rather than reproducing the real Postgres error: I tried reproducing "stack depth limit exceeded" against PGLite directly (a ~306,213-character / ~30,000-token synthetic query passed to both `searchKeyword` and `searchTitles`) and both succeeded with 0 results, no error — PGLite's embedded Postgres apparently doesn't hit the same limit at this scale, for reasons I haven't dug into. The test exercises the fail-open contract this PR adds, not the specific Postgres failure mode. #4091 has the live-Postgres reproduction (standalone Postgres 16 brain, ~208KB query) for `searchTitles`.

<!-- maintainer-lens: SAFE @ 0baefe808e5f91855cfbbed52ddaf3fa87499d28 2026-08-21T04:04:22Z -->



**Second commit note**: after the fix landed, `test/think-pipeline.serial.test.ts`'s `runGather — per-stream typed warnings` suite failed CI — two of its tests asserted `GATHER_HYBRID_FAILED` by making `engine.searchKeyword` throw, relying on that rejection propagating uncaught out of `hybridSearch` (the exact behavior this PR removes). Updated both to `spyOn` the `hybridSearch` module export directly instead, so they exercise `gather.ts`'s own `.catch()` around the whole `hybridSearch` call — independent of which internal arm would have failed it. `bun test test/think-pipeline.serial.test.ts` — 35 pass / 0 fail after the change.
