### PR TITLE
fix(cycle): thread the cycle's resolved source into synthesize_concepts writes

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2426,6 +2426,10 @@ export async function runCycle(
         const { runPhaseSynthesizeConcepts } = await import('./cycle/synthesize-concepts.ts');
         const { result, duration_ms } = await racedTimePhase(() => runPhaseSynthesizeConcepts(engine, {
           brainDir: brainDir ?? undefined,
+          // Thread the cycle's resolved source into the phase's page/receipt/
+          // rollup writes; the engine's `?? 'default'` fallback throws on any
+          // brain without a source literally named 'default'.
+          sourceId: cycleSourceId,
           dryRun,
           // v0.41.19.0 (T3): closure refreshes cycle lock + fires outer hook.
           yieldDuringPhase: buildYieldDuringPhase(lock, opts.yieldDuringPhase, onStolen),

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -54,6 +54,15 @@ const TIER_T3_MIN = 2;
 
 export interface SynthesizeConceptsOpts {
   brainDir?: string;
+  /**
+   * The cycle's resolved source scope (cycleSourceId in cycle.ts). Without
+   * it every write below falls through to the engine's `?? 'default'`
+   * literal, which is fatal on any brain whose sole source is not named
+   * `default`: getPage's undefined-source path is source-agnostic, so the
+   * existence probe passes, then createVersion throws
+   * "page ... (source=default) not found" and kills the cycle.
+   */
+  sourceId?: string;
   dryRun?: boolean;
   yieldDuringPhase?: (() => Promise<void>) | undefined;
   /**
@@ -324,6 +333,7 @@ export async function runPhaseSynthesizeConcepts(
       );
       await importFromContent(engine, `concepts/${title}`, md, {
         noEmbed: !isAvailable('embedding'),
+        sourceId: opts.sourceId,
       });
     }
     conceptsWritten++;
@@ -337,15 +347,16 @@ export async function runPhaseSynthesizeConcepts(
   }
 
   // v0.42 Wave B3: receipt + rollup for synthesize_concepts. Brain-global
-  // phase — uses 'default' source_id because concepts span sources. Receipt
-  // only fires when concepts were actually written; rollup always fires so
-  // doctor sees the phase ran.
+  // phase — receipt/rollup carry the cycle's resolved source (opts.sourceId);
+  // 'default' survives only as the fallback for engines that really have a
+  // default source. Receipt only fires when concepts were actually written;
+  // rollup always fires so doctor sees the phase ran.
   if (!opts.dryRun && conceptsWritten > 0) {
     const runId = `concepts-${Date.now().toString(36)}`;
     try {
       await writeReceipt(engine, {
         kind: 'concepts',
-        source_id: 'default',
+        source_id: opts.sourceId ?? 'default',
         run_id: runId,
         round: 'single',
         extracted_at: new Date().toISOString(),
@@ -365,7 +376,7 @@ export async function runPhaseSynthesizeConcepts(
   if (!opts.dryRun) {
     await upsertExtractRollup(engine, {
       kind: 'concepts',
-      source_id: 'default',
+      source_id: opts.sourceId ?? 'default',
       cost_delta: estimatedSpendUsd,
       round_completed_delta: failures.length === 0 ? 1 : 0,
       halt_delta: failures.length > 0 ? 1 : 0,

--- a/test/cycle/synthesize-concepts-source-scope.test.ts
+++ b/test/cycle/synthesize-concepts-source-scope.test.ts
@@ -1,0 +1,98 @@
+// Regression: synthesize_concepts must thread the cycle's resolved source
+// (opts.sourceId) into its page/receipt/rollup writes.
+//
+// Before the fix the phase wrote concept pages via importFromContent with no
+// sourceId and hardcoded source_id: 'default' into the receipt + rollup.
+// Every write in that path substitutes the literal 'default' when sourceId
+// is undefined, so on a brain whose content lives in a source not named
+// 'default' (the one-brain-one-source layout in
+// docs/architecture/brains-and-sources.md) every synthesized concept page
+// silently lands under the seeded 'default' source instead of the cycle's
+// source - wrong provenance, invisible to source-scoped reads.
+//
+// On v0.45.x the same missing sourceId was fatal rather than silent: the
+// existence probe there was source-agnostic, so an update to an existing
+// concept page found the row in the real source, then createVersion looked
+// it up under 'default' and threw
+//   createVersion failed: page "concepts/..." (source=default) not found
+// which killed the cycle and every phase ordered after synthesize_concepts.
+// Observed in production on a single-source brain.
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-concepts.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name) VALUES ('personal', 'Personal') ON CONFLICT (id) DO NOTHING`,
+    [],
+  );
+});
+
+// Two atoms sharing one concept ref → T3 tier → deterministic narrative,
+// no LLM call needed.
+const atoms = [
+  { slug: 'a1', title: 'A1', body: 'b1', concept_refs: ['theme'] },
+  { slug: 'a2', title: 'A2', body: 'b2', concept_refs: ['theme'] },
+];
+
+describe('synthesize_concepts source scoping', () => {
+  test('writes concept page + rollup under opts.sourceId; re-run (createVersion path) survives on a non-default source', async () => {
+    const first = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms, sourceId: 'personal' });
+    expect(first.status).toBe('ok');
+
+    const pages = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM pages WHERE slug = 'concepts/theme'`,
+      [],
+    );
+    expect(pages.length).toBe(1);
+    expect(pages[0].source_id).toBe('personal');
+
+    // Update path: importFromContent finds the existing page (source-agnostic
+    // getPage), then createVersion must target the page's real source. Pre-fix
+    // this threw `createVersion failed: page "concepts/theme" (source=default)
+    // not found` because opts.sourceId was never passed.
+    const second = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms, sourceId: 'personal' });
+    expect(second.status).toBe('ok');
+
+    const rollup = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM extract_rollup_7d WHERE kind = 'concepts'`,
+      [],
+    );
+    expect(rollup.length).toBeGreaterThan(0);
+    expect(rollup.every((r) => r.source_id === 'personal')).toBe(true);
+  });
+
+  test('omitting sourceId keeps the legacy default fallback', async () => {
+    const result = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
+    expect(result.status).toBe('ok');
+
+    const pages = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM pages WHERE slug = 'concepts/theme'`,
+      [],
+    );
+    expect(pages.length).toBe(1);
+    expect(pages[0].source_id).toBe('default');
+
+    const rollup = await engine.executeRaw<{ source_id: string }>(
+      `SELECT source_id FROM extract_rollup_7d WHERE kind = 'concepts'`,
+      [],
+    );
+    expect(rollup.length).toBeGreaterThan(0);
+    expect(rollup.every((r) => r.source_id === 'default')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #4416.

`synthesize_concepts` was the one cycle phase not receiving the cycle's already-resolved `cycleSourceId` - its page/receipt/rollup writes fall through to the engine's `?? 'default'` literal. On any brain whose content lives in a source not named `default` (the one-brain-one-source layout in `docs/architecture/brains-and-sources.md`), every synthesized concept page silently lands under the seeded `default` source instead of the source the cycle is scoped to - wrong provenance, invisible to source-scoped reads, duplicate slugs once the same concept is later written correctly.

On v0.45.x the same missing `sourceId` was fatal rather than silent (source-agnostic existence probe + default-scoped `createVersion`): `createVersion failed: page "concepts/..." (source=default) not found`, killing every phase ordered after it (`grade_takes`, `calibration_profile`, `drift`, `skillopt`, `embed`, `orphans`, `purge`). Observed in production on a single-source brain.

- `cycle.ts`: pass `cycleSourceId` into `runPhaseSynthesizeConcepts` (same pattern as the extract, orphans, and calibration phases at `cycle.ts:2169,2206,2389,2530`).
- `synthesize-concepts.ts`: thread `opts.sourceId` into `importFromContent`, the receipt, and the rollup; `?? 'default'` kept as fallback - brains whose content actually lives in `default` are byte-for-byte unchanged.
- New regression test (`test/cycle/synthesize-concepts-source-scope.test.ts`): concept page + rollup land under the given source; the re-run (createVersion) path survives on a non-default-source brain; the legacy no-sourceId fallback still lands under `default`. Verified failing on master pre-fix: the concept page lands under `default` instead of the given source.

`bun test test/cycle/synthesize-concepts`: 8/8 across 3 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
