### PR TITLE
fix(core): resolveSourceLocalFilePath treats POSIX backslash-in-filename as a directory separator

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -879,7 +879,7 @@ function extractTags(frontmatter: Record<string, unknown>): string[] {
 // ---------------------------------------------------------------------------
 
 import { existsSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep as pathSep } from 'node:path';
 
 /** Options for serializePageToMarkdown. */
 export interface SerializePageOpts {
@@ -961,7 +961,19 @@ export function resolvePageFilePath(
  *
  * Returns null for an unsafe or non-markdown source path. Callers must still
  * enforce their normal realpath containment check before a write.
+ *
+ * Segment splitting is platform-aware (`pathSep`), not a blanket
+ * `[\\/]+` split: on POSIX, `\` is a legal filename character (real
+ * gbrain data has Apple Notes titles containing one), not a directory
+ * separator, so splitting on it there reconstructs a path that doesn't
+ * exist on disk even though the file does (issue: undeclared_db_only_pages
+ * false positive + silent restore/export failure for any such file). On
+ * Windows, `\` is the real separator, so it still needs to split there.
  */
+function splitLocalPathSegments(value: string): string[] {
+  return (pathSep === '\\' ? value.split(/[\\/]+/) : value.split(/\/+/)).filter(Boolean);
+}
+
 export function resolveSourceLocalFilePath(
   localPath: string,
   rawSourcePath: string | null | undefined,
@@ -970,14 +982,14 @@ export function resolveSourceLocalFilePath(
   const value = rawSourcePath.trim();
   if (!value || value.includes('\0') || !/\.mdx?$/i.test(value)) return null;
   if (isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value)) return null;
-  const sourceSegments = value.split(/[\\/]+/).filter(Boolean);
+  const sourceSegments = splitLocalPathSegments(value);
   if (sourceSegments.length === 0 || sourceSegments.some(segment => segment === '..')) return null;
 
   const absoluteLocalPath = resolve(localPath);
   let cursor = absoluteLocalPath;
   while (true) {
     if (existsSync(join(cursor, '.git'))) {
-      const scope = relative(cursor, absoluteLocalPath).split(/[\\/]+/).filter(Boolean);
+      const scope = splitLocalPathSegments(relative(cursor, absoluteLocalPath));
       if (scope.length > 0 && scope.every((segment, index) => segment === sourceSegments[index])) {
         return join(absoluteLocalPath, ...sourceSegments.slice(scope.length));
       }

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,5 +1,8 @@
-import { describe, test, expect } from 'bun:test';
-import { parseMarkdown, serializeMarkdown, splitBody } from '../src/core/markdown.ts';
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { parseMarkdown, serializeMarkdown, splitBody, resolveSourceLocalFilePath } from '../src/core/markdown.ts';
 
 describe('Markdown Parser', () => {
   test('parses frontmatter + compiled_truth + timeline (explicit sentinel)', () => {
@@ -612,5 +615,65 @@ ${first.timeline}
     const third = parseMarkdown(reserialized, 'companies/acme-example.md');
     expect(third.timeline).toContain('Series A closed');
     expect(third.compiled_truth).not.toContain('Series A closed');
+  });
+});
+
+describe('resolveSourceLocalFilePath — POSIX backslash-in-filename (undeclared_db_only_pages false positive)', () => {
+  let repoRoot: string;
+
+  afterEach(() => {
+    if (repoRoot) rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test('a real file whose name contains a literal backslash resolves to its actual on-disk path', () => {
+    if (process.platform === 'win32') return; // `\` is the real separator there — no such filename is possible
+    // Reproduces production data: an Apple Notes export can legitimately
+    // contain a `\` character in a note title, which lands verbatim in the
+    // exported filename on a POSIX filesystem (where `\` is a normal
+    // filename character, not a path separator).
+    repoRoot = mkdtempSync(join(tmpdir(), 'gbrain-backslash-'));
+    mkdirSync(join(repoRoot, '.git'));
+    mkdirSync(join(repoRoot, 'Archive', 'POL'), { recursive: true });
+    const filename = '2019-10-03 \\event title-.md';
+    const filePath = join(repoRoot, 'Archive', 'POL', filename);
+    writeFileSync(filePath, '# note');
+
+    const sourcePath = `Archive/POL/${filename}`;
+    const resolved = resolveSourceLocalFilePath(repoRoot, sourcePath);
+
+    expect(resolved).toBe(filePath);
+  });
+
+  test('negative control: a genuinely missing file still resolves to null-equivalent (no such path)', () => {
+    if (process.platform === 'win32') return; // relies on `\` staying a filename character (POSIX-only)
+    repoRoot = mkdtempSync(join(tmpdir(), 'gbrain-backslash-missing-'));
+    mkdirSync(join(repoRoot, '.git'));
+    mkdirSync(join(repoRoot, 'Archive', 'POL'), { recursive: true });
+    // No file written — the resolved path must point at a location that
+    // does not exist, so callers' existsSync() check correctly reports it
+    // as unbacked (this stays a real gap, not a resolution bug).
+    const sourcePath = 'Archive/POL/2019-10-03 \\never-written-.md';
+    const resolved = resolveSourceLocalFilePath(repoRoot, sourcePath);
+
+    expect(resolved).toBe(join(repoRoot, 'Archive', 'POL', '2019-10-03 \\never-written-.md'));
+  });
+
+  test('path traversal via a real `/`-separated `..` segment is still rejected', () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'gbrain-backslash-traversal-'));
+    mkdirSync(join(repoRoot, '.git'));
+    expect(resolveSourceLocalFilePath(repoRoot, '../../etc/passwd.md')).toBeNull();
+  });
+
+  test('a Windows drive-letter absolute path is still rejected', () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'gbrain-backslash-drive-'));
+    mkdirSync(join(repoRoot, '.git'));
+    expect(resolveSourceLocalFilePath(repoRoot, 'C:\\Windows\\evil.md')).toBeNull();
+  });
+
+  test('on Windows, `\\` stays a real separator and `..\\` traversal is still rejected', () => {
+    if (process.platform !== 'win32') return; // the platform-aware split only changes POSIX behavior
+    repoRoot = mkdtempSync(join(tmpdir(), 'gbrain-backslash-win-'));
+    mkdirSync(join(repoRoot, '.git'));
+    expect(resolveSourceLocalFilePath(repoRoot, '..\\..\\evil.md')).toBeNull();
   });
 });


### PR DESCRIPTION
## Bug

`resolveSourceLocalFilePath` (src/core/markdown.ts) splits a stored
`pages.source_path` on `/[\\/]+/` unconditionally, treating `\` as a
directory separator regardless of platform. On POSIX, `\` is a legal
filename character, not a separator — a source_path like
`Archive/POL/2019-10-03 \title-.md` (reproducible from a real Apple
Notes export whose note title contains a backslash) gets split into an
extra bogus path segment, reconstructing a path that does not exist on
disk even though the real file does.

Observed impact: the `undeclared_db_only_pages` doctor check
false-positives for any such page ("Fix: restore or export the files,
or declare their prefixes under storage.db_only" — both wrong, since
the file already exists and is already file-backed). The same helper
is reused by write-through/takes-write paths, so a restore/export flow
that resolves this exact page would silently target a non-existent
path too.

## Fix

Split on the platform's real separator (gated by `node:path`'s own
`sep`) instead of a blanket `[\\/]+` regex: on POSIX, only `/` splits;
on Windows, `\` remains a real separator so behavior there is
unchanged. Traversal (`..`) rejection and the drive-letter/absolute-path
guard are unaffected on both platforms — verified with dedicated tests.

## Testing

- Added a positive control reproducing the exact production
  misresolution against the pre-fix code (confirmed failing before the
  fix, via a temporary `git stash` of the source change — not part of
  the final diff).
- Added negative controls: traversal via a real `/`-separated `..`
  segment, a Windows drive-letter absolute path, and (Windows-only,
  platform-gated) `\`-separated `..` traversal.
- `bun test test/markdown.test.ts`: 69 pass, 0 fail.
- `bun run typecheck`: clean.
- `bun run verify`: 54/54 checks pass.
- Reviewed with Codex CLI (bounded exec, high effort, focused on the
  path-confinement security properties): 0 Critical. 1 Warning (POSIX
  tests not platform-gated) and 1 Suggestion (add Windows-specific
  traversal coverage) — both addressed before this PR.

Not run locally: the full `bun test` suite hit pre-existing embedding
API retry/backoff loops unrelated to this change (network/credentials
in this local sandbox, not this diff — nothing in the diff touches
embedding code). Deferring to CI for full-suite confirmation.

## Dedup check

Searched issues/PRs for `resolveSourceLocalFilePath`, `backslash`, and
`undeclared_db_only_pages` before filing. Two similar-sounding hits are
different root causes: #3766 (closed, fixed by #4444) was about
case-sensitivity in `storage-config.ts`'s db_only prefix matching for
code pages; #4187 (open) is about `concepts/` missing from
`DERIVE_PHASE_DB_ONLY_DEFAULTS`. Neither touches this function or this
POSIX/Windows separator handling.