### PR TITLE
fix(storage-config): match db_only prefixes case-insensitively against lowercased slugs

### DIFF
--- a/src/core/storage-config.ts
+++ b/src/core/storage-config.ts
@@ -372,9 +372,24 @@ export const DERIVE_PHASE_DB_ONLY_DEFAULTS: readonly string[] = [
   'dream-cycle-summaries/',
 ];
 
-/** Declared db_only dirs plus the derive-phase defaults, deduped. */
+/**
+ * Declared db_only dirs plus the derive-phase defaults, deduped.
+ *
+ * `declared` is lowercased before the union (issue #3766): its only consumer
+ * (`checkUndeclaredDbOnlyPages`) matches these prefixes against page `slug`
+ * values via a plain `.startsWith()`, and slugs are ALWAYS lowercased at
+ * creation time (`pathToSlug`/`slugifyCodePath` in sync.ts) regardless of the
+ * host filesystem's case sensitivity. Without this, a `storage.db_only`
+ * entry typed with any uppercase (e.g. `Notes/` in gbrain.yml) silently never
+ * matches a single slug and every page under it gets falsely flagged as
+ * undeclared. This is deliberately NOT done in `normalizeAndValidateStorageConfig`
+ * / `loadStorageConfig` — `manageGitignore` (sync.ts) reads that raw,
+ * case-preserved config to write `.gitignore` entries that must match the
+ * REAL on-disk directory name (case-sensitive on Linux); lowercasing there
+ * would break gitignore management instead of fixing this doctor check.
+ */
 export function effectiveDbOnlyDirs(declared: string[]): string[] {
-  return [...new Set([...declared, ...DERIVE_PHASE_DB_ONLY_DEFAULTS])];
+  return [...new Set([...declared.map((d) => d.toLowerCase()), ...DERIVE_PHASE_DB_ONLY_DEFAULTS])];
 }
 
 /**

--- a/test/doctor-silent-death-checks.test.ts
+++ b/test/doctor-silent-death-checks.test.ts
@@ -210,6 +210,62 @@ describe('undeclared_db_only_pages (#2784)', () => {
     expect(c.status).toBe('ok');
   });
 
+  // #3766 — a `storage.db_only` prefix typed with any uppercase (a plausible
+  // authoring choice — nothing in gbrain.yml's schema requires lowercase)
+  // used to never match, because page slugs are ALWAYS lowercased at write
+  // time (pathToSlug/slugifyCodePath) regardless of the host filesystem's
+  // case sensitivity, while the declared prefix was compared verbatim. Every
+  // page under the declared directory was falsely flagged undeclared.
+  test('declared db_only prefix with different case still matches the (always-lowercase) slug', async () => {
+    const repo = makeRepo();
+    writeFileSync(join(repo, 'gbrain.yml'), 'storage:\n  db_only:\n    - Notes/\n');
+    await addSource('src-a', repo);
+    await addPage('notes/db-resident', { sourceId: 'src-a' });
+    const c = await checkUndeclaredDbOnlyPages(engine);
+    expect(c.status).toBe('ok');
+  });
+
+  // False-negative guard for the fix above: a case-insensitive prefix match
+  // must not become a blanket "everything is covered" match. A page under an
+  // UNRELATED directory in the same source (with the same mixed-case
+  // declaration active) must still be flagged exactly as before.
+  test('mixed-case declared prefix does not swallow pages under an unrelated directory', async () => {
+    const repo = makeRepo();
+    writeFileSync(join(repo, 'gbrain.yml'), 'storage:\n  db_only:\n    - Notes/\n');
+    await addSource('src-a', repo);
+    await addPage('notes/db-resident', { sourceId: 'src-a' });
+    await addPage('people/ghost-page', { sourceId: 'src-a' });
+    const c = await checkUndeclaredDbOnlyPages(engine);
+    expect(c.status).toBe('warn');
+    expect(c.message).toContain('people/ghost-page');
+    expect(c.message).not.toContain('notes/db-resident');
+    expect((c.details as any).total).toBe(1);
+  });
+
+  // #3766 literal repro check: the reporter's symptom (a code source
+  // indexing a Next.js App Router repo — bracketed dynamic-route
+  // directories, camelCase filenames — got 225/254 pages falsely flagged).
+  // Code pages (`page_kind: 'code'`) use a different, non-lossy slug scheme
+  // (`slugifyCodePath`, which — unlike the markdown slugifier — intentionally
+  // keeps framework paths like `app/[id]/page.tsx` indexable) and this check
+  // scopes its SQL to `page_kind = 'markdown'` only, so no code page can ever
+  // reach this check's matching logic in the first place. Locks in current
+  // (already-correct) behavior against regression.
+  test('#3766 repro: bracket-route + camelCase code page is never considered (page_kind=code out of scope)', async () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, 'app', 'shop', '[id]'), { recursive: true });
+    writeFileSync(join(repo, 'app', 'shop', '[id]', 'page.tsx'), 'export default function Page() {}');
+    mkdirSync(join(repo, 'components'), { recursive: true });
+    writeFileSync(join(repo, 'components', 'ArchiveButton.tsx'), 'export function ArchiveButton() {}');
+    await addSource('src-a', repo);
+    // Slugs mirror what slugifyCodePath('app/shop/[id]/page.tsx') /
+    // slugifyCodePath('components/ArchiveButton.tsx') actually produce.
+    await addPage('app-shop-id-page-tsx', { sourceId: 'src-a', pageKind: 'code' });
+    await addPage('components-archivebutton-tsx', { sourceId: 'src-a', pageKind: 'code' });
+    const c = await checkUndeclaredDbOnlyPages(engine);
+    expect(c.status).toBe('ok');
+  });
+
   test('page with no backing file outside every db_only path → warn with sample + fix', async () => {
     const repo = makeRepo();
     await addSource('src-a', repo);
@@ -243,6 +299,20 @@ describe('undeclared_db_only_pages (#2784)', () => {
     expect(dirs.filter(d => d === 'atoms/').length).toBe(1);
     expect(dirs).toContain('notes/');
     for (const d of DERIVE_PHASE_DB_ONLY_DEFAULTS) expect(dirs).toContain(d);
+  });
+
+  // #3766 — declared prefixes are lowercased before the union, since the
+  // only consumer (checkUndeclaredDbOnlyPages) matches them against
+  // always-lowercase page slugs. A mixed-case declaration still dedupes
+  // against an already-lowercase default/declaration for the same directory.
+  test('effectiveDbOnlyDirs lowercases declared dirs (case-insensitive match against always-lowercase slugs)', () => {
+    const dirs = effectiveDbOnlyDirs(['Notes/', 'ATOMS/']);
+    expect(dirs).toContain('notes/');
+    expect(dirs).not.toContain('Notes/');
+    // 'ATOMS/' lowercases to 'atoms/', which collides with (dedupes against)
+    // the derive-phase default of the same name.
+    expect(dirs.filter(d => d === 'atoms/').length).toBe(1);
+    expect(dirs).not.toContain('ATOMS/');
   });
 });
 


### PR DESCRIPTION
## Summary

`storage.db_only` prefixes declared in `gbrain.yml` are matched verbatim
(case-sensitively) against page slugs in `checkUndeclaredDbOnlyPages`, but
page slugs are **always lowercased at write time** (`pathToSlug` /
`slugifyCodePath` in `sync.ts`), regardless of the host filesystem's case
sensitivity. So a mixed-case declaration such as:

```yaml
storage:
  db_only:
    - Notes/
```

never matches a single slug, and every page under that directory is
silently flagged by `gbrain doctor` as "undeclared db-only" — a false
positive with no actionable fix, since the declaration is already correct
from the user's point of view.

**Fix:** `effectiveDbOnlyDirs()` now lowercases declared dirs before the
prefix-match union. `normalizeAndValidateStorageConfig` / `loadStorageConfig`
are deliberately left untouched — `manageGitignore` (sync.ts) reads the raw,
case-preserved config to write `.gitignore` entries that must match the real
on-disk directory name (case-sensitive on Linux), so lowercasing there would
break gitignore management instead of fixing this doctor check.

## Related to #3766 — important caveat, please read

This fix was found while investigating #3766, but it does **not** fix the
symptom #3766 actually reports, and I want to be upfront about that rather
than claim a close.

#3766 describes false positives from `checkUndeclaredDbOnlyPages` on a
Next.js App Router repo — bracketed dynamic-route directories
(`app/[id]/page.tsx`) and camelCase filenames — for **code** pages. I could
not reproduce that against current `master`: `checkUndeclaredDbOnlyPages`'s
SQL is already scoped to `page_kind = 'markdown'` only (this scoping
predates #3766 being filed), so a `page_kind: 'code'` page can never reach
this check's matching logic in the first place. I added a regression test
(`#3766 repro: bracket-route + camelCase code page is never considered`)
that reconstructs the reporter's scenario and confirms it already passes
cleanly on master.

What I *did* find while digging through this code path is the case-
sensitivity bug described above — a real, adjacent defect, but a different
one from what #3766 reports. This PR addresses that adjacent bug only —
issue #3766 should stay open. I'm not able to explain the originally
reported symptom from the current code, so I'm leaving that one for the
reporter/maintainer rather than speculating further in this PR.

## Testing

- `bun test test/doctor-silent-death-checks.test.ts` — 28 pass / 0 fail (4
  new tests added: the case-insensitive match itself, a false-negative
  guard that an unrelated directory in the same source is still correctly
  flagged, the #3766 repro showing code pages are already out of scope,
  and a unit test on `effectiveDbOnlyDirs` covering both the lowercase
  match and correct dedup against an already-lowercase default).
- `bun run typecheck` — clean.
- `bun run check:module-size` — within ceilings.
