### PR TITLE
fix(extract): attribute cross-source wikilink drops distinctly, not as missing-target (#2589)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -17,7 +17,7 @@ src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + mast
 src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352)
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
-src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)
+src/commands/extract.ts	2368	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4) + PR#4486 rebase onto current master
 src/commands/extract-conversation-facts.ts	2045	ratchet	grown v0.46.x per-provider gateway-unavailable copy
 src/core/import-file.ts	2142	ratchet	grown v0.46.26.0 megawave: OCR budget + image import + embed-retry rewire (#3973 #3374)
 src/core/cycle/synthesize.ts	2792	ratchet	merged waves; grown v0.46.26.0 megawave + master rolling lease via shared throttled renewer

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -196,20 +196,33 @@ function refsWithSnapshotStamps(
  * v0.42.7 (#1696): pure cross-source resolution for one extracted link
  * candidate. Validates both endpoints exist (else the batch JOIN drops the row),
  * then picks from_source_id / to_source_id: prefer the origin page's source,
- * fall back to 'default', else skip (never push a wrong-source edge). Returns
- * null when the candidate should be skipped. Shared by extractLinksFromDB and
- * extractStaleFromDB so the F10 multi-source resolution can't drift.
+ * fall back to 'default', else skip (never push a wrong-source edge). Shared
+ * by extractLinksFromDB and extractStaleFromDB so the F10 multi-source
+ * resolution can't drift.
+ *
+ * v0.46.28.0 (#2589): the failure case now carries a `reason` instead of a
+ * bare `null`. A target that resolves via `global_basename` to a page that
+ * exists ONLY in a source other than the origin's or 'default' was
+ * indistinguishable from a genuinely-missing target — both silently dropped
+ * the candidate and both counted (misleadingly) as "target page doesn't
+ * exist". This stays default-deny by design: cross-source edges remain
+ * unwritten (source isolation — see CLAUDE.md), but callers can now
+ * attribute the drop correctly instead of reporting a wrong reason.
  */
+export type CandidateSourceResolution =
+  | { ok: true; fromSlug: string; fromSourceId: string; toSourceId: string }
+  | { ok: false; reason: 'missing_target' | 'missing_from' | 'cross_source' };
+
 export function resolveCandidateSources(
   c: LinkCandidate,
   pageSlug: string,
   pageSourceId: string,
   allSlugs: Set<string>,
   slugToSources: Map<string, string[]>,
-): { fromSlug: string; fromSourceId: string; toSourceId: string } | null {
+): CandidateSourceResolution {
   const fromSlug = c.fromSlug ?? pageSlug;
-  if (!allSlugs.has(c.targetSlug)) return null;
-  if (!allSlugs.has(fromSlug)) return null;
+  if (!allSlugs.has(c.targetSlug)) return { ok: false, reason: 'missing_target' };
+  if (!allSlugs.has(fromSlug)) return { ok: false, reason: 'missing_from' };
   const fromSources = slugToSources.get(fromSlug) ?? [];
   const fromSourceId = fromSources.includes(pageSourceId) ? pageSourceId
     : (fromSources.includes('default') ? 'default' : fromSources[0]);
@@ -220,9 +233,9 @@ export function resolveCandidateSources(
   } else if (targetSources.includes('default')) {
     toSourceId = 'default';
   } else {
-    return null;
+    return { ok: false, reason: 'cross_source' };
   }
-  return { fromSlug, fromSourceId, toSourceId };
+  return { ok: true, fromSlug, fromSourceId, toSourceId };
 }
 
 // isRetryableConnError reference retained for any inline classification at
@@ -1621,6 +1634,10 @@ async function extractLinksFromDB(
   let processed = 0, created = 0;
   // #2576: skipped-candidate counter — see extractStaleFromDB's twin.
   let skippedMissingTarget = 0;
+  // #2589: target resolved (via global_basename) to a page that exists only
+  // in a source other than the origin's or 'default' — default-deny by
+  // design (source isolation), but distinct from a genuinely missing target.
+  let skippedCrossSource = 0;
   // v0.42.7 (#1696): pages whose links we extracted this run — stamped after
   // the loop so a manual `gbrain extract links|all --source db` clears the
   // links_extraction_lag doctor signal. Non-dry-run only.
@@ -1669,10 +1686,15 @@ async function extractLinksFromDB(
     for (const c of extracted.candidates) {
       // v0.32.8 F10 cross-source link resolution, extracted to the shared pure
       // helper in v0.42.7 (#1696) so extract --stale reuses the exact same
-      // endpoint-validation + from/to source-id picking (null = skip: missing
-      // endpoint OR target only in a non-origin/non-default source).
+      // endpoint-validation + from/to source-id picking. #2589: the reason
+      // is now distinguished (missing endpoint vs. target only in a
+      // non-origin/non-default source) so the two don't get counted as one.
       const resolved = resolveCandidateSources(c, slug, source_id, allSlugs, slugToSources);
-      if (!resolved) { skippedMissingTarget++; continue; }
+      if (!resolved.ok) {
+        if (resolved.reason === 'cross_source') skippedCrossSource++;
+        else skippedMissingTarget++;
+        continue;
+      }
       const { fromSlug, fromSourceId, toSourceId } = resolved;
 
       if (dryRunSeen) {
@@ -1731,6 +1753,9 @@ async function extractLinksFromDB(
     console.log(`Links: ${label} ${created} from ${processed} pages (db source)`);
     if (skippedMissingTarget > 0) {
       console.log(`Skipped ${skippedMissingTarget} candidate(s) whose target page doesn't exist (references to non-pages are never persisted).`);
+    }
+    if (skippedCrossSource > 0) {
+      console.log(`Skipped ${skippedCrossSource} candidate(s) whose target page exists only in another source (cross-source edges are not written — see docs/architecture/brains-and-sources.md).`);
     }
     if (includeFrontmatter && unresolved.length > 0) {
       // Top-20 preview of unresolvable frontmatter names so the user can
@@ -1884,7 +1909,7 @@ export async function extractStaleFromDB(
      */
     timeBudgetMs?: number;
   },
-): Promise<{ linksCreated: number; timelineCreated: number; pagesProcessed: number; staleRemaining: number; skippedMissingTarget?: number }> {
+): Promise<{ linksCreated: number; timelineCreated: number; pagesProcessed: number; staleRemaining: number; skippedMissingTarget?: number; skippedCrossSource?: number }> {
   const { dryRun, jsonMode, includeFrontmatter, sourceIdFilter, catchUp } = opts;
   const timeBudgetMs = opts.timeBudgetMs ?? STALE_TIME_BUDGET_MS;
   const versionTs = LINK_EXTRACTOR_VERSION_TS;
@@ -1943,6 +1968,10 @@ export async function extractStaleFromDB(
   // persisted. Counted so a dropped reference is observable in the summary
   // instead of vanishing silently (the failure mode that hid bug 2).
   let skippedMissingTarget = 0;
+  // #2589: target resolved (via global_basename) to a page that exists only
+  // in a source other than the origin's or 'default' — default-deny by
+  // design (source isolation), but distinct from a genuinely missing target.
+  let skippedCrossSource = 0;
 
   for (;;) {
     const rows = await engine.listStalePagesForExtraction({
@@ -1962,7 +1991,11 @@ export async function extractStaleFromDB(
       );
       for (const c of extracted.candidates) {
         const r = resolveCandidateSources(c, page.slug, page.source_id, allSlugs, slugToSources);
-        if (!r) { skippedMissingTarget++; continue; }
+        if (!r.ok) {
+          if (r.reason === 'cross_source') skippedCrossSource++;
+          else skippedMissingTarget++;
+          continue;
+        }
         linkRows.push({
           from_slug: r.fromSlug, to_slug: c.targetSlug, link_type: c.linkType,
           context: c.context, link_source: c.linkSource, origin_slug: c.originSlug,
@@ -2030,6 +2063,9 @@ export async function extractStaleFromDB(
     if (skippedMissingTarget > 0) {
       console.log(`Skipped ${skippedMissingTarget} candidate(s) whose target page doesn't exist (references to non-pages are never persisted).`);
     }
+    if (skippedCrossSource > 0) {
+      console.log(`Skipped ${skippedCrossSource} candidate(s) whose target page exists only in another source (cross-source edges are not written — see docs/architecture/brains-and-sources.md).`);
+    }
     if (budgetHit && staleRemaining > 0) {
       console.log(`Time budget reached — ${staleRemaining} page(s) still stale. Re-run 'gbrain extract --stale' (or pass --catch-up) to continue.`);
     }
@@ -2037,10 +2073,10 @@ export async function extractStaleFromDB(
     process.stdout.write(JSON.stringify({
       action: 'extract_stale_done', links_created: linksCreated, timeline_created: timelineCreated,
       pages_processed: pagesProcessed, stale_remaining: staleRemaining, budget_hit: budgetHit,
-      skipped_missing_target: skippedMissingTarget,
+      skipped_missing_target: skippedMissingTarget, skipped_cross_source: skippedCrossSource,
     }) + '\n');
   }
-  return { linksCreated, timelineCreated, pagesProcessed, staleRemaining, skippedMissingTarget };
+  return { linksCreated, timelineCreated, pagesProcessed, staleRemaining, skippedMissingTarget, skippedCrossSource };
 }
 
 /**

--- a/src/core/sweep.ts
+++ b/src/core/sweep.ts
@@ -396,7 +396,7 @@ async function runLinksTimelinePass(
     for (const { slug, candidates } of pageCandidates) {
       for (const c of candidates) {
         const resolved = resolveCandidateSources(c, slug, sourceId, allSlugs, slugToSources);
-        if (!resolved) continue;
+        if (!resolved.ok) continue;
         linkBatch.push({
           from_slug: resolved.fromSlug,
           to_slug: c.targetSlug,

--- a/test/extract-cross-source-resolution-observability.test.ts
+++ b/test/extract-cross-source-resolution-observability.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `resolveCandidateSources` must distinguish a cross-source drop (target
+ * resolves via global_basename to a page that exists only in a source other
+ * than the origin's or 'default') from a genuinely missing target/from-slug.
+ * Both used to return a bare `null`, making a real multi-source graph
+ * sparsity problem indistinguishable from a plain dead link (#2589).
+ *
+ * This is default-deny by design (source isolation — see CLAUDE.md's
+ * "Source isolation" cross-cutting invariant): a cross-source drop still
+ * does NOT create the edge. Only the *reason* callers can attribute to the
+ * drop changes.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { resolveCandidateSources } from '../src/commands/extract.ts';
+import type { LinkCandidate } from '../src/core/link-extraction.ts';
+
+function candidate(targetSlug: string, fromSlug?: string): LinkCandidate {
+  return { fromSlug, targetSlug, linkType: 'mentions', context: 'ctx' };
+}
+
+describe('resolveCandidateSources — reason attribution (#2589)', () => {
+  test('resolves when target exists in the origin source', () => {
+    const allSlugs = new Set(['origin-page', 'target-page']);
+    const slugToSources = new Map<string, string[]>([
+      ['origin-page', ['source-a']],
+      ['target-page', ['source-a']],
+    ]);
+    const r = resolveCandidateSources(candidate('target-page'), 'origin-page', 'source-a', allSlugs, slugToSources);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.fromSourceId).toBe('source-a');
+      expect(r.toSourceId).toBe('source-a');
+    }
+  });
+
+  test('falls back to default when target only exists there', () => {
+    const allSlugs = new Set(['origin-page', 'target-page']);
+    const slugToSources = new Map<string, string[]>([
+      ['origin-page', ['source-a']],
+      ['target-page', ['default']],
+    ]);
+    const r = resolveCandidateSources(candidate('target-page'), 'origin-page', 'source-a', allSlugs, slugToSources);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.toSourceId).toBe('default');
+  });
+
+  test('reason=missing_target when the target slug is not in allSlugs at all', () => {
+    const allSlugs = new Set(['origin-page']);
+    const slugToSources = new Map<string, string[]>([['origin-page', ['source-a']]]);
+    const r = resolveCandidateSources(candidate('nonexistent-page'), 'origin-page', 'source-a', allSlugs, slugToSources);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('missing_target');
+  });
+
+  test('reason=missing_from when the origin slug is not in allSlugs', () => {
+    const allSlugs = new Set(['target-page']);
+    const slugToSources = new Map<string, string[]>([['target-page', ['source-a']]]);
+    const r = resolveCandidateSources(candidate('target-page'), 'origin-page', 'source-a', allSlugs, slugToSources);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('missing_from');
+  });
+
+  test('reason=cross_source when the target exists only in an unrelated source (#2589 repro)', () => {
+    // 6-source federated brain: origin in comms-imessage, target only in
+    // people-vault. Neither the origin source nor 'default' — exactly the
+    // silently-dropped case reported on #2589.
+    const allSlugs = new Set(['comms-imessage/thread-1', 'people-vault/alice-example']);
+    const slugToSources = new Map<string, string[]>([
+      ['comms-imessage/thread-1', ['comms-imessage']],
+      ['people-vault/alice-example', ['people-vault']],
+    ]);
+    const r = resolveCandidateSources(
+      candidate('people-vault/alice-example'),
+      'comms-imessage/thread-1',
+      'comms-imessage',
+      allSlugs,
+      slugToSources,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('cross_source');
+  });
+
+  test('cross_source is still a drop, not an edge — never returns fromSlug/toSourceId', () => {
+    const allSlugs = new Set(['origin-page', 'target-page']);
+    const slugToSources = new Map<string, string[]>([
+      ['origin-page', ['source-a']],
+      ['target-page', ['source-b']],
+    ]);
+    const r = resolveCandidateSources(candidate('target-page'), 'origin-page', 'source-a', allSlugs, slugToSources);
+    expect(r).not.toHaveProperty('toSourceId');
+    expect(r).not.toHaveProperty('fromSourceId');
+  });
+});


### PR DESCRIPTION
## Summary
- On a multi-source (federated) brain, a bare wikilink resolved via `global_basename` to a page that exists only in a source other than the origin's or `'default'` was silently dropped — indistinguishable from a genuinely missing target. Both counted as "target page doesn't exist" and `dead_links` stayed 0.
- **This stays default-deny by design**: source isolation is a documented cross-cutting invariant in this repo's `CLAUDE.md` ("Don't hand-roll source filtering — a missed thread is a cross-source data leak"). This PR does **not** change resolution behavior — a cross-source candidate still does not become an edge.
- `resolveCandidateSources`'s failure case now carries a `reason: 'missing_target' | 'missing_from' | 'cross_source'` instead of a bare `null`, so `extract`'s console/JSON summaries can attribute the drop correctly instead of reporting a misleading "target doesn't exist" for a target that does exist, just in another source. This makes the real multi-source graph sparsity reported on #2589 observable (a new "Skipped N candidate(s) whose target page exists only in another source" line + `skipped_cross_source` JSON field), without touching the isolation behavior itself.

## Test plan
- [x] New test `test/extract-cross-source-resolution-observability.test.ts` (6 cases against the pure `resolveCandidateSources` helper, including the exact 6-federated-source repro shape from the issue). Verified RED against the pre-fix bare-`null` return shape (temporarily reverted via `git stash`), GREEN after (6/6 pass).
- [x] Full existing extract/sweep suites — `extract-stale`, `link-extraction` (x2), `sweep`, `sync-deferred-extract-queue`: 244 + 7 tests, 0 regressions.
- [x] `bun run verify`: 54/54 green (bumped `scripts/module-size-limits.tsv` ceiling for `extract.ts` by the exact new line count in the same commit).
- [x] `bun run typecheck`: clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EY6s1KwmznCuJnZTRPxmBp