### PR TITLE
fix(ai): grant reasoning headroom to thinking-by-default Ollama models

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -60,6 +60,22 @@ export const ollama: Recipe = {
       supports_subagent_loop: false,
       supports_prompt_cache: false,
       supports_structured_outputs: false,
+      // Reasoning-by-default local families spend output budget on internal
+      // reasoning before emitting answer text, and Ollama bills it against
+      // `max_tokens` — so callers that size output caps must grant headroom
+      // (same contract as DeepSeek v4, gbrain#4172). Without this, a 4000-token
+      // default is consumed entirely by reasoning and the caller gets EMPTY
+      // content with finish_reason "length". Verified on qwen38-27b:latest:
+      // max_tokens=16 returned "" (16 reasoning tokens), max_tokens=600
+      // returned "PONG". Model ids are user-managed, so this is a predicate
+      // over the known reasoning families rather than a recipe-wide boolean —
+      // non-reasoning local models (qwen2.5-coder, llama3.x, mistral) keep the
+      // conservative default. `qwen3` is matched with a boundary so the
+      // qwen2.5-* tags can never be swallowed by it.
+      thinking_by_default: (modelId: string) =>
+        /^(?:qwen3[0-9]*(?:[.\-:]|$)|deepseek-r[0-9]|gpt-oss(?:[.\-:]|$)|magistral(?:[.\-:]|$)|phi[0-9]+-reasoning)/i.test(
+          modelId,
+        ),
       // Provider-wide routing ceiling only; Ollama still enforces each loaded
       // model's actual context window at request time.
       max_context_tokens: 128_000,

--- a/test/ai/recipe-ollama-thinking.test.ts
+++ b/test/ai/recipe-ollama-thinking.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Ollama thinking-by-default headroom (companion to gbrain#4172).
+ *
+ * Reasoning-by-default local models (Qwen3 / qwen38, DeepSeek-R1, gpt-oss,
+ * magistral, phi4-reasoning) spend output-token budget on internal reasoning
+ * BEFORE emitting any answer text, and Ollama bills that reasoning against
+ * `max_tokens`. Without a recipe-declared `thinking_by_default`, callers that
+ * size output caps (`think`'s `maxOutputTokensFor`) hand these models the
+ * conservative 4000-token default, the whole budget is consumed by reasoning,
+ * and the caller gets EMPTY content back with `finish_reason: "length"`.
+ *
+ * Reproduced against a local Ollama daemon (qwen38-27b:latest), which reports
+ * `capabilities: ["completion","vision","tools","thinking"]`:
+ *
+ *   max_tokens=16  -> content: "",     reasoning: 16 tokens, finish: length
+ *   max_tokens=600 -> content: "PONG", reasoning present,    finish: stop
+ *
+ * The failure is silent: gbrain's own chat probe reports a GREEN result with
+ * empty content, so the misconfiguration is invisible in `providers test`.
+ *
+ * Non-reasoning local models (qwen2.5-coder, llama3.x, mistral) must NOT be
+ * flagged — blanket headroom would over-allocate for every local chat call.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { getProviderCapabilities } from '../../src/core/ai/capabilities.ts';
+
+describe('recipe: ollama thinking-by-default', () => {
+  test('declares thinking_by_default as a per-model predicate', () => {
+    const chat = getRecipe('ollama')!.touchpoints.chat!;
+    expect(typeof chat.thinking_by_default).toBe('function');
+  });
+
+  test.each([
+    'ollama:qwen38-27b',
+    'ollama:qwen38-27b:latest',
+    'ollama:qwen3:8b',
+    'ollama:deepseek-r1:14b',
+    'ollama:gpt-oss:20b',
+    'ollama:magistral:24b',
+    'ollama:phi4-reasoning:14b',
+  ])('%s is thinking-by-default', (model) => {
+    expect(getProviderCapabilities(model).supportsThinking).toBe(true);
+  });
+
+  test.each([
+    'ollama:qwen2.5-coder:14b',
+    'ollama:llama3.2:3b',
+    'ollama:mistral:7b',
+    'ollama:nomic-embed-text',
+  ])('%s is not thinking-by-default', (model) => {
+    expect(getProviderCapabilities(model).supportsThinking).toBe(false);
+  });
+
+  test('qwen2.5 coder is not mistaken for a qwen3 reasoning tag', () => {
+    // Guards the boundary the regex has to respect: the `qwen3` family match
+    // must not swallow `qwen2.5-*`, and must not match a bare `qwen` prefix.
+    expect(getProviderCapabilities('ollama:qwen2.5:7b').supportsThinking).toBe(false);
+    expect(getProviderCapabilities('ollama:qwen:7b').supportsThinking).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Declares `thinking_by_default` on the Ollama chat touchpoint so reasoning-by-default local models get output-token headroom. Follow-up to #4315 (the chat touchpoint that shipped in v0.46.25.0) and the direct analogue of #4172, which established this contract for DeepSeek v4.

## The bug

Reasoning-by-default local families spend output budget on internal reasoning **before** emitting any answer text, and Ollama bills that reasoning against `max_tokens`. Because the recipe declared no `thinking_by_default`, `getProviderCapabilities().supportsThinking` was `false`, so `maxOutputTokensFor()` (`src/core/think/index.ts`) handed these models the conservative 4000-token default instead of the 16000-token reasoning headroom. The budget is consumed by reasoning and the caller gets **empty content**.

Reproduced against a local Ollama daemon on `qwen38-27b:latest`, which reports `capabilities: ["completion","vision","tools","thinking"]`:

```
max_tokens=16   -> content: ""      reasoning: 16 tokens   finish_reason: length
max_tokens=600  -> content: "PONG"  reasoning present      finish_reason: stop
```

The failure is **silent**. `gbrain providers test --touchpoint chat` reports a green probe on the empty result:

```
✓ 1027ms · model=ollama:qwen38-27b:latest · stop=length · in=17/out=16 · "<empty>"
```

A green checkmark with `"<empty>"` and `stop=length` is exactly the signature of this bug, which makes it hard to spot from the probe alone.

## The fix

`thinking_by_default` as a **per-model predicate** rather than a recipe-wide boolean, since Ollama model ids are user-managed and the same recipe serves both reasoning and non-reasoning models. Matches `qwen3*` (incl. `qwen38*`), `deepseek-r[0-9]`, `gpt-oss`, `magistral`, `phi[0-9]+-reasoning`; everything else keeps the conservative default.

The `qwen3` arm is boundary-matched so it cannot swallow `qwen2.5-*` tags — `qwen2.5-coder:14b` is the recipe's own documented chat default, and regressing it to 16000 tokens would over-allocate on the most common local setup. There is an explicit test for that boundary.

No behavior change for any non-reasoning model, and none for other providers.

## Validation

New test `test/ai/recipe-ollama-thinking.test.ts`, written failing-first — **8 failures before the recipe change, 13/13 green after**.

```
bun test test/ai/recipe-ollama-thinking.test.ts     # 13 pass
bun test test/ai/recipe-ollama.test.ts test/ai/recipe-ollama-dims.test.ts \
  test/ai/capabilities.test.ts test/ai/gateway-chat.test.ts \
  test/model-config.serial.test.ts test/providers.test.ts \
  test/models-doctor-chat-probe-timeout.test.ts       # 144 pass, 0 fail
bun run typecheck                                     # clean
bun run wave-security-scan upstream/master..HEAD      # all lanes 0, gitleaks 0
```

Also verified live end-to-end on 0.46.29.0: `gbrain models doctor` reports `✔ chat ollama:qwen38-27b ok`.

No VERSION or CHANGELOG bump — release-time maintainer lane, consistent with #4315.

## Note on #4315 attribution

Small thing, no action needed if intentional: the merge comment on #4315 said the change landed "with your commits intact and you are credited in the CHANGELOG." It shipped squashed into the v0.46.25.0 release commit (`055ac6c`), which is fine, but I couldn't find a `Contributed by @chrispaterson` credit in the CHANGELOG — the v0.46.25.0 section credits the other community contributors by handle. Mentioning it only because `docs/RELEASING.md` calls contributor credit an explicit rule.
