### PR TITLE
docs(ai-providers): fix broken Qwen3-Reranker GGUF link in llama-server-reranker doc

### DIFF
--- a/docs/ai-providers/llama-server-reranker.md
+++ b/docs/ai-providers/llama-server-reranker.md
@@ -10,8 +10,10 @@ already drives for ZeroEntropy's hosted reranker. The
 
 Two flavors of "local" this recipe covers:
 
-- **Qwen3-Reranker** (0.6B / 4B / 8B) — open-weight cross-encoder; pull
-  the GGUF from HuggingFace and serve.
+- **Qwen3-Reranker** (0.6B / 4B / 8B) — open-weight cross-encoder. Qwen
+  publishes official GGUFs for its embedding models but not for the
+  rerankers — pull a community GGUF conversion instead (see step 2)
+  and serve.
 - **Self-hosted ZeroEntropy** (`zerank-2`, `zerank-1-small`) — the
   weights are on HuggingFace too. GGUF-convert them and serve them the
   same way. **Quality is not guaranteed to match ZE-hosted:** GGUF
@@ -48,14 +50,25 @@ across releases. The recipe sends to `/v1/rerank`.
 
 ### 2. Pull a reranker GGUF
 
-For Qwen3-Reranker-4B (quantized Q4_K_M is the sweet spot for CPU):
+Qwen doesn't publish an official reranker GGUF, so grab a community
+conversion. `mradermacher` mirrors all three Qwen3-Reranker sizes with
+consistent naming (community-maintained, not Qwen-published — pin your
+own eval per [docs/eval-bench.md](../eval-bench.md) if this feeds
+production retrieval):
 
 ```bash
 # Pick a quant level — Q4_K_M is the usual CPU sweet spot.
 huggingface-cli download \
-  Qwen/Qwen3-Reranker-4B-GGUF qwen3-reranker-4b-q4_k_m.gguf \
+  mradermacher/Qwen3-Reranker-4B-GGUF Qwen3-Reranker-4B.Q4_K_M.gguf \
   --local-dir ./models
 ```
+
+For the 0.6B or 8B variant, swap the size in both the repo
+(`mradermacher/Qwen3-Reranker-<size>-GGUF`) and the file
+(`Qwen3-Reranker-<size>.Q4_K_M.gguf`). Any other community conversion,
+or `convert_hf_to_gguf.py` run against the real `Qwen/Qwen3-Reranker-<size>`
+weights, works too — just match step 3's `--model` path to whatever
+file you end up with.
 
 For self-hosted ZeroEntropy weights, find a community GGUF conversion
 or convert from the HuggingFace weights yourself (out of scope of this
@@ -65,7 +78,7 @@ doc — see llama.cpp's `convert_hf_to_gguf.py`).
 
 ```bash
 ./build/bin/llama-server \
-  --model ./models/qwen3-reranker-4b-q4_k_m.gguf \
+  --model ./models/Qwen3-Reranker-4B.Q4_K_M.gguf \
   --alias qwen3-reranker-4b \
   --reranking \
   --port 8081


### PR DESCRIPTION
Fixes the broken download link reported in #3689: `docs/ai-providers/llama-server-reranker.md` step 2 told readers to `huggingface-cli download` from `Qwen/Qwen3-Reranker-{0.6B,4B,8B}-GGUF`, none of which exist (Qwen publishes official GGUFs for its embedding models but not its rerankers — confirmed 401 on all three by the issue reporter and the verified-real triage comment).

## Fix

- Step 2 now points at `mradermacher/Qwen3-Reranker-<size>-GGUF`, a community GGUF conversion, with a caveat (mirroring the existing self-hosted-ZE caveat a few lines down) that it's community-maintained and to pin your own eval if it feeds production retrieval.
- The intro bullet (line 13-14) now says up front that Qwen doesn't publish official reranker GGUFs, instead of silently implying "pull the GGUF from HuggingFace" resolves cleanly.
- Step 3's `--model` path is updated to match the actual filename the new step 2 command downloads (`Qwen3-Reranker-4B.Q4_K_M.gguf`, not the old lowercase-dashed guess).

## How I verified the replacement (all done today, read-only)

```
$ curl -s -o /dev/null -w "%{http_code}" https://huggingface.co/api/models/mradermacher/Qwen3-Reranker-4B-GGUF
200
$ curl -s -o /dev/null -w "%{http_code}" https://huggingface.co/api/models/mradermacher/Qwen3-Reranker-0.6B-GGUF
200
$ curl -s -o /dev/null -w "%{http_code}" https://huggingface.co/api/models/mradermacher/Qwen3-Reranker-8B-GGUF
200
```

For each repo, confirmed the exact `Q4_K_M` filename via the HF API's `siblings` listing:
- `mradermacher/Qwen3-Reranker-4B-GGUF` → `Qwen3-Reranker-4B.Q4_K_M.gguf`
- `mradermacher/Qwen3-Reranker-0.6B-GGUF` → `Qwen3-Reranker-0.6B.Q4_K_M.gguf`
- `mradermacher/Qwen3-Reranker-8B-GGUF` → `Qwen3-Reranker-8B.Q4_K_M.gguf`

And confirmed the actual download resolves (not just the repo metadata):

```
$ curl -sI -L https://huggingface.co/mradermacher/Qwen3-Reranker-4B-GGUF/resolve/main/Qwen3-Reranker-4B.Q4_K_M.gguf
HTTP/2 302
location: https://us.aws.cdn.hf.co/xet-bridge-us/...  (real CDN asset, x-linked-size: 2496714144)
```

Did **not** download the ~2.5GB file itself, and did not test the file under `llama-server --reranking` (quality/serving is out of scope for a docs link fix, same as the issue's own "not verified" scope).

## Scope

Docs only, matches the issue's own scope note: `src/core/ai/recipes/llama-server-reranker.ts` takes a user-supplied `--alias` string, not a repo id, so it's unaffected. `grep -rn "Qwen3-Reranker-4B-GGUF"` over the tree shows the concrete broken repo path appeared exactly once (this doc); `CHANGELOG.md` has one historical mention of the old filename in a past release entry, left untouched per the repo's own convention that CHANGELOG entries are historical record, not current-state docs.

Ran `bun run typecheck` (clean) and `bun test test/build-llms.test.ts` (12/12 pass, no `build:llms` regen needed since this doc has `includeInFull: false` in `scripts/llms-config.ts` — only its title/description/path are in the bundle, and those are unchanged).
