### PR TITLE
fix(enrich): make durable skip markers survive a clean tick, not just this run (#3629)

### DIFF
--- a/src/commands/enrich.ts
+++ b/src/commands/enrich.ts
@@ -179,6 +179,15 @@ export function enrichFingerprint(opts: {
   order: EnrichOrder;
   thinThreshold: number;
   model: string;
+  /** #3629: durable skip markers now survive across clean runs (see
+   *  runEnrichCore), so a `minContextChars` change MUST mint a new
+   *  fingerprint — otherwise a page durably skip-marked under a strict
+   *  threshold stays wrongly suppressed after the caller relaxes it, since
+   *  `minContextChars` is exactly what assessGrounding's pre-LLM gate
+   *  decides against. Optional + defaulted (not required) so existing call
+   *  sites that never pass it keep resolving to the same fingerprint
+   *  runEnrichCore already computes for its own default. */
+  minContextChars?: number;
 }): string {
   return fingerprint({
     sourceId: opts.sourceId,
@@ -186,6 +195,7 @@ export function enrichFingerprint(opts: {
     order: opts.order,
     thinThreshold: opts.thinThreshold,
     model: opts.model,
+    minContextChars: opts.minContextChars ?? MIN_CONTEXT_CHARS,
   });
 }
 
@@ -195,6 +205,33 @@ function checkpointKey(fp: string): OpCheckpointKey {
 
 function completedKey(sourceId: string, slug: string): string {
   return `${sourceId}|${slug}`;
+}
+
+/**
+ * #3629: a distinct marker (stored alongside, never instead of, the plain
+ * `completedKey`) for a page whose grounding was judged genuinely
+ * insufficient — the pre-LLM `assessGrounding` gate, or an explicit
+ * model-side SKIP verdict. It is intentionally NOT written for a blank/
+ * unparseable synthesis output (`pages_empty_output`): that's a synthesis
+ * FAILURE shape (transient — a flaky call, malformed output), not a
+ * grounding verdict, and durably suppressing retries for it would trade one
+ * bug (re-billing a permanently-insufficient page) for a different one
+ * (never retrying a page that failed for an unrelated, possibly transient,
+ * reason). `pending` filtering (below) only ever checks the plain
+ * `completedKey`, so this marker's sole job is answering "does the
+ * checkpoint currently believe ANY candidate is durably insufficient?" —
+ * the signal `runEnrichCore` uses to decide whether a clean run's checkpoint
+ * is safe to clear. Checking the full persisted `done` set (loaded via
+ * `loadOpCheckpoint`, unbounded by this tick's `LIMIT`ed candidate window)
+ * rather than only this tick's freshly-processed pages is what makes the
+ * fix correct when a permanently-insufficient page falls outside the
+ * current tick's ranked/limited candidate window (a higher-priority page
+ * occupies the slot instead) — see #3629 for the field repro.
+ */
+const SKIP_MARK_PREFIX = 'skip:';
+
+function skipMarkerKey(sourceId: string, slug: string): string {
+  return `${SKIP_MARK_PREFIX}${completedKey(sourceId, slug)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -361,7 +398,10 @@ async function enrichOneLocked(ctx: EnrichOneCtx, candidate: EnrichCandidate): P
   if (!grounding.grounded) {
     ctx.result.pages_skipped_insufficient++;
     ctx.result.pages_skipped_pre_llm = (ctx.result.pages_skipped_pre_llm ?? 0) + 1;
-    if (!ctx.dryRun) ctx.done.add(completedKey(sourceId, slug));
+    if (!ctx.dryRun) {
+      ctx.done.add(completedKey(sourceId, slug));
+      ctx.done.add(skipMarkerKey(sourceId, slug)); // #3629: durable — never re-billed until --force
+    }
     return;
   }
 
@@ -392,12 +432,18 @@ async function enrichOneLocked(ctx: EnrichOneCtx, candidate: EnrichCandidate): P
     // #2085 split: an explicit SKIP is a grounding verdict; blank output (or a
     // body that strips to nothing) is a synthesis failure shape. parseSynthesis
     // reports skip=true for blank raw too, so discriminate on the raw text.
+    let isModelSkip = false;
     if (parsed.skip && (raw ?? '').trim().length > 0) {
       ctx.result.pages_model_skip = (ctx.result.pages_model_skip ?? 0) + 1;
+      isModelSkip = true;
     } else {
       ctx.result.pages_empty_output = (ctx.result.pages_empty_output ?? 0) + 1;
     }
     ctx.done.add(completedKey(sourceId, slug));
+    // #3629: only an explicit model SKIP is a durable grounding verdict — a
+    // blank/unparseable output is a synthesis failure shape (see the
+    // skipMarkerKey doc comment) and stays eligible for retry next tick.
+    if (isModelSkip) ctx.done.add(skipMarkerKey(sourceId, slug));
     return;
   }
 
@@ -491,11 +537,16 @@ export async function runEnrichCore(
   result.candidates_considered = candidates.length;
   if (candidates.length === 0) return result;
 
-  const fp = enrichFingerprint({ sourceId, types, order, thinThreshold, model });
+  const fp = enrichFingerprint({ sourceId, types, order, thinThreshold, model, minContextChars });
   const cpKey = checkpointKey(fp);
 
   const body = async () => {
-    if (opts.force) await clearOpCheckpoint(engine, cpKey);
+    // #3629: force-clearing must still respect dryRun's "no checkpoint
+    // advance" contract (see EnrichCoreOpts.dryRun doc) — `--dry-run --force`
+    // together previously wiped a REAL checkpoint (including durable skip
+    // markers from a prior real run) as an unintended side effect of a
+    // preview-only invocation.
+    if (opts.force && !dryRun) await clearOpCheckpoint(engine, cpKey);
     const done = new Set<string>(opts.force ? [] : await loadOpCheckpoint(engine, cpKey));
 
     // Filter out already-completed candidates (resume).
@@ -546,10 +597,37 @@ export async function runEnrichCore(
 
     if (!dryRun) {
       await recordCompleted(engine, cpKey, [...done]);
-      // Clear the checkpoint only on a clean, complete run so an immediate
-      // re-run starts fresh (enriched pages drop out of the thin set anyway).
       if (!pool.aborted && !signal?.aborted) {
-        await clearOpCheckpoint(engine, cpKey);
+        // #3629: a clean, complete run resets the checkpoint to ONLY its
+        // durable skip markers (plus each marker's paired plain completedKey,
+        // which is what `pending` actually checks), dropping everything else
+        // — enriched successes (harmless: they've stopped being thin and
+        // fall out of `candidates` on their own) AND blank/empty-output
+        // completions (NOT harmless to keep: #2085 already classifies a
+        // blank/unparseable model response as a synthesis-failure shape, not
+        // a grounding verdict, so it must stay eligible for retry next tick —
+        // an earlier version of this fix cleared the WHOLE checkpoint or
+        // NONE of it, so a single durable skip anywhere in the run made every
+        // blank-output completion permanent too, by accident).
+        //
+        // `done` here is the FULL persisted set (loaded via `loadOpCheckpoint`
+        // at the top of `body()`, not bounded by this tick's `limit`), so a
+        // skip banked in an earlier tick survives being reset even when the
+        // page it belongs to isn't in this tick's `candidates`/`pending` at
+        // all (a higher-priority candidate occupying the LIMITed window
+        // instead) — the #3629 field repro this fix targets.
+        const skipMarkers = [...done].filter((k) => k.startsWith(SKIP_MARK_PREFIX));
+        if (skipMarkers.length === 0) {
+          await clearOpCheckpoint(engine, cpKey);
+        } else {
+          // recordCompleted is REPLACE (not append) semantics — see its own
+          // doc comment — so re-recording just the trimmed `keep` set here
+          // overwrites the full `completed_keys` array in one UPSERT; no
+          // separate clearOpCheckpoint round-trip needed first.
+          const durableSlugKeys = new Set(skipMarkers.map((k) => k.slice(SKIP_MARK_PREFIX.length)));
+          const keep = [...done].filter((k) => durableSlugKeys.has(k) || k.startsWith(SKIP_MARK_PREFIX));
+          await recordCompleted(engine, cpKey, keep);
+        }
       }
     }
   };

--- a/test/e2e/enrich-pglite.test.ts
+++ b/test/e2e/enrich-pglite.test.ts
@@ -239,6 +239,48 @@ describe('runEnrichCore', () => {
     expect(page!.compiled_truth.trim()).toBe(STUB);
   }, 30000);
 
+  test('#3629: relaxing --min-context after a durable pre-LLM skip re-evaluates the page', async () => {
+    // A durable skip marker (see enrichFingerprint's minContextChars doc
+    // comment) must not outlive the very knob that produced it. A page
+    // rejected by assessGrounding under a strict threshold, then re-run with
+    // a relaxed threshold and no --force, must be evaluated fresh — because
+    // minContextChars is part of enrichFingerprint, the relaxed run computes
+    // a DIFFERENT checkpoint fingerprint, so it never even sees the strict
+    // run's durable marker.
+    await seedStub('people/thin-context', 'Thin Context', 'person');
+    await seedLinkInto('people/thin-context', 'meetings/tc1', RICH_CONTEXT);
+    let calls = 0;
+    const synth: SynthesizeFn = async () => { calls++; return goodSynth({ system: '', user: '', model: 'test:model' }); };
+
+    const strict = await runEnrichCore(engine, {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links',
+      thinThreshold: 400,
+      model: 'test:model',
+      minContextChars: 100_000, // impossibly strict — pre-LLM gate always rejects
+      synthesizeFn: synth,
+    });
+    expect(strict.pages_skipped_insufficient).toBe(1);
+    expect(strict.pages_skipped_pre_llm).toBe(1);
+    expect(calls).toBe(0); // pre-LLM gate — no billing either way
+
+    const relaxed = await runEnrichCore(engine, {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links',
+      thinThreshold: 400,
+      model: 'test:model',
+      minContextChars: 1, // relaxed — same page now passes grounding
+      synthesizeFn: synth,
+    });
+    expect(calls).toBe(1); // re-evaluated under the new threshold, not suppressed
+    expect(relaxed.pages_enriched).toBe(1);
+
+    const page = await engine.getPage('people/thin-context', { sourceId: 'default' });
+    expect(page!.compiled_truth).toContain('## Overview');
+  }, 30000);
+
   test('model returns SKIP → skipped, no write', async () => {
     await seedStub('people/erin-example', 'Erin Example', 'person');
     await seedLinkInto('people/erin-example', 'meetings/sync', RICH_CONTEXT);
@@ -254,6 +296,218 @@ describe('runEnrichCore', () => {
     expect(r.pages_skipped_insufficient).toBe(1);
     const page = await engine.getPage('people/erin-example', { sourceId: 'default' });
     expect(page!.compiled_truth.trim()).toBe(STUB);
+  }, 30000);
+
+  test('#3629: model SKIP verdict is durable across clean ticks — no re-billing', async () => {
+    // Reproduces the autopilot's enrich_thin tick loop: same source/fingerprint,
+    // called repeatedly (every 600s in production). A page with rich enough
+    // context to pass the pre-LLM assessGrounding gate, but whose model call
+    // ALWAYS answers SKIP, must be billed exactly once — not once per tick.
+    await seedStub('people/permanently-thin', 'Permanently Thin', 'person');
+    await seedLinkInto('people/permanently-thin', 'meetings/sync', RICH_CONTEXT);
+    let calls = 0;
+    const alwaysSkip: SynthesizeFn = async () => { calls++; return 'SKIP'; };
+
+    const runOpts = {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links' as const,
+      thinThreshold: 400,
+      model: 'test:model',
+      synthesizeFn: alwaysSkip,
+    };
+
+    const tick1 = await runEnrichCore(engine, runOpts);
+    expect(calls).toBe(1); // billed once — grounding gate passed, model call made
+    expect(tick1.pages_skipped_insufficient).toBe(1);
+    expect(tick1.pages_enriched).toBe(0);
+
+    const tick2 = await runEnrichCore(engine, runOpts);
+    // Pre-fix: clearOpCheckpoint wiped the SKIP verdict on tick 1's clean exit,
+    // so tick 2 re-selected + re-billed the same permanently-insufficient page.
+    expect(calls).toBe(1); // NOT re-billed
+    expect(tick2.pages_enriched).toBe(0);
+    expect(tick2.pages_skipped_insufficient).toBe(0); // nothing processed — filtered by checkpoint
+
+    const tick3 = await runEnrichCore(engine, runOpts);
+    expect(calls).toBe(1); // still not re-billed on a third tick
+
+    const page = await engine.getPage('people/permanently-thin', { sourceId: 'default' });
+    expect(page!.compiled_truth.trim()).toBe(STUB); // never written
+  }, 30000);
+
+  test('#3629: a clean run with no skips still clears the checkpoint (no regression)', async () => {
+    // The old "immediate re-run starts fresh" behavior must survive for the
+    // ordinary happy path: a run that enriches everything with zero
+    // insufficient-context skips clears its checkpoint exactly as before.
+    await seedStub('people/alice-example', 'Alice Example', 'person');
+    await seedLinkInto('people/alice-example', 'meetings/2026-summit', RICH_CONTEXT);
+
+    const fpOpts = {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links' as const,
+      thinThreshold: 400,
+      model: 'test:model',
+    };
+    const r = await runEnrichCore(engine, { ...fpOpts, synthesizeFn: goodSynth });
+    expect(r.pages_enriched).toBe(1);
+    expect(r.pages_skipped_insufficient).toBe(0);
+
+    const fp = enrichFingerprint(fpOpts);
+    const done = await loadOpCheckpoint(engine, { op: CHECKPOINT_OP, fingerprint: fp });
+    expect(done).toEqual([]); // cleared on clean, all-enriched completion
+  }, 30000);
+
+  test('#3629: a permanently-SKIP page outside this tick\'s LIMIT window is still not re-billed', async () => {
+    // Deeper regression than the "durable across ticks" test above: here the
+    // permanently-insufficient page falls OUTSIDE the current tick's ranked +
+    // LIMITed candidate window (a higher-priority page occupies the one slot
+    // instead), so `pages_skipped_insufficient` reads 0 and the page is absent
+    // from BOTH `candidates` and `pending` for that tick. A fix that infers
+    // "any carried-forward skip?" from `candidates.length > pending.length`
+    // (bounded by this tick's LIMIT) misses this — the checkpoint gets
+    // cleared anyway and the page is re-billed once it re-enters the window.
+    // The fix must key off the FULL persisted checkpoint instead.
+    await seedStub('people/never-grounds', 'Never Grounds', 'person');
+    await seedLinkInto('people/never-grounds', 'meetings/ng1', RICH_CONTEXT); // 1 inbound
+    await seedStub('people/late-riser', 'Late Riser', 'person'); // 0 inbound — ranks below
+
+    const calls: Record<string, number> = { 'never-grounds': 0, 'late-riser': 0 };
+    const synth: SynthesizeFn = async ({ user }) => {
+      if (user.includes('Never Grounds')) { calls['never-grounds']++; return 'SKIP'; }
+      calls['late-riser']++;
+      return '## Overview\nLate Riser joined the team. [Source: meetings/lr1]';
+    };
+
+    const runOpts = {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links' as const,
+      thinThreshold: 400,
+      limit: 1, // forces the LIMIT-window race: only the top-ranked candidate is queried
+      model: 'test:model',
+      synthesizeFn: synth,
+    };
+
+    // Tick 1: never-grounds (1 inbound) outranks late-riser (0 inbound) → the
+    // only candidate this tick. It gets a model SKIP verdict — billed once.
+    const tick1 = await runEnrichCore(engine, runOpts);
+    expect(tick1.candidates_considered).toBe(1);
+    expect(calls['never-grounds']).toBe(1);
+    expect(calls['late-riser']).toBe(0);
+
+    // Promote late-riser above never-grounds (2 inbound > 1) and give it
+    // enough context to pass grounding, so it wins the LIMIT=1 slot next tick
+    // and never-grounds isn't even returned by listEnrichCandidates.
+    await seedLinkInto('people/late-riser', 'meetings/lr1', RICH_CONTEXT);
+    await seedLinkInto('people/late-riser', 'meetings/lr2', RICH_CONTEXT);
+
+    // Tick 2: late-riser occupies the single slot and enriches successfully.
+    // never-grounds is outside this tick's candidate window entirely.
+    const tick2 = await runEnrichCore(engine, runOpts);
+    expect(tick2.candidates_considered).toBe(1);
+    expect(calls['never-grounds']).toBe(1); // not queried this tick — can't be re-billed here
+    expect(calls['late-riser']).toBe(1);
+    expect(tick2.pages_enriched).toBe(1);
+
+    // Tick 3: late-riser is no longer thin (enriched) and drops out of the
+    // candidate query entirely, so never-grounds is the only candidate again.
+    // The money assertion: it must NOT be re-billed — the durable skip marker
+    // from tick 1 must have survived tick 2's clean, all-enriched completion.
+    const tick3 = await runEnrichCore(engine, runOpts);
+    expect(tick3.candidates_considered).toBe(1);
+    expect(calls['never-grounds']).toBe(1); // still exactly once across 3 ticks
+    expect(tick3.pages_enriched).toBe(0);
+
+    const page = await engine.getPage('people/never-grounds', { sourceId: 'default' });
+    expect(page!.compiled_truth.trim()).toBe(STUB); // never written
+  }, 30000);
+
+  test('#3629: a durable skip elsewhere in the checkpoint does not permanently suppress an unrelated blank-output page', async () => {
+    // A blank/unparseable synthesis response is a synthesis-FAILURE shape
+    // (#2085 splits it from an explicit model SKIP — see pages_empty_output
+    // vs pages_model_skip), not a grounding verdict, so it must stay eligible
+    // for retry next tick. An earlier version of this fix made the
+    // clear-vs-keep decision checkpoint-WIDE (all-or-nothing): as soon as ANY
+    // page in the run got a durable skip marker, the entire checkpoint
+    // stopped clearing — which accidentally made every OTHER page's plain
+    // completedKey permanent too, including blank-output pages that were
+    // never meant to be durably suppressed.
+    await seedStub('people/never-grounds', 'Never Grounds', 'person');
+    await seedLinkInto('people/never-grounds', 'meetings/ng1', RICH_CONTEXT);
+    await seedStub('people/flaky-output', 'Flaky Output', 'person');
+    await seedLinkInto('people/flaky-output', 'meetings/fo1', RICH_CONTEXT);
+
+    let flakyCalls = 0;
+    const synth: SynthesizeFn = async ({ user }) => {
+      if (user.includes('Never Grounds')) return 'SKIP'; // durable
+      flakyCalls++;
+      return flakyCalls === 1 ? '' : goodSynth({ system: '', user: '', model: 'test:model' }); // blank once, then recovers
+    };
+
+    const runOpts = {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links' as const,
+      thinThreshold: 400,
+      model: 'test:model',
+      synthesizeFn: synth,
+    };
+
+    const tick1 = await runEnrichCore(engine, runOpts);
+    expect(tick1.pages_model_skip).toBe(1); // never-grounds — durable
+    expect(tick1.pages_empty_output).toBe(1); // flaky-output — NOT durable
+    expect(flakyCalls).toBe(1);
+
+    // Tick 2: flaky-output must be retried (its blank-output completedKey was
+    // dropped, not carried forward with never-grounds's durable skip marker)
+    // and this time succeeds.
+    const tick2 = await runEnrichCore(engine, runOpts);
+    expect(flakyCalls).toBe(2); // retried
+    expect(tick2.pages_enriched).toBe(1);
+    const flaky = await engine.getPage('people/flaky-output', { sourceId: 'default' });
+    expect(flaky!.compiled_truth).toContain('## Overview');
+
+    // never-grounds must still be untouched by all of this — its own skip
+    // marker survived tick 1 → tick 2 unaffected by flaky-output's retry.
+    const never = await engine.getPage('people/never-grounds', { sourceId: 'default' });
+    expect(never!.compiled_truth.trim()).toBe(STUB);
+  }, 30000);
+
+  test('#3629: dry-run + force must not clear a real checkpoint (no destructive preview)', async () => {
+    // EnrichCoreOpts.dryRun is documented as "no checkpoint advance". Before
+    // this fix, `if (opts.force) await clearOpCheckpoint(...)` ran BEFORE the
+    // dryRun check — a `--dry-run --force` preview silently destroyed a REAL
+    // checkpoint (including durable skip markers), re-exposing an already-
+    // resolved permanently-insufficient page to billing on the next real run.
+    await seedStub('people/never-grounds', 'Never Grounds', 'person');
+    await seedLinkInto('people/never-grounds', 'meetings/ng1', RICH_CONTEXT);
+    const skipSynth: SynthesizeFn = async () => 'SKIP';
+
+    const fpOpts = {
+      sourceId: 'default',
+      types: ['person'],
+      order: 'inbound-links' as const,
+      thinThreshold: 400,
+      model: 'test:model',
+    };
+    await runEnrichCore(engine, { ...fpOpts, synthesizeFn: skipSynth });
+    const fp = enrichFingerprint(fpOpts);
+    const beforeDryRun = await loadOpCheckpoint(engine, { op: CHECKPOINT_OP, fingerprint: fp });
+    expect(beforeDryRun.length).toBeGreaterThan(0); // the real run's skip marker is persisted
+
+    let dryRunCalled = false;
+    await runEnrichCore(engine, {
+      ...fpOpts,
+      dryRun: true,
+      force: true,
+      synthesizeFn: async () => { dryRunCalled = true; return 'should not run'; },
+    });
+    expect(dryRunCalled).toBe(false); // dryRun's "no LLM call" contract holds even under --force
+
+    const afterDryRun = await loadOpCheckpoint(engine, { op: CHECKPOINT_OP, fingerprint: fp });
+    expect(afterDryRun).toEqual(beforeDryRun); // untouched by the dry-run + force preview
   }, 30000);
 
   test('resume: pre-seeded checkpoint skips an already-completed page', async () => {


### PR DESCRIPTION
## Summary

`enrich_thin` re-billed the same permanently-insufficient candidate pages on every 600s autopilot tick. Root cause was not the billing *order* (the model-side SKIP verdict is inherently post-call — it can't be known before `synthesizeFn` returns), it was checkpoint **durability**: `clearOpCheckpoint()` ran unconditionally on any clean run, wiping the pre-LLM `assessGrounding` rejection or model-side SKIP verdict every tick, so the next tick re-selected and re-billed the exact same pages. Reported field impact: 107 runs / 7 days, $3.56 spent, 0 pages enriched (~$15/mo for zero output).

## Fix

- A durable `skip:` marker is added to the checkpoint (alongside the existing plain completedKey used for resume) at exactly two sites: the pre-LLM grounding rejection, and an **explicit model-side SKIP verdict**. A blank/unparseable model response is deliberately excluded — `#2085` already classifies that as a synthesis-failure shape, not a grounding verdict, so it stays retryable.
- A clean run's checkpoint reset now keeps only the durable subset (each skip marker + its paired completedKey) instead of an all-or-nothing clear, checked against the **full persisted checkpoint** — not this tick's `limit`-bounded candidate window, which can miss an already-skipped page entirely when a higher-ranked candidate occupies its slot.
- `minContextChars` is now part of the checkpoint fingerprint, since it's exactly the knob the pre-LLM gate decides against — a durable skip must not outlive the threshold that produced it.
- `--dry-run --force` no longer destroys a real checkpoint (`dryRun`'s own doc comment says "no checkpoint advance"; the force-clear now checks `!dryRun` too).

## Known, deliberately deferred limitation

A durably-skip-marked page whose ranking never drops below the SQL `LIMIT` window stays unreachable to lower-ranked candidates — same as on master today. This fix does not worsen that; it only stops the re-billing. The issue's own verified-collaborator comment frames the real fix for that ("checkpoint-aware selection with a decay/TTL window consulted by `listEnrichCandidates` itself") as the *better long-term* option requiring an engine-parity change across both `pglite-engine.ts` and `postgres-engine.ts` — out of scope for this minimal fix.

## Tests

Six new tests in `test/e2e/enrich-pglite.test.ts`:
- durable skip survives 3 consecutive clean ticks (no re-billing)
- durable skip survives a `limit=1` ranking shift that hides the page from the current tick's candidate window entirely
- a durable skip elsewhere in the checkpoint does not permanently suppress an unrelated blank-output page
- `--dry-run --force` leaves a real checkpoint untouched
- relaxing `--min-context` after a durable pre-LLM skip re-evaluates the page fresh (positive-controlled: reverted the fingerprint change locally, confirmed this test goes red, restored)
- the ordinary happy path (all-enriched, zero skips) still clears the checkpoint exactly as before

## Verification

- `bun run typecheck` — clean
- `bun test test/e2e/enrich-pglite.test.ts` — 22 pass / 0 fail
- `bun test` across the broader enrich suites — 102 pass / 0 fail
- `bun run check:module-size` / `bun run check:structural-manifest` — OK

Adversarially reviewed over 4 rounds (Codex, effort=high): round 1 caught a checkpoint-clearing off-by-one-tick bug in an earlier version of this fix; round 2 caught the LIMIT-window durability gap and a blank-output over-suppression bug; round 3 caught the missing `minContextChars` fingerprint dimension. Round 4: clean, MERGE verdict.

Fixes #3629.
