### PR TITLE
fix(autopilot): give alive-unknown the same takeover grace as alive-foreign (#4300)

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -282,14 +282,14 @@ export function decideLockAcquisition(
 
   const holderPid = Number.parseInt(raw, 10);
   const holder = classifyAutopilotLockHolder(holderPid, currentPid, deps);
-
-  if (holder.state === 'alive-autopilot' || holder.state === 'alive-unknown') {
+  if (holder.state === 'alive-autopilot') {
     return { action: 'exit', holderPid };
   }
-  if (holder.state === 'alive-foreign') {
+  if (holder.state === 'alive-foreign' || holder.state === 'alive-unknown') {
     const lockAgeMs = autopilotLockAgeMs(lockPath);
     if (lockAgeMs !== null && lockAgeMs >= AUTOPILOT_FOREIGN_PID_TAKEOVER_GRACE_MS) {
-      return { action: 'takeover', reason: `foreign pid ${raw || '<empty>'} with stale lock` };
+      const identity = holder.state === 'alive-foreign' ? 'foreign' : 'unknown';
+      return { action: 'takeover', reason: `${identity} pid ${raw || '<empty>'} with stale lock` };
     }
     return { action: 'exit', holderPid };
   }

--- a/src/core/autopilot-lock.ts
+++ b/src/core/autopilot-lock.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 export type AutopilotLockHolder =
   | { state: 'dead' }
@@ -12,6 +13,20 @@ export interface AutopilotLockProbeDeps {
   readProcessCommand?: (pid: number) => string | null;
 }
 
+export interface ReadProcessCommandDeps {
+  platform?: NodeJS.Platform;
+  readFileSync?: (path: string, encoding: 'utf8') => string;
+  execFileSync?: (
+    file: string,
+    args: string[],
+    options: {
+      encoding: 'utf8';
+      stdio: ['ignore', 'pipe', 'ignore'];
+      timeout: number;
+    },
+  ) => string;
+}
+
 export function isPidAlive(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;
   try {
@@ -22,10 +37,25 @@ export function isPidAlive(pid: number): boolean {
   }
 }
 
-export function readProcessCommand(pid: number): string | null {
+export function readProcessCommand(
+  pid: number,
+  deps: ReadProcessCommandDeps = {},
+): string | null {
   if (!Number.isFinite(pid) || pid <= 0) return null;
+
+  if ((deps.platform ?? process.platform) === 'linux') {
+    try {
+      const read = deps.readFileSync ?? ((path: string, encoding: 'utf8') => readFileSync(path, encoding));
+      const out = read(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ').trim();
+      return out.length > 0 ? out : null;
+    } catch {
+      return null;
+    }
+  }
+
   try {
-    const out = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+    const run = deps.execFileSync ?? ((file, args, options) => execFileSync(file, args, options));
+    const out = run('ps', ['-p', String(pid), '-o', 'args='], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 1000,

--- a/test/autopilot-lock.test.ts
+++ b/test/autopilot-lock.test.ts
@@ -7,7 +7,10 @@ import {
   decideLockAcquisition,
   isPidAlive,
 } from '../src/commands/autopilot.ts';
-import { looksLikeGbrainAutopilotCommand } from '../src/core/autopilot-lock.ts';
+import {
+  looksLikeGbrainAutopilotCommand,
+  readProcessCommand,
+} from '../src/core/autopilot-lock.ts';
 
 let tmp: string;
 let lockPath: string;
@@ -81,7 +84,7 @@ describe('decideLockAcquisition', () => {
     });
   });
 
-  test('keeps a live lock when process identity cannot be inspected', () => {
+  test('keeps a fresh live lock when process identity cannot be inspected', () => {
     writeFileSync(lockPath, '1234');
     expect(decideLockAcquisition(lockPath, process.pid, {
       isPidAlive: (pid) => pid === 1234,
@@ -92,11 +95,80 @@ describe('decideLockAcquisition', () => {
     });
   });
 
+  test('takes over a stale lock when process identity cannot be inspected', () => {
+    writeFileSync(lockPath, '1234');
+    const stale = new Date(Date.now() - AUTOPILOT_FOREIGN_PID_TAKEOVER_GRACE_MS - 1000);
+    utimesSync(lockPath, stale, stale);
+    expect(decideLockAcquisition(lockPath, process.pid, {
+      isPidAlive: (pid) => pid === 1234,
+      readProcessCommand: () => null,
+    })).toEqual({
+      action: 'takeover',
+      reason: 'unknown pid 1234 with stale lock',
+    });
+  });
+
+  test('grace-period boundary: exits just before the threshold, takes over at/after it (unknown identity)', () => {
+    writeFileSync(lockPath, '1234');
+    const deps = {
+      isPidAlive: (pid: number) => pid === 1234,
+      readProcessCommand: () => null,
+    };
+
+    const justUnderGrace = new Date(Date.now() - AUTOPILOT_FOREIGN_PID_TAKEOVER_GRACE_MS + 1000);
+    utimesSync(lockPath, justUnderGrace, justUnderGrace);
+    expect(decideLockAcquisition(lockPath, process.pid, deps)).toEqual({
+      action: 'exit',
+      holderPid: 1234,
+    });
+
+    const atGrace = new Date(Date.now() - AUTOPILOT_FOREIGN_PID_TAKEOVER_GRACE_MS);
+    utimesSync(lockPath, atGrace, atGrace);
+    expect(decideLockAcquisition(lockPath, process.pid, deps).action).toBe('takeover');
+  });
+
   test('takes over malformed and empty locks', () => {
     writeFileSync(lockPath, 'not-a-pid');
     expect(decideLockAcquisition(lockPath, process.pid).action).toBe('takeover');
     writeFileSync(lockPath, '');
     expect(decideLockAcquisition(lockPath, process.pid).action).toBe('takeover');
+  });
+});
+
+describe('readProcessCommand', () => {
+  test('reads Linux procfs cmdline without spawning ps', () => {
+    let psCalls = 0;
+    expect(readProcessCommand(1234, {
+      platform: 'linux',
+      readFileSync: (path, encoding) => {
+        expect(path).toBe('/proc/1234/cmdline');
+        expect(encoding).toBe('utf8');
+        return 'bun\0/usr/local/bin/gbrain\0autopilot\0--repo\0repo\0';
+      },
+      execFileSync: () => {
+        psCalls++;
+        return 'unexpected';
+      },
+    })).toBe('bun /usr/local/bin/gbrain autopilot --repo repo');
+    expect(psCalls).toBe(0);
+  });
+
+  test('falls back to ps on hosts without Linux procfs', () => {
+    let procReads = 0;
+    expect(readProcessCommand(1234, {
+      platform: 'darwin',
+      readFileSync: () => {
+        procReads++;
+        return 'unexpected';
+      },
+      execFileSync: (file, args, options) => {
+        expect(file).toBe('ps');
+        expect(args).toEqual(['-p', '1234', '-o', 'args=']);
+        expect(options.timeout).toBe(1000);
+        return 'gbrain autopilot --repo repo\n';
+      },
+    })).toBe('gbrain autopilot --repo repo');
+    expect(procReads).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #4300.

## The bug

`decideLockAcquisition` (`src/commands/autopilot.ts`) treated an `alive-unknown` lock holder (the liveness probe found a live PID, but `readProcessCommand` couldn't identify what it is — e.g. no `ps` binary on minimal containers) as equally certain as a CONFIRMED live autopilot instance (`alive-autopilot`), exiting unconditionally with no age-based grace period. Meanwhile `alive-foreign` (a live PID confirmed NOT to be autopilot) already gets an age-based takeover grace via `AUTOPILOT_FOREIGN_PID_TAKEOVER_GRACE_MS`. `alive-unknown` — where the probe outright failed and we know nothing — got LESS benefit of the doubt than the more-informed `alive-foreign` state, which is backwards.

On a fresh container that reassigns PIDs from 1, a stale lock's PID is very likely to coincidentally match some live unrelated process, producing a permanent, silent restart-loop deadlock: `process.exit(0)` every time, no error logged, the supervisor sees a "clean" exit and restarts forever. Measured on the reporter's setup: 17 hours of zero jobs run, container reported healthy the entire time.

## Fix (both suggestions from the issue)

1. `alive-unknown` now shares the same age-based grace branch as `alive-foreign` in `decideLockAcquisition` — before the grace period it still exits (protection isn't removed, just bounded); after it, it's taken over like a confirmed-foreign holder.
2. `readProcessCommand` tries `/proc/<pid>/cmdline` on Linux first (no `ps` spawn, sidesteps the whole problem on Linux hosts), falling back to `ps` on non-Linux platforms (macOS has no `/proc`). Both paths take injectable deps for testing; the exported signature change `(pid)` → `(pid, deps = {})` is backward compatible — verified via an adversarial review pass that this doesn't break any other call site.

## Adversarial review notes (documented, not code changes)

An independent Codex review pass raised three points I evaluated and am documenting rather than acting on:
- Reusing the same grace constant for `alive-unknown` is intentional and matches the issue's own suggestion #1 — `alive-foreign` already accepts this same takeover-risk tradeoff; extending it to `alive-unknown` is symmetric, not a new risk category.
- The NUL→space join in the `/proc` path and the catch-all that conflates ENOENT/EACCES/unavailable-procfs into a single `null` result are both pre-existing characteristics already shared identically by the old `ps`-based path (`ps -o args=` is also a flat, space-joined string, and its catch block already collapsed every error to `null`) — not new regressions introduced by this patch.

## Test plan

`test/autopilot-lock.test.ts` (extended): fresh unknown-identity holder still exits; stale unknown-identity holder now takes over (was the bug); existing foreign-holder behavior unchanged; a new grace-period boundary test (just-under vs at-the-threshold); Linux `/proc` read path; non-Linux `ps` fallback path.

```
bun test test/autopilot-lock.test.ts test/status-autopilot-lock.test.ts   # 17 pass, 0 fail
bun run typecheck                                                          # pass
bun run check:module-size                                                  # pass
bun run check:structural-manifest                                          # pass
```
