### PR TITLE
fix(doctor): schema_version warns instead of ok on forward DB skew (#2036)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4422	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958)
+src/commands/doctor.ts	4434	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958) + PR#4484 rebase onto current master
 src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown v0.46.26.0 megawave op wiring
 src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1902,8 +1902,20 @@ export async function buildChecks(
   try {
     const version = await engine.getConfig('version');
     schemaVersion = parseInt(version || '0', 10);
-    if (schemaVersion >= LATEST_VERSION) {
+    if (schemaVersion === LATEST_VERSION) {
       checks.push({ name: 'schema_version', status: 'ok', message: `Version ${schemaVersion} (latest: ${LATEST_VERSION})` });
+    } else if (schemaVersion > LATEST_VERSION) {
+      // Forward skew: another node migrated the shared DB past what this
+      // client knows (multi-node brain, hub + spokes on one Postgres). This
+      // client will read/write tables, columns, and indexes it doesn't know
+      // about — more dangerous than backward skew, which at least blocks on
+      // the next `apply-migrations`. See #2036.
+      checks.push({
+        name: 'schema_version',
+        status: 'warn',
+        message: `Version ${schemaVersion} is AHEAD of this client's latest known version (${LATEST_VERSION}). ` +
+                 `Another node migrated this DB past what this client knows — upgrade this client before writing.`,
+      });
     } else if (schemaVersion === 0) {
       checks.push({
         name: 'schema_version',

--- a/test/doctor-schema-version-forward-skew.test.ts
+++ b/test/doctor-schema-version-forward-skew.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `schema_version` must not report `ok` when the DB is AHEAD of this
+ * client's LATEST_VERSION (forward skew). On a multi-node brain (hub +
+ * spokes sharing one Postgres), a spoke whose checkout is older than the
+ * hub sees `schema_version: ok — Version 111 (latest: 80)` — the old
+ * client silently reads/writes tables, columns, and indexes it doesn't
+ * know about. Forward skew is more dangerous than backward skew (pending
+ * migrations at least block on the next `apply-migrations`), so it must
+ * not report a friendlier status than the pending-migrations case.
+ *
+ * Reported on #2036: a 31-version skew hid for weeks on a real mesh, found
+ * only by reading the "Version N (latest: M)" message by eye.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { buildChecks } from '../src/commands/doctor.ts';
+import { LATEST_VERSION } from '../src/core/migrate.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+describe('schema_version — forward skew (#2036)', () => {
+  test('warns, not oks, when the DB version is ahead of this client\'s latest known version', async () => {
+    await engine.setConfig('version', String(LATEST_VERSION + 31));
+
+    const checks = await buildChecks(engine, [], undefined);
+    const schemaCheck = checks.find((c) => c.name === 'schema_version');
+
+    expect(schemaCheck).toBeDefined();
+    expect(schemaCheck?.status).toBe('warn');
+    expect(schemaCheck?.message).toContain('AHEAD');
+    expect(schemaCheck?.message).toContain(String(LATEST_VERSION + 31));
+    expect(schemaCheck?.message).toContain(String(LATEST_VERSION));
+  });
+
+  test('still oks when the DB version exactly matches latest', async () => {
+    await engine.setConfig('version', String(LATEST_VERSION));
+
+    const checks = await buildChecks(engine, [], undefined);
+    const schemaCheck = checks.find((c) => c.name === 'schema_version');
+
+    expect(schemaCheck?.status).toBe('ok');
+    expect(schemaCheck?.message).toBe(`Version ${LATEST_VERSION} (latest: ${LATEST_VERSION})`);
+  });
+
+  test('still warns (unchanged) when the DB version is behind latest (pending migrations)', async () => {
+    await engine.setConfig('version', String(LATEST_VERSION - 1));
+
+    const checks = await buildChecks(engine, [], undefined);
+    const schemaCheck = checks.find((c) => c.name === 'schema_version');
+
+    expect(schemaCheck?.status).toBe('warn');
+    expect(schemaCheck?.message).toContain('apply-migrations');
+  });
+});


### PR DESCRIPTION
## Summary
- `schema_version` used `schemaVersion >= LATEST_VERSION`, so a DB **ahead** of this client (forward skew — another node migrated a shared multi-node brain past what this client knows) reported the same `ok` as an exact match.
- Forward skew is more dangerous than backward skew (pending migrations at least block on the next `apply-migrations`), yet it was reported as healthier — hiding a real 31-version skew for weeks on a reporter's mesh, surfaced only by reading the "Version N (latest: M)" message by eye.
- Split the `>=` branch: exact match stays `ok`; `schemaVersion > LATEST_VERSION` is now a new `warn` branch with an explicit "another node migrated this DB past what this client knows — upgrade this client before writing" message, matching the existing `warn` severity already used for the backward-skew case.

Closes #2036

## Test plan
- [x] New test `test/doctor-schema-version-forward-skew.test.ts`: verified RED against the pre-fix `>=` branch (temporarily reverted `src/commands/doctor.ts` via `git stash`, confirmed exactly the forward-skew case failed), GREEN after restoring the fix (3/3 pass), with the exact-match and backward-skew cases unchanged.
- [x] `bun run verify`: 54/54 green (bumped `scripts/module-size-limits.tsv` ceiling for `doctor.ts` by the exact new line count in the same commit).
- [x] `bun run typecheck`: clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EY6s1KwmznCuJnZTRPxmBp