### PR TITLE
v0.46.28.0 fix(facts): a Facts fence below the timeline sentinel is preserved, not deleted (#3625)

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -57,7 +57,7 @@ import type { BrainEngine } from '../engine.ts';
 import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede-resolve.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
-import { parseFactsFence } from '../facts-fence.ts';
+import { parseFactsFence, FACTS_FENCE_BEGIN } from '../facts-fence.ts';
 import {
   extractFactsFromFenceText,
   FENCE_SOURCE_DEFAULT,
@@ -184,6 +184,75 @@ export interface ExtractFactsResult {
   phantomsSkippedDrift: number;
   phantomsLockBusy: boolean;
   phantomsMorePending: boolean;
+}
+
+/**
+ * #3625 (adversarial review, 2 rounds): whether `timeline` contains a
+ * GENUINE Facts fence marker, as opposed to the marker text merely being
+ * mentioned inside a fenced code example or quoted prose. A naive
+ * `.includes(FACTS_FENCE_BEGIN)` false-positives on both — e.g. a page
+ * whose real fence WAS removed, but whose timeline documents the fence
+ * syntax in a ```markdown code block or a `> ...` blockquote, would wrongly
+ * be treated as "misplaced" and block a genuine deletion, leaving stale
+ * facts indexed indefinitely.
+ *
+ * Round 1 tried reusing fence-scan.ts's scanFencedBlocks() + string removal
+ * of its extracted fence bodies. Round-2 adversarial review broke that:
+ * scanFencedBlocks normalizes line endings (splits on `\r\n|\r|\n`, joins
+ * fence bodies with plain `\n`) and strips opener indentation before
+ * returning fence text — so `stripped.split(fenceText).join('')` on the
+ * ORIGINAL (un-normalized) string silently fails to match a CRLF or
+ * indented code block, leaving the marker inside it undetected and still
+ * false-positive. Reconstructed-text removal can't safely undo a lossy
+ * normalization.
+ *
+ * Fix: a self-contained single-pass line scanner (mirroring fence-scan.ts's
+ * own CommonMark-subset opener/closer grammar, applied directly against
+ * `timeline.split(/\r\n|\r|\n/)` — ONE split, no re-normalization, no
+ * text-based removal) that skips lines between a real ``` /~~~ opener and
+ * its closer, then checks whether any remaining line, trimmed, exactly
+ * equals the marker. A real fence marker is always written as its own line
+ * (see FENCE_BODY-shaped output from fence-write.ts / upsertFactRow), so
+ * exact-line-match — on lines outside any code fence — rules out both
+ * hazards without needing a full markdown AST (mirrors
+ * findTimelineSplitIndex's own `trimmed === sentinel` pattern for the same
+ * class of problem on the timeline sentinel itself). An unclosed opener
+ * runs to EOF (matches fence-scan.ts's documented behavior) — a marker
+ * appearing after it is inside an ambiguous, unclosed block and is not
+ * trusted as genuine.
+ */
+function timelineHasGenuineFactsFenceMarker(timeline: string): boolean {
+  if (!timeline.includes(FACTS_FENCE_BEGIN)) return false;
+  const lines = timeline.split(/\r\n|\r|\n/);
+  const OPEN_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+  const CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const open = OPEN_RE.exec(line);
+    if (open) {
+      const marker = open[1]!;
+      const fenceChar = marker[0]!;
+      const info = open[2]!.trim();
+      // Mirrors fence-scan.ts: a backtick opener whose info string contains
+      // a backtick is inline code, not a fence opener.
+      if (!(fenceChar === '`' && info.includes('`'))) {
+        let j = i + 1;
+        for (; j < lines.length; j++) {
+          const close = CLOSE_RE.exec(lines[j]!);
+          if (close && close[1]![0] === fenceChar && close[1]!.length >= marker.length) {
+            j++;
+            break;
+          }
+        }
+        i = j; // unclosed fence: j reaches lines.length, ending the scan
+        continue;
+      }
+    }
+    if (line.trim() === FACTS_FENCE_BEGIN) return true;
+    i++;
+  }
+  return false;
 }
 
 /**
@@ -398,6 +467,36 @@ export async function runExtractFacts(
       // could still recover. That partial result is not authoritative: using
       // it for reconciliation would interpret skipped rows as deletions.
       // Preserve this page's existing index and continue with other pages.
+      continue;
+    }
+
+    // #3625: splitBody() puts everything below the timeline sentinel into
+    // page.timeline, not compiled_truth — a `## Facts` fence written there
+    // (agent-composed bodies commonly append it at the bottom) is invisible
+    // to the parseFactsFence(body) call above. Without this check,
+    // parsed.facts.length === 0 reads as "the user deleted the fence" and
+    // the block below prunes every previously-indexed row for the page —
+    // when the fence is actually just misplaced, not absent. Distinguish
+    // the two by checking whether a fence marker ALSO landed in
+    // page.timeline: if so, the page is non-authoritative — malformed
+    // placement (loud warning, preserve the existing index), never treated
+    // as absence (destructive delete). Checked unconditionally on
+    // parsed.facts.length (not just when it's 0): a page can have a valid
+    // fence above the sentinel AND a stray/duplicate one below it (e.g. a
+    // partial hand-edit), in which case parsed.facts.length > 0 but
+    // reconciling from compiled_truth alone would still misread the
+    // below-sentinel rows as deleted. Uses timelineHasGenuineFactsFenceMarker
+    // rather than a raw .includes() (adversarial review finding: the naive
+    // substring check false-positives on the marker text merely being
+    // mentioned in a doc code-block or quoted prose, wrongly blocking a
+    // genuine deletion and leaving stale facts indexed indefinitely).
+    if (timelineHasGenuineFactsFenceMarker(page.timeline ?? '')) {
+      result.warnings.push(
+        `${slug}: FACTS_FENCE_BELOW_SENTINEL: a ## Facts fence was found below ` +
+        `the <!-- timeline --> sentinel, where extract_facts cannot see it. ` +
+        `Move the fence above the sentinel and re-save — leaving it in place ` +
+        `preserves the existing indexed facts but they will not update.`,
+      );
       continue;
     }
 

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExtractFacts } from '../src/core/cycle/extract-facts.ts';
 import { parseFactsFence } from '../src/core/facts-fence.ts';
+import { importFromContent } from '../src/core/import-file.ts';
 
 let engine: PGLiteEngine;
 
@@ -49,6 +50,20 @@ async function putPage(slug: string, body: string): Promise<void> {
     compiled_truth: body,
     frontmatter: {},
     timeline: '',
+  });
+}
+
+// #3625: writes compiled_truth and timeline as SEPARATE columns, mirroring
+// what splitBody() produces when a `## Facts` fence sits below the
+// `<!-- timeline -->` sentinel — the fence text lands in `timeline`, not
+// `compiled_truth`, exactly as MCP put_page would store it.
+async function putPageWithTimeline(slug: string, compiledTruth: string, timeline: string): Promise<void> {
+  await engine.putPage(slug, {
+    title: slug,
+    type: 'person',
+    compiled_truth: compiledTruth,
+    frontmatter: {},
+    timeline,
   });
 }
 
@@ -297,6 +312,261 @@ describe('runExtractFacts — happy path', () => {
       `SELECT COUNT(*) AS n FROM facts WHERE source_markdown_slug = 'people/alice'`,
     );
     expect(Number(rows.rows[0].n)).toBe(0);
+  });
+
+  test('#3625: a Facts fence below the timeline sentinel is preserved, not deleted, and warns loudly', async () => {
+    // Seed the page with the fence in its normal place (above the sentinel)
+    // and let it index normally.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  | linkedin |  |
+| 2 | Prefers async | preference | 0.85 | private | medium | 2026-04-29 |  | OH |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seeded = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(seeded.rows).toHaveLength(2);
+
+    // #3625 repro: rewrite the page so the SAME fence content now lives in
+    // `timeline` (below the sentinel) instead of `compiled_truth` — exactly
+    // what splitBody() produces for a page whose `## Facts` fence was
+    // written below `<!-- timeline -->`. compiled_truth carries none of the
+    // fence text, so parseFactsFence(compiled_truth) sees zero facts.
+    await putPageWithTimeline(
+      'people/alice',
+      '# Page\n\nBody.\n',
+      FACT_FENCE(
+        `| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  | linkedin |  |
+| 2 | Prefers async | preference | 0.85 | private | medium | 2026-04-29 |  | OH |  |`,
+      ),
+    );
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // The fix: this must NOT read as "fence removed" and must NOT delete
+    // the previously-indexed rows.
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Founded Acme', 'Prefers async']);
+  });
+
+  test('#3625 control: a genuinely fence-less page (no fence anywhere in the body) still wipes as before', async () => {
+    // Same shape as the misplaced-fence case above, but this time the fence
+    // is truly absent from BOTH compiled_truth and timeline — the existing
+    // "user deleted the fence" contract must still hold; the #3625 guard
+    // must not swallow genuine deletions.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline('people/alice', '# Just a page\n\nNo fence.\n', 'Some unrelated timeline prose.\n');
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT COUNT(*) AS n FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(Number(rows.rows[0].n)).toBe(0);
+  });
+
+  test('#3625 adversarial review finding: the marker merely mentioned inside a ```code block``` does not block a genuine deletion', async () => {
+    // A naive `.includes(FACTS_FENCE_BEGIN)` check false-positives here — the
+    // marker text is present in timeline, but only as documentation, not as
+    // a real fence. The real fence was genuinely removed and must delete.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '## Docs\n\n```markdown\n<!--- gbrain:facts:begin -->\nexample only\n```\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 adversarial review finding: the marker merely quoted in prose does not block a genuine deletion', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '> Historical docs mention the token <!--- gbrain:facts:begin -->, but this is not a fence.\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 control: a genuine unbalanced marker (own line, not inside a code block) still blocks deletion', async () => {
+    // Contrast with the two false-positive tests above — this marker IS a
+    // real (if malformed/unbalanced) fence occurrence and must still guard.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nNo compiled fence.\n',
+      '<!--- gbrain:facts:begin -->\nPRIVATE_UNBALANCED_ROW\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+  });
+
+  test('#3625 adversarial review round 2: a CRLF-line-ending code block mentioning the marker does not false-positive', async () => {
+    // Round-1 fix (scanFencedBlocks + string removal) normalized line
+    // endings internally but tried to remove fence text from the
+    // UN-normalized original string, silently failing to strip a CRLF code
+    // block and leaving the false positive in place. The round-2 fix
+    // (single-pass line scanner, one \r\n|\r|\n split applied throughout)
+    // must handle this correctly.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      '## Docs\r\n\r\n```markdown\r\n<!--- gbrain:facts:begin -->\r\nexample only\r\n```\r\n',
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 adversarial review round 2: two identical code-block mentions of the marker do not false-positive', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | seeded | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    const codeBlock = '```markdown\n<!--- gbrain:facts:begin -->\nexample only\n```\n';
+    await putPageWithTimeline(
+      'people/alice',
+      '# Alice\n\nThe real Facts fence was removed.\n',
+      `${codeBlock}\n${codeBlock}`,
+    );
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsDeleted).toBe(1);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('#3625 via the real MCP write path: a stray fence below the sentinel is preserved even when import-file.ts is in play', async () => {
+    // Codex review finding: the two tests above write compiled_truth/timeline
+    // directly via engine.putPage, bypassing importFromContent's own #2044
+    // remote-preservation logic (restores an old fence into compiled_truth
+    // when an incoming remote write's compiled half has ZERO facts — which
+    // would otherwise mask a below-sentinel duplicate by never even letting
+    // this test reach the state it wants to prove: confirmed by running the
+    // simpler "compiled_truth ends up with zero facts" version of this test
+    // first — #2044 fired and restored the OLD fence, so compiled_truth
+    // never went empty and this guard was never exercised).
+    //
+    // Reproduce a case #2044 does NOT swallow: the incoming remote write's
+    // compiled_truth keeps ONE valid fact above the sentinel (so
+    // incomingFacts.facts.length > 0 — #2044's restore condition requires
+    // exactly 0 and does not fire) while ALSO carrying a stray duplicate
+    // fence below the sentinel (e.g. an agent re-appending a "## Facts"
+    // section near new content it's adding at the bottom of the page).
+    // splitBody() (inside putPage, called by importFromContent) does the
+    // real fence/sentinel split — no direct column poking.
+    const seed = `---
+title: alice
+type: person
+---
+
+Some body content.
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  |  linkedin |  |
+| 2 | Prefers async | preference | 0.85 | world | medium | 2026-04-29 |  |  OH |  |
+<!--- gbrain:facts:end -->
+
+<!-- timeline -->
+`;
+    await importFromContent(engine, 'people/alice', seed, { noEmbed: true, remote: true });
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seeded = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(seeded.rows).toHaveLength(2);
+
+    // A malformed remote rewrite: row 1 stays correctly placed above the
+    // sentinel (so #2044's restore never fires — incomingFacts.facts.length
+    // is 1, not 0), but row 2 got duplicated into a second fence below it.
+    const misplaced = `---
+title: alice
+type: person
+---
+
+Some body content.
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Founded Acme | fact | 1.0 | world | high | 2017-01-01 |  |  linkedin |  |
+<!--- gbrain:facts:end -->
+
+<!-- timeline -->
+
+## Facts
+
+<!--- gbrain:facts:begin -->
+| # | claim | kind | confidence | visibility | notability | valid_from | valid_until | source | context |
+|---|-------|------|------------|------------|------------|------------|-------------|--------|---------|
+| 1 | Prefers async | preference | 0.85 | world | medium | 2026-04-29 |  |  OH |  |
+<!--- gbrain:facts:end -->
+`;
+    await importFromContent(engine, 'people/alice', misplaced, { noEmbed: true, remote: true });
+
+    const page = await engine.getPage('people/alice');
+    // Sanity: confirm the real write path actually reproduces the #3625
+    // precondition (#2044 did NOT restore anything away, and a fence marker
+    // really did land in timeline) before trusting the assertions below.
+    expect(parseFactsFence(page!.compiled_truth ?? '').facts).toHaveLength(1);
+    expect((page!.timeline ?? '')).toContain('gbrain:facts:begin');
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    expect(r.factsDeleted).toBe(0);
+    expect(r.warnings.some(w => w.includes('FACTS_FENCE_BELOW_SENTINEL'))).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(rows.rows).toHaveLength(2);
   });
 
   test('dry-run does not touch DB', async () => {


### PR DESCRIPTION
## Summary

Fixes #3625 (p0, verified-real). `put_page` accepts a `## Facts` fence written below the `<!-- timeline -->` sentinel — `splitBody()` routes everything below the sentinel into the `timeline` column, not `compiled_truth`, so the fence lands somewhere `extract_facts`'s reconciliation never looks. It reads only `page.compiled_truth`, sees zero facts, and — believing the user deleted the fence — calls `deleteFactsForPage`, permanently destroying every previously-indexed fact row for that page. Measured on a live brain: 10 pages drifted into this state, 21 fence rows reduced to 1 surviving DB fact before manual recovery.

## Fix

When a genuine fence marker is also found in `page.timeline`, treat the page as non-authoritative (malformed placement — loud warning, existing rows preserved) rather than fence-absent (deletion). This is checked unconditionally on `parsed.facts.length`, not just when it's 0: a page can have a valid fence above the sentinel and a stray duplicate below it (e.g. a partial edit), in which case reconciling from `compiled_truth` alone would still misread the below-sentinel rows as deleted.

## "Genuine fence marker" detection — 2 rounds of adversarial review

A naive `.includes(FACTS_FENCE_BEGIN)` false-positives on the marker text merely being mentioned in a documentation code block or quoted prose — not a real fence — wrongly blocking a genuine deletion and leaving stale facts indexed indefinitely.

The fix (`timelineHasGenuineFactsFenceMarker`) is a self-contained single-pass line scanner: split `timeline` on one `\r\n|\r|\n` pattern throughout (no re-normalization, no text-based removal — a first attempt reusing `fence-scan.ts`'s `scanFencedBlocks()` + string removal silently failed for CRLF/indented code blocks, since that scanner normalizes line endings and strips indentation before returning fence text), skip lines between a real ` ``` `/`~~~` opener and its closer (same CommonMark-subset grammar `fence-scan.ts` documents), then check whether any remaining line, trimmed, exactly equals the marker — mirrors `findTimelineSplitIndex`'s own `trimmed === sentinel` pattern for the identical class of problem on the timeline sentinel itself.

## Scope

Deliberately scoped to the read-side reconciliation guard only. A separate, related issue was found during review (`get_page`/`fetch_page` not stripping private facts from `timeline` for remote readers, plus a round-trip data-loss hazard in the existing `#2044` restoration mechanism) — that is independently-motivated (the leak predates this fix; it isn't caused by it) and is filed as #4546, fixed in #4547 (further follow-up in #4548).

## Test plan

- 8 new regression tests, verified red (fail without the fix, reproducing the reported deletion and each false-positive class) and green (pass with it).
- `bun test test/extract-facts-phase.test.ts`: 47/47 pass.
- Broader regression sweep (4 related files touching `runExtractFacts`/`extract-facts`): 98/98 pass, 0 failures.
- `tsc --noEmit`: clean.

<!-- maintainer-lens: SAFE @ 5cf41c3e513821e191495c7b48996d57bb84bde7 2026-08-24T07:05:16Z -->
