### PR TITLE
fix(markdown): split timeline only on the exact ## Timeline / ## History heading

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -550,7 +550,7 @@ export function findTimelineSplitIndex(lines: string[]): number {
       for (let j = i + 1; j < lines.length; j++) {
         const next = lines[j].trim();
         if (next.length === 0) continue;
-        if (/^##\s+(timeline|history)\b/i.test(next)) return i;
+        if (/^##\s+(timeline|history)\s*$/i.test(next)) return i;
         break;
       }
     }

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -139,6 +139,25 @@ describe('splitBody', () => {
     expect(timeline).toContain('## History');
   });
 
+  // rule 3's heading match used \b, which matches any heading that
+  // merely STARTS with "Timeline"/"History" ("## History & Reach",
+  // "## Timeline of Events"). That silently moved the rest of an ordinary
+  // article into the timeline half. Rule 3 is a back-compat shim for pages
+  // gbrain itself wrote, so it takes the exact heading only.
+  test('does NOT split at --- when the heading only STARTS with History', () => {
+    const body = 'Article content\n\n---\n\n## History & Reach\n\n- item';
+    const { compiled_truth, timeline } = splitBody(body);
+    expect(compiled_truth).toBe(body);
+    expect(timeline).toBe('');
+  });
+
+  test('does NOT split at --- when the heading only STARTS with Timeline', () => {
+    const body = 'Article content\n\n---\n\n## Timeline of Events\n\ntext';
+    const { compiled_truth, timeline } = splitBody(body);
+    expect(compiled_truth).toBe(body);
+    expect(timeline).toBe('');
+  });
+
   test('does NOT split at plain --- (horizontal rule in article body)', () => {
     const body = 'Above the line\n\n---\n\nBelow the line';
     const { compiled_truth, timeline } = splitBody(body);
@@ -255,6 +274,42 @@ Second section.
     expect(parsed.compiled_truth).toContain('Second section.');
     expect(parsed.compiled_truth).not.toContain('Timeline entry');
     expect(parsed.timeline).toContain('Timeline entry');
+  });
+
+  test('keeps the whole body when a section heading merely starts with History', () => {
+    // Real shape from an imported chat transcript: HR-separated sections,
+    // one of them '## History & Reach'. Pre-fix the page was cut at the HR
+    // and everything below it landed in the timeline column.
+    const md = `---
+type: source
+title: Example show
+---
+
+Here's a breakdown of how it works.
+
+---
+
+## Format & Premise
+
+- 30 singles date in pods.
+
+---
+
+## History & Reach
+
+- The show premiered in 2020.
+
+---
+
+## Reception
+
+- Critics noted the format.`;
+    const parsed = parseMarkdown(md);
+    expect(parsed.timeline).toBe('');
+    expect(parsed.compiled_truth).toContain('## Format & Premise');
+    expect(parsed.compiled_truth).toContain('## History & Reach');
+    expect(parsed.compiled_truth).toContain('premiered in 2020');
+    expect(parsed.compiled_truth).toContain('## Reception');
   });
 
   test('handles frontmatter without type or title', () => {


### PR DESCRIPTION
## What

`splitBody` treated any H2 that merely *starts with* "Timeline" or "History" as a timeline
sentinel. A page like

```markdown
Intro paragraph.

---

## History & Reach

- The show premiered in 2020.

---

## Reception

- Critics noted the format.
```

was cut at the first `---`: `compiled_truth` kept only `Intro paragraph.`, and
`## History & Reach` plus every section after it moved into the `timeline` column.
`put_page` returned success. The writer had no way to know.

After this PR the page stays whole, the `---` stays a horizontal rule, and `timeline` is empty.

## Why

`findTimelineSplitIndex` rule 3 — a bare `---` immediately before a `## Timeline` /
`## History` heading — is a back-compat shim for pages gbrain itself wrote. It matched the
heading with `\b`:

```ts
if (/^##\s+(timeline|history)\b/i.test(next)) return i;
```

`\b` rules out a *suffixed* word (`## Timelines` correctly does not match — there is a test
for that), but it still matches every *multi-word* heading: `## History & Reach`,
`## Timeline of Events`, `## History of the Company`. Those are ordinary article headings,
not sentinels.

Rule 3 exists to parse gbrain's own `---` + `## Timeline` output, so the exact heading is
the whole intended surface. Anchoring at end-of-line is the fix:

```ts
if (/^##\s+(timeline|history)\s*$/i.test(next)) return i;
```

The docstring above `splitBody` already describes rule 3 as *"the next non-empty line is
`## Timeline` or `## History`"* — this makes the code match the doc.

`findBareTimelineSection` (the #2225 no-sentinel path) uses the same regex but is gated on
the section being dated-bullet-shaped, so prose sections cannot fall through it. **It is
deliberately not touched here.**

### How it showed up

Auditing an imported chat archive: 2 of 829 pages had their body cut at a `---` preceding a
`## History & Reach` / `## History & Scale` section, relocating 7,969 characters into
`timeline`. Symptoms are quiet — no error, and `get_page` still returns both fields — but
the page's compiled truth is truncated and the chunks land with `chunk_source: 'timeline'`.

**It also self-perpetuates.** `put_page`'s write-through renders the page with
`serializeMarkdown`, which emits `<!-- timeline -->` whenever `timeline` is non-empty. So the
original `---` horizontal rule is *replaced on disk* by an explicit sentinel:

```diff
  - After the finale, there's usually a reunion special ...

- ---
+ <!-- timeline -->

  ## History & Reach
```

Once that lands, rule 1 matches on every subsequent parse and rule 3 never runs again — the
wrong split survives the code fix and any later `gbrain sync`. Recovering a page means
rewriting it from its pre-import source, not re-syncing the brain repo.

### Minimal repro

```ts
import { splitBody } from './src/core/markdown.ts';

splitBody('Article content\n\n---\n\n## History & Reach\n\n- item');
// before: { compiled_truth: 'Article content', timeline: '## History & Reach\n\n- item' }
// after:  { compiled_truth: <whole body>,      timeline: '' }
```

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/markdown.ts` to merge-base, ran `test/markdown.test.ts` → `64 pass / 3 fail`. Restored → all pass.

## Tests

`test/markdown.test.ts` (+3 cases, +55 lines):

- `splitBody` — `---` + `## History & Reach` does NOT split
- `splitBody` — `---` + `## Timeline of Events` does NOT split
- `parseMarkdown` — real frontmatter + four `---`-separated sections including
  `## History & Reach`: whole body stays in `compiled_truth`, `timeline` is empty

Existing back-compat cases (`---` + exact `## Timeline`, `---` + exact `## History`) still
pass unchanged, as does the whole #2225 bare-heading suite (`## Timelines` word boundary,
prose `## History`, fenced `## Timeline`, `### Timeline`, dated-bullet shape gate).

```
$ bun test test/markdown.test.ts test/markdown-serializer.test.ts test/markdown-validation.test.ts \
           test/fuzz/mixed-validators.test.ts test/gbrain-to-envelope.test.ts
186 pass / 0 fail   (exit 0)
```

---
