### PR TITLE
fix(arbiter): probe validity/immediacy/schema at the catalog, not a pg_indexes text scan (#550 residual)

### DIFF
--- a/src/core/pages-upsert-arbiter.ts
+++ b/src/core/pages-upsert-arbiter.ts
@@ -67,8 +67,25 @@ export async function checkPagesUpsertArbiter(engine: BrainEngine): Promise<Page
   if (!tablePresent) {
     return { tablePresent: false, arbiterPresent: false, needsRepair: false, duplicateGroups: 0 };
   }
+  // Catalog-anchored candidate set (#550 residual): pg_indexes was a bare
+  // text scan on tablename, which false-passed on exactly the drift shapes
+  // this module exists to catch — an INVALID index (a failed CREATE INDEX
+  // CONCURRENTLY remnant renders a normal-looking indexdef but cannot
+  // arbitrate), a DEFERRABLE unique (indimmediate = false, unusable for ON
+  // CONFLICT), and a same-named table in ANOTHER schema (tablename has no
+  // schema qualifier, while the table probe above resolved via search_path).
+  // Anchoring on the SAME to_regclass('pages') plus the catalog validity
+  // flags closes all three; indpred IS NULL keeps the existing
+  // partial-index exclusion at the catalog level too.
   const rows = await engine.executeRaw<{ indexdef: string }>(
-    `SELECT indexdef FROM pg_indexes WHERE tablename = 'pages'`,
+    `SELECT pg_get_indexdef(x.indexrelid) AS indexdef
+       FROM pg_index x
+      WHERE x.indrelid = to_regclass('pages')
+        AND x.indisunique
+        AND x.indisvalid
+        AND x.indisready
+        AND x.indimmediate
+        AND x.indpred IS NULL`,
   );
   const arbiterPresent = rows.some(r => isArbiterShape(r.indexdef));
   let duplicateGroups = 0;

--- a/test/pages-upsert-arbiter.test.ts
+++ b/test/pages-upsert-arbiter.test.ts
@@ -167,3 +167,74 @@ describe('doctor pages_upsert_arbiter check (#550)', () => {
     expect(check.message).toContain('apply-migrations');
   });
 });
+
+describe('#550 residual — catalog validity gates on the arbiter probe', () => {
+  test('an INVALID arbiter index does not count (failed CONCURRENTLY remnant shape)', async () => {
+    // Healthy first, then flip the catalog validity bit — the exact state a
+    // failed CREATE INDEX CONCURRENTLY leaves behind. pg_indexes still
+    // renders a normal-looking indexdef for it, but ON CONFLICT cannot use
+    // it, so the check must flag needsRepair instead of masking the outage.
+    expect((await checkPagesUpsertArbiter(engine)).arbiterPresent).toBe(true);
+    await engine.executeRaw(
+      `UPDATE pg_index SET indisvalid = false
+        WHERE indexrelid = 'pages_source_slug_key'::regclass`,
+    );
+    try {
+      const st = await checkPagesUpsertArbiter(engine);
+      expect(st.arbiterPresent).toBe(false);
+      expect(st.needsRepair).toBe(true);
+    } finally {
+      await engine.executeRaw(
+        `UPDATE pg_index SET indisvalid = true
+          WHERE indexrelid = 'pages_source_slug_key'::regclass`,
+      );
+    }
+  });
+
+  test('repair replaces an INVALID arbiter and putPage works again', async () => {
+    await engine.executeRaw(
+      `UPDATE pg_index SET indisvalid = false
+        WHERE indexrelid = 'pages_source_slug_key'::regclass`,
+    );
+    const r = await repairPagesUpsertArbiter(engine);
+    expect(r.repaired).toBe(true);
+    expect((await checkPagesUpsertArbiter(engine)).arbiterPresent).toBe(true);
+    await putProbePage('probe/invalid-heal');
+  });
+
+  test('a DEFERRABLE unique constraint does not count (indimmediate = false)', async () => {
+    await dropArbiter();
+    await engine.executeRaw(
+      `ALTER TABLE pages ADD CONSTRAINT pages_deferrable_probe
+         UNIQUE (source_id, slug) DEFERRABLE INITIALLY IMMEDIATE`,
+    );
+    try {
+      const st = await checkPagesUpsertArbiter(engine);
+      expect(st.arbiterPresent).toBe(false);
+      expect(st.needsRepair).toBe(true);
+    } finally {
+      await engine.executeRaw(
+        `ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_deferrable_probe`,
+      );
+    }
+  });
+
+  test('an arbiter on a same-named table in ANOTHER schema does not count', async () => {
+    await engine.executeRaw(`CREATE SCHEMA IF NOT EXISTS arbiter_decoy`);
+    await engine.executeRaw(
+      `CREATE TABLE IF NOT EXISTS arbiter_decoy.pages (
+         source_id TEXT NOT NULL, slug TEXT NOT NULL,
+         CONSTRAINT decoy_source_slug_key UNIQUE (source_id, slug)
+       )`,
+    );
+    await dropArbiter();
+    try {
+      const st = await checkPagesUpsertArbiter(engine);
+      expect(st.arbiterPresent).toBe(false);
+      expect(st.needsRepair).toBe(true);
+    } finally {
+      await engine.executeRaw(`DROP TABLE IF EXISTS arbiter_decoy.pages`);
+      await engine.executeRaw(`DROP SCHEMA IF EXISTS arbiter_decoy`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`checkPagesUpsertArbiter` listed candidates with `SELECT indexdef FROM pg_indexes WHERE tablename = 'pages'` — a bare text scan that **false-passes on exactly the drift shapes this module exists to catch**:

- An **INVALID index** (the remnant a failed `CREATE INDEX CONCURRENTLY` leaves behind) renders a normal-looking `indexdef` but cannot arbitrate `ON CONFLICT` — the check reported "arbiter present" while every `putPage` failed brain-wide, masking the very outage #550 detects.
- A **DEFERRABLE unique** (`indimmediate = false`) is likewise unusable for `ON CONFLICT` but passed the text shape test.
- `tablename` carries no schema qualifier, so an arbiter on a same-named `pages` table in **another schema** satisfied the check while the search_path table (the one `to_regclass` probed two lines above) had none.

Follow-up to my closed #4420 (the shared local+remote doctor wiring landed independently in the wave; the probe robustness did not).

## Fix

Anchor the candidate set on the SAME `to_regclass('pages')` the table probe used, via `pg_index` with `indisunique AND indisvalid AND indisready AND indimmediate AND indpred IS NULL`, rendering defs with `pg_get_indexdef`. `isArbiterShape` keeps its existing column-set parse (its UNIQUE/partial regexes stay as belt-and-braces). `repairPagesUpsertArbiter` reuses the check, so an invalid arbiter now correctly triggers the existing drop-and-re-add heal.

## Tests

Four regressions in `test/pages-upsert-arbiter.test.ts`: invalid index flagged AND healed (with a working `putPage` after), deferrable excluded, cross-schema decoy excluded. All four fail on the unfixed probe — verified (10 pass / 4 fail pristine, 14/14 fixed) — and the catalog flags were exercised on the repo's PGLite engine (real Postgres WASM). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE