### PR TITLE
fix(cli): put refuses empty/whitespace-only stdin instead of writing a 0-chunk page (#2822)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -10,7 +10,7 @@ src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + 
 src/core/migrate.ts	687	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted — grown v0.46.26.0: repair-handler hooks (#3957 pages-upsert-arbiter)
 src/commands/sync.ts	4512	ratchet	grown v0.46.26.0 megawave: image sync, ingest-log gating, dry-run purity, checkpoint honesty (#2683 #4342 #3875) + 3 nosemgrep dataflow annotations (path-traversal audit)
 src/core/ai/gateway.ts	4494	ratchet	grown v0.46.26.0 megawave: config-plane probes + halt telemetry (#3387 #4312)
-src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silent-failure surfacing, confirm-race gate (#2443 #2898 #2297)
+src/cli.ts	3735	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silent-failure surfacing, confirm-race gate (#2443 #2898 #2297) + PR#4457 rebase onto current master
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -577,11 +577,23 @@ async function main() {
   // transform, and required-param check are all engine-free; refactoring
   // them out of the engine try/catch is safe and unlocks routing.
   const params = parseOpArgs(op, subArgs);
+  const stdinParamWasUnset = op.cliHints?.stdin !== undefined && params[op.cliHints.stdin] === undefined;
 
   // #3513: stdin fill moved out of parseOpArgs so a non-TTY stdin with no
   // piped input can't block the parse forever — the bounded read leaves the
   // param unset on timeout and the required-param check below fails fast.
   await applyStdinParam(op, params);
+  // #2822: `put` with empty/whitespace-only piped stdin used to silently
+  // write a 0-chunk page (invisible to `embed --stale`, no error). This is
+  // a CLI-dispatch-only guard — importFromContent (the file-sync path) is
+  // untouched and keeps its existing {status:'skipped', error} convention
+  // for a genuinely empty on-disk placeholder file, which is a legitimate
+  // state importFile must not throw on.
+  if (op.name === 'put_page' && stdinParamWasUnset && typeof params.content === 'string' && params.content.trim() === '') {
+    console.error('Error: gbrain put received empty or whitespace-only stdin; refusing to write an empty page.');
+    console.error('Use `gbrain put <slug> < file.md` or `gbrain capture --file PATH --slug SLUG`.');
+    process.exit(1);
+  }
 
   // v0.27.1 (`gbrain query --image <path>`): swap the `image` param from
   // a filesystem path into base64 bytes + mime. The op accepts base64; the

--- a/test/cli-stdin-hang.test.ts
+++ b/test/cli-stdin-hang.test.ts
@@ -14,6 +14,8 @@
  * connect, so no brain/DB is touched.
  */
 import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 
 const REPO = dirname(import.meta.dir);
@@ -22,6 +24,7 @@ const CLI = join(REPO, 'src', 'cli.ts');
 interface CliRun {
   exited: boolean;
   exitCode: number | null;
+  stdout: string;
   stderr: string;
 }
 
@@ -41,10 +44,11 @@ async function runCliWithStdin(
   args: string[],
   stdin: 'hold-open' | 'closed-empty' | { data: string } | { file: string },
   windowMs: number,
+  env: Record<string, string | undefined> = process.env,
 ): Promise<CliRun> {
   const proc = Bun.spawn(['bun', 'run', CLI, ...args], {
     cwd: REPO,
-    env: { ...process.env, GBRAIN_STDIN_TIMEOUT_MS: '500' },
+    env: { ...env, GBRAIN_STDIN_TIMEOUT_MS: '500' },
     stdin: typeof stdin === 'object' && 'file' in stdin ? Bun.file(stdin.file) : 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
@@ -62,13 +66,14 @@ async function runCliWithStdin(
     exited = false;
     try { proc.kill('SIGKILL'); } catch { /* already dead */ }
   }, windowMs);
-  const [exitCode, stderr] = await Promise.all([
+  const [exitCode, stdout, stderr] = await Promise.all([
     proc.exited,
+    new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ]);
   clearTimeout(killer);
   try { pipeSink(proc).end(); } catch { /* hold-open cleanup */ }
-  return { exited, exitCode: exited ? exitCode : null, stderr };
+  return { exited, exitCode: exited ? exitCode : null, stdout, stderr };
 }
 
 describe('#3513 — stdin-capable op with a non-TTY, never-written stdin', () => {
@@ -92,17 +97,63 @@ describe('#3513 — stdin-capable op with a non-TTY, never-written stdin', () =>
     expect(run.stderr).toContain('Usage: gbrain put');
   }, 30_000);
 
-  test('empty-but-real input (`< /dev/null`) does not hang', async () => {
-    const run = await runCliWithStdin(['put'], { file: '/dev/null' }, 20_000);
+  test('empty non-TTY stdin (`< /dev/null`) fails clearly before engine dispatch (#2822)', async () => {
+    const run = await runCliWithStdin(
+      ['put', './note.md', '--slug', 'notes/foo'],
+      { file: '/dev/null' },
+      20_000,
+    );
     expect(run.exited).toBe(true);
     expect(run.exitCode).toBe(1);
+    expect(run.stderr).toContain('gbrain put received empty or whitespace-only stdin');
+    expect(run.stderr).toContain('gbrain put <slug> < file.md');
+    expect(run.stderr).not.toContain('No brain configured');
   }, 30_000);
 
-  test('an empty pipe that closes immediately does not hang', async () => {
-    const run = await runCliWithStdin(['put'], 'closed-empty', 20_000);
+  test('an empty pipe that closes immediately gets the same clear error (#2822)', async () => {
+    const run = await runCliWithStdin(['put', 'stdin-empty-test-slug'], 'closed-empty', 20_000);
     expect(run.exited).toBe(true);
     expect(run.exitCode).toBe(1);
+    expect(run.stderr).toContain('gbrain put received empty or whitespace-only stdin');
   }, 30_000);
+
+  test('whitespace-only piped stdin is rejected too (#2822)', async () => {
+    const run = await runCliWithStdin(['put', 'stdin-empty-test-slug'], { data: '  \n\t \n' }, 20_000);
+    expect(run.exited).toBe(true);
+    expect(run.exitCode).toBe(1);
+    expect(run.stderr).toContain('gbrain put received empty or whitespace-only stdin');
+  }, 30_000);
+});
+
+describe('#2822 — normal non-empty CLI put remains functional', () => {
+  test('non-empty piped markdown reaches put_page and writes successfully', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-put-stdin-'));
+    try {
+      const configDir = join(home, '.gbrain');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+        engine: 'pglite',
+        database_path: join(configDir, 'brain.pglite'),
+        embedding_disabled: true,
+      }));
+
+      const env: Record<string, string | undefined> = { ...process.env, GBRAIN_HOME: home };
+      delete env.DATABASE_URL;
+      delete env.GBRAIN_DATABASE_URL;
+      const run = await runCliWithStdin(
+        ['put', 'inbox/non-empty-stdin', '--json'],
+        { data: '---\ntitle: Non-empty stdin\n---\n\nReal body text.\n' },
+        30_000,
+        env,
+      );
+
+      expect(run.exited).toBe(true);
+      expect(run.exitCode).toBe(0);
+      expect(JSON.parse(run.stdout).status).toBe('created_or_updated');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 45_000);
 });
 
 describe('#3513 — applyStdinParam content preservation (subprocess driver)', () => {

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -143,6 +143,20 @@ This is the compiled truth.
     expect(chunkCall).toBeTruthy();
   });
 
+  test('an empty placeholder file stays on the file-import result path instead of throwing (#2822)', async () => {
+    const filePath = join(TMP, 'empty-placeholder.md');
+    writeFileSync(filePath, '');
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'inbox/empty-placeholder.md', { noEmbed: true });
+
+    // Disk files are authoritative and may intentionally be empty. Most
+    // importantly, this path must keep returning an ImportResult rather than
+    // inherit a CLI-only rejection as a thrown exception mid-sync.
+    expect(result.status).toBe('imported');
+    expect(result.chunks).toBe(0);
+  });
+
   test('skips files larger than MAX_FILE_SIZE (5MB)', async () => {
     const filePath = join(TMP, 'big-file.md');
     const bigContent = '---\ntitle: Big\n---\n' + 'x'.repeat(5_100_000);


### PR DESCRIPTION
Related to #2822.

## The bug

`gbrain put` (CLI dispatch for `put_page`'s stdin `cliHint`) silently wrote an empty page (0 chunks, invisible to `embed --stale`) when given piped empty or whitespace-only stdin.

## Why this is scoped the way it is

A prior attempt (#3163) was closed for two specific, avoidable reasons — this PR is designed around both:

1. **Scope creep.** That PR bundled three unrelated hardening changes with the core fix. This PR touches exactly one thing: the empty-stdin gap.
2. **`importFromContent` must not throw on empty content.** The maintainer's own words: *"the importFromContent throw is the part I can't take: every other rejection in that function returns `{status:'skipped', error}` and `importFile` routes file syncs through it, so a zero-byte placeholder note in someone's vault would start throwing mid-sync."* This fix does not touch `importFromContent` at all — it stays on its existing `{status: 'imported', chunks: 0}` convention for a genuinely empty on-disk file, which is a legitimate state the file-sync path must not throw on.

## Fix

A CLI-dispatch-only guard in `cli.ts`, placed after `applyStdinParam` and before op dispatch: if `put_page`'s stdin param was empty specifically because stdin filled it empty (not because the caller supplied the param some other way), reject with a clear error and usage hint instead of silently writing an empty page.

The "stray file-path positional silently discarded" half of the original issue is a separate, unrelated code path and is left as a follow-up rather than folded into this fix.

## Test plan

`test/cli-stdin-hang.test.ts` (extended): `/dev/null` stdin, an immediately-closed empty pipe, and whitespace-only piped stdin all now get the same clear error instead of writing an empty page; normal non-empty piped content still succeeds end-to-end.

`test/import-file.test.ts` (new regression guard): an empty on-disk placeholder file through `importFromContent` still returns `{status: 'imported', chunks: 0}` — proving this fix did not touch that path's throw/skip behavior.

```
bun run typecheck                       # pass
bun run check:module-size               # pass (src/cli.ts ceiling raised, reviewer-visible in scripts/module-size-limits.tsv)
bun run check:structural-manifest       # pass
bun test (focused suites)               # 40 pass, 0 fail
```
