### PR TITLE
fix(enrich): blank output stays retryable, min-context joins the fingerprint, dry-run --force is read-only (#3629 residual)

### DIFF
--- a/src/commands/enrich.ts
+++ b/src/commands/enrich.ts
@@ -182,6 +182,14 @@ export function enrichFingerprint(opts: {
   order: EnrichOrder;
   thinThreshold: number;
   model: string;
+  /**
+   * #3629 residual: the pre-LLM grounding gate decides against exactly this
+   * knob, so a banked skip must not outlive a relaxed --min-context — a
+   * non-default value is a genuinely different run. Folded only when it
+   * differs from MIN_CONTEXT_CHARS so every existing default-config
+   * checkpoint keeps its key (no one-time re-bill on upgrade).
+   */
+  minContextChars?: number;
 }): string {
   return fingerprint({
     sourceId: opts.sourceId,
@@ -189,6 +197,9 @@ export function enrichFingerprint(opts: {
     order: opts.order,
     thinThreshold: opts.thinThreshold,
     model: opts.model,
+    ...(opts.minContextChars !== undefined && opts.minContextChars !== MIN_CONTEXT_CHARS
+      ? { minContextChars: opts.minContextChars }
+      : {}),
   });
 }
 
@@ -397,10 +408,14 @@ async function enrichOneLocked(ctx: EnrichOneCtx, candidate: EnrichCandidate): P
     // reports skip=true for blank raw too, so discriminate on the raw text.
     if (parsed.skip && (raw ?? '').trim().length > 0) {
       ctx.result.pages_model_skip = (ctx.result.pages_model_skip ?? 0) + 1;
+      // A real grounding verdict — durable until the checkpoint TTL/--force.
+      ctx.done.add(completedKey(sourceId, slug));
     } else {
       ctx.result.pages_empty_output = (ctx.result.pages_empty_output ?? 0) + 1;
+      // Synthesis-failure shape (#2085), usually transient provider trouble —
+      // banking it would suppress the page for the full checkpoint TTL, so it
+      // stays out of `done` and is re-attempted on the next run.
     }
-    ctx.done.add(completedKey(sourceId, slug));
     return;
   }
 
@@ -482,13 +497,15 @@ export async function runEnrichCore(
   const workersResolved = resolveWorkersWithClamp(engine, opts.workers, 'enrich', 0);
   const workers = workersResolved.workers;
 
-  const fp = enrichFingerprint({ sourceId, types, order, thinThreshold, model });
+  const fp = enrichFingerprint({ sourceId, types, order, thinThreshold, model, minContextChars });
   const cpKey = checkpointKey(fp);
 
   // #3629: load the checkpoint BEFORE enumerating candidates. SKIP'd pages
   // stay thin (nothing is written), so they re-enter the candidate list on
   // every run — the checkpoint is the ONLY thing that stops them re-billing.
-  if (opts.force) await clearOpCheckpoint(engine, cpKey);
+  // #3629 residual: --dry-run promises "no checkpoint advance"; a dry-run
+  // --force must not destroy the real checkpoint either.
+  if (opts.force && !dryRun) await clearOpCheckpoint(engine, cpKey);
   const done = new Set<string>(opts.force ? [] : await loadOpCheckpoint(engine, cpKey));
 
   // Candidate enumeration — ONE source-aware, memory-bounded SQL query.

--- a/test/e2e/enrich-pglite.test.ts
+++ b/test/e2e/enrich-pglite.test.ts
@@ -548,3 +548,78 @@ describe('checkpoint persistence (#3629)', () => {
     expect(synthCalls).toBe(2); // --force re-bills deliberately
   }, 60000);
 });
+
+describe('checkpoint residuals (#3629 follow-up)', () => {
+  test('blank model output stays retryable: NOT banked in the checkpoint', async () => {
+    await seedStub('people/blank-example', 'Blank Example', 'person');
+    await seedLinkInto('people/blank-example', 'meetings/blank-m', RICH_CONTEXT);
+
+    let synthCalls = 0;
+    const blankSynth: SynthesizeFn = async () => { synthCalls++; return ''; };
+    const opts = {
+      sourceId: 'default',
+      types: ['person' as const],
+      model: 'test:model',
+      synthesizeFn: blankSynth,
+    };
+
+    const r1 = await runEnrichCore(engine, opts);
+    expect(synthCalls).toBe(1);
+    expect(r1.pages_empty_output).toBe(1);
+
+    // A blank response is a synthesis-failure shape (#2085), not a grounding
+    // verdict — the next run must re-attempt it instead of suppressing the
+    // page for the checkpoint TTL.
+    const r2 = await runEnrichCore(engine, opts);
+    expect(synthCalls).toBe(2);
+    expect(r2.pages_empty_output).toBe(1);
+  }, 60000);
+
+  test('relaxing --min-context re-evaluates a page banked under the stricter gate', async () => {
+    await seedStub('people/thin-ctx', 'Thin Ctx', 'person');
+    await seedLinkInto('people/thin-ctx', 'meetings/thin-m', RICH_CONTEXT);
+
+    let synthCalls = 0;
+    const synth: SynthesizeFn = async () => { synthCalls++; return 'SKIP'; };
+    const base = {
+      sourceId: 'default',
+      types: ['person' as const],
+      model: 'test:model',
+      synthesizeFn: synth,
+    };
+
+    // Strict gate: pre-LLM rejection banks the page under THIS fingerprint.
+    const strict = await runEnrichCore(engine, { ...base, minContextChars: 100000 });
+    expect(synthCalls).toBe(0);
+    expect(strict.pages_skipped_pre_llm ?? 0).toBe(1);
+
+    // Relaxed gate is a different run: the banked pre-LLM skip must not
+    // suppress the page under the new knob value.
+    await runEnrichCore(engine, { ...base, minContextChars: 10 });
+    expect(synthCalls).toBe(1);
+  }, 60000);
+
+  test('--dry-run --force does not destroy the real checkpoint', async () => {
+    await seedStub('people/dryforce', 'Dry Force', 'person');
+    await seedLinkInto('people/dryforce', 'meetings/df-m', RICH_CONTEXT);
+
+    let synthCalls = 0;
+    const skipSynth: SynthesizeFn = async () => { synthCalls++; return 'SKIP'; };
+    const opts = {
+      sourceId: 'default',
+      types: ['person' as const],
+      model: 'test:model',
+      synthesizeFn: skipSynth,
+    };
+
+    await runEnrichCore(engine, opts);
+    expect(synthCalls).toBe(1);
+
+    // A dry-run preview with --force must stay read-only.
+    await runEnrichCore(engine, { ...opts, dryRun: true, force: true });
+
+    const r3 = await runEnrichCore(engine, opts);
+    expect(synthCalls).toBe(1); // still banked — the dry-run didn't clear it
+    expect(r3.pages_enriched).toBe(0);
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

Three residual gaps in the #3629 checkpoint-durability fix (v0.46.28.0):

1. **A blank/unparseable model response was banked as done** alongside real SKIP verdicts. #2085 already classifies blank raw as a synthesis-failure shape (usually transient provider trouble); banking it suppresses the page for the full checkpoint TTL.
2. **`minContextChars` was absent from the checkpoint fingerprint** even though the pre-LLM grounding gate decides against exactly that knob — a page banked under a strict `--min-context` stayed suppressed after the operator relaxed it.
3. **`--dry-run --force` cleared the real checkpoint** before the dry-run returned — a preview destroyed durable skip state, contradicting `--dry-run`'s documented "no checkpoint advance" contract.

Follow-up to my closed #4430 (checkpoint-before-enumeration + clean-run retention landed independently in the wave; these three pieces did not).

## Fix

1. The done-key is added only for an explicit model-side SKIP; the empty-output path stays retryable next run.
2. `minContextChars` folds into the fingerprint **only when it differs from `MIN_CONTEXT_CHARS`**, so every default-config checkpoint keeps its key (no one-time re-bill on upgrade).
3. The `--force` clear now requires `!dryRun`.

## Tests

Three regressions in `test/e2e/enrich-pglite.test.ts`, one per gap; each fails on the unfixed `enrich.ts` (verified: 20 pass / 3 fail pristine, 23/23 fixed). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE