### PR TITLE
fix(search): offset cache-skip also covers negative offsets (#4358)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silen
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating
-src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352)
+src/core/search/hybrid.ts	2855	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352) + PR#4414 rebase onto current master
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
 src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2361,8 +2361,18 @@ export async function hybridSearchCached(
   // floor), making offset a result-affecting input that sits OUTSIDE the
   // knobs hash. Bypass the cache entirely (lookup AND store — the store is
   // gated on cacheStatus === 'miss' below, so 'disabled' covers both) for
-  // offset>0 requests; offset===0 semantics are unchanged.
-  const pagedRequest = (opts?.offset ?? 0) > 0;
+  // any nonzero offset; offset===0 semantics are unchanged. #4358 residual
+  // gap (this condition landed via #4368's wave as `> 0`, which absorbed
+  // the positive-offset half of the original fix but not this one): a
+  // negative offset re-slices the stored page just as badly as a positive
+  // one (Array.prototype.slice treats a negative start as counting from
+  // the array's end) — e.g. for offset=-21/limit=9 on a 21-row pool, the
+  // store-time slice correctly returns the pool's first 9 rows, but
+  // re-applying that same negative offset a second time (hit path, now
+  // against the already-9-row stored page) clamps both bounds to the
+  // array's start and returns nothing — so `> 0` let those requests
+  // read/write the cache anyway.
+  const pagedRequest = (opts?.offset ?? 0) !== 0;
   // #4352 follow-up — excludePrivate no longer skips the cache: the posture
   // is folded into knobsHash (xp=, v=23), so a private-included (trusted)
   // write can never serve a private-excluding lookup and vice versa. The

--- a/src/core/search/mode.ts
+++ b/src/core/search/mode.ts
@@ -896,7 +896,20 @@ export function attributeKnob<K extends keyof ModeBundle>(
 // ~50% cache savings back. Same contamination class as detail (v=16) and
 // hardExcludes (v=12); same one-time global cold-miss pattern as the bumps
 // above, refills within cache.ttl_seconds (3600s default).
-export const KNOBS_HASH_VERSION = 23;
+//
+// bump 23→24 (#4358 residual): hybrid.ts's `pagedRequest` skip-cache gate
+// only bypassed the cache for offset>0 (the #4368 wave absorbed the
+// positive-offset half of the original #4358 fix, which used `!== 0`, as
+// `> 0`). A negative offset re-slices an already-sliced stored page just as
+// badly as a positive one, and — since offset isn't part of this hash — a
+// negative-offset request could read OR write the same cache row an
+// offset=0 (or any other offset) request shares. Any row written while that
+// gap was live may hold a wrong page under a knobsHash a clean request can
+// still reach. No new key part; the bump alone invalidates (the PR authored
+// this as v=22; master had already reached 23, so it sequences here per the
+// D8 convention). Same one-time global cold-miss pattern as the bumps
+// above; refills within cache.ttl_seconds (3600s).
+export const KNOBS_HASH_VERSION = 24;
 
 /**
  * v0.36 (D8 / CDX-2) — second-arg context for the cache key. The

--- a/test/cross-modal-phase1.test.ts
+++ b/test/cross-modal-phase1.test.ts
@@ -136,7 +136,7 @@ describe('D2 — knobsHash differs across cross-modal knob values', () => {
     return resolveSearchMode({ mode: 'balanced' });
   }
 
-  test('KNOBS_HASH_VERSION is 23 (cross-modal still appended; 20→21 recency fallback re-key #895; 21→22 result-stamp/injection epoch; 22→23 excludePrivate posture fold #4352)', () => {
+  test('KNOBS_HASH_VERSION is 24 (cross-modal still appended; 20→21 recency fallback re-key #895; 21→22 result-stamp/injection epoch; 22→23 excludePrivate posture fold #4352; 23→24 negative-offset cache-skip gap #4358 residual)', () => {
     // v0.35 ladder: 1→2 reranker, 2→3 floor_ratio. v0.36 piggybacks on v=3
     // with 7 cross-modal knobs + column/provider context. v0.40.4 (salem) +
     // v0.39 T21 (master) bump to v=4 for graph_signals + schema-pack fields.
@@ -161,7 +161,9 @@ describe('D2 — knobsHash differs across cross-modal knob values', () => {
     // status alter stored rows for identical knobs.
     // 22→23 (#4352 follow-up): private-visibility posture fold (xp=) —
     // replaces the wholesale cache skip for excludePrivate=true callers.
-    expect(KNOBS_HASH_VERSION).toBe(23);
+    // 23→24 (#4358 residual): negative-offset requests could read/write the
+    // same cache row an offset=0 request shares.
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 
   test('flipping unified_multimodal changes the hash', () => {

--- a/test/hybrid-degraded-cache-meta.serial.test.ts
+++ b/test/hybrid-degraded-cache-meta.serial.test.ts
@@ -169,6 +169,16 @@ describe('cache-hit stamping', () => {
     expect(meta.cache?.status).toBe('disabled');
     expect(typeof meta.retrieved_count).toBe('number');
   });
+
+  test('offset<0 also bypasses the cache entirely (#4358 residual — negative offsets re-slice a stored page just as badly as positive ones)', async () => {
+    const { results: missResults } = await cachedRun('builder', { limit: 5 });
+    expect(missResults.length).toBeGreaterThan(0);
+    await awaitPendingSearchCacheWrites();
+
+    const { meta } = await cachedRun('builder', { limit: 5, offset: -50 });
+    expect(meta.cache?.status).toBe('disabled');
+    expect(typeof meta.retrieved_count).toBe('number');
+  });
 });
 
 describe('cache_prestamp — pre-upgrade rows cannot claim clean', () => {

--- a/test/search-alias-resolved-boost.test.ts
+++ b/test/search-alias-resolved-boost.test.ts
@@ -89,9 +89,10 @@ describe('alias_resolved boost stage', () => {
 });
 
 describe('KNOBS_HASH_VERSION', () => {
-  it('is 23 (20→21 recency fallback re-key #895; 21→22 result-stamp/injection epoch #1663 #3995 #3783 #4220; 22→23 excludePrivate posture fold #4352)', () => {
+  it('is 24 (20→21 recency fallback re-key #895; 21→22 result-stamp/injection epoch #1663 #3995 #3783 #4220; 22→23 excludePrivate posture fold #4352; 23→24 negative-offset cache-skip gap #4358 residual)', () => {
     // mw2: 21→22 result-stamp/injection epoch (#1663 #3995 #3783 #4220).
     // #4352 follow-up: 22→23 private-visibility posture fold (xp=).
-    expect(KNOBS_HASH_VERSION).toBe(23);
+    // #4358 residual: 23→24 negative-offset cache-skip gap.
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 });

--- a/test/search-mode.test.ts
+++ b/test/search-mode.test.ts
@@ -442,7 +442,10 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // semantic cache for every remote MCP caller (excludePrivate=true is
     // their default). A private-included write must not serve a
     // private-excluding lookup and vice versa.
-    expect(KNOBS_HASH_VERSION).toBe(23);
+    // #4358 residual: bumped 23→24 — negative-offset requests could
+    // read/write the same cache row an offset=0 request shares
+    // (pagedRequest previously skipped only offset>0).
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 
   test('#3515: detail set vs unset produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -464,7 +467,8 @@ describe('knobsHash determinism + cross-mode separation (CDX-4)', () => {
     // 19→20 pool floor (#3002); 20→21 recency fallback re-key (#895).
     // mw2: 21→22 result-stamp/injection epoch (#1663 #3995 #3783 #4220).
     // #4352 follow-up: 22→23 private-visibility posture fold (xp=).
-    expect(KNOBS_HASH_VERSION).toBe(23);
+    // #4358 residual: 23→24 negative-offset cache-skip gap.
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 
   test('#4352 follow-up: excludePrivate true vs false produces DIFFERENT hashes (cache contamination prevention)', () => {
@@ -646,8 +650,8 @@ describe('v0.40.4 — graph_signals knob', () => {
 });
 
 describe('v0.42.3.0 — autocut knobs', () => {
-  test('KNOBS_HASH_VERSION is 23 (21→22 result-stamp/injection epoch #1663 #3995 #3783 #4220; 22→23 excludePrivate posture fold #4352)', () => {
-    expect(KNOBS_HASH_VERSION).toBe(23);
+  test('KNOBS_HASH_VERSION is 24 (21→22 result-stamp/injection epoch #1663 #3995 #3783 #4220; 22→23 excludePrivate posture fold #4352; 23→24 negative-offset cache-skip gap #4358 residual)', () => {
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 
   test('bundle defaults: conservative off, balanced/tokenmax on @0.20', () => {

--- a/test/search/knobs-hash-reranker.test.ts
+++ b/test/search/knobs-hash-reranker.test.ts
@@ -83,7 +83,8 @@ describe('KNOBS_HASH_VERSION + version invariants', () => {
     // #3995 relational page-1 slot, #3783 keyword_hit, #4220 status).
     // #4352 follow-up: 22→23 excludePrivate posture fold (xp=) — replaces
     // the wholesale cache skip that disabled caching for remote callers.
-    expect(KNOBS_HASH_VERSION).toBe(23);
+    // #4358 residual: 23→24 negative-offset cache-skip gap.
+    expect(KNOBS_HASH_VERSION).toBe(24);
   });
 
   test('hash is 16 hex chars regardless of reranker config', () => {


### PR DESCRIPTION
Fixes #4358

## Residual gap after #4368's wave

`hybridSearchCached`'s cache-skip condition for offset-bearing requests reads `(opts?.offset ?? 0) > 0` on current master. This landed via the giant merged wave PR #4368, which independently re-implemented the skip-cache half of an existing, not-yet-merged fix PR (#4397, opened for this same issue #4358) — but only the positive-offset half of it. #4397's own version used `!== 0`, plus a `KNOBS_HASH_VERSION` bump to invalidate cache rows written while the bug was live; neither made it into #4368.

A negative offset re-slices an already offset/limit-sliced stored cache page exactly as badly as a positive one does — `Array.prototype.slice` treats a negative start as counting from the array's end. E.g. for `offset=-21, limit=9` against a 21-row pool: the store-time slice `pool.slice(-21, -12)` correctly returns the pool's first 9 rows (that 9-row page is what gets stored), but the hit-time RE-slice `storedPage.slice(-21, -12)` — applying the same negative offset a second time, now against the already-9-row stored page — clamps both bounds to the array's start and returns nothing (verified directly in a Node REPL: `[0..8].slice(-21,-12)` → `[]`). `> 0` still let those requests read from and write to the cache.

This PR is scoped to only that gap: **#4368 mostly absorbed #4397; the remaining gap is negative offsets only.**

## The fix

One-line condition widening in `src/core/search/hybrid.ts`:

```ts
const pagedRequest = (opts?.offset ?? 0) !== 0;  // was: > 0
```

Plus a `KNOBS_HASH_VERSION` bump (`src/core/search/mode.ts`, 21→22 — the constant has moved past #4397's original 19→20 due to unrelated bumps landing since). Since `offset` is not itself part of the cache key, a negative-offset request could previously write a corrupted row under the same `(source_id, knobsHash, embedding)` key a *different* request (e.g. `offset=0`) later reads as a hit — merely stopping future writes doesn't purge a row already sitting in some installation's `query_cache` table. This is the same one-time global cold-miss invalidation pattern the module has used ~10 times before for identical reasons (see the comment ladder above the constant); no new key part.

## Scope

Deliberately minimal — same operator-widening + version-bump pattern #4368 already used for the positive-offset half, applied to the remaining case. No new CLI flag, config key, doctor check, or public API surface.

## Verification

```
$ bun test test/hybrid-degraded-cache-meta.serial.test.ts test/search-mode.test.ts \
    test/cross-modal-phase1.test.ts test/search-alias-resolved-boost.test.ts \
    test/search/knobs-hash-reranker.test.ts test/search-compiled-truth-boost-scope.test.ts
 165 pass
 0 fail

$ bun run typecheck          # clean
$ bun run check:module-size  # OK (hybrid.ts ceiling raised 2703→2709, comment growth only)
$ bun run build:flag-registry  # clean, no drift
$ bun run verify             # 54/54 checks green
```

One `scripts/module-size-limits.tsv` ceiling raised (`src/core/search/hybrid.ts` 2703→2713, +10 lines for the expanded comment).

**Red/green check**: reverted both production files (`hybrid.ts`, `mode.ts`) to `upstream/master` (test files kept), re-ran — 7 failures as expected, including the new negative-offset test itself failing with `cache.status: 'hit'` (not `'disabled'`) against pre-fix code — a live reproduction of the bug, not just a version-pin mismatch. Restored the fix — all green again.

New test in `test/hybrid-degraded-cache-meta.serial.test.ts`, a sibling of the file's existing `offset>0` case: `offset=-50` against a stored 5-result page now also asserts `cache.status: 'disabled'`. Four other test files' hardcoded `KNOBS_HASH_VERSION` expectations updated to 22 (mechanical, matching the constant), with their descriptive ladder comments extended to note this bump.

<!-- maintainer-lens: SAFE @ 432d43c73f75c310828a777164e7bbf48a85f929 2026-08-21T12:28:05Z -->
