### PR TITLE
fix(doctor): exclude fact-extraction-disabled pages from backlog

### DIFF
--- a/src/commands/doctor/checks/search-eval.ts
+++ b/src/commands/doctor/checks/search-eval.ts
@@ -633,6 +633,10 @@ export async function computeConversationFactsBacklogCheck(
             COALESCE(TO_CHAR(p.effective_date AT TIME ZONE 'UTC', 'YYYY-MM-DD'), 'none')
          WHERE p.type = ANY($1::text[])
            AND p.deleted_at IS NULL
+           AND COALESCE(
+             LOWER(BTRIM(p.frontmatter->>'fact_extraction')) NOT IN ('false', '0', 'no', 'off'),
+             true
+           )
            AND COALESCE(BTRIM(p.frontmatter->>'raw_transcript'), '') = ''
            AND p.content_hash IS NOT NULL
          GROUP BY p.source_id, p.slug
@@ -660,6 +664,10 @@ export async function computeConversationFactsBacklogCheck(
          FROM pages
         WHERE type = ANY($1::text[])
           AND deleted_at IS NULL
+          AND COALESCE(
+            LOWER(BTRIM(frontmatter->>'fact_extraction')) NOT IN ('false', '0', 'no', 'off'),
+            true
+          )
           AND (
             COALESCE(BTRIM(frontmatter->>'raw_transcript'), '') <> ''
             OR content_hash IS NULL
@@ -680,6 +688,14 @@ export async function computeConversationFactsBacklogCheck(
           });
           if (batch.length === 0) break;
           const verifyInProcess = batch.filter((page) => {
+            const factExtraction = page.frontmatter?.fact_extraction;
+            if (
+              factExtraction === false ||
+              (typeof factExtraction === 'string' &&
+                ['false', '0', 'no', 'off'].includes(
+                  factExtraction.trim().toLowerCase(),
+                ))
+            ) return false;
             const raw = page.frontmatter?.raw_transcript;
             return (typeof raw === 'string' && raw.trim().length > 0) ||
               page.content_hash == null;

--- a/test/doctor-conversation-facts-backlog.test.ts
+++ b/test/doctor-conversation-facts-backlog.test.ts
@@ -81,6 +81,21 @@ describe('conversation_facts_backlog durable outcomes', () => {
     expect(result.details?.scanned_not_extractable).toBe(1);
   });
 
+  test('excludes pages whose source policy disables fact extraction', async () => {
+    await engine.putPage('conversations/raw-evidence', {
+      type: 'conversation',
+      title: 'Raw evidence copy',
+      compiled_truth: 'A raw support page that must not enter the extraction backlog.',
+      timeline: '',
+      frontmatter: { fact_extraction: false },
+    });
+
+    const result = await computeConversationFactsBacklogCheck(engine);
+    expect(result.details?.backlog).toBe(0);
+    expect(result.details?.completed).toBe(0);
+    expect(result.details?.scanned_not_extractable).toBe(0);
+  });
+
   test('a content change invalidates the prior outcome', async () => {
     await seedPage('meetings/growing', 'meeting');
     await seedOutcome('meetings/growing', TERMINAL_AUDIT_SOURCE);


### PR DESCRIPTION
## Summary
- make `conversation_facts_backlog` use the same `fact_extraction: false|0|no|off` exclusion as the extractor selectors
- apply the exclusion to regular pages and exceptional sidecar/null-hash verification
- add a regression proving disabled raw evidence pages do not inflate the backlog

## Why
The extraction command deliberately skips pages whose source policy disables fact extraction, but Doctor counted them as unfinished forever. On large transcript brains this turns tens of thousands of intentional raw/support pages into a false backlog warning.

## Verification
- `bun test test/doctor-conversation-facts-backlog.test.ts` (4 pass)
- `bun run typecheck`
- `bun run check:module-size`
- `bun run ci:local:diff` reached Docker E2E setup; Docker daemon was unavailable on the host
