### PR TITLE
fix(embed): retry embed batches on timeout with a fresh signal budget (#3374)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -21,7 +21,7 @@ src/commands/extract.ts	2066	ratchet	lowered: timeline extractor hoisted to core
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2016	ratchet	grown v0.46.24.0 overnight wave: embedding_plane_split named error (#4287)
 src/core/cycle/synthesize.ts	2702	ratchet	merged: five-issue wave + dream-wave C7 peel + C8 manifest + C9 mode/telemetry/backfill + adversarial fix batches
-src/commands/embed.ts	2046	ratchet	grown v0.46.25.0 delegated wave (#3971)
+src/commands/embed.ts	2122	ratchet	grown v0.46.25.0 fix waves: timeout-aware embed retry via embedBatchWithBackoff (#3374)
 src/core/types.ts	1882	ratchet	grown v0.46.22.0 phone wave: supersession rerank result fields + effective-date page filters (#4056 #4389)
 src/commands/skillpack.ts	1360	ratchet
 src/core/minions/queue.ts	2138	ratchet	grown by #4078 subagent-loop capability fix

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1811,6 +1811,15 @@ async function embedAllStale(
  * v0.33.3: rate-limit-aware embedBatch wrapper.
  * #3966: also retries transient gateway errors (502/503/504) that NIM and
  * similar providers emit under sustained bulk load.
+ * #3374: also retries the gateway's own per-attempt `AI_EMBED_TIMEOUT_MS`
+ * abort (a `TimeoutError`). Each retry re-enters `embedBatch` with
+ * `maxRetries: 0`, which re-enters the gateway's `embedSubBatch` — and that
+ * builds a FRESH `withDefaultTimeout()` / `AbortSignal.timeout()` on every
+ * call (see gateway.ts). So each retry attempt gets its own full timeout
+ * window rather than sharing one; the AI SDK's own internal retries (the
+ * bug this wrapper exists to route around — see `embedBatch(...,
+ * {maxRetries: 0})` below) run all their attempts inside a SINGLE
+ * `_embedTransport` call, and therefore a SINGLE timeout window.
  *
  * The OpenAI SDK has built-in retry with exponential backoff, but its
  * backoff window (max ~4s) is too short for TPM (tokens-per-minute)
@@ -1831,8 +1840,13 @@ async function embedAllStale(
  *     sleep wakes up early AND the abortSignal is threaded into the gateway
  *     embed call so an in-flight HTTP request cancels too.
  *
- * Up to MAX_RATE_LIMIT_RETRIES attempts with the parsed (jittered) delay
- * (or a 60s fallback when the message can't be parsed).
+ * Up to MAX_RATE_LIMIT_RETRIES attempts. Rate-limit/gateway retries sleep
+ * the parsed (jittered) Retry-After delay (or a 60s fallback when the
+ * message can't be parsed); timeout retries (#3374) sleep a short fixed
+ * jittered delay instead (see `timeoutRetryDelayMs` — a timeout message
+ * carries no Retry-After hint, so reusing `parseRetryDelayMs` there would
+ * silently take the 60s fallback and recreate the shared-budget symptom
+ * this fix removes).
  *
  * @internal Exported for unit tests; not part of the public surface.
  */
@@ -1903,6 +1917,47 @@ export function parseRetryDelayMs(msg: string, rng: () => number = Math.random):
 }
 
 /**
+ * Walk the cause chain looking for a `TimeoutError` name — what
+ * `AbortSignal.timeout()` produces when it fires (Node/the AI SDK surface
+ * it as `{ name: 'TimeoutError', message: 'The operation timed out.' }`).
+ * The gateway's `normalizeAIError` wraps this in `AITransientError` with
+ * the original on `.cause` (same shape `detect429FromCause` walks), so this
+ * mirrors that helper rather than inspecting `e.name` directly (#3374).
+ *
+ * @internal exported for unit tests.
+ */
+export function detectTimeoutFromCause(e: unknown): boolean {
+  let cur: unknown = e;
+  for (let depth = 0; depth < 5 && cur !== undefined && cur !== null; depth++) {
+    const obj = cur as { name?: unknown; cause?: unknown };
+    if (obj.name === 'TimeoutError') return true;
+    cur = obj.cause;
+  }
+  return false;
+}
+
+/**
+ * Bounded jittered backoff before a timeout-classified retry (#3374).
+ * Deliberately distinct from `parseRetryDelayMs`: a client-side
+ * `AI_EMBED_TIMEOUT_MS` abort carries no "try again in Xms" hint, so
+ * parsing it with `parseRetryDelayMs` would silently take the 60s
+ * `RATE_LIMIT_FALLBACK_MS` path — burning most of a fresh retry's value on
+ * a sleep instead of the request itself. The actual fix for a timeout is
+ * that the retried attempt gets its OWN fresh timeout window (gateway.ts's
+ * `withDefaultTimeout` builds a new `AbortSignal.timeout()` on every
+ * `embedSubBatch` call), so the pre-retry sleep here only needs to be long
+ * enough to avoid hammering a possibly-still-slow backend.
+ *
+ * @internal exported for unit tests.
+ */
+export const TIMEOUT_RETRY_DELAY_MS = 250;
+
+export function timeoutRetryDelayMs(rng: () => number = Math.random): number {
+  const jitterFactor = 1 + (rng() * 2 - 1) * RATE_LIMIT_JITTER;
+  return Math.max(1, Math.floor(TIMEOUT_RETRY_DELAY_MS * jitterFactor));
+}
+
+/**
  * Sleep for `ms` milliseconds. Resolves early (not rejects) when `signal`
  * fires, so the retry loop's caller can re-check `signal.aborted` and
  * exit cleanly without an unhandled rejection.
@@ -1943,12 +1998,15 @@ export async function embedBatchWithBackoff(
     } catch (e: unknown) {
       // If the budget fired we may have been aborted mid-fetch; bubble out.
       if (signal?.aborted) throw e;
-      const msg = e instanceof Error ? e.message : String(e);
-      if (!isEmbedRetriableError(e) || attempt === MAX_RATE_LIMIT_RETRIES) throw e;
+      const cls = classifyEmbedRetryError(e);
+      if (!cls || attempt === MAX_RATE_LIMIT_RETRIES) throw e;
 
-      const delayMs = parseRetryDelayMs(msg);
-      // One label for every retriable class — 429 and gateway blips share the loop.
-      serr(`  [embed-retry] attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES}, waiting ${delayMs}ms...`);
+      // #3374: timeout retries use a short fixed backoff (the fresh
+      // per-attempt timeout window is the fix, not the sleep); rate-limit
+      // and gateway-overload retries use the parsed Retry-After delay.
+      const msg = e instanceof Error ? e.message : String(e);
+      const delayMs = cls === 'timeout' ? timeoutRetryDelayMs() : parseRetryDelayMs(msg);
+      serr(`  [embed-retry] attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES} (${cls}), waiting ${delayMs}ms...`);
       await abortableSleep(delayMs, signal);
     }
   }
@@ -1957,20 +2015,35 @@ export async function embedBatchWithBackoff(
 }
 
 /**
- * Retriable embed errors: 429 rate limits plus transient gateway overload
- * (502/503/504). Shared by embedBatchWithBackoff (retry decision) and
+ * Classify a thrown embed error for retry purposes: 429 rate limits,
+ * transient gateway overload (502/503/504), or a SDK-internal per-attempt
+ * timeout (#3374 — `AI_EMBED_TIMEOUT_MS` firing via `withDefaultTimeout`).
+ * Returns `null` for anything else (non-retriable). Shared by
+ * embedBatchWithBackoff (retry decision + backoff strategy) and
  * embedPageTexts (fan-out decision). D4: structured detection first
  * (gateway-wrapped errors via cause chain); message-match as fallback for
- * providers whose wrappers strip `cause.status`.
+ * providers whose wrappers strip `cause.status`/`cause.name`.
+ *
+ * @internal exported for unit tests.
+ */
+export function classifyEmbedRetryError(e: unknown): 'rate_limit' | 'gateway' | 'timeout' | null {
+  const msg = e instanceof Error ? e.message : String(e);
+  if (detect429FromCause(e) || /rate.?limit|429/i.test(msg)) return 'rate_limit';
+  if (detectGatewayErrorFromCause(e) || /bad gateway|502|503|504|service unavailable|gateway timeout/i.test(msg)) {
+    return 'gateway';
+  }
+  if (detectTimeoutFromCause(e) || /\btimed out\b/i.test(msg)) return 'timeout';
+  return null;
+}
+
+/**
+ * Retriable embed errors: 429 rate limits, transient gateway overload
+ * (502/503/504), and SDK-internal per-attempt timeouts (#3374). Thin
+ * boolean wrapper over `classifyEmbedRetryError` for call sites that only
+ * need the yes/no decision.
  */
 function isEmbedRetriableError(e: unknown): boolean {
-  const msg = e instanceof Error ? e.message : String(e);
-  return (
-    detect429FromCause(e) ||
-    detectGatewayErrorFromCause(e) ||
-    /rate.?limit|429/i.test(msg) ||
-    /bad gateway|502|503|504|service unavailable|gateway timeout/i.test(msg)
-  );
+  return classifyEmbedRetryError(e) !== null;
 }
 
 /** Walk the cause chain (like detect429FromCause) for the first HTTP status. */
@@ -1996,8 +2069,11 @@ function statusFromCause(e: unknown): number | undefined {
  * costs one chunk.
  *
  * Cost bounding — when we do NOT fan out (rethrow instead):
- *   - 429 / rate limit: embedBatchWithBackoff already retried with backoff;
- *     fanning out N single-chunk calls would hammer the same limiter N-fold.
+ *   - 429 / rate limit, gateway overload (502/503/504), or a SDK-internal
+ *     per-attempt timeout (#3374): embedBatchWithBackoff already retried
+ *     with backoff (a fresh timeout window per retry, in the timeout case);
+ *     fanning out N single-chunk calls would either hammer the same limiter
+ *     N-fold or re-hit the same slow/degraded backend N times over.
  *   - AITransientError (5xx / network / unknown, per normalizeAIError): the
  *     batch CONTENT isn't the problem, so isolation can't help — during an
  *     outage it would just multiply failing calls per page.

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -9,7 +9,14 @@ import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION }
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { planEmbeddingReuse } from './embed-reuse.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
-import { embedBatch, embedMultimodal, currentEmbeddingSignature } from './embedding.ts';
+import { embedMultimodal, currentEmbeddingSignature } from './embedding.ts';
+// #3374: both embed call sites below route through embedBatchWithBackoff
+// (not the raw gatewayEmbed embedBatch) so a transient failure — 429,
+// gateway overload, or the gateway's own AI_EMBED_TIMEOUT_MS abort — gets
+// a genuine retry with a FRESH per-attempt timeout budget instead of
+// sharing one timeout window across the AI SDK's internal retry attempts.
+// Same pattern src/core/embed-stale.ts already uses for embed --stale.
+import { embedBatchWithBackoff } from '../commands/embed.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath, hasMalformedPathSegment } from './sync.ts';
 import type { ChunkInput, PageInput, PageType } from './types.ts';
 import { computeEffectiveDate } from './effective-date.ts';
@@ -819,7 +826,7 @@ export async function importFromContent(
     const wrappedTexts = prefix
       ? chunks.map((c) => wrapChunkForEmbedding(c.chunk_text, prefix, c.chunk_source))
       : chunks.map((c) => c.chunk_text);
-    const embeddings = await embedBatch(wrappedTexts);
+    const embeddings = await embedBatchWithBackoff(wrappedTexts);
     for (let i = 0; i < chunks.length; i++) {
       chunks[i].embedding = embeddings[i];
       // token_count tracks the wrapped string length so cost reporting
@@ -1413,7 +1420,7 @@ export async function importCodeFile(
   if (!opts.noEmbed && needsEmbedIndexes.length > 0) {
     try {
       const textsToEmbed = needsEmbedIndexes.map((i) => chunks[i]!.chunk_text);
-      const embeddings = await embedBatch(textsToEmbed);
+      const embeddings = await embedBatchWithBackoff(textsToEmbed);
       for (let j = 0; j < needsEmbedIndexes.length; j++) {
         const i = needsEmbedIndexes[j]!;
         chunks[i]!.embedding = embeddings[j]!;

--- a/test/gateway-embed-timeout-fresh-signal.test.ts
+++ b/test/gateway-embed-timeout-fresh-signal.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #3374 — regression guard for the architectural property the fix depends
+ * on: each `embed()` call builds its OWN abort signal via
+ * `withDefaultTimeout()` inside `embedSubBatch` (src/core/ai/gateway.ts),
+ * not a shared/memoized one.
+ *
+ * gateway.ts itself is UNCHANGED by this fix — this file doesn't test new
+ * behavior, it pins the pre-existing behavior that makes the fix safe. The
+ * issue's "There is no per-attempt vs. overall-deadline tradeoff here"
+ * section argues that a fresh per-attempt signal already exists for
+ * `gbrain embed` / `embed --stale` (which route through
+ * `embedBatchWithBackoff`); nothing in the test suite pinned that claim
+ * before this fix, so a future gateway change could silently make attempt
+ * 2's signal reuse or inherit attempt 1's — which would quietly turn
+ * `embedBatchWithBackoff`'s retries back into the shared-budget bug this
+ * issue reports, without any test catching it.
+ *
+ * Uses the existing `__setEmbedTransportForTests` seam (same pattern as
+ * test/gateway-embed-model-override.test.ts) rather than mock.module, so
+ * this file does NOT need the *.serial.test.ts quarantine.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  configureGateway,
+  embed,
+  resetGateway,
+  __setEmbedTransportForTests,
+} from '../src/core/ai/gateway.ts';
+
+const seenSignals: (AbortSignal | undefined)[] = [];
+
+beforeEach(() => {
+  seenSignals.length = 0;
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-small',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-test' },
+  });
+  __setEmbedTransportForTests(async ({ values, abortSignal }: any) => {
+    seenSignals.push(abortSignal);
+    return {
+      embeddings: values.map(() => new Array(1536).fill(0)),
+      usage: { tokens: 0 },
+    } as any;
+  });
+});
+
+afterEach(() => {
+  __setEmbedTransportForTests(null);
+  resetGateway();
+});
+
+describe('gateway embed() — per-attempt timeout signal freshness (#3374)', () => {
+  test('two sequential embed() calls each receive a DISTINCT AbortSignal instance', async () => {
+    // This is what embedBatchWithBackoff's retry loop actually does: each
+    // retry attempt is a separate embedBatch(...) call, which re-enters
+    // embed() -> embedSubBatch() -> a fresh withDefaultTimeout() here.
+    await embed(['first attempt text']);
+    await embed(['second attempt text']);
+
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals[0]).toBeInstanceOf(AbortSignal);
+    expect(seenSignals[1]).toBeInstanceOf(AbortSignal);
+    // A shared/reused signal object here would BE the shared-budget bug
+    // #3374 reports (all attempts bounded by one outer deadline).
+    expect(seenSignals[0]).not.toBe(seenSignals[1]);
+  });
+
+  test('neither call\'s signal starts pre-aborted — each attempt gets a live budget', async () => {
+    await embed(['a']);
+    await embed(['b']);
+
+    for (const s of seenSignals) {
+      expect(s?.aborted).toBe(false);
+    }
+  });
+
+  test('attempt 2 is unaffected by attempt 1 having already failed/aborted', async () => {
+    // Simulate the retry-driven shape: attempt 1's transport call fails
+    // (its signal is irrelevant to what attempt 2 gets, since attempt 2
+    // is a wholly separate embed() call — this is precisely what makes
+    // embedBatchWithBackoff's retries "fresh budget" rather than
+    // "shared budget").
+    let call = 0;
+    __setEmbedTransportForTests(async ({ values, abortSignal }: any) => {
+      call++;
+      seenSignals.push(abortSignal);
+      if (call === 1) {
+        throw Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+      }
+      return { embeddings: values.map(() => new Array(1536).fill(0)), usage: { tokens: 0 } } as any;
+    });
+
+    await expect(embed(['x'])).rejects.toThrow(/timed out/i);
+    const v = await embed(['x']);
+
+    expect(v).toHaveLength(1);
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals[0]).not.toBe(seenSignals[1]);
+    expect(seenSignals[1]?.aborted).toBe(false);
+  });
+});

--- a/test/import-file-embed-retry.serial.test.ts
+++ b/test/import-file-embed-retry.serial.test.ts
@@ -1,0 +1,337 @@
+/**
+ * #3374 — import embed path: SDK-internal retries share one
+ * AI_EMBED_TIMEOUT_MS budget, so transient timeouts on large pages were
+ * never actually retried.
+ *
+ * Two gaps the issue identified:
+ *   1. `import-file.ts`'s two embed call sites used the raw `embedBatch`
+ *      (gatewayEmbed passthrough), so retries were SDK-internal — all
+ *      attempts run inside ONE `_embedTransport` call, bounded by ONE
+ *      `withDefaultTimeout(..., AI_EMBED_TIMEOUT_MS)` signal. Fix: route
+ *      both call sites through `embedBatchWithBackoff` (src/commands/embed.ts),
+ *      same as `src/core/embed-stale.ts` already does for `embed --stale`.
+ *      Each wrapper-driven retry is a SEPARATE `embedBatch(..., {maxRetries:
+ *      0})` call, and the gateway's `embedSubBatch` builds a FRESH
+ *      `withDefaultTimeout()` / `AbortSignal.timeout()` on every call (see
+ *      src/core/ai/gateway.ts) — so each retry gets its own timeout window.
+ *   2. `embedBatchWithBackoff`'s retry predicate was 429/5xx-only — a
+ *      timeout-classified failure fell through to `throw e` on attempt 1,
+ *      so even a wrapper-routed caller wouldn't have retried it. Fix:
+ *      `classifyEmbedRetryError` now also recognizes the gateway's
+ *      `TimeoutError` (structural cause-chain walk + message fallback,
+ *      mirroring the existing 429/gateway detectors) and retries it with a
+ *      short jittered backoff (`timeoutRetryDelayMs`) instead of
+ *      `parseRetryDelayMs`'s 60s rate-limit fallback.
+ *
+ * This file mocks `../src/core/embedding.ts` (mock.module — hence
+ * `*.serial.test.ts`, same pattern as test/embed.serial.test.ts) so it can
+ * simulate a first-attempt timeout and observe how many times the mocked
+ * `embedBatch` primitive gets called, with what options, and how long the
+ * retry takes to resolve.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+// ────────────────────────────────────────────────────────────────
+// Mock core/embedding.ts BEFORE importing import-file.ts / embed.ts, so
+// both pick up the mocked embedBatch. embedBatchWithBackoff (commands/
+// embed.ts) calls this same `embedBatch` internally, so mocking it here
+// intercepts both the direct test calls AND import-file.ts's calls that
+// route through the wrapper.
+// ────────────────────────────────────────────────────────────────
+let totalEmbedCalls = 0;
+let lastEmbedBatchOpts: unknown = undefined;
+let embedBatchBehavior: ((texts: string[], opts?: unknown) => Promise<Float32Array[]>) | null = null;
+
+mock.module('../src/core/embedding.ts', () => ({
+  embedBatch: async (texts: string[], opts?: unknown) => {
+    totalEmbedCalls++;
+    lastEmbedBatchOpts = opts;
+    if (embedBatchBehavior) return embedBatchBehavior(texts, opts);
+    return texts.map(() => new Float32Array(1536));
+  },
+  embedMultimodal: async () => {
+    throw new Error('embedMultimodal should not be invoked by these text-only fixtures');
+  },
+  currentEmbeddingSignature: () => 'test:model:1536',
+}));
+
+// Import AFTER mocking.
+const { importFromContent, importCodeFile } = await import('../src/core/import-file.ts');
+const {
+  embedBatchWithBackoff,
+  classifyEmbedRetryError,
+  detectTimeoutFromCause,
+  MAX_RATE_LIMIT_RETRIES,
+} = await import('../src/commands/embed.ts');
+
+/** A TimeoutError-shaped error matching what the gateway actually throws
+ * (normalizeAIError wraps the raw DOMException in AITransientError, with
+ * the original — carrying `name: 'TimeoutError'` — preserved on `.cause`).
+ * Message matches the production evidence quoted in #3374:
+ * "[embed(openai:text-embedding-3-small)] The operation timed out." */
+function makeTimeoutError(): Error {
+  const raw = Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+  const wrapped = new Error('[embed(openai:text-embedding-3-small)] The operation timed out.');
+  (wrapped as { cause?: unknown }).cause = raw;
+  wrapped.name = 'AITransientError';
+  return wrapped;
+}
+
+// Proxy-based mock engine — same shape as test/import-file.test.ts's mockEngine.
+function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
+  const calls: { method: string; args: any[] }[] = [];
+  const pageStore = new Map<string, any>();
+  const track = (method: string) => (...args: any[]) => {
+    calls.push({ method, args });
+    if (overrides[method]) return overrides[method](...args);
+    return Promise.resolve(null);
+  };
+  const engine = new Proxy({} as any, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (prop === 'getTags') return overrides.getTags || (() => Promise.resolve([]));
+      if (prop === 'getPage') {
+        return async (slug: string, opts?: { sourceId?: string }) => {
+          if (overrides.getPage) {
+            const overrideResult = await overrides.getPage(slug, opts);
+            if (overrideResult) {
+              const stored = pageStore.get(slug);
+              return stored ? { ...overrideResult, content_hash: stored.content_hash } : overrideResult;
+            }
+          }
+          return pageStore.get(slug) ?? null;
+        };
+      }
+      if (prop === 'putPage') {
+        return async (slug: string, page: any, _opts?: { sourceId?: string }) => {
+          calls.push({ method: 'putPage', args: [slug, page, _opts] });
+          if (overrides.putPage) overrides.putPage(slug, page, _opts);
+          pageStore.set(slug, {
+            slug,
+            content_hash: page.content_hash ?? '',
+            title: page.title ?? '',
+            type: page.type ?? '',
+            frontmatter: page.frontmatter ?? {},
+          });
+          return Promise.resolve(undefined);
+        };
+      }
+      if (prop === 'transaction') return async (fn: (tx: BrainEngine) => Promise<any>) => fn(engine);
+      return track(prop);
+    },
+  });
+  return engine;
+}
+
+beforeEach(() => {
+  totalEmbedCalls = 0;
+  lastEmbedBatchOpts = undefined;
+  embedBatchBehavior = null;
+});
+
+afterEach(() => {
+  embedBatchBehavior = null;
+});
+
+// ────────────────────────────────────────────────────────────────
+// Gap 1: import-file.ts's two call sites now route through
+// embedBatchWithBackoff, so a first-attempt timeout is retried instead of
+// propagating immediately.
+// ────────────────────────────────────────────────────────────────
+
+describe('importFromContent (markdown path) — embed retry routing', () => {
+  test('a first-attempt timeout is retried and the import succeeds', async () => {
+    embedBatchBehavior = async (texts) => {
+      if (totalEmbedCalls === 1) throw makeTimeoutError();
+      return texts.map(() => new Float32Array(1536));
+    };
+    const engine = mockEngine();
+    const content = [
+      '---',
+      'title: Retry Test',
+      '---',
+      '',
+      'This body is long enough to produce at least one real chunk of text',
+      'for the recursive chunker to embed, so the embed call site actually fires.',
+    ].join('\n');
+
+    const result = await importFromContent(engine, 'retry-test/markdown', content, {});
+
+    expect(result.status).toBe('imported');
+    // Two embedBatch invocations: attempt 1 (timeout) + attempt 2 (success).
+    // Proves import-file.ts is no longer calling raw embedBatch once and
+    // propagating — it's going through the retrying wrapper.
+    expect(totalEmbedCalls).toBe(2);
+  });
+
+  test('every retry attempt disables the AI SDK\'s own internal retries (maxRetries: 0)', async () => {
+    // Guards against the "double-retrying" failure mode a reviewer would
+    // flag: if the wrapper's outer retry loop did NOT pass maxRetries:0,
+    // each of ITS attempts would ALSO trigger the SDK's up-to-3-attempt
+    // internal stack, multiplying retries (5 wrapper attempts x 3 SDK
+    // attempts = 15, per the D4a doc comment in commands/embed.ts).
+    embedBatchBehavior = async (texts) => {
+      if (totalEmbedCalls === 1) throw makeTimeoutError();
+      return texts.map(() => new Float32Array(1536));
+    };
+    const engine = mockEngine();
+    await importFromContent(engine, 'retry-test/maxretries', [
+      '---',
+      'title: MaxRetries Test',
+      '---',
+      '',
+      'Body text long enough to chunk and embed for this assertion to run.',
+    ].join('\n'), {});
+
+    expect(lastEmbedBatchOpts).toBeDefined();
+    expect((lastEmbedBatchOpts as { maxRetries?: number }).maxRetries).toBe(0);
+  });
+
+  test('a persistently timing-out backend exhausts retries and the error still propagates (Codex C2: no silent drop)', async () => {
+    embedBatchBehavior = async () => {
+      throw makeTimeoutError();
+    };
+    const engine = mockEngine();
+    const content = [
+      '---',
+      'title: Exhausted Retries',
+      '---',
+      '',
+      'Body text long enough to chunk and embed for this assertion to run.',
+    ].join('\n');
+
+    await expect(importFromContent(engine, 'retry-test/exhausted', content, {})).rejects.toThrow(/timed out/i);
+    // MAX_RATE_LIMIT_RETRIES retries + the initial attempt = bounded, not infinite.
+    expect(totalEmbedCalls).toBe(MAX_RATE_LIMIT_RETRIES + 1);
+  });
+});
+
+describe('importCodeFile (code path) — embed retry routing', () => {
+  test('a first-attempt timeout is retried and the file imports with embeddings intact', async () => {
+    embedBatchBehavior = async (texts) => {
+      if (totalEmbedCalls === 1) throw makeTimeoutError();
+      return texts.map(() => new Float32Array(1536));
+    };
+    const engine = mockEngine();
+    const src = [
+      'export function retryTarget(a: number, b: number): number {',
+      '  // A body with enough substance to produce a real chunk.',
+      '  let total = 0;',
+      '  for (let i = 0; i < a; i++) { total += b; }',
+      '  return total;',
+      '}',
+    ].join('\n');
+
+    const result = await importCodeFile(engine, 'src/retry-target.ts', src, {});
+
+    expect(result.status).toBe('imported');
+    expect(totalEmbedCalls).toBe(2);
+  });
+
+  test('a persistently timing-out backend exhausts retries; importCodeFile keeps its existing swallow-and-warn contract', async () => {
+    // importCodeFile wraps its embed call in a try/catch that warns and
+    // continues (unlike importFromContent, which propagates) — that
+    // existing design choice is untouched by this fix. We only assert the
+    // retry count is bounded, not that the behavior on exhaustion changed.
+    embedBatchBehavior = async () => {
+      throw makeTimeoutError();
+    };
+    const engine = mockEngine();
+    const src = [
+      'export function neverEmbeds(x: number): number {',
+      '  return x * 2;',
+      '}',
+    ].join('\n');
+
+    const result = await importCodeFile(engine, 'src/never-embeds.ts', src, {});
+
+    expect(result.status).toBe('imported'); // swallow-and-warn: import still succeeds
+    expect(totalEmbedCalls).toBe(MAX_RATE_LIMIT_RETRIES + 1);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────
+// Gap 2: embedBatchWithBackoff's retry predicate now covers
+// timeout-classified errors, with a distinct (short) backoff from the
+// rate-limit path's parsed Retry-After / 60s fallback.
+// ────────────────────────────────────────────────────────────────
+
+describe('classifyEmbedRetryError / detectTimeoutFromCause (#3374 predicate widening)', () => {
+  test('a TimeoutError on the cause chain classifies as "timeout"', () => {
+    expect(detectTimeoutFromCause(makeTimeoutError())).toBe(true);
+    expect(classifyEmbedRetryError(makeTimeoutError())).toBe('timeout');
+  });
+
+  test('a bare (unwrapped) TimeoutError-named error also classifies as "timeout" (no .cause needed)', () => {
+    const e = Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+    // No .cause here — detectTimeoutFromCause checks the object itself at
+    // depth 0 before walking into .cause, so this needs no nesting.
+    expect(detectTimeoutFromCause(e)).toBe(true);
+    expect(classifyEmbedRetryError(e)).toBe('timeout');
+  });
+
+  test('a wrapper that strips .cause.name still classifies via the message fallback', () => {
+    // Mirrors the existing 429/gateway detectors' documented fallback for
+    // "providers whose wrappers strip cause.status" — here the wrapper
+    // strips cause.name instead, leaving only the message text.
+    const e = new Error('[embed(local:custom-model)] The operation timed out.');
+    (e as { cause?: unknown }).cause = { message: 'The operation timed out.' }; // no .name
+    expect(detectTimeoutFromCause(e)).toBe(false);
+    expect(classifyEmbedRetryError(e)).toBe('timeout');
+  });
+
+  test('429 / gateway-overload errors keep their prior classification (unaffected by the timeout addition)', () => {
+    const rateLimited = new Error('Rate limit reached. Please try again in 10ms.');
+    (rateLimited as { cause?: unknown }).cause = { status: 429 };
+    expect(classifyEmbedRetryError(rateLimited)).toBe('rate_limit');
+
+    const gateway = new Error('Bad Gateway');
+    (gateway as { cause?: unknown }).cause = { status: 502 };
+    expect(classifyEmbedRetryError(gateway)).toBe('gateway');
+  });
+
+  test('an unrelated permanent error still classifies as null (non-retriable, unchanged)', () => {
+    expect(classifyEmbedRetryError(new Error('Invalid request: unsupported model'))).toBeNull();
+    expect(detectTimeoutFromCause(new Error('Invalid request: unsupported model'))).toBe(false);
+  });
+
+  test('a deep cause-chain wrap still resolves (defensive depth walk, same bound as detect429FromCause)', () => {
+    const deep = { cause: { cause: { name: 'TimeoutError' } } };
+    expect(detectTimeoutFromCause(deep)).toBe(true);
+  });
+});
+
+describe('embedBatchWithBackoff — timeout retries use a short bounded backoff, not the 60s rate-limit fallback', () => {
+  test('a single timeout retry resolves well under the 60s rate-limit fallback window', async () => {
+    let calls = 0;
+    embedBatchBehavior = async () => {
+      calls++;
+      if (calls === 1) throw makeTimeoutError();
+      return [new Float32Array(1536)];
+    };
+    const t0 = Date.now();
+    const result = await embedBatchWithBackoff(['x']);
+    const elapsed = Date.now() - t0;
+
+    expect(calls).toBe(2);
+    expect(result).toHaveLength(1);
+    // parseRetryDelayMs's unparseable-message fallback is 60s; timeoutRetryDelayMs
+    // is a few hundred ms. A generous 5s ceiling proves we took the short path.
+    expect(elapsed).toBeLessThan(5000);
+  });
+
+  test('a wall-clock abort during a timeout retry sleep wakes up early (same abort contract as the rate-limit path)', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    embedBatchBehavior = async (_texts, opts) => {
+      calls++;
+      expect((opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal).toBe(controller.signal);
+      if (calls === 1) throw makeTimeoutError();
+      return [new Float32Array(1536)];
+    };
+    setTimeout(() => controller.abort(), 10);
+    await expect(embedBatchWithBackoff(['x'], { abortSignal: controller.signal })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`import-file.ts` has two embed call sites that call `embedBatch` directly instead
of the retry-aware `embedBatchWithBackoff` wrapper. That wrapper already exists
specifically to route around a bug in the AI SDK's own internal retry: all of
the SDK's internal retry attempts run inside a single `_embedTransport` call,
and therefore share a single timeout window (see the existing `#3966` comment
in `embed.ts` for the 502/503/504 case this wrapper was built for).

A slow-but-healthy large-page embed that times out on attempt 1 currently gets
no real retry with a fresh timeout budget — it just fails.

**Production evidence (#3374):** a 1106-file nightly import produced 2
file-level timeout errors. Both files succeeded on an immediate manual
re-run with no other changes, confirming these were transient/slow embeds,
not permanently-broken inputs — exactly the case a fresh-timeout retry
should absorb automatically.

## Fix

- Add `detectTimeoutFromCause` (mirrors the existing `detect429FromCause`)
  to recognize the gateway's own `TimeoutError` (from
  `AI_EMBED_TIMEOUT_MS` / `AbortSignal.timeout()`) as a retryable cause.
- Widen `classifyEmbedRetryError` to route timeout errors into the same
  backoff-and-retry path as rate-limit and transient gateway errors.
- Route both `import-file.ts` embed call sites through
  `embedBatchWithBackoff` instead of bare `embedBatch`. Each retry
  re-enters `embedBatch` with `maxRetries: 0`, which re-enters the
  gateway's `embedSubBatch` — and that builds a **fresh**
  `withDefaultTimeout()` / `AbortSignal.timeout()` on every call, so each
  retry attempt gets its own full timeout window instead of inheriting a
  budget already partially consumed by a prior attempt.

## Test coverage

- `test/gateway-embed-timeout-fresh-signal.test.ts` — asserts each retry
  attempt gets a fresh `AbortSignal`/timeout budget rather than a shared
  one.
- `test/import-file-embed-retry.serial.test.ts` — exercises both
  `import-file.ts` call sites through a simulated timeout-then-succeed
  gateway to confirm the retry path is actually wired in (not just
  present in `embed.ts`).

Both files pass locally (16/16). `bun run typecheck` is clean.

## Other changes in this PR

`scripts/module-size-limits.tsv`: bumped the `src/commands/embed.ts`
ratchet ceiling from 2046 to 2122 lines to match the actual line count
after adding `detectTimeoutFromCause` + the widened classifier, per the
repo's module-size-ratchet convention (raise the ceiling in the same
commit as the growth, reviewer-visible).

Fixes #3374