### PR TITLE
fix(pglite-repair): use the shared confirm-prompt helper to close the same #4318 race

### DIFF
--- a/test/pglite-repair-command.serial.test.ts
+++ b/test/pglite-repair-command.serial.test.ts
@@ -22,6 +22,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
+import { PassThrough } from 'node:stream';
 
 import { runPgliteRepair } from '../src/commands/pglite-repair.ts';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -38,6 +39,31 @@ function makeFakeLayout(dir: string): void {
   mkdirSync(join(dir, 'pg_wal'), { recursive: true });
   writeFileSync(join(dir, 'PG_VERSION'), '17\n');
   writeFileSync(join(dir, 'global', 'pg_control'), Buffer.alloc(8192));
+}
+
+/**
+ * Swap the global `process.stdin` for a fake TTY-flagged PassThrough for the
+ * duration of `fn`, writing `answer` to it shortly after `fn` starts (so the
+ * interactive `rl.question` inside `promptYesNo` has already attached its
+ * listener). Restores the real `process.stdin` in `finally` regardless of
+ * outcome. Confirmed to work under both node and bun (readline reads
+ * `process.stdin` at call time, not import time).
+ */
+async function withInteractiveAnswer<T>(answer: string, fn: () => Promise<T>): Promise<T> {
+  // Restore the ORIGINAL property descriptor, not just the original value:
+  // on Node this is a getter, and on Bun a plain data property whose
+  // writable/enumerable flags must match what we found (codex review).
+  const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')!;
+  const fake = new PassThrough() as unknown as NodeJS.ReadStream;
+  (fake as unknown as { isTTY: boolean }).isTTY = true;
+  Object.defineProperty(process, 'stdin', { value: fake, configurable: true });
+  try {
+    const resultPromise = fn();
+    setTimeout(() => (fake as unknown as PassThrough).write(`${answer}\n`), 20);
+    return await resultPromise;
+  } finally {
+    Object.defineProperty(process, 'stdin', realStdinDescriptor);
+  }
 }
 
 function writeLockFile(dir: string, lock: Record<string, unknown>): string {
@@ -293,7 +319,34 @@ describe('gbrain pglite-repair — TTY + config gates', () => {
     expect(existsSync(`${dir}.wal-repair-attempt.json`)).toBe(false);
   });
 
-  test('9. no --path with a non-pglite configured engine: exit 1, not_pglite', async () => {
+  test('9. interactive "y" answer proceeds with repair (#4318 close-before-resolve race)', async () => {
+    // Regression for #4318: the old inline promptYesNo in this file called
+    // rl.close() BEFORE resolving the answer, and its unguarded
+    // rl.on('close', () => resolve(false)) fired synchronously during that
+    // close — so a typed "y" still resolved false and the command took the
+    // "Aborted" branch. This pins that a "y" answer is honored end-to-end
+    // through the actual interactive confirm gate (not just via the shared
+    // helper's own unit tests in test/confirm-prompt.test.ts).
+    const dir = join(tmp('gbrain-repair-interactive-'), 'brain.pglite');
+    makeFakeLayout(dir);
+
+    const cap = captureConsole();
+    try {
+      await withInteractiveAnswer('y', () => runPgliteRepair(['--path', dir, '--json']));
+    } finally {
+      cap.restore();
+    }
+
+    const out = parseJsonLine(cap.logs);
+    // The race resolved the confirm to `false` even for a typed "y" — the
+    // broken behavior always produced this exact receipt. Assert its absence
+    // rather than a specific return code, since what happens AFTER a
+    // correctly-honored "y" (repair attempted on this fake layout) is
+    // covered by other tests in this file.
+    expect(out).not.toEqual({ status: 'aborted', reason: 'user_declined' });
+  }, 30_000);
+
+  test('10. no --path with a non-pglite configured engine: exit 1, not_pglite', async () => {
     // Hermetic GBRAIN_HOME (same convention as apply-migrations-pglite-spawn):
     // configDir() appends '.gbrain', so the config lands at <home>/.gbrain/.
     const home = tmp('gbrain-repair-home-');


### PR DESCRIPTION
Fixes the same close-before-resolve race from #4318 for the one call site the
original fix missed.

## Background

#4318 reported that `promptYesNo` could resolve `false` even when the user
typed "y", because the old inline implementations called `rl.close()` before
resolving the answer, and their unguarded `rl.on('close', ...)` listener fired
synchronously during that close, settling the promise to `false` first.

The maintainer's fix introduced a shared helper, `src/core/confirm-prompt.ts`
(resolves the real answer first, then closes; the `close` listener only
declines on a true EOF), and migrated `src/core/sync-cost-gate.ts` and
`src/commands/reindex-code.ts` to use it. `src/commands/pglite-repair.ts` was
not migrated and still carries its own inline `promptYesNo` with the exact
same bug: an interactive "y" answer to `Repair now? [y/N]` could still be
read as a decline.

## Fix

Removes `pglite-repair.ts`'s local `promptYesNo` (and its now-unused
`readline` import) and switches its one call site to the shared helper,
matching the pattern already used by `sync-cost-gate.ts` / `reindex-code.ts`.
No new design — same helper, same question text (`Repair now? [y/N] `), same
stderr-not-stdout prompt destination (so `--json` output stays clean on
stdout), same "EOF declines" semantics. The TTY guard that gated this call
site already lives at the call site (`if (!process.stdin.isTTY)`, a few lines
above), so it doesn't need to be re-checked inside the prompt helper itself —
this matches how the other two call sites are wired.

## Test

Added a regression test to `test/pglite-repair-command.serial.test.ts` that
exercises the real interactive confirm path through `runPgliteRepair` itself
(not just the shared helper's own unit tests in `test/confirm-prompt.test.ts`):
swaps the global `process.stdin` for a fake TTY-flagged stream, types "y",
and asserts the command does NOT take the `{status: 'aborted', reason:
'user_declined'}` branch — the exact receipt the pre-fix race produced for a
typed "y".

Discrimination test: reverted `src/commands/pglite-repair.ts` to HEAD, ran
`test/pglite-repair-command.serial.test.ts` → 12 pass / 1 fail. Restored →
all pass.

## Scope

This PR only migrates `pglite-repair.ts` to the shared helper — no other
changes.
