### PR TITLE
feat(auth): verify external gateway JWTs against a JWKS and map callers to registered clients

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "express-rate-limit": "^7.5.0",
         "gray-matter": "^4.0.3",
         "heic-decode": "^2.1.0",
+        "jose": "^6.0.11",
         "js-yaml": "^3.15.1",
         "jsonc-parser": "^3.3.1",
         "marked": "^18.0.2",

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -223,6 +223,31 @@ Remote agents cannot reach local filesystem surface area.
 Write ops can additionally be fenced per client with `--bound-slug-prefixes`
 (see [Register OAuth clients](#2-register-oauth-clients) above).
 
+## External Gateway JWTs (optional)
+
+If clients reach GBrain through an AI gateway that signs each MCP call with
+a short-lived JWT (e.g. LiteLLM's `mcp_jwt_signer` guardrail), GBrain can
+verify those JWTs directly and act as the registered client the caller maps
+to — one gateway credential per user, no second GBrain token to distribute.
+
+```bash
+export GBRAIN_EXTERNAL_TOKEN_ISSUER="https://gateway.example.com"
+export GBRAIN_EXTERNAL_TOKEN_AUDIENCE="gbrain"
+# JWT sub (or email) -> registered oauth_clients.client_id
+export GBRAIN_EXTERNAL_TOKEN_CALLER_MAP='{"user-3f9":"acl-alice","bob@example.com":"acl-bob"}'
+# optional: defaults to <issuer>/.well-known/jwks.json; inline JWKS via
+# GBRAIN_EXTERNAL_TOKEN_JWKS for air-gapped deploys
+```
+
+Verification is fail-closed: RS256 signature against the issuer's JWKS,
+`iss`/`aud`/`exp` enforced, unmapped subjects rejected, and the mapped
+client must exist (not deleted). Scopes and source isolation (`--source`,
+`--federated-read`, slug fences, surface) come from the mapped client's
+registration — the JWT only establishes who is calling. Opaque GBrain
+tokens are unaffected; the JWT path only engages for three-segment
+bearer values when all three required variables are set. Partial
+configuration is a startup error rather than a silently disabled verifier.
+
 ## Legacy Bearer Token Setup
 
 Bearer tokens are the simple path when you don't need per-client scoping.

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "postgres": "^3.4.0",
     "tree-sitter-wasms": "0.1.13",
     "web-tree-sitter": "0.22.6",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "jose": "^6.0.11"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2270,6 +2270,18 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
    * the ceiling is the only floor available (pre-WP4 behavior).
    */
   let lastKnownDefaultSurface: McpSurface | null = null;
+  /**
+   * Merge the gateway JWT subject into a request-log params object. Several
+   * gateway keys can map to one client_id (external-token-verifier caller
+   * map), so token_name alone cannot say WHICH key made the call —
+   * `params->>'external_sub'` can. No-op (params unchanged) for every
+   * non-external auth path.
+   */
+  function withExternalSub(auth: AuthInfo, paramsObj: unknown): unknown {
+    if (auth.externalSub === undefined) return paramsObj;
+    const base = typeof paramsObj === 'object' && paramsObj !== null ? paramsObj : {};
+    return { ...base, external_sub: auth.externalSub };
+  }
   async function resolveEffectiveSurface(authInfo: AuthInfo): Promise<{ ceiling: McpSurface; effective: McpSurface }> {
     const ceiling = clampSurface(serverSurfaceCeiling);
     // min() can never go below the narrowest surface: a 'verbs' ceiling makes
@@ -2371,7 +2383,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
           `INSERT INTO mcp_request_log (token_name, agent_name, operation, latency_ms, status, params)
            VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
           [authInfo.clientId, agentName, 'tools/list', latency, 'success'],
-          [{ tool_count: tools.length }],
+          [withExternalSub(authInfo, { tool_count: tools.length })],
         );
       } catch { /* best effort */ }
       broadcastEvent({
@@ -2399,7 +2411,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
             `INSERT INTO mcp_request_log (token_name, agent_name, operation, latency_ms, status, error_message, params)
              VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
             [authInfo.clientId, agentName, name, latency, 'error', `unknown_operation: ${name}`],
-            [null],
+            [withExternalSub(authInfo, null)],
           );
         } catch { /* best effort */ }
         broadcastEvent({
@@ -2440,7 +2452,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
             `INSERT INTO mcp_request_log (token_name, agent_name, operation, latency_ms, status, error_message, params)
              VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
             [authInfo.clientId, agentName, name, latency, 'denied_after_list', `insufficient_scope: requires '${requiredScope}'`],
-            [null],
+            [withExternalSub(authInfo, null)],
           );
         } catch { /* best effort */ }
         broadcastEvent({
@@ -2480,9 +2492,10 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       // 'tools/list'. Pre-existing string-shaped rows are normalized by
       // migration v41 in src/core/migrate.ts.
       const safeParamsSummary = summarizeMcpParams(name, params);
-      const logParamsObj: unknown = logFullParams
-        ? (params || null)
-        : (safeParamsSummary || null);
+      const logParamsObj: unknown = withExternalSub(
+        authInfo,
+        logFullParams ? (params || null) : (safeParamsSummary || null),
+      );
       const broadcastParams = logFullParams ? (params || {}) : safeParamsSummary;
 
       // v0.31 (D12 / eE1): refactor the inlined op.handler call to go through
@@ -2905,7 +2918,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
             // write_source_id is the security-relevant part of this request:
             // which partition the capture was routed to. Without it the audit
             // trail cannot answer "where did this client's writes land".
-            [{ content_type: contentType, content_hash: contentHash, bytes: body.length, job_id: job.id, write_source_id: writeSourceId }],
+            [withExternalSub(authInfo, { content_type: contentType, content_hash: contentHash, bytes: body.length, job_id: job.id, write_source_id: writeSourceId })],
           );
         } catch { /* best effort */ }
         broadcastEvent({

--- a/src/core/external-token-verifier.ts
+++ b/src/core/external-token-verifier.ts
@@ -1,0 +1,179 @@
+/**
+ * External-issuer JWT verification for the HTTP MCP surface.
+ *
+ * Lets an upstream gateway that signs MCP tool calls with short-lived JWTs
+ * (e.g. LiteLLM's `mcp_jwt_signer` guardrail, which publishes its keys at
+ * `<issuer>/.well-known/jwks.json`) act on behalf of registered GBrain
+ * clients. The JWT proves WHO called through the gateway; a deploy-owned
+ * caller map decides WHICH registered `oauth_clients` row that identity
+ * maps to. GBrain's own source isolation (source_id / federated_read /
+ * bound_slug_prefixes / surface) then applies exactly as it would for a
+ * token the client obtained directly — no new authorization axis.
+ *
+ * Fail-closed by design:
+ * - disabled unless issuer + audience + caller map are ALL configured;
+ * - signature, `iss`, `aud`, `exp`/`nbf` verified (RS256 only);
+ * - a verified JWT whose `sub`/`email` is not in the caller map is rejected;
+ * - a mapped client_id that does not exist (or is deleted) is rejected.
+ *
+ * Configuration (environment):
+ * - GBRAIN_EXTERNAL_TOKEN_ISSUER      required. Expected `iss` claim.
+ * - GBRAIN_EXTERNAL_TOKEN_AUDIENCE    required. Expected `aud` claim.
+ * - GBRAIN_EXTERNAL_TOKEN_CALLER_MAP  required. JSON object mapping a JWT
+ *   `sub` (or `email`) value to a registered oauth_clients.client_id, e.g.
+ *   `{"litellm-user-3f9":"acl-ruslan","hassan@example.com":"acl-hassan"}`.
+ * - GBRAIN_EXTERNAL_TOKEN_JWKS_URI    optional. Defaults to
+ *   `<issuer>/.well-known/jwks.json`.
+ * - GBRAIN_EXTERNAL_TOKEN_JWKS        optional. Inline JWKS JSON (offline /
+ *   air-gapped deploys and tests). Takes precedence over the URI.
+ */
+
+import {
+  createLocalJWKSet,
+  createRemoteJWKSet,
+  jwtVerify,
+  type JSONWebKeySet,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from 'jose';
+
+export type ExternalTokenVerifierConfig = {
+  issuer: string;
+  audience: string;
+  /** sub-or-email -> registered oauth_clients.client_id */
+  callerMap: Record<string, string>;
+  jwksUri?: string;
+  /** Inline key set; takes precedence over jwksUri. */
+  jwks?: JSONWebKeySet;
+};
+
+export class ExternalTokenVerificationError extends Error {}
+
+export class ExternalTokenVerifier {
+  private readonly getKey: JWTVerifyGetKey;
+
+  constructor(private readonly config: ExternalTokenVerifierConfig) {
+    if (config.jwks) {
+      this.getKey = createLocalJWKSet(config.jwks);
+    } else {
+      const uri =
+        config.jwksUri ?? `${config.issuer.replace(/\/$/, '')}/.well-known/jwks.json`;
+      // createRemoteJWKSet caches keys and refetches on unknown `kid`, so
+      // gateway key rotation needs no restart here.
+      this.getKey = createRemoteJWKSet(new URL(uri));
+    }
+  }
+
+  /**
+   * Verify a compact JWS and resolve it to a registered client_id.
+   * `subject` is the caller-map key that matched (`sub`, or `email` when the
+   * map matched on email) — the audit identity of the exact gateway key,
+   * since several keys can map to one client_id.
+   * Throws ExternalTokenVerificationError on any failure — callers must
+   * treat that as an invalid token, never fall through to another auth path.
+   */
+  async verify(token: string): Promise<{ clientId: string; subject: string; payload: JWTPayload }> {
+    let payload: JWTPayload;
+    try {
+      ({ payload } = await jwtVerify(token, this.getKey, {
+        issuer: this.config.issuer,
+        audience: this.config.audience,
+        algorithms: ['RS256'],
+      }));
+    } catch (err) {
+      throw new ExternalTokenVerificationError(
+        `external token rejected: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    const sub = typeof payload.sub === 'string' ? payload.sub : undefined;
+    const email = typeof payload.email === 'string' ? payload.email : undefined;
+    const subject =
+      sub !== undefined && this.config.callerMap[sub] !== undefined
+        ? sub
+        : email !== undefined && this.config.callerMap[email] !== undefined
+          ? email
+          : undefined;
+    if (subject === undefined) {
+      // Deliberately does not echo sub/email back to the caller.
+      throw new ExternalTokenVerificationError('external token subject is not a mapped caller');
+    }
+    return { clientId: this.config.callerMap[subject], subject, payload };
+  }
+}
+
+/** Opaque GBrain tokens never contain two dots; compact JWS always does. */
+export function looksLikeCompactJws(token: string): boolean {
+  return token.split('.').length === 3;
+}
+
+let cached: ExternalTokenVerifier | null | undefined;
+
+/**
+ * Build (once) the verifier from the environment, or null when not
+ * configured. Partial configuration is a hard startup error rather than a
+ * silently disabled verifier — a deploy that set the issuer but mangled the
+ * map must not fall back to "external tokens are simply never accepted
+ * locally but the operator believes they are".
+ */
+export function getExternalTokenVerifier(env: NodeJS.ProcessEnv = process.env): ExternalTokenVerifier | null {
+  if (cached !== undefined) return cached;
+
+  const issuer = env.GBRAIN_EXTERNAL_TOKEN_ISSUER?.trim();
+  const audience = env.GBRAIN_EXTERNAL_TOKEN_AUDIENCE?.trim();
+  const mapRaw = env.GBRAIN_EXTERNAL_TOKEN_CALLER_MAP?.trim();
+  const jwksUri = env.GBRAIN_EXTERNAL_TOKEN_JWKS_URI?.trim();
+  const jwksRaw = env.GBRAIN_EXTERNAL_TOKEN_JWKS?.trim();
+
+  if (!issuer && !audience && !mapRaw) {
+    cached = null;
+    return cached;
+  }
+  if (!issuer || !audience || !mapRaw) {
+    throw new Error(
+      'External token verification is partially configured: GBRAIN_EXTERNAL_TOKEN_ISSUER, ' +
+        'GBRAIN_EXTERNAL_TOKEN_AUDIENCE and GBRAIN_EXTERNAL_TOKEN_CALLER_MAP must all be set ' +
+        '(or none of them).',
+    );
+  }
+
+  let callerMap: Record<string, string>;
+  try {
+    const parsed: unknown = JSON.parse(mapRaw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('not a JSON object');
+    }
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v !== 'string' || v.trim() === '' || k.trim() === '') {
+        throw new Error(`entry ${JSON.stringify(k)} must map to a non-empty client_id string`);
+      }
+    }
+    callerMap = parsed as Record<string, string>;
+  } catch (err) {
+    throw new Error(
+      `GBRAIN_EXTERNAL_TOKEN_CALLER_MAP is not a valid {subject: client_id} JSON object: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  let jwks: JSONWebKeySet | undefined;
+  if (jwksRaw) {
+    try {
+      jwks = JSON.parse(jwksRaw) as JSONWebKeySet;
+    } catch (err) {
+      throw new Error(
+        `GBRAIN_EXTERNAL_TOKEN_JWKS is not valid JWKS JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  cached = new ExternalTokenVerifier({ issuer, audience, callerMap, jwksUri, jwks });
+  return cached;
+}
+
+/** Test hook: forget the env-derived singleton. */
+export function resetExternalTokenVerifierCache(): void {
+  cached = undefined;
+}

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -29,6 +29,11 @@ import { assertValidSourceId } from './source-id.ts';
 import { hasScope, assertAllowedScopes, parseScopeString, InvalidScopeError } from './scope.ts';
 import type { AuthInfo as CoreAuthInfo } from './operations.ts';
 import { parseLegacyTokenScope, parseTakesHoldersAllowList, coerceLegacyPermissions, normalizeTokenScopes } from './legacy-token-scope.ts';
+import {
+  getExternalTokenVerifier,
+  looksLikeCompactJws,
+  type ExternalTokenVerifier,
+} from './external-token-verifier.ts';
 
 /**
  * A slug-prefix write binding is only meaningful if every entry actually
@@ -723,6 +728,18 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
   // -------------------------------------------------------------------------
 
   async verifyAccessToken(token: string): Promise<SdkAuthInfo> {
+    // External-issuer JWTs (e.g. a gateway running LiteLLM's mcp_jwt_signer
+    // guardrail). Only consulted when the deploy configures a verifier AND
+    // the bearer parses as compact JWS — opaque GBrain tokens never contain
+    // two dots, so the hash paths below are unaffected. A JWS that fails
+    // verification or mapping is rejected here, never fed to the hash paths:
+    // falling through would let an attacker probe the opaque-token store
+    // with attacker-shaped JWTs.
+    const externalVerifier = getExternalTokenVerifier();
+    if (externalVerifier && looksLikeCompactJws(token)) {
+      return this.verifyExternalToken(externalVerifier, token);
+    }
+
     const tokenHash = hashToken(token);
     const now = Math.floor(Date.now() / 1000);
 
@@ -985,6 +1002,85 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     }
 
     throw new InvalidTokenError('Invalid token');
+  }
+
+  /**
+   * Resolve a gateway-signed JWT to the registered client it maps to and
+   * return the SAME client-scoped AuthInfo shape the OAuth branch builds —
+   * source isolation, federated reads, slug fences and surface all come from
+   * the mapped `oauth_clients` row, never from the JWT.
+   *
+   * Unlike the opaque-token path there is no schema degrade ladder here:
+   * external verification is a NEW opt-in feature, so a brain missing the
+   * isolation columns fails the SELECT and the token is rejected. Fail
+   * closed beats accepting a gateway caller on a brain that cannot express
+   * its source scope.
+   */
+  private async verifyExternalToken(
+    verifier: ExternalTokenVerifier,
+    token: string,
+  ): Promise<SdkAuthInfo> {
+    let clientId: string;
+    let externalSub: string;
+    let exp: number | undefined;
+    try {
+      const verified = await verifier.verify(token);
+      clientId = verified.clientId;
+      externalSub = verified.subject;
+      exp = verified.payload.exp;
+    } catch {
+      // Detail (bad signature vs unmapped subject) stays server-side.
+      throw new InvalidTokenError('Invalid token');
+    }
+
+    const rows = await this.sql`
+      SELECT client_id, client_name, scope, source_id, federated_read,
+             bound_slug_prefixes, surface, surface_set_by
+      FROM oauth_clients
+      WHERE client_id = ${clientId} AND deleted_at IS NULL
+    `;
+    if (rows.length === 0) {
+      // Mapped caller whose client row is gone (or soft-deleted) — the map
+      // is stale, not the caller's fault, but access still ends here.
+      throw new InvalidTokenError('Invalid token');
+    }
+    const row = rows[0];
+
+    // Scopes come from the client registration (space-separated per RFC
+    // 6749), NOT from the JWT: gateway scope claims use the gateway's own
+    // vocabulary. NULL/empty registration scope means no grant.
+    const scopes = typeof row.scope === 'string' ? parseScopeString(row.scope) : [];
+
+    // Same normalization as the OAuth branch above.
+    const rowSourceId = (row.source_id as string | null) ?? undefined;
+    const federatedRaw = row.federated_read;
+    let allowedSources = Array.isArray(federatedRaw) ? (federatedRaw as string[]) : undefined;
+    if (allowedSources === undefined && rowSourceId !== undefined) {
+      allowedSources = [rowSourceId];
+    }
+    const boundRaw = row.bound_slug_prefixes;
+    const boundSlugPrefixes = Array.isArray(boundRaw) ? (boundRaw as string[]) : undefined;
+    const rowSurface = typeof row.surface === 'string' ? row.surface : undefined;
+    const rowSurfaceSetBy = typeof row.surface_set_by === 'string' ? row.surface_set_by : undefined;
+
+    return {
+      token,
+      clientId: row.client_id as string,
+      clientName: (row.client_name as string | null) ?? undefined,
+      scopes,
+      // jwtVerify already enforced exp; mirror it for the SDK's bearerAuth
+      // `typeof expiresAt === 'number'` requirement. A JWT without exp gets
+      // a zero-length validity rather than an unbounded one.
+      expiresAt: exp ?? Math.floor(Date.now() / 1000),
+      sourceId: rowSourceId,
+      allowedSources,
+      boundSlugPrefixes,
+      // Audit identity of the exact gateway key (several keys can map to
+      // this client_id); serve-http writes it to mcp_request_log params.
+      externalSub,
+      ...(rowSurface !== undefined ? { surface: rowSurface } : {}),
+      ...(rowSurfaceSetBy !== undefined ? { surfaceSetBy: rowSurfaceSetBy } : {}),
+    } as CoreAuthInfo as SdkAuthInfo;
   }
 
   // -------------------------------------------------------------------------

--- a/src/core/ops/contract.ts
+++ b/src/core/ops/contract.ts
@@ -229,6 +229,16 @@ export interface AuthInfo {
    */
   fenceProjectionDegraded?: boolean;
   /**
+   * Gateway JWT `sub` (or `email` when the caller map matched on email) for
+   * external-issuer callers (src/core/external-token-verifier.ts). Several
+   * gateway keys can map to the SAME client_id, so the mapped client alone
+   * cannot attribute a request to the exact key that made it. serve-http
+   * threads this into `mcp_request_log.params` as `external_sub` so the row
+   * reads "acl-hassan / litellm-user-b", not just "acl-hassan". Undefined on
+   * every non-external auth path.
+   */
+  externalSub?: string;
+  /**
    * WP4 (D2): per-client tool surface from `oauth_clients.surface`, threaded
    * at token-verification time (same JOIN as sourceId/allowedSources). The
    * serve-http transport resolves the request's effective surface as

--- a/test/external-token-verifier.test.ts
+++ b/test/external-token-verifier.test.ts
@@ -1,0 +1,159 @@
+/**
+ * External-issuer JWT verification (src/core/external-token-verifier.ts +
+ * the verifyAccessToken external branch in src/core/oauth-provider.ts).
+ *
+ * OWN PGlite instance (mirrors oauth-surface-ladder.test.ts): these tests
+ * mutate process.env for the module-level verifier singleton, which would
+ * poison shared-db suites that also exercise verifyAccessToken.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { GBrainOAuthProvider } from '../src/core/oauth-provider.ts';
+import { PGLITE_SCHEMA_SQL } from '../src/core/pglite-schema.ts';
+import { resetExternalTokenVerifierCache } from '../src/core/external-token-verifier.ts';
+import type { AuthInfo as CoreAuthInfo } from '../src/core/operations.ts';
+
+const ISSUER = 'https://gateway.test.example';
+const AUDIENCE = 'gbrain';
+
+let db: PGlite;
+let sql: (strings: TemplateStringsArray, ...values: unknown[]) => Promise<any>;
+let provider: GBrainOAuthProvider;
+let privateKey: CryptoKey;
+let savedEnv: Record<string, string | undefined>;
+
+const ENV_KEYS = [
+  'GBRAIN_EXTERNAL_TOKEN_ISSUER',
+  'GBRAIN_EXTERNAL_TOKEN_AUDIENCE',
+  'GBRAIN_EXTERNAL_TOKEN_CALLER_MAP',
+  'GBRAIN_EXTERNAL_TOKEN_JWKS',
+  'GBRAIN_EXTERNAL_TOKEN_JWKS_URI',
+] as const;
+
+async function signJwt(claims: Record<string, unknown>, opts?: { issuer?: string; audience?: string; expired?: boolean }): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+    .setIssuer(opts?.issuer ?? ISSUER)
+    .setAudience(opts?.audience ?? AUDIENCE)
+    .setIssuedAt(opts?.expired ? now - 600 : now)
+    .setExpirationTime(opts?.expired ? now - 300 : now + 300)
+    .sign(privateKey);
+}
+
+beforeAll(async () => {
+  db = new PGlite({ extensions: { vector, pg_trgm } });
+  await db.exec(PGLITE_SCHEMA_SQL);
+  sql = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ''), '');
+    const result = await db.query(query, values as any[]);
+    return result.rows;
+  };
+  provider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300 });
+
+  const pair = await generateKeyPair('RS256');
+  privateKey = pair.privateKey as CryptoKey;
+  const jwk = await exportJWK(pair.publicKey);
+  jwk.kid = 'test-key';
+  jwk.alg = 'RS256';
+
+  savedEnv = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+  process.env.GBRAIN_EXTERNAL_TOKEN_ISSUER = ISSUER;
+  process.env.GBRAIN_EXTERNAL_TOKEN_AUDIENCE = AUDIENCE;
+  process.env.GBRAIN_EXTERNAL_TOKEN_CALLER_MAP = JSON.stringify({
+    'litellm-user-a': 'acl-client-a',
+    'someone@example.com': 'acl-client-b',
+    'stale-caller': 'acl-client-gone',
+  });
+  process.env.GBRAIN_EXTERNAL_TOKEN_JWKS = JSON.stringify({ keys: [jwk] });
+  delete process.env.GBRAIN_EXTERNAL_TOKEN_JWKS_URI;
+  resetExternalTokenVerifierCache();
+
+  await sql`
+    INSERT INTO sources (id, name) VALUES ('source-a', 'Source A'), ('source-b', 'Source B'), ('infra-curated', 'Infra')
+  `;
+  await sql`
+    INSERT INTO oauth_clients (client_id, client_name, scope, source_id, federated_read)
+    VALUES ('acl-client-a', 'ACL Client A', 'read write', 'source-a', '{"source-a","infra-curated"}'),
+           ('acl-client-b', 'ACL Client B', 'read', 'source-b', '{"source-b"}')
+  `;
+  await sql`
+    INSERT INTO oauth_clients (client_id, client_name, scope, deleted_at)
+    VALUES ('acl-client-gone', 'Deleted', 'read', now())
+  `;
+}, 30_000);
+
+afterAll(async () => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  resetExternalTokenVerifierCache();
+  if (db) await db.close();
+}, 15_000);
+
+describe('external-issuer JWT verification', () => {
+  test('mapped sub resolves to the registered client with its source scope', async () => {
+    const token = await signJwt({ sub: 'litellm-user-a' });
+    const info = (await provider.verifyAccessToken(token)) as unknown as CoreAuthInfo;
+    expect(info.clientId).toBe('acl-client-a');
+    expect(info.clientName).toBe('ACL Client A');
+    expect(info.scopes).toEqual(['read', 'write']);
+    expect(info.sourceId).toBe('source-a');
+    expect(info.allowedSources).toEqual(['source-a', 'infra-curated']);
+    expect(typeof info.expiresAt).toBe('number');
+    // Audit identity of the exact gateway key — several keys can map to one
+    // client_id, so the request log needs the JWT sub, not just the client.
+    expect(info.externalSub).toBe('litellm-user-a');
+  });
+
+  test('email fallback maps when sub is unmapped', async () => {
+    const token = await signJwt({ sub: 'unmapped-internal-id', email: 'someone@example.com' });
+    const info = (await provider.verifyAccessToken(token)) as unknown as CoreAuthInfo;
+    expect(info.clientId).toBe('acl-client-b');
+    expect(info.allowedSources).toEqual(['source-b']);
+    // The map matched on email, so email IS the audit identity here.
+    expect(info.externalSub).toBe('someone@example.com');
+  });
+
+  test('verified JWT with unmapped subject is rejected (fail closed)', async () => {
+    const token = await signJwt({ sub: 'not-in-the-map' });
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow('Invalid token');
+  });
+
+  test('expired JWT is rejected', async () => {
+    const token = await signJwt({ sub: 'litellm-user-a' }, { expired: true });
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow('Invalid token');
+  });
+
+  test('wrong audience is rejected', async () => {
+    const token = await signJwt({ sub: 'litellm-user-a' }, { audience: 'somebody-else' });
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow('Invalid token');
+  });
+
+  test('JWT signed by a different key is rejected', async () => {
+    const rogue = await generateKeyPair('RS256');
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ sub: 'litellm-user-a' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(rogue.privateKey as CryptoKey);
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow('Invalid token');
+  });
+
+  test('mapped caller whose client row is soft-deleted is rejected', async () => {
+    const token = await signJwt({ sub: 'stale-caller' });
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow('Invalid token');
+  });
+
+  test('non-JWT bearer still takes the opaque-token path', async () => {
+    await expect(provider.verifyAccessToken('not-a-jwt-opaque-token')).rejects.toThrow('Invalid token');
+  });
+});


### PR DESCRIPTION
## What

Opt-in verification of external-issuer JWTs on the HTTP MCP surface, so an upstream gateway that signs MCP tool calls with short-lived RS256 JWTs (e.g. LiteLLM's `mcp_jwt_signer` guardrail, which publishes keys at `<issuer>/.well-known/jwks.json`) can act on behalf of registered GBrain clients — without sharing client secrets with the gateway.

The JWT proves WHO called through the gateway; a deploy-owned caller map (`sub`-or-`email` → `oauth_clients.client_id`) decides WHICH registered client that identity maps to. GBrain's own source isolation (source_id / federated_read / bound_slug_prefixes / surface) then applies exactly as for a token the client obtained directly — no new authorization axis.

## Design

- **Fully dormant unless configured**: `GBRAIN_EXTERNAL_TOKEN_ISSUER` + `AUDIENCE` + `CALLER_MAP` must all be set. Partial config is a hard startup error, not a silently disabled verifier.
- **Fail closed everywhere**: signature/`iss`/`aud`/`exp`/`nbf` verified (RS256 only); a verified JWT whose subject is not in the caller map is rejected; a mapped client_id that is missing or soft-deleted is rejected; a compact JWS that fails verification is never fed to the opaque-token hash paths (no probing the token store with attacker-shaped JWTs).
- **No impact on existing auth**: opaque GBrain tokens never contain two dots, so the JWS sniff (`looksLikeCompactJws`) leaves every existing path untouched.
- **Key rotation without restart**: `createRemoteJWKSet` refetches on unknown `kid`; inline `GBRAIN_EXTERNAL_TOKEN_JWKS` supported for air-gapped deploys and tests.
- **Auditability**: the matched caller-map subject is threaded as `AuthInfo.externalSub` and written to `mcp_request_log.params` as `external_sub` — several gateway keys can map to one client_id, and this attributes each row to the exact key. Plain JSONB key, no schema migration.

## Testing

`test/external-token-verifier.test.ts` (own PGlite instance, mirrors oauth-surface-ladder.test.ts): mapped sub resolves with client's source scope, email fallback, unmapped subject / expired / wrong audience / rogue key / soft-deleted client all rejected, opaque tokens still take the hash path. 8/8 on this branch; `tsc --noEmit` clean.

Running in our GKE test environment behind a LiteLLM gateway since 2026-08-23: per-key source isolation holds both directions, cross-source reads return zero rows, unauthenticated calls 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPYgaXuSYjk8cyNzLg4DHZ
