### PR TITLE
fix(cycle): enforce conversation_facts_backfill's per-source caps instead of parsing and discarding them (#3627)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -18,7 +18,7 @@ src/core/search/hybrid.ts	2703	ratchet	grown v0.46.25.0 fix waves: cache scope i
 src/core/engine.ts	2415	ratchet	grown v0.46.25.0 fix waves: timeline dedup contract + registry write contract (#3827 #1262)
 src/commands/autopilot.ts	2349	ratchet	grown v0.46.25.0 fix waves: positional validation (#1525) + liveness takeover (#4300)
 src/commands/extract.ts	2066	ratchet	lowered: timeline extractor hoisted to core/timeline-extract.ts (module-cycle fix)
-src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
+src/commands/extract-conversation-facts.ts	2105	ratchet	grown v0.46.x per-provider gateway-unavailable copy; #3627 per-source maxWalltimeMin/perSourceMaxCostUsd caps in the enumeration loop
 src/core/import-file.ts	2016	ratchet	grown v0.46.24.0 overnight wave: embedding_plane_split named error (#4287)
 src/core/cycle/synthesize.ts	2702	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches
 src/commands/embed.ts	2046	ratchet	grown v0.46.25.0 delegated wave (#3971)

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -322,6 +322,30 @@ export interface ExtractConversationFactsCoreOpts {
    * dedup → provenance all execute THIS production pipeline with zero LLM calls.
    */
   extractor?: (input: ExtractInput) => Promise<ExtractedFact[]>;
+  /**
+   * #3627: per-invocation wall-clock cap (minutes). Checked between page
+   * batches (same granularity as the brain-wide walltime check the cycle
+   * phase already does between sources). Distinct from the cycle phase's
+   * `maxTotalWalltimeMin` — that one bounds the whole multi-source run and,
+   * with a single source, only evaluates once at ~elapsed 0 and never again,
+   * so it never actually bounds a single source's runtime. Unset = no cap
+   * (back-compat; CLI/Minion callers that never set this see no behavior
+   * change).
+   */
+  maxWalltimeMin?: number;
+  /**
+   * #3627: per-invocation cost cap (USD), enforced independently of
+   * `opts.maxCostUsd`/`opts.budgetTracker`'s own cap. Only meaningful when
+   * `opts.budgetTracker` is set (a caller-managed, possibly brain-wide
+   * tracker) — reads `budgetTracker.totalSpent` (public getter) and checks
+   * the delta since this invocation started, so a single source can't
+   * exhaust a shared multi-source budget alone before other sources get a
+   * turn. Does NOT create or wrap a tracker (the caller-managed-tracker
+   * contract above is unchanged). No-op when `budgetTracker` is absent —
+   * the owned-tracker branch already gets its own hard cap via
+   * `opts.maxCostUsd`.
+   */
+  perSourceMaxCostUsd?: number;
 }
 
 export interface ExtractConversationFactsResult {
@@ -368,6 +392,12 @@ export interface ExtractConversationFactsResult {
   facts_inserted: number;
   budget_exhausted?: boolean;
   spent_usd?: number;
+  /**
+   * #3627: set when `opts.maxWalltimeMin` or `opts.perSourceMaxCostUsd` was
+   * exceeded and the enumeration loop halted early (partial run, same
+   * "halt cleanly, don't crash" posture as `budget_exhausted`).
+   */
+  halted_by_source_cap?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -1332,6 +1362,17 @@ export async function runExtractConversationFactsCore(
     llmFallbackModel,
   };
 
+  // #3627: per-invocation caps, checked between page batches below (same
+  // "yield cleanly at its own budget" posture the issue asked for). Both
+  // read-only: sourceStartedAt is a fresh Date.now() for THIS call, and
+  // budgetTrackerSpentAtStart snapshots the caller-managed tracker's public
+  // totalSpent so the per-source cost delta can be checked without creating
+  // or wrapping a tracker (that would violate the caller-managed-tracker
+  // contract documented on `opts.budgetTracker` above).
+  const sourceStartedAt = Date.now();
+  const budgetTrackerSpentAtStart = opts.budgetTracker?.totalSpent ?? 0;
+  let haltedBySourceCap = false;
+
   // Run body. Either inside the externally-provided tracker scope (no
   // wrap; opts.budgetTracker is in scope upstream OR caller passes it
   // explicitly via withBudgetTracker), or inside a fresh local wrap.
@@ -1451,6 +1492,23 @@ export async function runExtractConversationFactsCore(
         while (true) {
           if (signal?.aborted) throw new Error('aborted');
           if (opts.limit && processedPagesCount >= opts.limit) break pageLoop;
+          // #3627: per-source caps, checked between batches (same
+          // granularity the aborted/limit checks above already use).
+          if (
+            opts.maxWalltimeMin !== undefined &&
+            Date.now() - sourceStartedAt > opts.maxWalltimeMin * 60_000
+          ) {
+            haltedBySourceCap = true;
+            break pageLoop;
+          }
+          if (
+            opts.perSourceMaxCostUsd !== undefined &&
+            opts.budgetTracker !== undefined &&
+            opts.budgetTracker.totalSpent - budgetTrackerSpentAtStart > opts.perSourceMaxCostUsd
+          ) {
+            haltedBySourceCap = true;
+            break pageLoop;
+          }
 
           const batch = await engine.listPages({
             type,
@@ -1568,6 +1626,10 @@ export async function runExtractConversationFactsCore(
     throw err;
   }
 
+  if (haltedBySourceCap) {
+    result.halted_by_source_cap = true;
+  }
+
   // gateway.chat preserves a successful provider result when the final
   // tracker.record() discovers an underestimated overage. Usually the next
   // reserve surfaces it, but a fallback that yields fewer than two messages
@@ -1593,7 +1655,7 @@ export async function runExtractConversationFactsCore(
       engine,
       sourceId,
       result,
-      /* halted */ result.budget_exhausted === true,
+      /* halted */ result.budget_exhausted === true || result.halted_by_source_cap === true,
     );
   }
 

--- a/src/core/cycle/conversation-facts-backfill.ts
+++ b/src/core/cycle/conversation-facts-backfill.ts
@@ -237,6 +237,16 @@ export async function runPhaseConversationFactsBackfill(
             // per-source worker count. Default 1 — opt-in concurrency
             // for cycle paths.
             workers: cfg.workers,
+            // #3627: per-source caps (cycle.conversation_facts_backfill.
+            // max_walltime_min / max_cost_usd) were parsed into `cfg` above
+            // but never threaded into the core call, so they were dead
+            // config — the ONLY effective bound was the brain-wide walltime
+            // check between sources, which with a single source evaluates
+            // once at ~elapsed 0 and never again. Wire them through so a
+            // misbehaving single source can't drag the whole cycle into the
+            // autopilot's outer-timeout SIGKILL.
+            maxWalltimeMin: cfg.maxWalltimeMin,
+            perSourceMaxCostUsd: cfg.maxCostUsd,
           }, opts.signal);
           perSourceResults[src.id] = result;
           if (result.budget_exhausted) {

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -21,6 +21,7 @@ import {
   __setChatTransportForTests,
   __setEmbedTransportForTests,
   resetGateway,
+  withBudgetTracker,
   type ChatResult,
 } from '../src/core/ai/gateway.ts';
 import {
@@ -43,7 +44,7 @@ import {
   ALLOWED_TYPE_ALIASES,
 } from '../src/commands/extract-conversation-facts.ts';
 import { _resetLlmCacheForTests } from '../src/core/conversation-parser/llm-base.ts';
-import { BudgetExhausted } from '../src/core/budget/budget-tracker.ts';
+import { BudgetExhausted, BudgetTracker } from '../src/core/budget/budget-tracker.ts';
 
 // ---------------------------------------------------------------------------
 // pageTypesForAllowed — logical→concrete page-type expansion.
@@ -1210,6 +1211,109 @@ describe('runExtractConversationFactsCore', () => {
     });
     expect(result.pages_failed).toBe(1);
     expect(result.pages_processed).toBe(0);
+  });
+
+  test('#3627: maxWalltimeMin already exceeded at call start halts before any page is fetched', async () => {
+    // A negative cap guarantees the very FIRST check trips deterministically
+    // (elapsed ms since call start is always >= 0 > any negative bound), so
+    // this test has no timing dependency. It proves the check exists and
+    // halts cleanly (zero pages touched) — the between-batches placement is
+    // covered separately below.
+    await engine.putPage('conversations/walltime-cap-immediate', {
+      type: 'slack',
+      title: 'Walltime cap immediate fixture',
+      compiled_truth: SAMPLE_BODY,
+      timeline: '',
+      frontmatter: {},
+    });
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      types: ['slack'],
+      maxWalltimeMin: -1,
+      sleepMs: 0,
+    });
+    expect(result.halted_by_source_cap).toBe(true);
+    expect(result.pages_processed).toBe(0);
+    expect(result.pages_considered).toBe(0);
+  });
+
+  test('#3627: maxWalltimeMin trips BETWEEN batches, after batch 1 is fully processed', async () => {
+    // PAGE_LIST_BATCH is 10 — seed 11 so the loop must fetch a SECOND
+    // batch, which is where the between-batches walltime check actually
+    // lives (distinct from the immediate-trip case above). Deterministic
+    // without a fake clock: sleepMs fires a REAL `await sleep()` once per
+    // segment (line ~1160), so processing batch 1 (10 pages x >=1 segment
+    // each) accumulates >= 1000ms of genuine elapsed time before the loop
+    // loops back to check the cap again — while the FIRST check (before
+    // batch 1 is even fetched, just after a couple of fast local PGLite
+    // reads) has to stay under the 500ms cap. That's a wide margin on both
+    // sides specifically so this isn't flaky on a loaded CI runner (a
+    // Codex review round flagged a tighter 150ms/300ms version as
+    // timing-sensitive); it's still not as airtight as an injectable
+    // clock, which this file has no existing seam for.
+    for (let i = 0; i < 11; i++) {
+      await engine.putPage(`conversations/walltime-cap-${i}`, {
+        type: 'slack',
+        title: `Walltime cap fixture ${i}`,
+        compiled_truth: SAMPLE_BODY,
+        timeline: '',
+        frontmatter: {},
+      });
+    }
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      types: ['slack'],
+      maxWalltimeMin: 500 / 60_000,
+      sleepMs: 100,
+    });
+    expect(result.halted_by_source_cap).toBe(true);
+    expect(result.pages_processed).toBe(10);
+  });
+
+  test('#3627: perSourceMaxCostUsd halts the enumeration loop after the first batch exceeds a caller-managed tracker\'s per-source delta', async () => {
+    // Same 11-page/2-batch shape as the walltime test above, but this cap
+    // reads BudgetTracker.totalSpent (public getter) rather than wall-clock,
+    // so it needs a real spend to accrue during the call. Route all 11
+    // pages through the LLM fallback (unparseable "novel" separator format)
+    // with an oversized per-call usage so batch 1 alone blows well past a
+    // $1 per-source cap; batch 2 must never be fetched.
+    for (let i = 0; i < 11; i++) {
+      await engine.putPage(`conversations/cost-cap-${i}`, {
+        type: 'conversation',
+        title: `Cost cap fixture ${i}`,
+        compiled_truth: [
+          'Alpha Example ~~ 09:00 ~~ first',
+          'Beta Example ~~ 09:05 ~~ second',
+        ].join('\n'),
+        timeline: '',
+        frontmatter: { date: '2026-06-02' },
+      });
+    }
+    await engine.setConfig('conversation_parser.llm_fallback_enabled', 'true');
+    fallbackUsage = { input_tokens: 10_000_000, output_tokens: 1_000_000 };
+    const tracker = new BudgetTracker({ label: 'test:3627-cost-cap' });
+    await withEnv({ ANTHROPIC_API_KEY: 'sk-test' }, async () => {
+      const result = await withBudgetTracker(tracker, () =>
+        runExtractConversationFactsCore(engine, {
+          sourceId: 'default',
+          types: ['conversation'],
+          budgetTracker: tracker,
+          perSourceMaxCostUsd: 1,
+          sleepMs: 0,
+        }),
+      );
+      expect(result.halted_by_source_cap).toBe(true);
+      // Batch 1 (10 pages, identical body) processed via fallback; the
+      // 11th page in batch 2 was never fetched because the cap tripped
+      // first. Only the first page makes a REAL LLM call — the other 9
+      // hit conversation_parser_llm_cache (content-keyed), so fallbackCalls
+      // stays at 1 even though all 10 pages get facts. The oversized
+      // per-call usage still pushes that single real call's cost well past
+      // the $1 cap, which is what this test is actually exercising.
+      expect(result.pages_processed).toBe(10);
+      expect(fallbackCalls).toBeGreaterThanOrEqual(1);
+      expect(tracker.totalSpent).toBeGreaterThan(1);
+    });
   });
 
   test('content identity reopens a page even when updated_at is unchanged', async () => {


### PR DESCRIPTION
Fixes #3627

## What's broken

`cycle.conversation_facts_backfill` parses per-source caps (`max_cost_usd`, `max_walltime_min`) from config into `ResolvedConfig` (`src/core/cycle/conversation-facts-backfill.ts:85-97,152,154`), but never threads either value into the per-source `runExtractConversationFactsCore` call it makes for each source. Both were structurally dead config.

The only walltime bound in the whole phase is the wrapper's brain-wide check, `Date.now() - startedAt > maxTotalWalltimeMs`, evaluated once at the top of the outer `for (const src of sources)` loop. On a brain with a single source, that check evaluates exactly once at ~elapsed 0 (always false) and is never re-evaluated for the rest of that source's run — so the phase has no effective bound and runs until an external process supervisor kills it. Reported: 5 consecutive 60-minute SIGKILLs, with every phase downstream of `conversation_facts_backfill` in the cycle order never running for 2+ days as a result.

`runExtractConversationFactsCore` itself (`src/commands/extract-conversation-facts.ts`) has no walltime concept at all, and its own `maxCostUsd` option is explicitly documented as "used when `budgetTracker` is NOT passed" — the cycle phase always passes a caller-managed brain-wide tracker, so that field is also inert for this call path.

## The fix

Two new options on `ExtractConversationFactsCoreOpts`, checked between page-list batches inside the existing multi-page enumeration loop (same granularity the file's pre-existing `signal?.aborted`/`opts.limit` checks already use, right above where I added mine):

- **`maxWalltimeMin`** — wall-clock cap for *this* invocation (distinct from the wrapper's brain-wide `maxTotalWalltimeMin`, which bounds the whole multi-source run, not one source).
- **`perSourceMaxCostUsd`** — cost cap for *this* invocation. Reads `budgetTracker.totalSpent` (a public getter already on `BudgetTracker`) and checks the delta since the invocation started, rather than creating or wrapping a new tracker — the file has an explicit, load-bearing comment that a nested wrap would *replace* the active `AsyncLocalStorage` scope (defeating the brain-wide cap it's nested inside), so this reads the existing tracker instead of touching its lifecycle.

Both set a new `halted_by_source_cap` result field, which mirrors the file's existing `budget_exhausted` halt pattern exactly: same "yield cleanly, don't crash" posture, and both flow through the same end-of-function `writeRunReceiptAndRollup(..., halted=true)` path, so a capped run leaves the same consistent partial-run receipt/checkpoint state the pre-existing budget-exhaustion path already produces — the next cycle tick resumes from where it left off rather than restarting from scratch.

`conversation-facts-backfill.ts` now passes the previously-parsed-and-discarded `cfg.maxWalltimeMin`/`cfg.maxCostUsd` into the core call as these two new options.

One `scripts/module-size-limits.tsv` ceiling raised (`extract-conversation-facts.ts` 2045→2100) with a reviewer-visible note — the file itself grows by 62 net lines from this diff (2038→2100; the old 2045 ceiling had 7 lines of pre-existing headroom). The new checks live inline in the existing enumeration loop rather than a new module, since they need direct access to loop-local state (`sourceStartedAt`, `budgetTrackerSpentAtStart`).

## Scope note (maintainer-lens self-check)

Verified this doesn't touch a destructive/critical path in the sense flagged by prior close patterns on this repo (reconcile/delete/branch-adding changes) — it adds no new destructive primitive, deletion, or checkpoint-semantics change; it only makes an already-effectively-unbounded loop bounded, using the file's own existing halt pattern.

## Verification

```
$ bun test test/extract-conversation-facts.test.ts
 73 pass
 0 fail

$ bun test test/brainbench-writeback.test.ts test/conversation-facts-type-allowlist-drift.test.ts \
    test/doctor-conversation-facts-backlog.test.ts test/e2e/conversation-parser-pglite.test.ts \
    test/e2e/transcripts-writeback-fidelity.test.ts test/extract-conversation-facts-workers.test.ts \
    test/extract-conversation-facts.test.ts test/extract/receipt-writer.test.ts \
    test/foreground-chat-gateway-init.serial.test.ts
 162 pass, 0 fail   # every test file importing either touched module

$ bun run typecheck   # clean
$ bun run check:module-size   # OK (ceiling raised, see above)
$ bun run verify   # 54/54 checks green
```

**Red/green check**: reverted both production files to `upstream/master` (test files kept), re-ran all 3 new test cases — all 3 failed as expected (`halted_by_source_cap` undefined; between-batches and cost-cap cases processed all 11 pages instead of halting after 10). Restored the fix — all green again, 3x in a row with no flakiness.

Three new tests in `test/extract-conversation-facts.test.ts`:
- **Immediate-trip case**: a negative `maxWalltimeMin` guarantees the very first check (before any page is fetched) trips deterministically — proves the check exists and halts cleanly with zero pages touched, no timing dependency.
- **Between-batches case**: seeds 11 pages (`PAGE_LIST_BATCH` is 10, so this forces a second batch fetch — the actual code path the issue is about). Uses `sleepMs` (an existing option that already awaits once per segment during real page processing, unchanged by this diff) so batch 1's processing accumulates ≥1000ms of genuine elapsed time before the loop re-checks the cap, against a 500ms cap the fast pre-batch-1 checkpoint/config reads shouldn't come close to. Asserts exactly 10 pages processed (batch 1 complete) and `halted_by_source_cap===true` (batch 2's 11th page never fetched). Ran 3x locally with no flakiness; an earlier, tighter-margin version of this test (150ms cap / 300ms accumulated) was flagged as timing-sensitive in review and widened.
- **Cost-cap case**: same 11-page/2-batch shape, but drives real spend through the LLM parser fallback path (`conversation_parser.llm_fallback_enabled`) with an oversized per-call token usage. All 10 pages in batch 1 share identical body content; observed locally during test development that only the first actually reaches the stubbed LLM call (`fallbackCalls===1`) while the other 9 hit `conversation_parser_llm_cache` (content-keyed) and still get a fact inserted each (`pages_processed===10`) — but the test only asserts `fallbackCalls>=1` (looser, so it doesn't overfit to that exact cache-hit count). That single real call's inflated cost still pushes well past the $1 per-source cap, which is what the test's actual assertions pin: `pages_processed===10`, `halted_by_source_cap===true`, `tracker.totalSpent>1`.

This repo has no injectable-clock test seam, so the between-batches walltime test relies on real elapsed time with a 2x safety margin (≥1000ms accumulated against a 500ms cap) rather than a fake clock — noted here in case a reviewer wants to weigh that tradeoff differently than I did.

<!-- maintainer-lens: SAFE @ 011adebf9cdfdf15a0d3289fd3cd9d0c29ca8b9b 2026-08-21T08:05:00Z -->
