### PR TITLE
fix(code-intel): recognize method_declaration in symbol extraction (#3789)

### DIFF
--- a/src/commands/code-def.ts
+++ b/src/commands/code-def.ts
@@ -44,6 +44,10 @@ export const DEF_TYPES = [
   'table', 'view', 'index', 'procedure', 'schema', 'database', 'trigger',
   'method declaration', 'method definition', 'constructor declaration',
   'field declaration', 'field definition', 'struct specifier', 'protocol declaration',
+  // #3789: same fallthrough — C#/Kotlin property_declaration → 'property
+  // declaration', Java/C# record_declaration → 'record declaration'. Without
+  // these, code-def is blind to every C# property and every Java/C# record.
+  'property declaration', 'record declaration',
   // Dart: normalizeSymbolType has no rule for these four, so they arrive as
   // the node type with underscores replaced. class_definition/enum_declaration/
   // type_alias/function_signature already normalize into the list above.

--- a/test/code-def-refs.test.ts
+++ b/test/code-def-refs.test.ts
@@ -184,6 +184,98 @@ describe('findCodeDef', () => {
   });
 });
 
+describe('findCodeDef — #3789 property_declaration / record_declaration', () => {
+  let repoEngine: PGLiteEngine;
+
+  beforeAll(async () => {
+    repoEngine = new PGLiteEngine();
+    await repoEngine.connect({});
+    await repoEngine.initSchema();
+
+    // Java: record_declaration is already a top-level chunk in
+    // normalizeSymbolType's fallthrough ("record declaration") AND the
+    // chunker already extracts symbol_name for it correctly end-to-end —
+    // this is a real, reachable repro of #3789's residual gap after PR
+    // #1628 fixed method/constructor/field/struct/protocol.
+    const javaSrc = `package com.acme.widgets;
+
+/**
+ * Immutable configuration record describing how many times a widget
+ * refresh should be retried before giving up. Validates its own
+ * invariants in a compact canonical constructor so every call site gets
+ * the same guarantee without duplicating the check.
+ */
+public record WidgetRecord(String name, int retryCount) {
+    public WidgetRecord {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount must be >= 0, got " + retryCount);
+        }
+        if (retryCount > 100) {
+            throw new IllegalArgumentException("retryCount must be <= 100, got " + retryCount);
+        }
+        System.out.println("constructed WidgetRecord " + name + " with retryCount " + retryCount);
+    }
+
+    public WidgetRecord withRetryCount(int newRetryCount) {
+        return new WidgetRecord(name, newRetryCount);
+    }
+}
+`;
+    await importCodeFile(repoEngine, 'src/WidgetRecord.java', javaSrc, { noEmbed: true });
+
+    // C#: property_declaration hits the same normalizeSymbolType
+    // fallthrough ("property declaration"), but C# properties only ever
+    // appear nested inside a class body — and unlike java/typescript/etc,
+    // c_sharp has no NESTED_EMIT_CONFIG entry, so the chunker never emits
+    // a class's members as their own top-level chunks (a separate,
+    // pre-existing chunker limitation outside this fix's scope). Seed a
+    // content_chunks row directly, the same shape importCodeFile would
+    // write, to isolate exactly what DEF_TYPES controls: whether
+    // findCodeDef's WHERE ... symbol_type IN (...) filter admits
+    // "property declaration" rows that are already indexed.
+    await repoEngine.putPage('src-widgetoptions-cs', {
+      type: 'code',
+      page_kind: 'code',
+      title: 'src/WidgetOptions.cs',
+      compiled_truth: 'public int RetryCount { get; set; }',
+      frontmatter: { language: 'c_sharp', file: 'src/WidgetOptions.cs' },
+    });
+    await repoEngine.upsertChunks('src-widgetoptions-cs', [{
+      chunk_index: 0,
+      chunk_text: '[C#] src/WidgetOptions.cs:3-3\n\npublic int RetryCount { get; set; }',
+      chunk_source: 'compiled_truth',
+      language: 'c_sharp',
+      symbol_name: 'RetryCount',
+      symbol_type: 'property declaration',
+      start_line: 3,
+      end_line: 3,
+    }]);
+  });
+
+  afterAll(async () => {
+    await repoEngine.disconnect();
+  });
+
+  test('finds a Java record declaration', async () => {
+    const results = await findCodeDef(repoEngine, 'WidgetRecord');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const match = results.find((r) => r.slug === 'src-widgetrecord-java');
+    expect(match).toBeDefined();
+    expect(match!.symbol_type).toBe('record declaration');
+  });
+
+  test('finds an indexed C# property declaration', async () => {
+    const results = await findCodeDef(repoEngine, 'RetryCount');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const match = results.find((r) => r.slug === 'src-widgetoptions-cs');
+    expect(match).toBeDefined();
+    expect(match!.symbol_type).toBe('property declaration');
+  });
+});
+
 describe('findCodeRefs', () => {
   test('finds multiple usage sites across files', async () => {
     const results = await findCodeRefs(engine, 'BrainEngine');


### PR DESCRIPTION
## Problem

`code_def` still can't find every symbol in a C#/Java codebase, even after #1628. `DEF_TYPES` in `src/commands/code-def.ts` filters `content_chunks.symbol_type` — and the chunker's `normalizeSymbolType` (`src/core/chunkers/code.ts`) only canonicalizes some tree-sitter node types, letting the rest fall through `type.replace(/_/g, ' ')`. #1628 already fixed the headline case (`method_declaration` and friends). Two node types still fall through the same gap:

| tree-sitter node | stored `symbol_type` | in `DEF_TYPES`? |
|---|---|---|
| `property_declaration` (C#, Kotlin) | `"property declaration"` | ❌ before this PR |
| `record_declaration` (Java, C#) | `"record declaration"` | ❌ before this PR |

`code_refs`/`code_callers` already find these symbols (they match `chunk_text` + the edge tables, not this allowlist), so the tools contradict each other for properties/records the same way they used to for methods.

Confirmed still present on current `master` (`055ac6c7`) before this fix.

## Fix

Mirrors #1628's established pattern exactly: add the two fallthrough spellings to `DEF_TYPES`. Read-path only — no schema change, no reindex, no migration. It surfaces symbols already present in `content_chunks`.

```diff
   'method declaration', 'method definition', 'constructor declaration',
   'field declaration', 'field definition', 'struct specifier', 'protocol declaration',
+  'property declaration', 'record declaration',
```

## Before / after

```
$ gbrain code-def RetryCount   # a C# property
Before: No definitions found for "RetryCount"
After:  Found 1 definition(s) for "RetryCount":
          src/WidgetOptions.cs:3  (property declaration)
```

## Test coverage

Added a new `describe` block to `test/code-def-refs.test.ts`:

- **Java `record_declaration`** — a real end-to-end repro via `importCodeFile` (the chunker already extracts `symbol_name` correctly for Java records; the only bug is the `DEF_TYPES` filter).
- **C# `property_declaration`** — a seeded-chunk repro (`putPage` + `upsertChunks` directly) rather than an end-to-end `importCodeFile` repro. Reason: `c_sharp` has no `NESTED_EMIT_CONFIG` entry, so the chunker never emits a class's members as their own top-level chunks — a real C# property is always nested inside a `class_declaration` and today gets folded into the class-level chunk (or a `merged` sibling group) rather than surfacing as its own `property_declaration` chunk. That's a separate, pre-existing chunker-emission limitation this PR does not touch (it's orthogonal to the `DEF_TYPES` allowlist bug #3789 reports). The seeded-chunk test isolates exactly what this PR's diff controls — whether `findCodeDef`'s `WHERE ... symbol_type IN (...)` filter admits an already-indexed `"property declaration"` row — without depending on that separate chunker behavior.

Verified **red without the fix**: reverting just the `DEF_TYPES` diff makes both new tests fail with 0 results (10 pass / 2 fail). **Green with the fix**: `bun test test/code-def-refs.test.ts test/code-edges.test.ts` → 21 pass / 0 fail. `bun run typecheck` and `bun run check:module-size` both clean.

## Scope note

Left out of this PR (flagged, not fixed, to keep the diff surgical and matched to what #3789 actually reports):
- Chunker-side fix (option 1 in the issue): extending `normalizeSymbolType` so these normalize going forward at chunk time. The issue's author explicitly chose the query-side fix (this PR's approach) because it's zero-migration and immediate on already-indexed data — same tradeoff #1628 made.
- The C# `property_declaration` chunker-emission gap noted above (no `NESTED_EMIT_CONFIG` entry for `c_sharp`) — a different bug from what #3789 is about.
- Kotlin top-level `property_declaration`: reachable as `symbol_type` after this fix, but `extractSymbolName` doesn't currently extract a name for Kotlin's `property_declaration` → `variable_declaration` nesting shape (a separate, pre-existing symbol-name-extraction bug), so it wasn't used for regression coverage here.

Fixes #3789
