### PR TITLE
fix(extract): surface idx_timeline_dedup collisions in --stale instead of silent exit 0 (#3737)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -17,7 +17,7 @@ src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + mast
 src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352)
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
-src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)
+src/commands/extract.ts	2388	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4) + PR#4468 rebase onto current master
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2142	ratchet	grown v0.46.26.0 megawave: OCR budget + image import + embed-retry rewire (#3973 #3374)
 src/core/cycle/synthesize.ts	2792	ratchet	merged waves; grown v0.46.26.0 megawave + master rolling lease via shared throttled renewer

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -823,13 +823,20 @@ export async function runExtract(engine: BrainEngine, args: string[]) {
     }
     const sidIdx = args.indexOf('--source-id');
     const staleSourceId = (sidIdx >= 0 && sidIdx + 1 < args.length) ? args[sidIdx + 1] : undefined;
-    await extractStaleFromDB(engine, {
+    const staleResult = await extractStaleFromDB(engine, {
       dryRun: args.includes('--dry-run'),
       jsonMode: args.includes('--json'),
       includeFrontmatter: args.includes('--include-frontmatter'),
       sourceIdFilter: staleSourceId,
       catchUp: args.includes('--catch-up'),
     });
+    // #3737: a run that skipped unwritable timeline entries is NOT a clean
+    // success — surface it via the exit code (same convention as the
+    // extract-timeline-from-meetings batch_errors handling above) instead of
+    // reporting exit 0 over silently-dropped entries.
+    if (staleResult.timelineWriteFailures > 0) {
+      setCliExitVerdict(1);
+    }
     return;
   }
 
@@ -1884,7 +1891,10 @@ export async function extractStaleFromDB(
      */
     timeBudgetMs?: number;
   },
-): Promise<{ linksCreated: number; timelineCreated: number; pagesProcessed: number; staleRemaining: number; skippedMissingTarget?: number }> {
+): Promise<{
+  linksCreated: number; timelineCreated: number; pagesProcessed: number; staleRemaining: number;
+  skippedMissingTarget?: number; timelineWriteFailures: number; firstTimelineWriteError?: string;
+}> {
   const { dryRun, jsonMode, includeFrontmatter, sourceIdFilter, catchUp } = opts;
   const timeBudgetMs = opts.timeBudgetMs ?? STALE_TIME_BUDGET_MS;
   const versionTs = LINK_EXTRACTOR_VERSION_TS;
@@ -1897,11 +1907,11 @@ export async function extractStaleFromDB(
     } else {
       console.log(`(dry run) ${totalStale} page(s) need link/timeline extraction. Run without --dry-run to extract.`);
     }
-    return { linksCreated: 0, timelineCreated: 0, pagesProcessed: 0, staleRemaining: totalStale };
+    return { linksCreated: 0, timelineCreated: 0, pagesProcessed: 0, staleRemaining: totalStale, timelineWriteFailures: 0 };
   }
   if (totalStale === 0) {
     if (!jsonMode) console.log('No stale pages — extraction is up to date.');
-    return { linksCreated: 0, timelineCreated: 0, pagesProcessed: 0, staleRemaining: 0 };
+    return { linksCreated: 0, timelineCreated: 0, pagesProcessed: 0, staleRemaining: 0, timelineWriteFailures: 0 };
   }
 
   // Resolver + cross-source resolution map built ONCE before the loop (the
@@ -1943,6 +1953,13 @@ export async function extractStaleFromDB(
   // persisted. Counted so a dropped reference is observable in the summary
   // instead of vanishing silently (the failure mode that hid bug 2).
   let skippedMissingTarget = 0;
+  // #3737: a timeline entry that fails to WRITE (e.g. a summary too large
+  // for idx_timeline_dedup's btree — see the row-level fallback below).
+  // Counted + named on stderr, same shape as skippedMissingTarget, so a
+  // structurally-unindexable entry surfaces instead of silently blocking
+  // the rest of the backlog.
+  let timelineWriteFailures = 0;
+  let firstTimelineWriteError: string | undefined;
 
   for (;;) {
     const rows = await engine.listStalePagesForExtraction({
@@ -2008,8 +2025,35 @@ export async function extractStaleFromDB(
     for (let i = 0; i < linkRows.length; i += BATCH_SIZE) {
       linksCreated += await engine.addLinksBatch(linkRows.slice(i, i + BATCH_SIZE), { auditSite: 'extract.stale' }); // gbrain-allow-direct-insert: gbrain extract --stale — canonical link reconciliation from markdown body
     }
+    // #3737: unlike links above, a timeline chunk can contain a row that is
+    // STRUCTURALLY unwritable — a summary long enough to blow
+    // idx_timeline_dedup's btree entry-size limit (Postgres caps a unique
+    // btree tuple at ~2704 bytes; an unbounded-TEXT summary can exceed it).
+    // That row will NEVER succeed on retry, so letting its throw propagate
+    // (the old CDX-4 behavior) aborted the ENTIRE chunk — including every
+    // healthy sibling row and, by extension, every page in this keyset batch
+    // — with no indication of which page was at fault (gbrain#3737). Isolate
+    // instead: on a chunk failure, retry row-by-row so only the genuinely
+    // unwritable row(s) are skipped; healthy rows still land. Skipped rows
+    // are counted + named (page slug + date) on stderr and flip the exit
+    // code non-zero (see the summary block below) instead of reporting a
+    // clean "N entries" success over a dropped entry.
     for (let i = 0; i < timelineRows.length; i += BATCH_SIZE) {
-      timelineCreated += await engine.addTimelineEntriesBatch(timelineRows.slice(i, i + BATCH_SIZE), { auditSite: 'extract.stale' });
+      const chunk = timelineRows.slice(i, i + BATCH_SIZE);
+      try {
+        timelineCreated += await engine.addTimelineEntriesBatch(chunk, { auditSite: 'extract.stale' });
+      } catch {
+        for (const row of chunk) {
+          try {
+            timelineCreated += await engine.addTimelineEntriesBatch([row], { auditSite: 'extract.stale' });
+          } catch (rowErr) {
+            timelineWriteFailures++;
+            const msg = rowErr instanceof Error ? rowErr.message : String(rowErr);
+            if (!firstTimelineWriteError) firstTimelineWriteError = msg;
+            console.error(`[extract.stale] skipping unwritable timeline entry on page "${row.slug}" (${row.date}): ${msg}`);
+          }
+        }
+      }
     }
     // Stamp LAST, directly (not the swallowing stampExtracted) so a stamp
     // failure surfaces instead of looping forever.
@@ -2030,6 +2074,13 @@ export async function extractStaleFromDB(
     if (skippedMissingTarget > 0) {
       console.log(`Skipped ${skippedMissingTarget} candidate(s) whose target page doesn't exist (references to non-pages are never persisted).`);
     }
+    if (timelineWriteFailures > 0) {
+      console.log(
+        `Skipped ${timelineWriteFailures} timeline entr${timelineWriteFailures === 1 ? 'y' : 'ies'} that couldn't be written` +
+        (firstTimelineWriteError ? ` (first error: ${firstTimelineWriteError})` : '') +
+        ` — see the "[extract.stale] skipping" warnings above for the affected page(s). Their page(s) were still marked extracted.`,
+      );
+    }
     if (budgetHit && staleRemaining > 0) {
       console.log(`Time budget reached — ${staleRemaining} page(s) still stale. Re-run 'gbrain extract --stale' (or pass --catch-up) to continue.`);
     }
@@ -2038,9 +2089,14 @@ export async function extractStaleFromDB(
       action: 'extract_stale_done', links_created: linksCreated, timeline_created: timelineCreated,
       pages_processed: pagesProcessed, stale_remaining: staleRemaining, budget_hit: budgetHit,
       skipped_missing_target: skippedMissingTarget,
+      timeline_write_failures: timelineWriteFailures,
+      first_timeline_write_error: firstTimelineWriteError,
     }) + '\n');
   }
-  return { linksCreated, timelineCreated, pagesProcessed, staleRemaining, skippedMissingTarget };
+  return {
+    linksCreated, timelineCreated, pagesProcessed, staleRemaining, skippedMissingTarget,
+    timelineWriteFailures, firstTimelineWriteError,
+  };
 }
 
 /**

--- a/src/commands/maintain.ts
+++ b/src/commands/maintain.ts
@@ -99,15 +99,25 @@ async function runStaleExtraction(
     catchUp: false,
   });
 
+  // #3737: extractStaleFromDB no longer throws on an unwritable timeline
+  // entry (e.g. a summary too large for idx_timeline_dedup's btree) — it
+  // skips + counts the offending row instead. Surface that count here too,
+  // same as `gbrain extract --stale`'s own summary, so `gbrain maintain`
+  // doesn't silently report a clean "applied" over a dropped entry.
+  const failureNote = result.timelineWriteFailures > 0
+    ? ` (${result.timelineWriteFailures} timeline entr${result.timelineWriteFailures === 1 ? 'y' : 'ies'} could not be written — see 'gbrain extract --stale' for details)`
+    : '';
+
   return {
     name: 'extract_stale',
     status: 'applied',
-    message: `Processed ${result.pagesProcessed} stale page(s); ${result.staleRemaining} remain.`,
+    message: `Processed ${result.pagesProcessed} stale page(s); ${result.staleRemaining} remain.${failureNote}`,
     details: {
       links_created: result.linksCreated,
       timeline_created: result.timelineCreated,
       pages_processed: result.pagesProcessed,
       stale_remaining: result.staleRemaining,
+      timeline_write_failures: result.timelineWriteFailures,
     },
   };
 }

--- a/test/extract-stale.test.ts
+++ b/test/extract-stale.test.ts
@@ -17,6 +17,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExtract, extractStaleFromDB } from '../src/commands/extract.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from '../src/core/link-extraction.ts';
+import { currentExitCode, _resetCliExitVerdictForTests } from '../src/core/cli-force-exit.ts';
 import type { PageInput } from '../src/core/types.ts';
 
 let engine: PGLiteEngine;
@@ -266,6 +267,101 @@ describe('gbrain extract --stale', () => {
     expect((await engine.getLinks('companies/acme')).some(l => l.to_slug === 'people/alice')).toBe(true);
     expect(await stampOf('companies/acme')).not.toBeNull();
     expect(await engine.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS })).toBe(0);
+  });
+
+  // ─── #3737: idx_timeline_dedup's unique btree covers unbounded TEXT
+  // (page_id, date, summary, source). A sufficiently long, low-compressibility
+  // summary exceeds Postgres's ~2704-byte btree entry-size cap and the insert
+  // is rejected — structurally, not transiently. Pre-fix this aborted the
+  // WHOLE flush chunk (and, propagating past extractStaleFromDB, the whole
+  // `--stale` run), leaving every page in the batch — including healthy
+  // siblings — unprocessed and unstamped, with no indication of which page or
+  // entry was at fault. ─────────────────────────────────────────────────────
+
+  // Deterministic low-compressibility ~3000-byte string. Mirrors the issue's
+  // own repro (md5-hash concatenation defeats btree key compression the way
+  // `repeat('a', N)` does not).
+  function unindexableSummary(): string {
+    const crypto = require('node:crypto') as typeof import('node:crypto');
+    return Array.from({ length: 94 }, (_, i) =>
+      crypto.createHash('md5').update(`${i}`).digest('hex'),
+    ).join('');
+  }
+
+  test('REGRESSION (#3737): an unwritable timeline entry is skipped-and-warned, not fatal to the sweep', async () => {
+    const bigSummary = unindexableSummary();
+    await engine.putPage('meetings/poison', {
+      type: 'meeting' as any, title: 'Poison Meeting', compiled_truth: 'A meeting page.',
+      timeline: `## Timeline\n- **2026-06-04** | ${bigSummary}\n`,
+    });
+    await engine.putPage('people/alice', personPage('Alice'));
+    await engine.putPage('companies/acme', companyPage('Acme', '[Alice](people/alice) advises [Acme](companies/acme).'));
+
+    _resetCliExitVerdictForTests();
+    const origErr = console.error;
+    let warnings = '';
+    console.error = (m?: unknown) => { warnings += String(m) + '\n'; };
+    try {
+      await runExtract(engine, ['--stale']); // must NOT throw
+    } finally {
+      console.error = origErr;
+    }
+
+    // The healthy pages in the SAME batch are unaffected: link created, both
+    // stamped, nothing left stale.
+    const links = await engine.getLinks('companies/acme');
+    expect(links.some(l => l.to_slug === 'people/alice')).toBe(true);
+    expect(await stampOf('people/alice')).not.toBeNull();
+    expect(await stampOf('companies/acme')).not.toBeNull();
+
+    // The poisoned page WAS processed (extraction ran; the page just has one
+    // unwritable timeline entry) and is stamped like any other processed page
+    // — consistent with the existing "every processed page is stamped, incl.
+    // zero-link" invariant. The unwritable entry itself never lands in
+    // timeline_entries.
+    expect(await stampOf('meetings/poison')).not.toBeNull();
+    const rows = await engine.executeRaw<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM timeline_entries te
+         JOIN pages p ON p.id = te.page_id WHERE p.slug = 'meetings/poison'`,
+    );
+    expect(rows[0].n).toBe('0');
+
+    // Backlog is unblocked, not stuck forever (the core #3737 complaint).
+    expect(await engine.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS })).toBe(0);
+
+    // Surfaced, not silent: the page is named in a stderr warning, and the
+    // exit code is non-zero instead of a clean success.
+    expect(warnings).toContain('meetings/poison');
+    expect(warnings).toContain('idx_timeline_dedup');
+    expect(currentExitCode()).toBe(1);
+  });
+
+  test('REGRESSION (#3737): --json summary reports timeline_write_failures instead of a clean success', async () => {
+    const bigSummary = unindexableSummary();
+    await engine.putPage('meetings/poison-json', {
+      type: 'meeting' as any, title: 'Poison Meeting JSON', compiled_truth: 'A meeting page.',
+      timeline: `## Timeline\n- **2026-06-05** | ${bigSummary}\n`,
+    });
+
+    _resetCliExitVerdictForTests();
+    const origLog = console.error;
+    console.error = () => {}; // silence the per-row warning for this assertion
+    const origWrite = process.stdout.write.bind(process.stdout);
+    let out = '';
+    (process.stdout as unknown as { write: unknown }).write = (chunk: unknown) => { out += String(chunk); return true; };
+    try {
+      await runExtract(engine, ['--stale', '--json']);
+    } finally {
+      console.error = origLog;
+      (process.stdout as unknown as { write: unknown }).write = origWrite;
+    }
+
+    const parsed = JSON.parse(out.trim().split('\n').pop()!);
+    expect(parsed.action).toBe('extract_stale_done');
+    expect(parsed.timeline_write_failures).toBe(1);
+    expect(typeof parsed.first_timeline_write_error).toBe('string');
+    expect(parsed.first_timeline_write_error).toContain('idx_timeline_dedup');
+    expect(currentExitCode()).toBe(1);
   });
 
   test('D4 race: a concurrent edit landing during the sweep is NOT masked', async () => {


### PR DESCRIPTION
## Summary

`gbrain extract --stale` writes timeline entries in chunked batch inserts.
`idx_timeline_dedup` is a unique btree over `(page_id, date, summary,
source)`, and `summary` is unbounded `TEXT`. A summary long enough (and
low-compressibility enough — Postgres compresses btree keys, so this is
size- *and* content-dependent) exceeds Postgres's ~2704-byte btree
entry-size cap, and the insert throws `index row size N exceeds btree
version 4 maximum 2704 for index "idx_timeline_dedup"`.

That throw used to propagate out of the whole `--stale` sweep (the
existing "CDX-4 non-swallowing flush" behavior, which is correct for
*link* inserts). For timeline inserts it meant **one unindexable entry
aborted the entire current keyset batch** — including every healthy
sibling page sharing that batch with the offending row — with no
indication anywhere of *which* page or entry was actually at fault. Since
`--stale` is the only path that stamps `pages.links_extracted_at`, the
whole backlog got permanently stuck and `doctor`'s `links_extraction_lag`
check could never clear — it kept recommending `extract --stale` as the
fix, which is exactly the command that couldn't run.

Confirmed still present on current `master` (verified locally against
`upstream/master` before starting).

## Fix

- On a timeline chunk-insert failure, retry that chunk **row-by-row** so
  only the genuinely unwritable row(s) are skipped; healthy rows in the
  same chunk still land.
- Skipped rows are counted, **named** (page slug + date) on `stderr`, and
  reported in both the human-readable and `--json` summaries
  (`timeline_write_failures` / `first_timeline_write_error`).
- The page itself is still marked extracted — consistent with the
  existing "every processed page is stamped, incl. zero-link" invariant,
  since extraction on it *did* run; only the one structurally-unindexable
  entry is dropped (mirrors the existing `skippedMissingTarget` pattern
  for links whose target page doesn't exist).
- `extract --stale` now exits non-zero (`setCliExitVerdict(1)`) when any
  entries were skipped, mirroring the existing `#2057` `batch_errors`
  convention already used by `extract timeline --from-meetings`.
- `gbrain maintain`'s `extract_stale` action (the only other caller of
  `extractStaleFromDB`) now surfaces the same failure count instead of
  silently reporting a clean `applied`.

I deliberately scoped this to "surface + isolate the failure," not to the
larger "index a digest of `summary` instead of the raw value" schema
change floated in the issue thread — that's a real unique-constraint
semantics change (migration + touching every `ON CONFLICT` insert site +
an existing-duplicate backfill) that deserves its own review, independent
of unblocking the backlog today.

## Test plan

- New regression tests in `test/extract-stale.test.ts` reproduce the
  **real** btree-size failure against PGLite (no mocking — PGLite
  enforces the same Postgres index-size limits, confirmed empirically
  before writing the fix) and assert:
  - the sweep does not throw
  - healthy sibling pages in the same batch are unaffected (link created,
    both stamped)
  - the poisoned page is still stamped, with its bad entry absent from
    `timeline_entries`
  - the backlog clears (`countStalePagesForExtraction() == 0`)
  - the page slug appears in a `stderr` warning
  - the exit code is non-zero (`currentExitCode()`)
  - a second test locks the `--json` summary shape
    (`timeline_write_failures`, `first_timeline_write_error`)
- `bun test test/extract-stale.test.ts test/maintain.test.ts
  test/sync-deferred-extract-queue.serial.test.ts
  test/sync-inline-extract-stamps.serial.test.ts test/link-extraction.test.ts
  test/link-extraction-dir-whitelist-2576.test.ts
  test/doctor-links-extraction-lag.test.ts` — 235 pass, 0 fail
- `bun run typecheck` — clean
- `bun run check:module-size` — clean (ceiling raised for
  `src/commands/extract.ts` 2066 → 2130 in the same commit, per the
  module-size-ratchet convention)
- `bun run verify` — 54/54 checks green

Fixes #3737