### PR TITLE
fix(skill-trigger-index): follow symlinks when scanning skill dirs

### DIFF
--- a/src/core/skill-trigger-index.ts
+++ b/src/core/skill-trigger-index.ts
@@ -25,7 +25,7 @@
  * risk codex flagged in #1451 review was consistency, not throughput.
  */
 
-import { existsSync, readFileSync, readdirSync, type Dirent } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, type Dirent } from 'fs';
 import { join } from 'path';
 import { parseResolverEntries, type ResolverEntry } from './check-resolvable.ts';
 import { findAllResolverFiles } from './resolver-filenames.ts';
@@ -84,8 +84,20 @@ function loadFrontmatterEntries(skillsDir: string): SkillTriggerEntry[] {
   }
 
   for (const dirent of dirents) {
-    if (!dirent.isDirectory()) continue;
     const name = dirent.name;
+    // readdirSync's Dirent.isDirectory() reflects the dirent's own type
+    // (DT_LNK for symlinks on macOS/Linux) and does NOT follow symlinks,
+    // so skill dirs symlinked in from a shared skills store (e.g.
+    // ~/.agents/skills/<name>) are silently skipped without this check.
+    const isDir = dirent.isDirectory()
+      || (dirent.isSymbolicLink() && (() => {
+        try {
+          return statSync(join(skillsDir, name)).isDirectory();
+        } catch {
+          return false;
+        }
+      })());
+    if (!isDir) continue;
     if (name.startsWith('_') || name.startsWith('.')) continue;
     if (FRONTMATTER_SKIP_DIRS.has(name)) continue;
 

--- a/test/skill-trigger-index.test.ts
+++ b/test/skill-trigger-index.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -112,6 +112,34 @@ body
 
     const entries = loadSkillTriggerIndex(skillsDir);
     expect(entries).toEqual([]);
+  });
+
+  test('symlinked skill directory (shared skills store) → frontmatter entries still appear', () => {
+    // Regression: readdirSync's Dirent.isDirectory() reflects the dirent's
+    // own type (DT_LNK on macOS/Linux for a symlink) and does NOT resolve
+    // the link target, so a skill dir symlinked in from a shared store
+    // (e.g. `~/.agents/skills/<name>` linked into `skills/<name>`) was
+    // silently skipped and its triggers never registered.
+    const skillsDir = makeSkillsDir();
+    const storeDir = mkdtempSync(join(tmpdir(), 'skill-trigger-index-store-'));
+    TEMPDIRS.push(storeDir);
+    const realSkillDir = join(storeDir, 'shared-skill');
+    mkdirSync(realSkillDir, { recursive: true });
+    writeFileSync(
+      join(realSkillDir, 'SKILL.md'),
+      skillWithTriggers('shared-skill', ['do the shared thing']),
+    );
+    symlinkSync(realSkillDir, join(skillsDir, 'shared-skill'), 'dir');
+
+    const entries = loadSkillTriggerIndex(skillsDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      trigger: 'do the shared thing',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      isGStack: false,
+      section: FRONTMATTER_SECTION,
+      source: 'frontmatter',
+    });
   });
 
   test('skill with empty triggers: array → not registered', () => {


### PR DESCRIPTION
## Summary
- `loadFrontmatterEntries` in `src/core/skill-trigger-index.ts` used `Dirent.isDirectory()` to decide which skill folders to scan for `triggers:` frontmatter. On macOS/Linux, `readdirSync(..., { withFileTypes: true })` reports a symlink's dirent type as `DT_LNK`, so `isDirectory()` returns `false` for symlinks even when the target is a directory — symlinked skill dirs were silently skipped.
- This affects any install where skills live in a shared store and are symlinked into `skills/<name>` (observed with several bundled ElevenLabs skills: `agents`, `find-skills`, `setup-api-key`, `speech-to-text`, `text-to-speech`, symlinked from `~/.agents/skills/<name>`). Their `triggers:` frontmatter was invisible to the trigger index, so `check-resolvable`/`gbrain doctor` reported them as unreachable no matter what was in their frontmatter.
- Fix: when the dirent is a symlink, `statSync` the resolved path and use that to decide if it's a directory.

## Test plan
- [x] Added a regression test (`test/skill-trigger-index.test.ts`) that creates a skill in a separate temp "store" dir and symlinks it into the skills dir — confirmed it **fails on unpatched `master`** (0 entries found) and **passes with the fix** (entry found).
- [x] Ran full existing suite for the touched module: `bun test test/skill-trigger-index.test.ts test/check-resolvable.test.ts test/check-resolvable-cli.test.ts test/check-resolvable-openclaw-compact.test.ts` — same 2 pre-existing failures on master and on this branch (unrelated `resolveSkillsDir` cwd-walk-up vs install-path test-environment quirk), no new failures.
- [x] Verified end-to-end against a real install with 5 symlinked skills: `gbrain check-resolvable` went from 4 errors / 5 warnings to 0/0, and `gbrain doctor` health score went 65 → 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)