### PR TITLE
fix(doctor): emit self_upgrade_health from the local buildChecks() too (#3747)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
+src/commands/doctor.ts	4370	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning, local self-upgrade health parity (#3626 #1871 #4382 #3747)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
 src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -82,6 +82,7 @@ test/doctor-frontmatter-partial.test.ts	doctor frontmatter_integrity — load-be
 test/doctor-frontmatter-partial.test.ts	doctor frontmatter_integrity — structural rendering (source-grep)	6	doctor-source-helper
 test/doctor-orphan-ratio.test.ts	cross-surface parity contract	3	doctor-source-helper,readFileSync
 test/doctor-orphan-ratio.test.ts	runOrphanRatioCheck — thin-client surface (D11)	1	readFileSync
+test/doctor-self-upgrade.test.ts	self_upgrade_health doctor registry parity	3	doctor-source-helper
 test/doctor-supervisor-singleton-pidfile.test.ts	doctor supervisor_singleton — honors the recorded pid_file (custom --pid-file)	2	doctor-source-helper
 test/doctor-supervisor-singleton-pidfile.test.ts	doctor supervisor_singleton — pid_file fallback (source-grep)	1	doctor-source-helper
 test/doctor-volunteer-channels.test.ts	checkVolunteerChannels	9	doctor-source-helper,readFileSync

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1694,6 +1694,10 @@ export async function buildChecks(
     }
   }
 
+  // v0.42 self_upgrade_health: mode, whether behind, recent failures.
+  // File-plane only (no engine) — keep in parity with doctorReportRemote.
+  checks.push(checkSelfUpgradeHealth());
+
   // --- DB checks (skip if --fast or no engine) ---
 
   if (fastMode || !engine) {

--- a/test/doctor-self-upgrade.test.ts
+++ b/test/doctor-self-upgrade.test.ts
@@ -1,12 +1,30 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { doctorSource } from './helpers/doctor-source.ts';
 import { withEnv } from './helpers/with-env.ts';
-import { checkSelfUpgradeHealth } from '../src/commands/doctor.ts';
+import {
+  buildChecks,
+  checkSelfUpgradeHealth,
+  doctorReportRemote,
+} from '../src/commands/doctor.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { writeUpdateCache } from '../src/core/self-upgrade.ts';
 import { logSelfUpgrade } from '../src/core/audit/self-upgrade-audit.ts';
 import { VERSION } from '../src/version.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
 
 async function withHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
   const dir = mkdtempSync(join(tmpdir(), 'gbrain-doctor-su-'));
@@ -77,5 +95,26 @@ describe('checkSelfUpgradeHealth', () => {
       expect(c.message).toContain('known-bad');
       expect(c.message).toContain('0.50.0');
     });
+  });
+});
+
+describe('self_upgrade_health doctor registry parity', () => {
+  test('buildChecks() includes the check against a live engine', async () => {
+    await withHome(async () => {
+      const checks = await buildChecks(engine, ['--scope=brain']);
+      expect(checks.map((check) => check.name)).toContain('self_upgrade_health');
+    });
+  });
+
+  test('doctorReportRemote() still includes the check', async () => {
+    await withHome(async () => {
+      const report = await doctorReportRemote(engine);
+      expect(report.checks.map((check) => check.name)).toContain('self_upgrade_health');
+    });
+  });
+
+  test('check-building call stays wired into both doctor surfaces', () => {
+    const matches = doctorSource().match(/checks\.push\(checkSelfUpgradeHealth\(\)\)/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
Fixes #3747.

## The bug

`self_upgrade_health` is registered as a doctor check, but was only ever built by the remote path (`doctorReportRemote`, backing the MCP surface) — the local `buildChecks()` (backing the CLI `gbrain doctor`) never called it. A CLI install's `gbrain doctor` silently omitted this check while the MCP surface reported it correctly.

## Fix

Adds the same `checkSelfUpgradeHealth()` call to `buildChecks()`, placed before the `--fast` / no-engine DB-checks gate — the check is file-plane only (self-upgrade mode, staleness, recent-failure history) and needs no engine, so it should run in every mode, matching the remote path's existing behavior.

Also adds a cross-surface parity guard (source-grep, same pattern as the existing `embedding_env_override` guard) so this specific bug class — a check wired into one doctor surface but not the other — can't silently regress for this check again.

## Test plan

`test/doctor-self-upgrade.test.ts` (extended): `buildChecks()` now includes `self_upgrade_health` against a live PGLite engine; `doctorReportRemote()` still includes it (regression guard); a source-grep guard asserts the `checkSelfUpgradeHealth()` call appears in both doctor surfaces.

```
bun run typecheck                       # pass
bun run check:module-size               # pass
bun run check:structural-manifest       # pass
bun test test/doctor-self-upgrade.test.ts  # 9 pass, 0 fail
```
