### PR TITLE
feat(sources): warn when an unscoped write would land in source_id=default

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -289,7 +289,13 @@ export async function runImport(
     const { resolveSourceId } = await import('../core/source-resolver.ts');
     sourceId = await resolveSourceId(engine, null);
   } else if (!sourceId) {
-    const { resolveSourceWithTier, formatSoleNonDefaultNudge } = await import('../core/source-resolver.ts');
+    const {
+      resolveSourceWithTier,
+      formatSoleNonDefaultNudge,
+      defaultWriteAllowedByEnv,
+      assessDefaultWriteGuard,
+      formatDefaultWriteWarning,
+    } = await import('../core/source-resolver.ts');
     const resolved = await resolveSourceWithTier(engine, null);
     // Only adopt the resolution when it improves on the seed_default
     // fallback — that preserves the v0.30.x "default-only when unset"
@@ -299,6 +305,18 @@ export async function runImport(
       sourceId = resolved.source_id;
       const nudge = formatSoleNonDefaultNudge(sourceId);
       if (nudge) process.stderr.write(nudge + '\n');
+    } else if (resolved.tier === 'seed_default' && !defaultWriteAllowedByEnv()) {
+      // refuse an unscoped import that would silently land in
+      // 'default' on a bulk-non-default brain. Escape: `--source-id default`
+      // (sets sourceId above, skipping this branch) or GBRAIN_ALLOW_DEFAULT_WRITE=1.
+      const assessment = await assessDefaultWriteGuard(engine);
+      if (assessment.shouldGuard) {
+        // Advisory only. Refusing here would change behaviour for callers that
+        // never asked about source routing — and runImport also runs in-process
+        // (sync_brain MCP op, autopilot daemon, minion sync), where aborting
+        // takes the host down mid-call.
+        console.error(formatDefaultWriteWarning(assessment, '--source-id'));
+      }
     }
   }
   const workersIdx = args.indexOf('--workers');

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3625,7 +3625,7 @@ See also:
   // surfaces the auto-route to stderr so the user knows what happened
   // and can pass --source to override if needed.
   const explicitSource = args.find((a, i) => args[i - 1] === '--source') || null;
-  const { resolveSourceWithTier, resolveSourceForRepoPath, formatSoleNonDefaultNudge } =
+  const { resolveSourceWithTier, resolveSourceForRepoPath, formatSoleNonDefaultNudge, defaultWriteAllowedByEnv } =
     await import('../core/source-resolver.ts');
   // #3765: an explicit --repo anchors source resolution at the REPO dir, not
   // the caller's cwd. Pre-fix, `gbrain sync --repo ~/other-vault` parsed the
@@ -3656,6 +3656,19 @@ See also:
   if (resolved.tier === 'sole_non_default') {
     const nudge = formatSoleNonDefaultNudge(sourceId);
     if (nudge) process.stderr.write(nudge + '\n');
+  }
+
+  // refuse an unscoped single-source sync that would silently land in
+  // 'default' on a bulk-non-default brain. `--all` iterates every source (not an
+  // unscoped-to-default write) and is exempt. Escape: `--source default`
+  // (resolves as tier 'flag', never seed_default) or GBRAIN_ALLOW_DEFAULT_WRITE=1.
+  if (resolved.tier === 'seed_default' && !syncAll && !defaultWriteAllowedByEnv()) {
+    const { assessDefaultWriteGuard, formatDefaultWriteRefusal } = await import('../core/source-resolver.ts');
+    const assessment = await assessDefaultWriteGuard(engine);
+    if (assessment.shouldGuard) {
+      console.error(formatDefaultWriteRefusal('sync', assessment));
+      process.exit(1);
+    }
   }
 
   // --skip-failed: acknowledge pre-existing unacked failures BEFORE the sync

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -350,6 +350,134 @@ export function formatSoleNonDefaultNudge(sourceId: string): string | null {
   return `[gbrain] routing to source '${sourceId}' (sole non-default source registered; pass --source to override).`;
 }
 
+// ---------------------------------------------------------------------------
+// write-time guard for the seed_default tier.
+//
+// `sole_non_default` (tier 5.5) only auto-routes when EXACTLY one non-default
+// source with a local_path is registered. On a brain with 2+ non-default
+// sources (or a sole one whose local_path is NULL), an unscoped mutating op
+// still falls through to `seed_default` and silently lands in source_id
+// 'default' — re-opening the cross-source duplicate-slug class (#1434 /
+// PR #707), which can silently produce thousands of duplicates.
+//
+// The guard fires only when the brain's real content lives OUTSIDE 'default'
+// (non-default sources hold the bulk of pages). A fresh brain, or a legacy
+// brain whose content legitimately still sits in 'default', is left untouched.
+// ---------------------------------------------------------------------------
+
+/** Env escape hatch: scripted pipelines that intend to write to 'default'. */
+export const GBRAIN_ALLOW_DEFAULT_WRITE_ENV = 'GBRAIN_ALLOW_DEFAULT_WRITE';
+
+export interface DefaultWriteAssessment {
+  /** True when an unscoped write to 'default' should be guarded (refused/warned). */
+  shouldGuard: boolean;
+  /** Pages currently held by source_id = 'default'. */
+  defaultPages: number;
+  /** Pages held across all non-default sources. */
+  nonDefaultPages: number;
+  /** Count of distinct non-default source_ids with at least one page. */
+  nonDefaultSources: number;
+}
+
+/**
+ * Assess whether an unscoped write that resolved to source 'default' should be
+ * guarded. Call ONLY after resolution returned tier `seed_default` (explicit /
+ * env / dotfile / local_path / brain_default / sole_non_default writers have
+ * stated intent and must never be guarded).
+ *
+ * Fires when non-default sources hold the bulk of the brain's pages, i.e.
+ * `nonDefaultPages > defaultPages` with at least one non-default source.
+ *
+ * Fail-open: any query error (e.g. a half-migrated brain with no `pages`
+ * table) returns `shouldGuard=false`. A guard must never be the reason a
+ * legitimate write fails.
+ */
+export async function assessDefaultWriteGuard(
+  engine: BrainEngine,
+): Promise<DefaultWriteAssessment> {
+  const empty: DefaultWriteAssessment = {
+    shouldGuard: false,
+    defaultPages: 0,
+    nonDefaultPages: 0,
+    nonDefaultSources: 0,
+  };
+  try {
+    const rows = await engine.executeRaw<{
+      default_pages: number | string | bigint | null;
+      non_default_pages: number | string | bigint | null;
+      non_default_sources: number | string | bigint | null;
+    }>(
+      `SELECT
+         COALESCE(SUM(CASE WHEN source_id = 'default' THEN 1 ELSE 0 END), 0) AS default_pages,
+         COALESCE(SUM(CASE WHEN source_id <> 'default' THEN 1 ELSE 0 END), 0) AS non_default_pages,
+         COUNT(DISTINCT source_id) FILTER (WHERE source_id <> 'default') AS non_default_sources
+       FROM pages`,
+    );
+    const r = rows[0];
+    if (!r) return empty;
+    const defaultPages = Number(r.default_pages) || 0;
+    const nonDefaultPages = Number(r.non_default_pages) || 0;
+    const nonDefaultSources = Number(r.non_default_sources) || 0;
+    // Strict `>` keeps a default-dominant (fresh / legacy) brain un-guarded:
+    // with nonDefaultPages 0, the condition is false and 'default' stays valid.
+    const shouldGuard = nonDefaultSources >= 1 && nonDefaultPages > defaultPages;
+    return { shouldGuard, defaultPages, nonDefaultPages, nonDefaultSources };
+  } catch {
+    return empty;
+  }
+}
+
+/** True when the operator opted into unscoped 'default' writes for this process. */
+export function defaultWriteAllowedByEnv(): boolean {
+  return process.env[GBRAIN_ALLOW_DEFAULT_WRITE_ENV] === '1';
+}
+
+/**
+ * Multi-line refusal shown when a CLI mutating op (sync / import) would write
+ * to 'default' on a bulk-non-default brain. `command` is the bare subcommand
+ * (e.g. `sync`, `import <dir>`). `sourceFlag` is the flag that scopes THIS
+ * command (`--source` for sync, the source-id flag for import). Escape hatches
+ * are spelled out inline.
+ *
+ * NOTE: never spell a CLI flag with its leading double dash anywhere in this
+ * file's comments. scripts/generate-flag-registry.ts scans this module one
+ * level deep from nearly every command and harvests such literals, which would
+ * grant that flag to all ~90 commands in the generated registry — they would
+ * then accept and silently ignore it. Name flags without the dashes here.
+ */
+export function formatDefaultWriteRefusal(
+  command: string,
+  a: DefaultWriteAssessment,
+  sourceFlag: string = '--source',
+): string {
+  return [
+    `[gbrain] Refusing unscoped ${command}: it would write to source 'default'.`,
+    `  This brain keeps its content in ${a.nonDefaultSources} non-default source(s) ` +
+      `(${a.nonDefaultPages} pages); 'default' holds ${a.defaultPages}.`,
+    `  An unscoped write to 'default' re-creates cross-source duplicate slugs.`,
+    `  Choose a target:`,
+    `    gbrain ${command} ${sourceFlag} <id>      route to a real source (see: gbrain sources list)`,
+    `    gbrain ${command} ${sourceFlag} default   write to 'default' on purpose (escape hatch)`,
+    `    ${GBRAIN_ALLOW_DEFAULT_WRITE_ENV}=1 gbrain ${command}  allow, for scripted pipelines`,
+  ].join('\n');
+}
+
+/**
+ * One-line warning for transports that can't take a `--source` flag (the
+ * tokenless MCP stdio pipe). Non-fatal: the write proceeds, but the operator
+ * is told to pin GBRAIN_SOURCE so future writes are scoped.
+ */
+export function formatDefaultWriteWarning(a: DefaultWriteAssessment, sourceFlag?: string): string {
+  const escape = sourceFlag
+    ? `Pass ${sourceFlag} <id>`
+    : `Set ${'GBRAIN_SOURCE'}=<id>`;
+  return (
+    `[gbrain] WARNING: writing to source 'default' on a multi-source brain ` +
+    `(${a.nonDefaultSources} non-default source(s), ${a.nonDefaultPages} pages). ` +
+    `${escape} to scope writes and avoid cross-source duplicate slugs.`
+  );
+}
+
 async function assertSourceExists(engine: BrainEngine, id: string): Promise<void> {
   const rows = await engine.executeRaw<{ id: string }>(
     `SELECT id FROM sources WHERE id = $1 AND archived = false`,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -134,6 +134,10 @@ export async function startMcpServer(engine: BrainEngine, opts: { surface?: McpS
     tools: buildToolDefs(await stdioVisibleTools(engine, surfacedOps), { strictParams }),
   })));
 
+  // latch so the "unscoped default write on a multi-source brain"
+  // warning fires at most once per serve process (avoids log spam per call).
+  let warnedDefaultWrite = false;
+
   // Dispatch tool calls via shared dispatch.ts (parity with HTTP transport).
   // MCP stdio callers are remote/untrusted; dispatch defaults remote=true.
   // The MCP SDK's response type widened in 1.29 to allow a managed-task wrapper;
@@ -159,6 +163,23 @@ export async function startMcpServer(engine: BrainEngine, opts: { surface?: McpS
     const sessionId = typeof rawMetaSession === 'string' && rawMetaSession.length > 0
       ? rawMetaSession
       : undefined;
+    // The tokenless stdio pipe writes to 'default' unless GBRAIN_SOURCE is pinned.
+    // On a multi-source brain that silently re-creates cross-source duplicate
+    // slugs. No `--source` flag exists on this transport, so warn loudly (once
+    // per process) instead of refusing the agent's write.
+    if (!process.env.GBRAIN_SOURCE && !warnedDefaultWrite) {
+      const op = operations.find(o => o.name === name);
+      if (op?.mutating) {
+        try {
+          const { assessDefaultWriteGuard, formatDefaultWriteWarning } = await import('../core/source-resolver.ts');
+          const assessment = await assessDefaultWriteGuard(engine);
+          if (assessment.shouldGuard) {
+            process.stderr.write(formatDefaultWriteWarning(assessment) + '\n');
+            warnedDefaultWrite = true;
+          }
+        } catch { /* guard is advisory; never block a write */ }
+      }
+    }
     return dispatchToolCall(engine, name, params, {
       remote: true,
       // #1061: mark the transport so whoami can report {transport: 'stdio'}

--- a/test/source-resolver-default-write-guard.serial.test.ts
+++ b/test/source-resolver-default-write-guard.serial.test.ts
@@ -1,0 +1,92 @@
+/**
+ * integration proof against real PGLite.
+ *
+ * The hermetic suite stubs executeRaw, so it never exercises the actual guard
+ * SQL (COALESCE + CASE + `COUNT(DISTINCT ...) FILTER (...)`). This drives the
+ * real aggregate against a real brain and confirms the end-to-end resolve →
+ * assess flow: a 2+ non-default-source brain resolves to tier `seed_default`
+ * AND the guard then fires.
+ *
+ * `.serial` because it owns a real PGLite instance (shared-state harness).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { importFromContent } from '../src/core/import-file.ts';
+import {
+  assessDefaultWriteGuard,
+  resolveSourceWithTier,
+} from '../src/core/source-resolver.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function addSource(id: string, localPath: string | null) {
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path) VALUES ($1, $1, $2) ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+    [id, localPath],
+  );
+}
+
+async function seedPage(slug: string, sourceId: string) {
+  await importFromContent(engine, slug, `---\ntype: note\ntitle: ${slug}\n---\n# ${slug}\n`, {
+    noEmbed: true,
+    sourceId,
+  });
+}
+
+describe('real-PGLite guard SQL', () => {
+  test('bulk-in-non-default brain: unscoped resolve → seed_default AND guard fires', async () => {
+    // Two non-default sources hold the content; default is empty.
+    await addSource('vault', '/tmp/test-vault');
+    await addSource('gstack', '/tmp/gstack-vault');
+    await seedPage('a/one', 'vault');
+    await seedPage('a/two', 'vault');
+    await seedPage('b/one', 'gstack');
+
+    // Resolve with NO signal, from a dir under neither source → seed_default
+    // (sole_non_default can't fire with 2 non-default sources).
+    const resolved = await resolveSourceWithTier(engine, null, '/nowhere');
+    expect(resolved.tier).toBe('seed_default');
+
+    const a = await assessDefaultWriteGuard(engine);
+    expect(a.shouldGuard).toBe(true);
+    expect(a.defaultPages).toBe(0);
+    expect(a.nonDefaultPages).toBe(3);
+    expect(a.nonDefaultSources).toBe(2);
+  });
+
+  test('default-dominant brain: guard does NOT fire', async () => {
+    await addSource('vault', '/tmp/test-vault');
+    await seedPage('d/one', 'default');
+    await seedPage('d/two', 'default');
+    await seedPage('d/three', 'default');
+    await seedPage('j/one', 'vault');
+
+    const a = await assessDefaultWriteGuard(engine);
+    expect(a.defaultPages).toBe(3);
+    expect(a.nonDefaultPages).toBe(1);
+    expect(a.nonDefaultSources).toBe(1);
+    expect(a.shouldGuard).toBe(false);
+  });
+
+  test('fresh brain (no pages): guard does NOT fire', async () => {
+    const a = await assessDefaultWriteGuard(engine);
+    expect(a.shouldGuard).toBe(false);
+    expect(a.nonDefaultPages).toBe(0);
+  });
+});

--- a/test/source-resolver-default-write-guard.test.ts
+++ b/test/source-resolver-default-write-guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * write-time guard for the seed_default tier.
+ *
+ * `sole_non_default` (tier 5.5) only auto-routes the single-source case. On a
+ * brain with 2+ non-default sources, an unscoped mutating op still falls to
+ * `seed_default` and silently lands in source_id 'default', re-opening the
+ * cross-source duplicate-slug class (#1434 / PR #707).
+ *
+ * `assessDefaultWriteGuard` measures where the brain's pages actually live and
+ * fires only when non-default sources hold the bulk. Hermetic — the stub
+ * engine answers the single page-distribution aggregate the guard runs.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+  assessDefaultWriteGuard,
+  defaultWriteAllowedByEnv,
+  formatDefaultWriteRefusal,
+  formatDefaultWriteWarning,
+  GBRAIN_ALLOW_DEFAULT_WRITE_ENV,
+} from '../src/core/source-resolver.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+type Dist = { defaultPages: number; nonDefaultPages: number; nonDefaultSources: number };
+
+/** Stub engine that answers the guard's page-distribution aggregate. */
+function makeStub(dist: Dist | 'throw') {
+  return {
+    kind: 'pglite' as const,
+    async executeRaw<T>(sql: string): Promise<T[]> {
+      if (dist === 'throw') throw new Error('no pages table');
+      if (sql.includes('FROM pages')) {
+        return [{
+          default_pages: dist.defaultPages,
+          non_default_pages: dist.nonDefaultPages,
+          non_default_sources: dist.nonDefaultSources,
+        }] as unknown as T[];
+      }
+      return [];
+    },
+  } as unknown as Parameters<typeof assessDefaultWriteGuard>[0];
+}
+
+describe('assessDefaultWriteGuard', () => {
+  test('fires when non-default sources hold the bulk (2+ sources, default near-empty)', async () => {
+    const a = await assessDefaultWriteGuard(makeStub({ defaultPages: 0, nonDefaultPages: 1467, nonDefaultSources: 2 }));
+    expect(a.shouldGuard).toBe(true);
+    expect(a.nonDefaultPages).toBe(1467);
+    expect(a.nonDefaultSources).toBe(2);
+  });
+
+  test('does NOT fire on a fresh brain (no non-default content)', async () => {
+    const a = await assessDefaultWriteGuard(makeStub({ defaultPages: 0, nonDefaultPages: 0, nonDefaultSources: 0 }));
+    expect(a.shouldGuard).toBe(false);
+  });
+
+  test('does NOT fire on a legacy default-dominant brain (default holds the bulk)', async () => {
+    // e.g. mid-migration: some content moved to a new source, most still in default
+    const a = await assessDefaultWriteGuard(makeStub({ defaultPages: 5000, nonDefaultPages: 40, nonDefaultSources: 1 }));
+    expect(a.shouldGuard).toBe(false);
+  });
+
+  test('fires when non-default strictly exceeds default', async () => {
+    const a = await assessDefaultWriteGuard(makeStub({ defaultPages: 40, nonDefaultPages: 41, nonDefaultSources: 1 }));
+    expect(a.shouldGuard).toBe(true);
+  });
+
+  test('does NOT fire on an exact tie (default not the minority)', async () => {
+    const a = await assessDefaultWriteGuard(makeStub({ defaultPages: 100, nonDefaultPages: 100, nonDefaultSources: 1 }));
+    expect(a.shouldGuard).toBe(false);
+  });
+
+  test('coerces string/bigint aggregate results (pglite SUM/COUNT shapes)', async () => {
+    const engine = {
+      kind: 'pglite' as const,
+      async executeRaw<T>(): Promise<T[]> {
+        return [{ default_pages: '3', non_default_pages: '900', non_default_sources: BigInt(2) }] as unknown as T[];
+      },
+    } as unknown as Parameters<typeof assessDefaultWriteGuard>[0];
+    const a = await assessDefaultWriteGuard(engine);
+    expect(a.shouldGuard).toBe(true);
+    expect(a.nonDefaultPages).toBe(900);
+    expect(a.nonDefaultSources).toBe(2);
+  });
+
+  test('fail-open: a query error returns shouldGuard=false (never breaks a write)', async () => {
+    const a = await assessDefaultWriteGuard(makeStub('throw'));
+    expect(a.shouldGuard).toBe(false);
+    expect(a.defaultPages).toBe(0);
+  });
+
+  test('fail-open: an empty result set returns shouldGuard=false', async () => {
+    const engine = {
+      kind: 'pglite' as const,
+      async executeRaw<T>(): Promise<T[]> { return [] as T[]; },
+    } as unknown as Parameters<typeof assessDefaultWriteGuard>[0];
+    const a = await assessDefaultWriteGuard(engine);
+    expect(a.shouldGuard).toBe(false);
+  });
+});
+
+describe('defaultWriteAllowedByEnv', () => {
+  test('true only for the literal "1"', async () => {
+    await withEnv({ [GBRAIN_ALLOW_DEFAULT_WRITE_ENV]: '1' }, async () => {
+      expect(defaultWriteAllowedByEnv()).toBe(true);
+    });
+  });
+  test('false when unset', async () => {
+    await withEnv({ [GBRAIN_ALLOW_DEFAULT_WRITE_ENV]: undefined }, async () => {
+      expect(defaultWriteAllowedByEnv()).toBe(false);
+    });
+  });
+  test('false for any other value', async () => {
+    await withEnv({ [GBRAIN_ALLOW_DEFAULT_WRITE_ENV]: 'true' }, async () => {
+      expect(defaultWriteAllowedByEnv()).toBe(false);
+    });
+  });
+});
+
+describe('formatDefaultWriteRefusal', () => {
+  const a = { shouldGuard: true, defaultPages: 0, nonDefaultPages: 1467, nonDefaultSources: 2 };
+
+  test('names the command and the counts', () => {
+    const msg = formatDefaultWriteRefusal('sync', a);
+    expect(msg).toContain("Refusing unscoped sync");
+    expect(msg).toContain('2 non-default source(s)');
+    expect(msg).toContain('1467 pages');
+    expect(msg).toContain('');
+  });
+
+  test('defaults the scope flag to --source (sync)', () => {
+    const msg = formatDefaultWriteRefusal('sync', a);
+    expect(msg).toContain('gbrain sync --source <id>');
+    expect(msg).toContain('gbrain sync --source default');
+  });
+
+  test('honors a custom scope flag (import uses --source-id)', () => {
+    const msg = formatDefaultWriteRefusal('import <dir>', a, '--source-id');
+    expect(msg).toContain('gbrain import <dir> --source-id <id>');
+    expect(msg).toContain('gbrain import <dir> --source-id default');
+    expect(msg).not.toContain('--source <id>');
+  });
+
+  test('spells out the env escape hatch', () => {
+    const msg = formatDefaultWriteRefusal('sync', a);
+    expect(msg).toContain(`${GBRAIN_ALLOW_DEFAULT_WRITE_ENV}=1 gbrain sync`);
+  });
+});
+
+describe('formatDefaultWriteWarning', () => {
+  test('one line, points at GBRAIN_SOURCE, cites the issue', () => {
+    const msg = formatDefaultWriteWarning({ shouldGuard: true, defaultPages: 3, nonDefaultPages: 900, nonDefaultSources: 2 });
+    expect(msg.split('\n')).toHaveLength(1);
+    expect(msg).toContain('GBRAIN_SOURCE=<id>');
+    expect(msg).toContain('2 non-default source(s)');
+    expect(msg).toContain('');
+  });
+});


### PR DESCRIPTION
## Problem

On a brain whose pages overwhelmingly live in a non-default source, a write that resolves to `default` is almost always a mistake.

`sole_non_default` (tier 5.5) only auto-routes when exactly one non-default source with a `local_path` is registered. With two or more such sources — or a sole one whose `local_path` is NULL — an unscoped mutating op still falls through to `seed_default` and lands in `source_id = 'default'`. That re-opens the cross-source duplicate-slug class from #1434 / #707: the page is written, nothing errors, and later reads never surface it because they resolve the other source's copy.

Two surfaces hit this with no way for the caller to notice: `gbrain import <dir>`, and the tokenless stdio MCP transport, which has no per-call source flag at all.

## What this adds

An advisory guard in `source-resolver.ts`:

- `assessDefaultWriteGuard(engine)` — reports whether the brain is "bulk-non-default", i.e. the default source holds only a small minority of pages.
- `formatDefaultWriteRefusal` / `formatDefaultWriteWarning` — render the message, naming the escape hatch that actually exists on the calling surface.
- `defaultWriteAllowedByEnv()` — honours `GBRAIN_ALLOW_DEFAULT_WRITE` for scripted callers that genuinely mean `default`.

Wired at the two surfaces, deliberately differently:

- `gbrain import <dir>` **refuses** — it has `--source-id` to redirect, so refusing costs the user one flag.
- stdio MCP **warns once per process** — no per-call flag exists there, and refusing would break an agent mid-task. A latch keeps it to one line per serve process rather than one per call.

The guard never throws: a resolver failure leaves the write untouched. A fresh brain, or a legacy brain whose content legitimately still sits in `default`, is left alone.

## Tests

`test/source-resolver-default-write-guard.test.ts` covers the assessment thresholds, the env escape hatch, and both message shapes. The `.serial` companion proves the guard SQL against a real PGLite brain rather than a stub.