### PR TITLE
fix(search): cosineReScore no longer gives chunkless rows a raw-score head start (#3695)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -14,7 +14,7 @@ src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silen
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
 src/commands/jobs.ts	3111	ratchet	grown v0.46.26.0 megawave (#4098 #2308) + master v0.46.26.0 worker startup recovery + stats gating
-src/core/search/hybrid.ts	2845	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352)
+src/core/search/hybrid.ts	2856	ratchet	grown v0.46.26.0 megawave: CRAG escalation seam, degradation visibility, excludePrivate knobs-fold v23 (#1663 #3873 #4352) + PR#4487 rebase onto current master
 src/core/engine.ts	2495	ratchet	grown v0.46.26.0 megawave: relational/visibility/usage contract surface (#4352 #4218)
 src/commands/autopilot.ts	2641	ratchet	grown v0.46.26.0 megawave (#4300 #4285 #3696) + master v0.46.27.0 env-file lane + boot warning + reload-safe install (#2608 #4443) + 1 nosemgrep dataflow annotation (path-traversal audit)
 src/commands/extract.ts	2332	ratchet	grown v0.46.26.0 megawave: FS-walk stamp snapshot + legacy timeline repair wiring (#3957 D4)

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -2785,8 +2785,11 @@ export function rrfFusion(lists: SearchResult[][], k: number, applyBoost = true)
 /**
  * Cosine re-scoring: blend RRF score with query-chunk cosine similarity.
  * Runs before dedup so semantically better chunks survive.
+ *
+ * Exported (only) for direct unit testing of the chunkless-row blend fix
+ * (#3695) — not part of the public search API surface.
  */
-async function cosineReScore(
+export async function cosineReScore(
   engine: BrainEngine,
   results: SearchResult[],
   queryEmbedding: Float32Array,
@@ -2816,10 +2819,18 @@ async function cosineReScore(
   const maxRrf = Math.max(...results.map(r => r.score));
 
   return results.map(r => {
+    // v0.46.28.0 (#3695): a row with no hydratable chunk embedding (the
+    // synthetic chunkless row for an embed_skip'd oversized page, or a
+    // chunk_id whose embedding didn't hydrate) used to return `r` untouched
+    // — keeping its RAW post-RRF score on a [0, ~2.0] scale while every
+    // other row got compressed onto the [0, 1.0] blended scale below. That
+    // gave chunkless rows a structural 2x head start (#3695's reported
+    // symptom: an empty-snippet embed_skip page outranking on-point
+    // results). Route it through the SAME blend with cosine=0 instead of
+    // excluding it — excluding would make embed_skip pages unsearchable,
+    // a different (undesired) behavior change.
     const chunkEmb = r.chunk_id != null ? embeddingMap.get(r.chunk_id) : undefined;
-    if (!chunkEmb) return r;
-
-    const cosine = cosineSimilarity(queryEmbedding, chunkEmb);
+    const cosine = chunkEmb ? cosineSimilarity(queryEmbedding, chunkEmb) : 0;
     const normRrf = maxRrf > 0 ? r.score / maxRrf : 0;
     const blended = 0.7 * normRrf + 0.3 * cosine;
 

--- a/test/cosine-rescore-chunkless-headstart.test.ts
+++ b/test/cosine-rescore-chunkless-headstart.test.ts
@@ -1,0 +1,119 @@
+/**
+ * cosineReScore must not give a chunkless row (the synthetic
+ * chunk_id=0/COALESCE row for a chunkless page, e.g. an embed_skip'd
+ * oversized page — or any chunk_id whose embedding failed to hydrate) a
+ * raw-scale head start over rows that got compressed onto the [0, 1.0]
+ * blended scale.
+ *
+ * Pre-fix: `if (!chunkEmb) return r;` returned the row completely
+ * untouched, so its RAW post-RRF score (on whatever scale upstream fusion
+ * produced, up to ~2.0 with the compiled_truth boost) survived alongside
+ * every other row's [0, 1.0]-scale blended score — a structural 2x head
+ * start. Reported on #3695: a 602KB embed_skip page with an empty snippet
+ * became the #1 result for 15/25 queries in a regression set, displacing
+ * on-point pages, purely from this scale mismatch (not from actual
+ * relevance).
+ *
+ * Fix: route the chunkless row through the identical blend formula with
+ * cosine=0, so it's compressed onto the same scale as every other row —
+ * without excluding it (which would make embed_skip pages unsearchable, a
+ * different behavior change).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { cosineReScore } from '../src/core/search/hybrid.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { SearchResult } from '../src/core/types.ts';
+
+function fakeEngine(embeddings: Map<number, Float32Array>): BrainEngine {
+  return {
+    getEmbeddingsByChunkIds: async (chunkIds: number[]) => {
+      const map = new Map<number, Float32Array>();
+      for (const id of chunkIds) {
+        const v = embeddings.get(id);
+        if (v) map.set(id, v);
+      }
+      return map;
+    },
+  } as unknown as BrainEngine;
+}
+
+function result(overrides: Partial<SearchResult> & { chunk_id: number; score: number }): SearchResult {
+  return {
+    slug: 'test/page',
+    page_id: 1,
+    title: 'Test',
+    type: 'note',
+    chunk_text: 'text',
+    chunk_source: 'compiled_truth',
+    chunk_index: 0,
+    stale: false,
+    ...overrides,
+  } as SearchResult;
+}
+
+describe('cosineReScore — chunkless-row head start (#3695)', () => {
+  test('a chunkless row (chunk_id=0, no hydratable embedding) is compressed onto the same [0,1.0] scale, not left on its raw score', async () => {
+    const queryEmbedding = new Float32Array([1, 0, 0]);
+    // Chunked row's embedding is orthogonal to the query — cosine=0, so its
+    // blend is entirely lexical: 0.7 * normRrf.
+    const chunkedEmbedding = new Float32Array([0, 1, 0]);
+    const engine = fakeEngine(new Map([[42, chunkedEmbedding]]));
+
+    // Same base (post-fusion, pre-boost) RRF score for both rows — an
+    // apples-to-apples comparison of what the rescore step alone does.
+    const chunklessRaw = 1.8650; // reproduces the exact #3695 reported score
+    const chunkedRaw = 1.8650;
+
+    const results: SearchResult[] = [
+      result({ slug: 'chunkless/embed-skip-page', chunk_id: 0, chunk_text: '', score: chunklessRaw }),
+      result({ slug: 'chunked/on-point-page', chunk_id: 42, score: chunkedRaw }),
+    ];
+
+    const rescored = await cosineReScore(engine, results, queryEmbedding, 'embedding');
+    const chunkless = rescored.find(r => r.slug === 'chunkless/embed-skip-page')!;
+    const chunked = rescored.find(r => r.slug === 'chunked/on-point-page')!;
+
+    // The chunkless row must NOT retain its raw ~1.86 score — it must be
+    // compressed to the blended scale, same as the chunked row.
+    expect(chunkless.score).not.toBeCloseTo(chunklessRaw, 2);
+    expect(chunkless.score).toBeLessThanOrEqual(1.0);
+    expect(chunked.score).toBeLessThanOrEqual(1.0);
+
+    // Both rows had identical base scores and cosine=0 (chunkless has no
+    // embedding; the chunked row's embedding is orthogonal to the query) —
+    // so both should land on the exact same blended score. Neither
+    // structurally outranks the other from the rescore step alone.
+    expect(chunkless.score).toBeCloseTo(chunked.score, 6);
+    expect(chunkless.cosine).toBe(0);
+  });
+
+  test('a chunkless page with genuine lexical relevance still surfaces (not excluded)', async () => {
+    const queryEmbedding = new Float32Array([1, 0, 0]);
+    const engine = fakeEngine(new Map());
+
+    const results: SearchResult[] = [
+      result({ slug: 'chunkless/lexical-hit', chunk_id: 0, chunk_text: '', score: 0.9 }),
+    ];
+
+    const rescored = await cosineReScore(engine, results, queryEmbedding, 'embedding');
+    expect(rescored).toHaveLength(1);
+    expect(rescored[0].slug).toBe('chunkless/lexical-hit');
+    expect(Number.isFinite(rescored[0].score)).toBe(true);
+  });
+
+  test('an embedded row with a genuinely relevant embedding still outranks an unrelated chunkless row', async () => {
+    const queryEmbedding = new Float32Array([1, 0, 0]);
+    // Perfectly aligned with the query — cosine=1.
+    const relevantEmbedding = new Float32Array([1, 0, 0]);
+    const engine = fakeEngine(new Map([[7, relevantEmbedding]]));
+
+    const results: SearchResult[] = [
+      result({ slug: 'chunkless/unrelated', chunk_id: 0, chunk_text: '', score: 1.8 }),
+      result({ slug: 'chunked/relevant', chunk_id: 7, score: 1.8 }),
+    ];
+
+    const rescored = await cosineReScore(engine, results, queryEmbedding, 'embedding');
+    expect(rescored[0].slug).toBe('chunked/relevant');
+  });
+});


### PR DESCRIPTION
## Summary
- `cosineReScore` compresses every row's post-RRF score onto a `[0, 1.0]` blended scale, **except** a row with no hydratable chunk embedding — that row was returned untouched via an early `if (!chunkEmb) return r;`, keeping its raw post-RRF score (up to ~2.0 with the `compiled_truth` boost every synthetic chunkless row inherits). A structural 2x head start over every properly-blended row.
- Reported symptom: a 602KB oversized page crossed the `embed_skip` threshold (0 chunk rows) and its chunkless synthetic row's raw ~1.865 score beat every properly-blended on-point result — the #1 result for 15/25 queries in a regression set, with an empty snippet.
- Fix: route the chunkless case through the **same blend formula with `cosine=0`**, instead of excluding it. Excluding it entirely would make `embed_skip`'d pages unsearchable — a different, undesired behavior change; this only removes the incomparable-scale head start while keeping the page's lexical/`compiled_truth`-derived base score meaningful.
- **Scoped to cause (1)** of the 6 stacking causes + 2 compounding defects reported on #3695 — the minimal change that directly stops the reported #1-result symptom. The other 5 (`searchTitles`' unconditional OR-fallback, `floor_ratio` being unreachable from config, the backlink mention-filter column mismatch, `search_vector`'s un-normalized timeline-heavy ranking, and the synthetic row's `compiled_truth`-boost inheritance) are separate ranking contracts per the issue's own "happy to split into separate issues" framing, and are left for follow-up so this PR doesn't conflate root causes or destabilize unrelated ranking behavior in one shot.

## Test plan
- [x] New test `test/cosine-rescore-chunkless-headstart.test.ts` reproduces the exact reported symptom on pre-fix code (an irrelevant chunkless row with cosine=0 relevance outranks a perfectly-relevant chunked row at equal base score). Verified RED (confirmed via a targeted temporary revert of just the fixed lines), GREEN (3/3 pass) after.
- [x] Full non-serial hybrid/search-related suite: 254 tests across 17 files, 0 regressions.
- [x] All 13 affected `*.serial.test.ts` files run **individually** (matching CI's actual one-process-per-file execution unit per `scripts/run-serial-tests.sh` — a batched multi-file `bun test` run is NOT representative, since bun shares the module registry across files in one process and that alone produced one spurious failure I ruled out this way): 0 regressions across all 13.
- [x] `bun run verify`: 54/54 green (bumped `scripts/module-size-limits.tsv` ceiling for `hybrid.ts` by the exact new line count in the same commit).
- [x] `bun run typecheck`: clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EY6s1KwmznCuJnZTRPxmBp