### PR TITLE
fix(sources): absolutize a relative --clone-dir before the overlap check and INSERT (#3696 residual)

### DIFF
--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -394,6 +394,16 @@ export async function addSource(
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- cloneDir only flows here from the trusted local CLI (sources_add hard-rejects it unless ctx.remote === false); absolutizing the operator's own directory is the #3696 fix
     opts = { ...opts, cloneDir: resolvePath(msysToNativePath(opts.cloneDir)) };
   }
+  if (opts.github) {
+    // #3696 residual (sibling of the cloneDir case above): `--kind github
+    // --dir clones/x` stores opts.github.dir verbatim as local_path (Path C
+    // below never resolves it), so the same phantom-path class survives
+    // through the github-kind registration path — a launchd daemon at
+    // cwd=/, autopilot dispatch, or a sync anchor running from a different
+    // cwd than the CLI join-resolves a path that does not exist.
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- opts.github.dir only flows here from the trusted local CLI (sources_add hard-rejects opts.github unless ctx.remote === false); absolutizing the operator's own directory is the #3696 fix
+    opts = { ...opts, github: { ...opts.github, dir: resolvePath(msysToNativePath(opts.github.dir)) } };
+  }
 
   // Q4: pre-flight collision check before any clone work.
   const existing = await engine.executeRaw<{ id: string; local_path: string | null }>(

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -385,6 +385,15 @@ export async function addSource(
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- localPath only flows here from the trusted local CLI: the sources_add op hard-rejects `path` unless ctx.remote === false (remote callers get null), so this is the operator registering their own directory; absolutizing it is the #3696 fix
     opts = { ...opts, localPath: resolvePath(msysToNativePath(opts.localPath)) };
   }
+  if (opts.cloneDir) {
+    // #3696 residual: same phantom-path class as localPath above — a relative
+    // `--clone-dir clones/x` was stored verbatim as local_path, so every
+    // consumer running from a different cwd (launchd daemon at cwd=/,
+    // autopilot dispatch, sync anchors) join-resolved a path that does not
+    // exist and silently missed the clone.
+    // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- cloneDir only flows here from the trusted local CLI (sources_add hard-rejects it unless ctx.remote === false); absolutizing the operator's own directory is the #3696 fix
+    opts = { ...opts, cloneDir: resolvePath(msysToNativePath(opts.cloneDir)) };
+  }
 
   // Q4: pre-flight collision check before any clone work.
   const existing = await engine.executeRaw<{ id: string; local_path: string | null }>(

--- a/test/sources-abs-path-3696.test.ts
+++ b/test/sources-abs-path-3696.test.ts
@@ -97,3 +97,41 @@ describe('#3696 autopilot dispatch skips relative local_path', () => {
     expect(relativeLocalPathSkipWarning('ok-src', '/abs/vault')).toBeNull();
   });
 });
+
+describe('#3696 residual — a relative --clone-dir is absolutized before use', () => {
+  test('relative clone-dir participates in the overlap check as an absolute path', async () => {
+    // The overlap check runs BEFORE any clone work and compares finalPath
+    // (localPath OR cloneDir) against every registered local_path — all
+    // absolute. A verbatim relative clone-dir can never match, so the same
+    // phantom-path class #3696 fixed for --path survived through --clone-dir.
+    // Observable seam: register a source at the ABSOLUTE parent, then add a
+    // URL source whose RELATIVE clone-dir resolves inside it. Fixed code
+    // throws overlapping_path before touching git/network; unfixed code
+    // sails past the check (and would try to clone).
+    const parent = mkdtempSync(join(tmpdir(), 'gbrain-3696-clone-'));
+    const origCwd = process.cwd();
+    try {
+      // chdir FIRST, then derive both paths from the same (realpathed) cwd —
+      // macOS chdir realpaths /var → /private/var, so a join(parent, ...)
+      // expectation would compare the unrealpathed spelling (same trap the
+      // relative --path test above documents).
+      process.chdir(parent);
+      await addSource(engine, { id: 'abs-parent-3696', localPath: resolve('clones'), force: true });
+      const relCloneDir = 'clones/rel-3696';
+      expect(isAbsolute(relCloneDir)).toBe(false);
+
+      let err: unknown;
+      try {
+        await addSource(engine, {
+          id: 'rel-clone-3696',
+          remoteUrl: 'https://invalid.invalid/repo.git',
+          cloneDir: relCloneDir,
+        });
+      } catch (e) { err = e; }
+      expect(String((err as { code?: string } | undefined)?.code ?? err)).toBe('overlapping_path');
+    } finally {
+      process.chdir(origCwd);
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sources-abs-path-3696.test.ts
+++ b/test/sources-abs-path-3696.test.ts
@@ -135,3 +135,42 @@ describe('#3696 residual — a relative --clone-dir is absolutized before use', 
     }
   });
 });
+
+describe('#3696 residual — a relative --kind github --dir is absolutized before use', () => {
+  test('relative github.dir is resolved against cwd before INSERT', async () => {
+    // Path C (--kind github) never went through the cloneDir/localPath
+    // absolutization above — `finalPath = opts.github.dir` was used verbatim
+    // for both mkdirSync and the local_path INSERT, so the same phantom-path
+    // class #3696 fixed for --path/--clone-dir survived through --dir.
+    const parent = mkdtempSync(join(tmpdir(), 'gbrain-3696-ghdir-'));
+    const origCwd = process.cwd();
+    try {
+      process.chdir(parent);
+      const relDir = 'clones/gh-rel-3696';
+      expect(isAbsolute(relDir)).toBe(false);
+      const expected = resolve(relDir);
+
+      await addSource(engine, {
+        id: 'gh-rel-3696',
+        github: {
+          tokenEnv: 'GH_TOKEN',
+          handle: '',
+          scope: 'auto',
+          repos: [],
+          dir: relDir,
+          involvement: true,
+        },
+      });
+
+      const rows = await engine.executeRaw<{ local_path: string }>(
+        `SELECT local_path FROM sources WHERE id = 'gh-rel-3696'`,
+      );
+      expect(rows.length).toBe(1);
+      expect(isAbsolute(rows[0]!.local_path)).toBe(true);
+      expect(rows[0]!.local_path).toBe(expected);
+    } finally {
+      process.chdir(origCwd);
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

#3696 absolutized `--path`, but `--clone-dir` kept flowing verbatim into `finalPath`: a relative clone-dir was stored as `local_path` unchanged, so every later consumer running from a different cwd (launchd daemon at cwd=/, autopilot dispatch, sync anchors) join-resolved a phantom path and silently missed the clone — and the pre-clone overlap check could never match it against the registered absolute paths.

Follow-up to my closed #4463: the wave absorbed its `--path` + launchd + dispatch halves; this carries the clone-dir half that did not land.

## Fix

Mirrors the `localPath` normalization exactly (`msysToNativePath` + `resolve`) two lines below it, same trust posture: `clone_dir` reaches `addSource` only from the trusted local CLI (`sources_add` ignores the override unless `ctx.remote === false`).

Scope note: the overlap check itself compares with a hard-coded `/` separator (pre-existing, shared with the `--path` flow) — this change makes clone-dir participate in the check on the same terms as `--path`; it does not extend the check itself.

## Tests

New case in `test/sources-abs-path-3696.test.ts`: registers a source at the absolute parent, then adds a URL source whose RELATIVE clone-dir resolves inside it — fixed code throws `overlapping_path` BEFORE any git/network work; unfixed code sails past the check (verified: the pre-fix run reaches `cloneRepo` and dies with `clone_failed` instead). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE