### PR TITLE
fix(sources): exclude archived sources from automatic operations (#3880)

### DIFF
--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -290,7 +290,7 @@ export async function checkUndeclaredDbOnlyPages(engine: BrainEngine): Promise<C
   const name = 'undeclared_db_only_pages';
   try {
     const sources = await engine.executeRaw<{ id: string; local_path: string | null }>(
-      `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL`,
+      `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE`,
     );
     const checkable = sources.filter(s => s.local_path && existsSync(s.local_path));
     if (checkable.length === 0) {
@@ -371,7 +371,7 @@ export async function checkDbOnlyCollectorCollision(
       return { name, status: 'ok', message: 'No configured collectors declare output paths' };
     }
     const sources = await engine.executeRaw<{ id: string; local_path: string | null }>(
-      `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL`,
+      `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE`,
     );
     const hits: string[] = [];
     for (const src of sources) {
@@ -699,7 +699,7 @@ export async function checkSyncFreshness(
     }>(
       // v0.41.32.0: newest_content_at feeds the REMOTE (non-localOnly) lag so
       // doctorReportRemote never shells out to git on a DB-supplied local_path.
-      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at FROM sources WHERE local_path IS NOT NULL`,
+      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE`,
     );
 
     if (sources.length === 0) {

--- a/src/commands/frontmatter-install-hook.ts
+++ b/src/commands/frontmatter-install-hook.ts
@@ -63,7 +63,7 @@ interface SourceRow {
   local_path: string | null;
 }
 
-export async function runFrontmatterInstallHook(args: string[]): Promise<void> {
+export async function runFrontmatterInstallHook(args: string[], engineOverride?: BrainEngine): Promise<void> {
   let force = false;
   let uninstall = false;
   let sourceId: string | undefined;
@@ -82,13 +82,13 @@ export async function runFrontmatterInstallHook(args: string[]): Promise<void> {
     return;
   }
 
-  const config = loadConfig();
-  if (!config) {
+  const config = engineOverride ? null : loadConfig();
+  if (!engineOverride && !config) {
     throw new Error('No brain configured. Run: gbrain init');
   }
-  const engineConfig = toEngineConfig(config);
-  const engine = await createEngine(engineConfig);
-  await engine.connect(engineConfig);
+  const engineConfig = config ? toEngineConfig(config) : null;
+  const engine = engineOverride ?? await createEngine(engineConfig!);
+  if (!engineOverride) await engine.connect(engineConfig!);
   try {
     const sources = await listSources(engine, sourceId);
     if (sources.length === 0) {
@@ -134,7 +134,7 @@ export async function runFrontmatterInstallHook(args: string[]): Promise<void> {
 
     console.log(`\nDone. ${installed} ${uninstall ? 'removed' : 'installed/updated'}, ${skipped} skipped.`);
   } finally {
-    await engine.disconnect();
+    if (!engineOverride) await engine.disconnect();
   }
 }
 
@@ -158,7 +158,7 @@ async function listSources(engine: BrainEngine, sourceId?: string): Promise<Sour
   if (sourceId) {
     return engine.executeRaw<SourceRow>(`SELECT id, local_path FROM sources WHERE id = $1`, [sourceId]);
   }
-  return engine.executeRaw<SourceRow>(`SELECT id, local_path FROM sources WHERE local_path IS NOT NULL ORDER BY id`);
+  return engine.executeRaw<SourceRow>(`SELECT id, local_path FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE ORDER BY id`);
 }
 
 function isGitRepo(dir: string): boolean {

--- a/src/commands/sources-harden.ts
+++ b/src/commands/sources-harden.ts
@@ -40,9 +40,10 @@ function configHost(config: unknown): string | null {
   return null;
 }
 
-async function loadSourceRows(engine: BrainEngine, id: string | undefined, all: boolean): Promise<SourceRow[]> {
+/** @internal Exported for live-engine source-selection regression coverage. */
+export async function loadSourceRows(engine: BrainEngine, id: string | undefined, all: boolean): Promise<SourceRow[]> {
   if (all) {
-    return engine.executeRaw<SourceRow>(`SELECT id, local_path, config FROM sources WHERE local_path IS NOT NULL ORDER BY id`);
+    return engine.executeRaw<SourceRow>(`SELECT id, local_path, config FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE ORDER BY id`);
   }
   if (!id) throw new Error('Usage: gbrain sources harden <id|--all> [--pat-file <p>] [--branch <b>] [--no-cron] [--no-verify] [--dry-run] [--json]');
   return engine.executeRaw<SourceRow>(`SELECT id, local_path, config FROM sources WHERE id = $1`, [id]);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3368,7 +3368,7 @@ See also:
     // Both columns predate v0.41 (writeSyncAnchor / writeChunkerVersion); no
     // schema migration needed.
     const sources = await engine.executeRaw<{ id: string; name: string; local_path: string | null; config: Record<string, unknown>; last_commit: string | null; chunker_version: string | null }>(
-      `SELECT id, name, local_path, config, last_commit, chunker_version FROM sources WHERE local_path IS NOT NULL`,
+      `SELECT id, name, local_path, config, last_commit, chunker_version FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE`,
     );
     if (!sources || sources.length === 0) {
       console.log('No sources with local_path configured. Use `gbrain sources add <id> --path <path>` first.');

--- a/src/core/brain-writer.ts
+++ b/src/core/brain-writer.ts
@@ -757,6 +757,6 @@ async function listSources(engine: BrainEngine, sourceId?: string): Promise<Sour
     return rows;
   }
   return engine.executeRaw<SourceRow>(
-    `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL ORDER BY id`,
+    `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL AND archived IS NOT TRUE ORDER BY id`,
   );
 }

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -128,6 +128,11 @@ export async function resolveSourceId(
   // 4. Registered source whose local_path contains CWD.
   //    Uses longest-prefix match so nested-path configurations (e.g.
   //    gstack at ~/gstack + plans at ~/gstack/plans) pick the deepest.
+  //    Deliberately NOT filtering archived here (#3880): an archived source
+  //    must still win the longest-prefix match so assertSourceExists()
+  //    below throws its "archived" error — filtering it out of this SELECT
+  //    would make cwd resolution silently fall through past it to a parent
+  //    path or the brain default instead of failing closed.
   const registered = await engine.executeRaw<{ id: string; local_path: string }>(
     `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL`,
   );
@@ -409,6 +414,9 @@ export async function resolveSourceWithTier(
   }
 
   // 4. Registered source whose local_path contains CWD.
+  //    Deliberately NOT filtering archived here (#3880) — see the matching
+  //    comment in resolveSourceId: assertSourceExists() below must see the
+  //    archived match to fail closed instead of falling through silently.
   const registered = await engine.executeRaw<{ id: string; local_path: string }>(
     `SELECT id, local_path FROM sources WHERE local_path IS NOT NULL`,
   );

--- a/test/archived-source-automatic-operations.test.ts
+++ b/test/archived-source-automatic-operations.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Issue #3880 — archived sources are historical rows, not candidates for
+ * automatic operations that enumerate filesystem-backed active sources.
+ *
+ * These tests use a real PGLite engine so every fixed SQL predicate is
+ * executed against the production schema. Explicit single-source lookups are
+ * intentionally left alone; this suite covers only automatic/all-source paths.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSync } from '../src/commands/sync.ts';
+import { runFrontmatterInstallHook } from '../src/commands/frontmatter-install-hook.ts';
+import { loadSourceRows } from '../src/commands/sources-harden.ts';
+import {
+  checkDbOnlyCollectorCollision,
+  checkSyncFreshness,
+  checkUndeclaredDbOnlyPages,
+} from '../src/commands/doctor.ts';
+import { scanBrainSources } from '../src/core/brain-writer.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resolveSourceId, resolveSourceWithTier } from '../src/core/source-resolver.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+let engine: PGLiteEngine;
+let scratch: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  scratch = mkdtempSync(join(tmpdir(), 'gbrain-archived-sources-'));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+async function addSource(
+  id: string,
+  localPath: string | null,
+  archived: boolean,
+): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config, archived)
+     VALUES ($1, $1, $2, '{}'::jsonb, $3)`,
+    [id, localPath, archived],
+  );
+}
+
+async function addPage(sourceId: string, slug: string): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO pages
+       (slug, source_id, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash)
+     VALUES ($1, $2, 'concept', 'markdown', $1, 'body', '', '{}'::jsonb, $3)`,
+    [slug, sourceId, `hash-${sourceId}-${slug}`],
+  );
+}
+
+function gitInit(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q', dir]);
+}
+
+async function captureConsoleLogs(fn: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const logSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+  try {
+    await fn();
+  } finally {
+    logSpy.mockRestore();
+  }
+  return lines;
+}
+
+describe('automatic active-source operations', () => {
+  test('sync --all includes the active source and excludes the archived source', async () => {
+    const activePath = join(scratch, 'missing-active');
+    const archivedPath = join(scratch, 'missing-archived');
+    await addSource('active-sync', activePath, false);
+    await addSource('archived-sync', archivedPath, true);
+
+    const logs = await captureConsoleLogs(() => runSync(engine, [
+      '--all',
+      '--source', 'active-sync',
+      '--dry-run',
+      '--no-embed',
+      '--no-pull',
+      '--serial',
+      '--missing-path', 'skip',
+      '--json',
+    ]));
+    const envelope = JSON.parse(logs.at(-1)!) as {
+      sources: Array<{ source_id: string }>;
+    };
+
+    expect(envelope.sources.map((source) => source.source_id)).toEqual(['active-sync']);
+  });
+
+  test('brain-writer automatic scan includes active and excludes archived repos', async () => {
+    const activePath = join(scratch, 'active-writer');
+    const archivedPath = join(scratch, 'archived-writer');
+    mkdirSync(activePath, { recursive: true });
+    mkdirSync(archivedPath, { recursive: true });
+    writeFileSync(join(activePath, 'bad.md'), '---\ntitle: active\n---\nbody\u0000');
+    writeFileSync(join(archivedPath, 'bad.md'), '---\ntitle: archived\n---\nbody\u0000');
+    await addSource('active-writer', activePath, false);
+    await addSource('archived-writer', archivedPath, true);
+
+    const report = await scanBrainSources(engine);
+
+    expect(report.per_source.map((source) => source.source_id)).toEqual(['active-writer']);
+    expect(report.per_source[0]?.errors_by_code.NULL_BYTES).toBeGreaterThanOrEqual(1);
+  });
+
+  test('both cwd resolvers fail closed on a deeper archived path instead of falling to the active parent', async () => {
+    // Codex review correction: the archived child is the longest-prefix
+    // match, so both resolvers must still find it and reject it via the
+    // existing assertSourceExists() fail-closed contract (see
+    // test/cli-ambient-source-fail-closed.test.ts) rather than silently
+    // resolving up to the active parent source.
+    const activePath = join(scratch, 'active-resolver');
+    const archivedPath = join(activePath, 'historical-copy');
+    mkdirSync(archivedPath, { recursive: true });
+    await addSource('active-resolver', activePath, false);
+    await addSource('archived-resolver', archivedPath, true);
+
+    await withEnv({ GBRAIN_SOURCE: undefined }, async () => {
+      await expect(resolveSourceId(engine, null, archivedPath)).rejects.toThrow(/archived/i);
+      await expect(resolveSourceWithTier(engine, null, archivedPath)).rejects.toThrow(/archived/i);
+    });
+  });
+
+  test('doctor filesystem and freshness checks include active and exclude archived sources', async () => {
+    const activePath = join(scratch, 'active-doctor');
+    const archivedPath = join(scratch, 'archived-doctor');
+    mkdirSync(activePath, { recursive: true });
+    mkdirSync(archivedPath, { recursive: true });
+    writeFileSync(join(activePath, 'gbrain.yml'), 'storage:\n  db_only:\n    - inbox/\n');
+    writeFileSync(join(archivedPath, 'gbrain.yml'), 'storage:\n  db_only:\n    - inbox/\n');
+    await addSource('active-doctor', activePath, false);
+    await addSource('archived-doctor', archivedPath, true);
+    await addPage('active-doctor', 'people/active-missing');
+    await addPage('archived-doctor', 'people/archived-missing');
+
+    const undeclared = await checkUndeclaredDbOnlyPages(engine);
+    expect(undeclared.status).toBe('warn');
+    expect(undeclared.details).toMatchObject({
+      total: 1,
+      per_source: { 'active-doctor': 1 },
+    });
+    expect(JSON.stringify(undeclared.details)).not.toContain('archived-doctor');
+
+    const collision = await checkDbOnlyCollectorCollision(engine, {
+      collectors: [{ id: 'collector-a', output_path: 'inbox/' }],
+    });
+    expect(collision.status).toBe('warn');
+    expect((collision.details as { collisions: string[] }).collisions).toHaveLength(1);
+    expect(JSON.stringify(collision.details)).toContain('active-doctor');
+    expect(JSON.stringify(collision.details)).not.toContain('archived-doctor');
+
+    const freshness = await checkSyncFreshness(engine);
+    expect(freshness.status).toBe('fail');
+    expect(freshness.details).toMatchObject({
+      unchanged_count: 0,
+      synced_recently_count: 0,
+      stale_count: 1,
+    });
+    expect(freshness.message).toContain("'active-doctor'");
+    expect(freshness.message).not.toContain('archived-doctor');
+  });
+
+  test('default hook installation touches the active repo only', async () => {
+    const activePath = join(scratch, 'active-hook');
+    const archivedPath = join(scratch, 'archived-hook');
+    gitInit(activePath);
+    gitInit(archivedPath);
+    await addSource('active-hook', activePath, false);
+    await addSource('archived-hook', archivedPath, true);
+
+    await captureConsoleLogs(() => runFrontmatterInstallHook([], engine));
+
+    expect(existsSync(join(activePath, '.githooks', 'pre-commit'))).toBe(true);
+    expect(existsSync(join(archivedPath, '.githooks', 'pre-commit'))).toBe(false);
+  });
+
+  test('sources harden --all selection includes active and excludes archived rows', async () => {
+    const activePath = join(scratch, 'active-harden');
+    const archivedPath = join(scratch, 'archived-harden');
+    await addSource('active-harden', activePath, false);
+    await addSource('archived-harden', archivedPath, true);
+
+    const automatic = await loadSourceRows(engine, undefined, true);
+    expect(automatic.map((source) => source.id)).toEqual(['active-harden']);
+
+    // Explicit recovery/history addressing remains available by design.
+    const explicit = await loadSourceRows(engine, 'archived-harden', false);
+    expect(explicit.map((source) => source.id)).toEqual(['archived-harden']);
+  });
+});


### PR DESCRIPTION
Fixes #3880.

## The bug

Several automatic all-source operations selected sources with a SQL filter shaped like `WHERE local_path IS NOT NULL`, with no `archived` check. A source archived via `gbrain sources archive <id>` (with its historical local_path left on disk) stayed eligible for:

- `sync --all` source selection (`src/commands/sync.ts`)
- automatic filesystem source scanning (`src/core/brain-writer.ts`)
- three doctor checks: `checkUndeclaredDbOnlyPages`, `checkDbOnlyCollectorCollision`, `checkSyncFreshness` (`src/commands/doctor/checks/extraction-sync.ts`)
- all-source hook installation (`src/commands/frontmatter-install-hook.ts`)
- `sources harden --all` selection (`src/commands/sources-harden.ts`)

## Fix

Added `AND archived IS NOT TRUE` to each of these automatic all-source queries. Explicit single-source lookups (`--source <id>`, `sources harden <id>`) are intentionally left alone — that's a deliberate recovery/history path.

`src/core/source-resolver.ts` (cwd-based auto-resolution) deliberately does **not** get the same treatment — this project went through two rounds before landing here. An adversarial Codex review round caught that filtering archived rows out of that tier-4 `SELECT` would make an archived source's `local_path` silently fall through cwd resolution to a parent directory's source or the brain default, instead of failing closed. Both tier-4 call sites (`resolveSourceId`, `resolveSourceWithTier`) already have the correct protection via the existing `assertSourceExists()` check immediately after the longest-prefix match, which throws `"not found or is archived"` — this is the existing fail-closed contract pinned by `test/cli-ambient-source-fail-closed.test.ts`. I independently reproduced the regression (the fail-closed test failed against the initial patch) before correcting it.

## Scope

The Codex review pass additionally found 5 more call sites with the same unfiltered pattern, outside the issue's originally-reported 6 areas: `doctor.ts` `multi_source_drift` (x2 — local + remote report), `routing-federation.ts` `source_routing_health`, `status.ts` local sync-status snapshot, `jobs.ts` sync-job `sourceId` inference from `repoPath`, and `advisor/collect-stalled-jobs.ts` stale-source recommendation. Leaving these as follow-up rather than silently expanding this PR's diff.

## Test plan

`test/archived-source-automatic-operations.test.ts` (new, live PGLite): covers all 6 in-scope call sites (active included / archived excluded), plus a case proving both cwd resolvers still fail closed on a deeper archived path rather than silently falling to the active parent.

```
test/cli-ambient-source-fail-closed.test.ts     # 4 pass, 0 fail (existing regression suite)
test/source-resolver*.test.ts (4 files)         # 62 pass, 0 fail
test/archived-source-automatic-operations.test.ts + test/cli-ambient-source-fail-closed.test.ts  # 10 pass, 0 fail
bun run typecheck                               # pass
bun run check:module-size                       # pass
bun run check:structural-manifest               # pass
```
