### PR TITLE
fix(cycle): preserve UTF-16 surrogate boundaries in extract_atoms and embedding truncation (#4528)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -31,12 +31,12 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
 
+import { truncateUtf8 } from '../text-safe.ts';
 import {
   BudgetTracker,
   extractUsageFromError as _extractUsageFromError,
   type BudgetKind,
 } from '../budget/budget-tracker.ts';
-
 import type {
   AIGatewayConfig,
   EmbedMultimodalOpts,
@@ -1783,7 +1783,7 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const resolveTarget = opts?.embeddingModel ?? getEmbeddingModel();
   const tracker = __budgetStore.getStore() ?? null;
   const { model, recipe, modelId } = await resolveEmbeddingProvider(resolveTarget);
-  const truncated = texts.map(t => (t ?? '').slice(0, MAX_CHARS));
+  const truncated = texts.map(t => truncateUtf8(t ?? '', MAX_CHARS));
 
   // Reserve up front for the worst-case batch token count. Embeddings have
   // no output rate, so maxOutputTokens=0. record() at the end uses the

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -57,6 +57,7 @@ import { chat as gatewayChat, withBudgetTracker, isAvailable } from '../ai/gatew
 import { createGlobalLlmHaltTracker, haltedClassOf, type GlobalLlmErrorClass } from '../ai/errors.ts';
 import { importFromContent } from '../import-file.ts';
 import { serializeMarkdown } from '../markdown.ts';
+import { truncateUtf8 } from '../text-safe.ts';
 import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budget-tracker.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
@@ -714,7 +715,7 @@ export async function runPhaseExtractAtoms(
         messages: [
           {
             role: 'user',
-            content: `Source: ${originLabel}\n\n---\n\n${item.content.slice(0, 50_000)}`,
+            content: `Source: ${originLabel}\n\n---\n\n${truncateUtf8(item.content, 50_000)}`,
           },
         ],
         maxTokens: 4096,

--- a/test/ai/embedQuery.test.ts
+++ b/test/ai/embedQuery.test.ts
@@ -75,6 +75,28 @@ describe('embedQuery — return shape', () => {
   });
 });
 
+describe('embed — input truncation', () => {
+  test('never splits a UTF-16 surrogate pair at MAX_CHARS', async () => {
+    configureOpenAI();
+    const input = `${'a'.repeat(7_999)}💡trailing prose`;
+    let captured = '';
+    __setEmbedTransportForTests((async (args: any) => {
+      captured = args.values[0];
+      return fakeEmbeddings(1, 1536);
+    }) as any);
+
+    await embed([input]);
+
+    expect(input.slice(0, 8_000).isWellFormed()).toBe(false); // positive control
+    expect(captured.isWellFormed()).toBe(true);
+    // Truncation must actually occur (not a no-op that trivially passes well-formedness):
+    // the straddling pair moves the safe cut back to 7,999, dropping both the emoji and
+    // the trailing prose entirely.
+    expect(captured.length).toBe(7_999);
+    expect(captured).not.toContain('trailing prose');
+  });
+});
+
 describe('embedQuery — inputType plumbing (ZE asymmetric)', () => {
   beforeEach(() => configureZE());
 

--- a/test/extract-atoms-failure-classes.test.ts
+++ b/test/extract-atoms-failure-classes.test.ts
@@ -90,6 +90,31 @@ describe('parseAtomsOutcome — typed parse (gbrain#4148)', () => {
 });
 
 describe('runPhaseExtractAtoms — failure classes (gbrain#4148)', () => {
+  test('prompt truncation never splits a UTF-16 surrogate pair', async () => {
+    await seedPage('note/surrogate-boundary');
+    const content = `${'a'.repeat(49_999)}💡trailing prose`;
+    let capturedPrompt = '';
+
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: [{ slug: 'note/surrogate-boundary', content, contentHash: HASH_A }],
+      _chat: async (opts: ChatOpts) => {
+        capturedPrompt = String(opts.messages[0]?.content);
+        return okChatResult('[]');
+      },
+    });
+
+    expect(content.slice(0, 50_000).isWellFormed()).toBe(false); // positive control
+    expect(capturedPrompt.isWellFormed()).toBe(true);
+    // Truncation must actually occur (not a no-op that trivially passes well-formedness):
+    // the straddling pair moves the safe cut back to 49,999 'a's, dropping both the emoji
+    // and the trailing prose from the sent prompt entirely.
+    expect(capturedPrompt).not.toContain('trailing prose');
+    expect(capturedPrompt).toContain('a'.repeat(49_999));
+    expect(capturedPrompt.length).toBe(`Source: note/surrogate-boundary\n\n---\n\n${'a'.repeat(49_999)}`.length);
+  });
+
   test('malformed output is a counted failure, NOT a zero-yield tombstone', async () => {
     await seedPage('note/m1');
     const result = await runPhaseExtractAtoms(engine, {


### PR DESCRIPTION
## What

`runPhaseExtractAtoms()` truncates page content with a raw `item.content.slice(0, 50_000)` before it goes into the chat request body. When the cut lands between the high and low half of a UTF-16 surrogate pair, the resulting string carries a lone surrogate. `JSON.stringify()` doesn't error on this, but the UTF-8 bytes on the wire are invalid, and the provider rejects the request with `Invalid body: failed to parse JSON value`. Because the page's content hash never changes, the same boundary is hit on every retry — the page fails **100% deterministically, forever** (there's no retry cap; `atoms_fail_count` is written to frontmatter but never read for eligibility exclusion). This also inflates the `extract_health` doctor check's per-kind halt-rate (batch-level: any batch containing the stuck page counts as a full halt).

Same root cause as #2011 (`excerpt()`, fixed) and #4199/PR #4311 (`gatherReflections()`, merged in v0.46.23.0) — both moved to the existing `truncateUtf8()` helper in `src/core/text-safe.ts`. This call site wasn't covered by either prior fix.

Also applies the same fix to the embedding batch truncation in `src/core/ai/gateway.ts` (`texts.map(t => (t ?? '').slice(0, MAX_CHARS))`) — structurally identical pattern, flagged as preventive since I haven't independently reproduced a live failure there.

## Why

Fixes #4528. Observed in production: a single ChatGPT-export page (79,989 chars, contains an emoji straddling the 50,000-char cut) failed 500+ times across one drain session before the root cause was isolated (instrumented with a temporary debug print, confirmed `LONE HIGH SURROGATE at 49999, 0xd83d`, then reverted).

## Discrimination test

Discrimination test: reverted `src/core/cycle/extract-atoms.ts` to upstream/master, ran `test/extract-atoms-failure-classes.test.ts` → 16 pass / 1 fail. Restored → all pass.

Discrimination test: reverted `src/core/ai/gateway.ts` to upstream/master, ran `test/ai/embedQuery.test.ts` → 8 pass / 1 fail. Restored → all pass.

Both regression tests also assert a positive control: the *original* `.slice()` output on the same fixture is `!isWellFormed()` (proves the pre-fix bug is real), then asserts the fixed output `isWellFormed()`.

## Tests

- `test/extract-atoms-failure-classes.test.ts` — new case: `prompt truncation never splits a UTF-16 surrogate pair`
- `test/ai/embedQuery.test.ts` — new case: `never splits a UTF-16 surrogate pair at MAX_CHARS`
- `bun test test/extract-atoms-failure-classes.test.ts test/ai/embedQuery.test.ts` → 26 pass / 0 fail (86 assertions)
- `bun run typecheck` → clean
- `bun run verify` (54 checks) → all green