### PR TITLE
fix(search): image-similarity limit honors the active search mode (#4356 Problem 2)

### DIFF
--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -276,12 +276,13 @@ const query: Operation = {
     // similarity branch below it) — none of which support a literal
     // empty-result request today; introducing that only here would be a
     // new, undocumented asymmetry rather than a limit-consistency fix.
-    // (`search_by_image`, a separate op in src/core/ops/image.ts, has the
-    // same convention but isn't "in this file".) The image-similarity path
-    // (`image` param) is unaffected by this change and still hard-defaults
-    // to 20 regardless of mode — out of scope here, tracked separately
-    // (#4356 Problem 2).
-    limit: { type: 'number', description: 'Max results. For text queries, omitted or 0 resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax by default, or the configured `search.searchLimit` override). For image-similarity queries (`image` param), always defaults to 20 regardless of mode.' },
+    // (`search_by_image`, a separate op in src/core/ops/image.ts, keeps its
+    // own independent flat-20 default — different public contract, out of
+    // scope here.) #4356 Problem 2: the image-similarity path (`image`
+    // param) below now resolves the SAME mode-derived searchLimit as the
+    // text path (was hard `|| 20` regardless of mode, the last search arm
+    // in this op that didn't honor conservative/balanced/tokenmax).
+    limit: { type: 'number', description: 'Max results. Omitted or 0 resolves from the active search mode (10 conservative / 25 balanced / 50 tokenmax by default, or the configured `search.searchLimit` override) — for both text queries and image-similarity queries (`image` param).' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     // #3985: multi-type filter (plumbing shipped v0.33; exposed here).
     types: { type: 'array', items: { type: 'string' }, description: TYPES_PARAM_DESCRIPTION },
@@ -411,8 +412,22 @@ const query: Operation = {
       // hybridSearch and calls searchVector directly, so it needs its
       // own thread of the source scope. Pre-fix, this branch leaked
       // image pages across sources independent of the text path's fix.
+      // #4356 Problem 2: the image path also bypasses hybridSearch's mode
+      // resolution, so its default limit didn't honor the active search
+      // mode. Resolve mode here the same way hybridSearch does, including
+      // its remote trust gate (`resolvePerCallMode` — a remote caller's
+      // `mode` param still can't select the mode-derived default; an
+      // explicit `limit` still overrides it either way, same as every
+      // other limit surface in this op).
+      const imagePerCallMode = resolvePerCallMode(ctx, p.mode);
+      const { loadSearchModeConfig, resolveSearchMode } = await import('../search/mode.ts');
+      const imageModeInput = await loadSearchModeConfig(ctx.engine);
+      const imageResolvedMode = resolveSearchMode({
+        mode: imagePerCallMode ?? imageModeInput.mode,
+        overrides: imageModeInput.overrides,
+      });
       const results = await ctx.engine.searchVector(vec, {
-        limit: (p.limit as number) || 20,
+        limit: (p.limit as number) || imageResolvedMode.searchLimit,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
         excludePrivate,

--- a/src/core/search/mode.ts
+++ b/src/core/search/mode.ts
@@ -102,11 +102,14 @@ export interface ModeBundle {
   expansion: boolean;
   /**
    * Default `limit` for the operation layer (`src/core/operations.ts:1087`).
-   * Note: production `query` op TODAY defaults to 20. Mode bundle becomes
-   * the default ONLY when the caller omits the field — same chain semantics
-   * as model-tier resolution. See `[CDX-1+2+3]` in the plan: the original
-   * "tokenmax preserves Garry's setup" framing is wrong; tokenmax is an
-   * EXPANSION from the implicit current default (limit 20).
+   * Mode bundle becomes the default ONLY when the caller omits the field —
+   * same chain semantics as model-tier resolution. See `[CDX-1+2+3]` in the
+   * plan: the original "tokenmax preserves Garry's setup" framing is wrong;
+   * tokenmax is an EXPANSION from the implicit historical default (limit 20).
+   * (That flat-20 default no longer exists anywhere in `query`: #4360 fixed
+   * the text/hybrid path's cache-hit slice, #4356 Problem 2 fixed the
+   * image-similarity branch. `search_by_image`, a separate op with no mode
+   * param, still hard-defaults to 20 — a different public contract.)
    */
   searchLimit: number;
   /**

--- a/test/query-image-mode-limit.serial.test.ts
+++ b/test/query-image-mode-limit.serial.test.ts
@@ -1,0 +1,150 @@
+// #4356 Problem 2 regression: the `query` op's image-similarity branch used
+// to hard-default `limit` to 20 regardless of the active search mode — the
+// only search arm in this op that didn't honor conservative/balanced/
+// tokenmax's searchLimit (10/25/50). This pins the fix: the image branch now
+// resolves the same mode-derived searchLimit as the text path, through the
+// same resolution chain (loadSearchModeConfig + resolveSearchMode), and
+// respects the same remote trust gate as `resolvePerCallMode` (a remote
+// caller's `mode` param must never escalate cost/result-count).
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { operations as OPERATIONS } from '../src/core/operations.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+function fakeImage1024(seed: number): Float32Array {
+  const out = new Float32Array(1024);
+  for (let i = 0; i < 1024; i++) out[i] = (i + seed) / 1024;
+  return out;
+}
+
+async function seedImagePages(count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    const slug = `photos/img-${i}`;
+    await engine.putPage(slug, {
+      type: 'image', page_kind: 'image', title: slug, compiled_truth: '', timeline: '',
+    });
+    await engine.upsertChunks(slug, [
+      {
+        chunk_index: 0,
+        chunk_text: slug,
+        chunk_source: 'image_asset',
+        // Small seed spread so every page is a plausible near-neighbor —
+        // the point of these tests is counting how many come back, not
+        // ranking correctness (covered by query-image-flag.serial.test.ts).
+        embedding_image: fakeImage1024(i * 0.01),
+        modality: 'image',
+      },
+    ]);
+  }
+}
+
+const queryOp = OPERATIONS.find(o => o.name === 'query')!;
+
+async function runImageQuery(opts: { limit?: number; mode?: string; remote?: boolean }) {
+  mock.module('../src/core/ai/gateway.ts', () => ({
+    embedMultimodal: async () => [fakeImage1024(0)],
+  }));
+  const ctx = {
+    engine, config: null, logger: console, dryRun: false, remote: opts.remote ?? false,
+  } as any;
+  const params: Record<string, unknown> = {
+    image: Buffer.from('fake image bytes').toString('base64'),
+    image_mime: 'image/jpeg',
+  };
+  if (opts.limit !== undefined) params.limit = opts.limit;
+  if (opts.mode !== undefined) params.mode = opts.mode;
+  return queryOp.handler(ctx, params) as Promise<Array<{ slug: string }>>;
+}
+
+describe('query op image branch — mode-derived limit (#4356 Problem 2)', () => {
+  test('limit omitted, conservative mode → 10 results', async () => {
+    await seedImagePages(15);
+    await engine.setConfig('search.mode', 'conservative');
+    const results = await runImageQuery({});
+    expect(results.length).toBe(10);
+  });
+
+  test('limit omitted, balanced mode → 25 results', async () => {
+    await seedImagePages(30);
+    await engine.setConfig('search.mode', 'balanced');
+    const results = await runImageQuery({});
+    expect(results.length).toBe(25);
+  });
+
+  test('limit omitted, tokenmax mode → 50 results', async () => {
+    await seedImagePages(60);
+    await engine.setConfig('search.mode', 'tokenmax');
+    const results = await runImageQuery({});
+    expect(results.length).toBe(50);
+  });
+
+  test('no mode configured → balanced fallback (25), not the old flat 20', async () => {
+    await seedImagePages(30);
+    const results = await runImageQuery({});
+    expect(results.length).toBe(25);
+  });
+
+  test('search.searchLimit config override is honored', async () => {
+    await seedImagePages(20);
+    await engine.setConfig('search.mode', 'conservative');
+    await engine.setConfig('search.searchLimit', '15');
+    const results = await runImageQuery({});
+    expect(results.length).toBe(15);
+  });
+
+  test('explicit limit param wins over the resolved mode', async () => {
+    await seedImagePages(20);
+    await engine.setConfig('search.mode', 'tokenmax');
+    const results = await runImageQuery({ limit: 3 });
+    expect(results.length).toBe(3);
+  });
+
+  test('explicit limit=0 is treated as unset (falls back to resolved mode), matching the text path convention', async () => {
+    await seedImagePages(15);
+    await engine.setConfig('search.mode', 'conservative');
+    const results = await runImageQuery({ limit: 0 });
+    expect(results.length).toBe(10);
+  });
+
+  test('trusted local caller can select a per-call mode', async () => {
+    await seedImagePages(15);
+    await engine.setConfig('search.mode', 'balanced');
+    const results = await runImageQuery({ mode: 'conservative', remote: false });
+    expect(results.length).toBe(10);
+  });
+
+  test("remote caller's mode param is ignored for the mode-derived default (uses server-configured mode)", async () => {
+    await seedImagePages(60);
+    await engine.setConfig('search.mode', 'conservative');
+    // A remote caller asking for tokenmax's mode-derived default must be
+    // silently ignored — the server-configured mode (conservative=10) wins,
+    // not tokenmax's 50. This is the `resolvePerCallMode` trust gate that
+    // the text path already relies on; it governs the DEFAULT only — an
+    // explicit `limit` still overrides it for any caller, same as every
+    // other limit surface in this op (see the explicit-limit-wins test
+    // above), so this is not a hard per-call result-count ceiling.
+    const results = await runImageQuery({ mode: 'tokenmax', remote: true });
+    expect(results.length).toBe(10);
+  });
+});


### PR DESCRIPTION
## What

Resolves issue #4356 Problem 2, an open design question: the `query` op's image-similarity branch (`image` param) hard-defaults `limit` to 20 regardless of the active search mode — the only search arm in this op that didn't honor conservative/balanced/tokenmax's `searchLimit` (10/25/50). #4360 already fixed the equivalent gap for the text/hybrid path (Problem 1); this closes the second, independent site the same issue tracked as "awaiting maintainer input."

## The open question, and how this PR answers it

The issue's Problem 2 asked directly: *"Should image-similarity search follow the same mode-derived limit convention as text search, or is a flat 20 intentional there (e.g. because image results are typically smaller/costlier per item)?"*

This PR implements the mode-consistent answer: **yes, follow the same convention, no image-specific cap.** Reasoning:

- The mode system's whole purpose is letting an operator control retrieval breadth/cost uniformly. Exempting one search arm means a conservative-mode caller leaks extra cost through images without realizing it, and a tokenmax caller silently gets fewer image results than the mode promises.
- The per-item cost of an image result is a real consideration, but it argues for *choosing* conservative mode when cost-sensitive — exactly what the mode system is for — not for one arm silently overriding the caller's chosen mode.
- No new image-specific cap is introduced. The existing per-mode default (10/25/50) is treated as sufficient, and an explicit `limit` param still overrides it either way — same convention as every other limit surface in this op, not a new hard ceiling.

**I know this is a product-semantics call, not a mechanical bugfix, and the issue explicitly deferred it to a maintainer decision.** I'm opening this as a concrete, tested proposal rather than leaving it as prose on the issue — if the intended answer is actually "keep image flat-20 on purpose," this is easy to close with that reasoning, and I'm glad to rework it (e.g. as a narrower `imageSearchLimit` knob) if the direction is wrong.

## Implementation

Resolves mode the same way `hybridSearch` resolves it for the text path (`resolveSearchMode` at the top of bare `hybridSearch`, per `mode.ts`'s own doc comment) rather than a naive mode-bundle lookup, so the existing remote trust gate carries over unchanged: `resolvePerCallMode(ctx, p.mode)` still returns `undefined` for any non-`false` `ctx.remote`, so a remote/MCP caller's `mode` param cannot select the mode-derived default (an explicit `limit` param still overrides it for any caller, same as the text path).

`search_by_image` (a separate op in `src/core/ops/image.ts`, a different public contract with no `mode` param) is untouched — out of scope for this issue.

## Testing

9 new regression tests (`test/query-image-mode-limit.serial.test.ts`, needs `.serial` per this repo's `mock.module` test-isolation lint): conservative/balanced/tokenmax → 10/25/50, no mode configured → balanced fallback (not the old flat 20), `search.searchLimit` config override, explicit `limit` still wins, `limit: 0` treated as unset (matching the text-path convention), trusted-local per-call mode selection, and the remote-mode-ignored case.

8/9 confirmed red against the pre-fix upstream/master file; the 9th (explicit-limit-wins) was already correct pre-fix and is a non-regression pin.

```
bun test test/query-image-mode-limit.serial.test.ts test/query-image-flag.serial.test.ts  # 12 pass / 0 fail
bun run typecheck  # clean
bun run verify      # 54/54 green
```

Not addressed here: `loadSearchModeConfig` reads ~33 config keys per call (the mode + all per-key overrides) — this branch now pays that cost on every image-similarity search, same as the text path already pays on every text search via the identical call in `hybrid.ts`. Pre-existing pattern this PR extends to one more call site, not a new cost class.
