### PR TITLE
fix(doctor): don't assert 'supervisor not running' when --fast never attempted the check that could prove it

### DIFF
--- a/scripts/module-size-limits.tsv
+++ b/scripts/module-size-limits.tsv
@@ -3,7 +3,7 @@
 # Raising a ceiling is a conscious, reviewer-visible act. Lower ceilings in
 # the same commit as any peel (the guard fails on >50 lines of stale slack).
 # Columns: path	max_lines	policy	note
-src/commands/doctor.ts	4422	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958)
+src/commands/doctor.ts	4443	ratchet	grown v0.46.26.0 megawave: silent-death checks, self-upgrade honesty, noise pruning (#3944 #3925 #3958); +21 lines (#4518: don't assert "supervisor not running" when the --fast mode DB-lock fallback was never attempted)
 src/core/operations.ts	315	ratchet	peel target: containment sprint C4-C7; grown v0.46.26.0 megawave op wiring
 src/core/postgres-engine.ts	6166	ratchet	grown v0.46.26.0 megawave (#4218 #3986 #4352) + master v0.46.26.0 private-queue token bootstrap probe
 src/core/pglite-engine.ts	6062	ratchet	grown v0.46.26.0 megawave parity twins + master v0.46.26.0 private-queue columns

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -815,6 +815,16 @@ export async function buildChecks(
       } catch { /* pre-migration / transient: pidfile-only */ }
     }
     const running = pidfileRunning || detectedViaDbLock;
+    // #4518: under --fast, `engine` is null (the CLI dispatcher never
+    // connects — see cli.ts's `if (args.includes('--fast'))` branch), so the
+    // #1849 DB-lock fallback above is structurally unreachable. A supervisor
+    // running the documented multi-queue pattern (distinct --pid-file per
+    // named queue, e.g. `supervisor-cron.pid` + `supervisor-default.pid`)
+    // never writes DEFAULT_PID_FILE either, so `running` is always false for
+    // that install shape under --fast — not because it's actually down, but
+    // because the ONE check that could prove otherwise was never attempted.
+    // Don't assert "not running" on a check we know is inconclusive here.
+    const dbLockCheckSkippedUnderFast = fastMode && !pidfileRunning && !engine;
 
     const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
     const lastStart = events.filter(e => e.event === 'started').pop()?.ts ?? null;
@@ -842,6 +852,17 @@ export async function buildChecks(
           name: 'supervisor',
           status: 'fail',
           message: `Supervisor gave up at ${maxCrashesEvent.ts} (max_crashes_exceeded). Restart with: gbrain jobs supervisor start --detach`,
+        });
+      } else if (!running && dbLockCheckSkippedUnderFast && events.length > 0) {
+        // #4518: pidfile check found nothing at the HOME-derived default
+        // path, but under --fast we never got to try the #1849 DB-lock
+        // fallback that would prove a per-queue --pid-file supervisor is
+        // actually alive. Say so instead of asserting a liveness verdict
+        // this run structurally couldn't determine.
+        checks.push({
+          name: 'supervisor',
+          status: 'ok',
+          message: `Not found at the default pidfile path (last_start=${lastStart ?? 'unknown'}) — inconclusive under --fast (DB-lock fallback needs a connection). Run \`gbrain doctor\` without --fast to verify a per-queue --pid-file supervisor.`,
         });
       } else if (!running && events.length > 0) {
         checks.push({

--- a/test/doctor-fast-supervisor.test.ts
+++ b/test/doctor-fast-supervisor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withEnv } from './helpers/with-env.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+import { writeSupervisorEvent } from '../src/core/minions/handlers/supervisor-audit.ts';
+
+async function withIsolatedHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-doctor-fast-sup-'));
+  try {
+    return await withEnv(
+      { GBRAIN_HOME: dir, GBRAIN_AUDIT_DIR: join(dir, 'audit') },
+      () => fn(dir),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function supervisorCheck(checks: Awaited<ReturnType<typeof buildChecks>>) {
+  return checks.find((c) => c.name === 'supervisor');
+}
+
+describe('#4518: supervisor check under --fast with no default-path pidfile', () => {
+  test('no supervisor ever observed → no check surfaced at all (unaffected by the fix)', async () => {
+    await withIsolatedHome(async () => {
+      const checks = await buildChecks(null, ['--fast']);
+      expect(supervisorCheck(checks)).toBeUndefined();
+    });
+  });
+
+  test('supervisor WAS observed (audit events exist) but no pidfile at the default path, under --fast → ok/inconclusive, not a false "not running" warn', async () => {
+    await withIsolatedHome(async () => {
+      // Simulates the documented multi-queue pattern: a supervisor that was
+      // started with an explicit, non-default --pid-file (e.g.
+      // supervisor-cron.pid) never writes DEFAULT_PID_FILE, so
+      // readSupervisorPid(DEFAULT_PID_FILE) reports not-running even though
+      // the process is alive — the audit trail is the only local evidence.
+      writeSupervisorEvent({ event: 'started', ts: new Date().toISOString() }, 12345);
+
+      const checks = await buildChecks(null, ['--fast']);
+      const check = supervisorCheck(checks);
+      expect(check).toBeDefined();
+      // The regression this guards against: this used to be status:'warn',
+      // message starting with "Supervisor not running" — a false positive,
+      // because the #1849 DB-lock fallback that could have proven liveness
+      // was never attempted (engine is null under --fast by CLI design).
+      expect(check?.status).not.toBe('warn');
+      expect(check?.message).not.toContain('Supervisor not running');
+      expect(check?.message).toContain('inconclusive under --fast');
+    });
+  });
+
+  test('same fixture WITHOUT --fast (engine still null here, simulating DB-down rather than DB-skipped) → still just inconclusive, never asserts running=true', async () => {
+    await withIsolatedHome(async () => {
+      writeSupervisorEvent({ event: 'started', ts: new Date().toISOString() }, 12345);
+      // No --fast this time: engine is still null (this test doesn't stand
+      // up a real DB), but dbLockCheckSkippedUnderFast requires fastMode to
+      // be true — so this exercises the ORIGINAL (pre-#4518) branch, which
+      // legitimately warns when nothing can prove liveness and it isn't the
+      // --fast case. Confirms the fix is --fast-specific, not a blanket
+      // "engine is null" suppression that would swallow a real DB-down signal.
+      const checks = await buildChecks(null, []);
+      const check = supervisorCheck(checks);
+      expect(check?.status).toBe('warn');
+      expect(check?.message).toContain('Supervisor not running');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4518.

`gbrain doctor --fast` could permanently report `supervisor: not running` for a supervisor that is demonstrably alive, on the documented multi-queue pattern (distinct `--pid-file` per named queue, e.g. `--queue cron --pid-file ~/.gbrain/supervisor-cron.pid` alongside `--queue default --pid-file ~/.gbrain/supervisor-default.pid`).

## Root cause

The check reads a single un-scoped `DEFAULT_PID_FILE` (`~/.gbrain/supervisor.pid`). Any install using per-queue `--pid-file` values never writes that path, so `pidfileRunning` is always `false` for that install shape. The intended fallback — a DB singleton-lock lookup added specifically by #1849 to catch exactly this pidfile-path mismatch class — requires `engine`, which `cli.ts` hard-codes to `null` under `--fast` (`if (args.includes('--fast')) { ... runDoctor(null, ...) }`) before ever attempting a connection. So the #1849 fix is structurally unreachable under `--fast`, and the check falls back to asserting "not running" on evidence (an empty pidfile check) it never actually completed.

## Fix

Track when the DB-lock fallback was skipped *specifically because of `--fast`* (not a "DB is actually down" case — see the added test that confirms a real DB-down scenario, i.e. `engine` null WITHOUT `--fast`, still correctly warns). When that's the situation, downgrade to an `'ok'` check that says the pidfile check came back inconclusive under `--fast`, rather than asserting a liveness verdict the run structurally couldn't determine.

## Tests

3 new cases (`test/doctor-fast-supervisor.test.ts`):
- no supervisor ever observed → no check at all (unaffected baseline)
- audit events exist but no default-path pidfile under `--fast` → ok/inconclusive, not the false "not running" warn (the #4518 regression case itself)
- same fixture without `--fast` → still warns (confirms the fix is `--fast`-specific, not a blanket engine-null suppression that would swallow a real DB-down signal)

0 fail. 133 existing doctor/self-upgrade/categories/supervisor-pidfile tests — 0 fail, unchanged.

`bun run typecheck`, `bun run check:module-size`, `bun run verify` (54/54) all clean.

`scripts/module-size-limits.tsv`: `doctor.ts` 4422→4443 (new branch + comment explaining the `--fast`/DB-lock interaction).

No schema migration.