### PR TITLE
fix(cli): route eval --help to its own detailed usage instead of the circular generic stub (#3686)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -10,7 +10,7 @@ src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)
 src/core/ai/gateway.ts	4441	ratchet	grown v0.46.25.0 D2: env-key snapshot stash (#2119)
-src/cli.ts	3628	ratchet	grown v0.46.25.0 D2: stdout interposer install (#4383)
+src/cli.ts	3641	ratchet	#3686: eval added to CLI_ONLY_SELF_HELP (with a comment explaining why storage/reindex are deliberately excluded)
 src/core/cycle.ts	3099	ratchet	grown v0.46.25.0 fix waves: refresher abort gating + keyless honesty (#4309 #2821) | signal feature-detect (#4309 handler shape)
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3041	ratchet	grown v0.46.25.0 fix waves: jobs list/get --json (#3685)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,6 +193,19 @@ const CLI_ONLY_SELF_HELP = new Set([
   // ZE interim cleanup: the retired ze-switch shim ships truthful help
   // (sunset refusal + canonical migration command); the generic stub hid it.
   'ze-switch',
+  // #3686: eval already parses '--help'/'-h' into opts.help and has its own
+  // printHelp() (14 subcommands' worth of usage) — both unreachable behind
+  // the generic short-circuit. Same "sources" pattern (#4133).
+  // #3686 also named `storage` and `reindex`, but neither has a real --help
+  // path to route to today: runStorage's only real subcommand is `status`,
+  // with no help renderer (an unrecognized subcommand exits 1 with an
+  // error, so adding it here would turn `--help` into an error+exit1 —
+  // worse than today's stub); reindex has no --help handling anywhere in
+  // its dispatch chain, so `--help` would fall through and actually START
+  // a reindex run. Both need real help text written first — a different,
+  // larger fix than routing around this short-circuit — so they're left
+  // out of this PR.
+  'eval',
 ]);
 
 /**

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -15,9 +15,9 @@
  * cli.ts internals).
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -297,4 +297,118 @@ describe('`sources webhook --help` reaches its own detailed help, not the genera
     expect(stderr).not.toContain('--github-repo');
     expect(stderr).not.toContain('TypeError');
   });
+});
+
+describe('#3686 — eval --help reaches its own detailed usage instead of the circular generic stub', () => {
+  // Unlike `sources` (#4133), `eval` still needs a brain to reach this point
+  // at all — `case 'eval':` in cli.ts receives an already-connected engine
+  // (see test/cli-help-without-brain.serial.test.ts's STILL_NEEDS_A_BRAIN
+  // entry for that half). This describe block tests the OTHER half: once
+  // runEvalCommand IS reached (with any engine — the help path never
+  // dereferences it, verified by reading eval.ts's dispatch chain), does
+  // `opts.help` actually reach printHelp()'s full 14-subcommand-adjacent
+  // usage instead of the generic one-line stub the issue reported. Cheaper
+  // and more direct than a subprocess spawn against a real PGLite brain.
+  test('runEvalCommand(engine, ["--help"]) prints the detailed usage block, not the generic stub', async () => {
+    const { runEvalCommand } = await import('../src/commands/eval.ts');
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg?: unknown) => { logs.push(String(msg)); };
+    try {
+      // The help path (opts.help check, line ~124-127 of eval.ts) runs
+      // before `engine` is ever touched — confirmed by reading every `if
+      // (sub === ...)` branch above it, none of which match '--help'.
+      await runEvalCommand({} as never, ['--help']);
+    } finally {
+      console.log = originalLog;
+    }
+    const out = logs.join('\n');
+    expect(out).toContain('gbrain eval — measure and compare retrieval quality');
+    expect(out).toContain('--qrels <path|json>');
+    expect(out).toContain('QRELS FORMAT');
+    expect(out).toContain('--rrf-k <n>');
+    // The generic short-circuit's stub text must never appear — its
+    // presence would mean this test is exercising the OLD unreached path.
+    expect(out).not.toContain('run gbrain --help for the full command list');
+  });
+
+  test('runEvalCommand(engine, ["-h"]) reaches the same detailed usage', async () => {
+    const { runEvalCommand } = await import('../src/commands/eval.ts');
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (msg?: unknown) => { logs.push(String(msg)); };
+    try {
+      await runEvalCommand({} as never, ['-h']);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(logs.join('\n')).toContain('gbrain eval — measure and compare retrieval quality');
+  });
+});
+
+describe('#3686 — `gbrain eval --help` end-to-end through the real dispatcher (with a brain)', () => {
+  // Codex review flagged that the two unit tests above call runEvalCommand
+  // directly — they'd pass even without the CLI_ONLY_SELF_HELP change,
+  // since eval.ts's own --help parsing was already correct before this fix;
+  // they only prove eval.ts's half. This block proves the OTHER half: that
+  // `gbrain eval --help`, spawned as the real CLI entrypoint, actually
+  // reaches that code instead of the dispatcher's generic short-circuit.
+  //
+  // Needs a brain (unlike this file's other tests, which use runCli's fixed
+  // nonexistent GBRAIN_HOME) — same lightweight setup as
+  // test/ambient-recall-cli.test.ts: hand-write config.json pointing at a
+  // PGLite path and let the first real CLI invocation run initSchema, no
+  // full `gbrain init` subprocess needed.
+  let home: string;
+
+  function runWithBrain(args: string[]): { stdout: string; stderr: string; status: number } {
+    const r = spawnSync('bun', ['--no-env-file', 'run', 'src/cli.ts', ...args], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GBRAIN_HOME: home,
+        DATABASE_URL: '',
+        GBRAIN_DATABASE_URL: '',
+        GBRAIN_SKIP_STARTUP_HOOKS: '1',
+      },
+      timeout: 60_000,
+    });
+    return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+  }
+
+  beforeAll(() => {
+    home = mkdtempSync(join(tmpdir(), 'gbrain-eval-help-'));
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'pglite', database_path: join(home, '.gbrain', 'brain.pglite') }),
+    );
+    // Warm the brain once (pays initSchema/migrations here, not in the
+    // timed assertions below).
+    const warm = runWithBrain(['status', '--json']);
+    expect(warm.status).toBe(0);
+  }, 60_000);
+
+  afterAll(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test('`gbrain eval --help` exits 0 with the detailed usage, not the generic one-line stub', () => {
+    const { stdout, status } = runWithBrain(['eval', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('gbrain eval — measure and compare retrieval quality');
+    expect(stdout).toContain('QRELS FORMAT');
+    // This exact phrase is printCliOnlyHelp's stub text (src/cli.ts). Its
+    // presence would mean the dispatcher never reached CLI_ONLY_SELF_HELP's
+    // new 'eval' entry and this test would be exercising the pre-fix path.
+    expect(stdout).not.toContain('run gbrain --help for the full command list');
+    expect(stdout).not.toBe('Usage: gbrain eval\n\ngbrain eval - run gbrain --help for the full command list.\n');
+  }, 60_000);
+
+  test('`gbrain eval -h` reaches the same detailed usage', () => {
+    const { stdout, status } = runWithBrain(['eval', '-h']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('gbrain eval — measure and compare retrieval quality');
+  }, 60_000);
 });

--- a/test/cli-help-without-brain.serial.test.ts
+++ b/test/cli-help-without-brain.serial.test.ts
@@ -51,6 +51,13 @@ const STILL_NEEDS_A_BRAIN = [
   'brainstorm',
   'config',
   'embed',
+  // #3686: eval's `case 'eval':` in cli.ts receives an already-connected
+  // `engine` (connectEngine() runs earlier in main(), unconditionally for
+  // any CLI_ONLY command not registered in SELF_HELP_WITHOUT_ENGINE), so
+  // `eval --help` still needs a brain even though eval.ts's own printHelp()
+  // is now reachable once one exists. Making it brainless too would mean
+  // wiring eval into SELF_HELP_WITHOUT_ENGINE — a bigger, separate change.
+  'eval',
   'lsd',
   'migrate',
   'pages',


### PR DESCRIPTION
Fixes #3686

## What's broken

`eval`, `storage`, `reindex` are `CLI_ONLY` commands whose `--help` hits the dispatcher's generic one-line stub (`printCliOnlyHelp`) instead of their real usage. For `eval` this hides the most: `eval.ts` already parses `'--help'`/`'-h'` into `opts.help` and has a `printHelp()` covering 14 subcommands (`brainstorm`, `code-retrieval`, `compare`, `conversation-parser`, `cross-modal`, `export`, `gate`, `prune`, `replay`, `retrieval-quality`, `run-all`, `suspected-contradictions`, `trajectory`, `whoknows`) plus the qrels/config flow — all completely unreachable. The only way to see the real help was to trigger the missing-required-arg error path (`gbrain eval` with no flags at all).

This is the same bug class already fixed for `sources` via PR #4133 (my own earlier PR — accepted, landed upstream, credited: "Adopted from PR #4133 by @Masashi-Ono0611 (pinned patch)", commit `864dec4f`, v0.46.14.0 fix-wave #4226).

## The fix

Adds `eval` to `CLI_ONLY_SELF_HELP` (`src/cli.ts`) — the exact same pattern #4133 used for `sources`.

## Scope: `storage` and `reindex` are deliberately excluded

The issue also named `storage` and `reindex`. I verified directly against current master that neither is actually safe to fix with this pattern today — their premise in the issue appears to predate some other refactor:

- **`storage`**'s only real subcommand is `status`; there's no help renderer anywhere in `storage.ts`. `runStorage`'s dispatch is:
  ```ts
  const subcommand = args[0];
  if (!subcommand || subcommand === 'status') { ... return; }
  console.error(`Unknown storage subcommand: ${subcommand}`);
  console.error('Available subcommands: status');
  process.exit(1);
  ```
  Adding `storage` to `CLI_ONLY_SELF_HELP` would route `--help` past the generic stub into this function, where `'--help'` matches neither branch — turning today's graceful exit-0 one-line stub into an `Unknown storage subcommand: --help` error at **exit 1**. A regression, not a fix.

- **`reindex`** has *zero* `--help`/`-h` handling anywhere in its ~47-line inline dispatch block in `cli.ts` (`case 'reindex':`), nor in `normalizeReindexArgs`/`validateReindexModeScope`/`runReindex` in `reindex.ts`. If none of the recognized flags (`--multimodal`, `--aliases`) match, it falls straight through to `await runReindex(engine, args)` — a **real reindex operation**. Adding `reindex` to `CLI_ONLY_SELF_HELP` would make `gbrain reindex --help` silently *start a real reindex* instead of showing help. That's not a UX regression, it's a safety hazard.

Both need real help text written before they can safely join this set — a bigger, different task than routing around the generic short-circuit. Left out of this PR, with an inline comment at the `eval` entry explaining why (so a future contributor reading `CLI_ONLY_SELF_HELP` doesn't wonder why the issue's other two targets are missing).

## `eval --help` still needs a brain (unlike `sources`)

`sources` also got wired into a brainless-help fast path in #4133 (`SELF_HELP_WITHOUT_ENGINE`). This PR does *not* do that for `eval` — `case 'eval':` in `cli.ts` receives an already-connected `engine` (via `connectEngine()` earlier in `main()`), so `gbrain eval --help` on a machine with no brain configured still exits 1 with "No brain configured." Pinned as a known limitation in `test/cli-help-without-brain.serial.test.ts`'s `STILL_NEEDS_A_BRAIN` list — the same documented pattern `config`/`embed`/`migrate`/`lsd` already use there. Making `eval --help` fully brainless is a separate, larger change (wiring it into `SELF_HELP_WITHOUT_ENGINE`).

## Verification

```
$ bun test test/cli-help-discoverability.test.ts test/cli-help-without-brain.serial.test.ts
 37 pass
 0 fail

$ bun run typecheck   # clean
$ bun run check:module-size   # OK (ceiling raised, see below)
$ bun run build:flag-registry   # clean, no drift
$ bun run verify   # 54/54 checks green
```

One `scripts/module-size-limits.tsv` ceiling raised (`src/cli.ts` 3628→3641, matching the 13-line addition including the explanatory comment).

**Red/green check, twice** (two rounds of review found and closed two real gaps — noted below): reverted `src/cli.ts` to `upstream/master` (test files kept), re-ran — failed as expected each time, restored, green again.

Five new/extended test cases:
- `test/cli-help-without-brain.serial.test.ts`: `eval` added to `STILL_NEEDS_A_BRAIN` — proves the dispatcher now reaches `eval.ts`'s `connectEngine()` prerequisite instead of stopping at the generic stub (the generic stub's output would *not* contain "No brain configured", so this is a genuine, red/green-verified proof that `CLI_ONLY_SELF_HELP` now includes `eval`, not a vacuous check).
- `test/cli-help-discoverability.test.ts`, two unit tests calling `runEvalCommand(engine, ...)` directly: the `['--help']` case asserts the full detailed content (heading, `--qrels`, `QRELS FORMAT`, `--rrf-k`) and the absence of the generic stub text; the `['-h']` case is a lighter smoke test confirming the same code path (just the heading, not every line). Together they prove `eval.ts`'s own help-printing is correct. **A code-quality review round flagged these as insufficient on their own** — they call `runEvalCommand` directly, bypassing the dispatcher entirely, so they'd pass even without the `cli.ts` change (confirmed: reverting `src/cli.ts` alone did NOT make either fail).
- `test/cli-help-discoverability.test.ts`, two new end-to-end tests spawning the real `bun run src/cli.ts eval --help`/`-h` as a subprocess against a hand-configured PGLite brain (same lightweight `config.json`-write pattern as `test/ambient-recall-cli.test.ts` — no full `gbrain init` subprocess needed): the `--help` case asserts exit 0, the real detailed usage text, and the *absence* of the generic stub's exact wording; the `-h` case asserts exit 0 and the heading, confirming the same real dispatcher path. Both **do** fail on revert (confirmed: the `--help` case showed the literal stub output `"Usage: gbrain eval\n\ngbrain eval - run gbrain --help for the full command list.\n"` before the fix), closing the gap the review found.

<!-- maintainer-lens: SAFE @ 420ecc5e2b31e892444086a4196f5be1f23186ae 2026-08-21T10:15:00Z -->
