### PR TITLE
fix(facts): reconcile a Facts fence below the timeline sentinel loudly, not destructively (#3625)

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -409,9 +409,13 @@ export async function runExtractFacts(
     // even though the fence is still on the page (just mis-placed). Detect
     // the mis-placement and treat it the same as the malformed-parse branch
     // above: loud (warn), never destructive (preserve the existing index).
-    // Require BOTH markers (not a bare BEGIN substring hit) so prose that
-    // merely mentions or quotes the marker text doesn't false-trigger the
-    // guard on an otherwise fence-less page.
+    // Require BOTH markers, in order (not a bare BEGIN substring hit), so a
+    // page that only happens to mention the BEGIN marker text in passing
+    // doesn't false-trigger the guard. This is a narrowing, not a full
+    // guarantee — prose that quotes a complete begin+end marker pair
+    // verbatim would still match — but a false positive here only costs an
+    // extra warning-and-preserve cycle, never data loss, so the tradeoff
+    // favors the cheaper check.
     const timeline = page.timeline ?? '';
     const timelineBeginIdx = timeline.indexOf(FACTS_FENCE_BEGIN);
     const hasTimelineFence = timelineBeginIdx !== -1

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -413,9 +413,10 @@ export async function runExtractFacts(
     // page that only happens to mention the BEGIN marker text in passing
     // doesn't false-trigger the guard. This is a narrowing, not a full
     // guarantee — prose that quotes a complete begin+end marker pair
-    // verbatim would still match — but a false positive here only costs an
-    // extra warning-and-preserve cycle, never data loss, so the tradeoff
-    // favors the cheaper check.
+    // verbatim would still match, and would keep matching every cycle
+    // (blocking the page's empty-fence reconcile until the text is edited
+    // out of the timeline) — but it never causes data loss, so the
+    // tradeoff favors the cheaper check over a full markdown-table parse.
     const timeline = page.timeline ?? '';
     const timelineBeginIdx = timeline.indexOf(FACTS_FENCE_BEGIN);
     const hasTimelineFence = timelineBeginIdx !== -1

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -57,7 +57,7 @@ import type { BrainEngine } from '../engine.ts';
 import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede-resolve.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
-import { parseFactsFence } from '../facts-fence.ts';
+import { parseFactsFence, FACTS_FENCE_BEGIN, FACTS_FENCE_END } from '../facts-fence.ts';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
@@ -398,6 +398,28 @@ export async function runExtractFacts(
       // could still recover. That partial result is not authoritative: using
       // it for reconciliation would interpret skipped rows as deletions.
       // Preserve this page's existing index and continue with other pages.
+      continue;
+    }
+
+    // #3625: splitBody() routes everything below the timeline sentinel into
+    // page.timeline, so a `## Facts` fence placed below the sentinel is
+    // invisible to parseFactsFence(compiled_truth) above — it comes back as
+    // "no facts", indistinguishable from a page that never had a fence. Left
+    // unguarded, that false negative deletes this page's fence-owned DB rows
+    // even though the fence is still on the page (just mis-placed). Detect
+    // the mis-placement and treat it the same as the malformed-parse branch
+    // above: loud (warn), never destructive (preserve the existing index).
+    // Require BOTH markers (not a bare BEGIN substring hit) so prose that
+    // merely mentions or quotes the marker text doesn't false-trigger the
+    // guard on an otherwise fence-less page.
+    const timeline = page.timeline ?? '';
+    const timelineBeginIdx = timeline.indexOf(FACTS_FENCE_BEGIN);
+    const hasTimelineFence = timelineBeginIdx !== -1
+      && timeline.indexOf(FACTS_FENCE_END, timelineBeginIdx + FACTS_FENCE_BEGIN.length) !== -1;
+    if (parsed.facts.length === 0 && hasTimelineFence) {
+      result.warnings.push(
+        `${slug}: FACTS_FENCE_BELOW_TIMELINE — a Facts fence exists below the timeline sentinel and is not being reconciled; move it above the sentinel`,
+      );
       continue;
     }
 

--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -228,6 +228,15 @@ const get_page: Operation = {
             stripTakesFence(page.compiled_truth),
             { keepVisibility: ['world'] },
           ),
+          // #3625: a `## Facts` fence placed below the timeline sentinel
+          // lands in page.timeline (splitBody's routing), not
+          // compiled_truth. Stripping only compiled_truth left that fence
+          // — including private rows — readable verbatim by untrusted
+          // remote callers. Apply the same strip to timeline.
+          timeline: stripFactsFence(
+            stripTakesFence(page.timeline ?? ''),
+            { keepVisibility: ['world'] },
+          ),
         }
       : page;
     // v0.42 (#1699) agent-warning channel: surface the page's content_flag

--- a/test/e2e/system-of-record-invariant.test.ts
+++ b/test/e2e/system-of-record-invariant.test.ts
@@ -43,6 +43,8 @@ import { runExtractCore } from '../../src/commands/extract.ts';
 import { extractTakes } from '../../src/core/cycle/extract-takes.ts';
 import { runExtractFacts } from '../../src/core/cycle/extract-facts.ts';
 import { parseFactsFence, stripFactsFence } from '../../src/core/facts-fence.ts';
+import { operationsByName } from '../../src/core/operations.ts';
+import type { OperationContext } from '../../src/core/operations.ts';
 
 let engine: PGLiteEngine;
 let brainDir: string;
@@ -344,6 +346,117 @@ ${remoteBody}`, { noEmbed: true, sourceId: 'default', remote: true });
     const after = await engine.getPage(slug, { sourceId: 'default' });
     expect(after?.compiled_truth).toContain('PRIVATE_ONLY_FACT');
     expect(parseFactsFence(after?.compiled_truth ?? '').facts).toHaveLength(1);
+  });
+
+  // #3625 escalation: splitBody() routes a `## Facts` fence placed below the
+  // timeline sentinel into page.timeline instead of compiled_truth. The
+  // get_page strip trigger above only covered compiled_truth, so an
+  // untrusted remote caller could read a private fence row verbatim via the
+  // `timeline` field. Exercises the real get_page operation handler (not
+  // just the stripFactsFence helper) with ctx.remote=true.
+  test('a below-sentinel facts fence in page.timeline is stripped for untrusted remote readers too', async () => {
+    const slug = 'people/timeline-fence-leak';
+    await engine.putPage(slug, {
+      title: 'Timeline Fence Leak',
+      type: 'person',
+      compiled_truth: '# Timeline Fence Leak\n\nSome text.\n\n<!-- timeline -->\n',
+      frontmatter: {},
+      timeline: `## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | WORLD_TIMELINE_ROW | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_TIMELINE_ROW | fact | 1.0 | private | high | 2026-01-01 |  | s |  |
+<!--- gbrain:facts:end -->
+`,
+    });
+
+    const ctx = { engine, remote: true, sourceId: 'default' } as unknown as OperationContext;
+    const remote = await operationsByName.get_page.handler(ctx, { slug }) as { timeline?: string };
+    expect(remote.timeline).toContain('WORLD_TIMELINE_ROW');
+    expect(remote.timeline).not.toContain('PRIVATE_TIMELINE_ROW');
+
+    // Local CLI callers still see the full fence, unaffected by the strip.
+    const local = await operationsByName.get_page.handler(
+      { engine, remote: false, sourceId: 'default' } as unknown as OperationContext,
+      { slug },
+    ) as { timeline?: string };
+    expect(local.timeline).toContain('PRIVATE_TIMELINE_ROW');
+  });
+
+  // #3625, real splitBody() path (not a hand-built post-split fixture): a
+  // page authored with the `## Facts` fence below `<!-- timeline -->` — the
+  // LLM-composed shape the issue describes — imported through the actual
+  // production write path (importFromContent → parseMarkdown → splitBody).
+  test('a fence written below the sentinel really does land in page.timeline via splitBody, and extract_facts preserves the existing index instead of wiping it', async () => {
+    const slug = 'people/real-split-fence';
+    const fenceRows = `| 1 | REAL_SPLIT_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |`;
+
+    // v1: fence correctly placed above the sentinel — reconciles normally.
+    await importFromContent(engine, slug, `---
+type: person
+title: Real Split Fence
+slug: ${slug}
+---
+
+# Real Split Fence
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+${fenceRows}
+<!--- gbrain:facts:end -->
+
+<!-- timeline -->
+`, { noEmbed: true, sourceId: 'default' });
+
+    const seeded = await engine.getPage(slug, { sourceId: 'default' });
+    expect(seeded?.compiled_truth).toContain('gbrain:facts:begin');
+    await runExtractFacts(engine, { slugs: [slug] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seededRows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = $1`, [slug],
+    );
+    expect(seededRows.rows.map((r: { fact: string }) => r.fact)).toEqual(['REAL_SPLIT_FACT']);
+
+    // v2: same fence, moved below the sentinel — the LLM-composed shape.
+    await importFromContent(engine, slug, `---
+type: person
+title: Real Split Fence
+slug: ${slug}
+---
+
+# Real Split Fence
+
+<!-- timeline -->
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+${fenceRows}
+<!--- gbrain:facts:end -->
+`, { noEmbed: true, sourceId: 'default' });
+
+    // Prove splitBody really did route it to timeline, not compiled_truth —
+    // the premise this whole fix rests on.
+    const moved = await engine.getPage(slug, { sourceId: 'default' });
+    expect(moved?.compiled_truth ?? '').not.toContain('gbrain:facts:begin');
+    expect(moved?.timeline ?? '').toContain('gbrain:facts:begin');
+
+    const r = await runExtractFacts(engine, { slugs: [slug] });
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_TIMELINE'))).toBe(true);
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const afterRows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = $1`, [slug],
+    );
+    expect(afterRows.rows.map((r: { fact: string }) => r.fact)).toEqual(['REAL_SPLIT_FACT']);
   });
 });
 

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -278,6 +278,39 @@ describe('runExtractFacts — happy path', () => {
     expect(cleanRows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Clean']);
   });
 
+  test('#3625: a Facts fence below the timeline sentinel is loud-skipped, never treated as absence', async () => {
+    await putPage('people/carol', FACT_FENCE(
+      `| 1 | Seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/carol'] });
+
+    // splitBody() would route a fence placed below the timeline sentinel
+    // into page.timeline instead of compiled_truth (the LLM-composed shape
+    // the issue describes). Simulate that post-split state directly: the
+    // fence is present on the page, just in the wrong column.
+    await engine.putPage('people/carol', {
+      title: 'people/carol',
+      type: 'person',
+      compiled_truth: '# Page\n\nBody.\n\n<!-- timeline -->\n',
+      frontmatter: {},
+      timeline: FACT_FENCE(
+        `| 1 | Seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+      ),
+    });
+
+    const r = await runExtractFacts(engine, { slugs: ['people/carol'] });
+
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_TIMELINE'))).toBe(true);
+    expect(r.factsDeleted).toBe(0);
+    expect(r.factsInserted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/carol'`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Seeded']);
+  });
+
   test('page with no facts fence → DB facts for that page wiped (empty fence reconciles to empty index)', async () => {
     await putPage('people/alice', FACT_FENCE(
       `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,


### PR DESCRIPTION
Fixes #3625

## What's broken

A page body written through `put_page` can carry its `## Facts` fence **below** the `<!-- timeline -->` sentinel — LLM-composed bodies commonly append Facts at the page bottom. `splitBody()` (`src/core/markdown.ts`) routes everything below the recognized timeline sentinel into `page.timeline`, not `compiled_truth`. `extract_facts` (`src/core/cycle/extract-facts.ts`) parses `page.compiled_truth` only, so a below-sentinel fence is invisible to it — the parse comes back as "no facts," indistinguishable from a page that never had a fence. On the next `extract_facts` cycle, that false negative deletes the page's already-indexed fact rows via the empty-fence reconcile branch, even though the fence is still on the page.

The issue's own reproduction (`gh issue view 3625`) and a subsequent verified-real triage comment confirm this against current master: seeding a fence above the sentinel reconciles normally (`factsInserted:2`), moving the same fence below the sentinel and re-running `extract_facts` reports `factsDeleted:2, factsInserted:0, warnings:[]` — a silent wipe.

**Escalation found during triage** (same issue thread): `get_page`'s privacy strip for untrusted remote/MCP callers (`src/core/ops/pages.ts`) only stripped `page.compiled_truth`. A `## Facts` fence misplaced below the sentinel lands in `page.timeline`, which was never stripped — so a private fence row in that position was readable verbatim by an untrusted remote caller.

## The fix

Two small guards at the two sites the fence-reconcile/privacy-strip logic already routes through (mirrors the triage comment's suggested fix):

1. **`src/core/cycle/extract-facts.ts`** — right after `parseFactsFence(compiled_truth)`, if the parse found zero facts **and** `page.timeline` contains both `FACTS_FENCE_BEGIN` and `FACTS_FENCE_END` (in order — narrower than a bare substring hit on one marker, so a page that only happens to mention the BEGIN marker text in passing doesn't false-trigger this; it isn't a full guarantee against prose that quotes a complete marker pair verbatim — that would keep matching every cycle until the text is edited out of the timeline — but it never causes data loss), treat it the same as the file's existing malformed-fence branch a few lines above: push a `FACTS_FENCE_BELOW_TIMELINE` warning and `continue` — preserve the page's existing DB index, never delete it. Same "loud, never destructive" posture the file already uses for unparseable fences.

2. **`src/core/ops/pages.ts`** (`get_page`) — the existing `isUntrustedReader` branch already applies `stripFactsFence(stripTakesFence(...), { keepVisibility: ['world'] })` to `compiled_truth`. Applies the identical call to `page.timeline` too, so a private fence row misplaced below the sentinel gets the same strip.

`put_page`-side fence-placement normalization (the issue's alternate suggested fix) is intentionally out of scope — the issue's own "Suggested fix" section says either fix alone closes the class; this PR takes the reconcile+privacy-strip side since it's the destructive/leaking half.

## Verification

```
$ bun test test/extract-facts-phase.test.ts test/e2e/system-of-record-invariant.test.ts test/facts-fence.test.ts test/privacy-strip-and-forget.test.ts
 87 pass
 0 fail

$ bun test test/ai/silent-drop-regression.test.ts test/cycle-abort.test.ts test/e2e/phantom-redirect.test.ts \
    test/e2e/system-of-record-invariant.test.ts test/extract-facts-embed-warn.serial.test.ts \
    test/extract-facts-phase.test.ts test/extract-from-fence.test.ts test/extract/receipt-writer.test.ts \
    test/facts-fence-typed.test.ts test/facts-fence.test.ts test/fuzz/pure-validators.test.ts \
    test/lock-keys.test.ts test/migrations-v0_32_2.test.ts test/phantom-redirect.test.ts \
    test/privacy-strip-and-forget.test.ts
 222 pass, 4 skip, 0 fail   # every test file importing extract-facts.ts / facts-fence.ts / ops/pages.ts

$ bun run typecheck   # clean
$ bun run check:module-size   # OK, no ceiling changes needed
$ bun run verify   # 54/54 checks green
```

**Red/green check**: reverted both production files to `upstream/master` (test files kept), re-ran the 3 new/extended test cases — all 3 failed as expected (private row leaked in `timeline`, `FACTS_FENCE_BELOW_TIMELINE` warning absent, existing rows deleted). Restored the fix — all green again.

Three test additions:
- `test/extract-facts-phase.test.ts`: a hand-built post-split DB fixture (fence directly in `page.timeline`) proving `extract_facts` preserves the index instead of wiping it.
- `test/e2e/system-of-record-invariant.test.ts`: (a) the same guard exercised through the real `get_page` operation handler with `ctx.remote=true`, proving a private row in `page.timeline` no longer leaks (local `ctx.remote=false` still sees the full fence); (b) an end-to-end case that goes through the actual production write path (`importFromContent` → `parseMarkdown` → `splitBody`) — not a hand-built fixture — confirming the fence really does land in `page.timeline` for a below-sentinel body, and that `extract_facts` preserves the existing index on that real split.

Ran only the tests above; did not run the full `bun test test/` suite. An initial full unsharded `bun test test/` run (this diff applied) timed out at 10 minutes with ~51 failing tests, none touching extract-facts/facts-fence/ops-pages (embedding gateway, reranker config, atom extraction, doctor migration plans, etc.). Stashed this diff and re-ran 2 of those ~51 failing test files in isolation against a clean `upstream/master` checkout — both passed cleanly (38/38). That's consistent with the full-suite failures being pre-existing environmental noise (resource contention from running thousands of test files unsharded/serially in one process) rather than a regression from this diff, but it's a 2-file spot check, not exhaustive verification across all ~51 failures.

<!-- maintainer-lens: SAFE @ 52fc86e07e896a3fab5bd99c7c4c1def62a51ef7 2026-08-21T07:45:00Z -->
