### PR TITLE
fix(planner): a gateway-merged DB-plane chat key no longer reads as missing (#3944 residual)

### DIFF
--- a/src/core/ai/anthropic-key.ts
+++ b/src/core/ai/anthropic-key.ts
@@ -57,6 +57,16 @@ export function setGatewayAnthropicKeySnapshot(key: string | undefined): void {
   _gatewayEnvKeySnapshot = key;
 }
 
+/**
+ * Read-only view of the gateway env snapshot for presence probes (#3944
+ * follow-up: chatApiKeyConfigured). A non-undefined value means a DB-plane
+ * key was merged into the RUNNING gateway env — i.e. chat is actually
+ * servable — without exposing a raw engine.getConfig read to the planner.
+ */
+export function getGatewayAnthropicKeySnapshot(): string | undefined {
+  return _gatewayEnvKeySnapshot;
+}
+
 export function hasAnthropicKey(): boolean {
   return resolveAnthropicKey() !== undefined;
 }

--- a/src/core/brain-score-recommendations.ts
+++ b/src/core/brain-score-recommendations.ts
@@ -4,6 +4,7 @@ import { canonicalLookup } from './model-pricing.ts';
 import { lookupEmbeddingPrice, estimateCostFromChars } from './embedding-pricing.ts';
 import { getRecipe } from './ai/recipes/index.ts';
 import { parseModelId } from './ai/model-resolver.ts';
+import { getGatewayAnthropicKeySnapshot } from './ai/anthropic-key.ts';
 
 /**
  * v0.40.x: env-var name → file/DB config field, for hosted embedding providers
@@ -57,19 +58,25 @@ export const HOSTED_EMBED_KEY_CONFIG: Record<string, string> = {
  */
 /**
  * #3944: chat-key presence for the remediation planner, judged on the planes
- * both planner surfaces can rely on — process env + the FILE config plane.
- * NOT `engine.getConfig()`: a DB-only `anthropic_api_key` is only usable on
- * paths that ran the loadConfigWithEngine DB merge before configuring the
- * gateway, and doctor's planner (remediation/context.ts) judges the file
- * plane (#2662 is the same rule for embed keys). Pre-fix, autopilot read the
- * DB plane here while doctor read the file plane, so autopilot dispatched
- * chat jobs doctor classified as blocked. Shared by
- * loadRecommendationContext and the autopilot dispatch loop.
+ * both planner surfaces can rely on — process env, the FILE config plane,
+ * and the gateway env snapshot (a DB-plane key that loadConfigWithEngine
+ * already merged into the RUNNING gateway, i.e. a key that is actually
+ * serving chat right now). NOT a raw `engine.getConfig()` read: a DB-only
+ * key that never reached the gateway is unusable on planner paths, and the
+ * raw read is what diverged autopilot from doctor pre-#3944 (doctor's
+ * planner judges the file plane, #2662 is the same rule for embed keys).
+ * The snapshot keeps both surfaces CONVERGENT — it flows through this one
+ * shared helper — while a genuinely-usable key no longer reads as missing.
+ * Shared by loadRecommendationContext and the autopilot dispatch loop.
  */
 export function chatApiKeyConfigured(
   fileCfg: { anthropic_api_key?: unknown } | null | undefined,
 ): boolean {
-  return !!(process.env.ANTHROPIC_API_KEY || fileCfg?.anthropic_api_key);
+  return !!(
+    process.env.ANTHROPIC_API_KEY ||
+    fileCfg?.anthropic_api_key ||
+    getGatewayAnthropicKeySnapshot()
+  );
 }
 
 export function embeddingProviderConfigured(

--- a/test/chat-key-plane.test.ts
+++ b/test/chat-key-plane.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { withEnv } from './helpers/with-env.ts';
 import { chatApiKeyConfigured } from '../src/core/brain-score-recommendations.ts';
+import { setGatewayAnthropicKeySnapshot } from '../src/core/ai/anthropic-key.ts';
 
 describe('#3944 chatApiKeyConfigured', () => {
   test('no env, no file key → false (a DB-only key is invisible by design)', async () => {
@@ -61,5 +62,25 @@ describe('#3944 both planner surfaces share the helper (source guard)', () => {
     const src = readFileSync(join(import.meta.dir, '../src/core/remediation/context.ts'), 'utf-8');
     expect(src).toContain('chatApiKeyConfigured(fileCfg)');
     expect(src).not.toContain('process.env.ANTHROPIC_API_KEY ||');
+  });
+});
+
+describe('#3944 follow-up — gateway env snapshot plane', () => {
+  test('a gateway-merged DB-plane key reads as configured, and only while the snapshot is live', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: undefined }, () => {
+      // A raw DB-only key stays invisible (no engine reaches this helper) —
+      // but once loadConfigWithEngine merged it into the RUNNING gateway env
+      // (modeled by the snapshot seam), the key is actually serving chat and
+      // must not read as missing on either planner surface.
+      try {
+        setGatewayAnthropicKeySnapshot('sk-test-db-merged');
+        expect(chatApiKeyConfigured(null)).toBe(true);
+        expect(chatApiKeyConfigured({})).toBe(true);
+      } finally {
+        setGatewayAnthropicKeySnapshot(undefined);
+      }
+      // Gateway reset clears the snapshot → back to not-configured.
+      expect(chatApiKeyConfigured(null)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

#3944 aligned autopilot and doctor on env + FILE plane via the shared `chatApiKeyConfigured` helper — correct for the raw DB plane (a DB-only key that never reached the gateway is unusable on planner paths, and the raw `engine.getConfig` read is what diverged the two surfaces). But a DB-plane key that `loadConfigWithEngine` ALREADY merged into the running gateway env — a key actually serving chat right now — was still reported missing: autopilot skipped chat jobs that would have succeeded, and doctor recommended configuring a key that was already working.

Follow-up to my closed #4465 (the shared-helper convergence landed independently in the wave; the gateway-snapshot plane did not).

## Fix

The shared helper also consults the gateway env snapshot (`anthropic-key.ts`, the same seam `resolveAnthropicKey` uses) through a new read-only `getGatewayAnthropicKeySnapshot()`. Both planner surfaces keep flowing through the ONE helper, so the #3944 convergence invariant holds — only the false negative goes away. A never-configured gateway leaves the snapshot `undefined`, so raw DB-only keys stay invisible exactly as before (the existing "DB-only key is invisible by design" test still passes unchanged).

## Tests

`test/chat-key-plane.test.ts` pins the new plane (snapshot live → configured; cleared → back to missing); fails on the unfixed helper (verified: 6 pass / 1 fail pristine, 7/7 fixed). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE