### PR TITLE
fix(search): collapse duplicate exact identity chunks

### DIFF
--- a/src/core/search/exact-lookup.ts
+++ b/src/core/search/exact-lookup.ts
@@ -173,16 +173,27 @@ export async function applyExactLookupTier(
 
   for (const hit of hits) {
     injectScore += 1e-6;
-    const idx = out.findIndex(
-      (r) => r.slug === hit.slug && (r.source_id ?? 'default') === (hit.source_id ?? 'default'),
-    );
-    if (idx >= 0) {
-      // Promote in place: identity match outranks every scored row.
-      out[idx].score = injectScore;
-      out[idx].exact_lookup = hit.exact_lookup;
-      if (hit.alias_hit) out[idx].alias_hit = true;
+    const matchingIndexes = out.flatMap((r, idx) => (
+      r.slug === hit.slug && (r.source_id ?? 'default') === (hit.source_id ?? 'default')
+        ? [idx]
+        : []
+    ));
+    if (matchingIndexes.length > 0) {
+      // Search is chunk-grained, but an exact identity lookup is page-grained.
+      // Promote the best existing chunk and remove the same page's remaining
+      // chunks so the canonical identity appears exactly once on the wire.
+      const idx = matchingIndexes.reduce((best, candidate) => (
+        out[candidate].score > out[best].score ? candidate : best
+      ));
+      const promoted = out[idx];
+      promoted.score = injectScore;
+      promoted.exact_lookup = hit.exact_lookup;
+      if (hit.alias_hit) promoted.alias_hit = true;
       if (hit.title_match_boost) {
-        out[idx].title_match_boost = Math.max(out[idx].title_match_boost ?? 1.0, hit.title_match_boost);
+        promoted.title_match_boost = Math.max(promoted.title_match_boost ?? 1.0, hit.title_match_boost);
+      }
+      for (const duplicateIdx of matchingIndexes.slice().sort((a, b) => b - a)) {
+        if (duplicateIdx !== idx) out.splice(duplicateIdx, 1);
       }
       continue;
     }

--- a/test/search/exact-lookup.test.ts
+++ b/test/search/exact-lookup.test.ts
@@ -129,14 +129,20 @@ describe('applyExactLookupTier (#1663)', () => {
     expect(out.length).toBe(3);
   });
 
-  test('promotes (does not duplicate) an identity match already in the set', async () => {
+  test('promotes and collapses an identity match repeated by chunk results', async () => {
     await engine.putPage('people/alice-example', {
       type: 'person', title: 'Alice Example', compiled_truth: 'Founder.',
     });
-    const organic = [res('notes/unrelated', 0.9), res('people/alice-example', 0.2)];
+    const organic = [
+      res('notes/unrelated', 0.9),
+      res('people/alice-example', 0.2, { chunk_text: 'best page chunk' }),
+      res('people/alice-example', 0.1, { chunk_text: 'weaker page chunk' }),
+    ];
     const out = await applyExactLookupTier(engine, organic, 'people/alice-example', { sourceId: 'default' });
     expect(out.filter((r) => r.slug === 'people/alice-example').length).toBe(1);
+    expect(out.length).toBe(2);
     expect(out[0].slug).toBe('people/alice-example');
+    expect(out[0].chunk_text).toBe('best page chunk');
     expect(out[0].exact_lookup).toBe('slug');
   });
 


### PR DESCRIPTION
## Summary

- keep only one result for an exact `(source_id, slug)` identity page when hybrid search returns multiple chunks
- preserve and promote the strongest-scoring matching chunk
- leave unrelated organic results unchanged

## Regression coverage

- exact identity match repeated by two chunk results collapses to one rank-1 result
- strongest chunk is retained
- source isolation and supersession behavior remain covered

## Verification

- `bun test test/search/exact-lookup.test.ts` (10 pass)
- `bun run typecheck`
- `bun run check:module-size`
- `git diff --check`