### PR TITLE
fix(sync): record import status-"error" results as failures instead of checkpointing them as done (#2683 residual)

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -8,7 +8,7 @@ src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown 
 src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns
 src/core/migrate.ts	687	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted — grown v0.46.26.0: repair-handler hooks (#3957 pages-upsert-arbiter)
-src/commands/sync.ts	4512	ratchet	grown v0.46.26.0 megawave: image sync, ingest-log gating, dry-run purity, checkpoint honesty (#2683 #4342 #3875) + 3 nosemgrep dataflow annotations (path-traversal audit)
+src/commands/sync.ts	4530	ratchet	grown v0.46.26.0 megawave: image sync, ingest-log gating, dry-run purity, checkpoint honesty (#2683 #4342 #3875) + 3 nosemgrep dataflow annotations (path-traversal audit); +#2683 residual: status-error failure recording at both import sites
 src/core/ai/gateway.ts	4494	ratchet	grown v0.46.26.0 megawave: config-plane probes + halt telemetry (#3387 #4312)
 src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silent-failure surfacing, confirm-race gate (#2443 #2898 #2297)
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1859,6 +1859,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- `to` is a git-diff rename path from the synced repo (repo content can be hostile), but the joined path is used ONLY inside the isPathSafe(filePath, gitContextRoot) realpath containment check on the next line — a path escaping the repo root (dot-dot or committed symlink) is refused before any read
       const filePath = join(syncImportRoot, to);
       let importResult: Awaited<ReturnType<typeof importFile>> | undefined;
+      // #2683 residual: a failed destination import (status 'error' OR a
+      // throw) must not checkpoint `to` — the resume filter would skip the
+      // rename forever, leaving the target permanently unimported.
+      let importErrored = false;
       if (existsSync(filePath) && isPathSafe(filePath, gitContextRoot)) {
         try {
           // #2683: dispatch renamed images to importImageFile (binary bytes
@@ -1875,8 +1879,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
             serr(`  Skipped (malformed filename): ${sanitizePathForDisplay(to)}`);
           } else if (result.status === 'skipped' && (result as { error?: string }).error) {
             failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
+          } else if (result.status === 'error') {
+            // importImageFile (and importFile's frontmatter gate) report
+            // failures as status 'error', which no branch above recorded —
+            // the rename silently succeeded with a dead target.
+            importErrored = true;
+            failedFiles.push({ path: to, error: String((result as { error?: string }).error ?? 'import error') });
           }
         } catch (e: unknown) {
+          importErrored = true;
           failedFiles.push({ path: to, error: e instanceof Error ? e.message : String(e) });
         }
       }
@@ -1935,13 +1946,14 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       }
       // Converged (cheap rename, clean reconcile, or nothing to reconcile):
       // clear any `<rename:…>` sentinel a previous failing run recorded.
-      if (!reconcileFailed) succeededPaths.push(`<rename:${to}>`);
+      if (!reconcileFailed && !importErrored) succeededPaths.push(`<rename:${to}>`);
       pagesAffected.push(newSlug);
       deletedSlugs.delete(newSlug); // #1284: rename landed on a previously-deleted slug → embeddable again
-      // A failed reconcile must NOT checkpoint: banking `to` would make the
-      // resume filter skip this rename on the retry run, turning a transient
-      // delete failure into a permanent duplicate — the exact bug being fixed.
-      if (!reconcileFailed) await markCompleted(to);
+      // A failed reconcile OR a failed destination import must NOT checkpoint:
+      // banking `to` would make the resume filter skip this rename on the
+      // retry run — a permanent duplicate (reconcile) or a permanently
+      // unimported target (import error) — the exact bug class being fixed.
+      if (!reconcileFailed && !importErrored) await markCompleted(to);
       progress.tick(1, newSlug);
     }
     progress.finish();
@@ -2168,6 +2180,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           await markCompleted(path);
         } else if (result.status === 'skipped' && (result as any).error) {
           failedFiles.push({ path, error: String((result as any).error) });
+        } else if (result.status === 'error') {
+          // status 'error' (frontmatter validation, importImageFile OCR/read
+          // failures) must feed the failure ledger like a thrown error — the
+          // fall-through below would checkpoint the path as DONE and the file
+          // would never be re-attempted.
+          failedFiles.push({ path, error: String((result as any).error ?? 'import error') });
         } else {
           // status 'skipped' with no error == content_hash short-circuit
           // (already imported, unchanged). It IS done for checkpoint purposes,

--- a/test/sync-incremental-image-2683.test.ts
+++ b/test/sync-incremental-image-2683.test.ts
@@ -118,3 +118,51 @@ test('gate off: a committed png stays excluded (no image page, no failure)', asy
     expect(slugs.some(s => s.endsWith('photo.png'))).toBe(false);
   });
 }, 90_000);
+
+describe('#2683 residual — import status "error" feeds the failure gate, not the checkpoint', () => {
+  test('an image whose decode fails blocks the bookmark and is re-attempted on the next sync', async () => {
+    await withEnv({ GBRAIN_EMBEDDING_MULTIMODAL: 'true' }, async () => {
+      const seed = await syncOnce();
+      expect(seed.status === 'first_sync' || seed.status === 'synced').toBeTruthy();
+
+      // Garbage bytes under a .heic name: decodeIfNeeded throws, and
+      // importImageFile reports it as { status: 'error' } WITHOUT throwing —
+      // the branch this regression pins. Pre-fix that result fell into the
+      // checkpoint else-branch: the run said 'synced', banked the path as
+      // done, and the image was never re-attempted.
+      writeFileSync(join(repo, 'broken.heic'), Buffer.from('not a real heic file'));
+      git('git add -A && git commit -m broken-image');
+
+      const r1 = await syncOnce();
+      expect(r1.status).toBe('blocked_by_failures');
+      expect(r1.failedFiles ?? 0).toBeGreaterThanOrEqual(1);
+      expect((await pageSlugs()).some(s => s.endsWith('broken.heic'))).toBe(false);
+
+      const r2 = await syncOnce();
+      expect(r2.status).toBe('blocked_by_failures');
+      expect(r2.failedFiles ?? 0).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test('a rename whose destination import errors is not checkpointed as done', async () => {
+    await withEnv({ GBRAIN_EMBEDDING_MULTIMODAL: 'true' }, async () => {
+      const seed = await syncOnce();
+      expect(seed.status === 'first_sync' || seed.status === 'synced').toBeTruthy();
+
+      // git-rename the synced markdown to a .heic name: importImageFile gets
+      // markdown bytes, decodeIfNeeded throws, the destination import reports
+      // status 'error'. Pre-fix the rename arm recorded the failure but STILL
+      // ran markCompleted(to) — the resume filter then skipped the rename
+      // forever, leaving the target permanently unimported.
+      git('git mv note.md renamed.heic && git commit -m rename-to-broken-image');
+
+      const r1 = await syncOnce();
+      expect(r1.status).toBe('blocked_by_failures');
+      expect(r1.failedFiles ?? 0).toBeGreaterThanOrEqual(1);
+
+      const r2 = await syncOnce();
+      expect(r2.status).toBe('blocked_by_failures');
+      expect(r2.failedFiles ?? 0).toBeGreaterThanOrEqual(1);
+    });
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

The incremental import dispatch and the rename arm branch on `status === "imported"` and the two `"skipped"` shapes, but an `ImportResult` with **`status: "error"`** — `importImageFile` decode/embed failures, and `importFile` frontmatter-gate results — matched no branch:

- **Incremental site** (`src/commands/sync.ts` add/modify drain): the result fell into the final else and was **checkpointed as DONE** — the run reported `synced`, the bookmark advanced, and the failed file was never re-attempted. Silent data loss.
- **Rename arm**: the failure was not recorded at all, AND `markCompleted(to)` still ran (`reconcileFailed` only covers the stale-row reconcile) — the resume filter then skipped the rename forever, a permanently unimported destination.

Follow-up to my closed #4442: the wave absorbed its image-admission half (`sync-incremental-image-2683.test.ts` shipped); this carries the failure-path half that did not land.

## Fix

- An explicit `status === "error"` branch at the incremental site pushes the path into `failedFiles`, feeding the #1939 failure ledger exactly like a thrown import error — the run reports `blocked_by_failures` and the file is re-attempted next sync.
- The rename arm records the failure and gates the success sentinel + `markCompleted(to)` on a new `importErrored` flag; a THROWN destination import (already recorded pre-fix) now also suppresses the checkpoint — same defect class.

## Tests

Two regressions in `test/sync-incremental-image-2683.test.ts` (real git repo + `performSync`): garbage bytes committed as `broken.heic` under `GBRAIN_EMBEDDING_MULTIMODAL=true` (incremental), and `git mv` of markdown onto a `.heic` name (rename arm). Both fail on the unfixed `sync.ts` — verified (3 pass / 2 fail pristine, 5/5 fixed) — and both assert the SECOND sync still reports the failure instead of `up_to_date`-ing past it. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE