### PR TITLE
fix(cycle): write a real graph edge for extract_atoms provenance, not just frontmatter (#3961)

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -833,7 +833,7 @@ export async function runPhaseExtractAtoms(
         const provenanceSourceSlug = item.kind === 'transcript'
           ? await resolveSlugByPathOrSourcePath(engine, item.filePath, sourceId)
           : item.slug;
-        await engine.addLinksBatch(importedSlugs.map((atomSlug) => ({
+        await engine.addLinksBatch(importedSlugs.map((atomSlug) => ({ // gbrain-allow-direct-insert: extract_atoms writes canonical atom → source provenance edges alongside its frontmatter receipt
           from_slug: atomSlug,
           to_slug: provenanceSourceSlug,
           link_type: 'derived_from',
@@ -841,7 +841,7 @@ export async function runPhaseExtractAtoms(
           context: `Extracted from ${originLabel}`,
           from_source_id: sourceId,
           to_source_id: sourceId,
-        }))); // gbrain-allow-direct-insert: extract_atoms writes canonical atom → source provenance edges alongside its frontmatter receipt
+        })));
         // Completion receipt: flip provisional → real in one statement, then
         // stamp the source page. A crash between flip and stamp degrades to
         // the legacy atom-rows-mean-done semantics — safe, not lossy.

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -62,6 +62,7 @@ import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
 import { slugifySegment } from '../sync.ts';
+import { resolveSlugByPathOrSourcePath } from '../sync-git.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 const DEFAULT_EXTRACT_ATOMS_MODEL = 'anthropic:claude-haiku-4-5';
@@ -819,6 +820,28 @@ export async function runPhaseExtractAtoms(
           importedSlugs.push(slug);
           totalAtomsExtracted++;
         }
+        // Match the generated-page provenance convention used by the other
+        // derived-page writers: the new page points OUT to the page it came
+        // from. Page inputs already carry a slug; transcript inputs carry a
+        // source_path, so resolve the actual stored slug first (including
+        // frontmatter-fallback slugs that cannot be derived from the path).
+        //
+        // Keep this before the source_hash completion flip. A transient link
+        // write failure therefore leaves the atoms provisional and the item
+        // retryable, while addLinksBatch safely JOIN-drops transcripts that do
+        // not have a corresponding brain page yet.
+        const provenanceSourceSlug = item.kind === 'transcript'
+          ? await resolveSlugByPathOrSourcePath(engine, item.filePath, sourceId)
+          : item.slug;
+        await engine.addLinksBatch(importedSlugs.map((atomSlug) => ({
+          from_slug: atomSlug,
+          to_slug: provenanceSourceSlug,
+          link_type: 'derived_from',
+          link_source: 'extract-atoms',
+          context: `Extracted from ${originLabel}`,
+          from_source_id: sourceId,
+          to_source_id: sourceId,
+        }))); // gbrain-allow-direct-insert: extract_atoms writes canonical atom → source provenance edges alongside its frontmatter receipt
         // Completion receipt: flip provisional → real in one statement, then
         // stamp the source page. A crash between flip and stamp degrades to
         // the legacy atom-rows-mean-done semantics — safe, not lossy.

--- a/test/extract-atoms-page-discovery.test.ts
+++ b/test/extract-atoms-page-discovery.test.ts
@@ -80,6 +80,7 @@ async function seedPage(opts: {
   content_hash?: string | null;
   frontmatter?: Record<string, unknown>;
   source_id?: string;
+  source_path?: string;
   compiled_truth?: string;
 }) {
   await engine.putPage(
@@ -106,6 +107,12 @@ async function seedPage(opts: {
     await engine.executeRaw(
       `UPDATE pages SET content_hash = NULL WHERE slug = $1 AND source_id = $2`,
       [opts.slug, opts.source_id ?? 'default'],
+    );
+  }
+  if (opts.source_path) {
+    await engine.executeRaw(
+      `UPDATE pages SET source_path = $1 WHERE slug = $2 AND source_id = $3`,
+      [opts.source_path, opts.slug, opts.source_id ?? 'default'],
     );
   }
 }
@@ -269,13 +276,15 @@ describe('v0.41.2.1: runPhaseExtractAtoms — dual-source merge + idempotency', 
     expect(result.details?.pages_processed).toBe(1);
   });
 
-  test('atom frontmatter: page-origin uses source_slug, transcript-origin uses source_path', async () => {
+  test('atom provenance: frontmatter strings and graph edges cover page + transcript origins', async () => {
+    await seedPage({ slug: 'meeting/p', type: 'meeting' });
+    await seedPage({ slug: 'transcripts/t', type: 'source', source_path: '/T.txt' });
     // Use stubChatUnique so the two work-items write to distinct slugs;
     // a constant title would upsert into one slug and mask one origin.
     const chat = stubChatUnique();
     await runPhaseExtractAtoms(engine, {
       _transcripts: [{ filePath: '/T.txt', content: 'tc', contentHash: 'tchash1234567890ab' }],
-      _pages: [{ slug: 'meeting/P', content: 'pc', contentHash: 'pchash1234567890ab' }],
+      _pages: [{ slug: 'meeting/p', content: 'pc', contentHash: 'pchash1234567890ab' }],
       _chat: chat,
     });
     const rows = await engine.executeRaw<{ slug: string; frontmatter: Record<string, unknown> }>(
@@ -288,8 +297,24 @@ describe('v0.41.2.1: runPhaseExtractAtoms — dual-source merge + idempotency', 
     expect(transcriptAtom!.frontmatter.source_path).toBe('/T.txt');
     expect(transcriptAtom!.frontmatter.source_hash).toBe('tchash1234567890');
     expect(pageAtom).toBeDefined();
-    expect(pageAtom!.frontmatter.source_slug).toBe('meeting/P');
+    expect(pageAtom!.frontmatter.source_slug).toBe('meeting/p');
     expect(pageAtom!.frontmatter.source_hash).toBe('pchash1234567890');
+
+    const pageOriginBacklinks = await engine.getBacklinks('meeting/p', { sourceId: 'default' });
+    expect(pageOriginBacklinks).toContainEqual(expect.objectContaining({
+      from_slug: pageAtom!.slug,
+      to_slug: 'meeting/p',
+      link_type: 'derived_from',
+      link_source: 'extract-atoms',
+    }));
+
+    const transcriptOriginBacklinks = await engine.getBacklinks('transcripts/t', { sourceId: 'default' });
+    expect(transcriptOriginBacklinks).toContainEqual(expect.objectContaining({
+      from_slug: transcriptAtom!.slug,
+      to_slug: 'transcripts/t',
+      link_type: 'derived_from',
+      link_source: 'extract-atoms',
+    }));
   });
 
   test('sourceId threads into putPage call (D9 #1 regression — atoms land in correct source)', async () => {


### PR DESCRIPTION
Fixes #3961.

## The bug

`extract_atoms` (`src/core/cycle/extract-atoms.ts`) knows exactly which source page each distilled "atom" page was extracted from, and records it — but only as a plain frontmatter string (`source_path` for transcripts, `source_slug` for other kinds), via `putPage`. No `addLink`/`addLinksBatch` call ever ran, so atom provenance was invisible to `backlinks`, `graph-query`, and any other graph-traversal-based tooling — it only existed as an unindexed string.

## Fix

Adds a `derived_from` edge (`link_source: extract-atoms`) from each newly-imported atom page to its origin page, in addition to the existing frontmatter string:

- Page-origin atoms use the origin's slug directly.
- Transcript-origin atoms resolve through the existing `resolveSlugByPathOrSourcePath` helper (matching the codebase's slug-resolution convention rather than reimplementing it).
- Written **before** the provisional→real completion flip, so a transient link-write failure leaves the atom retryable rather than silently missing its edge.
- `addLinksBatch` safely no-ops a transcript target that doesn't yet have a corresponding brain page (no FK-violation churn).

## Test plan

`test/extract-atoms-page-discovery.test.ts` (extended): after `extract_atoms` runs, both a page-origin atom and a transcript-origin atom have a real graph edge to their source, verified via `getBacklinks` (not just the frontmatter string) — alongside the existing frontmatter-string assertions.

```
bun run typecheck                          # pass
bun run check:module-size                  # pass
bun run check:structural-manifest          # pass
bun test (focused atom-extraction suites)  # 125 pass, 0 fail
```
