### PR TITLE
fix(cli): fix remaining #4318 confirm-prompt close races

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -186,6 +186,7 @@ test/openclaw-plugin-manifest.test.ts	bundled-skill reference closure (nothing b
 test/openclaw-plugin-manifest.test.ts	plugin membership curation (skills = plugin ∪ exclusions, disjoint)	9	readFileSync
 test/openclaw-plugin-manifest.test.ts	root OpenClaw plugin manifest	2	readFileSync
 test/pglite-engine.test.ts	PGLiteEngine: v0.13.1 error-wrap on connect() (#223)	1	readFileSync
+test/pglite-repair-command.serial.test.ts	gbrain pglite-repair — interactive confirm wiring (#4318 residual)	1	readFileSync
 test/pglite-wal-repair.serial.test.ts	WAL auto-repair — real-brain regression (#223/#1670/#2575)	6	readFileSync
 test/phantom-redirect-per-source-lock.test.ts	phantom-redirect lock contract	3	readFileSync
 test/postgres-engine-singleton-ownership.test.ts	postgres-engine / module-singleton ownership (#1471)	7	readFileSync
@@ -246,6 +247,7 @@ test/thin-client-routing-audit.test.ts	thin-client routing audit — v0.32 ROUTE
 test/timing-safe.test.ts	extraction contract	1	readFileSync
 test/tool-catalog.test.ts	freshness guard	2	readFileSync
 test/transcription-injection.test.ts	transcription — command injection (#245)	2	readFileSync
+test/upgrade-skill-publish-prompt-race.test.ts	gbrain upgrade — skill-publish prompt wiring (#4318 residual)	3	readFileSync
 test/upgrade.serial.test.ts	detectInstallMethod heuristic (source analysis)	13	readFileSync
 test/v0_37_fix_wave.serial.test.ts	v0.37 Lane A — defaults sweep	8	readFileSync
 test/v0_37_fix_wave.serial.test.ts	v0.37 Lane B — init paths	3	readFileSync

--- a/src/commands/pglite-repair.ts
+++ b/src/commands/pglite-repair.ts
@@ -20,7 +20,7 @@
  * repair does not help — `gbrain reinit-pglite` is the rebuild path.
  */
 
-import { createInterface } from 'readline';
+import { promptYesNo } from '../core/confirm-prompt.ts';
 import { loadConfig, gbrainPath } from '../core/config.ts';
 import { acquireLock, releaseLock, LiveServeLockError, msSinceLastReap } from '../core/pglite-lock.ts';
 import {
@@ -98,23 +98,6 @@ function emitError(jsonOutput: boolean, code: string, message: string): void {
   } else {
     console.error(`Error (${code}): ${message}`);
   }
-}
-
-async function promptYesNo(question: string): Promise<boolean> {
-  // W0 fix-wave (Tier-1 #15): non-interactive stdin (CI, pipes, spawned
-  // agents) must resolve to the safe default instead of hanging forever —
-  // this prompt had no TTY guard and no close/EOF handler, so a piped or
-  // closed stdin parked the process permanently.
-  if (!process.stdin.isTTY) return false;
-  // Prompt on stderr: stdout stays clean for --json payloads.
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  return new Promise((resolve) => {
-    rl.on('close', () => resolve(false)); // EOF (^D) = decline, never hang
-    rl.question(`${question} [y/N] `, (answer) => {
-      rl.close();
-      resolve(/^y(es)?$/i.test(answer.trim()));
-    });
-  });
 }
 
 export async function runPgliteRepair(args: string[]): Promise<number> {
@@ -223,7 +206,9 @@ export async function runPgliteRepair(args: string[]): Promise<number> {
     console.error(`About to reset the WAL of ${dataDir} in place.`);
     console.error('Data files are preserved; un-checkpointed transactions may be lost.');
     console.error('The current pg_wal + pg_control are kept in a sibling backup directory.');
-    const confirmed = await promptYesNo('Repair now?');
+    // Prompt on stderr (not the confirm-prompt default of stdout): stdout
+    // stays clean for --json payloads.
+    const confirmed = await promptYesNo('Repair now? [y/N] ', { output: process.stderr });
     if (!confirmed) {
       if (opts.jsonOutput) {
         console.log(JSON.stringify({ status: 'aborted', reason: 'user_declined' }));

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -666,14 +666,24 @@ export async function runPostUpgrade(args: string[] = []): Promise<void> {
             let enabled = false;
             if (isTty) {
               const { createInterface } = await import('readline');
+              // #4318 residual: rl.close() must not run before the answer's
+              // resolveAns() — the unguarded rl.on('close', ...) below would
+              // otherwise settle the promise `false` first (the close event
+              // fires synchronously during rl.close()), so an operator
+              // pressing Enter to accept this [Y/n]-default-yes prompt would
+              // always land on "declined" regardless of what they typed.
               enabled = await new Promise<boolean>((resolveAns) => {
                 const rl = createInterface({ input: process.stdin, output: process.stdout });
+                let answered = false;
                 rl.question('[gbrain] Enable skill publishing now? (recommended) [Y/n] ', (answer) => {
-                  rl.close();
+                  answered = true;
                   const a = answer.trim().toLowerCase();
                   resolveAns(a === '' || a === 'y' || a === 'yes');
+                  rl.close();
                 });
-                rl.on('close', () => resolveAns(false));
+                rl.on('close', () => {
+                  if (!answered) resolveAns(false);
+                });
               });
             } else {
               console.log('[AGENT] Relay this to your operator. Recommended: enable it.');

--- a/test/confirm-prompt.test.ts
+++ b/test/confirm-prompt.test.ts
@@ -59,3 +59,39 @@ describe('promptYesNo (#4318)', () => {
     expect(await p).toBe(true);
   });
 });
+
+/**
+ * pglite-repair.ts had its own inline promptYesNo (not this shared helper)
+ * with the same close-before-resolve race: `rl.close()` inside the
+ * rl.question callback fired the unguarded `rl.on('close', ...)` listener
+ * synchronously, so `resolve(false)` won before the typed "y" resolve ran —
+ * `gbrain pglite-repair` always treated an affirmative interactive answer as
+ * decline. Pins the exact call now wired at that call site (question text +
+ * `{ output: process.stderr }`, matching `src/commands/pglite-repair.ts`) so
+ * a regression to the old inline shape — or a stdout-leaking `output`
+ * default — is caught here rather than only in the generic cases above.
+ */
+describe('promptYesNo — pglite-repair call-site wiring (#4318 residual)', () => {
+  test('"Repair now?" [y/N] question resolves true on "y", written to stderr not stdout', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const written: string[] = [];
+    output.on('data', (chunk) => written.push(chunk.toString()));
+
+    const p = promptYesNo('Repair now? [y/N] ', { output, input });
+    input.write('y\n');
+
+    expect(await p).toBe(true);
+    // The prompt text itself must have gone to the injected `output` stream
+    // (which stands in for process.stderr at the real call site), not been
+    // silently dropped or duplicated with a second "[y/N]" suffix.
+    expect(written.join('')).toBe('Repair now? [y/N] ');
+  });
+
+  test('"Repair now?" [y/N] question resolves false on decline', async () => {
+    const { input, output } = mkStreams();
+    const p = promptYesNo('Repair now? [y/N] ', { output, input });
+    input.write('n\n');
+    expect(await p).toBe(false);
+  });
+});

--- a/test/pglite-repair-command.serial.test.ts
+++ b/test/pglite-repair-command.serial.test.ts
@@ -18,7 +18,7 @@
  */
 import { describe, test, expect } from 'bun:test';
 import {
-  existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -414,5 +414,32 @@ describe('gbrain pglite-repair — argument + quarantine hardening (adversarial 
     expect(parseJsonLine(cap.logs).code).toBe('refused_reap_quarantine');
     // No surgery: no backup dir created.
     expect(readdirSync(join(dir, '..')).some((f) => f.includes('.wal-repair-backup-'))).toBe(false);
+  });
+});
+
+describe('gbrain pglite-repair — interactive confirm wiring (#4318 residual)', () => {
+  test('uses the shared confirm-prompt helper, not a local reimplementation', () => {
+    // This file's own inline `promptYesNo` had the same close-before-resolve
+    // race that #4318 fixed in sync-cost-gate.ts/reindex-code.ts: `rl.close()`
+    // fired inside the answer callback synchronously triggered an unguarded
+    // `rl.on('close', () => resolve(false))`, so a typed "y" was silently
+    // read as decline. This pins the fix at the source level — a future
+    // change that reintroduces a local `promptYesNo`/`createInterface` here
+    // (rather than importing the shared, race-free helper) fails this test,
+    // even though `test/confirm-prompt.test.ts` cannot see this file at all.
+    // test-reads-source-ok: pins that the local reimplementation stays gone
+    // and the shared helper is wired with the exact stderr-preserving args —
+    // there's no exported/injectable seam to assert this behaviorally.
+    const src = readFileSync(join(import.meta.dir, '../src/commands/pglite-repair.ts'), 'utf8');
+    expect(src).toContain("import { promptYesNo } from '../core/confirm-prompt.ts';");
+    expect(src).not.toMatch(/\bfunction promptYesNo\b/);
+    expect(src).not.toContain("from 'readline'");
+    // The call site itself must keep the prompt on stderr — confirm-prompt's
+    // default `output` is stdout, and `--json` callers depend on stdout
+    // staying machine-readable-only. Checking the import above isn't enough:
+    // dropping `{ output: process.stderr }` from this call would still pass
+    // that assertion while leaking the prompt into --json output.
+    expect(src).toContain("await promptYesNo('Repair now? [y/N] ', { output: process.stderr });");
+    expect(src).not.toContain("from 'node:readline'");
   });
 });

--- a/test/upgrade-skill-publish-prompt-race.test.ts
+++ b/test/upgrade-skill-publish-prompt-race.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `gbrain upgrade`'s one-time "Enable skill publishing now? (recommended)
+ * [Y/n]" prompt (#4318 residual) — same close-before-resolve race the shared
+ * `src/core/confirm-prompt.ts` helper was written to fix, but this inline
+ * confirm in upgrade.ts predates that helper and was never migrated: it
+ * called `rl.close()` inside the answer callback BEFORE resolving, while an
+ * unguarded `rl.on('close', () => resolveAns(false))` listener fired
+ * synchronously during that close and settled the promise first — so
+ * pressing Enter (or typing "y") on this default-YES prompt always resolved
+ * `false`, silently leaving skill publishing disabled regardless of what the
+ * operator answered.
+ *
+ * The prompt is inline inside a large, side-effecting `runUpgrade()` flow
+ * (DB writes, network) rather than an exported, injectable function, so this
+ * pins the fix at the source level: a regression back to the close-before-
+ * resolve shape fails here even though `test/confirm-prompt.test.ts` (which
+ * only covers the shared helper) cannot see this file at all.
+ */
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('gbrain upgrade — skill-publish prompt wiring (#4318 residual)', () => {
+  // test-reads-source-ok: the prompt is inline inside a large, side-effecting,
+  // non-exported runUpgrade() with no injectable stdin — resolve/close
+  // ordering is only observable in source text, not an executable boundary.
+  const src = readFileSync(join(import.meta.dir, '../src/commands/upgrade.ts'), 'utf8');
+
+  test('the close listener is guarded by an `answered` flag, not unconditional', () => {
+    // The buggy shape was `rl.on('close', () => resolveAns(false));` with no
+    // guard. The fixed shape checks `answered` before declining on close.
+    const idx = src.indexOf('[gbrain] Enable skill publishing now?');
+    expect(idx).toBeGreaterThan(-1);
+    const promptRegion = src.slice(idx - 100, idx + 700);
+    expect(promptRegion).toContain('let answered = false;');
+    expect(promptRegion).toContain('answered = true;');
+    expect(promptRegion).toMatch(/rl\.on\('close',\s*\(\)\s*=>\s*\{\s*if \(!answered\) resolveAns\(false\);/);
+    // The regression this guards against: an unconditional decline-on-close.
+    expect(promptRegion).not.toMatch(/rl\.on\('close',\s*\(\)\s*=>\s*resolveAns\(false\)\);/);
+  });
+
+  test('resolveAns for the answer is called strictly before rl.close() in the question callback', () => {
+    const idx = src.indexOf('[gbrain] Enable skill publishing now?');
+    const promptRegion = src.slice(idx - 100, idx + 700);
+    const resolveIdx = promptRegion.indexOf('resolveAns(a === ');
+    const closeIdx = promptRegion.indexOf('rl.close();');
+    expect(resolveIdx).toBeGreaterThan(-1);
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(resolveIdx).toBeLessThan(closeIdx);
+  });
+
+  test('the [Y/n] default-yes contract is preserved: an empty (Enter-only) answer resolves true', () => {
+    // The prompt reads "(recommended) [Y/n]" — pressing Enter with no text
+    // must accept the recommendation. A fix that only reordered
+    // resolve/close without preserving this branch (e.g. narrowing to
+    // `a === 'y' || a === 'yes'`) would still pass the two tests above while
+    // silently flipping this prompt's default from accept to decline.
+    const idx = src.indexOf('[gbrain] Enable skill publishing now?');
+    const promptRegion = src.slice(idx - 100, idx + 700);
+    expect(promptRegion).toContain("resolveAns(a === '' || a === 'y' || a === 'yes');");
+  });
+});


### PR DESCRIPTION
## Summary

#4318 fixed a `promptYesNo` readline race (`rl.close()` fires `'close'` synchronously, so an unguarded `rl.on('close', () => resolve(false))` wins before the real answer's `resolve()` runs — a typed "y" reads as decline) by adding a shared, race-free helper (`src/core/confirm-prompt.ts`) and rewiring `sync-cost-gate.ts` / `reindex-code.ts` onto it.

Two more call sites still had the same bug on current master and are fixed here:

1. **`src/commands/pglite-repair.ts`** — its own separate inline `promptYesNo` (not the shared helper) had the identical unguarded-close-listener shape. This is a residual from my own earlier PR #4452, which reordered this same function in place; that reorder never landed, and the megawave (#4475) that introduced `confirm-prompt.ts` and rewired the other two sites didn't carry pglite-repair.ts's fix along. Fixed by deleting the local reimplementation and importing the shared helper instead, passing `{ output: process.stderr }` to preserve the existing "keep stdout clean for `--json`" behavior.
2. **`src/commands/upgrade.ts`** — a one-time "Enable skill publishing now? (recommended) `[Y/n]`" prompt has the same bug, inline inside `runUpgrade()`. This one is default-**yes** (`[Y/n]`, not `[y/N]`), so it isn't a drop-in for the shared helper; fixed in place with the same shape as the original #4318 fix (resolve the answer, then close; guard the close listener with an `answered` flag) without extracting it. Practical effect of the bug here: pressing Enter or typing "y" on this recommended-default prompt always left skill publishing disabled.

## Verification

- Reproduced the race directly (Node and Bun) on the pre-fix code for both sites: typed "y" resolves `false`.
- New tests pin both fixes and are confirmed red against the pre-fix source, green against the fix:
  - `test/confirm-prompt.test.ts` — the shared helper called with pglite-repair's exact question/stream arguments.
  - `test/pglite-repair-command.serial.test.ts` — asserts the shared helper is imported (not reimplemented) and that the real call site passes `{ output: process.stderr }`.
  - `test/upgrade-skill-publish-prompt-race.test.ts` — a source-shape regression guard (the prompt is inline inside a large, side-effecting, non-exported function, so this isn't an end-to-end interactive test): pins resolve-before-close ordering, the `answered`-guarded close listener, and the `[Y/n]` empty-answer-resolves-true branch.
- `bun run typecheck`, `bash scripts/check-module-size.sh`, `bun scripts/classify-tests.ts --check` all clean.
- Existing tests unaffected: 96 pass across the touched test files (pglite-repair command + core suites, confirm-prompt, upgrade-reembed-prompt, self-upgrade).

No schema migration. No new CLI surface, flags, or config keys — both changes only fix which boolean an existing prompt resolves to.
