### PR TITLE
fix(code-intel): distinguish out-of-grant-scope from genuinely-unbuilt in code_callers/code_callees readiness (#3707)

### DIFF
--- a/src/core/code-graph-readiness.ts
+++ b/src/core/code-graph-readiness.ts
@@ -54,6 +54,17 @@ export interface CodeGraphReadiness {
   has_code: boolean;
   /** Whether unresolved/stale edge chunks remain in scope (edge kind only). */
   pending_edges: boolean;
+  /**
+   * #3707: set only alongside `status: 'not_built'`, when the caller's scope
+   * was narrowed (a `sourceId` restriction, e.g. a federated_read grant that
+   * excludes the sources holding code) AND code chunks exist brain-wide.
+   * Distinguishes "genuinely never indexed" from "indexed, but outside your
+   * grant" — the latter's remedy is a wider grant, not `gbrain sync` (which
+   * re-indexes an already-correctly-indexed brain and changes nothing).
+   * `status` itself stays `'not_built'` for backward compatibility with
+   * existing consumers that branch on it; this is a supplementary signal.
+   */
+  out_of_scope?: boolean;
 }
 
 /** Scope for a readiness probe. Omit `sourceId` (or set `allSources`) for brain-wide. */
@@ -125,7 +136,19 @@ export async function resolveCodeReadiness(
   try {
     const hasCode = await codeChunksExist(engine, sourceId);
     if (!hasCode) {
-      return { status: 'not_built', ready: false, has_code: false, pending_edges: false };
+      // #3707: only when the scope was actually narrowed to one source —
+      // an unscoped/all-sources caller with no code has nothing wider to
+      // check. One extra EXISTS probe, only on this already-empty path
+      // (same cost posture the module doc already commits to: queries run
+      // ONLY when count === 0).
+      const outOfScope = sourceId !== undefined && await codeChunksExist(engine, undefined);
+      return {
+        status: 'not_built',
+        ready: false,
+        has_code: false,
+        pending_edges: false,
+        ...(outOfScope ? { out_of_scope: true } : {}),
+      };
     }
     if (opts.kind === 'symbol') {
       // Symbol metadata is set at chunk time; code chunks exist ⇒ genuinely none.
@@ -145,6 +168,13 @@ export async function resolveCodeReadiness(
 export function readinessHint(r: CodeGraphReadiness): string | null {
   switch (r.status) {
     case 'not_built':
+      // #3707: `gbrain sync` is actively wrong advice when the code is
+      // already indexed and just outside this caller's grant — it re-syncs
+      // an already-correctly-indexed brain and resolves nothing.
+      if (r.out_of_scope) {
+        return 'No code indexed within your current source grant, but code exists elsewhere in this brain. ' +
+          'Widen the federated_read grant for this client to include the source(s) holding code, or retry with --all-sources if permitted.';
+      }
       return 'Symbol graph not built (no code indexed in scope). Run `gbrain sync` to index code.';
     case 'indexing':
       return 'Symbol graph still building (edges pending resolution). Re-run after the next `gbrain dream` cycle / autopilot tick.';

--- a/src/core/code-graph-readiness.ts
+++ b/src/core/code-graph-readiness.ts
@@ -172,8 +172,14 @@ export function readinessHint(r: CodeGraphReadiness): string | null {
       // already indexed and just outside this caller's grant — it re-syncs
       // an already-correctly-indexed brain and resolves nothing.
       if (r.out_of_scope) {
-        return 'No code indexed within your current source grant, but code exists elsewhere in this brain. ' +
-          'Widen the federated_read grant for this client to include the source(s) holding code, or retry with --all-sources if permitted.';
+        // Deliberately does not name a specific flag or param spelling: this
+        // hint is shared by CLI commands that support an all-sources escape
+        // hatch (code-callers/code-callees) and ones that don't (code-def/
+        // code-refs have no such flag), plus the MCP ops surface (a JSON
+        // param, different spelling again). Naming one exact syntax here
+        // would be wrong advice for the others.
+        return 'No code indexed within your current source grant, but code exists elsewhere in this brain — ' +
+          'widen the federated_read grant for this client to include the source(s) holding code.';
       }
       return 'Symbol graph not built (no code indexed in scope). Run `gbrain sync` to index code.';
     case 'indexing':

--- a/test/code-graph-readiness.test.ts
+++ b/test/code-graph-readiness.test.ts
@@ -51,6 +51,9 @@ describe('resolveCodeReadiness — empty brain', () => {
     expect(r.status).toBe('not_built');
     expect(r.ready).toBe(false);
     expect(r.has_code).toBe(false);
+    // #3707: unscoped caller has no narrower scope to be "out of" — the
+    // brain-wide probe must not even run, let alone flip this on.
+    expect(r.out_of_scope).toBeUndefined();
   });
 
   test('edge grain → not_built when no code exists', async () => {
@@ -103,9 +106,10 @@ describe('resolveCodeReadiness — source scoping', () => {
     await importCodeFile(engine, 'src/sample.ts', SAMPLE, { noEmbed: true });
   });
 
-  test('scoped to a source with no code → not_built', async () => {
+  test('scoped to a source with no code → not_built, and out_of_scope since code exists brain-wide (#3707)', async () => {
     const r = await resolveCodeReadiness(engine, { kind: 'symbol', count: 0, sourceId: 'no-such-source' });
     expect(r.status).toBe('not_built');
+    expect(r.out_of_scope).toBe(true);
   });
 
   test('scoped to the default source (where code lives) → ready (symbol)', async () => {
@@ -118,6 +122,73 @@ describe('resolveCodeReadiness — source scoping', () => {
       kind: 'symbol', count: 0, sourceId: 'no-such-source', allSources: true,
     });
     expect(r.status).toBe('ready');
+  });
+});
+
+describe('resolveCodeReadiness — out_of_scope (#3707)', () => {
+  test('scoped miss with NO code anywhere in the brain → not_built, out_of_scope stays unset', async () => {
+    // No importCodeFile call here — the brain is genuinely empty, not just
+    // out of this scope's reach. The brain-wide probe must correctly report
+    // "no" and out_of_scope must NOT be true.
+    const r = await resolveCodeReadiness(engine, { kind: 'symbol', count: 0, sourceId: 'no-such-source' });
+    expect(r.status).toBe('not_built');
+    expect(r.out_of_scope).toBeUndefined();
+  });
+
+  test('edge grain scoped miss is also flagged out_of_scope when code exists elsewhere', async () => {
+    await importCodeFile(engine, 'src/sample.ts', SAMPLE, { noEmbed: true });
+    const r = await resolveCodeReadiness(engine, { kind: 'edge', count: 0, sourceId: 'no-such-source' });
+    expect(r.status).toBe('not_built');
+    expect(r.out_of_scope).toBe(true);
+  });
+
+  test('allSources bypasses the narrowing entirely — no out_of_scope even with a non-matching sourceId', async () => {
+    await importCodeFile(engine, 'src/sample.ts', SAMPLE, { noEmbed: true });
+    const r = await resolveCodeReadiness(engine, {
+      kind: 'symbol', count: 0, sourceId: 'no-such-source', allSources: true,
+    });
+    // allSources resolves to brain-wide, which DOES have code → ready, not not_built.
+    expect(r.status).toBe('ready');
+    expect(r.out_of_scope).toBeUndefined();
+  });
+
+  test('unscoped call makes exactly ONE probe query — the brain-wide out_of_scope probe never fires without a narrower scope', async () => {
+    // No code seeded at all: an unscoped miss has no narrower scope to be
+    // "out of", so the second probe must not even run (documented cost
+    // policy: probes run ONLY on the already-empty path, and this second
+    // one only when there WAS a scope to compare against).
+    let calls = 0;
+    const counting = {
+      ...engine,
+      executeRaw: (...args: Parameters<typeof engine.executeRaw>) => {
+        calls++;
+        return engine.executeRaw(...args);
+      },
+    } as unknown as BrainEngine;
+    const r = await resolveCodeReadiness(counting, { kind: 'symbol', count: 0 });
+    expect(r.status).toBe('not_built');
+    expect(calls).toBe(1);
+  });
+
+  test('scoped probe succeeds (finds nothing) but the brain-wide probe throws → still fails open to unknown, never throws', async () => {
+    await importCodeFile(engine, 'src/sample.ts', SAMPLE, { noEmbed: true });
+    let calls = 0;
+    const flaky = {
+      ...engine,
+      executeRaw: (...args: Parameters<typeof engine.executeRaw>) => {
+        calls++;
+        // 1st call = the scoped probe (real, finds nothing for the
+        // non-matching sourceId). 2nd call = the new brain-wide probe —
+        // synthetically fails to prove the whole out_of_scope check stays
+        // inside the module's existing fail-open try/catch.
+        if (calls === 2) throw new Error('synthetic brain-wide probe outage');
+        return engine.executeRaw(...args);
+      },
+    } as unknown as BrainEngine;
+    const r = await resolveCodeReadiness(flaky, { kind: 'symbol', count: 0, sourceId: 'no-such-source' });
+    expect(calls).toBe(2);
+    expect(r.status).toBe('unknown');
+    expect(r.ready).toBe(false);
   });
 });
 
@@ -139,5 +210,14 @@ describe('readinessHint', () => {
     expect(readinessHint({ status: 'indexing', ready: false, has_code: true, pending_edges: true })).toContain('still building');
     expect(readinessHint({ status: 'unknown', ready: false, has_code: false, pending_edges: false })).toContain('unavailable');
     expect(readinessHint({ status: 'ready', ready: true, has_code: true, pending_edges: false })).toBeNull();
+  });
+
+  test('#3707: not_built + out_of_scope produces a grant-widening hint, not the sync hint', () => {
+    const hint = readinessHint({
+      status: 'not_built', ready: false, has_code: false, pending_edges: false, out_of_scope: true,
+    });
+    expect(hint).not.toBeNull();
+    expect(hint).not.toContain('gbrain sync');
+    expect(hint).toContain('grant');
   });
 });

--- a/test/e2e/code-intel-mcp-ops-pglite.test.ts
+++ b/test/e2e/code-intel-mcp-ops-pglite.test.ts
@@ -224,6 +224,58 @@ describe('#1780 Gap 1 — readiness envelope on code_* ops', () => {
   });
 });
 
+describe('#3707 — out_of_scope must never cross a remote caller\'s grant', () => {
+  // Adversarial regression guard (Codex review flagged this as a Critical
+  // during #3707's review): resolveCodeReadiness's out_of_scope signal
+  // reveals whether code exists OUTSIDE the caller's scope. That's fine for
+  // trusted local CLI callers, but for a remote/grant-restricted caller it
+  // would be a cross-grant existence leak if it ever reached the response.
+  // Today it doesn't (code_callers/code_callees/code_def/code_refs in
+  // ops/code-intel.ts spread only {status, ready} from the readiness
+  // object, never the whole thing or readinessHint()'s text) — this test
+  // pins that behavior so a future "helpful" `...readiness` refactor, or
+  // an added `hint: readinessHint(readiness)` line, would fail loudly
+  // instead of silently leaking. Asserts the FULL response key set (not
+  // just "no out_of_scope key") so a leak via a differently-named field
+  // (e.g. a nested `readiness` object, or `hint`) is caught too. Covers
+  // both scoped handlers (code_callers AND code_callees) — code_def/
+  // code_refs are brain-wide by design (see ops/code-intel.ts) and can't
+  // reach this path at all: they call resolveCodeReadiness with no
+  // sourceId, so the new probe structurally never fires for them.
+  test.each(['code_callers', 'code_callees'] as const)(
+    '%s response has no out_of_scope/readiness leak for a remote caller whose grant excludes the source with code',
+    async (opName) => {
+      await registerSource(engine, 'source-a'); // granted, empty of code
+      await registerSource(engine, 'source-b'); // has code, NOT granted
+      const pageB = await insertCodePage(engine, 'source-b', 'src/foo.ts');
+      await insertChunk(engine, pageB, 0, 'parseMarkdown', 'function');
+
+      const remoteCtx: any = {
+        engine,
+        config: { engine: 'pglite' as const },
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+        dryRun: false,
+        remote: true,
+        auth: { token: 't', clientId: 'c', scopes: ['read'], allowedSources: ['source-a'] },
+      };
+      const result = await operationsByName[opName]!.handler(remoteCtx, { symbol: 'parseMarkdown' });
+      const edgesKey = opName === 'code_callers' ? 'callers' : 'callees';
+      expect(Object.keys(result as object).sort()).toEqual(['count', 'ready', 'status', 'symbol', edgesKey].sort());
+      expect((result as { status: string }).status).toBe('not_built');
+
+      // Positive control: prove the HANDLER's own internal call to
+      // resolveCodeReadiness genuinely computes out_of_scope: true for this
+      // exact scenario (same engine state, same scope) — not just that the
+      // bare helper can return true in isolation. Otherwise the assertion
+      // above could pass vacuously because the dangerous state never got
+      // computed on this code path in the first place.
+      const { resolveCodeReadiness } = await import('../../src/core/code-graph-readiness.ts');
+      const direct = await resolveCodeReadiness(engine, { kind: 'edge', count: 0, sourceId: 'source-a' });
+      expect(direct.out_of_scope).toBe(true);
+    },
+  );
+});
+
 // ─────────────────────────────────────────────────────────────────
 // Fixtures
 // ─────────────────────────────────────────────────────────────────

--- a/test/e2e/code-intel-mcp-ops-pglite.test.ts
+++ b/test/e2e/code-intel-mcp-ops-pglite.test.ts
@@ -263,12 +263,14 @@ describe('#3707 — out_of_scope must never cross a remote caller\'s grant', () 
       expect(Object.keys(result as object).sort()).toEqual(['count', 'ready', 'status', 'symbol', edgesKey].sort());
       expect((result as { status: string }).status).toBe('not_built');
 
-      // Positive control: prove the HANDLER's own internal call to
-      // resolveCodeReadiness genuinely computes out_of_scope: true for this
-      // exact scenario (same engine state, same scope) — not just that the
-      // bare helper can return true in isolation. Otherwise the assertion
-      // above could pass vacuously because the dangerous state never got
-      // computed on this code path in the first place.
+      // Positive control: a SEPARATE call to resolveCodeReadiness, using the
+      // same engine state and the same scope the handler resolved to,
+      // confirms out_of_scope genuinely evaluates true for this exact
+      // fixture — not just that the helper can return true for some
+      // unrelated input. This does not inspect the handler's own internal
+      // call (that's opaque from outside); it establishes the scenario
+      // itself is a real trigger, so the assertion above isn't vacuously
+      // passing because the dangerous state could never arise here.
       const { resolveCodeReadiness } = await import('../../src/core/code-graph-readiness.ts');
       const direct = await resolveCodeReadiness(engine, { kind: 'edge', count: 0, sourceId: 'source-a' });
       expect(direct.out_of_scope).toBe(true);


### PR DESCRIPTION
Fixes #3707

## What's broken

When a remote OAuth client's `federated_read` grant excludes the source(s) that hold code, `code_callers`/`code_callees` return `status: 'not_built'` with a hint recommending `gbrain sync` to index the code — but the code is already indexed, just outside the caller's grant. The suggested remedy is actively wrong: it re-syncs a brain that's already correctly indexed and resolves nothing.

`register-client` defaults a client's grant to `source_id='default'`, and on a brain where all real content lives in named sources, `default` holds zero pages — so a freshly registered client reads what looks like an empty brain via every tool, with nothing in the response saying "this is a permission issue, not an indexing one."

`resolveCodeReadiness`'s scoped `EXISTS` probe (`codeChunksExist`, `src/core/code-graph-readiness.ts`) genuinely can't tell "never indexed anywhere" apart from "indexed, just not in this scope" — both come back as a scoped miss.

## The fix

The issue's own "Suggested fix" section offers 3 options and says any one would help. This implements the smallest: when the scoped probe misses **and** the caller's scope was actually narrowed to one source (not brain-wide / `allSources`), a second brain-wide `EXISTS` probe (reuses the existing `codeChunksExist` helper, called with `sourceId=undefined`) checks whether code exists elsewhere in the brain.

- That second probe only runs on the already-empty scoped path — matches the module's documented cost policy ("probes run ONLY when `count === 0`"), so it doesn't add any query cost to the common case.
- It stays inside the function's existing `try`/`catch`, so a probe failure still fails open to `status: 'unknown'` rather than throwing — same fail-open contract the module already documents for DB errors.
- `CodeGraphStatus` (the existing 4-value status enum: `not_built` / `indexing` / `ready` / `unknown`) is **unchanged** — no contract break for the 5 existing consumers (`code-def.ts`, `code-refs.ts`, `code-callers.ts`, `code-callees.ts`, `ops/code-intel.ts`) that read `status` directly. The new `out_of_scope` field on `CodeGraphReadiness` is optional/supplementary.
- `readinessHint()` checks `out_of_scope` for the `not_built` case and returns a scope-aware message (widen the `federated_read` grant for this client) instead of the misleading `gbrain sync` suggestion. It deliberately does not name a specific flag/param spelling — the hint is shared across CLI commands that have an all-sources escape hatch (`code-callers`/`code-callees`) and ones that don't (`code-def`/`code-refs` have no such flag at all), plus the MCP ops surface (a JSON param, different spelling again) — naming one exact syntax would be wrong advice for the others. The other 3 status branches are untouched.

## Scope note

The issue report bundles 3 asks: (1) this readiness/hint bug, (2) an "adjacent request" for a `federated_read=['*']` grant-all sentinel, (3) a "minor" note about `code_blast`/`code_flow`'s `SUPPORTED_LANGS` allowlist not covering C#. This PR does only (1). (2) is a new capability (a wildcard grant flag), not a bug fix. (3) is a different file (`src/core/code-intel/recursive-walk.ts`) already tracked separately under #3602 (confirmed open) — the issue reporter themselves suggested tracking it there.

## Verification

```
$ bun test test/code-graph-readiness.test.ts
 17 pass
 0 fail

$ bun test test/code-graph-readiness.test.ts test/code-def-refs.test.ts test/code-callers-cli.test.ts \
    test/code-callers-pin.serial.test.ts test/e2e/code-intel-mcp-ops-pglite.test.ts \
    test/link-extraction-code-refs.test.ts test/code-intel/*.ts test/cli-flag-validation.test.ts
 161 pass, 0 fail   # every test file exercising the 5 call sites + this module

$ bun run typecheck   # clean
$ bun run check:module-size   # OK, no ceiling change needed
$ bun run build:flag-registry   # clean, no drift
$ bun run verify   # 54/54 checks green
```

**Red/green check**: reverted the production file to `upstream/master` (test files kept), re-ran the affected test cases — failed as expected (`out_of_scope` undefined where it should be `true`; the fail-open-through-a-second-probe-failure case never reached its second probe at all; the adversarial leak-guard test had nothing to catch since the field it checks for didn't exist). Restored the fix — all green again.

Two issues surfaced during review, both fixed before Ready:

1. **CI caught a real bug in the first push.** The initial `readinessHint()` wording named a specific flag (`--all-sources`) as the remedy. Two problems: (a) the repo's flag-registry freshness guard (`test/cli-flag-validation.test.ts`) flagged drift because that string, reachable from `code-def.ts`/`code-refs.ts` via this module, got picked up by `scripts/generate-flag-registry.ts`'s text scan as those commands "declaring" `--all-sources` — but they don't actually implement that flag. (b) That's not just a stale-generated-file problem — the original hint text was factually wrong for 3 of the module's 5 consumers (`code-def`/`code-refs` have no `--all-sources` flag; the MCP ops surface uses a JSON `all_sources` param, not a CLI flag at all). Reworded the hint to describe the remedy (widen the grant) without naming any specific flag/param syntax anywhere, including comments (the generator scans those too), regenerated the flag registry, reverified.

2. **A code-quality review round flagged a Critical**: the new `out_of_scope` field reveals whether code exists *outside* a caller's grant — for a remote caller, that's a cross-grant existence leak if it ever reached the response. I verified directly (read every consumer, not just the 2 files in this diff) that it doesn't today: all 4 `ops/code-intel.ts` handlers (`code_callers`/`code_callees`/`code_def`/`code_refs`) spread only `{status, ready, ...}` from the readiness object, never the whole thing, and never call `readinessHint()`. `code_def`/`code_refs` additionally can't reach the new probe path at all — they call `resolveCodeReadiness` with no `sourceId` (brain-wide by existing design), and the probe only runs when a narrower scope was passed. But that safety currently depends on caller discipline, not a guard, so I added an adversarial regression test (`test/e2e/code-intel-mcp-ops-pglite.test.ts`, covering both `code_callers` and `code_callees`) that builds a real remote `ctx` with a grant excluding the source holding code, calls the actual operation handler, and asserts the **full response key set** has no leak (not just "no `out_of_scope` key" — a differently-named leak like a nested `readiness` object or an added `hint` field would also be caught). Red/green-verified the guard itself: temporarily patched the handler to spread `...readiness`, confirmed the new test fails loudly and shows exactly which extra keys leaked (`has_code`, `out_of_scope`, `pending_edges`), reverted, confirmed green again.

Eight new/extended test cases in `test/code-graph-readiness.test.ts`:
- Scoped miss with code existing elsewhere (symbol + edge grain) → `out_of_scope: true`.
- Scoped miss with **no** code anywhere in the brain → `out_of_scope` stays `undefined` (the negative case — proves this isn't just always-true).
- `allSources` bypasses the narrowing entirely, even with a non-matching `sourceId` — resolves brain-wide and finds the code, so it's `ready`, not `not_built`.
- Unscoped call makes **exactly one** probe query, verified by an actual call-counting spy on `engine.executeRaw` (not just an unasserted code comment) — the second probe genuinely never fires without a narrower scope to compare against.
- Scoped probe succeeds (finds nothing) but the new brain-wide probe itself throws → still fails open to `status: 'unknown'`, confirmed via a spy that lets the first `executeRaw` call through for real and synthetically fails only the second.
- `readinessHint()` with `out_of_scope: true` returns a hint that mentions the grant and does **not** say `gbrain sync`.

Plus the 2-case adversarial leak guard in `test/e2e/code-intel-mcp-ops-pglite.test.ts` described above (`code_callers` + `code_callees`, via `test.each`), each with its own positive control: a separate call to `resolveCodeReadiness` using the same engine state and the same resolved scope confirms `out_of_scope` genuinely evaluates `true` for that exact fixture. This doesn't inspect the handler's own internal call (opaque from outside the handler) — it establishes the scenario itself is a real trigger, so the no-leak assertion isn't passing vacuously because the dangerous state could never arise for this fixture in the first place.

<!-- maintainer-lens: SAFE @ a9fb80dc746c948f72d1c3a458a4a1ff1fc463d4 2026-08-21T09:45:00Z -->
