### PR TITLE
fix(autopilot): hasChatApiKey plane-consistency (#3944)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -16,7 +16,7 @@ src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request te
 src/commands/jobs.ts	3093	ratchet	grown v0.46.25.0 (--json #3685) + v0.46.26.0: maybeRunWorkerStartupRecovery extraction + stats gating + help text
 src/core/search/hybrid.ts	2703	ratchet	grown v0.46.25.0 fix waves: cache scope isolation + pool floor + offset bypass (#3871 #3002)
 src/core/engine.ts	2415	ratchet	grown v0.46.25.0 fix waves: timeline dedup contract + registry write contract (#3827 #1262)
-src/commands/autopilot.ts	2487	ratchet	grown: daemon env-file lane + boot warning + reload-safe install (#2608 #4443)
+src/commands/autopilot.ts	2489	ratchet	grown: daemon env-file lane + boot warning + reload-safe install (#2608 #4443) + #3944: hasChatApiKey plane-consistency (shared anthropic-key.ts import)
 src/commands/extract.ts	2066	ratchet	lowered: timeline extractor hoisted to core/timeline-extract.ts (module-cycle fix)
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2016	ratchet	grown v0.46.24.0 overnight wave: embedding_plane_split named error (#4287)

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -137,6 +137,7 @@ test/fix-wave-structural.test.ts	v0.41.8.0 #1340 — PGLite WASM init classifier
 test/fix-wave-structural.test.ts	v0.42.20.0 — background-work registry drains every sink before disconnect	9	readFileSync
 test/fix-wave-structural.test.ts	v0.42.20.0 — search-cache drained via the background-work registry	1	readFileSync
 test/fix-wave-structural.test.ts	v0.42.43.0 #2095 — volunteer-events sink + cycle purge wiring (structural pins)	2	readFileSync
+test/haschatapikey-plane-consistency.test.ts	#3944 source-parity: hasChatApiKey computed identically in both call sites	4	readFileSync
 test/hook-command.serial.test.ts	user-prompt	14	readFileSync
 test/integrations-install.test.ts	installRecipeIntoHostRepo — happy path	6	readFileSync
 test/integrations.test.ts	CLI integration	3	readFileSync

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -25,6 +25,7 @@ import { execSync } from 'child_process';
 import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig, loadConfigFileOnly, saveConfig, gbrainPath as gbrainHomePath } from '../core/config.ts';
+import { hasAnthropicKey } from '../core/ai/anthropic-key.ts';
 import {
   classifyAutopilotLockHolder,
   type AutopilotLockProbeDeps,
@@ -1227,7 +1228,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
             const cfgField = HOSTED_EMBED_KEY_CONFIG[envVar];
             return !!(process.env[envVar] || (cfgField ? embedKeyCfg[cfgField] : undefined));
           }),
-          hasChatApiKey: !!(process.env.ANTHROPIC_API_KEY || await engine.getConfig('anthropic_api_key')),
+          // #3944: shared resolver (was a DB-plane probe that drifted from context.ts's file-plane one).
+          hasChatApiKey: hasAnthropicKey(),
         };
         // v0.41.18.0 (A5 + A19 + A22, T15): consult onboard recommendations
         // ALONGSIDE doctor's brain-score recommendations. Onboard's 4 new

--- a/src/core/remediation/context.ts
+++ b/src/core/remediation/context.ts
@@ -8,6 +8,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import type { RecommendationContext } from '../brain-score-recommendations.ts';
+import { hasAnthropicKey } from '../ai/anthropic-key.ts';
 
 // Re-export so consumers can `import { RecommendationContext } from '../remediation'`
 // — the canonical RecommendationContext type still lives in
@@ -84,7 +85,12 @@ export async function loadRecommendationContext(
     embeddingModel,
     embeddingDimensions,
     embeddingProviderConfigured: embeddingConfigured,
-    hasChatApiKey: !!(process.env.ANTHROPIC_API_KEY || fileCfg?.anthropic_api_key),
+    // #3944: use the single shared chat-key probe (src/core/ai/anthropic-key.ts)
+    // instead of hand-rolling env||fileCfg here — the autopilot.ts call site
+    // used to hand-roll env||DB and the two drifted apart. hasAnthropicKey()
+    // is the same env → gateway-snapshot → file-plane resolution every other
+    // chat-key consumer in the codebase already uses.
+    hasChatApiKey: hasAnthropicKey(),
     nullSignatureCohort,
   };
 }

--- a/test/haschatapikey-plane-consistency.test.ts
+++ b/test/haschatapikey-plane-consistency.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression test for #3944 — `hasChatApiKey` read the DB plane in
+ * `src/commands/autopilot.ts` but the file plane in
+ * `src/core/remediation/context.ts` (the sibling embed-key probe in the
+ * SAME autopilot.ts object literal already read the file plane). An
+ * operator whose real Anthropic key lived only in `~/.gbrain/config.json`
+ * (the plane the gateway actually resolves keys from) could have autopilot
+ * report `hasChatApiKey: false` while doctor/remediation reported `true` —
+ * or the inverse with a stale DB-only copy left behind by
+ * `gbrain config unset anthropic_api_key`.
+ *
+ * Fix: both call sites now delegate to the single shared probe,
+ * `hasAnthropicKey()` (src/core/ai/anthropic-key.ts) — the same
+ * env → gateway-snapshot → file-plane resolution every other chat-key
+ * consumer in the codebase already uses (think/index.ts,
+ * cycle/synthesize.ts, conversation-parser/llm-base.ts, gateway.ts's
+ * key-layer check, the subagent path). Neither call site queries the DB
+ * plane (`engine.getConfig('anthropic_api_key')`) anymore.
+ *
+ * Two complementary guards:
+ *  1. Source-parity: both files literally compute `hasChatApiKey` via the
+ *     identical `hasAnthropicKey()` call, and neither references the DB-plane
+ *     read anymore — so the two call sites cannot drift apart again the way
+ *     they did pre-fix (this is the codebase's established pattern for
+ *     cross-file consistency, e.g. `test/helpers/doctor-source.ts`).
+ *  2. Behavioral: `loadRecommendationContext()` (context.ts) is exercised
+ *     with a structurally-typed fake `BrainEngine` across the four plane
+ *     states the issue calls out — key only in the file plane, key only in
+ *     the (now-ignored) DB plane, in neither, and in both — proving the
+ *     DB plane no longer influences the result at all.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { loadRecommendationContext } from '../src/core/remediation/context.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+const REPO_ROOT = join(import.meta.dir, '..');
+const AUTOPILOT_SRC = readFileSync(join(REPO_ROOT, 'src', 'commands', 'autopilot.ts'), 'utf-8');
+const CONTEXT_SRC = readFileSync(join(REPO_ROOT, 'src', 'core', 'remediation', 'context.ts'), 'utf-8');
+
+describe('#3944 source-parity: hasChatApiKey computed identically in both call sites', () => {
+  test('autopilot.ts imports the shared hasAnthropicKey probe', () => {
+    expect(AUTOPILOT_SRC).toMatch(/import\s*\{\s*hasAnthropicKey\s*\}\s*from\s*['"]\.\.\/core\/ai\/anthropic-key\.ts['"]/);
+  });
+
+  test('remediation/context.ts imports the shared hasAnthropicKey probe', () => {
+    expect(CONTEXT_SRC).toMatch(/import\s*\{\s*hasAnthropicKey\s*\}\s*from\s*['"]\.\.\/ai\/anthropic-key\.ts['"]/);
+  });
+
+  test('both files compute the hasChatApiKey field via the identical hasAnthropicKey() call', () => {
+    // Pin the exact field assignment so a future edit that hand-rolls a new
+    // probe at either site fails loudly instead of silently re-diverging.
+    expect(AUTOPILOT_SRC).toMatch(/hasChatApiKey:\s*hasAnthropicKey\(\)\s*,/);
+    expect(CONTEXT_SRC).toMatch(/hasChatApiKey:\s*hasAnthropicKey\(\)\s*,/);
+  });
+
+  test('neither call site reads the DB-plane anthropic_api_key anymore', () => {
+    expect(AUTOPILOT_SRC).not.toContain("engine.getConfig('anthropic_api_key')");
+    expect(CONTEXT_SRC).not.toContain("engine.getConfig('anthropic_api_key')");
+  });
+});
+
+/**
+ * Structurally-typed fake BrainEngine — loadRecommendationContext only
+ * consumes `getConfig` and `countStaleChunks` (same pattern as
+ * `test/doctor-source-config-shape.test.ts`). `getConfig('anthropic_api_key')`
+ * throws: if the fix ever regresses and either call site starts reading the
+ * DB plane for the chat key again, this fake surfaces it immediately instead
+ * of silently returning a plausible-looking value.
+ */
+function makeFakeEngine(): BrainEngine {
+  return {
+    getConfig: async (key: string) => {
+      if (key === 'anthropic_api_key') {
+        throw new Error(
+          '#3944 regression: loadRecommendationContext must not read the DB plane for anthropic_api_key',
+        );
+      }
+      return null;
+    },
+    countStaleChunks: async () => 0,
+  } as unknown as BrainEngine;
+}
+
+const tmpDirs: string[] = [];
+function freshHome(withConfig?: Record<string, unknown>): string {
+  const home = mkdtempSync(join(tmpdir(), 'gbrain-3944-home-'));
+  tmpDirs.push(home);
+  if (withConfig) {
+    const dir = join(home, '.gbrain');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(withConfig), 'utf8');
+  }
+  return home;
+}
+
+describe('#3944 behavioral: loadRecommendationContext hasChatApiKey across plane states', () => {
+  test('key only in the FILE plane (config.json) → true', async () => {
+    const home = freshHome({ anthropic_api_key: 'sk-file-plane-only' });
+    try {
+      await withEnv(
+        { ANTHROPIC_API_KEY: undefined, GBRAIN_HOME: home, DATABASE_URL: undefined, GBRAIN_DATABASE_URL: undefined },
+        async () => {
+          const ctx = await loadRecommendationContext(makeFakeEngine());
+          expect(ctx.hasChatApiKey).toBe(true);
+        },
+      );
+    } finally {
+      const d = tmpDirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  test('key present in NEITHER plane → false (fake engine never even asked for the DB copy)', async () => {
+    const home = freshHome(); // no config.json written
+    try {
+      await withEnv(
+        { ANTHROPIC_API_KEY: undefined, GBRAIN_HOME: home, DATABASE_URL: undefined, GBRAIN_DATABASE_URL: undefined },
+        async () => {
+          const ctx = await loadRecommendationContext(makeFakeEngine());
+          expect(ctx.hasChatApiKey).toBe(false);
+        },
+      );
+    } finally {
+      const d = tmpDirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  test('key present in BOTH the file plane and env → true (env wins, file still agrees)', async () => {
+    const home = freshHome({ anthropic_api_key: 'sk-file-plane-copy' });
+    try {
+      await withEnv(
+        { ANTHROPIC_API_KEY: 'sk-env-plane', GBRAIN_HOME: home, DATABASE_URL: undefined, GBRAIN_DATABASE_URL: undefined },
+        async () => {
+          const ctx = await loadRecommendationContext(makeFakeEngine());
+          expect(ctx.hasChatApiKey).toBe(true);
+        },
+      );
+    } finally {
+      const d = tmpDirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  // The fourth state the issue names — "key only in the DB plane" — is
+  // covered by makeFakeEngine() itself: getConfig('anthropic_api_key')
+  // throws if either call site ever asks for it again, so a DB-only key can
+  // no longer make hasChatApiKey diverge between autopilot.ts and
+  // context.ts. Pre-fix, autopilot.ts would have read that DB value and
+  // reported `true` while context.ts (file-plane only, and now also this
+  // shared probe) reported `false` for the same underlying state — exactly
+  // the divergence #3944 reported.
+  test('a DB-only key (no file, no env) cannot flip hasChatApiKey to true — this is the bug #3944 reported', async () => {
+    const home = freshHome(); // no config.json — file plane is empty
+    try {
+      await withEnv(
+        { ANTHROPIC_API_KEY: undefined, GBRAIN_HOME: home, DATABASE_URL: undefined, GBRAIN_DATABASE_URL: undefined },
+        async () => {
+          // A fake engine whose DB plane DOES hold a key — but the fix means
+          // neither call site ever asks it, so it must never surface here.
+          const engineWithDbKey = {
+            getConfig: async (key: string) => (key === 'anthropic_api_key' ? 'sk-db-plane-only' : null),
+            countStaleChunks: async () => 0,
+          } as unknown as BrainEngine;
+          const ctx = await loadRecommendationContext(engineWithDbKey);
+          expect(ctx.hasChatApiKey).toBe(false);
+        },
+      );
+    } finally {
+      const d = tmpDirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`hasChatApiKey` was computed from two different config planes at two call sites:

- `src/commands/autopilot.ts` probed the **DB plane** (`engine.getConfig('anthropic_api_key')`).
- `src/core/remediation/context.ts` probed the **file plane** (`fileCfg?.anthropic_api_key`) — and the *sibling* embed-key probe inside the same `autopilot.ts` object literal already read the file plane too.

The gateway resolves chat keys `env -> gateway-snapshot -> file` only (`loadConfig()` is synchronous, so it can never see a DB row), so `autopilot.ts`'s DB-plane probe could report a key that no chat call could ever actually use — and the inverse: a real key living only in `~/.gbrain/config.json` could make autopilot silently conclude it has no chat key. It also made `gbrain config unset anthropic_api_key` unexpectedly destructive: on a machine with no `ANTHROPIC_API_KEY` in the environment, the DB copy was the only thing keeping the probe true, so unsetting a value the gateway never read could silently degrade autopilot's planning.

## Fix

Both call sites now delegate to the single shared probe, `hasAnthropicKey()` (`src/core/ai/anthropic-key.ts`) — the same `env -> gateway-snapshot -> file-plane` resolution already used by `think/index.ts`, `cycle/synthesize.ts`, `conversation-parser/llm-base.ts`, `gateway.ts`'s key-layer check, and the subagent path. This is a superset of the issue's suggested one-liner (matching `context.ts`'s `env || fileCfg` shape): it also picks up a DB-plane key that `configureGateway()`/`reconfigureGatewayWithEngine()` has already merged into the gateway's env snapshot, which a literal `env || fileCfg` match would still miss. Neither call site reads the DB plane for this field anymore, so the two can't drift apart again — addressing the issue's own "extract the predicate into one shared helper" suggestion.

## Test plan

- Added `test/haschatapikey-plane-consistency.test.ts`:
  - **Source-parity guard**: both files compute `hasChatApiKey` via the identical `hasAnthropicKey()` call, and neither references the DB-plane read anymore (prevents re-drift).
  - **Behavioral suite**: exercises `loadRecommendationContext()` with a structurally-typed fake `BrainEngine` across the plane states the issue calls out — key only in the file plane, key only in the (now-ignored) DB plane, in neither, and in both — proving the DB plane no longer influences the result.
- `bun test test/haschatapikey-plane-consistency.test.ts test/ai/anthropic-key.test.ts test/brain-score-recommendations.test.ts` — 49 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run check:module-size` — clean (bumped the `autopilot.ts` ratchet ceiling by 2 lines in the same commit for the new import + one-line comment, per the repo's module-size-ratchet convention).

Fixes #3944