### PR TITLE
fix(search): let CJK queries reach the cross-modal path

### DIFF
--- a/src/core/search/query-intent.ts
+++ b/src/core/search/query-intent.ts
@@ -191,6 +191,38 @@ const SALIENCE_ON_PATTERNS = [
 // where text might have worked." False negatives cost nothing (the legacy
 // text path still runs). The LLM-intent escalation in Commit 4 catches
 // genuinely ambiguous phrasings.
+//
+// CJK note: the English patterns are unreachable for Chinese and Japanese
+// queries, because JavaScript's `\b` is an ASCII word boundary.
+// A Han or Kana character is not a `\w` character, so no boundary ever exists
+// beside it — /\b照片\b/ cannot match the string "照片". CJK queries therefore
+// always fell through to 'text' and never reached the embedding_image column,
+// however many image chunks the brain holds.
+//
+// The CJK bank anchors on structure instead of word boundaries: the possessive
+// 的 / の, a picture measure word (张/幅/组), or an action verb next to the
+// visual noun. Conservatism matches the English bank on purpose — a bare
+// visual noun ("截图", like a bare "screenshot") stays 'text', because 'image'
+// modality is exclusive (D9 skips keyword search), so a false positive drops
+// text results rather than merely adding an image search.
+const CJK_VISUAL_NOUNS =
+  '照片|相片|图片|圖片|图像|圖像|截图|截圖|截屏|画面|畫面|影像|图表|圖表|' +
+  '写真|画像|イラスト|スクショ|スクリーンショット';
+
+const CJK_VISUAL_VERBS =
+  '找|搜|搜索|查找|翻出|给我|給我|看看|显示|顯示|展示';
+
+const CROSS_MODAL_PATTERNS_CJK: RegExp[] = [
+  // "蓝色羽绒服的照片" / "小花笑的图片" / "那张截图" / "猫の写真"
+  new RegExp(`(的|の|[张張幅组組])\\s*(${CJK_VISUAL_NOUNS})`),
+  // verb-initial (zh): "找一下蓝色羽绒服照片"
+  new RegExp(`(${CJK_VISUAL_VERBS})[^\\n]{0,20}?(${CJK_VISUAL_NOUNS})`),
+  // verb-final (ja): "写真を見せて" / "画像を探して"
+  new RegExp(`(${CJK_VISUAL_NOUNS})\\s*(を|が|は)?\\s*(見せ|見たい|探し|見つけ)`),
+  // "X 长什么样" — the CJK form of "what does X look like"
+  /长(得)?(什么|甚么|啥)样|長(得)?(什麼|甚麼)樣/,
+];
+
 const CROSS_MODAL_PATTERNS: RegExp[] = [
   /\b(show|find|get|pull)\s+(me\s+)?(the\s+)?(photos?|images?|pictures?|pics?|screenshots?)\b/i,
   /\b(photos?|images?|pictures?|pics?|screenshots?)\s+(of|from|at|with|showing|featuring)\b/i,
@@ -198,6 +230,7 @@ const CROSS_MODAL_PATTERNS: RegExp[] = [
   /\b(whiteboard|diagram|slide|screenshot|infographic|chart)s?\s+(of|from|about|showing)\b/i,
   /\bdiagram\s+(of|for|showing)\b/i,
   /\bvisual(s|ly)?\s+(of|from|about|showing|representation)\b/i,
+  ...CROSS_MODAL_PATTERNS_CJK,
 ];
 
 // v0.36 cross-modal wave (Commit 4 prep): visual nouns that combined with

--- a/test/cross-modal-phase1.test.ts
+++ b/test/cross-modal-phase1.test.ts
@@ -65,6 +65,49 @@ describe('query-intent — suggestedModality regex (D6 + D14)', () => {
   }
 });
 
+describe('query-intent — suggestedModality is multilingual (CJK)', () => {
+  // Discrimination: `\b` is an ASCII word boundary, so the English bank can
+  // never match a Han/Kana query. Every positive below returns 'text' against
+  // the English-only patterns.
+  const cjkImagePhrasings = [
+    '找一下那张蓝色羽绒服的照片',   // verb + measure word + 的 + 照片
+    '小花笑的图片',                 // 的 + 图片
+    '那张截图',                     // measure word + 截图
+    '搜索去年的相片',               // verb + 的 + 相片
+    '找一下蓝色羽绒服照片',         // verb-initial, no possessive
+    '这件衣服长什么样',             // "what does X look like"
+    '幫我找那張截圖',               // traditional Chinese
+    '猫の写真を見せて',             // Japanese, particle の
+    '画像を探して',                 // Japanese, verb-final
+  ];
+
+  for (const query of cjkImagePhrasings) {
+    test(`CJK image phrasing: "${query}" → image`, () => {
+      expect(classifyQuery(query).suggestedModality).toBe('image');
+    });
+  }
+
+  const cjkTextPhrasings = [
+    '图书馆的开放时间',   // 图书馆 is not a visual noun
+    '图片压缩算法的原理', // visual noun with no request structure around it
+    '截图',               // bare visual noun — parity with bare "screenshot"
+    '这个项目的进展',
+    '影像科的报告在哪',   // 影像科 is a department, not a request for images
+    '写真集の出版年',     // Japanese, no request verb
+  ];
+
+  for (const query of cjkTextPhrasings) {
+    test(`CJK text phrasing: "${query}" → text`, () => {
+      expect(classifyQuery(query).suggestedModality).toBe('text');
+    });
+  }
+
+  test('English classification is unchanged by the CJK bank', () => {
+    expect(classifyQuery('show me photos of acme').suggestedModality).toBe('image');
+    expect(classifyQuery('who is acme corp').suggestedModality).toBe('text');
+  });
+});
+
 describe('isAmbiguousModalityQuery (Commit 4 prep)', () => {
   // Genuinely ambiguous = visual noun present + reference marker present BUT
   // CROSS_MODAL_PATTERNS doesn't catch it (otherwise regex already classified


### PR DESCRIPTION
## What

`CROSS_MODAL_PATTERNS` in `src/core/search/query-intent.ts` is the only
thing that flips `suggestedModality` to `'image'`, and every pattern in it
is guarded by `\b`. That makes the whole cross-modal wave unreachable from a
Chinese or Japanese query. This adds a CJK pattern bank beside the English
one, using the same conservatism.

## Why

JavaScript's `\b` is an ASCII word boundary — it asserts that exactly one
side is a `\w` character (`[A-Za-z0-9_]`). Han, Kana and Hangul characters
are not `\w`, so no boundary position ever exists beside them:

```js
```

So `classifyQuery` returns `'text'` for every CJK query regardless of
phrasing, `hybridSearch` never embeds it with the multimodal model, and rows
carrying `embedding_image` are never candidates — their `embedding` column is
`null`, so the text arm cannot surface them either. On a brain with a few
thousand image chunks, image search is simply off for those users.

## How it showed up

A brain with 2,181 `modality='image'` chunks (all with `embedding IS NULL`
on the text column, as `reindex --multimodal` leaves them). Every English
phrasing routes to the image column. Every Chinese phrasing of the same
intent returns text chunks only, so the image corpus is unreachable in
practice, not merely lower-ranked.

## Minimal repro

```js
// before
classifyQuery('show me photos of the offsite').suggestedModality // 'image'

// after
classifyQuery('show me photos of the offsite').suggestedModality // 'image'
```

## Approach

The CJK bank cannot use word boundaries, so it anchors on structure instead:

- the possessive `的` / `の`, or a picture measure word (`张`/`幅`/`组`),
  immediately before a visual noun — `蓝色羽绒服的照片`, `那张截图`, `猫の写真`
- a request verb near the visual noun, for verb-initial Chinese
  (`找一下…照片`) and verb-final Japanese (`写真を見せて`)
- `长什么样`, the CJK form of the existing "what does X look like" pattern

Traditional forms are folded into the same alternations (`圖片`, `截圖`,
`長什麼樣`), since they share the Han block and cost nothing to add.

Two deliberate limits:

1. **A bare visual noun still classifies as `'text'`** — `截图` behaves like a
   bare `screenshot`, which the English bank also declines to fire on. This
   parity matters more than the existing comment suggests: under D9, `'image'`
   modality is *exclusive* — it skips the keyword arm entirely — so a false
   positive drops text results rather than merely adding an image search.
2. **`AMBIGUOUS_MODALITY_NOUNS` / `AMBIGUOUS_REFERENCE_MARKERS` are untouched.**
   They gate the opt-in LLM tie-break, which is off by default; widening them
   would add surface with no effect on the default path.

Korean is not covered here — the same structural approach extends to it, but
I have no corpus to validate the particle set against.

## Discrimination test

Reverting only `src/core/search/query-intent.ts` to `master` and keeping the
new tests:

```
52 pass, 9 fail   ← the 9 CJK positives, all returning 'text'
```

With the fix applied: `61 pass, 0 fail`. The 6 CJK negatives and the English
assertions pass in both directions, so the suite is not vacuous in either
state.

## Tests

`test/cross-modal-phase1.test.ts` gains one describe block:

- 9 positives across simplified Chinese, traditional Chinese and Japanese
- 6 negatives that must stay `'text'`: `图书馆的开放时间` (a library, not an
  image), `图片压缩算法的原理` (a visual noun with no request structure around
  it), the bare `截图`, `影像科的报告在哪` (a hospital department), and a
  Japanese noun-phrase with no request verb
- an explicit assertion that the English classifications are unchanged

Local runs:

- `bun test test/cross-modal-phase1.test.ts` — 61 pass
- `bun test` across the 8 neighbouring search/intent/cjk suites — 183 pass
- `tsc --noEmit` — clean for the touched files
