### PR TITLE
fix(guardrails): count registration events with a pre-import baseline — side-effect and same-id registrations no longer rejected (#3688 residual)

### DIFF
--- a/src/core/guardrails.ts
+++ b/src/core/guardrails.ts
@@ -82,7 +82,14 @@ const providers = new Map<string, GuardrailProvider>();
 export function registerGuardrailProvider(provider: GuardrailProvider): void {
   if (!provider || typeof provider.classify !== 'function' || !provider.id) return;
   providers.set(provider.id, provider);
+  // #3688 residual: the env loader counts registration EVENTS, not map
+  // growth — a same-id replacement (explicitly supported above) keeps
+  // providers.size constant and a size delta would misread it as zero.
+  registrationEvents++;
 }
+
+/** Monotonic count of accepted registerGuardrailProvider calls (see above). */
+let registrationEvents = 0;
 
 /** Remove a previously-registered provider. Returns true if one was removed. */
 export function unregisterGuardrailProvider(id: string): boolean {
@@ -163,6 +170,15 @@ export async function loadGuardrailProvidersFromEnv(
     target = pathToFileURL(resolve(expanded)).href;
   }
 
+  // #3688 residual: snapshot BEFORE the import, not after. A module that
+  // registers its providers as a top-level side effect (calling
+  // registerGuardrailProvider at import time) does so DURING the import —
+  // an after-import baseline counted those registrations as zero and the
+  // fail-closed zero-provider check below then rejected a module whose
+  // guardrails were in fact registered and active. Counting EVENTS (not
+  // providers.size) also keeps a same-id replacement — supported by
+  // registerGuardrailProvider — from reading as zero.
+  const before = registrationEvents;
   let mod: Record<string, unknown>;
   try {
     mod = (await import(target)) as Record<string, unknown>;
@@ -171,8 +187,6 @@ export async function loadGuardrailProvidersFromEnv(
       `GBRAIN_GUARDRAILS_MODULE=${spec} failed to load: ${(err as Error)?.message ?? String(err)}`,
     );
   }
-
-  const before = providers.size;
   const candidates: unknown[] = [];
   if (Array.isArray(mod.default)) candidates.push(...mod.default);
   else if (mod.default) candidates.push(mod.default);
@@ -184,7 +198,7 @@ export async function loadGuardrailProvidersFromEnv(
     await (mod.register as (r: typeof registerGuardrailProvider) => unknown)(registerGuardrailProvider);
   }
 
-  const loaded = providers.size - before;
+  const loaded = registrationEvents - before;
   if (loaded <= 0) {
     throw new GuardrailLoadError(
       `GBRAIN_GUARDRAILS_MODULE=${spec} loaded but registered no guardrail provider ` +

--- a/test/guardrails-env-load.test.ts
+++ b/test/guardrails-env-load.test.ts
@@ -117,3 +117,31 @@ describe('loadGuardrailProvidersFromEnv (#3688)', () => {
     ).rejects.toBeInstanceOf(GuardrailLoadError);
   });
 });
+
+describe('#3688 residual — top-level side-effect registration counts', () => {
+  test('a module that registers at import time is accepted, not rejected as zero-provider', async () => {
+    const guardrailsUrl = new URL('../src/core/guardrails.ts', import.meta.url).href;
+    const p = fixture('side-effect-provider.mjs', `
+      import { registerGuardrailProvider } from '${guardrailsUrl}';
+      registerGuardrailProvider({ id: 'fixture-side-effect', classify() {} });
+      export default undefined;
+    `);
+    const out = await loadGuardrailProvidersFromEnv({ GBRAIN_GUARDRAILS_MODULE: p });
+    expect(out.loaded).toBe(1);
+    expect(hasGuardrails()).toBe(true);
+  });
+
+  test('a same-id REPLACEMENT counts as a registration, not zero', async () => {
+    const guardrailsUrl = new URL('../src/core/guardrails.ts', import.meta.url).href;
+    // Pre-register the id, then load a module that replaces it: providers.size
+    // stays constant, so a size-delta count would misread the load as empty.
+    const { registerGuardrailProvider } = await import('../src/core/guardrails.ts');
+    registerGuardrailProvider({ id: 'fixture-replace', classify() {} });
+    const p = fixture('replace-provider.mjs', `
+      export default { id: 'fixture-replace', classify() {} };
+    `);
+    const out = await loadGuardrailProvidersFromEnv({ GBRAIN_GUARDRAILS_MODULE: p });
+    expect(out.loaded).toBe(1);
+    expect(hasGuardrails()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`loadGuardrailProvidersFromEnv` counted `providers.size` deltas with the baseline captured AFTER `await import(target)`. Two working operator configurations were rejected with the fail-closed `GuardrailLoadError` ("loaded but registered no guardrail provider") even though their guardrails were registered and active:

- A module registering via **top-level side effect** (calling `registerGuardrailProvider` at import time) registers DURING the import — the after-import baseline counted it as zero.
- A module **replacing an already-registered id** (explicitly supported: `registerGuardrailProvider` is "register or replace, by id") keeps `providers.size` constant, so even a pre-import size baseline reads the load as zero.

Follow-up to my closed #4464 (the loader + CLI wiring landed independently in the wave; this counting defect is in the landed version).

## Fix

`registerGuardrailProvider` increments a monotonic `registrationEvents` counter (only for accepted calls — the malformed-provider guard still returns early), and the loader measures the event delta from a PRE-import baseline. Only modules that register nothing at all still trip the zero-provider guard — the fail-closed posture is unchanged.

## Tests

Two regressions in `test/guardrails-env-load.test.ts` (side-effect module accepted with `loaded=1`; same-id replacement accepted). Both fail on the unfixed loader — verified (8 pass / 2 fail pristine, 10/10 fixed). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE6YAYA7WErcy3whGEoQTE