### PR TITLE
fix(engine): traverseGraph filters soft-deleted pages at seed, step, and displayed edges (#3754 residual)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -5,8 +5,8 @@
 # Columns: path	max_lines	policy	note
 src/commands/doctor.ts	4422	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958)
 src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown v0.46.26.0 megawave op wiring
-src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
-src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns
+src/core/postgres-engine.ts	6168	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe; +#3754 traverseGraph soft-delete filters
+src/core/pglite-engine.ts	6064	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns; +#3754 traverseGraph soft-delete filters
 src/core/migrate.ts	687	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted — grown v0.46.26.0: repair-handler hooks (#3957 pages-upsert-arbiter)
 src/commands/sync.ts	4512	ratchet	grown v0.46.26.0 megawave: image sync, ingest-log gating, dry-run purity, checkpoint honesty (#2683 #4342 #3875) + 3 nosemgrep dataflow annotations (path-traversal audit)
 src/core/ai/gateway.ts	4494	ratchet	grown v0.46.26.0 megawave: config-plane probes + halt telemetry (#3387 #4312)

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4041,6 +4041,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}
         ORDER BY p2.slug ASC, p2.id ASC
         LIMIT $${capIdx})`;
@@ -4051,6 +4052,7 @@ export class PGLiteEngine implements BrainEngine {
         JOIN pages p2 ON p2.id = l.to_page_id
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
+          AND p2.deleted_at IS NULL
           ${stepScope}`;
     }
 
@@ -4059,7 +4061,7 @@ export class PGLiteEngine implements BrainEngine {
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = $1 ${seedScope}
+        FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -4075,7 +4077,7 @@ export class PGLiteEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3917,6 +3917,7 @@ export class PostgresEngine implements BrainEngine {
              JOIN pages p2 ON p2.id = l.to_page_id
              WHERE g.depth < ${depth}
                AND NOT (p2.id = ANY(g.visited))
+               AND p2.deleted_at IS NULL
                ${stepScope}
              ORDER BY p2.slug ASC, p2.id ASC
              LIMIT ${cap})`
@@ -3926,12 +3927,13 @@ export class PostgresEngine implements BrainEngine {
             JOIN pages p2 ON p2.id = l.to_page_id
             WHERE g.depth < ${depth}
               AND NOT (p2.id = ANY(g.visited))
+              AND p2.deleted_at IS NULL
               ${stepScope}`;
     // Cycle prevention: visited array tracks page IDs already in the path.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug} ${seedScope}
+        FROM pages p WHERE p.slug = ${slug} AND p.deleted_at IS NULL ${seedScope}
 
         UNION ALL
 
@@ -3949,7 +3951,7 @@ export class PostgresEngine implements BrainEngine {
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
            JOIN pages p3 ON p3.id = l2.to_page_id
-           WHERE l2.from_page_id = g.id ${aggScope}),
+           WHERE l2.from_page_id = g.id AND p3.deleted_at IS NULL ${aggScope}),
           '[]'::jsonb
         ) as links
       FROM graph g

--- a/test/e2e/engine-parity.test.ts
+++ b/test/e2e/engine-parity.test.ts
@@ -655,6 +655,32 @@ describeBoth('Engine parity — Postgres vs PGLite', () => {
     }
   });
 
+  test('#3754 soft-deleted pages hidden from traverseGraph on both engines', async () => {
+    for (const engine of [pgEngine, pgliteEngine]) {
+      await engine.putPage('notes/sdg-from', {
+        type: 'note', title: 'sdg-from', compiled_truth: 'links out', timeline: '',
+      });
+      await engine.putPage('notes/sdg-to', {
+        type: 'note', title: 'sdg-to', compiled_truth: 'target', timeline: '',
+      });
+      await engine.addLink('notes/sdg-from', 'notes/sdg-to', 'ctx', 'wikilink');
+
+      const before = await engine.traverseGraph('notes/sdg-from', 1);
+      expect(before.map((n) => n.slug).sort()).toEqual(['notes/sdg-from', 'notes/sdg-to']);
+
+      await engine.softDeletePage('notes/sdg-to', { sourceId: 'default' });
+
+      // Node set, displayed links array, capped recursive variant, and the
+      // deleted-seed case all filter identically on both engines.
+      const after = await engine.traverseGraph('notes/sdg-from', 1);
+      expect(after.map((n) => n.slug)).toEqual(['notes/sdg-from']);
+      expect(after[0].links.map((l) => l.to_slug)).toEqual([]);
+      const capped = await engine.traverseGraph('notes/sdg-from', 1, { frontierCap: 10 });
+      expect(capped.map((n) => n.slug)).toEqual(['notes/sdg-from']);
+      expect(await engine.traverseGraph('notes/sdg-to', 1)).toEqual([]);
+    }
+  });
+
   test('v0.41.19.0 deletePages parity: both engines return same confirmed-deleted slugs', async () => {
     const realSlugs = ['wiki/dpp-1', 'wiki/dpp-2', 'wiki/dpp-3'];
     for (const slug of realSlugs) {

--- a/test/soft-delete-link-visibility.test.ts
+++ b/test/soft-delete-link-visibility.test.ts
@@ -139,3 +139,50 @@ describe('#3754 traversePaths hides soft-deleted pages', () => {
     expect(await engine.traversePaths('hop-a', { direction: 'out', depth: 3 })).toEqual([]);
   });
 });
+
+describe('#3754 traverseGraph hides soft-deleted pages', () => {
+  test('deleted neighbor disappears from nodes AND from the displayed links array', async () => {
+    await seedPair();
+    const before = await engine.traverseGraph('bl-a', 1);
+    expect(before.map((n) => n.slug).sort()).toEqual(['bl-a', 'bl-b']);
+
+    await engine.softDeletePage('bl-b', { sourceId: 'default' });
+    const after = await engine.traverseGraph('bl-a', 1);
+    expect(after.map((n) => n.slug)).toEqual(['bl-a']);
+    // The aggregation subquery must not display an edge to the deleted page.
+    expect(after[0].links.map((l) => l.to_slug)).toEqual([]);
+  });
+
+  test('a soft-deleted seed anchors nothing', async () => {
+    await seedPair();
+    await engine.softDeletePage('bl-a', { sourceId: 'default' });
+    expect(await engine.traverseGraph('bl-a', 1)).toEqual([]);
+  });
+
+  test('a soft-deleted relay breaks multi-hop traversal (recursive step filter)', async () => {
+    await engine.putPage('tg-a', { type: 'note', title: 'a', compiled_truth: 'x', timeline: '' });
+    await engine.putPage('tg-mid', { type: 'note', title: 'mid', compiled_truth: 'x', timeline: '' });
+    await engine.putPage('tg-c', { type: 'note', title: 'c', compiled_truth: 'x', timeline: '' });
+    await engine.addLink('tg-a', 'tg-mid', '', 'wikilink');
+    await engine.addLink('tg-mid', 'tg-c', '', 'wikilink');
+    expect((await engine.traverseGraph('tg-a', 3)).map((n) => n.slug).sort()).toEqual(['tg-a', 'tg-c', 'tg-mid']);
+
+    await engine.softDeletePage('tg-mid', { sourceId: 'default' });
+    expect((await engine.traverseGraph('tg-a', 3)).map((n) => n.slug)).toEqual(['tg-a']);
+  });
+
+  test('the frontier-capped recursive variant filters too', async () => {
+    await seedPair();
+    await engine.softDeletePage('bl-b', { sourceId: 'default' });
+    const nodes = await engine.traverseGraph('bl-a', 1, { frontierCap: 10 });
+    expect(nodes.map((n) => n.slug)).toEqual(['bl-a']);
+  });
+
+  test('restore brings the node back', async () => {
+    await seedPair();
+    await engine.softDeletePage('bl-b', { sourceId: 'default' });
+    await engine.restorePage('bl-b', { sourceId: 'default' });
+    const nodes = await engine.traverseGraph('bl-a', 1);
+    expect(nodes.map((n) => n.slug).sort()).toEqual(['bl-a', 'bl-b']);
+  });
+});


### PR DESCRIPTION
## Summary

The #3754 soft-delete sweep (v0.46.28.0) sealed `getLinks` / `getBacklinks` / `traversePaths`, but **`traverseGraph` — the engine surface behind `graph-query` — still walks through and displays soft-deleted pages**: it has no `deleted_at` filter at the seed, in either recursive-term variant (frontier-capped or uncapped), or in the links-aggregation subquery. A deleted page keeps appearing as a graph node, and edges pointing at deleted pages keep rendering in every node's `links` array — inconsistent with every other link-traversal surface.

Follow-up to my closed #4447: the wave absorbed its backlinks/traversePaths half; this PR carries only the traverseGraph half that did not land.

## Fix

`deleted_at IS NULL` on the seed row, on `p2` in both recursive terms, and on `p3` in the aggregation subquery — mirroring the #861 source-scope filter placement exactly, in BOTH engines.

## Tests

- 5 new cases in `test/soft-delete-link-visibility.test.ts` (node set, displayed links array, deleted seed, deleted relay, frontier-capped variant, restore). 4 of the 5 fail on the unfixed engine — verified by running the suite against the pristine `pglite-engine.ts` (11 pass / 4 fail) and re-running with the fix (15/15).
- A `traverseGraph` parity pin added to `test/e2e/engine-parity.test.ts` next to the existing #3754 parity case.
- `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE