### PR TITLE
fix(guardrails): wire the guardrail seam into the CLI so it's actually enforced (#3688)

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -68,8 +68,45 @@ registerGuardrailProvider({
 });
 ```
 
-Register once at process init (e.g. from a plugin entry or an operator boot
-hook). Registration is idempotent by `id`, so a re-init won't double-fire.
+Registration is idempotent by `id`, so a re-init won't double-fire. What
+"process init" means depends on whether you're embedding `gbrain` as a
+package or running the `gbrain` CLI/`gbrain serve`:
+
+### Registering from an embedding process (library consumers)
+
+If your process constructs the `gbrain` package itself (a custom server, a
+test harness, another CLI), import `registerGuardrailProvider` from
+`gbrain/core/guardrails` and call it yourself before invoking any operation
+that could reach a guardrail hook — the code block above is the whole thing.
+
+### Registering in the `gbrain` CLI process (operators)
+
+Operators who run the `gbrain` binary directly (not as a library) can't add
+an import — there's no process to embed into. Point `GBRAIN_GUARDRAIL_MODULE`
+at the **absolute path** of a local file that calls `registerGuardrailProvider`
+(the same code block above, saved to a file):
+
+```bash
+export GBRAIN_GUARDRAIL_MODULE=/etc/gbrain/guardrails/my-firewall.ts
+gbrain import ./notes
+```
+
+`gbrain` imports that module once, early in `main()`, before dispatching any
+command — including `gbrain serve` — so it's live for the very first
+ingest/chat/tool-input hit in that process. If the module also exports a
+`default` function, it's awaited after import (for setup that needs to be
+async); the common case — a top-level `registerGuardrailProvider(...)` call,
+exactly like the code block above — needs nothing further.
+
+`GBRAIN_GUARDRAIL_MODULE` is unset by default, so the OSS distribution still
+ships inert. An unset env var is silent; a *set but broken* one (relative
+path, missing file, an import that throws) prints one `[guardrail-boot] ...`
+line to stderr and the command proceeds anyway — fail-open, the same
+invariant `runGuardrails` itself guarantees. `GBRAIN_GUARDRAIL_MODULE` is
+operator-owned, already-trusted local code, not a downloaded skillpack — it
+carries none of `GBRAIN_PLUGIN_PATH`'s defs-only trust boundary
+(`docs/guides/plugin-authors.md`), because it's the operator's own file, not
+third-party code discovered off a manifest.
 
 ### Provider responsibilities
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "./ai/gateway": "./src/core/ai/gateway.ts",
     "./extract": "./src/commands/extract.ts",
     "./ingestion": "./src/core/ingestion/index.ts",
-    "./ingestion/test-harness": "./src/core/ingestion/test-harness.ts"
+    "./ingestion/test-harness": "./src/core/ingestion/test-harness.ts",
+    "./core/guardrails": "./src/core/guardrails.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/scripts/check-exports-count.sh
+++ b/scripts/check-exports-count.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=21
+EXPECTED_COUNT=22
 
 # Count top-level keys in the exports object. `node -e` parses JSON
 # reliably without needing jq (which isn't in every CI environment).

--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -10,7 +10,7 @@ src/core/pglite-engine.ts	5971	ratchet	grown v0.46.24.0 overnight wave: registry
 src/core/migrate.ts	668	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted
 src/commands/sync.ts	4334	ratchet	grown v0.46.25.0 fix waves: delete-slug resolver + msys healing (#3942 #2955)
 src/core/ai/gateway.ts	4441	ratchet	grown v0.46.25.0 D2: env-key snapshot stash (#2119)
-src/cli.ts	3628	ratchet	grown v0.46.25.0 D2: stdout interposer install (#4383)
+src/cli.ts	3641	ratchet	grown #3688: GBRAIN_GUARDRAIL_MODULE boot-hook call in main()
 src/core/cycle.ts	3123	ratchet	grown v0.46.25.0 fix waves (#4309 #2821) + v0.46.26.0: cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3093	ratchet	grown v0.46.25.0 (--json #3685) + v0.46.26.0: maybeRunWorkerStartupRecovery extraction + stats gating + help text

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -411,6 +411,19 @@ async function main() {
   // GBRAIN_SKIP_STARTUP_HOOKS for their children. Runs for every real command.
   maybeEmitUpdateMarker(command);
 
+  // #3688: operator guardrail boot hook. GBRAIN_GUARDRAIL_MODULE points at an
+  // operator-owned local module that registers guardrail provider(s) via
+  // registerGuardrailProvider() (docs/guardrails.md) before this process runs
+  // any command. Runs for every real command — including `serve` — so the
+  // very first ingest/chat/tool-input hit in this process is covered. No-op
+  // and zero-cost when unset (fail-open; matches every other guardrail
+  // default-inert invariant).
+  if (process.env.GBRAIN_GUARDRAIL_MODULE) {
+    const { loadGuardrailBootModule } = await import('./core/guardrail-boot.ts');
+    const { warning } = await loadGuardrailBootModule();
+    if (warning) console.error(warning);
+  }
+
   const subArgs = args.slice(1);
 
   // DX alias: `ask` is a natural-language alias for `query`

--- a/src/core/guardrail-boot.ts
+++ b/src/core/guardrail-boot.ts
@@ -1,0 +1,100 @@
+/**
+ * CLI-process boot hook for guardrail providers (#3688).
+ *
+ * docs/guardrails.md tells operators to "register once at process init
+ * (e.g. from a plugin entry or an operator boot hook)" — but before this
+ * file, no such hook existed. `GBRAIN_PLUGIN_PATH` (plugin-loader.ts,
+ * skillpack-load.ts) only loads markdown subagent definitions and
+ * IngestionSource factories for the ingestion daemon; it never executes
+ * arbitrary operator code inside the CLI process. `registerGuardrailProvider`
+ * (guardrails.ts) had zero production call sites, so `runGuardrails` always
+ * short-circuited on `providers.size === 0` for every CLI user.
+ *
+ * `GBRAIN_GUARDRAIL_MODULE` closes that gap: it points at operator-owned,
+ * already-trusted code (a local file the operator wrote or vetted — not a
+ * downloaded skillpack), so this loader is deliberately simpler than the
+ * plugin/skillpack loaders: no manifest, no permission negotiation, no
+ * `kind` collision handling. It resolves one absolute path, imports it once
+ * per process, and — if the module also exports a zero-arg `default`
+ * function — awaits it. The module itself owns calling
+ * `registerGuardrailProvider`; this loader never touches the provider
+ * registry directly.
+ *
+ * Fail-open, matching every other invariant in guardrails.ts: a missing
+ * env var, a relative/missing path, or an import that throws produces a
+ * warning string for the caller to log — never a thrown error that could
+ * abort the CLI command the operator is actually trying to run.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface LoadGuardrailBootModuleOpts {
+  /** Override the GBRAIN_GUARDRAIL_MODULE env (for tests). */
+  envPath?: string;
+  /** Test seam: alternative import() function for stubbing module loads. */
+  _import?: (specifier: string) => Promise<unknown>;
+}
+
+export interface LoadGuardrailBootModuleResult {
+  /** True only when the module imported (and any default export ran) cleanly. */
+  loaded: boolean;
+  /** The resolved path that was imported, when loaded is true. */
+  modulePath?: string;
+  /** Non-fatal problem description. Caller decides how/whether to surface it. */
+  warning?: string;
+}
+
+/**
+ * Load and run the operator-designated guardrail boot module, if
+ * `GBRAIN_GUARDRAIL_MODULE` is set. No-op (`loaded: false`, no warning) when
+ * unset — the OSS distribution ships inert by default, unchanged.
+ */
+export async function loadGuardrailBootModule(
+  opts: LoadGuardrailBootModuleOpts = {},
+): Promise<LoadGuardrailBootModuleResult> {
+  const raw = (opts.envPath ?? process.env.GBRAIN_GUARDRAIL_MODULE ?? '').trim();
+  if (!raw) return { loaded: false };
+
+  if (!path.isAbsolute(raw)) {
+    return {
+      loaded: false,
+      warning: `[guardrail-boot] GBRAIN_GUARDRAIL_MODULE must be an absolute path, got: ${raw}`,
+    };
+  }
+  if (!fs.existsSync(raw)) {
+    return {
+      loaded: false,
+      warning: `[guardrail-boot] GBRAIN_GUARDRAIL_MODULE path does not exist: ${raw}`,
+    };
+  }
+
+  const importer = opts._import ?? ((spec: string) => import(spec));
+  let mod: unknown;
+  try {
+    mod = await importer(raw);
+  } catch (e) {
+    return {
+      loaded: false,
+      warning: `[guardrail-boot] failed to import GBRAIN_GUARDRAIL_MODULE (${raw}): ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  // The common case: the module calls registerGuardrailProvider() as a
+  // top-level side effect of import (exactly the docs/guardrails.md
+  // example) — nothing further to do. A module MAY also export a default
+  // function for setup that needs to be async; if present, await it.
+  const m = mod as Record<string, unknown>;
+  if (typeof m.default === 'function') {
+    try {
+      await (m.default as () => unknown)();
+    } catch (e) {
+      return {
+        loaded: false,
+        warning: `[guardrail-boot] GBRAIN_GUARDRAIL_MODULE default export threw (${raw}): ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
+
+  return { loaded: true, modulePath: raw };
+}

--- a/test/e2e/guardrail-boot-cli.test.ts
+++ b/test/e2e/guardrail-boot-cli.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #3688 E2E — proves the guardrail seam is actually reachable from the real
+ * `gbrain` CLI process, not just from an in-process unit test of
+ * `runGuardrails`/`registerGuardrailProvider` (test/guardrails.test.ts
+ * already covers that half; it can't detect "nothing calls
+ * registerGuardrailProvider in production").
+ *
+ * Subprocess-driven: spawns the actual `bun run src/cli.ts` binary with
+ * `GBRAIN_GUARDRAIL_MODULE` pointed at a fixture file that registers a
+ * provider whose `classify()` appends one JSON line per invocation to a
+ * marker file. A real `gbrain import` then either does or doesn't produce
+ * that marker output, which is the only way to observe whether the CLI
+ * process actually imported the module and wired the provider in.
+ *
+ * Positive control (not just "silent when unset" — the CLAUDE.md
+ * "positive-control-for-guards" reflex): the first test asserts the
+ * fixture provider actually fires. The second test asserts the exact same
+ * setup produces NOTHING when GBRAIN_GUARDRAIL_MODULE is unset, so the
+ * marker-file mechanism itself is proven to only report real firings.
+ *
+ * Hermetic: GBRAIN_HOME is a fresh tmpdir per describe block; PGLite via
+ * `gbrain init --pglite --no-embedding` (keyless — no provider API keys
+ * required); `gbrain import --no-embed` so the import completes without a
+ * real embedding call. The guardrail hook fires before embedding anyway
+ * (see docs/guardrails.md's seam table), so this doesn't narrow what's
+ * being proven.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawn } from 'child_process';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const GUARDRAILS_MODULE_PATH = join(REPO_ROOT, 'src', 'core', 'guardrails.ts');
+
+function runCli(
+  args: string[],
+  opts: { gbrainHome: string; env?: NodeJS.ProcessEnv },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const child = spawn('bun', ['run', join(REPO_ROOT, 'src', 'cli.ts'), ...args], {
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        GBRAIN_HOME: opts.gbrainHome,
+        ...opts.env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: REPO_ROOT,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (b) => { stdout += b.toString(); });
+    child.stderr?.on('data', (b) => { stderr += b.toString(); });
+    child.on('close', (code) => resolve({ stdout, stderr, exitCode: code ?? -1 }));
+  });
+}
+
+/** Fixture guardrail module: registers a provider that appends one JSON
+ *  line per classify() call to GUARDRAIL_TEST_MARKER. */
+function writeFixtureModule(path: string): void {
+  writeFileSync(
+    path,
+    [
+      `import { registerGuardrailProvider } from ${JSON.stringify(GUARDRAILS_MODULE_PATH)};`,
+      `import { appendFileSync } from 'node:fs';`,
+      ``,
+      `const marker = process.env.GUARDRAIL_TEST_MARKER;`,
+      `if (!marker) throw new Error('GUARDRAIL_TEST_MARKER not set');`,
+      ``,
+      `registerGuardrailProvider({`,
+      `  id: 'e2e-fixture-3688',`,
+      `  classify(input) {`,
+      `    const slug = input.metadata && typeof input.metadata === 'object'`,
+      `      ? (input.metadata as Record<string, unknown>).slug`,
+      `      : null;`,
+      `    appendFileSync(marker, JSON.stringify({ hook: input.hook, slug }) + '\\n');`,
+      `  },`,
+      `});`,
+      ``,
+    ].join('\n'),
+  );
+}
+
+describe('#3688 — GBRAIN_GUARDRAIL_MODULE actually reaches the CLI process', () => {
+  let tmpHome: string;
+  let repoDir: string;
+  let fixtureDir: string;
+  let fixtureModule: string;
+
+  beforeAll(async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-guardrail-boot-home-'));
+    fixtureDir = mkdtempSync(join(tmpdir(), 'gbrain-guardrail-boot-fixture-'));
+    fixtureModule = join(fixtureDir, 'my-firewall.ts');
+    writeFixtureModule(fixtureModule);
+
+    repoDir = join(tmpHome, 'sample-repo');
+    // Each test imports its own subdirectory (`gbrain import <dir>` — a bare
+    // file path isn't a supported target) so a content-hash dedup skip in
+    // one test can never be mistaken for the guardrail (not) firing in
+    // another.
+    mkdirSync(join(repoDir, 'positive'), { recursive: true });
+    mkdirSync(join(repoDir, 'negative'), { recursive: true });
+    mkdirSync(join(repoDir, 'failopen'), { recursive: true });
+    writeFileSync(join(repoDir, 'positive', 'note.md'), '# Note Positive\n\nhello world, positive control.\n');
+    writeFileSync(join(repoDir, 'negative', 'note.md'), '# Note Negative\n\nhello world, negative control.\n');
+    writeFileSync(join(repoDir, 'failopen', 'note.md'), '# Note Fail Open\n\nhello world, fail-open control.\n');
+
+    // Keyless init: no provider API keys required, matches
+    // test/e2e/init-fresh-pglite.test.ts's D9 --no-embedding pattern.
+    const init = await runCli(['init', '--pglite', '--no-embedding'], { gbrainHome: tmpHome, env: {} });
+    expect(init.exitCode).toBe(0);
+  }, 60000);
+
+  afterAll(() => {
+    for (const d of [tmpHome, fixtureDir]) {
+      try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  test('positive control: a registered provider fires on a real `gbrain import`', async () => {
+    const marker = join(fixtureDir, 'marker-positive.jsonl');
+    expect(existsSync(marker)).toBe(false);
+
+    const result = await runCli(['import', join(repoDir, 'positive'), '--no-embed'], {
+      gbrainHome: tmpHome,
+      env: { GBRAIN_GUARDRAIL_MODULE: fixtureModule, GUARDRAIL_TEST_MARKER: marker },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+
+    const lines = readFileSync(marker, 'utf8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+    const events = lines.map((l) => JSON.parse(l));
+    expect(events.some((e) => e.hook === 'file_storage.markdown' && e.slug === 'note')).toBe(true);
+  }, 60000);
+
+  test('negative control: same import with GBRAIN_GUARDRAIL_MODULE unset never touches the marker', async () => {
+    const marker = join(fixtureDir, 'marker-negative.jsonl');
+    expect(existsSync(marker)).toBe(false);
+
+    const result = await runCli(['import', join(repoDir, 'negative'), '--no-embed'], {
+      gbrainHome: tmpHome,
+      env: { GUARDRAIL_TEST_MARKER: marker }, // GBRAIN_GUARDRAIL_MODULE intentionally unset
+    });
+
+    expect(result.exitCode).toBe(0);
+    // The OSS distribution ships inert: proves the marker mechanism itself
+    // only reports real firings, not test-harness noise.
+    expect(existsSync(marker)).toBe(false);
+  }, 60000);
+
+  test('fail-open: a broken GBRAIN_GUARDRAIL_MODULE warns on stderr but the command still succeeds', async () => {
+    const result = await runCli(['import', join(repoDir, 'failopen'), '--no-embed'], {
+      gbrainHome: tmpHome,
+      env: { GBRAIN_GUARDRAIL_MODULE: '/definitely/does/not/exist/guardrail-3688.ts' },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('[guardrail-boot]');
+    expect(result.stderr).toContain('does not exist');
+  }, 60000);
+});

--- a/test/guardrail-boot.test.ts
+++ b/test/guardrail-boot.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Guardrail CLI boot-hook loader tests (#3688).
+ *
+ * Covers `loadGuardrailBootModule` (src/core/guardrail-boot.ts) in
+ * isolation via the `_import` test seam — no real filesystem imports, no
+ * subprocess. The genuine CLI-reachability proof (the module actually gets
+ * imported by `main()` and its registered provider actually fires on a real
+ * `gbrain import`) lives in test/e2e/guardrail-boot-cli.test.ts; this file
+ * is the unit-level contract for the loader's own validation/fail-open
+ * behavior.
+ */
+
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadGuardrailBootModule } from '../src/core/guardrail-boot.ts';
+
+describe('loadGuardrailBootModule — unset env (default inert)', () => {
+  test('no envPath -> loaded: false, no warning, importer never called', async () => {
+    let called = false;
+    const result = await loadGuardrailBootModule({
+      envPath: '',
+      _import: async () => { called = true; return {}; },
+    });
+    expect(result).toEqual({ loaded: false });
+    expect(called).toBe(false);
+  });
+
+  test('whitespace-only envPath is treated as unset', async () => {
+    const result = await loadGuardrailBootModule({ envPath: '   ' });
+    expect(result).toEqual({ loaded: false });
+  });
+});
+
+describe('loadGuardrailBootModule — validation (fail-open, never throws)', () => {
+  test('relative path is rejected with a warning', async () => {
+    const result = await loadGuardrailBootModule({ envPath: 'relative/path.ts' });
+    expect(result.loaded).toBe(false);
+    expect(result.warning).toContain('must be an absolute path');
+  });
+
+  test('~-prefixed path is rejected (not absolute, not expanded)', async () => {
+    const result = await loadGuardrailBootModule({ envPath: '~/guardrails/my-firewall.ts' });
+    expect(result.loaded).toBe(false);
+    expect(result.warning).toContain('must be an absolute path');
+  });
+
+  test('absolute path that does not exist is rejected with a warning', async () => {
+    const result = await loadGuardrailBootModule({
+      envPath: '/definitely/does/not/exist/guardrail-module-3688.ts',
+    });
+    expect(result.loaded).toBe(false);
+    expect(result.warning).toContain('does not exist');
+  });
+});
+
+describe('loadGuardrailBootModule — import + default-export execution', () => {
+  let dir: string;
+
+  afterAll(() => {
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  });
+
+  function makeTempFile(name: string, contents = 'export {};\n'): string {
+    dir = dir ?? mkdtempSync(join(tmpdir(), 'gbrain-guardrail-boot-'));
+    const p = join(dir, name);
+    writeFileSync(p, contents);
+    return p;
+  }
+
+  test('a real file with no default export loads cleanly', async () => {
+    const p = makeTempFile('no-default.ts');
+    const result = await loadGuardrailBootModule({ envPath: p });
+    expect(result.loaded).toBe(true);
+    expect(result.modulePath).toBe(p);
+    expect(result.warning).toBeUndefined();
+  });
+
+  test('module import failure is caught and reported as a warning, not thrown', async () => {
+    const p = makeTempFile('broken.ts');
+    const result = await loadGuardrailBootModule({
+      envPath: p,
+      _import: async () => { throw new Error('boom'); },
+    });
+    expect(result.loaded).toBe(false);
+    expect(result.warning).toContain('failed to import');
+    expect(result.warning).toContain('boom');
+  });
+
+  test('default export function is awaited', async () => {
+    const p = makeTempFile('with-default.ts');
+    let ran = false;
+    const result = await loadGuardrailBootModule({
+      envPath: p,
+      _import: async () => ({ default: async () => { ran = true; } }),
+    });
+    expect(ran).toBe(true);
+    expect(result.loaded).toBe(true);
+  });
+
+  test('default export throwing is caught and reported as a warning, not thrown', async () => {
+    const p = makeTempFile('default-throws.ts');
+    const result = await loadGuardrailBootModule({
+      envPath: p,
+      _import: async () => ({ default: () => { throw new Error('setup failed'); } }),
+    });
+    expect(result.loaded).toBe(false);
+    expect(result.warning).toContain('default export threw');
+    expect(result.warning).toContain('setup failed');
+  });
+
+  test('a non-function default export is ignored, not called', async () => {
+    const p = makeTempFile('default-not-fn.ts');
+    const result = await loadGuardrailBootModule({
+      envPath: p,
+      _import: async () => ({ default: 'not-a-function' }),
+    });
+    expect(result.loaded).toBe(true);
+  });
+});

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -54,6 +54,11 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/extract', canary: [] },
   { subpath: 'gbrain/ingestion', canary: ['INGESTION_SOURCE_API_VERSION', 'validateIngestionEvent', 'computeContentHash'] },
   { subpath: 'gbrain/ingestion/test-harness', canary: ['IngestionTestHarness', 'expectEvent'] },
+  // #3688: docs/guardrails.md documents `import { registerGuardrailProvider }
+  // from 'gbrain/core/guardrails'` but the subpath was missing from the
+  // exports map, so the documented specifier hard-failed for every package
+  // consumer (ERR_PACKAGE_PATH_NOT_EXPORTED).
+  { subpath: 'gbrain/core/guardrails', canary: ['registerGuardrailProvider', 'runGuardrails', 'hasGuardrails'] },
 ];
 
 function readPackageExports(): Record<string, string> {
@@ -69,7 +74,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(21);
+    expect(count).toBe(22);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## What

Closes the gap in #3688: the guardrail seam (`src/core/guardrails.ts`) was permanently inert for every CLI user. `registerGuardrailProvider()` had zero production call sites, and the documented import specifier `gbrain/core/guardrails` wasn't in `package.json`'s `exports` map — so neither library consumers nor operators could ever reach it, despite `docs/guardrails.md` telling operators to "register once at process init (e.g. from a plugin entry or an operator boot hook)." No such hook existed.

This PR builds both halves the issue asks for:

1. **The export.** `"./core/guardrails": "./src/core/guardrails.ts"` added to `package.json` (exports surface 21 → 22), with `scripts/check-exports-count.sh` and `test/public-exports.test.ts` updated accordingly (new canary entry pinning `registerGuardrailProvider`/`runGuardrails`/`hasGuardrails`). This makes the doc's existing `import ... from 'gbrain/core/guardrails'` example resolve as written — no doc-text change needed there.

2. **A real boot hook.** `src/core/guardrail-boot.ts` is a new, deliberately minimal loader: `GBRAIN_GUARDRAIL_MODULE` points at an operator-owned absolute local path; the loader imports it once per process and, if it also exports a `default` function, awaits it. The module itself calls `registerGuardrailProvider` — the loader never touches the registry directly. Fail-open throughout (bad path, missing file, throwing import/default all produce a warning string, never a thrown error), matching every invariant `guardrails.ts` already documents.

   `src/cli.ts`'s `main()` calls the loader early — right after the existing update-heartbeat call — so it runs before any command dispatch (including `gbrain serve`) whenever `GBRAIN_GUARDRAIL_MODULE` is set. No-op and zero cost when unset; the OSS distribution still ships inert by default.

3. **Docs.** `docs/guardrails.md`'s vague "operator boot hook" promise is replaced with the concrete, testable `GBRAIN_GUARDRAIL_MODULE` mechanism, kept as an explicit, separate section from the library-embedder path (call `registerGuardrailProvider` directly, no env var needed).

### Why this shape, not just the export

A prior PR (#2848) added only the exports-map entry and was declined — the tracking issue's verification comment on #3688 is explicit: *"Do not ship the export alone without fixing the doc's boot-hook claim."* This PR ships both together: the export makes the documented library-consumer path work, and `GBRAIN_GUARDRAIL_MODULE` makes the documented "operator boot hook" a real, working thing instead of aspirational doc text.

I deliberately kept the CLI-side mechanism narrower than the `GBRAIN_PLUGIN_PATH` skillpack loader (`src/core/ingestion/skillpack-load.ts`) — no manifest, no permission negotiation, no multi-path discovery. `GBRAIN_GUARDRAIL_MODULE` is operator-owned, already-trusted code (a file the operator wrote or vetted), not third-party code discovered off a manifest, so it doesn't need that trust-negotiation machinery. Happy to extend to the richer form if maintainers would rather guardrail providers ship as skillpacks instead of a raw env-pointed file — I judged the smaller, testable surface as the safer first step for a P1 fix.

## Testing

- `test/guardrail-boot.test.ts` — unit coverage of the loader's own validation/fail-open contract via an injected `_import` seam (no filesystem imports touched).
- `test/e2e/guardrail-boot-cli.test.ts` — subprocess-driven proof that a **real** `gbrain import` in a **real spawned CLI process** actually invokes a provider registered through `GBRAIN_GUARDRAIL_MODULE`:
  - positive control: provider fires, marker file gets the expected `file_storage.markdown` event
  - negative control: `GBRAIN_GUARDRAIL_MODULE` unset → marker file never created (proves the marker mechanism itself only reports real firings, not test-harness noise)
  - fail-open control: a broken module path warns on stderr (`[guardrail-boot] ...`) but the command still exits 0

  Hermetic: fresh `GBRAIN_HOME` per test run + PGLite via `gbrain init --pglite --no-embedding` (keyless — no provider API keys required, since the guardrail hook fires before embedding anyway per the seam table in `docs/guardrails.md`).
- `test/public-exports.test.ts`, `test/guardrails.test.ts` — unaffected, still green (64 tests total across the three guardrail-adjacent unit files).
- `bun run typecheck` — clean.
- `bun run check:module-size` — clean (`src/cli.ts`'s ratchet ceiling bumped 3628 → 3641 in `scripts/module-size-limits.tsv` for the ~13-line boot-hook call).
- `bun run verify` — 54/54 checks green.

Fixes #3688