### PR TITLE
fix(doctor): detect pages(source_id, slug) unique-index arbiter (#550)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
+src/commands/doctor.ts	4399	ratchet	grown: pages_slug_unique_index detection check, buildChecks surface (#550)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -172,6 +172,7 @@ test/models-doctor-embed.test.ts	models doctor — embedding reachability probe 
 test/openclaw-plugin-manifest.test.ts	bundled-skill reference closure (nothing bundled points at a non-bundled skill)	1	readFileSync
 test/openclaw-plugin-manifest.test.ts	plugin membership curation (skills = plugin ∪ exclusions, disjoint)	9	readFileSync
 test/openclaw-plugin-manifest.test.ts	root OpenClaw plugin manifest	2	readFileSync
+test/pages-slug-index-check.test.ts	cross-surface parity (source-grep regression guard)	1	doctor-source-helper
 test/pglite-engine.test.ts	PGLiteEngine: v0.13.1 error-wrap on connect() (#223)	1	readFileSync
 test/pglite-wal-repair.serial.test.ts	WAL auto-repair — real-brain regression (#223/#1670/#2575)	6	readFileSync
 test/phantom-redirect-per-source-lock.test.ts	phantom-redirect lock contract	3	readFileSync

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1900,6 +1900,21 @@ export async function buildChecks(
     checks.push({ name: 'schema_version', status: 'warn', message: 'Could not check schema version' });
   }
 
+  // 6b. #550: pages(source_id, slug) unique-index presence. putPage upserts
+  // via ON CONFLICT (source_id, slug) on both engines; if the arbiter index
+  // is missing (dropped/renamed by an external migration, or a pages table
+  // created outside gbrain's own migration chain), every write fails while
+  // reads stay green and the version counter can't see it. Detection only —
+  // see pages-slug-index-check.ts for why no auto-repair.
+  progress.heartbeat('pages_slug_unique_index');
+  try {
+    const { checkPagesSlugUniqueIndex, describePagesSlugIndexStatus } = await import('../core/pages-slug-index-check.ts');
+    const idx = await checkPagesSlugUniqueIndex(engine);
+    checks.push({ name: 'pages_slug_unique_index', ...describePagesSlugIndexStatus(idx) });
+  } catch {
+    checks.push({ name: 'pages_slug_unique_index', status: 'warn', message: 'Could not check pages(source_id, slug) unique index' });
+  }
+
   // Note: we intentionally DO NOT fail on "schema v7+ but no preferences.json".
   // That's a valid fresh-install state after `gbrain init` — the migration
   // orchestrator writes preferences, but `init` alone doesn't run it. The

--- a/src/commands/doctor/report-remote.ts
+++ b/src/commands/doctor/report-remote.ts
@@ -155,6 +155,20 @@ export async function doctorReportRemote(
     checks.push({ name: 'timeline_dedup_index', status: 'warn', message: 'Could not check idx_timeline_dedup shape' });
   }
 
+  // 2c. #550: pages(source_id, slug) unique-index presence. putPage upserts
+  // via ON CONFLICT (source_id, slug) on both engines; if the arbiter index
+  // is missing (dropped/renamed by an external migration, or a pages table
+  // created outside gbrain's own migration chain), every write fails while
+  // reads stay green and the version counter can't see it. Detection only —
+  // see pages-slug-index-check.ts for why no auto-repair.
+  try {
+    const { checkPagesSlugUniqueIndex, describePagesSlugIndexStatus } = await import('../../core/pages-slug-index-check.ts');
+    const idx = await checkPagesSlugUniqueIndex(engine);
+    checks.push({ name: 'pages_slug_unique_index', ...describePagesSlugIndexStatus(idx) });
+  } catch {
+    checks.push({ name: 'pages_slug_unique_index', status: 'warn', message: 'Could not check pages(source_id, slug) unique index' });
+  }
+
   // v0.42.x — Life Chronicle (#2390): orphaned event projections. Reads already
   // hide projections whose event page is soft-deleted (read-time correctness);
   // this always-run probe surfaces the cleanup backlog. Keyed off the real

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -209,6 +209,7 @@ export const META_CHECK_NAMES: ReadonlySet<string> = new Set([
   'minions_migration',
   'multi_source_drift',
   'pack_upgrade_available',
+  'pages_slug_unique_index',
   'schema_pack_active',
   'schema_pack_consistency',
   'schema_pack_source_drift',

--- a/src/core/pages-slug-index-check.ts
+++ b/src/core/pages-slug-index-check.ts
@@ -1,0 +1,251 @@
+/**
+ * #550 — pages(source_id, slug) unique-index presence (detection only).
+ *
+ * `putPage` in BOTH engines upserts via `ON CONFLICT (source_id, slug)`,
+ * which needs a valid, non-deferrable, non-partial unique index whose KEY
+ * column set is exactly {source_id, slug} as its arbiter. Migration v23
+ * adds `pages_source_slug_key` by NAME, so a brain whose constraint was
+ * dropped/renamed by an external migration (or a `pages` table created
+ * outside gbrain's own migration chain) is stamped past v23 with the
+ * arbiter missing — every write then fails with "no unique or exclusion
+ * constraint matching the ON CONFLICT specification" while reads stay
+ * green, and the version counter can't see it. Match by column SET, not
+ * name — any conforming unique index satisfies the arbiter (mirror of the
+ * #2038 timeline_dedup shape check in timeline-dedup-repair.ts).
+ *
+ * Queries `pg_index`/`pg_attribute` directly rather than text-parsing
+ * `pg_indexes.indexdef`, so it correctly:
+ *  - separates KEY columns from INCLUDE columns (`indkey[0:indnkeyatts-1]`
+ *    — text-parsing the trailing parens of indexdef instead would grab the
+ *    INCLUDE list and false-negative on a real arbiter with INCLUDE cols)
+ *  - excludes expression-key indexes (`indexprs IS NULL`) — an expression
+ *    key's `indkey` slot is the sentinel attnum 0, which has no
+ *    `pg_attribute` row; without this exclusion the expression silently
+ *    drops out of the aggregated column list, so e.g.
+ *    `(source_id, slug, lower(title))` would be MIScounted as the exact
+ *    2-column {source_id, slug} shape — a false "healthy" read while the
+ *    real `ON CONFLICT (source_id, slug)` upsert fails (verified directly)
+ *  - excludes invalid indexes (`indisvalid = false`, e.g. a failed
+ *    CONCURRENTLY build)
+ *  - excludes partial indexes (`indpred IS NOT NULL` — can't arbitrate a
+ *    bare `ON CONFLICT (source_id, slug)`)
+ *  - excludes PG18 unique exclusion-constraint indexes (`indisexclusion`) —
+ *    a different arbiter class `ON CONFLICT` column-list inference doesn't
+ *    consider
+ *  - dedupes a key column list before comparing (`UNIQUE(source_id, slug,
+ *    slug)` verified live to still arbitrate `ON CONFLICT (source_id,
+ *    slug)` — Postgres compares key columns as a SET, so a 3-key-position
+ *    index with a repeated column must not miscount as a non-matching
+ *    3-column shape)
+ *  - treats a DEFERRABLE unique constraint on the matching columns as
+ *    POISONING the arbiter even when a separate non-deferrable one on the
+ *    same columns also exists: Postgres's column-list conflict inference
+ *    considers every matching index, and errors ("ON CONFLICT does not
+ *    support deferrable unique constraints/exclusion constraints as
+ *    arbiters") if ANY of them is deferrable — it does not just skip the
+ *    deferrable one and use the immediate one (verified directly).
+ *    Deferred-ness is read from `pg_index.indimmediate` (false exactly
+ *    when the constraint backing the index is DEFERRABLE, INITIALLY
+ *    IMMEDIATE or DEFERRED alike — verified directly against
+ *    `pg_constraint.condeferrable`), not a `pg_constraint` join: a plain
+ *    `CREATE UNIQUE INDEX` has no DEFERRABLE syntax, so any index with
+ *    `indimmediate = false` is necessarily constraint-backed and its own
+ *    name IS the constraint name — letting the repair message name the
+ *    exact offending constraint(s) without a second query (and without
+ *    the FK-fanout duplicate-row hazard a `pg_constraint` join on
+ *    `conindid` has: any table FK'ing to `pages.id` also registers a
+ *    constraint row whose `conindid` is `pages_pkey`'s oid)
+ *  - is schema-qualified via `to_regclass('pages')`'s OID rather than a
+ *    bare `tablename` string match, so a same-named table in another
+ *    schema can't produce a false "healthy" read
+ *
+ * Detection only, deliberately: an earlier attempt at this check paired it
+ * with an automatic repair path, which the maintainer declined at review —
+ * a brain in this state needs a human decision (a real column-set index
+ * exists elsewhere under a different name? a genuinely fresh migration
+ * run is needed?), not a silent DDL change on doctor's read path.
+ */
+
+import type { BrainEngine } from './engine.ts';
+
+const EXPECTED_COLUMNS = ['slug', 'source_id']; // sorted for order-independent comparison
+
+interface CandidateIndexRow {
+  index_name: string;
+  indisvalid: boolean;
+  is_partial: boolean;
+  is_deferrable: boolean;
+  is_primary: boolean;
+  key_columns: string[] | null;
+}
+
+export interface PagesSlugIndexStatus {
+  /** The `pages` table exists. A brain that's actually reached this check
+   *  (past `initSchema`) should always have it — a missing table here means
+   *  something outside gbrain's own migration chain dropped or never
+   *  created it, which is itself a fail condition (every write depends on
+   *  this table), not a "not yet initialized" state. */
+  tablePresent: boolean;
+  /** A valid, non-partial, non-deferrable unique index on exactly
+   *  {source_id, slug} exists — i.e. `ON CONFLICT (source_id, slug)` has an
+   *  arbiter to bind to. */
+  hasArbiter: boolean;
+  /** Names (sorted, for deterministic messaging) of DEFERRABLE unique/PK
+   *  constraints found on exactly {source_id, slug} — non-empty only when
+   *  `hasArbiter` is false BECAUSE a matching index exists but is poisoned
+   *  by deferrability, as opposed to no matching index existing at all.
+   *  Each name is a real constraint name (see file header: any deferrable
+   *  unique index is necessarily constraint-backed and shares its
+   *  constraint's name), safe to use in an `ALTER TABLE pages DROP
+   *  CONSTRAINT <name>` repair instruction PROVIDED it's identifier-quoted
+   *  (see `quoteIdent` — a constraint name is an arbitrary identifier that
+   *  can itself contain commas, quotes, or `;`). */
+  deferrablePoisonConstraints: string[];
+  /** Subset of `deferrablePoisonConstraints` that are PRIMARY KEY
+   *  constraints rather than plain UNIQUE ones. Dropping/recreating a
+   *  PRIMARY KEY changes NOT NULL enforcement and breaks any foreign key
+   *  referencing it — categorically different from a plain unique
+   *  constraint, so these must NOT get the generic drop-and-recreate DDL. */
+  deferrablePoisonPrimaryKeys: string[];
+  /** True when a non-deferrable matching index already exists ALONGSIDE the
+   *  poison — removing just the poisoning constraint(s) is then sufficient
+   *  to restore the arbiter, and suggesting `ADD CONSTRAINT
+   *  pages_source_slug_key` would collide with the one already there
+   *  (`relation "pages_source_slug_key" already exists`, verified live). */
+  healthyMatchExists: boolean;
+}
+
+/** Double-quotes a Postgres identifier per the standard escaping rule
+ *  (embedded `"` doubled) so a constraint name containing commas, spaces,
+ *  quotes, or `;` can't break or extend the generated DDL. */
+function quoteIdent(name: string): string {
+  return '"' + name.replace(/"/g, '""') + '"';
+}
+
+export async function checkPagesSlugUniqueIndex(engine: BrainEngine): Promise<PagesSlugIndexStatus> {
+  const tbl = await engine.executeRaw<{ reg: string | null }>(
+    `SELECT to_regclass('pages')::text AS reg`,
+  );
+  const tablePresent = !!tbl[0]?.reg;
+  if (!tablePresent) {
+    return {
+      tablePresent: false,
+      hasArbiter: false,
+      deferrablePoisonConstraints: [],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    };
+  }
+
+  const rows = await engine.executeRaw<CandidateIndexRow>(`
+    SELECT
+      ix_class.relname AS index_name,
+      i.indisvalid,
+      (i.indpred IS NOT NULL) AS is_partial,
+      (NOT i.indimmediate) AS is_deferrable,
+      i.indisprimary AS is_primary,
+      (SELECT array_agg(a.attname ORDER BY u.ord)
+         FROM unnest(i.indkey[0:i.indnkeyatts-1]) WITH ORDINALITY AS u(attnum, ord)
+         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = u.attnum
+      ) AS key_columns
+    FROM pg_index i
+    JOIN pg_class ix_class ON ix_class.oid = i.indexrelid
+    JOIN pg_class t ON t.oid = i.indrelid
+    WHERE t.oid = to_regclass('pages')
+      AND i.indisunique = true
+      AND i.indexprs IS NULL
+      AND NOT i.indisexclusion
+  `);
+
+  const matching = rows.filter(r => {
+    if (!r.indisvalid || r.is_partial) return false;
+    const cols = [...new Set(r.key_columns ?? [])].sort();
+    return cols.length === EXPECTED_COLUMNS.length && cols.every((c, i) => c === EXPECTED_COLUMNS[i]);
+  });
+  // A deferrable match poisons inference even alongside a non-deferrable
+  // one on the same columns (see file header) — require at least one
+  // matching index AND none of the matching indexes deferrable.
+  const poisonRows = matching.filter(r => r.is_deferrable);
+  const deferrablePoisonConstraints = poisonRows.map(r => r.index_name).sort();
+  const deferrablePoisonPrimaryKeys = poisonRows.filter(r => r.is_primary).map(r => r.index_name).sort();
+  const healthyMatchExists = matching.some(r => !r.is_deferrable);
+  const hasArbiter = matching.length > 0 && deferrablePoisonConstraints.length === 0;
+  return { tablePresent: true, hasArbiter, deferrablePoisonConstraints, deferrablePoisonPrimaryKeys, healthyMatchExists };
+}
+
+/**
+ * Turns a {@link PagesSlugIndexStatus} into the doctor check's status/message
+ * pair. Centralized so both doctor surfaces (buildChecks + doctorReportRemote)
+ * report byte-identical, and correctly branched, text — the two surfaces
+ * previously duplicated this logic inline and could drift (#550 Codex review:
+ * a deferrable-poison state was reported with a repair instruction naming the
+ * wrong constraint, since the inline text didn't distinguish "no matching
+ * index at all" from "a matching index exists but is deferrable").
+ */
+export function describePagesSlugIndexStatus(
+  status: PagesSlugIndexStatus,
+): { status: 'ok' | 'fail'; message: string } {
+  if (!status.tablePresent) {
+    return {
+      status: 'fail',
+      message:
+        'pages table does not exist — every put_page write, and most of gbrain, depends on it. ' +
+        'If this brain was ever initialized, something outside gbrain\'s own migration chain ' +
+        'dropped it; if it genuinely never was, run `gbrain init --migrate-only` to apply the base ' +
+        'schema (NOT `apply-migrations`, which can report a brain already up-to-date without ' +
+        'actually checking that core tables like `pages` exist).',
+    };
+  }
+  if (status.hasArbiter) {
+    return { status: 'ok', message: 'pages has a unique index on (source_id, slug)' };
+  }
+  if (status.deferrablePoisonPrimaryKeys.length > 0) {
+    const pkNames = status.deferrablePoisonPrimaryKeys.join(', ');
+    return {
+      status: 'fail',
+      message:
+        `A PRIMARY KEY constraint on pages(source_id, slug) — ${pkNames} — is DEFERRABLE and poisons ` +
+        'the ON CONFLICT arbiter (#550): Postgres refuses column-list conflict inference if ANY ' +
+        'matching index is deferrable, so every put_page write fails with "ON CONFLICT does not ' +
+        'support deferrable unique constraints/exclusion constraints as arbiters". This needs manual ' +
+        'review, not a copy-paste fix: unlike a plain unique constraint, dropping/recreating a ' +
+        'PRIMARY KEY changes NOT NULL enforcement and breaks any foreign key referencing it.',
+    };
+  }
+  if (status.deferrablePoisonConstraints.length > 0) {
+    const names = status.deferrablePoisonConstraints; // already sorted
+    const dropStatements = names.map((n) => `ALTER TABLE pages DROP CONSTRAINT ${quoteIdent(n)};`).join(' ');
+    // Only suggest re-adding pages_source_slug_key when nothing already
+    // arbitrates — if a healthy match coexists (the poison is a SEPARATE
+    // constraint on the same columns), dropping the poison alone restores
+    // the arbiter, and the ADD would collide with the constraint already
+    // there ("relation ... already exists", verified live).
+    const addStatement = status.healthyMatchExists
+      ? ''
+      : ' ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug);';
+    return {
+      status: 'fail',
+      message:
+        `DEFERRABLE unique constraint(s) on pages(source_id, slug) — ${names.join(', ')} — poison the ` +
+        'ON CONFLICT arbiter (#550): Postgres refuses column-list conflict inference if ANY ' +
+        'matching index is deferrable, even alongside a non-deferrable one on the same columns, ' +
+        'so every put_page write fails with "ON CONFLICT does not support deferrable unique ' +
+        'constraints/exclusion constraints as arbiters". Manual repair (drop and recreate NOT ' +
+        "DEFERRABLE — ALTER TABLE can't change an existing unique constraint's deferrability in place" +
+        (status.healthyMatchExists ? '; a healthy pages_source_slug_key already exists, so no re-add is needed' : '') +
+        '): ' +
+        dropStatements +
+        addStatement,
+    };
+  }
+  return {
+    status: 'fail',
+    message:
+      'No unique index on pages(source_id, slug) — every put_page write fails with ' +
+      '"no unique or exclusion constraint matching the ON CONFLICT specification" (#550). ' +
+      '`apply-migrations --force-schema` runs migrations forward from the CURRENT version, so ' +
+      'it will NOT replay v23 on a brain already stamped past it. Manual repair: ' +
+      '`ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug);` ' +
+      '(fails loudly if duplicate (source_id, slug) rows already exist — resolve those first).',
+  };
+}

--- a/test/pages-slug-index-check.test.ts
+++ b/test/pages-slug-index-check.test.ts
@@ -1,0 +1,402 @@
+/**
+ * #550 — pages(source_id, slug) unique-index presence (detection only).
+ *
+ * A brain whose `pages_source_slug_key` constraint was dropped or renamed
+ * by an external migration is stamped past v23 with the arbiter missing —
+ * `putPage`'s `ON CONFLICT (source_id, slug)` then fails brain-wide while
+ * reads stay green, and the version counter can't see it. These tests
+ * simulate the drifted states directly and pin: detection of the healthy
+ * fresh-init state, detection of an absent arbiter, and several shapes
+ * that must NOT count as the arbiter (wrong columns, partial, deferrable)
+ * or that must count despite looking unusual (renamed, INCLUDE clause).
+ *
+ * Each test restores `pages_source_slug_key` in a `finally` block so an
+ * assertion failure mid-test can't leave the shared engine in a state that
+ * cascades into unrelated failures in later tests.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { checkPagesSlugUniqueIndex, describePagesSlugIndexStatus } from '../src/core/pages-slug-index-check.ts';
+import { buildChecks, doctorReportRemote, type Check } from '../src/commands/doctor.ts';
+import { doctorSource } from './helpers/doctor-source.ts';
+
+function findCheck(checks: Check[], name: string): Check | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+/** Drop the standard arbiter, run `body`, then restore it — even on failure. */
+async function withArbiterDropped(engine: PGLiteEngine, body: () => Promise<void>): Promise<void> {
+  await engine.executeRaw(`ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_source_slug_key`);
+  try {
+    await body();
+  } finally {
+    await engine.executeRaw(
+      `ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug)`,
+    );
+  }
+}
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('#550 pages(source_id, slug) unique-index detection', () => {
+  test('a fresh-init brain has the arbiter', async () => {
+    const status = await checkPagesSlugUniqueIndex(engine);
+    expect(status.tablePresent).toBe(true);
+    expect(status.hasArbiter).toBe(true);
+  });
+
+  test('detects an absent arbiter after the constraint is dropped', async () => {
+    await withArbiterDropped(engine, async () => {
+      const status = await checkPagesSlugUniqueIndex(engine);
+      expect(status.tablePresent).toBe(true);
+      expect(status.hasArbiter).toBe(false);
+    });
+    const restored = await checkPagesSlugUniqueIndex(engine);
+    expect(restored.hasArbiter).toBe(true);
+  });
+
+  test('a unique index under a DIFFERENT name still satisfies the arbiter (matched by columns, not name)', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(`CREATE UNIQUE INDEX renamed_slug_arbiter ON pages(source_id, slug)`);
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(true);
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS renamed_slug_arbiter`);
+      }
+    });
+  });
+
+  test('a unique index on the wrong columns does NOT satisfy the arbiter', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(`CREATE UNIQUE INDEX wrong_cols_idx ON pages(slug)`);
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(false);
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS wrong_cols_idx`);
+      }
+    });
+  });
+
+  test('a PARTIAL unique index on the right columns does NOT satisfy the arbiter (cannot arbitrate a bare ON CONFLICT)', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(
+        `CREATE UNIQUE INDEX partial_slug_idx ON pages(source_id, slug) WHERE deleted_at IS NULL`,
+      );
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(false);
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS partial_slug_idx`);
+      }
+    });
+  });
+
+  test('a unique index with an INCLUDE clause on the right key columns DOES satisfy the arbiter (INCLUDE columns are not key columns)', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(`CREATE UNIQUE INDEX include_arbiter ON pages(source_id, slug) INCLUDE (title)`);
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(true);
+        // Ground truth: an actual ON CONFLICT (source_id, slug) upsert
+        // succeeds against this index — confirms the detection matches real
+        // behavior, not just the parsed shape.
+        await engine.executeRaw(
+          `INSERT INTO pages(source_id, slug, type, title) VALUES ('default', 'x-include', 'note', 'x') ` +
+          `ON CONFLICT (source_id, slug) DO UPDATE SET title = EXCLUDED.title`,
+        );
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS include_arbiter`);
+      }
+    });
+  });
+
+  test('a DEFERRABLE unique constraint on the right columns does NOT satisfy the arbiter (Postgres itself rejects deferrable arbiters)', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(
+        `ALTER TABLE pages ADD CONSTRAINT deferrable_arbiter UNIQUE (source_id, slug) DEFERRABLE INITIALLY IMMEDIATE`,
+      );
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(false);
+        // Ground truth: Postgres rejects this exact shape as an ON CONFLICT
+        // arbiter, confirming the check isn't over-cautious versus real
+        // behavior.
+        await expect(
+          engine.executeRaw(
+            `INSERT INTO pages(source_id, slug, type, title) VALUES ('default', 'x-defsingle', 'note', 'x') ` +
+            `ON CONFLICT (source_id, slug) DO UPDATE SET title = EXCLUDED.title`,
+          ),
+        ).rejects.toThrow(/deferrable/i);
+      } finally {
+        await engine.executeRaw(`ALTER TABLE pages DROP CONSTRAINT IF EXISTS deferrable_arbiter`);
+      }
+    });
+  });
+
+  test('a unique index with a DUPLICATE key column still satisfies the arbiter (Postgres compares key columns as a SET)', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(`CREATE UNIQUE INDEX dup_col_arbiter ON pages(source_id, slug, slug)`);
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(true);
+        // Ground truth: a real ON CONFLICT (source_id, slug) upsert succeeds
+        // against this 3-key-position index with a repeated column — a naive
+        // exact-length-2 comparison would false-negative here.
+        await engine.executeRaw(
+          `INSERT INTO pages(source_id, slug, type, title) VALUES ('default', 'x-dupcol', 'note', 'x') ` +
+          `ON CONFLICT (source_id, slug) DO UPDATE SET title = EXCLUDED.title`,
+        );
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS dup_col_arbiter`);
+      }
+    });
+  });
+
+  test('a unique index with an EXPRESSION key does NOT satisfy the arbiter, even though its plain-column keys match {source_id, slug}', async () => {
+    await withArbiterDropped(engine, async () => {
+      await engine.executeRaw(`CREATE UNIQUE INDEX expr_arbiter ON pages(source_id, slug, lower(title))`);
+      try {
+        const status = await checkPagesSlugUniqueIndex(engine);
+        expect(status.hasArbiter).toBe(false);
+        // Ground truth: the expression key makes this a 3-key-column index
+        // that ON CONFLICT (source_id, slug) can't infer, even though the
+        // first two key positions are the right plain columns.
+        await expect(
+          engine.executeRaw(
+            `INSERT INTO pages(source_id, slug, type, title) VALUES ('default', 'x-expr', 'note', 'x') ` +
+            `ON CONFLICT (source_id, slug) DO UPDATE SET title = EXCLUDED.title`,
+          ),
+        ).rejects.toThrow();
+      } finally {
+        await engine.executeRaw(`DROP INDEX IF EXISTS expr_arbiter`);
+      }
+    });
+  });
+
+  test('a DEFERRABLE constraint on the right columns poisons the arbiter even when a separate non-deferrable one on the same columns also exists', async () => {
+    // Note: does NOT use withArbiterDropped — the point is that the healthy
+    // pages_source_slug_key stays in place while a second, deferrable
+    // constraint on the SAME columns is added alongside it.
+    await engine.executeRaw(
+      `ALTER TABLE pages ADD CONSTRAINT deferrable_coexist UNIQUE (source_id, slug) DEFERRABLE INITIALLY IMMEDIATE`,
+    );
+    try {
+      const status = await checkPagesSlugUniqueIndex(engine);
+      expect(status.hasArbiter).toBe(false);
+      // The offending constraint is named specifically (not just "no
+      // arbiter") so the repair message can tell the operator what to
+      // actually drop, instead of always suggesting pages_source_slug_key
+      // (which, in this coexistence case, is the healthy one already there).
+      expect(status.deferrablePoisonConstraints).toEqual(['deferrable_coexist']);
+      expect(status.deferrablePoisonPrimaryKeys).toEqual([]);
+      expect(status.healthyMatchExists).toBe(true);
+      // Ground truth: Postgres's column-list conflict inference considers
+      // every matching index and errors if ANY of them is deferrable — it
+      // does not silently prefer the immediate one.
+      await expect(
+        engine.executeRaw(
+          `INSERT INTO pages(source_id, slug, type, title) VALUES ('default', 'x-poison', 'note', 'x') ` +
+          `ON CONFLICT (source_id, slug) DO UPDATE SET title = EXCLUDED.title`,
+        ),
+      ).rejects.toThrow(/deferrable/i);
+      // Ground truth for the repair advice itself (Codex round-4 finding):
+      // dropping ONLY the poison — no re-add — must be sufficient, since
+      // pages_source_slug_key is still there. Executing the actual DROP
+      // statement the message would generate must restore the arbiter
+      // without an "already exists" collision.
+      await engine.executeRaw(`ALTER TABLE pages DROP CONSTRAINT "deferrable_coexist"`);
+      const afterDropOnly = await checkPagesSlugUniqueIndex(engine);
+      expect(afterDropOnly.hasArbiter).toBe(true);
+    } finally {
+      await engine.executeRaw(`ALTER TABLE pages DROP CONSTRAINT IF EXISTS deferrable_coexist`);
+    }
+    const restored = await checkPagesSlugUniqueIndex(engine);
+    expect(restored.hasArbiter).toBe(true);
+    expect(restored.deferrablePoisonConstraints).toEqual([]);
+  });
+
+  test('a DEFERRABLE constraint whose name needs identifier-quoting (commas, spaces, embedded quotes) is detected and its repair DDL is actually executable', async () => {
+    // Codex round-4 finding: a constraint name is an arbitrary identifier —
+    // concatenating it unquoted into generated DDL can produce invalid SQL
+    // or let the name inject additional statements. This name deliberately
+    // has all three hazards.
+    const weirdName = 'odd,name "quoted"';
+    await engine.executeRaw(
+      `ALTER TABLE pages ADD CONSTRAINT "odd,name ""quoted""" UNIQUE (source_id, slug) DEFERRABLE INITIALLY IMMEDIATE`,
+    );
+    try {
+      const status = await checkPagesSlugUniqueIndex(engine);
+      expect(status.deferrablePoisonConstraints).toEqual([weirdName]);
+      const { message } = describePagesSlugIndexStatus(status);
+      // Ground truth: run the EXACT DROP CONSTRAINT statement the message
+      // embeds (regex-extracted, not hand-written) — it must execute
+      // without a syntax error and must drop the actual constraint.
+      const dropStmt = message.match(/ALTER TABLE pages DROP CONSTRAINT "[^;]+;/)?.[0];
+      expect(dropStmt).toBeDefined();
+      await engine.executeRaw(dropStmt!);
+      const afterDrop = await checkPagesSlugUniqueIndex(engine);
+      expect(afterDrop.hasArbiter).toBe(true);
+      expect(afterDrop.deferrablePoisonConstraints).toEqual([]);
+    } finally {
+      await engine.executeRaw(`ALTER TABLE pages DROP CONSTRAINT IF EXISTS "odd,name ""quoted"""`);
+    }
+  });
+});
+
+describe('#550 describePagesSlugIndexStatus (message construction, pure — no DB)', () => {
+  test('missing pages table reports FAIL (not ok — a versioned brain without its own core table is corrupt, not "not yet initialized"), and points at init --migrate-only', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: false,
+      hasArbiter: false,
+      deferrablePoisonConstraints: [],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('pages table does not exist');
+    expect(result.message).toContain('gbrain init --migrate-only');
+  });
+
+  test('no matching index at all gives the generic ADD CONSTRAINT pages_source_slug_key repair', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: [],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug);');
+    expect(result.message).not.toContain('DEFERRABLE');
+  });
+
+  test('a deferrable-poisoned arbiter with NO healthy match names the offending constraint and includes the re-add', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: ['deferrable_arbiter'],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('DROP CONSTRAINT "deferrable_arbiter";');
+    expect(result.message).toContain('NOT DEFERRABLE');
+    // No healthy arbiter exists yet, so the re-add IS needed here.
+    expect(result.message).toContain('ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug);');
+    // Quotes the actual runtime error, not the "no matching index" one.
+    expect(result.message).toContain('ON CONFLICT does not support deferrable unique constraints/exclusion constraints as arbiters');
+  });
+
+  test('a deferrable-poisoned arbiter that COEXISTS with a healthy match names the offending constraint but must NOT re-add pages_source_slug_key (round-4 Critical: it already exists)', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: ['deferrable_coexist'],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: true,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('DROP CONSTRAINT "deferrable_coexist";');
+    expect(result.message).not.toContain('ADD CONSTRAINT pages_source_slug_key');
+  });
+
+  test('multiple deferrable-poisoning constraints are all named in the repair instruction, each individually quoted', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: ['def_a', 'def_b'],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    });
+    expect(result.message).toContain('DROP CONSTRAINT "def_a";');
+    expect(result.message).toContain('DROP CONSTRAINT "def_b";');
+  });
+
+  test('constraint names containing special characters are identifier-quoted, not concatenated raw (round-4 Critical: SQL-injection-shaped hazard)', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: ['odd,name "quoted"; DROP TABLE pages'],
+      deferrablePoisonPrimaryKeys: [],
+      healthyMatchExists: false,
+    });
+    // Embedded double-quotes are doubled per Postgres identifier escaping;
+    // the whole thing is one quoted token, so the embedded `;` and comma
+    // stay inert data instead of terminating/extending the statement.
+    expect(result.message).toContain('DROP CONSTRAINT "odd,name ""quoted""; DROP TABLE pages";');
+  });
+
+  test('a DEFERRABLE PRIMARY KEY gets conservative manual-review advice, never a drop-and-recreate-as-UNIQUE prescription', () => {
+    const result = describePagesSlugIndexStatus({
+      tablePresent: true,
+      hasArbiter: false,
+      deferrablePoisonConstraints: ['pages_pkey'],
+      deferrablePoisonPrimaryKeys: ['pages_pkey'],
+      healthyMatchExists: false,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('pages_pkey');
+    expect(result.message).toContain('PRIMARY KEY');
+    expect(result.message).toContain('manual review');
+    // Must NOT hand out the generic unique-constraint DROP/ADD DDL for a PK
+    // — that would silently change NOT NULL enforcement and break FKs.
+    expect(result.message).not.toContain('DROP CONSTRAINT');
+    expect(result.message).not.toContain('ADD CONSTRAINT pages_source_slug_key');
+  });
+});
+
+describe('#550 doctor surface wiring', () => {
+  test('buildChecks() includes pages_slug_unique_index', async () => {
+    const checks = await buildChecks(engine, ['--scope=brain']);
+    const check = findCheck(checks, 'pages_slug_unique_index');
+    expect(check).toBeDefined();
+    expect(check!.status).toBe('ok');
+  });
+
+  test('doctorReportRemote() includes pages_slug_unique_index (cross-surface parity)', async () => {
+    const report = await doctorReportRemote(engine);
+    const check = findCheck(report.checks, 'pages_slug_unique_index');
+    expect(check).toBeDefined();
+    expect(check!.status).toBe('ok');
+  });
+
+  test('buildChecks() reports fail when the arbiter is absent, with an accurate (not --force-schema) recovery instruction', async () => {
+    await withArbiterDropped(engine, async () => {
+      const checks = await buildChecks(engine, ['--scope=brain']);
+      const check = findCheck(checks, 'pages_slug_unique_index');
+      expect(check!.status).toBe('fail');
+      expect(check!.message).toContain('#550');
+      // The recovery instruction must not claim --force-schema fixes a
+      // brain already stamped past v23 (it doesn't — it only runs
+      // migrations forward from the current version); it must instead
+      // give the actual manual repair.
+      expect(check!.message).not.toContain('Run `gbrain apply-migrations --force-schema` to restore it');
+      expect(check!.message).toContain('ALTER TABLE pages ADD CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug);');
+    });
+  });
+});
+
+describe('cross-surface parity (source-grep regression guard)', () => {
+  test('doctor.ts wires checkPagesSlugUniqueIndex into BOTH buildChecks and doctorReportRemote', () => {
+    // Static regression assertion: the helper must be called from BOTH
+    // surfaces. If a future maintainer removes the call from one, this test
+    // fails pointing at the asymmetry (same pattern as the
+    // embedding_env_override guard in doctor-embedding-env-override.test.ts).
+    const src = doctorSource();
+    const matches = src.match(/await checkPagesSlugUniqueIndex\(engine\)/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Related to #550.

## The bug

`putPage` upserts via `ON CONFLICT (source_id, slug)` on both engines (`postgres-engine.ts`, `pglite-engine.ts`). If the arbiter unique index on `pages(source_id, slug)` is missing — dropped, renamed, or never created by an external migration — every write fails with `there is no unique or exclusion constraint matching the ON CONFLICT specification` while reads stay green, and `gbrain doctor` gives no indication anything is wrong.

Migration v23's guard matches the constraint by *name* (`pg_constraint.conname = 'pages_source_slug_key'`), not by columns, so a brain that reached that version without the DDL actually executing never gets it — and neither `initSchema()` (a no-op past head) nor `apply-migrations --force-schema` (only replays from the current version) can self-heal it.

## Scope

Detection only — this PR adds one doctor check (`pages_slug_unique_index`, wired into both `buildChecks()` and `doctorReportRemote()`) that probes `pg_index`/`pg_attribute` directly for a valid, non-partial, non-deferrable unique index whose key-column *set* is exactly `{source_id, slug}` (matched by shape, not by name — so a renamed or externally-created index still counts). No write to the migration path, no auto-repair.

I kept this scoped down after reading the thread: a prior attempt (#3530) paired detection with automatic migration repair and was closed at your discretion, with a note that the plain detection half was separable if the objection was to the auto-repair rather than the diagnosis itself. This PR is that separated half.

## What it catches beyond the straightforward "index missing" case

- A DEFERRABLE unique constraint on the right columns — Postgres's `ON CONFLICT` column-list inference refuses to use a deferrable arbiter, and refuses even when a *separate*, healthy non-deferrable index on the same columns also exists (verified live: it doesn't silently prefer the immediate one). The check reports the specific offending constraint name(s) rather than generic "no arbiter" text, and the repair instruction only suggests re-adding `pages_source_slug_key` when nothing else already arbitrates (re-adding it when it's already there just collides).
- A deferrable *primary key* on those columns gets a conservative "needs manual review" message instead of prescriptive drop/recreate DDL — replacing a PK with a plain UNIQUE constraint changes NOT NULL enforcement and can break referencing foreign keys, so it isn't safe to hand out as a one-liner.
- Constraint names are identifier-quoted before being embedded in the suggested repair DDL (a constraint name is an arbitrary identifier and can itself contain commas, quotes, or `;`).
- INCLUDE columns, expression keys, partial indexes, and duplicate key-column indexes (`UNIQUE(source_id, slug, slug)`, which Postgres still accepts as a valid arbiter) are all handled correctly against live-verified `ON CONFLICT` ground truth, not just the parsed index shape.

## Test plan

`test/pages-slug-index-check.test.ts` — 22 tests, all against a live PGLite engine with ground-truth `ON CONFLICT` upserts (not just asserting the parsed status): fresh-init healthy state, dropped/renamed/wrong-column/partial/INCLUDE/expression-key/duplicate-column index shapes, the deferrable-single and deferrable-alongside-healthy cases (including executing the actual generated repair DDL and confirming it restores the arbiter without an "already exists" collision), an identifier-quoting case with a constraint literally named `odd,name "quoted"` where the generated DROP statement is extracted from the message text and executed live, both doctor surfaces wired and cross-checked for parity, and a source-grep regression guard pinning that wiring.

```
bun run typecheck        # pass
bun run check:module-size        # pass
bun run check:structural-manifest        # pass
bun test test/pages-slug-index-check.test.ts   # 22 pass, 0 fail
```
