### PR TITLE
fix(#2044): surface (don't fix) the mixed-fence hidden-row gap (P1)

### DIFF
--- a/src/core/facts-fence.ts
+++ b/src/core/facts-fence.ts
@@ -345,6 +345,42 @@ export function renderFactsTable(facts: ParsedFact[]): string {
 }
 
 /**
+ * #2044 row-level restoration merge, replacing the original whole-block
+ * swap. Returns the merged row set for a privacy-boundary restoration, or
+ * null if nothing needs restoring.
+ *
+ * The whole-block swap (`incoming.facts.length === 0` -> re-append the
+ * entire old fence) has two bugs: (P1) a MIXED world+private fence never
+ * triggers it once the visible world row survives stripping (incoming
+ * length is 1+, not 0), silently losing the private row on write-back;
+ * (P2) a fully-visible world-only fence's legitimate deletion (caller saw
+ * every row and genuinely removed them) is silently undone, since the old
+ * incoming-length-0 check can't distinguish "caller couldn't see this row"
+ * from "caller saw and deleted this row."
+ *
+ * Fix: only rows that are NOT 'world'-visible are ever restoration
+ * candidates — those are the only rows a remote caller structurally could
+ * not have seen via get_page/fetch's privacy strip (stripFactsFence keeps
+ * 'world' rows, drops everything else). A row the caller COULD see
+ * (world-visible) and chose to remove or relocate is never restored — that
+ * edit is the caller's, honored as written. Returns null (no-op) whenever
+ * either parse produced warnings (non-authoritative fence) or there are no
+ * hidden rows missing from the incoming set.
+ */
+export function restoreHiddenFactRows(
+  incoming: { facts: ParsedFact[]; warnings: string[] },
+  existing: { facts: ParsedFact[]; warnings: string[] },
+): ParsedFact[] | null {
+  if (incoming.warnings.length > 0 || existing.warnings.length > 0) return null;
+  const hidden = existing.facts.filter((f) => f.visibility !== 'world');
+  if (hidden.length === 0) return null;
+  const incomingRowNums = new Set(incoming.facts.map((f) => f.rowNum));
+  const missing = hidden.filter((f) => !incomingRowNums.has(f.rowNum));
+  if (missing.length === 0) return null;
+  return [...incoming.facts, ...missing].sort((a, b) => a.rowNum - b.rowNum);
+}
+
+/**
  * Append a new fact row to the body. If a fenced facts table exists, the
  * row is added to the end of it. If not, a new `## Facts` section + fence
  * is created at the end of the body.

--- a/src/core/facts-fence.ts
+++ b/src/core/facts-fence.ts
@@ -345,39 +345,30 @@ export function renderFactsTable(facts: ParsedFact[]): string {
 }
 
 /**
- * Surfacing-only diagnostic for #2044's two known gaps in the compiled_truth
- * restoration guard (import-file.ts). Returns a warning string, or null if
- * nothing to flag. Pure and side-effect-free — the caller decides how to
- * surface it (console.warn today); no restoration behavior is changed here.
+ * Surfacing-only diagnostic for #2044's compiled_truth restoration guard
+ * (import-file.ts): the restoration only fires when the incoming fence
+ * went to exactly zero facts. A fence that still has SOME rows (e.g. a
+ * mixed world+private fence where only the visible world row survives
+ * stripping) never triggers it -- non-'world' rows present before the
+ * write that are missing from the incoming write are silently dropped,
+ * even though the caller structurally could never have seen them.
  *
- * - `restored` case: the whole-block restore just re-appended EVERY old
- *   row, including any the caller could see ('world'-visible) and may have
- *   genuinely, intentionally deleted in full. It can't distinguish that
- *   from "caller never saw this row" -- flag when a restored row was
- *   'world'-visible.
- * - not-`restored` case: the restoration only fires when the incoming
- *   fence went to exactly zero facts. A fence that still has SOME rows
- *   (e.g. a mixed world+private fence where only the visible world row
- *   survives stripping) never triggers it -- flag when non-'world' rows
- *   present before the write are missing from the incoming write.
+ * Returns a warning string, or null if nothing to flag. Pure and
+ * side-effect-free — the caller decides how to surface it (console.warn
+ * today); no restoration behavior is changed here. Only applies when
+ * `restored` is false (the restoration guard did not fire) — see #4553's
+ * sibling PR for the `restored === true` gap (a fully-visible deletion
+ * silently undone).
  */
-export function factsRestorationWarning(
+export function factsGapWarning(
   slug: string,
   incoming: { facts: ParsedFact[]; warnings: string[] },
   existing: { facts: ParsedFact[]; warnings: string[] },
   restored: boolean,
 ): string | null {
+  if (restored) return null;
   if (incoming.warnings.length > 0 || existing.warnings.length > 0) return null;
   if (existing.facts.length === 0) return null;
-
-  if (restored) {
-    const worldRows = existing.facts.filter((f) => f.visibility === 'world').length;
-    if (worldRows === 0) return null;
-    return `[gbrain] #2044 restoration on ${slug}: a remote write emptied the Facts fence and ` +
-      `${existing.facts.length} old row(s) were restored, including ${worldRows} 'world'-visible ` +
-      `row(s) the caller could have seen and may have genuinely deleted. If so, that deletion has ` +
-      `been undone -- verify.`;
-  }
 
   const incomingRowNums = new Set(incoming.facts.map((f) => f.rowNum));
   const dropped = existing.facts.filter(

--- a/src/core/facts-fence.ts
+++ b/src/core/facts-fence.ts
@@ -345,39 +345,49 @@ export function renderFactsTable(facts: ParsedFact[]): string {
 }
 
 /**
- * #2044 row-level restoration merge, replacing the original whole-block
- * swap. Returns the merged row set for a privacy-boundary restoration, or
- * null if nothing needs restoring.
+ * Surfacing-only diagnostic for #2044's two known gaps in the compiled_truth
+ * restoration guard (import-file.ts). Returns a warning string, or null if
+ * nothing to flag. Pure and side-effect-free — the caller decides how to
+ * surface it (console.warn today); no restoration behavior is changed here.
  *
- * The whole-block swap (`incoming.facts.length === 0` -> re-append the
- * entire old fence) has two bugs: (P1) a MIXED world+private fence never
- * triggers it once the visible world row survives stripping (incoming
- * length is 1+, not 0), silently losing the private row on write-back;
- * (P2) a fully-visible world-only fence's legitimate deletion (caller saw
- * every row and genuinely removed them) is silently undone, since the old
- * incoming-length-0 check can't distinguish "caller couldn't see this row"
- * from "caller saw and deleted this row."
- *
- * Fix: only rows that are NOT 'world'-visible are ever restoration
- * candidates — those are the only rows a remote caller structurally could
- * not have seen via get_page/fetch's privacy strip (stripFactsFence keeps
- * 'world' rows, drops everything else). A row the caller COULD see
- * (world-visible) and chose to remove or relocate is never restored — that
- * edit is the caller's, honored as written. Returns null (no-op) whenever
- * either parse produced warnings (non-authoritative fence) or there are no
- * hidden rows missing from the incoming set.
+ * - `restored` case: the whole-block restore just re-appended EVERY old
+ *   row, including any the caller could see ('world'-visible) and may have
+ *   genuinely, intentionally deleted in full. It can't distinguish that
+ *   from "caller never saw this row" -- flag when a restored row was
+ *   'world'-visible.
+ * - not-`restored` case: the restoration only fires when the incoming
+ *   fence went to exactly zero facts. A fence that still has SOME rows
+ *   (e.g. a mixed world+private fence where only the visible world row
+ *   survives stripping) never triggers it -- flag when non-'world' rows
+ *   present before the write are missing from the incoming write.
  */
-export function restoreHiddenFactRows(
+export function factsRestorationWarning(
+  slug: string,
   incoming: { facts: ParsedFact[]; warnings: string[] },
   existing: { facts: ParsedFact[]; warnings: string[] },
-): ParsedFact[] | null {
+  restored: boolean,
+): string | null {
   if (incoming.warnings.length > 0 || existing.warnings.length > 0) return null;
-  const hidden = existing.facts.filter((f) => f.visibility !== 'world');
-  if (hidden.length === 0) return null;
+  if (existing.facts.length === 0) return null;
+
+  if (restored) {
+    const worldRows = existing.facts.filter((f) => f.visibility === 'world').length;
+    if (worldRows === 0) return null;
+    return `[gbrain] #2044 restoration on ${slug}: a remote write emptied the Facts fence and ` +
+      `${existing.facts.length} old row(s) were restored, including ${worldRows} 'world'-visible ` +
+      `row(s) the caller could have seen and may have genuinely deleted. If so, that deletion has ` +
+      `been undone -- verify.`;
+  }
+
   const incomingRowNums = new Set(incoming.facts.map((f) => f.rowNum));
-  const missing = hidden.filter((f) => !incomingRowNums.has(f.rowNum));
-  if (missing.length === 0) return null;
-  return [...incoming.facts, ...missing].sort((a, b) => a.rowNum - b.rowNum);
+  const dropped = existing.facts.filter(
+    (f) => f.visibility !== 'world' && !incomingRowNums.has(f.rowNum),
+  ).length;
+  if (dropped === 0) return null;
+  return `[gbrain] #2044 gap on ${slug}: ${dropped} non-'world' fact row(s) present before this ` +
+    `remote write are missing from the incoming write and were NOT restored (#2044 only restores ` +
+    `when the incoming fence goes to exactly zero facts). If these rows were dropped by a caller ` +
+    `who never saw them, they are now lost.`;
 }
 
 /**

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -47,7 +47,7 @@ import { decorateEmbeddingDimError } from './embedding-dim-check.ts';
 import { computeCorpusGeneration, loadSourceRow } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
-import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from './facts-fence.ts';
+import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, renderFactsTable, restoreHiddenFactRows } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
 
 /**
@@ -108,14 +108,9 @@ function fenceTagToPseudoPath(lang: string | undefined): string | null {
 
 // MAX_FENCES_PER_PAGE (fence-bomb DOS cap, GBRAIN_MAX_FENCES_PER_PAGE env
 // override) moved to fence-scan.ts with the #2862 linear scanner.
-
-function extractFactsFenceBlock(body: string): string | null {
-  const beginIdx = body.indexOf(FACTS_FENCE_BEGIN);
-  if (beginIdx === -1) return null;
-  const endIdx = body.indexOf(FACTS_FENCE_END, beginIdx + FACTS_FENCE_BEGIN.length);
-  if (endIdx === -1) return null;
-  return body.slice(beginIdx, endIdx + FACTS_FENCE_END.length);
-}
+// extractFactsFenceBlock removed (#2044 row-level restoration merge fix):
+// the whole-block swap it supported is replaced by restoreHiddenFactRows()
+// in facts-fence.ts.
 
 function replaceOrAppendFactsFence(body: string, fenceBlock: string): string {
   const beginIdx = body.indexOf(FACTS_FENCE_BEGIN);
@@ -602,23 +597,23 @@ export async function importFromContent(
   // unscoped-check/scoped-write bug class).
   const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
 
-  // #2044: remote get_page intentionally strips private facts rows. A
-  // documented get_page -> edit -> put_page round-trip can therefore arrive
-  // with an empty/missing Facts fence even though the existing page still has
-  // canonical fence rows. Preserve the old fence in that narrow case so the
-  // system-of-record markdown is not truncated by the privacy boundary.
+  // #2044 (row-level restoration merge fix, replacing the original
+  // whole-block swap): remote get_page intentionally strips non-'world'
+  // facts rows before an untrusted caller ever sees them. A documented
+  // get_page -> edit -> put_page round-trip can therefore arrive missing
+  // rows the caller structurally could never have seen, let alone
+  // intentionally deleted. Restore only those specific rows — see
+  // restoreHiddenFactRows() in facts-fence.ts for the row-level,
+  // visibility-aware merge rationale (fixes two round-trip data-loss gaps
+  // in the old whole-block swap: a mixed public+private fence's hidden row
+  // was never restored, and a fully-visible world-only fence's legitimate
+  // deletion was silently undone).
   if (opts.remote === true && existing?.compiled_truth) {
     const incomingFacts = parseFactsFence(parsed.compiled_truth);
     const existingFacts = parseFactsFence(existing.compiled_truth);
-    const existingFenceBlock = extractFactsFenceBlock(existing.compiled_truth);
-    if (
-      incomingFacts.facts.length === 0 &&
-      incomingFacts.warnings.length === 0 &&
-      existingFacts.warnings.length === 0 &&
-      existingFacts.facts.length > 0 &&
-      existingFenceBlock
-    ) {
-      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock);
+    const merged = restoreHiddenFactRows(incomingFacts, existingFacts);
+    if (merged) {
+      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, renderFactsTable(merged));
     }
   }
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -47,7 +47,7 @@ import { decorateEmbeddingDimError } from './embedding-dim-check.ts';
 import { computeCorpusGeneration, loadSourceRow } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
-import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, renderFactsTable, restoreHiddenFactRows } from './facts-fence.ts';
+import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, factsRestorationWarning } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
 
 /**
@@ -108,9 +108,14 @@ function fenceTagToPseudoPath(lang: string | undefined): string | null {
 
 // MAX_FENCES_PER_PAGE (fence-bomb DOS cap, GBRAIN_MAX_FENCES_PER_PAGE env
 // override) moved to fence-scan.ts with the #2862 linear scanner.
-// extractFactsFenceBlock removed (#2044 row-level restoration merge fix):
-// the whole-block swap it supported is replaced by restoreHiddenFactRows()
-// in facts-fence.ts.
+
+function extractFactsFenceBlock(body: string): string | null {
+  const beginIdx = body.indexOf(FACTS_FENCE_BEGIN);
+  if (beginIdx === -1) return null;
+  const endIdx = body.indexOf(FACTS_FENCE_END, beginIdx + FACTS_FENCE_BEGIN.length);
+  if (endIdx === -1) return null;
+  return body.slice(beginIdx, endIdx + FACTS_FENCE_END.length);
+}
 
 function replaceOrAppendFactsFence(body: string, fenceBlock: string): string {
   const beginIdx = body.indexOf(FACTS_FENCE_BEGIN);
@@ -597,24 +602,21 @@ export async function importFromContent(
   // unscoped-check/scoped-write bug class).
   const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
 
-  // #2044 (row-level restoration merge fix, replacing the original
-  // whole-block swap): remote get_page intentionally strips non-'world'
-  // facts rows before an untrusted caller ever sees them. A documented
-  // get_page -> edit -> put_page round-trip can therefore arrive missing
-  // rows the caller structurally could never have seen, let alone
-  // intentionally deleted. Restore only those specific rows — see
-  // restoreHiddenFactRows() in facts-fence.ts for the row-level,
-  // visibility-aware merge rationale (fixes two round-trip data-loss gaps
-  // in the old whole-block swap: a mixed public+private fence's hidden row
-  // was never restored, and a fully-visible world-only fence's legitimate
-  // deletion was silently undone).
+  // #2044: remote get_page intentionally strips private facts rows. A
+  // documented get_page -> edit -> put_page round-trip can therefore arrive
+  // with an empty/missing Facts fence even though the existing page still has
+  // canonical fence rows. Preserve the old fence in that narrow case so the
+  // system-of-record markdown is not truncated by the privacy boundary.
   if (opts.remote === true && existing?.compiled_truth) {
     const incomingFacts = parseFactsFence(parsed.compiled_truth);
     const existingFacts = parseFactsFence(existing.compiled_truth);
-    const merged = restoreHiddenFactRows(incomingFacts, existingFacts);
-    if (merged) {
-      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, renderFactsTable(merged));
-    }
+    const existingFenceBlock = extractFactsFenceBlock(existing.compiled_truth);
+    const restored = incomingFacts.facts.length === 0 && incomingFacts.warnings.length === 0
+      && existingFacts.warnings.length === 0 && existingFacts.facts.length > 0 && !!existingFenceBlock;
+    if (restored) parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock as string);
+    // Surfacing-only: see factsRestorationWarning() in facts-fence.ts. No behavior change.
+    const gapWarning = factsRestorationWarning(slug, incomingFacts, existingFacts, restored);
+    if (gapWarning) console.warn(gapWarning);
   }
 
   // #1035: absence of an explicit frontmatter `type:` on an EXISTING page

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -47,7 +47,7 @@ import { decorateEmbeddingDimError } from './embedding-dim-check.ts';
 import { computeCorpusGeneration, loadSourceRow } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
-import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, factsRestorationWarning } from './facts-fence.ts';
+import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, factsGapWarning } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
 
 /**
@@ -614,8 +614,8 @@ export async function importFromContent(
     const restored = incomingFacts.facts.length === 0 && incomingFacts.warnings.length === 0
       && existingFacts.warnings.length === 0 && existingFacts.facts.length > 0 && !!existingFenceBlock;
     if (restored) parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock as string);
-    // Surfacing-only: see factsRestorationWarning() in facts-fence.ts. No behavior change.
-    const gapWarning = factsRestorationWarning(slug, incomingFacts, existingFacts, restored);
+    // Surfacing-only: see factsGapWarning() in facts-fence.ts. No behavior change.
+    const gapWarning = factsGapWarning(slug, incomingFacts, existingFacts, restored);
     if (gapWarning) console.warn(gapWarning);
   }
 

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -12,7 +12,7 @@
  * Real PGLite + tempdir filesystem.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -139,18 +139,14 @@ describe('Layer B — get_page strip trigger (Codex R2-#5)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────
-// #2044 row-level restoration merge (row-level, visibility-aware merge
-// replacing the original whole-block swap)
+// #2044 surfacing-only gap warnings (P1 mixed-fence / P2 world-only-
+// deletion) — data behavior is UNCHANGED; these tests confirm the
+// diagnostic actually fires under the two known gap conditions, and does
+// NOT fire for the unaffected baseline/local-write cases (positive
+// control for the guard, both directions).
 // ─────────────────────────────────────────────────────────────────
-//
-// The old restoration only fired when the incoming fence had gone to
-// EXACTLY zero facts, and re-appended the ENTIRE old fence block. Two bugs
-// follow: (P1) a mixed world+private fence's hidden row is never restored
-// once the visible world row survives stripping (incoming length is 1+,
-// not 0); (P2) a fully-visible world-only fence's legitimate deletion is
-// silently undone (the whole-block swap can't distinguish "caller couldn't
-// see this row" from "caller saw and deleted this row").
-describe('#2044 row-level restoration merge (P1 mixed-fence / P2 world-only-deletion fix)', () => {
+
+describe('#2044 gap warnings (console.warn diagnostics, no behavior change)', () => {
   function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
     return {
       engine,
@@ -164,110 +160,123 @@ describe('#2044 row-level restoration merge (P1 mixed-fence / P2 world-only-dele
     };
   }
 
-  test('all-private Facts fence survives a remote get_page -> edit -> put_page round-trip (baseline, unchanged behavior)', async () => {
-    const putPageOp = operations.find((o) => o.name === 'put_page')!;
-    const getPageOp = operations.find((o) => o.name === 'get_page')!;
-    const slug = 'people/allprivate-roundtrip';
-    const fence = FENCE_BODY(
-      '| 1 | PRIVATE_ONLY_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |',
-    );
-    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+  test('P1 gap: mixed world+private fence — warns that the private row was dropped, and the row IS still dropped (unchanged pre-existing behavior)', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      const slug = 'people/p1-mixed-warn';
+      const fence = FENCE_BODY(
+        `| 1 | PUBLIC_P1_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_P1_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
 
-    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
-      slug,
-      include_content: true,
-    }) as { content?: string };
-    expect(remote.content).not.toContain('PRIVATE_ONLY_FACT');
-    const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
-    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug,
+        include_content: true,
+      }) as { content?: string };
+      warnSpy.mockClear(); // only assert on the put_page call below
+      const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
+      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
 
-    const raw = await engine.getPage(slug, { sourceId: 'default' });
-    expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_ONLY_FACT');
+      const warnedGap = warnSpy.mock.calls.some((c) => String(c[0]).includes('#2044 gap') && String(c[0]).includes(slug));
+      expect(warnedGap).toBe(true);
+      // Unchanged pre-existing behavior: the row is still actually dropped
+      // (this PR is diagnostics-only, not a data-behavior fix).
+      const raw = await engine.getPage(slug, { sourceId: 'default' });
+      expect((raw?.compiled_truth ?? '')).not.toContain('PRIVATE_P1_FACT');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  test('P1 fix: a MIXED world+private Facts fence preserves the private row on round-trip (previously lost — old restoration only fired at incoming.facts.length===0)', async () => {
-    const putPageOp = operations.find((o) => o.name === 'put_page')!;
-    const getPageOp = operations.find((o) => o.name === 'get_page')!;
-    const slug = 'people/mixed-roundtrip';
-    const fence = FENCE_BODY(
-      `| 1 | PUBLIC_MIXED_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
-| 2 | PRIVATE_MIXED_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
-    );
-    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+  test('P2 gap: deleting a world-only fence — warns that the deletion was undone, and the row IS still restored (unchanged pre-existing behavior)', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      const slug = 'people/p2-worldonly-warn';
+      const fence = FENCE_BODY(
+        '| 1 | WORLD_ONLY_P2_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
 
-    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
-      slug,
-      include_content: true,
-    }) as { content?: string };
-    expect(remote.content).toContain('PUBLIC_MIXED_FACT');
-    expect(remote.content).not.toContain('PRIVATE_MIXED_FACT');
-    const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
-    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug,
+        include_content: true,
+      }) as { content?: string };
+      const body = remote.content ?? '';
+      const factsHeadingIdx = body.indexOf('## Facts');
+      const fenceEndIdx = body.indexOf(FACTS_FENCE_END) + FACTS_FENCE_END.length;
+      const edited = body.slice(0, factsHeadingIdx).replace('Some text.', 'Some text, fence removed.')
+        + body.slice(fenceEndIdx);
+      warnSpy.mockClear();
+      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
 
-    const raw = await engine.getPage(slug, { sourceId: 'default' });
-    expect((raw?.compiled_truth ?? '')).toContain('PUBLIC_MIXED_FACT');
-    expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_MIXED_FACT');
+      const warnedRestoration = warnSpy.mock.calls.some(
+        (c) => String(c[0]).includes('#2044 restoration') && String(c[0]).includes(slug),
+      );
+      expect(warnedRestoration).toBe(true);
+      // Unchanged pre-existing behavior: the deletion is still undone.
+      const raw = await engine.getPage(slug, { sourceId: 'default' });
+      expect((raw?.compiled_truth ?? '')).toContain('WORLD_ONLY_P2_FACT');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  test('P2 fix: deleting a fully-visible world-only fence is honored, not silently undone (previously the whole-block swap re-appended every old row)', async () => {
-    const putPageOp = operations.find((o) => o.name === 'put_page')!;
-    const getPageOp = operations.find((o) => o.name === 'get_page')!;
-    const slug = 'people/world-only-delete';
-    const fence = FENCE_BODY(
-      '| 1 | WORLD_ONLY_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
-    );
-    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+  test('no warning: an all-private fence round-trip (no world rows involved) does not fire the P2 warning', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      const slug = 'people/no-warn-allprivate';
+      const fence = FENCE_BODY(
+        '| 1 | PRIVATE_NOWARN_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |',
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
 
-    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
-      slug,
-      include_content: true,
-    }) as { content?: string };
-    expect(remote.content).toContain('WORLD_ONLY_FACT');
-    // The caller saw the fence in full and deletes it entirely — remove
-    // just the `## Facts` section (heading + fence block), keeping the
-    // rest of the page (and its non-blank body) intact, mirroring a real
-    // caller's edit.
-    const body = remote.content ?? '';
-    const factsHeadingIdx = body.indexOf('## Facts');
-    const fenceEndIdx = body.indexOf(FACTS_FENCE_END) + FACTS_FENCE_END.length;
-    const edited = body.slice(0, factsHeadingIdx).replace('Some text.', 'Some text, fence removed.')
-      + body.slice(fenceEndIdx);
-    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug,
+        include_content: true,
+      }) as { content?: string };
+      warnSpy.mockClear();
+      const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
+      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
 
-    const raw = await engine.getPage(slug, { sourceId: 'default' });
-    expect((raw?.compiled_truth ?? '')).not.toContain('WORLD_ONLY_FACT');
+      const anyGapWarning = warnSpy.mock.calls.some((c) => String(c[0]).includes('#2044'));
+      expect(anyGapWarning).toBe(false);
+      // The row is restored (unchanged pre-existing #2044 behavior).
+      const raw = await engine.getPage(slug, { sourceId: 'default' });
+      expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_NOWARN_FACT');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  test('a LOCAL (non-remote) write that deletes a private row is honored — restoration only applies to remote writes', async () => {
-    // Guards against an over-eager merge firing regardless of trust
-    // boundary: a local caller (ctx.remote === false) sees the fence in
-    // full via get_page, so a subsequent local put_page that omits a row
-    // is a genuine, fully-informed deletion — never a restoration
-    // candidate, since restoration exists specifically to protect rows a
-    // caller structurally could not have seen.
-    const putPageOp = operations.find((o) => o.name === 'put_page')!;
-    const getPageOp = operations.find((o) => o.name === 'get_page')!;
-    const slug = 'people/local-full-delete';
-    const fence = FENCE_BODY(
-      `| 1 | LOCAL_KEEP_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
-| 2 | LOCAL_DELETE_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
-    );
-    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+  test('no warning: a normal local (non-remote) edit never triggers either diagnostic', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const slug = 'people/no-warn-local';
+      const fence = FENCE_BODY(
+        `| 1 | LOCAL_WORLD_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | LOCAL_PRIVATE_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+      warnSpy.mockClear();
+      // Local write that drops both rows -- fully-informed, no diagnostic.
+      await putPageOp.handler(makeCtx({ remote: false }), {
+        slug,
+        content: '# Page\n\nSome text edited.\n',
+      });
 
-    const local = await getPageOp.handler(makeCtx({ remote: false }), {
-      slug,
-      include_content: true,
-    }) as { content?: string };
-    expect(local.content).toContain('LOCAL_DELETE_FACT');
-    const edited = (local.content ?? '').replace(
-      /\| 2 \| LOCAL_DELETE_FACT[^\n]*\n/,
-      '',
-    );
-    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: edited });
-
-    const raw = await engine.getPage(slug, { sourceId: 'default' });
-    expect((raw?.compiled_truth ?? '')).toContain('LOCAL_KEEP_FACT');
-    expect((raw?.compiled_truth ?? '')).not.toContain('LOCAL_DELETE_FACT');
+      const anyGapWarning = warnSpy.mock.calls.some((c) => String(c[0]).includes('#2044'));
+      expect(anyGapWarning).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -139,14 +139,16 @@ describe('Layer B — get_page strip trigger (Codex R2-#5)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────
-// #2044 surfacing-only gap warnings (P1 mixed-fence / P2 world-only-
-// deletion) — data behavior is UNCHANGED; these tests confirm the
-// diagnostic actually fires under the two known gap conditions, and does
-// NOT fire for the unaffected baseline/local-write cases (positive
-// control for the guard, both directions).
+// #2044 surfacing-only P1 gap warning (mixed world+private fence — the
+// hidden row is silently dropped because restoration only fires when the
+// incoming fence goes to exactly zero facts) — data behavior is
+// UNCHANGED; these tests confirm the diagnostic actually fires under the
+// gap condition, and does NOT fire for the unaffected baseline/local-write
+// cases (positive control for the guard, both directions). The sibling P2
+// gap (world-only deletion silently undone) is a separate PR.
 // ─────────────────────────────────────────────────────────────────
 
-describe('#2044 gap warnings (console.warn diagnostics, no behavior change)', () => {
+describe('#2044 P1 gap warning (console.warn diagnostic, no behavior change)', () => {
   function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
     return {
       engine,
@@ -191,42 +193,7 @@ describe('#2044 gap warnings (console.warn diagnostics, no behavior change)', ()
     }
   });
 
-  test('P2 gap: deleting a world-only fence — warns that the deletion was undone, and the row IS still restored (unchanged pre-existing behavior)', async () => {
-    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const putPageOp = operations.find((o) => o.name === 'put_page')!;
-      const getPageOp = operations.find((o) => o.name === 'get_page')!;
-      const slug = 'people/p2-worldonly-warn';
-      const fence = FENCE_BODY(
-        '| 1 | WORLD_ONLY_P2_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
-      );
-      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
-
-      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
-        slug,
-        include_content: true,
-      }) as { content?: string };
-      const body = remote.content ?? '';
-      const factsHeadingIdx = body.indexOf('## Facts');
-      const fenceEndIdx = body.indexOf(FACTS_FENCE_END) + FACTS_FENCE_END.length;
-      const edited = body.slice(0, factsHeadingIdx).replace('Some text.', 'Some text, fence removed.')
-        + body.slice(fenceEndIdx);
-      warnSpy.mockClear();
-      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
-
-      const warnedRestoration = warnSpy.mock.calls.some(
-        (c) => String(c[0]).includes('#2044 restoration') && String(c[0]).includes(slug),
-      );
-      expect(warnedRestoration).toBe(true);
-      // Unchanged pre-existing behavior: the deletion is still undone.
-      const raw = await engine.getPage(slug, { sourceId: 'default' });
-      expect((raw?.compiled_truth ?? '')).toContain('WORLD_ONLY_P2_FACT');
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  test('no warning: an all-private fence round-trip (no world rows involved) does not fire the P2 warning', async () => {
+  test('no warning: an all-private fence round-trip (incoming goes to exactly zero, restoration fires normally) does not fire the gap warning', async () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const putPageOp = operations.find((o) => o.name === 'put_page')!;
@@ -255,7 +222,7 @@ describe('#2044 gap warnings (console.warn diagnostics, no behavior change)', ()
     }
   });
 
-  test('no warning: a normal local (non-remote) edit never triggers either diagnostic', async () => {
+  test('no warning: a normal local (non-remote) edit never triggers the diagnostic', async () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const putPageOp = operations.find((o) => o.name === 'put_page')!;

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -21,6 +21,8 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { chunkText } from '../src/core/chunkers/recursive.ts';
 import { forgetFactInFence } from '../src/core/facts/forget.ts';
 import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from '../src/core/facts-fence.ts';
+import { operations } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/ops/contract.ts';
 
 let engine: PGLiteEngine;
 let brainDir: string;
@@ -133,6 +135,139 @@ describe('Layer B — get_page strip trigger (Codex R2-#5)', () => {
     const stripped = stripFactsFence(body, { keepVisibility: ['world'] });
     expect(stripped).toContain('WORLD_ROW');
     expect(stripped).not.toContain('PRIVATE_ROW');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// #2044 row-level restoration merge (row-level, visibility-aware merge
+// replacing the original whole-block swap)
+// ─────────────────────────────────────────────────────────────────
+//
+// The old restoration only fired when the incoming fence had gone to
+// EXACTLY zero facts, and re-appended the ENTIRE old fence block. Two bugs
+// follow: (P1) a mixed world+private fence's hidden row is never restored
+// once the visible world row survives stripping (incoming length is 1+,
+// not 0); (P2) a fully-visible world-only fence's legitimate deletion is
+// silently undone (the whole-block swap can't distinguish "caller couldn't
+// see this row" from "caller saw and deleted this row").
+describe('#2044 row-level restoration merge (P1 mixed-fence / P2 world-only-deletion fix)', () => {
+  function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
+    return {
+      engine,
+      config: { engine: 'pglite' as const },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+      sourceId: 'default',
+      deferEmbeds: true,
+      ...opts,
+    };
+  }
+
+  test('all-private Facts fence survives a remote get_page -> edit -> put_page round-trip (baseline, unchanged behavior)', async () => {
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/allprivate-roundtrip';
+    const fence = FENCE_BODY(
+      '| 1 | PRIVATE_ONLY_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |',
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).not.toContain('PRIVATE_ONLY_FACT');
+    const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_ONLY_FACT');
+  });
+
+  test('P1 fix: a MIXED world+private Facts fence preserves the private row on round-trip (previously lost — old restoration only fired at incoming.facts.length===0)', async () => {
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/mixed-roundtrip';
+    const fence = FENCE_BODY(
+      `| 1 | PUBLIC_MIXED_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | PRIVATE_MIXED_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).toContain('PUBLIC_MIXED_FACT');
+    expect(remote.content).not.toContain('PRIVATE_MIXED_FACT');
+    const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.compiled_truth ?? '')).toContain('PUBLIC_MIXED_FACT');
+    expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_MIXED_FACT');
+  });
+
+  test('P2 fix: deleting a fully-visible world-only fence is honored, not silently undone (previously the whole-block swap re-appended every old row)', async () => {
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/world-only-delete';
+    const fence = FENCE_BODY(
+      '| 1 | WORLD_ONLY_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+    const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(remote.content).toContain('WORLD_ONLY_FACT');
+    // The caller saw the fence in full and deletes it entirely — remove
+    // just the `## Facts` section (heading + fence block), keeping the
+    // rest of the page (and its non-blank body) intact, mirroring a real
+    // caller's edit.
+    const body = remote.content ?? '';
+    const factsHeadingIdx = body.indexOf('## Facts');
+    const fenceEndIdx = body.indexOf(FACTS_FENCE_END) + FACTS_FENCE_END.length;
+    const edited = body.slice(0, factsHeadingIdx).replace('Some text.', 'Some text, fence removed.')
+      + body.slice(fenceEndIdx);
+    await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.compiled_truth ?? '')).not.toContain('WORLD_ONLY_FACT');
+  });
+
+  test('a LOCAL (non-remote) write that deletes a private row is honored — restoration only applies to remote writes', async () => {
+    // Guards against an over-eager merge firing regardless of trust
+    // boundary: a local caller (ctx.remote === false) sees the fence in
+    // full via get_page, so a subsequent local put_page that omits a row
+    // is a genuine, fully-informed deletion — never a restoration
+    // candidate, since restoration exists specifically to protect rows a
+    // caller structurally could not have seen.
+    const putPageOp = operations.find((o) => o.name === 'put_page')!;
+    const getPageOp = operations.find((o) => o.name === 'get_page')!;
+    const slug = 'people/local-full-delete';
+    const fence = FENCE_BODY(
+      `| 1 | LOCAL_KEEP_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |
+| 2 | LOCAL_DELETE_FACT | fact | 1.0 | private | high | 2026-01-02 |  | s |  |`,
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+    const local = await getPageOp.handler(makeCtx({ remote: false }), {
+      slug,
+      include_content: true,
+    }) as { content?: string };
+    expect(local.content).toContain('LOCAL_DELETE_FACT');
+    const edited = (local.content ?? '').replace(
+      /\| 2 \| LOCAL_DELETE_FACT[^\n]*\n/,
+      '',
+    );
+    await putPageOp.handler(makeCtx({ remote: false }), { slug, content: edited });
+
+    const raw = await engine.getPage(slug, { sourceId: 'default' });
+    expect((raw?.compiled_truth ?? '')).toContain('LOCAL_KEEP_FACT');
+    expect((raw?.compiled_truth ?? '')).not.toContain('LOCAL_DELETE_FACT');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #4548. The `#2044` mechanism (`src/core/import-file.ts`) protects `compiled_truth` from a documented hazard: a remote `get_page` → edit → `put_page` round-trip that never saw the privacy-stripped rows can otherwise silently erase them from the canonical page on write-back. It restores the **entire old fence block** — but only when the incoming write's fence has gone to **exactly zero** facts.

That precondition has a gap: a fence with a mix of `world`-visible and non-`world`-visible rows only has its non-`world` rows stripped, so the incoming fence still has 1+ rows. `incoming.facts.length === 0` is false, restoration never fires, and the non-`world` (hidden) row is silently dropped — even though the caller structurally never saw it, let alone intentionally deleted it.

## Fix — surfacing-only diagnostic

`factsGapWarning()` (new, in `src/core/facts-fence.ts`) detects this exact condition and emits a `console.warn()`. **`#2044`'s original whole-block-swap logic in `import-file.ts` is unchanged** — same precondition, same restoration behavior, same data outcome. The diagnostic only observes and reports; nothing about what gets written changes.

(An earlier version of this PR fixed the gap directly with a row-level, visibility-aware merge; a maintainer-lens review flagged that as touching write-back/critical-path semantics regardless of scope, with a stated preference for observe/warn before any behavioral change. A second earlier version bundled this diagnostic with a sibling gap — a fully-visible world-only fence's legitimate deletion silently undone — which a further review flagged as violating "1 PR = 1 logical change." That sibling gap is now #4554, fixed in #4555.)

## Test plan

- 3 tests: the gap warning fires AND the row is still actually dropped (unchanged pre-existing behavior); two negative controls confirm the warning does NOT fire for an unaffected all-private round-trip or a normal local (non-remote) edit.
- Positive-control red-green: reverted to pristine upstream master, the warning assertion fails (no warning fires); restored, passes. 18/18 in the file.
- `bun run verify`: 54/54 checks green.
- `tsc --noEmit`: clean.
- Broader regression sweep (`import-file.test.ts` + `facts-fence.test.ts` + `facts-fence-typed.test.ts`): 83/83 pass.


<!-- maintainer-lens: SAFE @ c7ad8e7826cc57865531e01dc9251927de2ae7f9 2026-08-24T13:01:13Z (rebound after empty-commit CI retrigger; diff byte-identical, verified via gh pr diff) -->

