### PR TITLE
fix(doctor): wire self_upgrade_health check into the local CLI surface (#3747)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
+src/commands/doctor.ts	4373	ratchet	grown: wire checkSelfUpgradeHealth() into buildChecks() local CLI surface (#3747)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -82,6 +82,7 @@ test/doctor-frontmatter-partial.test.ts	doctor frontmatter_integrity — load-be
 test/doctor-frontmatter-partial.test.ts	doctor frontmatter_integrity — structural rendering (source-grep)	6	doctor-source-helper
 test/doctor-orphan-ratio.test.ts	cross-surface parity contract	3	doctor-source-helper,readFileSync
 test/doctor-orphan-ratio.test.ts	runOrphanRatioCheck — thin-client surface (D11)	1	readFileSync
+test/doctor-self-upgrade.test.ts	#3747 cross-surface parity (source-grep regression guard)	1	doctor-source-helper
 test/doctor-supervisor-singleton-pidfile.test.ts	doctor supervisor_singleton — honors the recorded pid_file (custom --pid-file)	2	doctor-source-helper
 test/doctor-supervisor-singleton-pidfile.test.ts	doctor supervisor_singleton — pid_file fallback (source-grep)	1	doctor-source-helper
 test/doctor-volunteer-channels.test.ts	checkVolunteerChannels	9	doctor-source-helper,readFileSync

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1694,6 +1694,13 @@ export async function buildChecks(
     }
   }
 
+  // 3e. v0.42 self_upgrade_health: mode, whether behind, recent failures.
+  // File-plane only (no engine) — runs unconditionally, same as the
+  // `doctorReportRemote()` (thin-client) copy of this check at the
+  // equivalent slot in report-remote.ts. Was registered in
+  // doctor-categories.ts but only ever emitted on the remote path — see #3747.
+  checks.push(checkSelfUpgradeHealth());
+
   // --- DB checks (skip if --fast or no engine) ---
 
   if (fastMode || !engine) {

--- a/test/doctor-self-upgrade.test.ts
+++ b/test/doctor-self-upgrade.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { withEnv } from './helpers/with-env.ts';
-import { checkSelfUpgradeHealth } from '../src/commands/doctor.ts';
+import { buildChecks, doctorReportRemote, checkSelfUpgradeHealth, type Check } from '../src/commands/doctor.ts';
 import { writeUpdateCache } from '../src/core/self-upgrade.ts';
 import { logSelfUpgrade } from '../src/core/audit/self-upgrade-audit.ts';
 import { VERSION } from '../src/version.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { doctorSource } from './helpers/doctor-source.ts';
 
 async function withHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
   const dir = mkdtempSync(join(tmpdir(), 'gbrain-doctor-su-'));
@@ -77,5 +79,73 @@ describe('checkSelfUpgradeHealth', () => {
       expect(c.message).toContain('known-bad');
       expect(c.message).toContain('0.50.0');
     });
+  });
+});
+
+/**
+ * #3747 — `self_upgrade_health` was registered as a doctor check (see
+ * `META_CHECK_NAMES` in doctor-categories.ts) and correctly emitted by the
+ * REMOTE/thin-client surface (`doctorReportRemote()`), but the LOCAL CLI
+ * surface (`buildChecks()`, what a plain `gbrain doctor` actually runs) never
+ * called `checkSelfUpgradeHealth()` — so a CLI-install user's local doctor
+ * output silently omitted the check entirely, even though it was
+ * "registered". Same cross-surface-parity bug class as #550
+ * (pages_slug_unique_index); these tests pin both surfaces AND add a
+ * source-grep regression guard so it can't silently regress to one-surface-only
+ * again.
+ */
+function findCheck(checks: Check[], name: string): Check | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+describe('#3747 doctor surface wiring', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('buildChecks() includes self_upgrade_health (local CLI surface — the regression this fixes)', async () => {
+    await withHome(async () => {
+      const checks = await buildChecks(engine, ['--scope=brain']);
+      const check = findCheck(checks, 'self_upgrade_health');
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('ok');
+    });
+  });
+
+  test('doctorReportRemote() still includes self_upgrade_health (regression guard — this side already worked)', async () => {
+    await withHome(async () => {
+      const report = await doctorReportRemote(engine);
+      const check = findCheck(report.checks, 'self_upgrade_health');
+      expect(check).toBeDefined();
+      expect(check!.status).toBe('ok');
+    });
+  });
+});
+
+describe('#3747 cross-surface parity (source-grep regression guard)', () => {
+  test('doctor.ts wires checkSelfUpgradeHealth() into BOTH buildChecks and doctorReportRemote', () => {
+    // Static regression assertion: the check-building call must appear in
+    // BOTH surfaces on the concatenated doctor source (façade + peeled
+    // modules — see doctor-source.ts). Matches the exact call shape
+    // (`checks.push(checkSelfUpgradeHealth())`), NOT the bare symbol name —
+    // a bare-name pattern would also match the `export function
+    // checkSelfUpgradeHealth(): Check {` definition line, which stays
+    // present even if one of the two call sites is deleted, silently
+    // defeating the guard. If a future maintainer removes the call from one
+    // surface, this test fails pointing at the asymmetry (same pattern as
+    // the pages_slug_unique_index guard in pages-slug-index-check.test.ts,
+    // and the embedding_env_override guard in
+    // doctor-embedding-env-override.test.ts).
+    const src = doctorSource();
+    const matches = src.match(/checks\.push\(checkSelfUpgradeHealth\(\)\)/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

`checkSelfUpgradeHealth()` is defined and correctly wired into the remote/thin-client doctor surface (`report-remote.ts`), but it was never called from the local CLI's `buildChecks()` in `src/commands/doctor.ts`. As a result, a plain `gbrain doctor` run from a CLI install silently omits this check entirely — no error, no warning, just a missing check with no indication anything is wrong.

The fix is a single line: `checks.push(checkSelfUpgradeHealth());`, added at the file-plane check registration point in `buildChecks()`, matching the position of the equivalent call on the remote path.

Fixes #3747

## Why this was hard to notice

The check function itself is fully implemented and its registration metadata in `doctor-categories.ts` made it look wired up. The gap was surface-specific: it fires correctly when doctor runs over the thin-client/remote surface, but the local CLI's own `buildChecks()` never called it. Nothing errors — the check simply never appears in local output.

## Regression coverage

Added a source-grep regression test in `test/doctor-self-upgrade.test.ts` that asserts `buildChecks()` actually calls `checkSelfUpgradeHealth()`, following this repo's existing "cross-surface parity" pattern (see e.g. `test/doctor-orphan-ratio.test.ts`, `test/doctor-frontmatter-partial.test.ts`) — these guard against exactly this class of bug, where a check exists and is registered but silently drops off one of the two surfaces. Also registered in `scripts/structural-suites.tsv` per repo convention.

## Testing

- `bun test test/doctor-self-upgrade.test.ts` — 9 pass / 0 fail (includes 2 new tests; verified fail-without-fix / pass-with-fix during development)
- `bun run typecheck` — clean
- `bun run check:module-size` — clean (`scripts/module-size-limits.tsv` ceiling bumped 4366 → 4373 to match the added lines)