### PR TITLE
fix(source-resolver): parallelize tier-4 registered-source realpath resolution

### DIFF
--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -20,6 +20,7 @@
  */
 
 import { realpathSync, existsSync, type Stats } from 'fs';
+import { realpath as realpathAsync } from 'fs/promises';
 import { resolve as resolvePath, relative, isAbsolute, dirname, basename, join, sep } from 'path';
 
 /**
@@ -137,6 +138,25 @@ export function msysToNativePath(
   const drive = m[1]!.toUpperCase();
   const rest = (m[2] ?? '').replace(/\//g, '\\');
   return `${drive}:${rest || '\\'}`;
+}
+
+/**
+ * Async twin of `realpathOrResolve` — same fallback contract, but backed by
+ * `fs.promises.realpath` instead of `realpathSync`. Exists so a caller
+ * resolving N independent paths (e.g. every registered source's local_path)
+ * can `Promise.all` them and let a slow/interrupted filesystem stall on ONE
+ * path without serializing behind the others: `realpathSync` blocks the
+ * event loop for its full duration no matter how many `Promise.all`-wrapped
+ * calls surround it (#4091-class root-cause), so parallelizing the SYNC
+ * function would still take sum-of-durations, not max-of-durations. Use this
+ * version whenever more than one path is being resolved together.
+ */
+export async function realpathOrResolveAsync(p: string): Promise<string> {
+  try {
+    return await realpathAsync(p);
+  } catch {
+    return resolvePath(p);
+  }
 }
 
 /**

--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -155,6 +155,14 @@ export async function realpathOrResolveAsync(p: string): Promise<string> {
   try {
     return await realpathAsync(p);
   } catch {
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    // Same fallback as the sync `realpathOrResolve` above (unflagged there
+    // only because semgrep's diff-scoped scan doesn't re-flag pre-existing
+    // lines): `p` is not raw untrusted input here — it's a registered
+    // source's local_path or the CLI's own cwd, and this is the LEXICAL
+    // fallback for a path that already failed to realpath (ENOENT/stale
+    // registration). The security boundary is the caller's realpath-both-
+    // sides prefix/containment check afterward, not this resolve() call.
     return resolvePath(p);
   }
 }

--- a/src/core/path-confine.ts
+++ b/src/core/path-confine.ts
@@ -150,19 +150,21 @@ export function msysToNativePath(
  * calls surround it (#4091-class root-cause), so parallelizing the SYNC
  * function would still take sum-of-durations, not max-of-durations. Use this
  * version whenever more than one path is being resolved together.
+ *
+ * The lexical fallback below is the same shape as the sync version above
+ * (unflagged there only because semgrep's diff-scoped CI scan doesn't
+ * re-flag pre-existing lines): `p` is never raw untrusted input at this
+ * call site — a registered source's local_path or the CLI's own cwd — and
+ * this is the fallback for a path that already failed to realpath
+ * (ENOENT/stale registration). The security boundary is the caller's
+ * realpath-both-sides prefix/containment check afterward, not this
+ * resolve() call.
  */
 export async function realpathOrResolveAsync(p: string): Promise<string> {
   try {
     return await realpathAsync(p);
   } catch {
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
-    // Same fallback as the sync `realpathOrResolve` above (unflagged there
-    // only because semgrep's diff-scoped scan doesn't re-flag pre-existing
-    // lines): `p` is not raw untrusted input here — it's a registered
-    // source's local_path or the CLI's own cwd, and this is the LEXICAL
-    // fallback for a path that already failed to realpath (ENOENT/stale
-    // registration). The security boundary is the caller's realpath-both-
-    // sides prefix/containment check afterward, not this resolve() call.
     return resolvePath(p);
   }
 }

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -18,7 +18,7 @@ import { join, dirname, resolve } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { isSourceFederated, parseSourceConfig } from './sources-load.ts';
 import { SOURCE_ID_RE, isValidSourceId, ALL_SOURCES } from './source-id.ts';
-import { isTrustedDotfile, realpathOrResolve } from './path-confine.ts';
+import { isTrustedDotfile, realpathOrResolveAsync } from './path-confine.ts';
 
 // Re-export so scope-resolution call sites can import the sentinel from
 // either module (#1712).
@@ -90,6 +90,59 @@ function readDotfileWalk(startDir: string): string | null {
  *          (prevents silently writing to a nonexistent source and bloating
  *          pages with a dead FK).
  */
+/**
+ * Tier-4 shared core: "registered source whose local_path contains CWD",
+ * longest-prefix-wins. Realpaths BOTH sides (not bare resolve) so a
+ * symlinked CWD can't forge a prefix match against a registered local_path
+ * it doesn't really live under (codex #9); `realpathOrResolveAsync` falls
+ * back to lexical resolve() for a stale registration whose path no longer
+ * exists.
+ *
+ * All N `local_path` realpaths (plus cwd's) resolve via `Promise.all`
+ * (#4091-class fix): a synchronous `realpathSync` loop blocks the event
+ * loop for the FULL duration of every call in sequence, so wrapping the
+ * sync calls in `Promise.all` doesn't parallelize anything — a single slow
+ * or interrupted filesystem path (network mount, macOS on-access security
+ * scan, degraded disk) still serializes the whole tier behind itself times
+ * the registered-source count. The async realpath here truly overlaps I/O
+ * across sources, so the tier's cost is bounded by the SLOWEST single
+ * source, not their sum.
+ *
+ * Shared by `resolveSourceId` and `resolveSourceWithTier` so the two
+ * resolution-chain entry points can't drift on this tier (mirrors how
+ * `pickSoleNonDefaultSource` is already shared for tier 5.5).
+ */
+async function resolveRegisteredPathMatch(
+  engine: BrainEngine,
+  cwd: string,
+): Promise<{ id: string; path: string; pathLen: number } | null> {
+  const registered = await listRegisteredLocalPathSources(engine);
+  if (registered.length === 0) return null;
+  const [cwdResolved, resolvedPaths] = await Promise.all([
+    realpathOrResolveAsync(cwd),
+    Promise.all(registered.map(r => realpathOrResolveAsync(r.local_path))),
+  ]);
+  // #3880: ACTIVE sources win the prefix match — an archived (deeper)
+  // registration must not shadow an active parent source. When cwd lands
+  // ONLY in archived trees, the caller's assertSourceExists still throws
+  // (explicit unavailable target — never silent continuation). The paths
+  // are already resolved above, so the tiering is a pure in-memory pass.
+  for (const archivedTier of [false, true]) {
+    let best: { id: string; path: string; pathLen: number } | null = null;
+    for (let i = 0; i < registered.length; i++) {
+      if ((registered[i].archived === true) !== archivedTier) continue;
+      const p = resolvedPaths[i];
+      if (cwdResolved === p || cwdResolved.startsWith(p + '/')) {
+        if (!best || p.length > best.pathLen) {
+          best = { id: registered[i].id, path: p, pathLen: p.length };
+        }
+      }
+    }
+    if (best) return best;
+  }
+  return null;
+}
+
 export async function resolveSourceId(
   engine: BrainEngine,
   explicit: string | null | undefined,
@@ -128,32 +181,9 @@ export async function resolveSourceId(
   // 4. Registered source whose local_path contains CWD.
   //    Uses longest-prefix match so nested-path configurations (e.g.
   //    gstack at ~/gstack + plans at ~/gstack/plans) pick the deepest.
-  //    #3880: ACTIVE sources win the prefix match — an archived (deeper)
-  //    registration must not shadow an active parent source. When cwd lands
-  //    ONLY in archived trees, the assertSourceExists below still throws
-  //    (explicit unavailable target — never silent continuation).
-  const registered = await listRegisteredLocalPathSources(engine);
-  // realpath BOTH sides (not bare resolve) so a symlinked CWD can't forge a
-  // prefix match against a registered local_path it doesn't really live under
-  // (codex #9). realpathOrResolve falls back to lexical resolve() for a stale
-  // registration whose path no longer exists. Resolving both sides keeps a
-  // legitimately symlinked vault matching — only one-sided symlinks break.
-  const cwdResolved = realpathOrResolve(cwd);
-  let best: { id: string; pathLen: number } | null = null;
-  for (const tier of [
-    registered.filter((r) => r.archived !== true),
-    registered.filter((r) => r.archived === true),
-  ]) {
-    for (const r of tier) {
-      const p = realpathOrResolve(r.local_path);
-      if (cwdResolved === p || cwdResolved.startsWith(p + '/')) {
-        if (!best || p.length > best.pathLen) {
-          best = { id: r.id, pathLen: p.length };
-        }
-      }
-    }
-    if (best) break;
-  }
+  //    #3880 active-over-archived tiering + parallel realpath both live in
+  //    the shared resolveRegisteredPathMatch helper.
+  const best = await resolveRegisteredPathMatch(engine, cwd);
   if (best) {
     // A local_path registration can outlive source archival. Treat landing in
     // that tree as an explicit unavailable target, never as permission to
@@ -486,25 +516,9 @@ export async function resolveSourceWithTier(
   }
 
   // 4. Registered source whose local_path contains CWD.
-  //    #3880: active-over-archived tiering — see resolveSourceId's block.
-  const registered = await listRegisteredLocalPathSources(engine);
-  // realpath both sides — see the matching block in resolveSourceId (codex #9).
-  const cwdResolved = realpathOrResolve(cwd);
-  let best: { id: string; path: string; pathLen: number } | null = null;
-  for (const tier of [
-    registered.filter((r) => r.archived !== true),
-    registered.filter((r) => r.archived === true),
-  ]) {
-    for (const r of tier) {
-      const p = realpathOrResolve(r.local_path);
-      if (cwdResolved === p || cwdResolved.startsWith(p + '/')) {
-        if (!best || p.length > best.pathLen) {
-          best = { id: r.id, path: p, pathLen: p.length };
-        }
-      }
-    }
-    if (best) break;
-  }
+  //    #3880 active-over-archived tiering + parallel realpath both live in
+  //    the shared resolveRegisteredPathMatch helper.
+  const best = await resolveRegisteredPathMatch(engine, cwd);
   if (best) {
     await assertSourceExists(engine, best.id);
     return { source_id: best.id, tier: 'local_path', detail: best.path };

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -18,7 +18,7 @@ import { join, dirname, resolve } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { isSourceFederated, parseSourceConfig } from './sources-load.ts';
 import { SOURCE_ID_RE, isValidSourceId, ALL_SOURCES } from './source-id.ts';
-import { isTrustedDotfile, realpathOrResolveAsync } from './path-confine.ts';
+import { isTrustedDotfile, realpathOrResolve, realpathOrResolveAsync } from './path-confine.ts';
 
 // Re-export so scope-resolution call sites can import the sentinel from
 // either module (#1712).

--- a/test/archived-source-scoping.test.ts
+++ b/test/archived-source-scoping.test.ts
@@ -118,6 +118,11 @@ describe('#3880 structural pins — all-source local_path selections filter arch
     // SourceTargetError instead of silently falling through.
     const src = readFileSync('src/core/source-resolver.ts', 'utf-8');
     expect(src).toContain('SELECT id, local_path, archived FROM sources WHERE local_path IS NOT NULL');
-    expect(src.match(/r\.archived !== true/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    // #4411: tier-4 realpath resolution was parallelized and the two
+    // active/archived filter passes were consolidated into one indexed loop
+    // over both tiers — same active-over-archived behavior (see the two
+    // behavioral tests above), expressed once instead of duplicated twice.
+    expect(src).toContain('for (const archivedTier of [false, true])');
+    expect(src.match(/\.archived === true\) !== archivedTier/g)?.length ?? 0).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/source-resolver-tier4-parallel-realpath.test.ts
+++ b/test/source-resolver-tier4-parallel-realpath.test.ts
@@ -33,9 +33,19 @@ import type { BrainEngine } from '../src/core/engine.ts';
 function makeStub(paths: Array<{ id: string; local_path: string }>): BrainEngine {
   return {
     kind: 'pglite',
-    executeRaw: async <T>(sql: string): Promise<T[]> => {
-      if (sql.includes('SELECT id, local_path FROM sources')) {
+    executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
+      // Matches both query shapes of listRegisteredLocalPathSources (#3880):
+      // the archived-column query and its pre-v34 column-less fallback. Rows
+      // carry no `archived` key here → treated as active.
+      if (sql.includes('FROM sources WHERE local_path IS NOT NULL')) {
         return paths as unknown as T[];
+      }
+      // #4368-added archival gate: resolveSourceId/resolveSourceWithTier call
+      // assertSourceExists on the tier-4 match before returning it. This test
+      // only exercises resolution ordering/concurrency, not archival — every
+      // id the resolver checks is treated as active.
+      if (sql.includes('SELECT id FROM sources WHERE id = $1 AND archived = false')) {
+        return [{ id: params?.[0] }] as unknown as T[];
       }
       return [] as unknown as T[];
     },

--- a/test/source-resolver-tier4-parallel-realpath.test.ts
+++ b/test/source-resolver-tier4-parallel-realpath.test.ts
@@ -1,0 +1,134 @@
+/**
+ * #4091-class root-cause fix — tier-4 registered-source realpath resolution
+ * must overlap I/O across sources, not serialize behind each other.
+ *
+ * Discovered while investigating why `gbrain takes-list` (and any other
+ * CLI command reaching tier 4 of source resolution with no --source/env/
+ * dotfile match) took ~40s on a brain with 9 registered sources whose
+ * local_path all lived under a directory macOS's on-access security scan
+ * makes slow to `realpath()`: each source added its own multi-second delay
+ * because the original code called the SYNCHRONOUS `realpathSync` in a
+ * plain `for` loop — `Promise.all`-wrapping a sync call does not
+ * parallelize it, since a sync call blocks the whole event loop for its
+ * full duration regardless of how many promises surround it. The fix
+ * switches to `fs.promises.realpath` (`realpathOrResolveAsync`) and
+ * resolves every source's path via a single `Promise.all`, so tier 4's
+ * cost is bounded by the SLOWEST single source, not their sum.
+ *
+ * This test can't reproduce the real macOS-scan slowness portably/in CI,
+ * so it spies on `realpathOrResolveAsync` to prove concurrency directly:
+ * every mocked call increments an in-flight counter and hangs on its own
+ * releaser (never auto-resolving), so the test can assert ALL N+1 calls
+ * (cwd + every registered source) were issued before ANY of them settled.
+ * This is deterministic — no wall-clock/timing assertion, so it can't flake
+ * under CI load, timer throttling, or coverage instrumentation (the wall
+ * clock version of this test hit exactly that risk in review).
+ */
+
+import { describe, test, expect, spyOn } from 'bun:test';
+import { resolveSourceId, resolveSourceWithTier } from '../src/core/source-resolver.ts';
+import * as pathConfine from '../src/core/path-confine.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+function makeStub(paths: Array<{ id: string; local_path: string }>): BrainEngine {
+  return {
+    kind: 'pglite',
+    executeRaw: async <T>(sql: string): Promise<T[]> => {
+      if (sql.includes('SELECT id, local_path FROM sources')) {
+        return paths as unknown as T[];
+      }
+      return [] as unknown as T[];
+    },
+    getConfig: async () => null,
+  } as unknown as BrainEngine;
+}
+
+describe('resolveSourceWithTier — tier 4 realpath resolution is parallel, not serial (#4091-class)', () => {
+  test('all N+1 realpath calls (cwd + every registered source) are in flight together before any settles', async () => {
+    const N = 6;
+    const paths = Array.from({ length: N }, (_, i) => ({ id: `src${i}`, local_path: `/slow/path${i}` }));
+    const engine = makeStub(paths);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const releasers: Array<() => void> = [];
+
+    const spy = spyOn(pathConfine, 'realpathOrResolveAsync').mockImplementation((p: string) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise<string>((resolvePromise) => {
+        releasers.push(() => {
+          inFlight--;
+          resolvePromise(p);
+        });
+      });
+    });
+
+    try {
+      const resultPromise = resolveSourceWithTier(engine, null, '/slow/path3/nested');
+      // Let the microtask queue drain so every Promise.all-issued call has
+      // started (but none have been released yet — they all hang on their
+      // own releaser above). If the tier-4 loop were serial, only the FIRST
+      // call would be in flight at this point; the rest would not even have
+      // been issued yet, since each `await` blocks starting the next one.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // cwd's own realpath + one per registered source, all outstanding at once.
+      expect(maxInFlight).toBe(N + 1);
+      expect(inFlight).toBe(N + 1); // none settled yet either
+
+      // Release everything and let resolution complete.
+      for (const release of releasers) release();
+      const result = await resultPromise;
+
+      expect(result.source_id).toBe('src3');
+      expect(result.tier).toBe('local_path');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('control: same scenario without the spy still resolves correctly (regression guard)', async () => {
+    const paths = [
+      { id: 'gstack', local_path: '/work/gstack' },
+      { id: 'other', local_path: '/work/other' },
+    ];
+    const engine = makeStub(paths);
+    const result = await resolveSourceWithTier(engine, null, '/work/gstack/src');
+    expect(result.source_id).toBe('gstack');
+    expect(result.tier).toBe('local_path');
+  });
+
+  test('resolveSourceId (the other tier-4 caller) shares the same fix — parity check', async () => {
+    // resolveSourceWithTier is covered directly above; resolveSourceId shares
+    // resolveRegisteredPathMatch under the hood, so this pins that the
+    // refactor didn't let the two entry points drift.
+    const paths = [
+      { id: 'gstack', local_path: '/work/gstack' },
+      { id: 'other', local_path: '/work/other' },
+    ];
+    const engine = makeStub(paths);
+    const id = await resolveSourceId(engine, null, '/work/gstack/src');
+    expect(id).toBe('gstack');
+  });
+
+  test('a genuine tie (two sources sharing the identical resolved path) keeps the pre-refactor first-row-wins order', async () => {
+    // The registered-sources query has no ORDER BY, so a real tie (both
+    // candidates resolve to the SAME length AND the same matched prefix) is
+    // broken by array/database row order — unchanged by the Promise.all
+    // refactor (Promise.all preserves input order). Two DIFFERENT local_path
+    // strings of equal length are not a tie unless both are prefixes of cwd;
+    // the simplest genuine tie is a duplicate registration (same path twice),
+    // which is a real edge case (an operator registering a source twice, or
+    // two ids sharing a symlinked vault).
+    const paths = [
+      { id: 'first', local_path: '/work/same' },
+      { id: 'second', local_path: '/work/same' },
+    ];
+    const engine = makeStub(paths);
+    const result = await resolveSourceWithTier(engine, null, '/work/same/nested');
+    expect(result.source_id).toBe('first');
+  });
+});


### PR DESCRIPTION
## What's broken

Source resolution's tier 4 ("registered source whose `local_path` contains CWD") runs a synchronous `realpathSync()` in a plain `for` loop over every registered source with a `local_path`. `makeContext()` in `cli.ts` calls `resolveSourceWithTier()` unconditionally, and every command dispatched through the generic operations.ts-generated command path goes through `makeContext()` (the separate `CLI_ONLY` hand-written commands, like `jobs`, don't) — so this tier runs for every one of those commands unless it resolves at an earlier tier (no `--source` flag, no `GBRAIN_SOURCE` env, no `.gbrain-source` dotfile), including read-only commands that have nothing to do with source paths, like `takes-list`.

A sync `realpathSync()` call blocks the whole event loop for its full duration; wrapping it in `Promise.all()` does not parallelize it — a common misconception I want to flag explicitly since the pre-fix code plausibly looked "fine" at a glance (a loop, not obviously wrong). So a brain with N registered sources on a filesystem where `realpath` is slow for any reason (network mount, degraded disk, an OS on-access security scan) pays the SUM of all N delays serially (worst case N times the slowest one, if delays are roughly uniform) on every single CLI invocation that reaches this tier.

## How I found this

Dogfooding my own personal brain (9 registered sources), `gbrain takes-list --limit 1` was consistently taking ~41s (`time` measured 41.3-41.6s across repeated runs). I measured the generated SQL directly via `EXPLAIN ANALYZE` against the live Postgres brain — 5.557ms execution time, ruling out the query itself. Isolating `fs.realpathSync()` against my 8 Downloads-nested registered sources' `local_path` values (in a standalone bun script, not through gbrain) measured 5004-5815ms EACH, one call at a time — consistent with ~41s total for a serial loop over 8 sources. The failure mode (`EINTR: interrupted system call`, also reproduced independently with `readdirSync` and plain `du`/`find` on the same paths) is consistent with macOS's on-access security scanning interfering with filesystem syscalls under that particular directory on my machine, though I haven't done a controlled experiment isolating that specific daemon as the cause. Either way, the underlying OS-level trigger is specific to my setup, but the missing-parallelization bug in this code is general and would bite any registered source on a slow/degraded/networked filesystem for any reason.

## The fix

Adds `realpathOrResolveAsync` (backed by `fs.promises.realpath`) alongside the existing sync `realpathOrResolve` in `path-confine.ts`, and resolves cwd's realpath together with every registered source's `local_path` realpath concurrently via `Promise.all` (an outer `Promise.all([cwd, Promise.all(sources)])`) in `source-resolver.ts`. This is a genuine event-loop-level concurrency fix, not a guarantee about OS/filesystem-level scheduling underneath it — the point is that this code no longer blocks issuing the Nth request until the (N-1)th one returns.

Also deduplicates the two near-identical copies of this loop that had drifted into `resolveSourceId` and `resolveSourceWithTier` into one shared `resolveRegisteredPathMatch` helper, so both entry points share the fix and can't drift again — mirrors the existing shared `pickSoleNonDefaultSource` pattern already used for tier 5.5. I considered leaving the two loops separate to keep this PR narrower, but fixing one copy and not the other would just move the bug rather than fix it, and the helper is a straight extraction (same SQL, same tie-break semantics, same fallback behavior) rather than a design change.

## Note on #4368

I noticed the maintainer's backlog-wave PR #4368 also touches `source-resolver.ts` and `path-confine.ts`, but for unrelated reasons (a new `SourceTargetError` class, archived-source handling on the tier-4 match, a `#3070` "sole non-default source" emptiness guard) — it does not touch the tier-4 realpath loop's performance characteristics; that loop is unchanged there and still has this bug. No functional overlap with this fix, but the two PRs will likely need a rebase against each other depending on merge order (nearby-line changes in the same functions).

## Tests

Adds a deterministic concurrency test: spies on `realpathOrResolveAsync` so every mocked call hangs on its own releaser (never auto-resolves), then asserts all N+1 calls (cwd + every registered source) are in flight simultaneously before any of them settle. No wall-clock/timing assertion — an earlier version of this test used `elapsed < Xms` and was flagged in my own review pass as flaky-prone under CI load/timer throttling, so I replaced it with this counter-based approach before submitting. Also adds a parity test through `resolveSourceId` (the other tier-4 caller) and a genuine-tie regression test (two sources sharing an identical resolved path, pinning the pre-refactor first-row-wins order — the registered-sources query has no `ORDER BY`).

```
$ bun test test/source-resolver-tier4-parallel-realpath.test.ts test/source-resolver.test.ts test/source-resolver-with-tier.test.ts test/source-resolver-sole-non-default.test.ts test/source-resolver-silent-fallback.test.ts test/path-confine.test.ts test/all-sources-sentinel.test.ts test/multi-source-integration.test.ts test/cli-bigint-normalize.test.ts test/config-set.test.ts test/dream-cli-flags.test.ts test/dream.test.ts test/local-federated-search-scope.test.ts test/no-grant-federated-scope.test.ts test/serve-source-guard.serial.test.ts test/sync-sole-non-default-routing.test.ts test/takes-command-source-scope.test.ts test/unfederate-read-scope-2928.test.ts test/watch-command.test.ts
 311 pass
 0 fail

$ bun run typecheck   # clean
$ bun run check:module-size   # clean, no ceiling change needed
```

**Red/green independently reproduced**: temporarily reverted the `Promise.all` back to a serial `for` loop (kept the async API, only removed the parallelization) — the new deterministic test correctly failed (`maxInFlight=1` instead of `N+1=7`) instead of hanging, confirming it actually detects a serialization regression rather than just "doesn't crash". Restored and confirmed green.
