### PR TITLE
fix(doctor): upgrade_errors warning stays silent once the target version is installed

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4422	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958)
+src/commands/doctor.ts	4438	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958); +16 lines (#4517: extracted checkUpgradeErrors as its own testable function, added staleness suppression)
 src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown v0.46.26.0 megawave op wiring
 src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -444,6 +444,44 @@ export function checkSelfUpgradeHealth(): Check {
 }
 
 /**
+ * Upgrade-error trail (v0.13+). `gbrain upgrade` silently swallows
+ * best-effort failures in `gbrain post-upgrade`; the failure record is
+ * appended to `~/.gbrain/upgrade-errors.jsonl` so we can surface it here
+ * with a paste-ready recovery hint. Without this, users end up with
+ * half-upgraded brains and no signal.
+ *
+ * #4517: a failure record on its own doesn't mean the brain is STILL
+ * broken — the recovery hint (e.g. `apply-migrations --yes`) may have
+ * already fixed it. The installed binary's own version is proof the
+ * failed upgrade did complete filesystem-side: if it's already at or past
+ * the record's `to_version`, the target was reached and this entry is
+ * stale. Returns null (stays silent) rather than downgrading to 'ok' so a
+ * clean doctor report doesn't grow a permanent "resolved" line for every
+ * past hiccup. File-plane only (no DB), matching checkSelfUpgradeHealth.
+ */
+export function checkUpgradeErrors(): Check | null {
+  try {
+    const errPath = gbrainPath('upgrade-errors.jsonl');
+    if (!existsSync(errPath)) return null;
+    const lines = readFileSync(errPath, 'utf-8').split('\n').filter(l => l.trim());
+    if (lines.length === 0) return null;
+    const latest = JSON.parse(lines[lines.length - 1]) as {
+      ts: string; phase: string; from_version: string; to_version: string; hint: string;
+    };
+    if (compareVersions(GBRAIN_BINARY_VERSION, latest.to_version) >= 0) return null;
+    const date = latest.ts.slice(0, 10);
+    return {
+      name: 'upgrade_errors',
+      status: 'warn',
+      message: `Post-upgrade failure on ${date} (${latest.from_version} → ${latest.to_version}, phase: ${latest.phase}). Recovery: ${latest.hint}`,
+    };
+  } catch {
+    // Read/parse failure is itself best-effort; skip silently.
+    return null;
+  }
+}
+
+/**
  * Re-exported from `src/core/env-number.ts`, which now owns the implementation
  * AND the warn-once memo. `source-health.ts` needs the hours resolver for the
  * staleness ceiling, and doctor already imports from source-health — so the
@@ -752,31 +790,9 @@ export async function buildChecks(
     // handles the "schema v7+ but no prefs" case.
   }
 
-  // 3b. Upgrade-error trail (v0.13+). `gbrain upgrade` silently swallows
-  // best-effort failures in `gbrain post-upgrade`; the failure record is
-  // appended to ~/.gbrain/upgrade-errors.jsonl so we can surface it here
-  // with a paste-ready recovery hint. Without this, users end up with
-  // half-upgraded brains and no signal.
-  try {
-    const home = process.env.HOME || '';
-    const errPath = join(home, '.gbrain', 'upgrade-errors.jsonl');
-    if (existsSync(errPath)) {
-      const lines = readFileSync(errPath, 'utf-8').split('\n').filter(l => l.trim());
-      if (lines.length > 0) {
-        const latest = JSON.parse(lines[lines.length - 1]) as {
-          ts: string; phase: string; from_version: string; to_version: string; hint: string;
-        };
-        const date = latest.ts.slice(0, 10);
-        checks.push({
-          name: 'upgrade_errors',
-          status: 'warn',
-          message: `Post-upgrade failure on ${date} (${latest.from_version} → ${latest.to_version}, phase: ${latest.phase}). Recovery: ${latest.hint}`,
-        });
-      }
-    }
-  } catch {
-    // Read/parse failure is itself best-effort; skip silently.
-  }
+  // 3b. Upgrade-error trail (v0.13+).
+  const upgradeErrorsCheck = checkUpgradeErrors();
+  if (upgradeErrorsCheck) checks.push(upgradeErrorsCheck);
 
   // 3b-ter. Self-upgrade health (#3747). Pure local-file check (config +
   // upgrade cache + audit trail; no DB) that was only ever pushed by the

--- a/test/doctor-upgrade-errors.test.ts
+++ b/test/doctor-upgrade-errors.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withEnv } from './helpers/with-env.ts';
+import { checkUpgradeErrors } from '../src/commands/doctor.ts';
+import { VERSION } from '../src/version.ts';
+
+async function withHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-doctor-upgrade-errors-'));
+  mkdirSync(join(dir, '.gbrain'), { recursive: true });
+  try {
+    return await withEnv({ GBRAIN_HOME: dir }, () => fn(dir));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeErrorRecord(home: string, rec: {
+  ts: string; phase: string; from_version: string; to_version: string; hint: string;
+}) {
+  writeFileSync(join(home, '.gbrain', 'upgrade-errors.jsonl'), JSON.stringify(rec) + '\n');
+}
+
+describe('checkUpgradeErrors', () => {
+  test('no jsonl file → null (fresh install)', async () => {
+    await withHome(() => {
+      expect(checkUpgradeErrors()).toBeNull();
+    });
+  });
+
+  test('empty jsonl file → null', async () => {
+    await withHome((home) => {
+      writeFileSync(join(home, '.gbrain', 'upgrade-errors.jsonl'), '');
+      expect(checkUpgradeErrors()).toBeNull();
+    });
+  });
+
+  test('failure record whose to_version the installed binary has not reached yet → warn', async () => {
+    await withHome((home) => {
+      // A to_version far ahead of the real running VERSION can never be
+      // "already reached" — deterministically exercises the still-warn path
+      // regardless of what VERSION happens to be when this test runs.
+      writeErrorRecord(home, {
+        ts: '2026-08-22T10:00:00Z',
+        phase: 'post-upgrade',
+        from_version: '0.1.0.0',
+        to_version: '999.999.999.999',
+        hint: 'gbrain apply-migrations --yes',
+      });
+      const check = checkUpgradeErrors();
+      expect(check).not.toBeNull();
+      expect(check?.status).toBe('warn');
+      expect(check?.name).toBe('upgrade_errors');
+      expect(check?.message).toContain('2026-08-22');
+      expect(check?.message).toContain('0.1.0.0 → 999.999.999.999');
+      expect(check?.message).toContain('post-upgrade');
+      expect(check?.message).toContain('gbrain apply-migrations --yes');
+    });
+  });
+
+  test('#4517: failure record whose to_version the installed binary has already reached → null (stale, suppressed)', async () => {
+    await withHome((home) => {
+      // The installed binary's own VERSION is >= itself by definition, so a
+      // record targeting exactly VERSION is provably already resolved.
+      writeErrorRecord(home, {
+        ts: '2026-08-22T10:00:00Z',
+        phase: 'post-upgrade',
+        from_version: '0.1.0.0',
+        to_version: VERSION,
+        hint: 'gbrain apply-migrations --yes',
+      });
+      expect(checkUpgradeErrors()).toBeNull();
+    });
+  });
+
+  test('only the LAST line of a multi-entry log is considered', async () => {
+    await withHome((home) => {
+      const lines = [
+        { ts: '2026-08-20T10:00:00Z', phase: 'post-upgrade', from_version: '0.1.0.0', to_version: '0.2.0.0', hint: 'old, irrelevant' },
+        { ts: '2026-08-22T10:00:00Z', phase: 'post-upgrade', from_version: '0.2.0.0', to_version: '999.999.999.999', hint: 'gbrain apply-migrations --yes' },
+      ];
+      writeFileSync(join(home, '.gbrain', 'upgrade-errors.jsonl'), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+      const check = checkUpgradeErrors();
+      expect(check?.message).toContain('2026-08-22');
+      expect(check?.message).not.toContain('2026-08-20');
+    });
+  });
+
+  test('malformed JSON on the last line → null (best-effort, does not throw)', async () => {
+    await withHome((home) => {
+      writeFileSync(join(home, '.gbrain', 'upgrade-errors.jsonl'), 'not valid json\n');
+      expect(checkUpgradeErrors()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4517.

`checkUpgradeErrors` (extracted from an inline block in `buildChecks`, now its own testable function) read the LAST line of `~/.gbrain/upgrade-errors.jsonl` and unconditionally surfaced it as a WARN — every single doctor run, forever — regardless of whether the underlying failure was actually resolved. Running the check's own suggested recovery (`gbrain apply-migrations --yes`) and confirming "All migrations up to date" did not clear the warning; it kept reappearing verbatim on every future run.

## Fix

The record already carries `to_version` — the version the failed upgrade was targeting. The installed binary's own `VERSION` is proof the upgrade did complete filesystem-side if it's already `>=` that target (`compareVersions()`, the same MAJOR.MINOR.PATCH comparator `apply-migrations`/`migration-ledger` already use). When that holds, the check returns `null` and stays silent rather than downgrading to `'ok'` — keeps a clean doctor report from growing a permanent "resolved" line for every past hiccup, matching how other silent-when-healthy checks in this file behave.

Also swapped the manual `join(process.env.HOME, '.gbrain', ...)` path join for the existing `gbrainPath()` helper — same effective path on a normal install, but honors `GBRAIN_HOME` (consistent with every other `.gbrain`-relative check in this file) and is what makes this testable without touching the real `$HOME`.

## Tests

6 new cases (`test/doctor-upgrade-errors.test.ts`): fresh install, empty file, still-warns when ahead, suppressed-when-caught-up (the #4517 regression case itself), only the last jsonl line matters, malformed JSON doesn't throw — 0 fail. 121 existing doctor/self-upgrade/categories tests — 0 fail, unchanged.

`bun run typecheck`, `bun run check:module-size`, `bun run verify` (54/54) all clean.

`scripts/module-size-limits.tsv`: `doctor.ts` 4422→4438 (extracted function + JSDoc; net new code is ~16 lines after removing the old inline block).

No schema migration.