### PR TITLE
fix(facts): canonicalize entity_slug in extract-conversation-facts (#3729)

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -95,6 +95,7 @@ import { writeReceipt, shortRunId } from '../core/extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../core/extract/rollup-writer.ts';
 import { ALLOWED_TYPES, type AllowedType } from '../core/facts/conversation-types.ts';
 import { TERMINAL_AUDIT_SOURCE, NON_EXTRACTABLE_AUDIT_SOURCE } from '../core/facts/audit-sources.ts';
+import { resolveEntitySlug } from '../core/entities/resolve.ts';
 
 // Re-exported verbatim so existing importers (this file's own helpers below
 // and this file's tests) keep working unchanged; doctor.ts, jobs.ts,
@@ -1104,11 +1105,12 @@ async function processPage(
     state.result.facts_extracted += extracted.length;
 
     if (!state.dryRun && extracted.length > 0) {
-      // Eng-v2 C1 / E11: page-global row_num. Each fact in this batch gets
-      // a unique row_num within (source_id, source_markdown_slug); the
-      // accumulator increments across the segment loop.
-      const rows = extracted.map((fact, i) => ({
+      // Eng-v2 C1 / E11: page-global row_num stays unique across segments.
+      const rows = await Promise.all(extracted.map(async (fact, i) => ({
         ...fact,
+        entity_slug: fact.entity_slug
+          ? await resolveEntitySlug(state.engine, state.sourceId, fact.entity_slug)
+          : null,
         row_num: rowNum + i,
         source_markdown_slug: page.slug,
         source: PER_SEGMENT_SOURCE_PREFIX,
@@ -1121,7 +1123,7 @@ async function processPage(
           : {}),
         context:
           fact.context ?? `from ${page.slug} segment ${seg.startIso}..${seg.endIso}`,
-      }));
+      })));
       const ins = await state.engine.insertFacts(rows, { source_id: state.sourceId }); // gbrain-allow-direct-insert: canonical bulk extraction path for conversation pages — fences-as-system-of-record doesn't apply because conversations don't carry `## Facts` fences (the chat-log shape is the source-of-truth)
       pageInsertedTotal += ins.inserted;
       state.result.facts_inserted += ins.inserted;

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -835,6 +835,58 @@ describe('runExtractConversationFactsCore', () => {
     expect(Number(terminalRows[0]?.count ?? 0)).toBe(1);
   });
 
+  test('canonicalizes a raw LLM entity display name before writing facts.entity_slug', async () => {
+    chatTextOverride = JSON.stringify({
+      facts: [{
+        fact: 'Alice Example signed the offer letter.',
+        kind: 'event',
+        entity: 'Alice Example',
+        confidence: 1.0,
+        notability: 'high',
+      }],
+    });
+
+    await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'conversations/imessage/alice-example',
+      sleepMs: 0,
+    });
+
+    const rows = await engine.executeRaw<{ entity_slug: string | null }>(
+      `SELECT entity_slug FROM facts
+        WHERE source = $1 AND source_markdown_slug = $2`,
+      [PER_SEGMENT_SOURCE_PREFIX, 'conversations/imessage/alice-example'],
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((row) => row.entity_slug === 'people/alice-example')).toBe(true);
+  });
+
+  test('preserves an already-canonical LLM entity slug', async () => {
+    chatTextOverride = JSON.stringify({
+      facts: [{
+        fact: 'Alice Example started the new role.',
+        kind: 'event',
+        entity: 'people/alice-example',
+        confidence: 1.0,
+        notability: 'high',
+      }],
+    });
+
+    await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'conversations/imessage/alice-example',
+      sleepMs: 0,
+    });
+
+    const rows = await engine.executeRaw<{ entity_slug: string | null }>(
+      `SELECT entity_slug FROM facts
+        WHERE source = $1 AND source_markdown_slug = $2`,
+      [PER_SEGMENT_SOURCE_PREFIX, 'conversations/imessage/alice-example'],
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((row) => row.entity_slug === 'people/alice-example')).toBe(true);
+  });
+
   test('terminal outcome skips a completed page after checkpoint GC', async () => {
     await runExtractConversationFactsCore(engine, {
       sourceId: 'default',


### PR DESCRIPTION
Fixes #3729.

## The bug

The extraction prompt (`src/core/facts/extract.ts`) documents the `entity` field as *"a display name the caller can canonicalize"* — canonicalization is explicitly a caller responsibility, not the extractor's. The sibling caller, `src/core/facts/backstop.ts`, correctly honors this by calling `resolveEntitySlug` before insert. `extract-conversation-facts.ts` wrote the LLM's raw `entity` string straight into `facts.entity_slug` instead, producing phantom/uncanonicalized slugs (reported 22.5% rate on real conversation data).

## Fix

Mirrors `backstop.ts`'s exact pattern: `resolveEntitySlug(engine, sourceId, entity_slug)` before insert. `null` entities stay `null`; an already-canonical slug is unchanged; a raw display name (e.g. `"Alice Example"`) now resolves to its canonical slug (`people/alice-example`) before the row is written.

## Test plan

`test/extract-conversation-facts.test.ts` (extended): a raw LLM entity display name is now canonicalized before insert; an already-canonical entity slug passed straight through is unchanged.

```
bun run typecheck                          # pass
bun run check:module-size                  # pass
bun run check:structural-manifest          # pass
bun test test/extract-conversation-facts.test.ts  # 73 pass, 0 fail
```
