### PR TITLE
fix(sync): promptYesNo resolves the real answer, not always false (#4318)

### DIFF
--- a/src/core/sync-cost-gate.ts
+++ b/src/core/sync-cost-gate.ts
@@ -314,15 +314,27 @@ async function resolveBackfillCapUsd(engine: BrainEngine): Promise<number> {
   }
 }
 
+interface PromptReadline {
+  question(question: string, callback: (answer: string) => void): void;
+  close(): void;
+  on(event: 'close', listener: () => void): unknown;
+}
+
+type PromptReadlineFactory = () => PromptReadline;
+
 /** Interactive [y/N] prompt. Resolves false on non-y answers or EOF. */
-async function promptYesNo(question: string): Promise<boolean> {
+export async function promptYesNo(
+  question: string,
+  createReadline: PromptReadlineFactory = () =>
+    createInterface({ input: process.stdin, output: process.stdout }),
+): Promise<boolean> {
   return new Promise((resolve) => {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes');
-    });
+    const rl = createReadline();
     rl.on('close', () => resolve(false));
+    rl.question(question, (answer) => {
+      resolve(answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes');
+      rl.close();
+    });
   });
 }
 

--- a/test/sync-cost-prompt.test.ts
+++ b/test/sync-cost-prompt.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { promptYesNo } from '../src/core/sync-cost-gate.ts';
+
+class FakeReadline {
+  private closeListeners: Array<() => void> = [];
+  private answerListener?: (answer: string) => void;
+
+  question(_question: string, callback: (answer: string) => void): void {
+    this.answerListener = callback;
+  }
+
+  on(event: 'close', listener: () => void): void {
+    if (event === 'close') this.closeListeners.push(listener);
+  }
+
+  close(): void {
+    for (const listener of this.closeListeners) listener();
+  }
+
+  answer(value: string): void {
+    this.answerListener?.(value);
+  }
+}
+
+function startPrompt(): { prompt: Promise<boolean>; readline: FakeReadline } {
+  const readline = new FakeReadline();
+  return {
+    prompt: promptYesNo('Proceed? [y/N] ', () => readline),
+    readline,
+  };
+}
+
+describe('sync cost-gate promptYesNo', () => {
+  for (const answer of ['y', 'yes', ' Y ', 'YES']) {
+    test(`accepts ${JSON.stringify(answer)} before synchronous close`, async () => {
+      const { prompt, readline } = startPrompt();
+
+      readline.answer(answer);
+
+      expect(await prompt).toBe(true);
+    });
+  }
+
+  for (const answer of ['n', 'no', '', 'anything else']) {
+    test(`rejects ${JSON.stringify(answer)}`, async () => {
+      const { prompt, readline } = startPrompt();
+
+      readline.answer(answer);
+
+      expect(await prompt).toBe(false);
+    });
+  }
+
+  test('closing without input resolves false', async () => {
+    const { prompt, readline } = startPrompt();
+
+    readline.close();
+
+    expect(await prompt).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4318.

## The bug

`promptYesNo` called `rl.close()` **before** `resolve(answer)`. `close()` emits `'close'` synchronously, so the `rl.on('close', () => resolve(false))` listener won the race and settled the Promise as `false` — a Promise only honors its first resolution, so the real typed answer was silently discarded.

Net effect: the interactive `Proceed? [y/N]` cost-gate prompt cancelled on **every** input, including explicit `y`/`yes`. Only `--yes` or a non-TTY session bypassed it.

## Fix

Resolve the parsed answer before closing the readline interface — one-line reorder. Also exports `promptYesNo` with an injectable readline factory so the test suite can reproduce the original race deterministically (a fake readline that emits `close()` synchronously, matching real readline's actual behavior) instead of needing real stdin/stdout.

## Test plan

`test/sync-cost-prompt.test.ts` (new, 9 cases): `y`/`yes` and case/whitespace variants resolve `true`; `n`/`no`/empty/arbitrary input resolves `false`; closing without any input (EOF) resolves `false`. Each test drives the fake readline through the exact synchronous-close sequence that exposed the original bug.

```
bun run typecheck                       # pass
bun run check:module-size               # pass
bun run check:structural-manifest       # pass
bun test test/sync-cost-prompt.test.ts  # 9 pass, 0 fail
bun test test/sync-cost-gate.serial.test.ts  # 9 pass, 0 fail (existing integration coverage, unaffected)
```
