### PR TITLE
fix(pricing): update gpt-5.6-luna to post-cut rates (#4560)

### DIFF
--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -65,7 +65,7 @@ export const openai: Recipe = {
     },
     expansion: {
       models: ['gpt-5.6-luna', 'gpt-4o-mini'],
-      cost_per_1m_tokens_usd: 1.00, // gpt-5.6-luna baseline
+      cost_per_1m_tokens_usd: 0.20, // gpt-5.6-luna baseline (price cut 2026-07-30)
       price_last_verified: '2026-08-17',
     },
     chat: {

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -123,7 +123,7 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   'openai:gpt-5.6':                       { input:  5.00, output: 30.00 },
   'openai:gpt-5.6-sol':                   { input:  5.00, output: 30.00 },
   'openai:gpt-5.6-terra':                 { input:  2.50, output: 15.00 },
-  'openai:gpt-5.6-luna':                  { input:  1.00, output:  6.00 },
+  'openai:gpt-5.6-luna':                  { input:  0.20, output:  1.20 },
 
   // ── Google ─────────────────────────────────────────────────────────────
   // `gemini-1.5-pro` was retired by Google (#3510); kept so historical


### PR DESCRIPTION
## What Problem This Solves

`CANONICAL_PRICING` carries `openai:gpt-5.6-luna` at the launch rate ($1.00 in / $6.00 out). OpenAI cut it by ~80% on 2026-07-30 to $0.20 in / $1.20 out. Every budget gate reads spend 5x high, so `autopilot.auto_drain.max_usd_per_day`, the `extract_atoms` cap and `--budget-usd` all throttle at a fifth of the ceiling the operator set.

## Why This Change Was Made

The pricing row was not updated after the price cut. Comment above the gpt-5.6 block says rates were "cross-checked 2026-08-17 across aggregator trackers" — several trackers still carried the launch price well after the cut.

## User Impact

Budget gates and cost estimates now reflect the actual post-cut rate for gpt-5.6-luna.

## Evidence

- Issue: https://github.com/garrytan/gbrain/issues/4560
- Root cause: stale pricing in `model-pricing.ts:126` and `openai.ts:68`
- Fix: updated both to $0.20 in / $1.20 out
- 2 files changed, 2 insertions, 2 deletions
