### PR TITLE
fix(links): backlinks and graph traversal now exclude soft-deleted endpoints (#3754)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -5,7 +5,7 @@
 # Columns: path	max_lines	policy	note
 src/commands/doctor.ts	4366	ratchet	grown v0.46.25.0 fix waves: sunset-aware search-mode check, dead-check pruning (#3626 #1871 #4382)
 src/core/operations.ts	303	ratchet	peel target: containment sprint C4-C7
-src/core/postgres-engine.ts	5989	ratchet	grown v0.46.25.0 fix waves: registry plane + timeline honesty + think temporal windows (#1262 #3827 #4389)
+src/core/postgres-engine.ts	6005	ratchet	grown #3754: soft-delete endpoint filters for backlinks and graph traversal
 src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry-aware writes + stale/invalidate plane unification (#1262); peeled cjk-search (#4299)
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3779,6 +3779,8 @@ export class PGLiteEngine implements BrainEngine {
     // #2200: federated grant scopes all three endpoints (mirrors getLinks) — the
     // referrer (from), the queried page (to), AND the origin — so neither a
     // foreign referrer nor a foreign origin slug is disclosed to the caller.
+    // #3754: links remain physically present during soft-delete recovery, so
+    // both edge endpoints must be live before a backlink is visible.
     if (opts?.sourceIds && opts.sourceIds.length > 0) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, f.source_id as from_source_id,
@@ -3790,7 +3792,8 @@ export class PGLiteEngine implements BrainEngine {
          JOIN pages f ON f.id = l.from_page_id
          JOIN pages t ON t.id = l.to_page_id
          LEFT JOIN pages o ON o.id = l.origin_page_id AND o.source_id = ANY($2::text[])
-         WHERE t.slug = $1 AND t.source_id = ANY($2::text[]) AND f.source_id = ANY($2::text[])`,
+         WHERE t.slug = $1 AND t.source_id = ANY($2::text[]) AND f.source_id = ANY($2::text[])
+           AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
         [slug, opts.sourceIds]
       );
       return rows as unknown as Link[];
@@ -3807,7 +3810,8 @@ export class PGLiteEngine implements BrainEngine {
          JOIN pages f ON f.id = l.from_page_id
          JOIN pages t ON t.id = l.to_page_id
          LEFT JOIN pages o ON o.id = l.origin_page_id
-         WHERE t.slug = $1 AND t.source_id = $2`,
+         WHERE t.slug = $1 AND t.source_id = $2
+           AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
         [slug, opts.sourceId]
       );
       return rows as unknown as Link[];
@@ -3822,7 +3826,8 @@ export class PGLiteEngine implements BrainEngine {
        JOIN pages f ON f.id = l.from_page_id
        JOIN pages t ON t.id = l.to_page_id
        LEFT JOIN pages o ON o.id = l.origin_page_id
-       WHERE t.slug = $1`,
+       WHERE t.slug = $1
+         AND f.deleted_at IS NULL AND t.deleted_at IS NULL`,
       [slug]
     );
     return rows as unknown as Link[];
@@ -3929,6 +3934,7 @@ export class PGLiteEngine implements BrainEngine {
     // ITERATION cap, which maps approximately to per-BFS-LAYER (exact when
     // fanout is bounded; for hub-fanout the cap fires early). Truncation
     // signal computed post-query by counting rows per depth.
+    // #3754: keep the seed, recursive neighbor, and displayed edge target live.
     const cap = opts?.frontierCap;
     let recursiveTerm: string;
     if (cap !== undefined && cap > 0) {
@@ -3940,6 +3946,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}
         ORDER BY p2.slug ASC, p2.id ASC
         LIMIT $${capIdx})`;
@@ -3950,6 +3957,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}`;
     }
 
@@ -3958,7 +3966,7 @@ export class PGLiteEngine implements BrainEngine {
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = $1 ${seedScope}
+        FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -3974,7 +3982,7 @@ export class PGLiteEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g
@@ -4029,12 +4037,14 @@ export class PGLiteEngine implements BrainEngine {
       ptScope = `AND pt.source_id = $${idx}`;
     }
 
+    // #3754: every seed, recursive neighbor, and projected edge endpoint must
+    // be live so graph-query cannot walk through or display deleted pages.
     let sql: string;
     if (direction === 'out') {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4042,6 +4052,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.to_page_id
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4051,6 +4062,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN links l ON l.from_page_id = w.id
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE w.depth < $2
+          AND p2.deleted_at IS NULL
           ${linkTypeWhere}
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -4059,7 +4071,7 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4067,6 +4079,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.from_page_id
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4076,6 +4089,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN links l ON l.to_page_id = w.id
         JOIN pages p2 ON p2.id = l.from_page_id
         WHERE w.depth < $2
+          AND p2.deleted_at IS NULL
           ${linkTypeWhere}
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -4086,7 +4100,7 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1 ${seedScope}
+          FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -4094,6 +4108,7 @@ export class PGLiteEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             ${linkTypeWhere}
             ${stepScope}
         )
@@ -4104,6 +4119,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages pf ON pf.id = l.from_page_id
         JOIN pages pt ON pt.id = l.to_page_id
         WHERE w.depth < $2
+          AND pf.deleted_at IS NULL AND pt.deleted_at IS NULL
           ${linkTypeWhere}
           ${pfScope}
           ${ptScope}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3595,6 +3595,8 @@ export class PostgresEngine implements BrainEngine {
       // #2200: federated grant scopes all three endpoints (mirrors getLinks) —
       // the referrer (from), the queried page (to), AND the origin — so neither
       // a foreign referrer nor a foreign origin slug is disclosed to the caller.
+      // #3754: links remain physically present during soft-delete recovery, so
+      // both edge endpoints must be live before a backlink is visible.
       if (opts?.sourceIds && opts.sourceIds.length > 0) {
         const ids = opts.sourceIds;
         const rows = await tx`
@@ -3608,6 +3610,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages t ON t.id = l.to_page_id
           LEFT JOIN pages o ON o.id = l.origin_page_id AND o.source_id = ANY(${ids}::text[])
           WHERE t.slug = ${slug} AND t.source_id = ANY(${ids}::text[]) AND f.source_id = ANY(${ids}::text[])
+            AND f.deleted_at IS NULL AND t.deleted_at IS NULL
         `;
         return rows as unknown as Link[];
       }
@@ -3624,6 +3627,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages t ON t.id = l.to_page_id
           LEFT JOIN pages o ON o.id = l.origin_page_id
           WHERE t.slug = ${slug} AND t.source_id = ${opts.sourceId}
+            AND f.deleted_at IS NULL AND t.deleted_at IS NULL
         `;
         return rows as unknown as Link[];
       }
@@ -3638,6 +3642,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN pages t ON t.id = l.to_page_id
         LEFT JOIN pages o ON o.id = l.origin_page_id
         WHERE t.slug = ${slug}
+          AND f.deleted_at IS NULL AND t.deleted_at IS NULL
       `;
       return rows as unknown as Link[];
     });
@@ -3756,6 +3761,7 @@ export class PostgresEngine implements BrainEngine {
     // exact when fanout is bounded; for hub-fanout graphs the cap fires
     // early). Post-query, count rows per depth — if any depth == cap, fire
     // the truncation callback.
+    // #3754: keep the seed, recursive neighbor, and displayed edge target live.
     const cap = opts?.frontierCap;
     const recursiveStep = cap !== undefined && cap > 0
       ? sql`(SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
@@ -3764,6 +3770,7 @@ export class PostgresEngine implements BrainEngine {
              JOIN pages p2 ON p2.id = l.to_page_id
              WHERE g.depth < ${depth}
                AND NOT (p2.id = ANY(g.visited))
+               AND p2.deleted_at IS NULL
                ${stepScope}
              ORDER BY p2.slug ASC, p2.id ASC
              LIMIT ${cap})`
@@ -3773,12 +3780,13 @@ export class PostgresEngine implements BrainEngine {
             JOIN pages p2 ON p2.id = l.to_page_id
             WHERE g.depth < ${depth}
               AND NOT (p2.id = ANY(g.visited))
+              AND p2.deleted_at IS NULL
               ${stepScope}`;
     // Cycle prevention: visited array tracks page IDs already in the path.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug} ${seedScope}
+        FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -3796,7 +3804,7 @@ export class PostgresEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g
@@ -3855,12 +3863,14 @@ export class PostgresEngine implements BrainEngine {
         ? sql`AND pt.source_id = ${opts.sourceId}`
         : sql``;
 
+    // #3754: every seed, recursive neighbor, and projected edge endpoint must
+    // be live so graph-query cannot walk through or display deleted pages.
     let rows;
     if (direction === 'out') {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3868,6 +3878,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.to_page_id
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3877,6 +3888,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN links l ON l.from_page_id = w.id
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE w.depth < ${depth}
+          AND p2.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -3885,7 +3897,7 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3893,6 +3905,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = l.from_page_id
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3902,6 +3915,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN links l ON l.to_page_id = w.id
         JOIN pages p2 ON p2.id = l.from_page_id
         WHERE w.depth < ${depth}
+          AND p2.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${stepScope}
         ORDER BY depth, from_slug, to_slug
@@ -3910,7 +3924,7 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} ${seedScope}
+          FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
@@ -3918,6 +3932,7 @@ export class PostgresEngine implements BrainEngine {
           JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
+            AND p2.deleted_at IS NULL
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
             ${stepScope}
         )
@@ -3928,6 +3943,7 @@ export class PostgresEngine implements BrainEngine {
         JOIN pages pf ON pf.id = l.from_page_id
         JOIN pages pt ON pt.id = l.to_page_id
         WHERE w.depth < ${depth}
+          AND pf.deleted_at IS NULL AND pt.deleted_at IS NULL
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
           ${pfScope}
           ${ptScope}

--- a/test/backlinks-graph-softdelete.test.ts
+++ b/test/backlinks-graph-softdelete.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #3754: backlink and graph reads must ignore every edge that touches a
+ * soft-deleted page. The links row remains during the recovery window, so
+ * endpoint visibility has to be enforced by each read query.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function seedPair(prefix: string): Promise<{ source: string; target: string }> {
+  const source = `${prefix}/source`;
+  const target = `${prefix}/target`;
+  await engine.putPage(source, {
+    type: 'note', title: 'Live source', compiled_truth: 'source body', timeline: '',
+  });
+  await engine.putPage(target, {
+    type: 'note', title: 'Live target', compiled_truth: 'target body', timeline: '',
+  });
+  await engine.addLink(source, target, '', 'mentions');
+  return { source, target };
+}
+
+describe('PGLite backlinks and graph traversal hide soft-deleted endpoints (#3754)', () => {
+  test('healthy live-to-live edge is still returned', async () => {
+    const { source, target } = await seedPair('softdelete/control');
+
+    expect((await engine.getBacklinks(target)).map((link) => link.from_slug)).toEqual([source]);
+    expect((await engine.traversePaths(source, { depth: 1 })).map((edge) => edge.to_slug)).toEqual([target]);
+    const nodes = await engine.traverseGraph(source, 1);
+    expect(nodes.map((node) => node.slug).sort()).toEqual([source, target].sort());
+    expect(nodes.find((node) => node.slug === source)?.links.map((link) => link.to_slug)).toEqual([target]);
+  });
+
+  test('edge is excluded when its source endpoint is soft-deleted', async () => {
+    const { source, target } = await seedPair('softdelete/dead-source');
+    await engine.softDeletePage(source);
+
+    expect(await engine.getBacklinks(target)).toEqual([]);
+    expect(await engine.traversePaths(target, { depth: 1, direction: 'in' })).toEqual([]);
+    expect(await engine.traverseGraph(source, 1)).toEqual([]);
+  });
+
+  test('edge is excluded when its target endpoint is soft-deleted', async () => {
+    const { source, target } = await seedPair('softdelete/dead-target');
+    await engine.softDeletePage(target);
+
+    expect(await engine.getBacklinks(target)).toEqual([]);
+    expect(await engine.traversePaths(source, { depth: 1, direction: 'out' })).toEqual([]);
+    const nodes = await engine.traverseGraph(source, 1);
+    expect(nodes.map((node) => node.slug)).toEqual([source]);
+    expect(nodes[0]?.links).toEqual([]);
+  });
+
+  test('a soft-deleted MIDDLE node breaks a multi-hop chain (A -> deleted B -> C)', async () => {
+    const a = 'softdelete/chain/a';
+    const b = 'softdelete/chain/b';
+    const c = 'softdelete/chain/c';
+    await engine.putPage(a, { type: 'note', title: 'A', compiled_truth: 'a', timeline: '' });
+    await engine.putPage(b, { type: 'note', title: 'B', compiled_truth: 'b', timeline: '' });
+    await engine.putPage(c, { type: 'note', title: 'C', compiled_truth: 'c', timeline: '' });
+    await engine.addLink(a, b, '', 'mentions');
+    await engine.addLink(b, c, '', 'mentions');
+
+    await engine.softDeletePage(b);
+
+    // A 2-hop traversal from A must not walk through the dead middle node.
+    const nodes = await engine.traverseGraph(a, 2);
+    expect(nodes.map((node) => node.slug)).toEqual([a]);
+    expect(nodes[0]?.links).toEqual([]);
+
+    expect(await engine.traversePaths(a, { depth: 2, direction: 'out' })).toEqual([]);
+    expect(await engine.traversePaths(a, { depth: 2, direction: 'both' })).toEqual([]);
+
+    // C's only backlink is via the dead B, so it must report none.
+    expect(await engine.getBacklinks(c)).toEqual([]);
+  });
+
+  test('direction "both" excludes an edge touching a soft-deleted endpoint in either direction', async () => {
+    const { source, target } = await seedPair('softdelete/both-direction');
+    await engine.softDeletePage(target);
+
+    expect(await engine.traversePaths(source, { depth: 1, direction: 'both' })).toEqual([]);
+    expect(await engine.traversePaths(target, { depth: 1, direction: 'both' })).toEqual([]);
+  });
+});

--- a/test/e2e/engine-parity.test.ts
+++ b/test/e2e/engine-parity.test.ts
@@ -1379,3 +1379,68 @@ describeBoth('Engine parity — putPage empty-overwrite guard', () => {
     }
   });
 });
+
+describeBoth('Engine parity — soft-deleted link endpoints (#3754)', () => {
+  let pgEngine: BrainEngine;
+  let pgliteEngine: PGLiteEngine;
+
+  beforeAll(async () => {
+    pgEngine = await setupDB();
+    pgliteEngine = new PGLiteEngine();
+    await pgliteEngine.connect({});
+    await pgliteEngine.initSchema();
+  }, 90_000);
+
+  afterAll(async () => {
+    await pgliteEngine.disconnect();
+    await teardownDB();
+  }, 30_000);
+
+  async function seedPair(
+    engine: BrainEngine,
+    prefix: string,
+  ): Promise<{ source: string; target: string }> {
+    const source = `${prefix}/source`;
+    const target = `${prefix}/target`;
+    await engine.putPage(source, {
+      type: 'note', title: 'Live source', compiled_truth: 'source body', timeline: '',
+    });
+    await engine.putPage(target, {
+      type: 'note', title: 'Live target', compiled_truth: 'target body', timeline: '',
+    });
+    await engine.addLink(source, target, '', 'mentions');
+    return { source, target };
+  }
+
+  test('healthy live-to-live link remains visible on both engines', async () => {
+    for (const [name, engine] of [['pg', pgEngine], ['pglite', pgliteEngine]] as const) {
+      const { source, target } = await seedPair(engine, `softdelete-parity/${name}/control`);
+      expect((await engine.getBacklinks(target)).map((link) => link.from_slug)).toEqual([source]);
+      expect((await engine.traversePaths(source, { depth: 1 })).map((edge) => edge.to_slug)).toEqual([target]);
+      expect((await engine.traverseGraph(source, 1)).map((node) => node.slug).sort())
+        .toEqual([source, target].sort());
+    }
+  });
+
+  test('soft-deleted source endpoint is excluded on both engines', async () => {
+    for (const [name, engine] of [['pg', pgEngine], ['pglite', pgliteEngine]] as const) {
+      const { source, target } = await seedPair(engine, `softdelete-parity/${name}/dead-source`);
+      await engine.softDeletePage(source);
+      expect(await engine.getBacklinks(target)).toEqual([]);
+      expect(await engine.traversePaths(target, { depth: 1, direction: 'in' })).toEqual([]);
+      expect(await engine.traverseGraph(source, 1)).toEqual([]);
+    }
+  });
+
+  test('soft-deleted target endpoint is excluded on both engines', async () => {
+    for (const [name, engine] of [['pg', pgEngine], ['pglite', pgliteEngine]] as const) {
+      const { source, target } = await seedPair(engine, `softdelete-parity/${name}/dead-target`);
+      await engine.softDeletePage(target);
+      expect(await engine.getBacklinks(target)).toEqual([]);
+      expect(await engine.traversePaths(source, { depth: 1 })).toEqual([]);
+      const nodes = await engine.traverseGraph(source, 1);
+      expect(nodes.map((node) => node.slug)).toEqual([source]);
+      expect(nodes[0]?.links).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3754.

## The bug

Soft-deleted pages are correctly hidden from `get`, `list`, `search`, and `orphans`, but the `backlinks` command and `graph-query` command still returned edges touching them. The links row stays present during a soft-delete's recovery window, so endpoint visibility has to be enforced by each read query — it can't be assumed from row presence.

This is separate from — and doesn't touch — #4165 (already merged), which fixed a related but distinct surface: `doctor`'s `graph_coverage` check counting soft-deleted entity pages in its own `entityCount`/`eligible` CTE. This PR is the `page_links` traversal itself, used by `backlinks` and `graph-query`.

## Fix

In both engines (`postgres-engine.ts`, `pglite-engine.ts`):

- **`getBacklinks`** — all three branches (federated, scoped, unscoped) now require both endpoints' `deleted_at IS NULL`.
- **`traverseGraph`** — the seed page, every recursive-CTE neighbor step (both the capped and uncapped variants), and the aggregated per-node links array all filter on `deleted_at IS NULL`.
- **`traversePaths`** — the seed, the recursive neighbor step, and the final projected endpoint, for all three directions (`out`/`in`/`both`).

A soft-deleted page in the *middle* of a multi-hop chain now correctly breaks the chain (verified: `A → deleted B → C` — traversal from A stops at A, `C` reports no backlink via `B`), not just its own direct edges.

## Test plan

`test/backlinks-graph-softdelete.test.ts` (new, PGLite): healthy live-to-live edges are unaffected; an edge is excluded when its source endpoint is soft-deleted; excluded when its target is soft-deleted; a soft-deleted **middle** node breaks a multi-hop chain; `direction: 'both'` excludes an edge touching a soft-deleted endpoint in either direction.

`test/e2e/engine-parity.test.ts` — parity coverage for both engines (Postgres cases require `DATABASE_URL`; skip without it, same as the rest of the suite).

```
bun run typecheck                          # pass
bun run check:module-size                  # pass
bun run check:structural-manifest          # pass
bun test test/backlinks-graph-softdelete.test.ts  # 5 pass, 0 fail
bun test test/e2e/engine-parity.test.ts    # 0 pass, 55 skip (no DATABASE_URL in this environment)
```
