### PR TITLE
fix(cycle): extract_atoms rollup no longer counts transient errors as a halt

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -652,6 +652,11 @@ export async function runPhaseExtractAtoms(
   // chat call resets the streak.
   const llmHalt = createGlobalLlmHaltTracker();
   let abortedGlobalError: GlobalLlmErrorClass | null = null;
+  // Rollup/doctor-health signal only. `failures` (below) stays inclusive of
+  // transient entries for CLI/receipt reporting; this counts everything
+  // EXCEPT the ones TRANSIENT_EXTRACT_ERROR_RE + the rate_limit abort class
+  // say are "retryable, never counted" — see that regex's doc comment.
+  let hardFailureCount = 0;
 
   /** Stamp the zero-yield/complete tombstone (hash-keyed; edits re-eligibilize). */
   async function stampAtomsScanHash(item: { slug: string; contentHash: string }): Promise<void> {
@@ -727,6 +732,7 @@ export async function runPhaseExtractAtoms(
       const parseOutcome = parseAtomsOutcome(result.text);
       if (!parseOutcome.ok) {
         malformedOutputs++;
+        hardFailureCount++;
         const failCount = await recordPageFailureCount(item);
         failures.push({
           source: originLabel,
@@ -889,6 +895,7 @@ export async function runPhaseExtractAtoms(
       const decision = llmHalt.observe(err);
       if (decision !== 'continue') {
         abortedGlobalError = haltedClassOf(decision);
+        if (abortedGlobalError !== 'rate_limit') hardFailureCount++;
         failures.push({
           source: originLabel,
           error: `aborting phase: ${llmHalt.note()} (${message})`,
@@ -897,7 +904,10 @@ export async function runPhaseExtractAtoms(
       }
       const transient =
         llmHalt.lastClass() === 'rate_limit' || TRANSIENT_EXTRACT_ERROR_RE.test(message);
-      if (!transient) await recordPageFailureCount(item);
+      if (!transient) {
+        await recordPageFailureCount(item);
+        hardFailureCount++;
+      }
       failures.push({
         source: originLabel,
         error: transient ? `${message} [transient — retried next run]` : message,
@@ -930,12 +940,18 @@ export async function runPhaseExtractAtoms(
     }
   }
   if (!opts.dryRun) {
+    // gbrain#4148 / TRANSIENT_EXTRACT_ERROR_RE: transient provider/infra
+    // failures (rate limits, timeouts, 5xx, network) are "retryable, never
+    // counted" by design — count only hardFailureCount here, not
+    // failures.length (which stays inclusive, for CLI/receipt reporting),
+    // so a heavy run that only ever hit transient errors doesn't trip the
+    // doctor extract_health halt-rate warning.
     await upsertExtractRollup(engine, {
       kind: 'atoms',
       source_id: sourceId,
       cost_delta: estimatedSpendUsd,
-      round_completed_delta: failures.length === 0 ? 1 : 0,
-      halt_delta: failures.length > 0 ? 1 : 0,
+      round_completed_delta: hardFailureCount === 0 ? 1 : 0,
+      halt_delta: hardFailureCount > 0 ? 1 : 0,
     });
   }
 

--- a/test/extract-atoms-failure-classes.test.ts
+++ b/test/extract-atoms-failure-classes.test.ts
@@ -240,6 +240,101 @@ describe('runPhaseExtractAtoms — global-error halt (#3044)', () => {
   });
 });
 
+// Doctor's extract_health check reads extract_rollup_7d's halt_count /
+// round_completed_count to compute a per-kind halt rate and WARNs above
+// 10%. TRANSIENT_EXTRACT_ERROR_RE's own doc comment says transient
+// provider/infra errors are "retryable, never counted" — these tests pin
+// that the rollup honors it, instead of using failures.length (which
+// includes transient entries for CLI/receipt reporting and would
+// misreport a heavy-but-healthy run as failing).
+describe('runPhaseExtractAtoms — extract_health rollup excludes transient failures', () => {
+  const mkPages = (slugs: string[]) =>
+    slugs.map((slug, i) => ({ slug, content: 'prose', contentHash: String(i).repeat(16) }));
+
+  async function rollupRow(kind: string): Promise<{ halt_count: number; round_completed_count: number } | undefined> {
+    const rows = await engine.executeRaw<{ halt_count: number; round_completed_count: number }>(
+      `SELECT halt_count, round_completed_count FROM extract_rollup_7d WHERE kind = $1 AND source_id = 'default'`,
+      [kind],
+    );
+    return rows[0];
+  }
+
+  test('a run with only transient item-level errors counts as completed, not halted', async () => {
+    await seedPage('note/rt1');
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: [{ slug: 'note/rt1', content: 'prose', contentHash: HASH_A }],
+      _chat: async (_o: ChatOpts) => { throw new Error('fetch failed: 503 upstream timeout'); },
+    });
+    const row = await rollupRow('atoms');
+    expect(row).toBeDefined();
+    expect(row!.halt_count).toBe(0);
+    expect(row!.round_completed_count).toBe(1);
+  });
+
+  test('a genuine non-transient failure (malformed output) still counts as a halt', async () => {
+    await seedPage('note/rh1');
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: [{ slug: 'note/rh1', content: 'prose', contentHash: HASH_A }],
+      _chat: async (_o: ChatOpts) => okChatResult('no json in sight'),
+    });
+    const row = await rollupRow('atoms');
+    expect(row).toBeDefined();
+    expect(row!.halt_count).toBe(1);
+    expect(row!.round_completed_count).toBe(0);
+  });
+
+  test('a genuine non-transient THROWN error (not malformed output, not a global-abort class) still counts as a halt', async () => {
+    await seedPage('note/rh2');
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: [{ slug: 'note/rh2', content: 'prose', contentHash: HASH_A }],
+      _chat: async (_o: ChatOpts) => { throw new Error('unexpected internal error: null pointer'); },
+    });
+    const row = await rollupRow('atoms');
+    expect(row).toBeDefined();
+    expect(row!.halt_count).toBe(1);
+    expect(row!.round_completed_count).toBe(0);
+  });
+
+  test('an auth-abort (genuinely broken credentials) still counts as a halt', async () => {
+    await seedPage('note/rg1');
+    await seedPage('note/rg2');
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: mkPages(['note/rg1', 'note/rg2']),
+      _chat: async (_o: ChatOpts) => {
+        throw Object.assign(new Error('invalid x-api-key'), { status: 401 });
+      },
+    });
+    const row = await rollupRow('atoms');
+    expect(row).toBeDefined();
+    expect(row!.halt_count).toBe(1);
+    expect(row!.round_completed_count).toBe(0);
+  });
+
+  test('a rate_limit-streak abort (3 consecutive 429s) does NOT count as a halt', async () => {
+    for (const slug of ['note/rr1', 'note/rr2', 'note/rr3', 'note/rr4']) await seedPage(slug);
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: mkPages(['note/rr1', 'note/rr2', 'note/rr3', 'note/rr4']),
+      _chat: async (_o: ChatOpts) => {
+        throw Object.assign(new Error('rate limited'), { status: 429 });
+      },
+    });
+    const row = await rollupRow('atoms');
+    expect(row).toBeDefined();
+    expect(row!.halt_count).toBe(0);
+    expect(row!.round_completed_count).toBe(1);
+  });
+});
+
 describe('runPhaseExtractAtoms — completion receipt (gbrain#4148)', () => {
   test('full success flips atoms to the real source_hash and stamps the page', async () => {
     await seedPage('note/ok1');


### PR DESCRIPTION
## Bug

`TRANSIENT_EXTRACT_ERROR_RE` in `src/core/cycle/extract-atoms.ts` has its own doc comment: "Transient provider/infra failure shapes — retryable, **never counted**." But the `extract_rollup_7d` upsert at the end of `runPhaseExtractAtoms` computed `round_completed_delta`/`halt_delta` from `failures.length`, which includes transient entries unconditionally (both the per-item catch branch and the whole-run `rate_limit`-class abort branch push to `failures` regardless of the `transient` flag).

Observed impact: on a brain doing a heavy `extract_atoms --drain` against a provider that's being rate-limited (exactly what a large backlog drain does), most/all "failures" in a run are transient retries — yet the rollup recorded every such run as a halt. `gbrain doctor`'s `extract_health` check reads that rollup and WARNs when a kind's halt rate exceeds 10%, so a perfectly healthy, self-resolving drain reported as "the extractor is failing too often" (observed: 41.5% halt rate over 7 days, entirely attributable to this).

## Fix

Added `hardFailureCount`, incremented only where the existing code already treats something as non-transient (the `parseOutcome.ok === false` malformed-output branch, the `!transient` per-item catch branch, and whole-run aborts whose class isn't `rate_limit`). The rollup upsert now keys off `hardFailureCount` instead of `failures.length`. `failures` itself is untouched — CLI output and receipts still report every transient hit as before (with its existing `[transient — retried next run]` annotation); only the doctor-health signal changes.

## Testing

- Added a `describe` block to `test/extract-atoms-failure-classes.test.ts` with 5 cases: pure transient item-level error (should NOT halt — the core fix), a rate_limit-streak whole-run abort (should NOT halt — the other half of the fix), and three negative controls confirming genuine failures still count (malformed output, a non-transient thrown error, and an auth-class whole-run abort).
- Positive control: reverted the source fix via `git stash`, confirmed the two "should not halt" tests fail against pre-fix code (`Expected: 0, Received: 1`), then restored the fix and confirmed all 16 tests in the file pass.
- `bun run typecheck`: clean.
- `bun run verify`: 54/54 checks pass.
- Reviewed with Codex CLI (bounded exec, medium effort): 0 Critical/Warning. 2 Suggestions — missing branch coverage for the non-transient-thrown-error path, and an ambiguous comment — both addressed before this PR (added the missing test; reworded the comment).

## Scope note

A related but distinct problem — `facts.conversation` (`extract-conversation-facts.ts`) and `propose-takes.ts` intentionally count hitting their own per-source budget/deadline caps as a halt, by design, which `extract_health` can't distinguish from a genuine failure — is filed separately as #4482. I kept this PR to the one self-contradicting implementation bug in `extract-atoms.ts` rather than bundling a broader schema/semantics discussion into the same change.

## Dedup check

Searched for `extract_health halt`, `TRANSIENT_EXTRACT_ERROR halt_delta`, and `extract_rollup_7d transient` before filing — no existing issue/PR describes this. The one adjacent hit, #3683 (closed via my own PR #4426, `facts.fence` rollup never firing due to early-return ordering), is a different defect in a different kind's rollup path.