### PR TITLE
fix(doctor): add read-only schema_columns check to catch ledger/live-schema drift

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4443	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958); +21 lines (#4518: don't assert "supervisor not running" when the --fast mode DB-lock fallback was never attempted)
+src/commands/doctor.ts	4477	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958); +21 lines (#4518: don't assert "supervisor not running" when the --fast mode DB-lock fallback was never attempted); + read-only schema_columns check (this PR, #4425)
 src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown v0.46.26.0 megawave op wiring
 src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { ALLOWED_TYPES } from '../core/facts/conversation-types.ts';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION, getIdleBlockers } from '../core/migrate.ts';
+import { detectMissingColumns } from '../core/schema-verify.ts';
 import { checkResolvable } from '../core/check-resolvable.ts';
 import { autoFixDryViolations, type AutoFixReport } from '../core/dry-fix.ts';
 import { autoDetectSkillsDirReadOnly } from '../core/repo-root.ts';
@@ -1941,6 +1942,39 @@ export async function buildChecks(
     }
   } catch {
     checks.push({ name: 'schema_version', status: 'warn', message: 'Could not check schema version' });
+  }
+
+  // 6b. Schema columns — gbrain#4421. schema_version above only compares the
+  // migrations-ledger counter; it reads as "ok" even when a migration's DDL
+  // never landed (the ledger row got written as applied, but e.g. PgBouncer
+  // transaction-mode silently swallowed the ALTER TABLE — see schema-verify.ts's
+  // module docstring). detectMissingColumns() does the same live-column check
+  // `gbrain init --migrate-only` already self-heals with, but read-only: a
+  // plain diagnostic run should never issue DDL on its own.
+  progress.heartbeat('schema_columns');
+  try {
+    const detected = await detectMissingColumns(engine);
+    if (detected.missing.length === 0) {
+      checks.push({ name: 'schema_columns', status: 'ok', message: `${detected.checked} column(s) verified against live schema` });
+    } else {
+      const cols = detected.missing.map(m => `${m.table}.${m.column}`).join(', ');
+      // Codex review (2026-08-22): only claim "despite schema_version being
+      // current" when it actually is — a DB that's genuinely behind
+      // (schema_version warn/fail above) is expected to have missing
+      // columns from migrations that haven't run yet, and that's a
+      // different, already-covered situation (see the check above's own
+      // "Fix: gbrain apply-migrations --yes").
+      const context = schemaVersion >= LATEST_VERSION
+        ? 'despite schema_version reporting up to date'
+        : '(schema_version above also reports pending migrations)';
+      checks.push({
+        name: 'schema_columns',
+        status: 'warn',
+        message: `${detected.missing.length} column(s) missing ${context}: ${cols}. Fix: gbrain init --migrate-only`,
+      });
+    }
+  } catch {
+    checks.push({ name: 'schema_columns', status: 'warn', message: 'Could not verify live schema columns' });
   }
 
   // Note: we intentionally DO NOT fail on "schema v7+ but no preferences.json".

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -219,6 +219,7 @@ export const META_CHECK_NAMES: ReadonlySet<string> = new Set([
   // coherence healed by `gbrain apply-migrations` (sibling of
   // timeline_dedup_index / schema_version).
   'pages_upsert_arbiter',
+  'schema_columns',
   'schema_pack_active',
   'schema_pack_consistency',
   'schema_pack_source_drift',

--- a/src/core/schema-verify.ts
+++ b/src/core/schema-verify.ts
@@ -187,28 +187,30 @@ export interface VerifyResult {
   failed: Array<{ table: string; column: string; error: string }>;
 }
 
+export interface DetectResult {
+  /** Total columns checked */
+  checked: number;
+  /** Columns that were missing */
+  missing: Array<{ table: string; column: string }>;
+}
+
 /**
- * Verify that every column defined in schema-embedded.ts actually exists
- * in the database. Self-heals missing columns via ALTER TABLE ADD COLUMN.
+ * Read-only pass: diff schema-embedded.ts's expected columns against
+ * information_schema.columns. Does NOT attempt any ALTER TABLE — callers
+ * that only need to detect drift (e.g. a doctor health check) should use
+ * this instead of verifySchema(), which mutates the database.
  *
- * Should be called after initSchema() + runMigrations() complete.
- *
- * @returns VerifyResult with details of what was checked and fixed.
- * @throws Error if any columns could not be healed (after attempting all).
+ * Extracted from verifySchema() (gbrain#4421) so `gbrain doctor` can report
+ * this same ledger-vs-live-schema drift without a plain diagnostic run
+ * silently issuing DDL.
  */
-export async function verifySchema(engine: BrainEngine): Promise<VerifyResult> {
+export async function detectMissingColumns(engine: BrainEngine): Promise<DetectResult> {
   const expected = parseExpectedColumns();
   const actualColumns = await getActualColumns(engine);
   const actualTables = await getActualTables(engine);
 
-  const result: VerifyResult = {
-    checked: 0,
-    missing: [],
-    healed: [],
-    failed: [],
-  };
+  const result: DetectResult = { checked: 0, missing: [] };
 
-  // Group expected columns by table for cleaner logging
   for (const col of expected) {
     // Skip tables that don't exist yet — they'll be created by schema.sql
     // on the next initSchema() call. We only verify columns on tables that
@@ -225,6 +227,29 @@ export async function verifySchema(engine: BrainEngine): Promise<VerifyResult> {
       result.missing.push({ table: col.table, column: col.column });
     }
   }
+
+  return result;
+}
+
+/**
+ * Verify that every column defined in schema-embedded.ts actually exists
+ * in the database. Self-heals missing columns via ALTER TABLE ADD COLUMN.
+ *
+ * Should be called after initSchema() + runMigrations() complete.
+ *
+ * @returns VerifyResult with details of what was checked and fixed.
+ * @throws Error if any columns could not be healed (after attempting all).
+ */
+export async function verifySchema(engine: BrainEngine): Promise<VerifyResult> {
+  const expected = parseExpectedColumns();
+  const detected = await detectMissingColumns(engine);
+
+  const result: VerifyResult = {
+    checked: detected.checked,
+    missing: detected.missing,
+    healed: [],
+    failed: [],
+  };
 
   if (result.missing.length === 0) {
     return result;

--- a/test/schema-verify.test.ts
+++ b/test/schema-verify.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'bun:test';
-import { parseExpectedColumns, simplifyColumnDef } from '../src/core/schema-verify.ts';
+import { parseExpectedColumns, simplifyColumnDef, detectMissingColumns } from '../src/core/schema-verify.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+/**
+ * Minimal executeRaw-only stub: routes on which information_schema view the
+ * SQL targets (schema-verify.ts's two queries never touch anything else).
+ * Not a shared test helper — narrow enough that a one-off stub here is
+ * clearer than adding a new file for a single caller (gbrain#4421).
+ */
+function stubEngine(opts: {
+  tables: string[];
+  columns: Array<{ table_name: string; column_name: string }>;
+}): BrainEngine {
+  return {
+    executeRaw: async (sql: string) => {
+      if (sql.includes('information_schema.tables')) {
+        return opts.tables.map(table_name => ({ table_name })) as unknown[];
+      }
+      if (sql.includes('information_schema.columns')) {
+        return opts.columns as unknown[];
+      }
+      throw new Error(`stubEngine.executeRaw: unexpected query: ${sql}`);
+    },
+  } as unknown as BrainEngine;
+}
 
 describe('parseExpectedColumns', () => {
   it('extracts columns from all major tables', () => {
@@ -51,6 +75,40 @@ describe('parseExpectedColumns', () => {
     for (const col of columns) {
       expect(col.definition.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('detectMissingColumns', () => {
+  it('reports missing when the ledger-expected column is absent from the live table (gbrain#4421 repro)', async () => {
+    // Positive control: content_chunks exists (so it's in-scope) but its
+    // actual columns don't include embedded_text_hash — the exact drift
+    // that made `gbrain doctor` report schema_version=ok while `gbrain
+    // import` failed on every file with "column ... does not exist".
+    const engine = stubEngine({
+      tables: ['content_chunks'],
+      columns: [{ table_name: 'content_chunks', column_name: 'chunk_text' }],
+    });
+    const result = await detectMissingColumns(engine);
+    expect(result.missing).toContainEqual({ table: 'content_chunks', column: 'embedded_text_hash' });
+  });
+
+  it('reports no missing columns when the live table matches every expected column (negative control)', async () => {
+    const expected = parseExpectedColumns();
+    const contentChunksCols = expected.filter(c => c.table === 'content_chunks');
+    const engine = stubEngine({
+      tables: ['content_chunks'],
+      columns: contentChunksCols.map(c => ({ table_name: 'content_chunks', column_name: c.column })),
+    });
+    const result = await detectMissingColumns(engine);
+    expect(result.missing).toEqual([]);
+    expect(result.checked).toBe(contentChunksCols.length);
+  });
+
+  it('skips tables that do not exist yet (fresh-install / not-yet-migrated tables are not false positives)', async () => {
+    const engine = stubEngine({ tables: [], columns: [] });
+    const result = await detectMissingColumns(engine);
+    expect(result.checked).toBe(0);
+    expect(result.missing).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `schema_version` only compares the migrations-ledger counter — it reports "ok" even when a migration's DDL never landed (the ledger row still gets written as applied, e.g. PgBouncer transaction-mode silently swallowing an ALTER TABLE — a failure mode `schema-verify.ts` already documents and self-heals for at init/migrate time via `verifySchema()`).
- Extracts that same live-column detection into a new read-only `detectMissingColumns()`, and wires it into `gbrain doctor` as a new `schema_columns` check right next to `schema_version`. A plain diagnostic run should never issue DDL on its own, so this only detects and reports — it does not self-heal (that stays `gbrain init --migrate-only`'s job).
- Fixes #4421.

## Repro (gbrain 0.46.25.0, Postgres)
`schema_version` reported "Version 135 (latest: 135)" while `content_chunks.embedded_text_hash` was actually missing, breaking `gbrain import` on every file for two nights running before `gbrain init --migrate-only` surfaced and healed it. Full repro steps in #4421.

## Review
Multi-model review via `/review:self-multi-model` (class=medium). Codex (gpt-5.6-sol, effort=medium) found 0 Critical, 1 Warning — applied: the new check's message claimed "despite schema_version reporting up to date" unconditionally, which would be misleading on a genuinely-behind DB (missing columns there are expected from not-yet-run migrations, not drift). Now gated on `schemaVersion >= LATEST_VERSION`.

## Test plan
- [x] `bun run typecheck` clean
- [x] New unit tests for `detectMissingColumns()`: positive control (reproduces the exact gbrain#4421 drift), negative control (all columns present), and the not-yet-migrated-table edge case — `test/schema-verify.test.ts`
- [x] `bun run verify` (54 structural checks) green, including the `doctor-categories` drift guard for the new `schema_columns` check name
- [x] Targeted doctor tests (`doctor-brain-checks-score`, `doctor-categories`, `schema-verify`, `doctor-cause-rank`) — 49/49 pass
- [x] Multi-model review (Codex, medium effort) completed, finding applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7J95erpMkRsTEjKh3fniW