### PR TITLE
fix(doctor): let intentional hub pages opt out of junk_entity_hubs via frontmatter marker

### DIFF
--- a/src/commands/doctor/checks/graph-embedding.ts
+++ b/src/commands/doctor/checks/graph-embedding.ts
@@ -662,6 +662,17 @@ export const JUNK_HUB_MAX_CHUNKS = 2;
  * accretion; this check finds hubs that predate those gates so the owner
  * can review/merge/delete them deliberately.
  *
+ * The shape this heuristic looks for — near-empty content, many inbound
+ * edges — is also the intended shape of a deliberately thin index/hub page
+ * (e.g. external tooling that creates a `topic/X` page via `capture`/
+ * `put_page` specifically to aggregate mentions across many member pages).
+ * Callers that mint such pages on purpose can opt them out with
+ * `junk_hub_exempt: true` in frontmatter (optionally paired with a
+ * `junk_hub_exempt_reason` string) — same "flag by default, let the owner
+ * declare intent" idea as the `raw_trace_exempt` / `raw_trace_exempt_reason`
+ * escape hatch `rawProvenanceCheck` (#1978) uses, though that one exempts on
+ * key *presence* while this one requires the value `true` specifically.
+ *
  * `opts` exists for tests (small corpora can't reach 1000 edges); the
  * production call site uses the exported defaults.
  */
@@ -697,6 +708,7 @@ export async function checkJunkEntityHubs(
        JOIN pages p ON p.id = ec.page_id AND p.deleted_at IS NULL
        LEFT JOIN chunk_counts cc ON cc.page_id = ec.page_id
        WHERE COALESCE(cc.chunks, 0) <= $2
+         AND COALESCE(p.frontmatter ->> 'junk_hub_exempt', 'false') <> 'true'
        ORDER BY ec.edges DESC
        LIMIT 20`,
       [edgeThreshold, maxChunks],
@@ -721,7 +733,8 @@ export async function checkJunkEntityHubs(
         `("Will", "Info") minted by an extractor and inflated by mention auto-links:\n${list}\n` +
         `Review each page and merge/delete deliberately (nothing is auto-deleted). ` +
         `New accretion is already gated: enrichEntity refuses generic single-token mints and ` +
-        `buildGazetteer drops single-generic-token person titles.`,
+        `buildGazetteer drops single-generic-token person titles. If a page is an intentional thin ` +
+        `hub/index page, opt it out with junk_hub_exempt: true in frontmatter.`,
       details: {
         hubs: rows.map(r => ({
           slug: r.slug,

--- a/test/junk-entity-guards.test.ts
+++ b/test/junk-entity-guards.test.ts
@@ -216,4 +216,98 @@ describe('junk_entity_hubs doctor check (#4222)', () => {
     const check = await checkJunkEntityHubs(engine);
     expect(check.status).toBe('ok');
   });
+
+  test('junk_hub_exempt: true opts an intentional thin hub page out', async () => {
+    await engine.putPage('topic/misc', {
+      type: 'concept',
+      title: 'misc — topic hub (auto-created for graph wiring). Groups its member pages.',
+      compiled_truth: 'stub',
+      timeline: '',
+      frontmatter: { junk_hub_exempt: true, junk_hub_exempt_reason: 'intentional topic-organization scaffolding' },
+    });
+    const batch: LinkBatchInput[] = [];
+    for (let i = 0; i < 4; i++) {
+      const slug = `notes/e-${i}`;
+      await engine.putPage(slug, { type: 'note', title: `Note ${i}`, compiled_truth: 'body', timeline: '' });
+      batch.push({ from_slug: slug, to_slug: 'topic/misc', link_source: 'mentions' });
+    }
+    await engine.addLinksBatch(batch);
+
+    const check = await checkJunkEntityHubs(engine, { edgeThreshold: 3, maxChunks: 2 });
+
+    // Same shape as the junk-hub case above (few chunks, edges over threshold) —
+    // opted out, so it must not appear at all, and with nothing else in the
+    // corpus the check reports ok.
+    expect(check.status).toBe('ok');
+    if (check.details) {
+      const hubs = (check.details as { hubs: Array<{ slug: string }> }).hubs;
+      expect(hubs.some(h => h.slug === 'topic/misc')).toBe(false);
+    }
+  });
+
+  test('a page with the same shape but no exempt marker is still caught (regression control)', async () => {
+    await engine.putPage('topic/unmarked', {
+      type: 'concept', title: 'unmarked hub', compiled_truth: 'stub', timeline: '',
+    });
+    const batch: LinkBatchInput[] = [];
+    for (let i = 0; i < 4; i++) {
+      const slug = `notes/u-${i}`;
+      await engine.putPage(slug, { type: 'note', title: `Note ${i}`, compiled_truth: 'body', timeline: '' });
+      batch.push({ from_slug: slug, to_slug: 'topic/unmarked', link_source: 'mentions' });
+    }
+    await engine.addLinksBatch(batch);
+
+    const check = await checkJunkEntityHubs(engine, { edgeThreshold: 3, maxChunks: 2 });
+
+    expect(check.status).toBe('warn');
+    const hubs = (check.details as { hubs: Array<{ slug: string }> }).hubs;
+    expect(hubs.some(h => h.slug === 'topic/unmarked')).toBe(true);
+  });
+
+  test.each([
+    ['boolean false', false],
+    ['string "false"', 'false'],
+    ['unrelated string', 'nope'],
+  ])('junk_hub_exempt: %s does NOT opt the page out', async (_label, value) => {
+    const slug = `topic/not-exempt-${String(value).replace(/[^a-z0-9]/gi, '')}`;
+    await engine.putPage(slug, {
+      type: 'concept', title: 'not actually exempt', compiled_truth: 'stub', timeline: '',
+      frontmatter: { junk_hub_exempt: value },
+    });
+    const batch: LinkBatchInput[] = [];
+    for (let i = 0; i < 4; i++) {
+      const noteSlug = `notes/${slug.replace('topic/', '')}-${i}`;
+      await engine.putPage(noteSlug, { type: 'note', title: `Note ${i}`, compiled_truth: 'body', timeline: '' });
+      batch.push({ from_slug: noteSlug, to_slug: slug, link_source: 'mentions' });
+    }
+    await engine.addLinksBatch(batch);
+
+    const check = await checkJunkEntityHubs(engine, { edgeThreshold: 3, maxChunks: 2 });
+
+    expect(check.status).toBe('warn');
+    const hubs = (check.details as { hubs: Array<{ slug: string }> }).hubs;
+    expect(hubs.some(h => h.slug === slug)).toBe(true);
+  });
+
+  test('junk_hub_exempt: "true" (string, not boolean) DOES opt the page out', async () => {
+    await engine.putPage('topic/string-true-marked', {
+      type: 'concept', title: 'string-true marked hub', compiled_truth: 'stub', timeline: '',
+      frontmatter: { junk_hub_exempt: 'true' },
+    });
+    const batch: LinkBatchInput[] = [];
+    for (let i = 0; i < 4; i++) {
+      const noteSlug = `notes/st-${i}`;
+      await engine.putPage(noteSlug, { type: 'note', title: `Note ${i}`, compiled_truth: 'body', timeline: '' });
+      batch.push({ from_slug: noteSlug, to_slug: 'topic/string-true-marked', link_source: 'mentions' });
+    }
+    await engine.addLinksBatch(batch);
+
+    const check = await checkJunkEntityHubs(engine, { edgeThreshold: 3, maxChunks: 2 });
+
+    expect(check.status).toBe('ok');
+    if (check.details) {
+      const hubs = (check.details as { hubs: Array<{ slug: string }> }).hubs;
+      expect(hubs.some(h => h.slug === 'topic/string-true-marked')).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

The `junk_entity_hubs` check (#4222) flags any page with `<=2` chunks and `>1000` edges as a likely junk entity — an extractor-minted generic-token page ("Will", "Info") inflated by mention auto-links.

That exact shape — near-empty content, many inbound edges — is also the intended shape of a deliberately thin index/hub page. External tooling that creates a `topic/X` page via `capture`/`put_page` specifically to aggregate mentions across many member pages will false-positive on this check, even though the page is working exactly as designed.

## Fix

Add a `junk_hub_exempt: true` frontmatter opt-out (paired with an optional `junk_hub_exempt_reason` string for documentation) that the page owner can set to declare intent. This is the same "flag by default, let the owner declare intent" idea `rawProvenanceCheck` (#1978) already uses via `raw_trace_exempt` / `raw_trace_exempt_reason` — this PR follows that existing convention rather than inventing a new one. (One difference worth calling out: `raw_trace_exempt` exempts on key *presence*; `junk_hub_exempt` requires the value `true` specifically, since a boolean field reads more naturally than a presence-only sentinel here.)

Scope is intentionally narrow: no change to `JUNK_HUB_EDGE_THRESHOLD`/`JUNK_HUB_MAX_CHUNKS`, no new CLI surface, no change to any other doctor check.

## Testing

- Added to `test/junk-entity-guards.test.ts`: a page with `junk_hub_exempt: true` is excluded from the warn list even though it has the same shape as a junk hub; a same-shape page with no marker is still caught (regression control); `false`/non-`"true"` string values do NOT opt out; the string `"true"` does opt out (documents the `->>`-as-text comparison semantics).
- Discrimination check: reverting just the SQL predicate change (keeping the tests) makes the new opt-out test fail with `status: 'warn'` instead of `'ok'` — confirms the test is actually pinned to the fix, not vacuously passing.
- `bun test test/junk-entity-guards.test.ts`: 19 pass / 0 fail.
- `bun run typecheck`: clean.