### PR TITLE
v0.46.24.1 fix(init): retry schema setup on pooler timeouts (#1915)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1551,7 +1551,8 @@ async function initPostgres(opts: {
     }
 
     console.log('Running schema migration...');
-    await engine.initSchema();
+    const { runInitSchemaWithRetry } = await import('../core/init-schema-retry.ts');
+    await runInitSchemaWithRetry(engine);
 
     // v0.37.10.0 T6 (D11): post-initSchema invariant assertion guardrail.
     if (resolvedDim) {

--- a/src/commands/migrations/in-process.ts
+++ b/src/commands/migrations/in-process.ts
@@ -80,8 +80,9 @@ export async function runMigrateOnlyCore(opts?: { timeoutMs?: number }): Promise
   const engine = await createEngine(toEngineConfig(config));
   try {
     await engine.connect(toEngineConfig(config));
+    const { runInitSchemaWithRetry } = await import('../../core/init-schema-retry.ts');
     await withTimeout(
-      engine.initSchema(),
+      runInitSchemaWithRetry(engine).then(() => undefined),
       timeoutMs,
       `schema init timed out after ${Math.round(timeoutMs / 1000)}s`,
     );

--- a/src/core/init-schema-retry.ts
+++ b/src/core/init-schema-retry.ts
@@ -1,0 +1,68 @@
+import type { BrainEngine } from './engine.ts';
+import {
+  isRetryableConnError,
+  isStatementTimeoutError,
+} from './retry-matcher.ts';
+
+export interface InitSchemaRetryOpts {
+  maxAttempts?: number;
+  backoffMs?: number;
+  log?: (line: string) => void;
+  _hooks?: {
+    initSchema?: () => Promise<void>;
+    sleep?: (ms: number) => Promise<void>;
+  };
+}
+
+export interface InitSchemaRetryResult {
+  attempts: number;
+}
+
+function isMigrationRetryExhausted(err: unknown): boolean {
+  return err instanceof Error && err.name === 'MigrationRetryExhausted';
+}
+
+function isRetryableInitSchemaError(err: unknown): boolean {
+  if (isMigrationRetryExhausted(err)) return false;
+  return isStatementTimeoutError(err) || isRetryableConnError(err);
+}
+
+function retryReason(err: unknown): string {
+  if (isStatementTimeoutError(err)) return 'statement_timeout';
+  if (isRetryableConnError(err)) return 'transient connection error';
+  return 'retryable schema error';
+}
+
+/**
+ * Retry the full idempotent initSchema pass for pooler-level cold-start flakes.
+ *
+ * Individual migration statements already have their own retry envelope inside
+ * runMigrations(); this wrapper only catches failures outside that envelope
+ * (for example the embedded schema replay before pending migrations run).
+ */
+export async function runInitSchemaWithRetry(
+  engine: Pick<BrainEngine, 'initSchema'>,
+  opts: InitSchemaRetryOpts = {},
+): Promise<InitSchemaRetryResult> {
+  const maxAttempts = opts.maxAttempts ?? 5;
+  const backoffMs = opts.backoffMs ?? 15_000;
+  const initSchema = opts._hooks?.initSchema ?? (() => engine.initSchema());
+  const sleep = opts._hooks?.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)));
+  const log = opts.log ?? ((line: string) => process.stderr.write(`${line}\n`));
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await initSchema();
+      return { attempts: attempt };
+    } catch (err) {
+      if (!isRetryableInitSchemaError(err) || attempt === maxAttempts) {
+        throw err;
+      }
+
+      log(`  [init retry ${attempt}/${maxAttempts}] schema setup hit ${retryReason(err)}; retrying in ${backoffMs}ms`);
+      await sleep(backoffMs);
+    }
+  }
+
+  throw new Error('initSchema retry loop exhausted unexpectedly');
+}

--- a/test/migrate-retry.test.ts
+++ b/test/migrate-retry.test.ts
@@ -13,13 +13,17 @@
  *   7. 250ms poll interval honored (custom interval respected)
  *   8. isDeadlockError matches SQLSTATE 40P01 in code field
  *   9. isDeadlockError matches "deadlock detected" in message text
+ *  10. initSchema retry catches raw 57014 setup flakes
+ *  11. initSchema retry does not wrap an exhausted per-migration retry
  */
 import { describe, test, expect } from 'bun:test';
 import {
   tryRunPendingMigrations,
   isDeadlockError,
+  MigrationRetryExhausted,
   type TryRunPendingMigrationsResult,
 } from '../src/core/migrate.ts';
+import { runInitSchemaWithRetry } from '../src/core/init-schema-retry.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 // Fake engine for typing — never used because _hooks override everything.
@@ -28,6 +32,14 @@ const fakeEngine = {} as BrainEngine;
 class FakeDeadlock extends Error {
   code = '40P01';
   constructor() { super('deadlock detected'); this.name = 'FakeDeadlock'; }
+}
+
+class FakeStatementTimeout extends Error {
+  code = '57014';
+  constructor() {
+    super('canceling statement due to statement timeout');
+    this.name = 'FakeStatementTimeout';
+  }
 }
 
 describe('isDeadlockError', () => {
@@ -55,6 +67,59 @@ describe('isDeadlockError', () => {
   test('returns false for null/undefined', () => {
     expect(isDeadlockError(null)).toBe(false);
     expect(isDeadlockError(undefined)).toBe(false);
+  });
+});
+
+describe('runInitSchemaWithRetry', () => {
+  test('retries raw statement_timeout failures from schema setup', async () => {
+    let initCalls = 0;
+    const sleeps: number[] = [];
+    const logs: string[] = [];
+
+    const result = await runInitSchemaWithRetry(fakeEngine, {
+      maxAttempts: 5,
+      backoffMs: 0,
+      log: (line) => logs.push(line),
+      _hooks: {
+        sleep: async (ms) => { sleeps.push(ms); },
+        initSchema: async () => {
+          initCalls++;
+          if (initCalls < 3) throw new FakeStatementTimeout();
+        },
+      },
+    });
+
+    expect(result.attempts).toBe(3);
+    expect(initCalls).toBe(3);
+    expect(sleeps).toEqual([0, 0]);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toContain('statement_timeout');
+  });
+
+  test('does not double-wrap an exhausted migration retry envelope', async () => {
+    const exhausted = new MigrationRetryExhausted(
+      16,
+      'sample_migration',
+      3,
+      [],
+      new FakeStatementTimeout(),
+    );
+    let initCalls = 0;
+    const sleeps: number[] = [];
+
+    await expect(runInitSchemaWithRetry(fakeEngine, {
+      backoffMs: 0,
+      _hooks: {
+        sleep: async (ms) => { sleeps.push(ms); },
+        initSchema: async () => {
+          initCalls++;
+          throw exhausted;
+        },
+      },
+    })).rejects.toBe(exhausted);
+
+    expect(initCalls).toBe(1);
+    expect(sleeps).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a small `runInitSchemaWithRetry` wrapper for idempotent schema setup, retrying raw `statement_timeout` / transient connection failures that happen before pending migrations reach their per-statement retry envelope.
- Wire that wrapper through the Postgres `gbrain init --supabase` path and the shared migrate-only schema bring-up path.
- Preserve `MigrationRetryExhausted` as terminal so a migration that already used its own retry budget is not wrapped in another full init retry loop.

Fixes #1915.

## Verification

- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/migrate-retry.test.ts` -> RESULT: GREEN
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/migrate-retry.test.ts` -> 16 pass, 0 fail
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun run typecheck` -> clean
- Diff-selected E2E: selector returned the full suite, so local gate skipped unrelated E2E; CI runs the full suite.
