### PR TITLE
fix(schema): lint the resolved manifest for a named pack (#4501)

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -728,7 +728,37 @@ async function runLintCmd(args: string[]): Promise<void> {
   let pack: SchemaPackManifest | null;
   if (name) {
     const p = packPathByName(name);
-    try { pack = p ? loadPackFromFile(p) : null; } catch { pack = null; }
+    try {
+      const child = p ? loadPackFromFile(p) : null;
+      // #lint-extends: lint the RESOLVED manifest, not the raw child. Every lint
+      // rule tests against `manifest.page_types`, so linting an unresolved
+      // extending pack reports each INHERITED type as undeclared -- e.g. a pack
+      // that extends gbrain-base-v2 and maps `frontmatter_links` onto `note` or
+      // `project` fails with frontmatter_links_undeclared_page_type for types the
+      // resolved pack plainly declares. The no-name branch below never had this
+      // bug because loadActivePack walks the extends chain. Falls back to the
+      // child manifest when the chain cannot be resolved (missing parent), so
+      // lint still reports something actionable instead of silently passing.
+      if (child) {
+        try {
+          const { resolvePack } = await import('../core/schema-pack/registry.ts');
+          const resolved = await resolvePack(
+            child,
+            async (parentName: string) => {
+              const pp = packPathByName(parentName);
+              if (!pp) throw new Error(`parent pack not found: ${parentName}`);
+              return loadPackFromFile(pp);
+            },
+            { loadByPath: (n: string) => packPathByName(n) },
+          );
+          pack = resolved.manifest;
+        } catch {
+          pack = child;
+        }
+      } else {
+        pack = null;
+      }
+    } catch { pack = null; }
   } else {
     pack = (await loadActivePack({ cfg, remote: false })).manifest;
   }

--- a/test/schema-lint-extends-resolution.test.ts
+++ b/test/schema-lint-extends-resolution.test.ts
@@ -1,0 +1,94 @@
+// `gbrain schema lint <name>` must lint the RESOLVED manifest.
+//
+// The named-pack branch of runLintCmd loads the manifest with loadPackFromFile,
+// which returns the raw child with its `extends` chain unresolved. Every lint
+// rule tests against `manifest.page_types`, so an extending pack that maps
+// `frontmatter_links` onto an INHERITED type (e.g. `note` from gbrain-base-v2)
+// is reported as referencing an undeclared page type -- a type the resolved
+// pack plainly declares.
+//
+// The no-name branch does not have this bug: it goes through loadActivePack,
+// which walks the chain.
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSchema } from '../src/commands/schema.ts';
+
+/** Extends gbrain-base-v2 and declares NO page types of its own. */
+const CHILD_PACK = `api_version: gbrain-schema-pack-v1
+name: extends-child-test
+version: 1.0.0
+description: extending pack that reuses inherited base-v2 types
+extends: gbrain-base-v2
+page_types: []
+link_types:
+  - name: part_of
+    inverse: contains
+frontmatter_links:
+  - page_type: note
+    fields: [part_of]
+    link_type: part_of
+`;
+
+let home: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-lint-extends-'));
+  const dir = join(home, '.gbrain', 'schema-packs', 'extends-child-test');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'pack.yaml'), CHILD_PACK);
+  prevHome = process.env.GBRAIN_HOME;
+  process.env.GBRAIN_HOME = home;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('schema lint resolves the extends chain for a named pack', () => {
+  test('an extending pack that reuses inherited types lints clean', async () => {
+    const lines: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    const origExit = process.exit;
+    let exitCode = 0;
+    console.log = (...a: unknown[]) => { lines.push(a.map(String).join(' ')); };
+    console.error = (...a: unknown[]) => { lines.push(a.map(String).join(' ')); };
+    (process as unknown as { exit: (c?: number) => void }).exit = ((c?: number) => {
+      exitCode = c ?? 0;
+      throw new Error('__exit__');
+    }) as never;
+
+    try {
+      await runSchema(['lint', 'extends-child-test', '--json']);
+    } catch (e) {
+      if ((e as Error).message !== '__exit__') throw e;
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+      (process as unknown as { exit: typeof origExit }).exit = origExit;
+    }
+
+    const out = lines.join('\n');
+    const start = out.indexOf('{');
+    expect(start, `expected JSON lint output, got:\n${out}`).toBeGreaterThanOrEqual(0);
+    const report = JSON.parse(out.slice(start));
+
+    const undeclared = (report.errors ?? []).filter(
+      (e: { rule: string }) =>
+        e.rule === 'frontmatter_links_undeclared_page_type' ||
+        e.rule === 'frontmatter_links_undeclared_link_type',
+    );
+
+    expect(
+      undeclared,
+      `inherited base-v2 types must not be reported undeclared: ${JSON.stringify(undeclared)}`,
+    ).toEqual([]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`gbrain schema lint <name>` linted the **raw child manifest** rather than the resolved one, so a pack that `extends` another had every **inherited** page type reported as undeclared. Fixes #4501.

The named-pack branch loaded the manifest with `loadPackFromFile`, which does not walk the `extends` chain. Every lint rule tests against `manifest.page_types`, so a pack extending `gbrain-base-v2` and mapping `frontmatter_links` onto the inherited `note` type failed with `frontmatter_links_undeclared_page_type` for a type the resolved pack plainly declares.

The no-name branch never had this bug, because it goes through `loadActivePack`, which resolves the chain.

## Why

Lint contradicted the rest of the toolchain on the same pack: `gbrain schema validate` passed, `gbrain schema active` reported the inherited types (17 page types / 22 link verbs), and `gbrain schema lint` rejected them.

That makes lint unusable as a gate for any pack built by extension. On a real pack extending `gbrain-base-v2` with ~13 `frontmatter_links` rules over inherited types, lint reported 13 errors that did not correspond to anything wrong. The only workaround — redeclaring every base type in the child — defeats the purpose of `extends` and creates a second copy to keep in sync.

The fix falls back to the child manifest when the chain cannot be resolved (missing parent), so lint still reports something actionable rather than silently passing.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/schema.ts` to merge-base, ran `test/schema-lint-extends-resolution.test.ts` → 0 pass / 1 fail. Restored → all pass.

Produced by `bash scripts/check-test-discriminates.sh test/schema-lint-extends-resolution.test.ts src/commands/schema.ts`.

## Tests

Added `test/schema-lint-extends-resolution.test.ts` — builds a pack extending `gbrain-base-v2` that declares no page types of its own and maps `frontmatter_links` onto the inherited `note` type, then asserts lint reports no undeclared-type errors and exits 0.

```console
$ bun test test/schema-pack-lint-rules.test.ts test/schema-pack-loader.test.ts \
           test/schema-pack-sync.test.ts test/schema-lint-extends-resolution.test.ts \
           test/link-extraction-pack-3190.test.ts
exit=0
 102 pass
 0 fail
 204 expect() calls
Ran 102 tests across 5 files.
```

`bunx tsc --noEmit` — 0 errors.

**Full unit suite not run to completion locally.** `scripts/run-unit-parallel.sh` exceeded my ten-minute budget; no failures had been recorded when it was stopped. Flagging that honestly rather than implying a clean full local run — CI will be the real check.
