### PR TITLE
docs(recipes): list gemini-embedding-2 in the Google embedding catalog

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -104,7 +104,7 @@ To switch an existing brain, run `gbrain migrate embeddings --to voyage:voyage-c
 
 ### Google Gemini
 
-Set `GOOGLE_GENERATIVE_AI_API_KEY` (the AI Studio public API key). Model: `gemini-embedding-001`. Default 768 dims; Matryoshka up to 3072. Cheap.
+Set `GOOGLE_GENERATIVE_AI_API_KEY` (the AI Studio public API key). Models: `gemini-embedding-2` (current, GA 2026-04-22) and `gemini-embedding-001`. Default 768 dims; Matryoshka up to 3072 (`--embedding-dimensions 1536` / `3072`). Cheap. The two models' vector spaces are not interchangeable — to move an existing brain from `-001` to `-2`, use `gbrain migrate embeddings --to google:gemini-embedding-2 --dim <N>`, not `config set`.
 
 For GCP service-account / Vertex AI auth (production deployments), see the v0.32.x follow-up — Vertex ADC is on the roadmap.
 

--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -41,7 +41,11 @@ export const google: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['gemini-embedding-001'],
+      // gemini-embedding-2 (GA 2026-04-22) is Google's current embedding model.
+      // `models` is informational (providers list / docs), not a runtime
+      // allowlist — see assertTouchpoint. Its vector space is incompatible
+      // with -001: switching an existing brain needs `gbrain migrate embeddings`.
+      models: ['gemini-embedding-001', 'gemini-embedding-2'],
       default_dims: 768,
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,

--- a/test/ai/recipe-google-embedding-2.test.ts
+++ b/test/ai/recipe-google-embedding-2.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Google recipe — gemini-embedding-2 catalog entry.
+ *
+ * `models` is informational since v0.44.1.0 (assertTouchpoint no longer
+ * enforces it), so the load-bearing assertion is the catalog one: the GA
+ * model must be listed so `gbrain providers list` and the docs advertise it.
+ * The second test pins that dimsProviderOptions() keeps forwarding
+ * outputDimensionality for the new id exactly as for gemini-embedding-001.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { assertTouchpoint, resolveRecipe } from '../../src/core/ai/model-resolver.ts';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+
+describe('google recipe — gemini-embedding-2', () => {
+  test('is listed in the embedding catalog', () => {
+    expect(getRecipe('google')?.touchpoints.embedding?.models).toContain('gemini-embedding-2');
+  });
+
+  test('resolves on the embedding touchpoint', () => {
+    const { parsed, recipe } = resolveRecipe('google:gemini-embedding-2');
+    expect(() => assertTouchpoint(recipe, 'embedding', parsed.modelId)).not.toThrow();
+  });
+
+  test('forwards outputDimensionality like gemini-embedding-001', () => {
+    expect(dimsProviderOptions('native-google', 'gemini-embedding-2', 1536))
+      .toEqual({ google: { outputDimensionality: 1536 } });
+  });
+});


### PR DESCRIPTION
## Summary
- Docs/catalog change, **no runtime behavior change**. Since v0.44.1.0 (#4014) the recipe `models` array is informational — `assertTouchpoint` does not enforce it — so `google:gemini-embedding-2` already resolves on `master`. (Earlier revision of this PR wrongly claimed it was rejected; that error came from a pre-0.44.1.0 install.)
- Lists `gemini-embedding-2` (GA 2026-04-22) in the native Google embedding catalog so `gbrain providers list` and `docs/integrations/embedding-providers.md` advertise it; the doc still said "Model: `gemini-embedding-001`".
- Adds the note that `-2` and `-001` vector spaces are incompatible: move an existing brain with `gbrain migrate embeddings`, not `config set`.
- Not touched (out of scope): native multimodal embedding (#1216), stale `gemini-2.0-flash*` chat/expansion ids (#2507), pricing rows.

Refs #1216, #2507.

## Test plan
- [x] `bun test test/ai/recipe-google-embedding-2.test.ts` — 3 pass; the catalog assertion fails against the pre-change recipe (verified by swapping in the `master` version of `google.ts`).
- [x] `bun run typecheck` — clean.
- [x] `bun test test/ai` on top of v0.46.30.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
