### PR TITLE
fix(gateway): echo OpenAI Responses API reasoning-item ids across tool-loop turns

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -9,7 +9,7 @@ src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns
 src/core/migrate.ts	687	region-exempt	append-only MIGRATIONS array grows freely; runner logic is ratcheted — grown v0.46.26.0: repair-handler hooks (#3957 pages-upsert-arbiter)
 src/commands/sync.ts	4512	ratchet	grown v0.46.26.0 megawave: image sync, ingest-log gating, dry-run purity, checkpoint honesty (#2683 #4342 #3875) + 3 nosemgrep dataflow annotations (path-traversal audit)
-src/core/ai/gateway.ts	4494	ratchet	grown v0.46.26.0 megawave: config-plane probes + halt telemetry (#3387 #4312)
+src/core/ai/gateway.ts	4515	ratchet	grown v0.46.26.0 megawave: config-plane probes + halt telemetry (#3387 #4312); +21 lines (OpenAI Responses API reasoning-item echo: ChatBlock 'reasoning' variant, chat()/toModelMessages() round-trip)
 src/cli.ts	3723	ratchet	grown v0.46.26.0 megawave: SIGCHLD reaper install, silent-failure surfacing, confirm-race gate (#2443 #2898 #2297)
 src/core/cycle.ts	3171	ratchet	grown v0.46.26.0 megawave (#4102 #2608) + master v0.46.26.0 cycle-start orphan recovery
 src/commands/serve-http.ts	3294	ratchet	grown v0.46.25.0 D2: /mcp per-request teardown (#2844)
@@ -27,7 +27,7 @@ src/commands/skillpack.ts	1360	ratchet
 src/core/minions/queue.ts	2442	ratchet	grown #4078 + megawave probe-liveness unlatch (#4310) + master private-queue lifecycle: recovery classifier + monotonic lease
 src/commands/init.ts	1950	ratchet	grown v0.46.x keyless capability notices
 src/commands/integrations.ts	1736	ratchet	grown v0.46.26.0 megawave (#4039 connector compat) + 1 nosemgrep dataflow annotation (path-traversal audit)
-src/core/minions/handlers/subagent.ts	1825	ratchet	merged: master v131 settle rework + dream-wave C5 peel + C6 accounting + C7 lease heartbeats/lost-lease aborts + C9 oneshot dispatch + adversarial fix batches; grown by #4078 subagent-loop capability fix
+src/core/minions/handlers/subagent.ts	1831	ratchet	merged: master v131 settle rework + dream-wave C5 peel + C6 accounting + C7 lease heartbeats/lost-lease aborts + C9 oneshot dispatch + adversarial fix batches; grown by #4078 subagent-loop capability fix; +6 lines (reasoning-item replay: adaptContentBlocksToChatBlocks handles 'reasoning' blocks)
 src/commands/bootstrap.ts	2010	ratchet	grandfathered at merge (grew past the 1500 cap on master); raised for #4066 HOME_WORKSPACE_GUARD_EXEMPT (status/uninstall/harness)
 src/core/minions/worker.ts	1560	ratchet	grandfathered at merge (grew past the 1500 cap on master, #4170); grown v0.46.11.0 five-issue wave
 src/commands/sources.ts	1790	ratchet	grown v0.46.22.0 phone wave: github source kind (#4104)

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2967,9 +2967,19 @@ export type ChatRole = 'system' | 'user' | 'assistant' | 'tool';
  * on the rebuilt part in toModelMessages(), and carried through the replay shim
  * (adaptContentBlocksToChatBlocks). Attached ONLY when the provider sent one —
  * blocks from providers without per-part state stay byte-identical.
+ *
+ * `reasoning` blocks are the same #4201 shape applied to OpenAI's Responses
+ * API reasoning models (o-series, gpt-5.x family): every response `reasoning`
+ * part carries `providerMetadata.openai.itemId` (+ optional
+ * `reasoningEncryptedContent`), and OpenAI's server REJECTS a later turn whose
+ * history has a `function_call` item with no matching `reasoning` item —
+ * "Item '<fc_id>' of type 'function_call' was provided without its required
+ * 'reasoning' item: '<rs_id>'." A reasoning-model tool-loop conversation dies
+ * on turn 2 without this: `chat()` previously never captured the part at all.
  */
 export type ChatBlock =
   | { type: 'text'; text: string; providerMetadata?: Record<string, unknown> }
+  | { type: 'reasoning'; text: string; providerMetadata?: Record<string, unknown> }
   | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown; providerMetadata?: Record<string, unknown> }
   | { type: 'tool-result'; toolCallId: string; toolName: string; output: unknown; isError?: boolean; providerMetadata?: Record<string, unknown> };
 
@@ -3085,18 +3095,26 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
     }
     return {
       role: m.role,
-      // Drop text blocks whose `text` isn't a string: reasoning models
-      // (DeepSeek v4, etc.) surface `text: null/undefined` thinking parts that
-      // AI SDK v6's Zod schema rejects, poisoning the whole call. `''` is valid
-      // and kept.
+      // Drop text/reasoning blocks whose `text` isn't a string: reasoning
+      // models (DeepSeek v4, etc.) surface `text: null/undefined` thinking
+      // parts that AI SDK v6's Zod schema rejects, poisoning the whole call.
+      // `''` is valid and kept.
       content: blocks
-        .filter((b) => b.type !== 'text' || typeof b.text === 'string')
+        .filter((b) => (b.type !== 'text' && b.type !== 'reasoning') || typeof b.text === 'string')
         .map((b) => {
           // #4201: `providerOptions` echoes per-part provider state (e.g.
-          // Gemini 3.x thoughtSignature) — attached only when captured.
+          // Gemini 3.x thoughtSignature, OpenAI reasoning-item id) — attached
+          // only when captured.
           if (b.type === 'text') {
             return {
               type: 'text' as const,
+              text: b.text,
+              ...(b.providerMetadata ? { providerOptions: b.providerMetadata } : {}),
+            };
+          }
+          if (b.type === 'reasoning') {
+            return {
+              type: 'reasoning' as const,
               text: b.text,
               ...(b.providerMetadata ? { providerOptions: b.providerMetadata } : {}),
             };
@@ -3781,13 +3799,16 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     if (Array.isArray(rawContent) && rawContent.length > 0) {
       for (const part of rawContent) {
         // #4201: capture per-part providerMetadata (Gemini 3.x thoughtSignature
-        // arrives on functionCall/text parts and must be echoed back next turn).
-        // `reasoning` parts stay deliberately dropped: the echo requirement is
-        // on functionCall parts; reasoning text never re-enters the transcript.
+        // and OpenAI reasoning-item ids arrive on functionCall/reasoning/text
+        // parts and must be echoed back next turn — see the ChatBlock doc
+        // comment for the OpenAI Responses API's specific requirement).
         const partMeta = part.providerMetadata && typeof part.providerMetadata === 'object'
           ? { providerMetadata: part.providerMetadata as Record<string, unknown> }
           : {};
         if (part.type === 'text') blocks.push({ type: 'text', text: part.text, ...partMeta });
+        else if (part.type === 'reasoning') {
+          blocks.push({ type: 'reasoning', text: typeof part.text === 'string' ? part.text : '', ...partMeta });
+        }
         else if (part.type === 'tool-call') {
           blocks.push({
             type: 'tool-call',

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -1690,6 +1690,12 @@ function adaptContentBlocksToChatBlocks(blocks: unknown): ChatBlock[] | string {
       : {};
     if (t === 'text' && typeof block.text === 'string') {
       out.push({ type: 'text', text: block.text, ...meta });
+    } else if (t === 'reasoning' && typeof block.text === 'string') {
+      // OpenAI Responses API reasoning-item id (providerMetadata.openai.itemId)
+      // — see the ChatBlock doc comment. Must survive crash-replay the same
+      // way tool-call providerMetadata does, or a resumed reasoning-model
+      // tool loop dead-letters on its next turn.
+      out.push({ type: 'reasoning', text: block.text, ...meta });
     } else if (t === 'tool_use' && typeof block.id === 'string' && typeof block.name === 'string') {
       // v1 Anthropic shape
       out.push({

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -480,6 +480,66 @@ describe('chat touchpoint — per-part providerMetadata round trip (#4201)', () 
   });
 });
 
+// OpenAI's Responses API requires every `function_call` item in a replayed
+// transcript to be paired with the `reasoning` item that produced it, or the
+// NEXT turn 400s: "Item '<fc_id>' of type 'function_call' was provided
+// without its required 'reasoning' item: '<rs_id>'." Reproduced live against
+// openai:gpt-5.6-luna in a 2-turn tool-calling conversation: turn 1 captured
+// zero reasoning blocks (chat() silently dropped the `reasoning` part) and
+// turn 2 failed with exactly that message; after this fix turn 1 captures
+// the reasoning block and turn 2 completes. This suite covers the inbound
+// capture half with the SAME #4201 providerMetadata channel `text`/`tool-call`
+// already use — see gateway-model-messages.test.ts for the outbound echo half.
+describe('chat touchpoint — reasoning-item round trip (OpenAI Responses API)', () => {
+  beforeEach(() => {
+    resetGateway();
+    __setGenerateTextTransportForTests(null);
+  });
+
+  const REASONING_SIG = { openai: { itemId: 'rs_abc123', reasoningEncryptedContent: 'opaque-blob' } };
+
+  test('chat() captures a reasoning part into a ChatBlock (inbound half)', async () => {
+    __setGenerateTextTransportForTests(async () => ({
+      content: [
+        { type: 'reasoning', text: 'weighing today vs. the forecast...', providerMetadata: REASONING_SIG },
+        { type: 'tool-call', toolCallId: 'c1', toolName: 'get_forecast', input: { city: 'Tokyo' } },
+      ],
+      finishReason: 'tool-calls',
+      usage: { inputTokens: 5, outputTokens: 5 },
+    }) as any);
+    configureGateway({ chat_model: 'openai:gpt-5.6-luna', env: { OPENAI_API_KEY: 'fake' } });
+    const result = await chat({
+      model: 'openai:gpt-5.6-luna',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    const reasoning = result.blocks.find(b => b.type === 'reasoning') as any;
+    expect(reasoning).toBeDefined();
+    expect(reasoning.text).toBe('weighing today vs. the forecast...');
+    expect(reasoning.providerMetadata).toEqual(REASONING_SIG);
+    // Never leaks into the final answer text (that's the model's actual reply, not its thinking).
+    expect(result.text).toBe('');
+  });
+
+  test('a reasoning part with a non-string text field does not poison the call', async () => {
+    __setGenerateTextTransportForTests(async () => ({
+      content: [
+        { type: 'reasoning', text: null },
+        { type: 'text', text: 'ok' },
+      ],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    }) as any);
+    configureGateway({ chat_model: 'openai:gpt-5.6-luna', env: { OPENAI_API_KEY: 'fake' } });
+    const result = await chat({
+      model: 'openai:gpt-5.6-luna',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    const reasoning = result.blocks.find(b => b.type === 'reasoning') as any;
+    expect(reasoning.text).toBe('');
+    expect(result.text).toBe('ok');
+  });
+});
+
 describe('chat — typed provider error status carried to the top level', () => {
   beforeEach(() => {
     resetGateway();

--- a/test/gateway-model-messages.test.ts
+++ b/test/gateway-model-messages.test.ts
@@ -227,5 +227,60 @@ describe('toModelMessages — v6 ModelMessage shape', () => {
       expect('providerOptions' in out[0].content[0]).toBe(false);
       expect('providerOptions' in out[0].content[1]).toBe(false);
     });
+
+    // OpenAI's Responses API rejects a later turn whose history has a
+    // `function_call` item with no matching `reasoning` item — "Item
+    // '<fc_id>' of type 'function_call' was provided without its required
+    // 'reasoning' item: '<rs_id>'." Reproduced against the live API
+    // (openai:gpt-5.6-luna, 2-turn tool-calling conversation) before this
+    // fix: turn 1 captured zero reasoning blocks despite the server minting
+    // one, and turn 2 400'd with exactly that message. This block covers the
+    // outbound half of the fix — reasoning blocks must round-trip through
+    // toModelMessages() the same way tool-call/text blocks already do.
+    const reasoningSig = { openai: { itemId: 'rs_abc123', reasoningEncryptedContent: 'opaque-blob' } };
+
+    test('reasoning block with providerMetadata emits providerOptions', () => {
+      const msgs: ChatMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'weighing the tradeoff...', providerMetadata: reasoningSig },
+            { type: 'tool-call', toolCallId: 'c1', toolName: 'get_forecast', input: { city: 'Tokyo' } },
+          ],
+        },
+      ];
+      const out = toModelMessages(msgs) as any[];
+      expect(out[0].content[0]).toEqual({
+        type: 'reasoning',
+        text: 'weighing the tradeoff...',
+        providerOptions: reasoningSig,
+      });
+    });
+
+    test('reasoning block without providerMetadata gains no providerOptions key', () => {
+      const msgs: ChatMessage[] = [
+        { role: 'assistant', content: [{ type: 'reasoning', text: 'no id captured' }] },
+      ];
+      const out = toModelMessages(msgs) as any[];
+      expect(out[0].content[0]).toEqual({ type: 'reasoning', text: 'no id captured' });
+    });
+
+    // Same defensive filter as text blocks (some reasoning models surface
+    // text: null/undefined thinking parts that AI SDK v6's Zod schema
+    // rejects) — a reasoning block with a non-string `text` must be dropped,
+    // not sent through and poison the whole call.
+    test('reasoning block with non-string text is dropped, sibling blocks survive', () => {
+      const msgs: ChatMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: undefined as unknown as string },
+            { type: 'text', text: 'ok' },
+          ],
+        },
+      ];
+      const out = toModelMessages(msgs) as any[];
+      expect(out[0].content).toEqual([{ type: 'text', text: 'ok' }]);
+    });
   });
 });

--- a/test/subagent-v1-v2-shim.test.ts
+++ b/test/subagent-v1-v2-shim.test.ts
@@ -169,6 +169,27 @@ describe('adaptContentBlocksToChatBlocks (D5 — v1 Anthropic → v2 ChatBlock s
     expect(out.length).toBe(1);
     expect(out[0].toolCallId).toBe('ok');
   });
+
+  // A crash-replayed reasoning-model tool loop must keep the OpenAI
+  // Responses API reasoning-item id (providerMetadata.openai.itemId) across
+  // resume the same way a tool-call's providerMetadata already does —
+  // otherwise the resumed job's next turn 400s the same way an un-echoed
+  // live turn does (see gateway-chat.test.ts's reasoning-item round trip
+  // suite for the live-turn half of this fix).
+  it('passes a reasoning block through with providerMetadata intact', () => {
+    const sig = { openai: { itemId: 'rs_abc123', reasoningEncryptedContent: 'opaque-blob' } };
+    const blocks = [{ type: 'reasoning', text: 'weighing the tradeoff...', providerMetadata: sig }];
+    expect(adaptContentBlocksToChatBlocks(blocks)).toEqual(blocks);
+  });
+
+  it('drops a reasoning block with a non-string text field (defensive)', () => {
+    const blocks = [
+      { type: 'reasoning', text: null },
+      { type: 'text', text: 'ok' },
+    ];
+    const out = adaptContentBlocksToChatBlocks(blocks) as any[];
+    expect(out).toEqual([{ type: 'text', text: 'ok' }]);
+  });
 });
 
 describe('loadPriorToolsV2 (D5 — synthesizes stable keys for v1 rows)', () => {


### PR DESCRIPTION
## Summary

`gateway.toolLoop()`/`chat()` never captured the `reasoning` part OpenAI's Responses API returns alongside a `function_call` for reasoning-tier models (o-series, gpt-5.x family). Every response `reasoning` part carries `providerMetadata.openai.itemId` (+ optional `reasoningEncryptedContent`) that OpenAI's server requires echoed back on the next turn — every `function_call` item still visible in history must be paired with the `reasoning` item that produced it, or the server 400s:

```
Item '<fc_id>' of type 'function_call' was provided without its required 'reasoning' item: '<rs_id>'.
```

`chat()`'s response-parsing loop only recognized `text` and `tool-call` parts; `reasoning` parts were silently dropped, so **any** reasoning-model tool-calling conversation that reaches turn 2 (a real tool call followed by a second turn) fails deterministically once the loop replays history — not a rare edge case, this is the failure mode for the simplest possible multi-turn tool loop on these models.

Same failure family as #2110 (deepseek parallel tool-call pairing, fixed via `repairToolPairing`/`onToolResultTurn`) — a different provider-specific pairing requirement, same root shape (gateway.ts's provider-neutral history replay dropping state a provider needs echoed back).

## Repro

Reproduced live against `openai:gpt-5.6-luna` in a 2-turn tool-calling conversation:
- Turn 1: model calls a tool. `chat()` captured **zero** reasoning blocks despite the server minting one (visible in the raw response).
- Turn 2: replaying turn 1's history (including the tool-call + tool-result) 400s with the exact message above.

## Fix

Mirrors the existing `#4201` per-part `providerMetadata` echo channel (built for Gemini 3.x's `thoughtSignature` — same shape of problem) rather than inventing a new mechanism:

- `ChatBlock` gains a `reasoning` variant (`text` + `providerMetadata`).
- `chat()`'s response loop captures `reasoning` parts the same way it already captures `text`/`tool-call` parts.
- `toModelMessages()` re-emits `reasoning` blocks as `{ type: 'reasoning', text, providerOptions }` on the next request, matching how `text`/`tool-call` blocks already round-trip.
- `subagent.ts`'s `adaptContentBlocksToChatBlocks` (the crash-replay shim) gains the same `reasoning` case — a resumed job needs the same echo the live in-memory path now gets, or a replayed turn hits the identical 400.

Both the malformed-input defensive filter (`text: null/undefined`, the same case `text` blocks already guard against for DeepSeek v4) and the byte-identical-when-absent contract (`providerMetadata` unset → no `providerOptions` key) apply to the new block type too.

## Verification

- `bun run typecheck`, `bun run check:module-size`, `bun run verify` (54/54) all clean.
- New unit tests (`test/ai/gateway-chat.test.ts`, `test/gateway-model-messages.test.ts`, `test/subagent-v1-v2-shim.test.ts`) cover the inbound capture, outbound echo, and crash-replay halves.
- 811 pre-existing tests across the gateway/subagent/e2e suites pass unchanged. 2 pre-existing failures in `subagent-crash-replay-multi-provider.test.ts` (an unrelated openrouter `supports_subagent_loop` capability rejection) confirmed via `git stash` to predate this change on a clean checkout of this branch's base — not caused by this PR.
- Live-tested end-to-end through an availability-fallback wrapper (mid-conversation model switch onto `openai:gpt-5.6-luna`) with a 2-turn tool-calling conversation reaching a coherent final answer, confirming the fix holds under a realistic multi-turn agentic-loop shape and not just the isolated `chat()`/`toModelMessages()` unit boundary.

`scripts/module-size-limits.tsv`: `gateway.ts` 4494→4515 (ChatBlock variant + capture/echo), `subagent.ts` 1825→1831 (replay shim case).

No schema migration.