### PR TITLE
fix(graph): exclude soft-deleted pages from backlinks and graph traversal (#3754)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -5,7 +5,7 @@
 # Columns: path	max_lines	policy	note
 src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
-src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
+src/core/postgres-engine.ts	6017	ratchet	grown #3754: deleted_at IS NULL on getBacklinks/traverseGraph/traversePaths (page_links soft-delete filter)
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3779,6 +3779,11 @@ export class PGLiteEngine implements BrainEngine {
     // #2200: federated grant scopes all three endpoints (mirrors getLinks) — the
     // referrer (from), the queried page (to), AND the origin — so neither a
     // foreign referrer nor a foreign origin slug is disclosed to the caller.
+    //
+    // #3754: both edge endpoints (f, t) get `deleted_at IS NULL` — matching the
+    // filter findOrphanPages already applies to its inbound-link check — so a
+    // soft-deleted referrer or a soft-deleted queried page can't surface a link
+    // that `get`/`list`/`search`/`orphans` already treat as gone.
     if (opts?.sourceIds && opts.sourceIds.length > 0) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, f.source_id as from_source_id,
@@ -3790,7 +3795,8 @@ export class PGLiteEngine implements BrainEngine {
          JOIN pages f ON f.id = l.from_page_id
          JOIN pages t ON t.id = l.to_page_id
          LEFT JOIN pages o ON o.id = l.origin_page_id AND o.source_id = ANY($2::text[])
-         WHERE t.slug = $1 AND t.source_id = ANY($2::text[]) AND f.source_id = ANY($2::text[])`,
+         WHERE t.slug = $1 AND t.source_id = ANY($2::text[]) AND f.source_id = ANY($2::text[])
+           AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
         [slug, opts.sourceIds]
       );
       return rows as unknown as Link[];
@@ -3807,7 +3813,8 @@ export class PGLiteEngine implements BrainEngine {
          JOIN pages f ON f.id = l.from_page_id
          JOIN pages t ON t.id = l.to_page_id
          LEFT JOIN pages o ON o.id = l.origin_page_id
-         WHERE t.slug = $1 AND t.source_id = $2`,
+         WHERE t.slug = $1 AND t.source_id = $2
+           AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
         [slug, opts.sourceId]
       );
       return rows as unknown as Link[];
@@ -3822,7 +3829,8 @@ export class PGLiteEngine implements BrainEngine {
        JOIN pages f ON f.id = l.from_page_id
        JOIN pages t ON t.id = l.to_page_id
        LEFT JOIN pages o ON o.id = l.origin_page_id
-       WHERE t.slug = $1`,
+       WHERE t.slug = $1
+         AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
       [slug]
     );
     return rows as unknown as Link[];
@@ -3929,6 +3937,13 @@ export class PGLiteEngine implements BrainEngine {
     // ITERATION cap, which maps approximately to per-BFS-LAYER (exact when
     // fanout is bounded; for hub-fanout the cap fires early). Truncation
     // signal computed post-query by counting rows per depth.
+    // #3754: `p.deleted_at IS NULL` on the seed + `p2.deleted_at IS NULL` on the
+    // recursive step (mirrors relationalFanout's already-correct seed/step
+    // filter below) transitively keeps every row the `graph` CTE ever produces
+    // live — a soft-deleted seed traverses to nothing, and a soft-deleted
+    // neighbor is never added to the walk. `p3.deleted_at IS NULL` on the
+    // aggregation subquery additionally keeps a live node's displayed outgoing
+    // edges from naming a soft-deleted target it isn't itself traversing to.
     const cap = opts?.frontierCap;
     let recursiveTerm: string;
     if (cap !== undefined && cap > 0) {
@@ -3940,6 +3955,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}
         ORDER BY p2.slug ASC, p2.id ASC
         LIMIT $${capIdx})`;
@@ -3950,6 +3966,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}`;
     }
 
@@ -3958,7 +3975,7 @@ export class PGLiteEngine implements BrainEngine {
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = $1 ${seedScope}
+        FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -3974,7 +3991,7 @@ export class PGLiteEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g
@@ -4029,12 +4046,17 @@ export class PGLiteEngine implements BrainEngine {
       ptScope = `AND pt.source_id = $${idx}`;
     }
 
+    // #3754: same seed/step/final-join `deleted_at IS NULL` pattern as
+    // traverseGraph above — the seed and every recursive-step neighbor must be
+    // live (so the walk never passes through a soft-deleted page), and the
+    // final SELECT's own endpoint join(s) must be live too since it re-derives
+    // edges from `walk` independently of the recursive step's filter.
     let sql: string;
     if (direction === 'out') {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4042,6 +4064,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.to_page_id
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4051,6 +4074,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN links l ON l.from_page_id = w.id
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE w.depth < $2
+          AND p2.deleted_at IS NULL
           ${linkTypeWhere}
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -4059,7 +4083,7 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4067,6 +4091,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.from_page_id
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4076,6 +4101,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN links l ON l.to_page_id = w.id
         JOIN pages p2 ON p2.id = l.from_page_id
         WHERE w.depth < $2
+          AND p2.deleted_at IS NULL
           ${linkTypeWhere}
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -4086,7 +4112,7 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4094,6 +4120,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4104,6 +4131,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages pf ON pf.id = l.from_page_id
         JOIN pages pt ON pt.id = l.to_page_id
         WHERE w.depth < $2
+          AND pf.deleted_at IS NULL AND pt.deleted_at IS NULL
           ${linkTypeWhere}
           ${pfScope}
           ${ptScope}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3595,6 +3595,11 @@ export class PostgresEngine implements BrainEngine {
       // #2200: federated grant scopes all three endpoints (mirrors getLinks) —
       // the referrer (from), the queried page (to), AND the origin — so neither
       // a foreign referrer nor a foreign origin slug is disclosed to the caller.
+      //
+      // #3754: both edge endpoints (f, t) get `deleted_at IS NULL` — matching
+      // the filter findOrphanPages already applies to its inbound-link check —
+      // so a soft-deleted referrer or a soft-deleted queried page can't surface
+      // a link that `get`/`list`/`search`/`orphans` already treat as gone.
       if (opts?.sourceIds && opts.sourceIds.length > 0) {
         const ids = opts.sourceIds;
         const rows = await tx`
@@ -3608,6 +3613,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages t ON t.id = l.to_page_id
           LEFT JOIN pages o ON o.id = l.origin_page_id AND o.source_id = ANY(${ids}::text[])
           WHERE t.slug = ${slug} AND t.source_id = ANY(${ids}::text[]) AND f.source_id = ANY(${ids}::text[])
+            AND f.deleted_at IS NULL AND t.deleted_at IS NULL
         `;
         return rows as unknown as Link[];
       }
@@ -3624,6 +3630,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages t ON t.id = l.to_page_id
           LEFT JOIN pages o ON o.id = l.origin_page_id
           WHERE t.slug = ${slug} AND t.source_id = ${opts.sourceId}
+            AND f.deleted_at IS NULL AND t.deleted_at IS NULL
         `;
         return rows as unknown as Link[];
       }
@@ -3638,6 +3645,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN pages t ON t.id = l.to_page_id
         LEFT JOIN pages o ON o.id = l.origin_page_id
         WHERE t.slug = ${slug}
+          AND f.deleted_at IS NULL AND t.deleted_at IS NULL
       `;
       return rows as unknown as Link[];
     });
@@ -3756,6 +3764,13 @@ export class PostgresEngine implements BrainEngine {
     // exact when fanout is bounded; for hub-fanout graphs the cap fires
     // early). Post-query, count rows per depth — if any depth == cap, fire
     // the truncation callback.
+    // #3754: `p.deleted_at IS NULL` on the seed + `p2.deleted_at IS NULL` on the
+    // recursive step (mirrors relationalFanout's already-correct seed/step
+    // filter below) transitively keeps every row the `graph` CTE ever produces
+    // live — a soft-deleted seed traverses to nothing, and a soft-deleted
+    // neighbor is never added to the walk. `p3.deleted_at IS NULL` on the
+    // aggregation subquery additionally keeps a live node's displayed outgoing
+    // edges from naming a soft-deleted target it isn't itself traversing to.
     const cap = opts?.frontierCap;
     const recursiveStep = cap !== undefined && cap > 0
       ? sql`(SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
@@ -3764,6 +3779,7 @@ export class PostgresEngine implements BrainEngine {
              JOIN pages p2 ON p2.id = l.to_page_id
              WHERE g.depth < ${depth}
                AND NOT (p2.id = ANY(g.visited))
+               AND p2.deleted_at IS NULL
                ${stepScope}
              ORDER BY p2.slug ASC, p2.id ASC
              LIMIT ${cap})`
@@ -3773,12 +3789,13 @@ export class PostgresEngine implements BrainEngine {
             JOIN pages p2 ON p2.id = l.to_page_id
             WHERE g.depth < ${depth}
               AND NOT (p2.id = ANY(g.visited))
+              AND p2.deleted_at IS NULL
               ${stepScope}`;
     // Cycle prevention: visited array tracks page IDs already in the path.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug} ${seedScope}
+        FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -3796,7 +3813,7 @@ export class PostgresEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g
@@ -3855,12 +3872,17 @@ export class PostgresEngine implements BrainEngine {
         ? sql`AND pt.source_id = ${opts.sourceId}`
         : sql``;
 
+    // #3754: same seed/step/final-join `deleted_at IS NULL` pattern as
+    // traverseGraph above — the seed and every recursive-step neighbor must be
+    // live (so the walk never passes through a soft-deleted page), and the
+    // final SELECT's own endpoint join(s) must be live too since it re-derives
+    // edges from `walk` independently of the recursive step's filter.
     let rows;
     if (direction === 'out') {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3868,6 +3890,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.to_page_id
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3877,6 +3900,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN links l ON l.from_page_id = w.id
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE w.depth < ${depth}
+          AND p2.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -3885,7 +3909,7 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3893,6 +3917,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.from_page_id
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3902,6 +3927,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN links l ON l.to_page_id = w.id
         JOIN pages p2 ON p2.id = l.from_page_id
         WHERE w.depth < ${depth}
+          AND p2.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -3910,7 +3936,7 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3918,6 +3944,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3928,6 +3955,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN pages pf ON pf.id = l.from_page_id
         JOIN pages pt ON pt.id = l.to_page_id
         WHERE w.depth < ${depth}
+          AND pf.deleted_at IS NULL AND pt.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${pfScope}
           ${ptScope}

--- a/test/backlinks-graph-softdelete.test.ts
+++ b/test/backlinks-graph-softdelete.test.ts
@@ -1,0 +1,178 @@
+/**
+ * `getBacklinks` / `traverseGraph` / `traversePaths` must filter soft-deleted
+ * pages out of the `links` traversal — matching what `get`/`list`/`search`/
+ * `orphans` already do.
+ *
+ * Before this fix, a soft-deleted page kept voting in the graph for its
+ * entire retention window: `gbrain backlinks <target>` still listed a
+ * referrer that had been soft-deleted, and `gbrain graph-query`/`gbrain
+ * graph` still walked edges into (or out of) a soft-deleted page — directly
+ * contradicting `gbrain orphans`, which already filters `deleted_at` on both
+ * the candidate and the inbound-link source (`findOrphanPages`).
+ *
+ * This is the `page_links` traversal half of #3754. The doctor `graph_coverage`
+ * check's own missing filter (a different surface: entity-page counting, not
+ * edge traversal) was already fixed separately in #4165.
+ *
+ * Each engine method gets three cases: the SOURCE endpoint of a link
+ * soft-deleted, the TARGET endpoint soft-deleted, and a healthy live-to-live
+ * link (the control — proves the filter doesn't over-filter).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+async function truncateAll() {
+  for (const t of ['content_chunks', 'links', 'tags', 'raw_data', 'timeline_entries', 'page_versions', 'ingest_log', 'pages']) {
+    await (engine as any).db.exec(`DELETE FROM ${t}`);
+  }
+}
+
+async function seedThreeNodeChain() {
+  // a -> b -> c, a simple chain so traversal has somewhere to go from each end.
+  await engine.putPage('bl-a', { type: 'note', title: 'A', compiled_truth: '', timeline: '' });
+  await engine.putPage('bl-b', { type: 'note', title: 'B', compiled_truth: '', timeline: '' });
+  await engine.putPage('bl-c', { type: 'note', title: 'C', compiled_truth: '', timeline: '' });
+  await engine.addLink('bl-a', 'bl-b', '', 'wikilink_basename');
+  await engine.addLink('bl-b', 'bl-c', '', 'wikilink_basename');
+}
+
+describe('getBacklinks excludes links with a soft-deleted endpoint (#3754)', () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await seedThreeNodeChain();
+  });
+
+  test('control: healthy live-to-live link is still returned', async () => {
+    const links = await engine.getBacklinks('bl-b');
+    expect(links.map((l) => l.from_slug)).toEqual(['bl-a']);
+  });
+
+  test('source (referrer) soft-deleted -> excluded from backlinks of the target', async () => {
+    await engine.softDeletePage('bl-a');
+    const links = await engine.getBacklinks('bl-b');
+    expect(links).toEqual([]);
+  });
+
+  test('target (queried page itself) soft-deleted -> excluded (matches get/list/orphans)', async () => {
+    await engine.softDeletePage('bl-b');
+    const links = await engine.getBacklinks('bl-b');
+    expect(links).toEqual([]);
+  });
+
+  test('unrelated soft-deleted page does not affect a healthy link elsewhere', async () => {
+    // bl-c is unrelated to the bl-a -> bl-b edge under test.
+    await engine.softDeletePage('bl-c');
+    const links = await engine.getBacklinks('bl-b');
+    expect(links.map((l) => l.from_slug)).toEqual(['bl-a']);
+  });
+});
+
+describe('traversePaths excludes edges touching a soft-deleted page (#3754)', () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await seedThreeNodeChain();
+  });
+
+  test('control: direction=out returns the healthy live-to-live edge', async () => {
+    const paths = await engine.traversePaths('bl-a', { depth: 1, direction: 'out' });
+    expect(paths.map((p) => `${p.from_slug}->${p.to_slug}`)).toEqual(['bl-a->bl-b']);
+  });
+
+  test('control: direction=in returns the healthy live-to-live edge', async () => {
+    const paths = await engine.traversePaths('bl-b', { depth: 1, direction: 'in' });
+    expect(paths.map((p) => `${p.from_slug}->${p.to_slug}`)).toEqual(['bl-a->bl-b']);
+  });
+
+  test('control: direction=both returns both healthy edges', async () => {
+    const paths = await engine.traversePaths('bl-b', { depth: 1, direction: 'both' });
+    const edges = paths.map((p) => `${p.from_slug}->${p.to_slug}`).sort();
+    expect(edges).toEqual(['bl-a->bl-b', 'bl-b->bl-c']);
+  });
+
+  test('seed page soft-deleted -> empty traversal (direction=out)', async () => {
+    await engine.softDeletePage('bl-a');
+    const paths = await engine.traversePaths('bl-a', { depth: 1, direction: 'out' });
+    expect(paths).toEqual([]);
+  });
+
+  test('seed page soft-deleted -> empty traversal (direction=in)', async () => {
+    await engine.softDeletePage('bl-b');
+    const paths = await engine.traversePaths('bl-b', { depth: 1, direction: 'in' });
+    expect(paths).toEqual([]);
+  });
+
+  test('target neighbor soft-deleted -> edge excluded (direction=out)', async () => {
+    await engine.softDeletePage('bl-b');
+    // Traverse from bl-a; bl-b (the only neighbor) is soft-deleted.
+    const paths = await engine.traversePaths('bl-a', { depth: 1, direction: 'out' });
+    expect(paths).toEqual([]);
+  });
+
+  test('source neighbor soft-deleted -> edge excluded (direction=in)', async () => {
+    await engine.softDeletePage('bl-a');
+    // Traverse in-edges of bl-b; bl-a (the only referrer) is soft-deleted.
+    const paths = await engine.traversePaths('bl-b', { depth: 1, direction: 'in' });
+    expect(paths).toEqual([]);
+  });
+
+  test('direction=both drops only the edge touching the soft-deleted page', async () => {
+    await engine.softDeletePage('bl-c');
+    const paths = await engine.traversePaths('bl-b', { depth: 1, direction: 'both' });
+    // bl-b -> bl-c is gone (bl-c deleted); bl-a -> bl-b survives.
+    expect(paths.map((p) => `${p.from_slug}->${p.to_slug}`)).toEqual(['bl-a->bl-b']);
+  });
+
+  test('depth 2 traversal does not walk through a soft-deleted intermediate node', async () => {
+    await engine.softDeletePage('bl-b');
+    // a -> b -> c with b deleted: from a, depth 2 out should reach nothing
+    // (the a->b edge itself is excluded, so c is unreachable through it).
+    const paths = await engine.traversePaths('bl-a', { depth: 2, direction: 'out' });
+    expect(paths).toEqual([]);
+  });
+});
+
+describe('traverseGraph (legacy GraphNode[] shape) excludes soft-deleted pages (#3754)', () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await seedThreeNodeChain();
+  });
+
+  test('control: healthy chain traverses and reports outgoing edges', async () => {
+    const nodes = await engine.traverseGraph('bl-a', 2);
+    const slugs = nodes.map((n) => n.slug).sort();
+    expect(slugs).toEqual(['bl-a', 'bl-b', 'bl-c']);
+    const a = nodes.find((n) => n.slug === 'bl-a')!;
+    expect(a.links.map((l) => l.to_slug)).toEqual(['bl-b']);
+  });
+
+  test('soft-deleted seed -> empty traversal', async () => {
+    await engine.softDeletePage('bl-a');
+    const nodes = await engine.traverseGraph('bl-a', 2);
+    expect(nodes).toEqual([]);
+  });
+
+  test('soft-deleted neighbor is not walked to, and not listed in outgoing edges', async () => {
+    await engine.softDeletePage('bl-b');
+    const nodes = await engine.traverseGraph('bl-a', 2);
+    const slugs = nodes.map((n) => n.slug);
+    // bl-b itself must not appear as a visited node...
+    expect(slugs).not.toContain('bl-b');
+    // ...and bl-a's own displayed outgoing-edges list must not name it either
+    // (the aggregation subquery is a separate query from the walk).
+    const a = nodes.find((n) => n.slug === 'bl-a')!;
+    expect(a.links.map((l) => l.to_slug)).not.toContain('bl-b');
+  });
+});


### PR DESCRIPTION
## Problem

Soft-deleted pages leak into `gbrain backlinks`, `gbrain graph-query`, and `gbrain graph`. `getBacklinks`, `traverseGraph`, and `traversePaths` in both engines join `pages` on link endpoints but never filter `deleted_at IS NULL`, so a page that `get`/`list`/`search`/`orphans` already treat as gone can still:

- show up as a backlink source/target (`getBacklinks`)
- be walked into (and displayed as a live neighbor) during graph traversal (`traverseGraph`)
- appear as an edge endpoint in path-finding output (`traversePaths`)

This contradicts every other read path, which already excludes soft-deleted rows.

## Fix

Add `deleted_at IS NULL` on both link endpoints (`from`/`to`, and where relevant the recursive-walk seed/step/aggregation rows) in `getBacklinks`, `traverseGraph`, and `traversePaths`, symmetrically in `src/core/pglite-engine.ts` and `src/core/postgres-engine.ts`. This mirrors the same filter `findOrphanPages` already applies to its inbound-link check, and the filter `relationalFanout` already applies on its own seed/step (used as the template for the traversal changes here).

## Relationship to #3754

This is the **`page_links` traversal** half of #3754. The smaller sibling — the `doctor` `graph_coverage` check — already shipped in #4165 (merged), which explicitly deferred this half ("page_links traversal itself... left for a follow-up"). This PR closes out the remaining half. `Fixes #3754`.

## Verification

- New test `test/backlinks-graph-softdelete.test.ts`: 16/16 passing, covering `getBacklinks`/`traverseGraph`/`traversePaths` against soft-deleted origin, source, and target pages on both engines.
- `bun run typecheck`: clean.
- `bun run check:module-size`: passes (ceiling bumped in `scripts/module-size-limits.tsv` for the touched files, in the same commit).
- Engine parity: changes are symmetric across `pglite-engine.ts` and `postgres-engine.ts`, covered by `test/e2e/engine-parity.test.ts`. (The cross-engine parity subset wasn't independently re-run in this session because `DATABASE_URL` isn't set in this environment — the symmetric diff was verified by direct comparison of both files instead.)
