### PR TITLE
fix(#2044): surface (don't fix) the world-only-deletion gap (P2)

### DIFF
--- a/src/core/facts-fence.ts
+++ b/src/core/facts-fence.ts
@@ -345,6 +345,32 @@ export function renderFactsTable(facts: ParsedFact[]): string {
 }
 
 /**
+ * Surfacing-only diagnostic for #2044's compiled_truth restoration guard
+ * (import-file.ts): when the guard fires (the incoming write emptied the
+ * Facts fence), it re-appends the ENTIRE old fence block — including any
+ * row that was `'world'`-visible, which the caller could have seen in
+ * full and may have genuinely, intentionally deleted. The guard can't
+ * distinguish that from "caller never saw this row," so a real deletion
+ * gets silently undone.
+ *
+ * Only call this once the restoration guard has actually fired. Returns
+ * a warning string, or null if nothing to flag. Pure and side-effect-free
+ * — the caller decides how to surface it (console.warn today); no
+ * restoration behavior is changed here.
+ */
+export function factsRestoredVisibleRowsWarning(
+  slug: string,
+  restoredFrom: { facts: ParsedFact[] },
+): string | null {
+  const worldRows = restoredFrom.facts.filter((f) => f.visibility === 'world').length;
+  if (worldRows === 0) return null;
+  return `[gbrain] #2044 restoration on ${slug}: a remote write emptied the Facts fence and ` +
+    `${restoredFrom.facts.length} old row(s) were restored, including ${worldRows} 'world'-visible ` +
+    `row(s) the caller could have seen and may have genuinely deleted. If so, that deletion has ` +
+    `been undone -- verify.`;
+}
+
+/**
  * Append a new fact row to the body. If a fenced facts table exists, the
  * row is added to the end of it. If not, a new `## Facts` section + fence
  * is created at the end of the body.

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -47,7 +47,7 @@ import { decorateEmbeddingDimError } from './embedding-dim-check.ts';
 import { computeCorpusGeneration, loadSourceRow } from './contextual-retrieval-service.ts';
 import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
-import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from './facts-fence.ts';
+import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, factsRestoredVisibleRowsWarning } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
 
 /**
@@ -611,14 +611,13 @@ export async function importFromContent(
     const incomingFacts = parseFactsFence(parsed.compiled_truth);
     const existingFacts = parseFactsFence(existing.compiled_truth);
     const existingFenceBlock = extractFactsFenceBlock(existing.compiled_truth);
-    if (
-      incomingFacts.facts.length === 0 &&
-      incomingFacts.warnings.length === 0 &&
-      existingFacts.warnings.length === 0 &&
-      existingFacts.facts.length > 0 &&
-      existingFenceBlock
-    ) {
-      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock);
+    const restored = incomingFacts.facts.length === 0 && incomingFacts.warnings.length === 0
+      && existingFacts.warnings.length === 0 && existingFacts.facts.length > 0 && !!existingFenceBlock;
+    if (restored) {
+      parsed.compiled_truth = replaceOrAppendFactsFence(parsed.compiled_truth, existingFenceBlock as string);
+      // Surfacing-only: see factsRestoredVisibleRowsWarning() in facts-fence.ts. No behavior change.
+      const warning = factsRestoredVisibleRowsWarning(slug, existingFacts);
+      if (warning) console.warn(warning);
     }
   }
 

--- a/test/privacy-strip-and-forget.test.ts
+++ b/test/privacy-strip-and-forget.test.ts
@@ -12,7 +12,7 @@
  * Real PGLite + tempdir filesystem.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -21,6 +21,8 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { chunkText } from '../src/core/chunkers/recursive.ts';
 import { forgetFactInFence } from '../src/core/facts/forget.ts';
 import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence } from '../src/core/facts-fence.ts';
+import { operations } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/ops/contract.ts';
 
 let engine: PGLiteEngine;
 let brainDir: string;
@@ -133,6 +135,119 @@ describe('Layer B — get_page strip trigger (Codex R2-#5)', () => {
     const stripped = stripFactsFence(body, { keepVisibility: ['world'] });
     expect(stripped).toContain('WORLD_ROW');
     expect(stripped).not.toContain('PRIVATE_ROW');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// #2044 surfacing-only P2 gap warning (a fully-visible world-only fence's
+// legitimate deletion is silently undone by the whole-block restore) —
+// data behavior is UNCHANGED; these tests confirm the diagnostic actually
+// fires under the gap condition, and does NOT fire for the unaffected
+// baseline/local-write cases (positive control for the guard, both
+// directions). The sibling P1 gap (mixed-fence hidden row dropped) is a
+// separate PR.
+// ─────────────────────────────────────────────────────────────────
+
+describe('#2044 P2 gap warning (console.warn diagnostic, no behavior change)', () => {
+  function makeCtx(opts: Partial<OperationContext> = {}): OperationContext {
+    return {
+      engine,
+      config: { engine: 'pglite' as const },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+      sourceId: 'default',
+      deferEmbeds: true,
+      ...opts,
+    };
+  }
+
+  test('P2 gap: deleting a world-only fence — warns that the deletion was undone, and the row IS still restored (unchanged pre-existing behavior)', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      const slug = 'people/p2-worldonly-warn';
+      const fence = FENCE_BODY(
+        '| 1 | WORLD_ONLY_P2_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug,
+        include_content: true,
+      }) as { content?: string };
+      const body = remote.content ?? '';
+      const factsHeadingIdx = body.indexOf('## Facts');
+      const fenceEndIdx = body.indexOf(FACTS_FENCE_END) + FACTS_FENCE_END.length;
+      const edited = body.slice(0, factsHeadingIdx).replace('Some text.', 'Some text, fence removed.')
+        + body.slice(fenceEndIdx);
+      warnSpy.mockClear();
+      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+      const warnedRestoration = warnSpy.mock.calls.some(
+        (c) => String(c[0]).includes('#2044 restoration') && String(c[0]).includes(slug),
+      );
+      expect(warnedRestoration).toBe(true);
+      // Unchanged pre-existing behavior: the deletion is still undone.
+      const raw = await engine.getPage(slug, { sourceId: 'default' });
+      expect((raw?.compiled_truth ?? '')).toContain('WORLD_ONLY_P2_FACT');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('no warning: an all-private fence round-trip (restored, but no world rows involved) does not fire the gap warning', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const getPageOp = operations.find((o) => o.name === 'get_page')!;
+      const slug = 'people/no-warn-allprivate';
+      const fence = FENCE_BODY(
+        '| 1 | PRIVATE_NOWARN_FACT | fact | 1.0 | private | high | 2026-01-01 |  | s |  |',
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+
+      const remote = await getPageOp.handler(makeCtx({ remote: true }), {
+        slug,
+        include_content: true,
+      }) as { content?: string };
+      warnSpy.mockClear();
+      const edited = (remote.content ?? '').replace('Some text.', 'Some text edited.');
+      await putPageOp.handler(makeCtx({ remote: true }), { slug, content: edited });
+
+      const anyGapWarning = warnSpy.mock.calls.some((c) => String(c[0]).includes('#2044'));
+      expect(anyGapWarning).toBe(false);
+      // The row is restored (unchanged pre-existing #2044 behavior) but
+      // it was never 'world'-visible, so nothing to flag.
+      const raw = await engine.getPage(slug, { sourceId: 'default' });
+      expect((raw?.compiled_truth ?? '')).toContain('PRIVATE_NOWARN_FACT');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('no warning: a normal local (non-remote) edit never triggers the diagnostic', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const putPageOp = operations.find((o) => o.name === 'put_page')!;
+      const slug = 'people/no-warn-local';
+      const fence = FENCE_BODY(
+        '| 1 | LOCAL_WORLD_FACT | fact | 1.0 | world | high | 2026-01-01 |  | s |  |',
+      );
+      await putPageOp.handler(makeCtx({ remote: false }), { slug, content: fence });
+      warnSpy.mockClear();
+      // Local write that drops the fence entirely -- fully-informed, no diagnostic.
+      await putPageOp.handler(makeCtx({ remote: false }), {
+        slug,
+        content: '# Page\n\nSome text edited.\n',
+      });
+
+      const anyGapWarning = warnSpy.mock.calls.some((c) => String(c[0]).includes('#2044'));
+      expect(anyGapWarning).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #4554. The `#2044` mechanism (`src/core/import-file.ts`) protects `compiled_truth` from a documented hazard: a remote `get_page` → edit → `put_page` round-trip that never saw the privacy-stripped rows can otherwise silently erase them from the canonical page on write-back. When it fires (the incoming write emptied the Facts fence), it restores the **entire old fence block** — including any row that was `world`-visible, which the caller could have seen in full and may have genuinely, intentionally deleted. The guard can't distinguish that from "caller never saw this row," so a real deletion gets silently undone.

## Fix — surfacing-only

`factsRestoredVisibleRowsWarning()` (new, in `src/core/facts-fence.ts`) detects when the restoration guard fired AND restored at least one `world`-visible row, and emits a `console.warn()`. `#2044`'s whole-block-swap write behavior is **completely unchanged** — the diagnostic only observes and reports; the deletion is still undone.

## Scope

Sibling to the P1 gap (#4548 — a mixed world+private fence's hidden row is silently dropped instead of restored, filed/submitted as its own PR). Same underlying `#2044` mechanism; split per a maintainer-lens review that flagged the combined P1+P2 diagnostic as bundling two distinct restoration failure modes ("1 PR = 1 logical change").

## Test plan

- 3 tests: P2 warns AND the deletion is still actually undone (unchanged pre-existing behavior); two negative controls confirm the warning does NOT fire for an unaffected all-private round-trip (restored, but no world rows involved) or a normal local (non-remote) edit.
- Positive-control red-green: reverted to pristine upstream master via `git stash`/checkout, the P2 warning assertion fails (no warning fires); restored, passes. 18/18 in the file.
- `bun run verify`: 54/54 checks green.
- `tsc --noEmit`: clean.
- Broader regression sweep (`import-file.test.ts` + `facts-fence.test.ts` + `facts-fence-typed.test.ts`): 83/83 pass.


<!-- maintainer-lens: SAFE @ 1706aba321a3706d3100f23793fc4720a2663d9d 2026-08-24T13:01:16Z -->
