### PR TITLE
fix(import): honor sources.set-cr-mode on the import path (#3885)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -791,14 +791,23 @@ export async function importFromContent(
   if (!opts.noEmbed) {
     const searchInput = await loadSearchModeConfig(engine);
     const knobs = resolveSearchMode(searchInput);
-    // Look up the source row for this import; default to host trust when
-    // the engine's getConfig path doesn't surface a source row (most calls).
+    // Load the stored per-source CR override (sources.set-cr-mode). A missing
+    // row — mock engines, pre-source callers — falls through to global mode.
+    const resolvedSourceId = sourceId ?? 'default';
+    const sourceRows = await engine.executeRaw<{
+      contextual_retrieval_mode: string | null;
+      trust_frontmatter_overrides: boolean | null;
+    }>(
+      `SELECT contextual_retrieval_mode, trust_frontmatter_overrides FROM sources WHERE id = $1`,
+      [resolvedSourceId],
+    );
+    const sourceRow = Array.isArray(sourceRows) ? sourceRows[0] : undefined;
     const resolution = resolveContextualRetrievalMode({
       pageFrontmatter: parsed.frontmatter,
       source: {
-        id: sourceId ?? 'default',
-        contextual_retrieval_mode: null,
-        trust_frontmatter_overrides: false,
+        id: resolvedSourceId,
+        contextual_retrieval_mode: sourceRow?.contextual_retrieval_mode ?? null,
+        trust_frontmatter_overrides: sourceRow?.trust_frontmatter_overrides === true,
       },
       globalMode: knobs.contextual_retrieval,
       killSwitchDisabled: knobs.contextual_retrieval_disabled,

--- a/test/e2e/contextual-retrieval-pglite.test.ts
+++ b/test/e2e/contextual-retrieval-pglite.test.ts
@@ -33,6 +33,10 @@ import {
   resetGateway,
 } from '../../src/core/ai/gateway.ts';
 import { MARKDOWN_CHUNKER_VERSION } from '../../src/core/chunkers/recursive.ts';
+import { operationsByName } from '../../src/core/operations.ts';
+import type { OperationContext } from '../../src/core/operations.ts';
+import { runReindex } from '../../src/commands/reindex.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
 
 const STUB_DIMS = 1536;
 
@@ -185,5 +189,108 @@ describe('T9 reindex sweep predicate', () => {
       [MARKDOWN_CHUNKER_VERSION],
     );
     expect(rows[0].count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('per-source CR mode on the import path (#3885)', () => {
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  });
+
+  async function seedSource(id: string, mode: string): Promise<void> {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config, contextual_retrieval_mode)
+       VALUES ($1, $1, '{}'::jsonb, $2)
+       ON CONFLICT (id) DO UPDATE SET contextual_retrieval_mode = EXCLUDED.contextual_retrieval_mode`,
+      [id, mode],
+    );
+  }
+
+  async function pageMode(slug: string, sourceId: string): Promise<string | null> {
+    const rows = await engine.executeRaw<{ mode: string | null }>(
+      `SELECT contextual_retrieval_mode AS mode FROM pages WHERE slug = $1 AND source_id = $2`,
+      [slug, sourceId],
+    );
+    return rows[0]?.mode ?? null;
+  }
+
+  function putPageCtx(sourceId: string): OperationContext {
+    return {
+      engine,
+      config: { engine: 'pglite' as const },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+      sourceId,
+    };
+  }
+
+  test('importFromContent honors sources.set-cr-mode=none over global title', async () => {
+    const sourceId = 'src-none-import';
+    await seedSource(sourceId, 'none');
+    const slug = 'wiki/concepts/source-none-import';
+    await importFromContent(
+      engine,
+      slug,
+      '---\ntitle: "Source None"\n---\n\nBody that must not wrap.',
+      { sourceId },
+    );
+
+    expect(await pageMode(slug, sourceId)).toBe('none');
+    const wrapped = embedderInputs.flat();
+    expect(wrapped.length).toBeGreaterThan(0);
+    expect(wrapped[0]).not.toContain('<context>');
+  });
+
+  test('put_page (capture write path) honors per-source none', async () => {
+    const sourceId = 'src-none-capture';
+    await seedSource(sourceId, 'none');
+    const slug = 'inbox/source-none-capture';
+    const result = await operationsByName['put_page']!.handler(putPageCtx(sourceId), {
+      slug,
+      content: '---\ntitle: "Capture None"\n---\n\nCaptured body for CR source override.',
+    });
+    expect(['imported', 'created_or_updated']).toContain((result as { status: string }).status);
+    expect(await pageMode(slug, sourceId)).toBe('none');
+    expect(embedderInputs.flat()[0]).not.toContain('<context>');
+  });
+
+  test('reindex --markdown honors per-source none', async () => {
+    const sourceId = 'src-none-reindex';
+    await seedSource(sourceId, 'none');
+    const slug = 'wiki/concepts/source-none-reindex';
+    await engine.executeRaw(
+      `INSERT INTO pages (source_id, slug, type, title, compiled_truth, chunker_version, contextual_retrieval_mode)
+       VALUES ($1, $2, 'concept', 'Reindex None', 'Body that must not wrap after markdown reindex.', 1, NULL)`,
+      [sourceId, slug],
+    );
+
+    const result = await runReindex(engine, ['--markdown', '--json', '--limit', '10']);
+    expect(result.reindexed).toBeGreaterThanOrEqual(1);
+    expect(await pageMode(slug, sourceId)).toBe('none');
+    const wrapped = embedderInputs.flat();
+    expect(wrapped.length).toBeGreaterThan(0);
+    expect(wrapped.every((text) => !text.includes('<context>'))).toBe(true);
+  });
+
+  test('source per_chunk_synopsis beats global conservative (inline demotes to title wrap)', async () => {
+    const sourceId = 'src-synopsis-import';
+    await seedSource(sourceId, 'per_chunk_synopsis');
+    await engine.setConfig('search.mode', 'conservative');
+    try {
+      const slug = 'wiki/concepts/source-synopsis-import';
+      await importFromContent(
+        engine,
+        slug,
+        '---\ntitle: "Source Synopsis"\n---\n\nBody that should wrap at the title tier.',
+        { sourceId },
+      );
+      // Inline import refuses paid synopsis generation; it must still SEE the
+      // source override and land at title instead of global none.
+      expect(await pageMode(slug, sourceId)).toBe('title');
+      expect(embedderInputs.flat()[0]).toContain('<context>Source Synopsis');
+    } finally {
+      await engine.setConfig('search.mode', 'balanced');
+    }
   });
 });


### PR DESCRIPTION
Fixes #3885.

## The bug

`importFromContent` (`src/core/import-file.ts`) resolved a page's contextual-retrieval mode with the source's fields hardcoded:

```ts
source: {
  id: sourceId ?? 'default',
  contextual_retrieval_mode: null,
  trust_frontmatter_overrides: false,
},
```

instead of reading the actual stored values from the `sources` row. `gbrain sources set-cr-mode <id> none` (or `title`/`per_chunk_synopsis`) is invisible on every write path that funnels through `importFromContent` — CLI `put`, `capture`, and `reindex --markdown` all silently fall back to the global `contextual_retrieval_mode` config, ignoring a per-source override the user explicitly configured.

## Fix

Look up the source row (`contextual_retrieval_mode`, `trust_frontmatter_overrides`) before resolving, with an `Array.isArray` guard so a missing row (mock engines, pre-source callers) falls through to the existing global-config behavior rather than throwing.

Does not touch the existing `per_chunk_synopsis -> title` demotion cost-containment logic — inline import still refuses paid synopsis generation; that stays Minion-backfill-only by design, and one of the new tests proves the source override is seen without triggering it.

## Test plan

4 new live-PGLite + embed-stub cases in `test/e2e/contextual-retrieval-pglite.test.ts`:
- `importFromContent` + source `none` beats global `title`
- `put_page` (capture write path) + source `none`
- `reindex --markdown` + source `none`
- source `per_chunk_synopsis` + global `conservative` correctly demotes to title wrap (proves the override is seen without triggering inline paid synopsis generation)

```
bun run typecheck                       # pass
bun run check:module-size               # pass
bun run check:structural-manifest       # pass
bun test test/e2e/contextual-retrieval-pglite.test.ts test/import-file.test.ts \
    test/contextual-retrieval-resolver.test.ts test/sources-set-cr-mode.test.ts
# 76 pass, 0 fail, 195 expect() calls
```
