### PR TITLE
v0.46.28.0 fix(facts): a Facts fence below the timeline sentinel is preserved, not deleted (#3625)

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -58,7 +58,6 @@ import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { parseFactsFence, FACTS_FENCE_BEGIN } from '../facts-fence.ts';
-import { scanFencedBlocks } from '../fence-scan.ts';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
@@ -188,7 +187,7 @@ export interface ExtractFactsResult {
 }
 
 /**
- * #3625 (adversarial review finding): whether `timeline` contains a
+ * #3625 (adversarial review, 2 rounds): whether `timeline` contains a
  * GENUINE Facts fence marker, as opposed to the marker text merely being
  * mentioned inside a fenced code example or quoted prose. A naive
  * `.includes(FACTS_FENCE_BEGIN)` false-positives on both — e.g. a page
@@ -197,27 +196,63 @@ export interface ExtractFactsResult {
  * be treated as "misplaced" and block a genuine deletion, leaving stale
  * facts indexed indefinitely.
  *
- * A real fence marker is always written as its own line (see
- * FENCE_BODY-shaped output from fence-write.ts / upsertFactRow), so this
- * checks: after stripping any ```-fenced code blocks (scanFencedBlocks,
- * the same linear scanner import-file.ts uses for chunk extraction), does
- * any remaining line, trimmed, exactly equal the marker? This rules out
- * both hazards without needing a full markdown AST: code-block mentions
- * are removed by the fence strip, and prose/blockquote mentions fail the
- * exact-line-match (mirrors findTimelineSplitIndex's own `trimmed ===
- * sentinel` pattern for the same class of problem on the timeline
- * sentinel itself).
+ * Round 1 tried reusing fence-scan.ts's scanFencedBlocks() + string removal
+ * of its extracted fence bodies. Round-2 adversarial review broke that:
+ * scanFencedBlocks normalizes line endings (splits on `\r\n|\r|\n`, joins
+ * fence bodies with plain `\n`) and strips opener indentation before
+ * returning fence text — so `stripped.split(fenceText).join('')` on the
+ * ORIGINAL (un-normalized) string silently fails to match a CRLF or
+ * indented code block, leaving the marker inside it undetected and still
+ * false-positive. Reconstructed-text removal can't safely undo a lossy
+ * normalization.
+ *
+ * Fix: a self-contained single-pass line scanner (mirroring fence-scan.ts's
+ * own CommonMark-subset opener/closer grammar, applied directly against
+ * `timeline.split(/\r\n|\r|\n/)` — ONE split, no re-normalization, no
+ * text-based removal) that skips lines between a real ``` /~~~ opener and
+ * its closer, then checks whether any remaining line, trimmed, exactly
+ * equals the marker. A real fence marker is always written as its own line
+ * (see FENCE_BODY-shaped output from fence-write.ts / upsertFactRow), so
+ * exact-line-match — on lines outside any code fence — rules out both
+ * hazards without needing a full markdown AST (mirrors
+ * findTimelineSplitIndex's own `trimmed === sentinel` pattern for the same
+ * class of problem on the timeline sentinel itself). An unclosed opener
+ * runs to EOF (matches fence-scan.ts's documented behavior) — a marker
+ * appearing after it is inside an ambiguous, unclosed block and is not
+ * trusted as genuine.
  */
 function timelineHasGenuineFactsFenceMarker(timeline: string): boolean {
   if (!timeline.includes(FACTS_FENCE_BEGIN)) return false;
-  const { fences } = scanFencedBlocks(timeline);
-  let stripped = timeline;
-  for (const fence of fences) {
-    if (fence.text.includes(FACTS_FENCE_BEGIN)) {
-      stripped = stripped.replace(fence.text, '');
+  const lines = timeline.split(/\r\n|\r|\n/);
+  const OPEN_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+  const CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const open = OPEN_RE.exec(line);
+    if (open) {
+      const marker = open[1]!;
+      const fenceChar = marker[0]!;
+      const info = open[2]!.trim();
+      // Mirrors fence-scan.ts: a backtick opener whose info string contains
+      // a backtick is inline code, not a fence opener.
+      if (!(fenceChar === '`' && info.includes('`'))) {
+        let j = i + 1;
+        for (; j < lines.length; j++) {
+          const close = CLOSE_RE.exec(lines[j]!);
+          if (close && close[1]![0] === fenceChar && close[1]!.length >= marker.length) {
+            j++;
+            break;
+          }
+        }
+        i = j; // unclosed fence: j reaches lines.length, ending the scan
+        continue;
+      }
     }
+    if (line.trim() === FACTS_FENCE_BEGIN) return true;
+    i++;
   }
-  return stripped.split(/\r\n|\r|\n/).some((line) => line.trim() === FACTS_FENCE_BEGIN);
+  return false;
 }
 
 /**

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -57,7 +57,7 @@ import type { BrainEngine } from '../engine.ts';
 import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede-resolve.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
-import { parseFactsFence } from '../facts-fence.ts';
+import { parseFactsFence, FACTS_FENCE_BEGIN } from '../facts-fence.ts';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
@@ -398,6 +398,32 @@ export async function runExtractFacts(
       // could still recover. That partial result is not authoritative: using
       // it for reconciliation would interpret skipped rows as deletions.
       // Preserve this page's existing index and continue with other pages.
+      continue;
+    }
+
+    // #3625: splitBody() puts everything below the timeline sentinel into
+    // page.timeline, not compiled_truth — a `## Facts` fence written there
+    // (agent-composed bodies commonly append it at the bottom) is invisible
+    // to the parseFactsFence(body) call above. Without this check,
+    // parsed.facts.length === 0 reads as "the user deleted the fence" and
+    // the block below prunes every previously-indexed row for the page —
+    // when the fence is actually just misplaced, not absent. Distinguish
+    // the two by checking whether a fence marker ALSO landed in
+    // page.timeline: if so, the page is non-authoritative — malformed
+    // placement (loud warning, preserve the existing index), never treated
+    // as absence (destructive delete). Checked unconditionally on
+    // parsed.facts.length (not just when it's 0): a page can have a valid
+    // fence above the sentinel AND a stray/duplicate one below it (e.g. a
+    // partial hand-edit), in which case parsed.facts.length > 0 but
+    // reconciling from compiled_truth alone would still misread the
+    // below-sentinel rows as deleted.
+    if ((page.timeline ?? '').includes(FACTS_FENCE_BEGIN)) {
+      result.warnings.push(
+        `${slug}: FACTS_FENCE_BELOW_SENTINEL: a ## Facts fence was found below ` +
+        `the <!-- timeline --> sentinel, where extract_facts cannot see it. ` +
+        `Move the fence above the sentinel and re-save — leaving it in place ` +
+        `preserves the existing indexed facts but they will not update.`,
+      );
       continue;
     }
 

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -58,6 +58,7 @@ import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { parseFactsFence, FACTS_FENCE_BEGIN } from '../facts-fence.ts';
+import { scanFencedBlocks } from '../fence-scan.ts';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
@@ -184,6 +185,39 @@ export interface ExtractFactsResult {
   phantomsSkippedDrift: number;
   phantomsLockBusy: boolean;
   phantomsMorePending: boolean;
+}
+
+/**
+ * #3625 (adversarial review finding): whether `timeline` contains a
+ * GENUINE Facts fence marker, as opposed to the marker text merely being
+ * mentioned inside a fenced code example or quoted prose. A naive
+ * `.includes(FACTS_FENCE_BEGIN)` false-positives on both — e.g. a page
+ * whose real fence WAS removed, but whose timeline documents the fence
+ * syntax in a ```markdown code block or a `> ...` blockquote, would wrongly
+ * be treated as "misplaced" and block a genuine deletion, leaving stale
+ * facts indexed indefinitely.
+ *
+ * A real fence marker is always written as its own line (see
+ * FENCE_BODY-shaped output from fence-write.ts / upsertFactRow), so this
+ * checks: after stripping any ```-fenced code blocks (scanFencedBlocks,
+ * the same linear scanner import-file.ts uses for chunk extraction), does
+ * any remaining line, trimmed, exactly equal the marker? This rules out
+ * both hazards without needing a full markdown AST: code-block mentions
+ * are removed by the fence strip, and prose/blockquote mentions fail the
+ * exact-line-match (mirrors findTimelineSplitIndex's own `trimmed ===
+ * sentinel` pattern for the same class of problem on the timeline
+ * sentinel itself).
+ */
+function timelineHasGenuineFactsFenceMarker(timeline: string): boolean {
+  if (!timeline.includes(FACTS_FENCE_BEGIN)) return false;
+  const { fences } = scanFencedBlocks(timeline);
+  let stripped = timeline;
+  for (const fence of fences) {
+    if (fence.text.includes(FACTS_FENCE_BEGIN)) {
+      stripped = stripped.replace(fence.text, '');
+    }
+  }
+  return stripped.split(/\r\n|\r|\n/).some((line) => line.trim() === FACTS_FENCE_BEGIN);
 }
 
 /**
@@ -416,8 +450,12 @@ export async function runExtractFacts(
     // fence above the sentinel AND a stray/duplicate one below it (e.g. a
     // partial hand-edit), in which case parsed.facts.length > 0 but
     // reconciling from compiled_truth alone would still misread the
-    // below-sentinel rows as deleted.
-    if ((page.timeline ?? '').includes(FACTS_FENCE_BEGIN)) {
+    // below-sentinel rows as deleted. Uses timelineHasGenuineFactsFenceMarker
+    // rather than a raw .includes() (adversarial review finding: the naive
+    // substring check false-positives on the marker text merely being
+    // mentioned in a doc code-block or quoted prose, wrongly blocking a
+    // genuine deletion and leaving stale facts indexed indefinitely).
+    if (timelineHasGenuineFactsFenceMarker(page.timeline ?? '')) {
       result.warnings.push(
         `${slug}: FACTS_FENCE_BELOW_SENTINEL: a ## Facts fence was found below ` +
         `the <!-- timeline --> sentinel, where extract_facts cannot see it. ` +

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -622,6 +622,32 @@ export async function importFromContent(
     }
   }
 
+  // #3625 residual: the identical #2044 hazard, but for a Facts fence that
+  // ended up in `timeline` (below the `<!-- timeline -->` sentinel) instead
+  // of `compiled_truth`. #3625's own fix made get_page/fetch_page strip
+  // private facts from `timeline` too (previously only `compiled_truth` was
+  // stripped) — so a remote get_page -> edit -> put_page round-trip on a
+  // page whose canonical fence lives in `timeline` now arrives with an
+  // empty/missing fence there for the exact same privacy-boundary reason
+  // #2044 already handles for `compiled_truth`. Without this, that
+  // round-trip would silently and permanently erase the private rows
+  // (adversarially proven while landing #3625 — see that PR's description).
+  // Apply the identical restoration, scoped to `timeline`.
+  if (opts.remote === true && existing?.timeline) {
+    const incomingTimelineFacts = parseFactsFence(parsed.timeline ?? '');
+    const existingTimelineFacts = parseFactsFence(existing.timeline);
+    const existingTimelineFenceBlock = extractFactsFenceBlock(existing.timeline);
+    if (
+      incomingTimelineFacts.facts.length === 0 &&
+      incomingTimelineFacts.warnings.length === 0 &&
+      existingTimelineFacts.warnings.length === 0 &&
+      existingTimelineFacts.facts.length > 0 &&
+      existingTimelineFenceBlock
+    ) {
+      parsed.timeline = replaceOrAppendFactsFence(parsed.timeline ?? '', existingTimelineFenceBlock);
+    }
+  }
+
   // #1035: absence of an explicit frontmatter `type:` on an EXISTING page
   // means "preserve the stored type", not "re-infer". Pre-fix, a round-trip
   // put (get_page → edit body → put_page without `type:`) silently regressed

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -47,7 +47,7 @@ import { decorateEmbeddingDimError } from './embedding-dim-check.ts';
 import { computeCorpusGeneration, loadSourceRow } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
-import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from './facts-fence.ts';
+import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, renderFactsTable, type ParsedFact } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
 
 /**
@@ -109,12 +109,32 @@ function fenceTagToPseudoPath(lang: string | undefined): string | null {
 // MAX_FENCES_PER_PAGE (fence-bomb DOS cap, GBRAIN_MAX_FENCES_PER_PAGE env
 // override) moved to fence-scan.ts with the #2862 linear scanner.
 
-function extractFactsFenceBlock(body: string): string | null {
-  const beginIdx = body.indexOf(FACTS_FENCE_BEGIN);
-  if (beginIdx === -1) return null;
-  const endIdx = body.indexOf(FACTS_FENCE_END, beginIdx + FACTS_FENCE_BEGIN.length);
-  if (endIdx === -1) return null;
-  return body.slice(beginIdx, endIdx + FACTS_FENCE_END.length);
+/**
+ * #3625 P1/P2 fix (adversarial review round 2, replacing the original
+ * #2044 whole-block-swap): compute the merged row set for a privacy-boundary
+ * restoration, or null if nothing needs restoring. Returns null (no-op)
+ * whenever either parse produced warnings (non-authoritative — mirrors the
+ * caution the rest of this file and extract-facts.ts already take with a
+ * warning-bearing fence) or when there are no hidden rows missing from the
+ * incoming set.
+ *
+ * "Hidden" = not 'world'-visibility: those are the only rows a remote,
+ * untrusted caller could never have seen via get_page/fetch (stripFactsFence
+ * keeps 'world' rows, drops everything else). A row the caller COULD see
+ * and chose to remove or relocate is never a restoration candidate — that
+ * edit is the caller's, honored as written.
+ */
+function restoreHiddenFactRows(
+  incoming: { facts: ParsedFact[]; warnings: string[] },
+  existing: { facts: ParsedFact[]; warnings: string[] },
+): ParsedFact[] | null {
+  if (incoming.warnings.length > 0 || existing.warnings.length > 0) return null;
+  const hidden = existing.facts.filter((f) => f.visibility !== 'world');
+  if (hidden.length === 0) return null;
+  const incomingRowNums = new Set(incoming.facts.map((f) => f.rowNum));
+  const missing = hidden.filter((f) => !incomingRowNums.has(f.rowNum));
+  if (missing.length === 0) return null;
+  return [...incoming.facts, ...missing].sort((a, b) => a.rowNum - b.rowNum);
 }
 
 function replaceOrAppendFactsFence(body: string, fenceBlock: string): string {
@@ -602,49 +622,39 @@ export async function importFromContent(
   // unscoped-check/scoped-write bug class).
   const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
 
-  // #2044: remote get_page intentionally strips private facts rows. A
-  // documented get_page -> edit -> put_page round-trip can therefore arrive
-  // with an empty/missing Facts fence even though the existing page still has
-  // canonical fence rows. Preserve the old fence in that narrow case so the
-  // system-of-record markdown is not truncated by the privacy boundary.
+  // #2044 (+ #3625 P1/P2 fix, adversarial review round 2): remote get_page
+  // intentionally strips non-'world' facts rows before an untrusted caller
+  // ever sees them. A documented get_page -> edit -> put_page round-trip can
+  // therefore arrive missing rows the caller structurally could never have
+  // seen, let alone intentionally deleted. Restore those specific rows —
+  // scoped to compiled_truth here, and identically to timeline below (the
+  // #3625 fix made get_page/fetch_page strip timeline's fences too, opening
+  // the same hazard there).
+  //
+  // Row-level, visibility-aware merge (not the original whole-block swap):
+  // only rows that are NOT 'world'-visible are ever restoration candidates
+  // — a caller who saw a row (world-visible) and removed it, or moved it
+  // elsewhere in the body, has that edit honored. This fixes two review
+  // findings against the original block-swap approach: (P1) a MIXED
+  // fence's hidden rows were never restored once ANY visible row survived
+  // in the incoming write (block-swap's incoming.facts.length===0 gate
+  // never fired); (P2) deleting or relocating a fully-visible world-only
+  // fence was silently undone by re-appending the entire old block.
   if (opts.remote === true && existing?.compiled_truth) {
     const incomingFacts = parseFactsFence(parsed.compiled_truth);
     const existingFacts = parseFactsFence(existing.compiled_truth);
-    const existingFenceBlock = extractFactsFenceBlock(existing.compiled_truth);
-    if (
-      incomingFacts.facts.length === 0 &&
-      incomingFacts.warnings.length === 0 &&
-      existingFacts.warnings.length === 0 &&
-      existingFacts.facts.length > 0 &&
-      existingFenceBlock
-    ) {
-      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock);
+    const merged = restoreHiddenFactRows(incomingFacts, existingFacts);
+    if (merged) {
+      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, renderFactsTable(merged));
     }
   }
 
-  // #3625 residual: the identical #2044 hazard, but for a Facts fence that
-  // ended up in `timeline` (below the `<!-- timeline -->` sentinel) instead
-  // of `compiled_truth`. #3625's own fix made get_page/fetch_page strip
-  // private facts from `timeline` too (previously only `compiled_truth` was
-  // stripped) — so a remote get_page -> edit -> put_page round-trip on a
-  // page whose canonical fence lives in `timeline` now arrives with an
-  // empty/missing fence there for the exact same privacy-boundary reason
-  // #2044 already handles for `compiled_truth`. Without this, that
-  // round-trip would silently and permanently erase the private rows
-  // (adversarially proven while landing #3625 — see that PR's description).
-  // Apply the identical restoration, scoped to `timeline`.
   if (opts.remote === true && existing?.timeline) {
     const incomingTimelineFacts = parseFactsFence(parsed.timeline ?? '');
     const existingTimelineFacts = parseFactsFence(existing.timeline);
-    const existingTimelineFenceBlock = extractFactsFenceBlock(existing.timeline);
-    if (
-      incomingTimelineFacts.facts.length === 0 &&
-      incomingTimelineFacts.warnings.length === 0 &&
-      existingTimelineFacts.warnings.length === 0 &&
-      existingTimelineFacts.facts.length > 0 &&
-      existingTimelineFenceBlock
-    ) {
-      parsed.timeline = replaceOrAppendFactsFence(parsed.timeline ?? '', existingTimelineFenceBlock);
+    const mergedTimeline = restoreHiddenFactRows(incomingTimelineFacts, existingTimelineFacts);
+    if (mergedTimeline) {
+      parsed.timeline = replaceOrAppendFactsFence(parsed.timeline ?? '', renderFactsTable(mergedTimeline));
     }
   }
 

--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -119,6 +119,30 @@ async function dropPrivateSlugs(
   return candidates.filter(c => !hidden.has(c));
 }
 
+/**
+ * #3625: strip the takes/private-facts fences from BOTH compiled_truth and
+ * timeline before a page reaches an untrusted reader. Pre-#3625 this only
+ * covered compiled_truth — a `## Facts` fence written below the
+ * `<!-- timeline -->` sentinel lands in the `timeline` column (splitBody's
+ * split boundary), which get_page/fetch_page returned verbatim, unstripped.
+ * A private fact fence misplaced there was fully readable by any remote MCP
+ * caller. Same stripping rule as compiled_truth: takes fence dropped
+ * entirely, facts fence keeps only `world`-visibility rows.
+ */
+function stripPrivacyFencesForRemoteReader(page: Page): Page {
+  return {
+    ...page,
+    compiled_truth: stripFactsFence(
+      stripTakesFence(page.compiled_truth),
+      { keepVisibility: ['world'] },
+    ),
+    timeline: stripFactsFence(
+      stripTakesFence(page.timeline ?? ''),
+      { keepVisibility: ['world'] },
+    ),
+  };
+}
+
 const get_page: Operation = {
   name: 'get_page',
   description: 'Read a page by slug (supports optional fuzzy matching). To edit a page, pass include_content: true — the returned `content` field is the canonical full markdown (frontmatter + body + timeline sentinel); edit THAT and pass it back to put_page to round-trip losslessly. Reassembling compiled_truth/timeline by hand risks dropping sections. Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated (see v0.26.5 recovery window).',
@@ -222,13 +246,7 @@ const get_page: Operation = {
     //    untrusted readers see them. Private facts never cross the boundary.
     const isUntrustedReader = ctx.remote === true;
     const visibleBody = isUntrustedReader
-      ? {
-          ...page,
-          compiled_truth: stripFactsFence(
-            stripTakesFence(page.compiled_truth),
-            { keepVisibility: ['world'] },
-          ),
-        }
+      ? stripPrivacyFencesForRemoteReader(page)
       : page;
     // v0.42 (#1699) agent-warning channel: surface the page's content_flag
     // marker as a top-level field (parallel to SearchResult.content_flag) so
@@ -300,13 +318,7 @@ const fetch_page: Operation = {
     // true — every MCP transport) never see takes or private facts fences.
     const visibleBody = ctx.remote === false
       ? page
-      : {
-          ...page,
-          compiled_truth: stripFactsFence(
-            stripTakesFence(page.compiled_truth),
-            { keepVisibility: ['world'] },
-          ),
-        };
+      : stripPrivacyFencesForRemoteReader(page);
     return {
       id: page.slug,
       title: page.title,

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExtractFacts } from '../src/core/cycle/extract-facts.ts';
 import { parseFactsFence } from '../src/core/facts-fence.ts';
+import { importFromContent } from '../src/core/import-file.ts';
 
 let engine: PGLiteEngine;
 
@@ -49,6 +50,20 @@ async function putPage(slug: string, body: string): Promise<void> {
     compiled_truth: body,
     frontmatter: {},
     timeline: '',
+  });
+}
+
+// #3625: writes compiled_truth and timeline as SEPARATE columns, mirroring
+// what splitBody() produces when a `## Facts` fence sits below the
+// `<!-- timeline -->` sentinel — the fence text lands in `timeline`, not
+// `compiled_truth`, exactly as MCP put_page would store it.
+async function putPageWithTimeline(slug: string, compiledTruth: string, timeline: string): Promise<void> {
+  await engine.putPage(slug, {
+    title: slug,
+    type: 'person',
+    compiled_truth: compiledTruth,
+    frontmatter: {},
+    timeline,
   });
 }
 
@@ -297,6 +312,164 @@ describe('runExtractFacts — happy path', () => {
       `SELECT COUNT(*) AS n FROM facts WHERE source_markdown_slug = 'people/alice'`,
     );
     expect(Number(rows.rows[0].n)).toBe(0);
+  });
+
+  test('#3625: a Facts fence below the timeline sentinel is preserved, not deleted, and warns loudly', async () => {
+    // Seed the page with the fence in its normal place (above the sentinel)
+    // and let it index normally.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  | linkedin |  |
+| 2 | Prefers async | preference | 0.85 | private | medium | 2026-04-29 |  | OH |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seeded = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(seeded.rows).toHaveLength(2);
+
+    // #3625 repro: rewrite the page so the SAME fence content now lives in
+    // `timeline` (below the sentinel) instead of `compiled_truth` — exactly
+    // what splitBody() produces for a page whose `## Facts` fence was
+    // written below `<!-- timeline -->`. compiled_truth carries none of the
+    // fence text, so parseFactsFence(compiled_truth) sees zero facts.
+    await putPageWithTimeline(
+      'people/alice',
+      '# Page\n\nBody.\n',
+      FACT_FENCE(
+        `| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  | linkedin |  |
+| 2 | Prefers async | preference | 0.85 | private | medium | 2026-04-29 |  | OH |  |`,
+      ),
+    );
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // The fix: this must NOT read as "fence removed" and must NOT delete
+    // the previously-indexed rows.
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Founded Acme', 'Prefers async']);
+  });
+
+  test('#3625 control: a genuinely fence-less page (no fence anywhere in the body) still wipes as before', async () => {
+    // Same shape as the misplaced-fence case above, but this time the fence
+    // is truly absent from BOTH compiled_truth and timeline — the existing
+    // "user deleted the fence" contract must still hold; the #3625 guard
+    // must not swallow genuine deletions.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline('people/alice', '# Just a page\n\nNo fence.\n', 'Some unrelated timeline prose.\n');
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT COUNT(*) AS n FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(Number(rows.rows[0].n)).toBe(0);
+  });
+
+  test('#3625 via the real MCP write path: a stray fence below the sentinel is preserved even when import-file.ts is in play', async () => {
+    // Codex review finding: the two tests above write compiled_truth/timeline
+    // directly via engine.putPage, bypassing importFromContent's own #2044
+    // remote-preservation logic (restores an old fence into compiled_truth
+    // when an incoming remote write's compiled half has ZERO facts — which
+    // would otherwise mask a below-sentinel duplicate by never even letting
+    // this test reach the state it wants to prove: confirmed by running the
+    // simpler "compiled_truth ends up with zero facts" version of this test
+    // first — #2044 fired and restored the OLD fence, so compiled_truth
+    // never went empty and this guard was never exercised).
+    //
+    // Reproduce a case #2044 does NOT swallow: the incoming remote write's
+    // compiled_truth keeps ONE valid fact above the sentinel (so
+    // incomingFacts.facts.length > 0 — #2044's restore condition requires
+    // exactly 0 and does not fire) while ALSO carrying a stray duplicate
+    // fence below the sentinel (e.g. an agent re-appending a "## Facts"
+    // section near new content it's adding at the bottom of the page).
+    // splitBody() (inside putPage, called by importFromContent) does the
+    // real fence/sentinel split — no direct column poking.
+    const seed = `---
+title: alice
+type: person
+---
+
+Some body content.
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  |  linkedin |  |
+| 2 | Prefers async | preference | 0.85 | world | medium | 2026-04-29 |  |  OH |  |
+<!--- gbrain:facts:end -->
+
+<!-- timeline -->
+`;
+    await importFromContent(engine, 'people/alice', seed, { noEmbed: true, remote: true });
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seeded = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(seeded.rows).toHaveLength(2);
+
+    // A malformed remote rewrite: row 1 stays correctly placed above the
+    // sentinel (so #2044's restore never fires — incomingFacts.facts.length
+    // is 1, not 0), but row 2 got duplicated into a second fence below it.
+    const misplaced = `---
+title: alice
+type: person
+---
+
+Some body content.
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  |  linkedin |  |
+<!--- gbrain:facts:end -->
+
+<!-- timeline -->
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Prefers async | preference | 0.85 | world | medium | 2026-04-29 |  |  OH |  |
+<!--- gbrain:facts:end -->
+`;
+    await importFromContent(engine, 'people/alice', misplaced, { noEmbed: true, remote: true });
+
+    const page = await engine.getPage('people/alice');
+    // Sanity: confirm the real write path actually reproduces the #3625
+    // precondition (#2044 did NOT restore anything away, and a fence marker
+    // really did land in timeline) before trusting the assertions below.
+    expect(parseFactsFence(page!.compiled_truth ?? '').facts).toHaveLength(1);
+    expect((page!.timeline ?? '')).toContain('gbrain:facts:begin');
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(rows.rows).toHaveLength(2);
   });
 
   test('dry-run does not touch DB', async () => {

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -435,6 +435,47 @@ describe('runExtractFacts — happy path', () => {
     expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
   });
 
+  test('#3625 adversarial review round 2: a CRLF-line-ending code block mentioning the marker does not false-positive', async () => {
+    // Round-1 fix (scanFencedBlocks + string removal) normalized line
+    // endings internally but tried to remove fence text from the
+    // UN-normalized original string, silently failing to strip a CRLF code
+    // block and leaving the false positive in place. The round-2 fix
+    // (single-pass line scanner, one \r\n|\r|\n split applied throughout)
+    // must handle this correctly.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '## Docs\r\n\r\n```markdown\r\n<!--- gbrain:facts:begin -->\r\nexample only\r\n```\r\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 adversarial review round 2: two identical code-block mentions of the marker do not false-positive', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    const codeBlock = '```markdown\n<!--- gbrain:facts:begin -->\nexample only\n```\n';
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      `${codeBlock}\n${codeBlock}`,
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
   test('#3625 via the real MCP write path: a stray fence below the sentinel is preserved even when import-file.ts is in play', async () => {
     // Codex review finding: the two tests above write compiled_truth/timeline
     // directly via engine.putPage, bypassing importFromContent's own #2044

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -379,6 +379,62 @@ describe('runExtractFacts — happy path', () => {
     expect(Number(rows.rows[0].n)).toBe(0);
   });
 
+  test('#3625 adversarial review finding: the marker merely mentioned inside a ```code block``` does not block a genuine deletion', async () => {
+    // A naive `.includes(FACTS_FENCE_BEGIN)` check false-positives here — the
+    // marker text is present in timeline, but only as documentation, not as
+    // a real fence. The real fence was genuinely removed and must delete.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '## Docs\n\n```markdown\n<!--- gbrain:facts:begin -->\nexample only\n```\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 adversarial review finding: the marker merely quoted in prose does not block a genuine deletion', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '> Historical docs mention the token <!--- gbrain:facts:begin -->, but this is not a fence.\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 control: a genuine unbalanced marker (own line, not inside a code block) still blocks deletion', async () => {
+    // Contrast with the two false-positive tests above — this marker IS a
+    // real (if malformed/unbalanced) fence occurrence and must still guard.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nNo compiled fence.\n',
+      '<!--- gbrain:facts:begin -->\nPRIVATE_UNBALANCED_ROW\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+  });
+
   test('#3625 via the real MCP write path: a stray fence below the sentinel is preserved even when import-file.ts is in play', async () => {
     // Codex review finding: the two tests above write compiled_truth/timeline
     // directly via engine.putPage, bypassing importFromContent's own #2044

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -21,6 +21,8 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { chunkText } from '../src/core/chunkers/recursive.ts';
 import { forgetFactInFence } from '../src/core/facts/forget.ts';
 import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from '../src/core/facts-fence.ts';
+import { operations } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/operations.ts';
 
 let engine: PGLiteEngine;
 let brainDir: string;
@@ -133,6 +135,98 @@ describe('Layer B — get_page strip trigger (Codex R2-#5)', () => {
     const stripped = stripFactsFence(body, { keepVisibility: ['world'] });
     expect(stripped).toContain('WORLD_ROW');
     expect(stripped).not.toContain('PRIVATE_ROW');
+  });
+
+  // #3625 Codex review Critical finding: get_page/fetch_page only ever
+  // stripped compiled_truth. A `## Facts` fence written below the
+  // `<!-- timeline -->` sentinel (splitBody's split boundary) lands in the
+  // `timeline` column instead — pre-existing, independent of the #3625
+  // reconciliation guard — and was returned to remote/untrusted callers
+  // completely unstripped, leaking private fact rows through both the
+  // `timeline` field and the serialized `content` round-trip field.
+  describe('#3625 Critical: get_page/fetch_page must ALSO strip the timeline column', () => {
+    function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
+      return {
+        engine,
+        config: { engine: 'pglite' as const },
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+        dryRun: false,
+        remote: false,
+        sourceId: 'default',
+        // Cross-file gateway-state hermeticity (see put-page-provenance.test.ts's
+        // beforeAll comment): put_page's noEmbed = ctx.deferEmbeds === true ||
+        // !isAvailable('embedding') — relying on the ambient isAvailable() check
+        // means a sibling file sharing this shard's process that configured a
+        // live embedding provider makes put_page attempt a real embed call here,
+        // which hangs without a stubbed transport. Force it off explicitly.
+        deferEmbeds: true,
+        ...opts,
+      };
+    }
+
+    const MISPLACED_FENCE_CONTENT = `---
+title: alice
+type: person
+---
+
+Some body content.
+
+<!-- timeline -->
+
+## Facts
+
+${FACTS_FENCE_BEGIN}
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | PUBLIC_TIMELINE_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_TIMELINE_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |
+${FACTS_FENCE_END}
+`;
+
+    test('get_page: remote caller sees the world row but never the private row, in timeline OR content', async () => {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      await putPageOp.handler(makeCtx({ remote: false }), {
+        slug: 'people/alice-timeline-leak',
+        content: MISPLACED_FENCE_CONTENT,
+      });
+
+      // Sanity: confirm the fence really landed in timeline, not
+      // compiled_truth — otherwise this test would pass for the wrong
+      // reason (the pre-existing compiled_truth strip would cover it).
+      const raw = await engine.getPage('people/alice-timeline-leak');
+      expect(parseFactsFence(raw!.compiled_truth ?? '').facts).toHaveLength(0);
+      expect((raw!.timeline ?? '')).toContain('PRIVATE_TIMELINE_FACT');
+
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug: 'people/alice-timeline-leak',
+        include_content: true,
+      }) as { timeline?: string; content?: string };
+      expect(remote.timeline).toContain('PUBLIC_TIMELINE_FACT');
+      expect(remote.timeline).not.toContain('PRIVATE_TIMELINE_FACT');
+      expect(remote.content).not.toContain('PRIVATE_TIMELINE_FACT');
+
+      // Control: a trusted local caller still sees everything, unstripped.
+      const local = await getPageOp.handler(makeCtx({ remote: false }), {
+        slug: 'people/alice-timeline-leak',
+      }) as { timeline?: string };
+      expect(local.timeline).toContain('PRIVATE_TIMELINE_FACT');
+    });
+
+    test('fetch_page: remote caller\'s serialized text never contains the private timeline row', async () => {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const fetchPageOp = operations.find((o) => o.name === 'fetch')!;
+      await putPageOp.handler(makeCtx({ remote: false }), {
+        slug: 'people/bob-timeline-leak',
+        content: MISPLACED_FENCE_CONTENT.replace('alice', 'bob'),
+      });
+
+      const remote = await fetchPageOp.handler(makeCtx({ remote: true }), {
+        id: 'people/bob-timeline-leak',
+      }) as { text?: string };
+      expect(remote.text).toContain('PUBLIC_TIMELINE_FACT');
+      expect(remote.text).not.toContain('PRIVATE_TIMELINE_FACT');
+    });
   });
 });
 

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -290,12 +290,11 @@ describe('#3625 residual — #2044 restoration mirrored to timeline', () => {
     expect((raw?.timeline ?? '')).toContain('PRIVATE_ONLY_TIMELINE_FACT');
   });
 
-  test('KNOWN PRE-EXISTING GAP (not introduced by #3625): a mixed world+private Facts fence in compiled_truth already loses the private row on round-trip today', async () => {
-    // Ground-truth control: same round-trip shape, but targeting
-    // compiled_truth (the original, long-standing #2044 mechanism) with a
-    // MIXED fence rather than an all-private one. Proves the "incoming
-    // must go to exactly zero facts" limitation predates #3625 and is not
-    // specific to the timeline mirror above.
+  test('#3625 P1 fix (adversarial review round 2): a MIXED world+private Facts fence in compiled_truth now preserves the private row on round-trip', async () => {
+    // Prior to the row-level merge fix, restoration only fired when the
+    // incoming fence went to exactly zero facts — a mixed fence where the
+    // world row survives stripping (incoming.facts.length===1, not 0) never
+    // triggered the old whole-block-swap, silently losing the private row.
     const putPageOp = operations.find((o) => o.name === 'put_page')!;
     const getPageOp = operations.find((o) => o.name === 'get_page')!;
     const slug = 'people/compiled-mixed-roundtrip';
@@ -312,15 +311,71 @@ describe('#3625 residual — #2044 restoration mirrored to timeline', () => {
       slug,
       include_content: true,
     }) as { content?: string };
+    expect(remote.content).toContain('PUBLIC_COMPILED_FACT');
     expect(remote.content).not.toContain('PRIVATE_COMPILED_FACT');
     const edited = (remote.content ?? '').replace('Body.', 'Body edited.');
     await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
 
     const raw = await engine.getPage(slug, { sourceId: 'default' });
-    // Documents the existing gap — this is NOT the behavior we want, but it
-    // is the behavior #2044 already has today, independent of #3625.
-    expect((raw?.compiled_truth ?? '')).not.toContain('PRIVATE_COMPILED_FACT');
     expect((raw?.compiled_truth ?? '')).toContain('PUBLIC_COMPILED_FACT');
+    expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_COMPILED_FACT');
+  });
+
+  test('#3625 P1 fix, timeline variant: a MIXED world+private Facts fence in timeline now preserves the private row on round-trip', async () => {
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/timeline-mixed-roundtrip';
+    const fence = FENCE_BODY(
+      `| 1 | PUBLIC_TIMELINE_MIXED_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_TIMELINE_MIXED_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), {
+      slug,
+      content: `---\ntitle: ${slug}\ntype: person\n---\n\nBody.\n\n<!-- timeline -->\n\n${fence}`,
+    });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).toContain('PUBLIC_TIMELINE_MIXED_FACT');
+    expect(remote.content).not.toContain('PRIVATE_TIMELINE_MIXED_FACT');
+    const edited = (remote.content ?? '').replace('Body.', 'Body edited.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.timeline ?? '')).toContain('PUBLIC_TIMELINE_MIXED_FACT');
+    expect((raw?.timeline ?? '')).toContain('PRIVATE_TIMELINE_MIXED_FACT');
+  });
+
+  test('#3625 P2 fix (adversarial review round 2): deleting a fully-visible world-only fence is honored, not silently undone', async () => {
+    // The old whole-block-swap restored EVERY existing row whenever the
+    // incoming fence went to zero — including a world-only fence the
+    // caller could see in full and genuinely chose to delete. The
+    // row-level merge only ever restores rows the caller could NOT see
+    // (non-'world'), so a world-only deletion has nothing to restore.
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/world-only-delete';
+    const fence = FENCE_BODY(
+      '| 1 | WORLD_ONLY_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), {
+      slug,
+      content: `---\ntitle: ${slug}\ntype: person\n---\n\nBody.\n\n${fence}`,
+    });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).toContain('WORLD_ONLY_FACT');
+    // The caller saw the fence in full and deletes it entirely.
+    const edited = (remote.content ?? '').replace(fence, '').replace('Body.', 'Body, fence removed.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.compiled_truth ?? '')).not.toContain('WORLD_ONLY_FACT');
   });
 });
 

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -231,6 +231,100 @@ ${FACTS_FENCE_END}
 });
 
 // ─────────────────────────────────────────────────────────────────
+// #3625 residual: #2044 restoration extended to `timeline`
+// ─────────────────────────────────────────────────────────────────
+//
+// Adversarial review on #3625's own PR caught this: the Critical fix above
+// (stripping private fences from `timeline`, not just `compiled_truth`)
+// closed a read-side leak but opened a write-side hazard identical to the
+// one #2044 already exists to prevent for `compiled_truth` — a remote
+// get_page -> edit -> put_page round-trip on a page whose canonical fence
+// lives in `timeline` now arrives with the private row(s) missing there,
+// for the exact same privacy-boundary reason. import-file.ts's `#2044`
+// restoration block is mirrored for `timeline`.
+//
+// Scope note: #2044's restoration (both the original compiled_truth block
+// and this timeline mirror) only fires when the INCOMING fence has gone to
+// ZERO facts — a fence that still has SOME rows (e.g. a mixed world+private
+// fence where only the private row was stripped) is not restored. This is
+// a pre-existing #2044 design limitation for compiled_truth (confirmed by
+// direct test below, unrelated to #3625) that the timeline mirror
+// necessarily inherits — not a regression #3625 introduces. A Takes fence
+// in EITHER column has no restoration mechanism at all today (#2044 only
+// ever covered Facts) — also pre-existing, also out of this PR's scope.
+describe('#3625 residual — #2044 restoration mirrored to timeline', () => {
+  function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
+    return {
+      engine,
+      config: { engine: 'pglite' as const },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+      sourceId: 'default',
+      deferEmbeds: true,
+      ...opts,
+    };
+  }
+
+  test('an all-private Facts fence in timeline (matches #2044\'s existing precondition: incoming goes to zero) survives a remote get_page -> edit -> put_page round-trip', async () => {
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/timeline-allprivate-roundtrip';
+    const fence = FENCE_BODY(
+      '| 1 | PRIVATE_ONLY_TIMELINE_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |',
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), {
+      slug,
+      content: `---\ntitle: ${slug}\ntype: person\n---\n\nBody.\n\n<!-- timeline -->\n\n${fence}`,
+    });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).not.toContain('PRIVATE_ONLY_TIMELINE_FACT');
+    const edited = (remote.content ?? '').replace('Body.', 'Body edited.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.timeline ?? '')).toContain('PRIVATE_ONLY_TIMELINE_FACT');
+  });
+
+  test('KNOWN PRE-EXISTING GAP (not introduced by #3625): a mixed world+private Facts fence in compiled_truth already loses the private row on round-trip today', async () => {
+    // Ground-truth control: same round-trip shape, but targeting
+    // compiled_truth (the original, long-standing #2044 mechanism) with a
+    // MIXED fence rather than an all-private one. Proves the "incoming
+    // must go to exactly zero facts" limitation predates #3625 and is not
+    // specific to the timeline mirror above.
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/compiled-mixed-roundtrip';
+    const fence = FENCE_BODY(
+      `| 1 | PUBLIC_COMPILED_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_COMPILED_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), {
+      slug,
+      content: `---\ntitle: ${slug}\ntype: person\n---\n\nBody.\n\n${fence}`,
+    });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).not.toContain('PRIVATE_COMPILED_FACT');
+    const edited = (remote.content ?? '').replace('Body.', 'Body edited.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    // Documents the existing gap — this is NOT the behavior we want, but it
+    // is the behavior #2044 already has today, independent of #3625.
+    expect((raw?.compiled_truth ?? '')).not.toContain('PRIVATE_COMPILED_FACT');
+    expect((raw?.compiled_truth ?? '')).toContain('PUBLIC_COMPILED_FACT');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
 // Forget-as-fence (Codex R2-#3)
 // ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #3625 (p0, verified-real). `put_page` accepts a `## Facts` fence written below the `<!-- timeline -->` sentinel — `splitBody()` routes everything below the sentinel into the `timeline` column, not `compiled_truth`, so the fence lands somewhere `extract_facts`'s reconciliation never looks. It reads only `page.compiled_truth`, sees zero facts, and — believing the user deleted the fence — calls `deleteFactsForPage`, permanently destroying every previously-indexed fact row for that page. Measured on a live brain: 10 pages drifted into this state, 21 fence rows reduced to 1 surviving DB fact before manual recovery.

## Fix

When the fence marker is also found in `page.timeline`, treat the page as non-authoritative (malformed placement — loud warning, existing rows preserved) rather than fence-absent (deletion). This is checked unconditionally on `parsed.facts.length`, not just when it's 0: a page can have a valid fence above the sentinel and a stray duplicate below it (e.g. a partial edit), in which case reconciling from `compiled_truth` alone would still misread the below-sentinel rows as deleted.

## A second issue found in review

`get_page`/`fetch_page` only ever stripped the private-facts privacy fence from `compiled_truth` for remote/untrusted readers — `timeline` was returned unstripped. A fence misplaced below the sentinel (this bug's own precondition) was therefore fully readable by any remote MCP caller if it happened to contain private rows. Both read paths now strip takes/facts fences from `compiled_truth` AND `timeline` via one shared helper (`stripPrivacyFencesForRemoteReader`).

## Scope

Deliberately scoped to the read-side guard (issue's suggested fix #2) rather than normalizing/rejecting the write at `put_page` (fix #1) — either closes the symptom class per the issue, and this is the narrower diff. No new CLI surface, no new config, no new doctor check.

## Test plan

- 5 new regression tests, verified red (fail without the fix, reproducing both the reported deletion and the privacy leak via direct execution) and green (pass with it).
- One test goes through the real MCP write path (`importFromContent`) rather than only direct `engine.putPage` column writes, specifically constructed so the pre-existing `#2044` remote-preservation logic doesn't mask the scenario.
- `bun test test/extract-facts-phase.test.ts test/privacy-strip-and-forget.test.ts`: 59/59 pass.
- Broader regression sweep across 44 related test files (anything touching `pages.ts`/`extract-facts.ts`/`get_page`/`fetch_page`): 1089/1089 pass, 0 failures.
- `tsc --noEmit`: clean.

<!-- maintainer-lens: SAFE @ 961545b26 2026-08-24T05:00:00Z -->