### PR TITLE
fix(bench): toRefKeySet dedupes by page identity, bounding recall_at_k to [0,1] (#4303)

### DIFF
--- a/src/core/bench/correctness-gate.ts
+++ b/src/core/bench/correctness-gate.ts
@@ -24,6 +24,7 @@ import {
   computeFirstRelevantHit,
   computeRecallAtK,
   DEFAULT_QRELS_THRESHOLDS,
+  makeRef,
   refKey,
   type QrelsFile,
   type QrelsEntry,
@@ -69,9 +70,9 @@ export interface CorrectnessResult {
   per_query: PerQueryResult[];
 }
 
-/** Build the canonical `${source_id}::${slug}` set for a SearchResult-like array. */
-function toRefKeySet(results: Array<{ source_id?: string; slug: string }>): string[] {
-  return results.map(r => `${r.source_id ?? 'default'}::${r.slug}`);
+/** Build the canonical, insertion-ordered page-key set for a SearchResult-like array. */
+function toRefKeySet(results: Array<{ source_id?: string; slug: string }>): Set<string> {
+  return new Set(results.map(r => makeRef(r.source_id ?? 'default', r.slug)));
 }
 
 async function runOneQuery(
@@ -83,7 +84,7 @@ async function runOneQuery(
   let retrieved: string[];
   try {
     const raw = await searchFn(engine, entry.query, { limit: k });
-    retrieved = toRefKeySet(raw);
+    retrieved = [...toRefKeySet(raw)];
   } catch (err) {
     return {
       query_id: entry.query_id,

--- a/test/bench/correctness-gate.test.ts
+++ b/test/bench/correctness-gate.test.ts
@@ -84,6 +84,67 @@ describe('correctness-gate: per-query iteration + aggregate math', () => {
     expect(result.summary.first_relevant_hit_rate).toBe(1); // top-1 was 'a' which is relevant
   });
 
+  test('duplicate chunk-level hits from relevant pages cannot inflate recall above 1', async () => {
+    const qrels = makeQrels([
+      {
+        query_id: 'q-duplicate-chunks',
+        query: 'x',
+        relevant: [
+          { source_id: 'default', slug: 'a' },
+          { source_id: 'default', slug: 'b' },
+          { source_id: 'default', slug: 'c' },
+          { source_id: 'default', slug: 'd' },
+        ],
+      },
+    ]);
+    const result = await runCorrectnessGate(fakeEngine, qrels, {
+      k: 10,
+      // Seven relevant chunk hits used to score 7 / 4 = 1.75 even though
+      // they represent only two distinct pages.
+      searchFn: async () => [
+        { source_id: 'default', slug: 'a' },
+        { source_id: 'default', slug: 'a' },
+        { source_id: 'default', slug: 'a' },
+        { source_id: 'default', slug: 'a' },
+        { source_id: 'default', slug: 'b' },
+        { source_id: 'default', slug: 'b' },
+        { source_id: 'default', slug: 'b' },
+      ],
+    });
+
+    expect(result.per_query[0]?.recall_at_k).toBe(0.5);
+    expect(result.per_query[0]?.recall_at_k).toBeLessThanOrEqual(1);
+    expect(result.per_query[0]?.retrieved_count).toBe(2);
+    expect(result.summary.mean_recall_at_k).toBe(0.5);
+  });
+
+  test('distinct relevant pages retain correct recall, including the same slug in different sources', async () => {
+    const qrels = makeQrels([
+      {
+        query_id: 'q-distinct-pages',
+        query: 'x',
+        relevant: [
+          { source_id: 'source-a', slug: 'shared' },
+          { source_id: 'source-b', slug: 'shared' },
+          { source_id: 'source-a', slug: 'unique-a' },
+          { source_id: 'source-b', slug: 'unique-b' },
+        ],
+      },
+    ]);
+    const result = await runCorrectnessGate(fakeEngine, qrels, {
+      k: 10,
+      searchFn: async () => [
+        { source_id: 'source-a', slug: 'shared' },
+        { source_id: 'source-b', slug: 'shared' },
+        { source_id: 'source-a', slug: 'unique-a' },
+      ],
+    });
+
+    expect(result.per_query[0]?.recall_at_k).toBe(0.75);
+    expect(result.per_query[0]?.retrieved_count).toBe(3);
+    expect(result.summary.mean_recall_at_k).toBe(0.75);
+  });
+
   test('empty retrieved list → recall=0 / first_relevant=0 / expected_top1=0', async () => {
     const qrels = makeQrels([
       {


### PR DESCRIPTION
Fixes #4303.

## The bug

`toRefKeySet` in `src/core/bench/correctness-gate.ts` is named as a set but was implemented as a plain `.map()` — no deduplication. `computeRecallAtK`'s own doc comment promises `"Returns a number in [0, 1]"`, but when chunk-level search results from the same page appeared multiple times (multiple chunks matching from one page), they were double/triple-counted in the recall numerator. A real 4-question qrels run with exactly one known-relevant page per question reported `recall_at_k = 1.75`.

## Fix

`toRefKeySet` now builds and returns an actual deduplicated `Set`, keyed by the existing canonical `makeRef(source_id, slug)` identity (matching this file's own `refKey` convention rather than inventing a new key format). A page contributes at most once to the recall numerator no matter how many of its chunks matched — and the same slug in two different sources still correctly counts as two distinct pages.

## Test plan

`test/bench/correctness-gate.test.ts` (extended): seven chunk-level hits from two relevant pages now correctly scores `0.5` (was inflating past 1.0 pre-fix); three distinct pages, including the same slug across two different sources, correctly scores `0.75` (proves the fix doesn't over-collapse genuinely distinct pages).

```
bun run typecheck                          # pass
bun run check:module-size                  # pass
bun run check:structural-manifest          # pass
bun test test/bench/correctness-gate.test.ts  # 8 pass, 0 fail
```
