### PR TITLE
fix(bootstrap): pin harness detection in the E2E, unblocking nightly coverage-full-e2e

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -28,7 +28,7 @@ src/core/minions/queue.ts	2130	ratchet	grown v0.46.11.0 five-issue wave
 src/commands/init.ts	1950	ratchet	grown v0.46.x keyless capability notices
 src/commands/integrations.ts	1675	ratchet
 src/core/minions/handlers/subagent.ts	1818	ratchet	merged: master v131 settle rework + dream-wave C5 peel + C6 accounting + C7 lease heartbeats/lost-lease aborts + C9 oneshot dispatch + adversarial fix batches
-src/commands/bootstrap.ts	1923	ratchet	grandfathered at merge (grew past the 1500 cap on master)
+src/commands/bootstrap.ts	1928	ratchet	grandfathered at merge (grew past the 1500 cap on master); +5 for the harnessDetect test seam (bulk lives in core/bootstrap/harness.ts)
 src/core/minions/worker.ts	1560	ratchet	grandfathered at merge (grew past the 1500 cap on master, #4170); grown v0.46.11.0 five-issue wave
 src/commands/sources.ts	1790	ratchet	grown v0.46.22.0 phone wave: github source kind (#4104)
 src/core/link-extraction.ts	1504	ratchet	new row: crossed the 1500 unlisted cap in v0.46.22.0 phone wave (relative-link resolution, #3804)

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -75,10 +75,12 @@ import {
   codexBlockOwnsName,
   codexPluginProvidesName,
   ensureHarnessHome,
+  harnessDetectDeps,
   parseHarnessArgs,
   removeHarness,
   statusHarness,
   type HarnessDeps,
+  type HarnessDetectOverrides,
 } from '../core/bootstrap/harness.ts';
 import { claudeUserSettingsPath, codexConfigPath, opencodeConfigDir, opencodeGlobalConfigPath, opencodeProjectConfigPath } from '../core/bootstrap/host-specs.ts';
 import {
@@ -1569,7 +1571,7 @@ export function workspaceBrainStats(ws: string): { sources: string[]; pages: num
 
 /** `gbrain bootstrap harness` (#4043) — machine-level, no workspace, no
  * agent.json. Locks on the gbrain HOME (there is no workspace to lock). */
-async function runHarness(rest: string[], home: string, runner: ExecRunner): Promise<number> {
+async function runHarness(rest: string[], home: string, runner: ExecRunner, detect?: HarnessDetectOverrides): Promise<number> {
   const flags = parseHarnessArgs(rest);
   if (flags.error) {
     console.error(flags.error);
@@ -1583,6 +1585,7 @@ async function runHarness(rest: string[], home: string, runner: ExecRunner): Pro
     gbrainBin: resolveGbrainBin(),
     isTTY: process.stdout.isTTY === true,
     prompt: promptLine,
+    ...harnessDetectDeps(detect),
   };
   // [X12] --status is READ-ONLY: no home mkdir, no lock — it must work (and
   // stay side-effect-free) even while an apply/remove holds the mutex.
@@ -1810,6 +1813,8 @@ export interface RunBootstrapOpts {
   /** Spawn seam for the opencode `mcp list` probe (tests capture argv, cwd,
    * and env; the default holds a real Bun.spawn handle so timeouts kill). */
   probeSpawn?: OpencodeProbeSpawn;
+  /** Harness-detection seam; see HarnessDetectOverrides in core/bootstrap/harness.ts. */
+  harnessDetect?: HarnessDetectOverrides;
 }
 
 /** Dispatch. Returns the process exit code (cli.ts passes it to setCliExitVerdict). */
@@ -1887,7 +1892,7 @@ export async function runBootstrap(args: string[], opts: RunBootstrapOpts = {}):
         code = await runUninstall(ws, rest, home, runner);
         break;
       case 'harness':
-        code = await runHarness(rest, home, runner);
+        code = await runHarness(rest, home, runner, opts.harnessDetect);
         break;
       default:
         return 2; // unreachable

--- a/src/core/bootstrap/harness.ts
+++ b/src/core/bootstrap/harness.ts
@@ -303,6 +303,33 @@ function whichSafe(bin: string): string | null {
   }
 }
 
+/** Optional overrides for the three harness-detection probes.
+ *
+ * Production leaves every field unset, so `resolveDeps` keeps its `Bun.which`
+ * defaults. E2E tests MUST pin them: `Bun.which` resolves against the live
+ * PATH and reads the real password-database HOME, so it ignores a test's
+ * remapped HOME/PATH entirely. Without a pin, an otherwise hermetic test
+ * silently asserts something different depending on which agent CLIs the host
+ * happens to have installed — `claude` is on a developer laptop's PATH but
+ * absent from a GitHub runner, so the claude lane never ran in CI, no
+ * `claude mcp add` was exec'd, and no user-scope settings file was written.
+ */
+export interface HarnessDetectOverrides {
+  claude?: () => boolean;
+  codex?: () => boolean;
+  opencode?: () => boolean;
+}
+
+/** Narrow the overrides to the HarnessDeps keys, omitting absent probes so
+ * resolveDeps' production defaults stay in charge of anything not pinned. */
+export function harnessDetectDeps(o?: HarnessDetectOverrides): Partial<HarnessDeps> {
+  return {
+    ...(o?.claude ? { detectClaude: o.claude } : {}),
+    ...(o?.codex ? { detectCodex: o.codex } : {}),
+    ...(o?.opencode ? { detectOpencode: o.opencode } : {}),
+  };
+}
+
 /** Production mint: open the configured engine just long enough to insert. */
 async function defaultMint(opts: { name: string; scopes: string[]; sourceGrant?: string[] }): Promise<MintedLegacyToken> {
   const cfg = loadConfig();

--- a/test/e2e/bootstrap-harness-lifecycle.serial.test.ts
+++ b/test/e2e/bootstrap-harness-lifecycle.serial.test.ts
@@ -51,6 +51,22 @@ describe('bootstrap harness lifecycle E2E (PGLite + real serve --http)', () => {
     return { runner, calls };
   }
 
+  // Harness detection MUST be pinned, not inherited from the host. The
+  // production default is Bun.which(), which reads the real password-database
+  // HOME and ignores this test's remapped HOME/PATH — so without this seam the
+  // suite silently asserts different things depending on which agent CLIs the
+  // machine happens to have installed. Concretely: `claude` is on a developer
+  // laptop's PATH but absent on a GitHub runner, so the claude lane never ran
+  // in CI, no `claude mcp add` was exec'd, and no user-scope settings file was
+  // written — failing at lines 175 and 220 every night since 2026-08-17 while
+  // passing locally. Both harnesses are declared present here because that is
+  // the scenario these assertions describe.
+  const HARNESS_DETECT = {
+    claude: () => true,
+    codex: () => true,
+    opencode: () => false,
+  } as const;
+
   async function capture<T>(fn: () => Promise<T>): Promise<{ result: T; out: string; err: string }> {
     const origLog = console.log;
     const origErr = console.error;
@@ -139,7 +155,7 @@ describe('bootstrap harness lifecycle E2E (PGLite + real serve --http)', () => {
     const { runner } = makeClaudeRunner();
     const { result, err } = await withEnv(envFor(), () =>
       capture(() =>
-        runBootstrap(['harness', '--yes', '--port', String(PORT), '--harness', 'codex'], { runner }),
+        runBootstrap(['harness', '--yes', '--port', String(PORT), '--harness', 'codex'], { runner, harnessDetect: HARNESS_DETECT }),
       ),
     );
     expect(result).toBe(1);
@@ -159,7 +175,7 @@ describe('bootstrap harness lifecycle E2E (PGLite + real serve --http)', () => {
             '--token', token,
             '--gbrain-bin', '/opt/fake/gbrain',
           ],
-          { runner },
+          { runner, harnessDetect: HARNESS_DETECT },
         ),
       ),
     );
@@ -203,7 +219,7 @@ describe('bootstrap harness lifecycle E2E (PGLite + real serve --http)', () => {
   test('--status: live probes, token recovered from the codex block, exit 0', async () => {
     const { runner } = makeClaudeRunner();
     const { result, out } = await withEnv(envFor(), () =>
-      capture(() => runBootstrap(['harness', '--status'], { runner })),
+      capture(() => runBootstrap(['harness', '--status'], { runner, harnessDetect: HARNESS_DETECT })),
     );
     expect(result).toBe(0);
     expect(out).toMatch(/serve: OK/);
@@ -213,7 +229,7 @@ describe('bootstrap harness lifecycle E2E (PGLite + real serve --http)', () => {
   test('--remove: host wiring cleared, codex config byte-identical to pre-apply, receipt consumed', async () => {
     const { runner } = makeClaudeRunner();
     const { result } = await withEnv(envFor(), () =>
-      capture(() => runBootstrap(['harness', '--remove', '--yes'], { runner })),
+      capture(() => runBootstrap(['harness', '--remove', '--yes'], { runner, harnessDetect: HARNESS_DETECT })),
     );
     expect(result).toBe(0);
     expect(readFileSync(codexConfig(), 'utf8')).toBe('# preexisting codex config\nmodel = "o5"\n');


### PR DESCRIPTION
## What

`coverage-full-e2e` has failed on **every nightly run since 2026-08-17** (runs 32453421876, 32338537649, 32222333677, 32105820276) with a byte-identical failure set. Every other job in the workflow passes.

`test/e2e/bootstrap-harness-lifecycle.serial.test.ts` fails at lines 175 and 220; `qm-provisioning.test.ts` and `serve-stdio-roundtrip.test.ts` co-occur on all four nights.

## Root cause

The E2E injects only `runner` into `runBootstrap`, so harness detection falls through to `resolveDeps`' production default, `Bun.which('claude')`.

`Bun.which` resolves against the **live PATH** and reads the **real password-database HOME** — it ignores the test's remapped `HOME`/`PATH` entirely (the file's own comment at the `envFor()` helper already documents this Bun behaviour for `CLAUDE_CONFIG_DIR`). So the suite asserts something different depending on which agent CLIs the host happens to have installed:

| host | `claude` | result |
|---|---|---|
| developer laptop | on PATH | claude lane runs → **green** |
| GitHub runner | absent | claude lane skipped, no `claude mcp add` exec'd, no user-scope settings file written → **red** |

That is exactly the two observed failures: `expect(add).toBeDefined()` (175) and `ENOENT .../.claude/settings.json` (220).

Not a flake, not an xdist isolation problem. Reproduced byte-for-byte locally by running the file with a claude-free PATH.

## Fix

Add a `harnessDetect` seam to `RunBootstrapOpts`, mirroring the existing `probeSpawn` seam, and pin all three probes in the E2E.

`HarnessDetectOverrides` and the `harnessDetectDeps()` narrowing live in `core/bootstrap/harness.ts` so the size-ratcheted `commands/bootstrap.ts` absorbs only the wiring. Its ceiling moves 1923 → 1928 in this same commit, which is what `check-module-size.sh` instructs when the sibling-module split is already done.

**Production behaviour is unchanged.** `harnessDetectDeps` omits any probe not explicitly supplied, so `resolveDeps` keeps its `Bun.which` defaults whenever the option is absent.

## The gate is strengthened, not weakened

Nothing is skipped, suppressed, or loosened. No assertion changed. CI can now exercise the claude lane it previously could not reach at all — before this, the nightly was silently *not testing* that lane.

Verified by mutation: disabling the claude lane (`wireClaude = false && ...`) makes the test fail 2/5. It still kills a real regression.

## Verification

| Check | Result |
|---|---|
| claude-free PATH, **before** | 2 fail (lines 175, 220) — matches CI exactly |
| claude-free PATH, **after** | 5 pass, 3/3 runs |
| claude on PATH, **after** | 5 pass |
| `qm-provisioning.test.ts` | 11 pass |
| `serve-stdio-roundtrip.test.ts` | 8 pass |
| `bun run verify` | 52 pass, module-size green |

`check:privacy` and `check:test-isolation` exceed `verify`'s 120s per-check harness cap on this machine, but both exit 0 on pristine `master` **and** on this branch when run with a real timeout — pre-existing, unrelated to this change.

## Note on the other two files

`qm-provisioning` and `serve-stdio-roundtrip` co-occur with the bootstrap failure on 4/4 nights but pass in isolation here, including through `scripts/run-e2e.sh` against a real pgvector container. This PR fixes the one file with a proven, reproduced root cause rather than guessing at the other two. Worth re-checking the next nightly once this lands.
