### PR TITLE
feat(atoms): honor pack prompts and complete source profiles

### DIFF
--- a/src/core/cycle/atom-extraction-profile.ts
+++ b/src/core/cycle/atom-extraction-profile.ts
@@ -1,0 +1,147 @@
+import { createHash } from 'node:crypto';
+import type { ResolvedExtractablePrompt } from '../schema-pack/prompt-template.ts';
+import type { ResolvedPack } from '../schema-pack/registry.ts';
+import type {
+  PreparedAtomSource,
+  ResolvedAtomInputProfile,
+} from '../schema-pack/source-input-profile.ts';
+
+export const ATOM_OUTPUT_CONTRACT_VERSION = 'gbrain.extract_atoms.output.v1';
+
+export const ATOM_TYPES = [
+  'insight', 'anecdote', 'quote', 'framework', 'statistic',
+  'story_angle', 'strategy_angle', 'strategy', 'endorsement',
+  'critique', 'collection',
+] as const;
+
+export interface ExtractedAtom {
+  title: string;
+  atom_type: typeof ATOM_TYPES[number];
+  body: string;
+  source_quote?: string;
+  lesson?: string;
+  concepts?: string[];
+  virality_score?: number;
+  emotional_register?: string;
+  evidence_refs?: string[];
+}
+
+export const CONCEPT_LABEL_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
+
+An atom is a single-source, self-contained idea that could become a tweet,
+quote, or short essay angle. Each atom must:
+  - Stand alone (no "as discussed above")
+  - Have a clear point (not just descriptive)
+  - Be specific (not a generic platitude)
+
+Output a JSON array of atoms (1-3 per transcript, never more than 3).
+Each atom: {title (≤80 chars), atom_type, body (2-4 sentences),
+source_quote (verbatim ≤200 chars), lesson (one sentence), concepts
+(1-3 topic labels), virality_score (0-100), emotional_register (one of:
+shocking, inspiring, funny, sobering, practical, controversial)}.
+
+atom_type MUST be one of: ${ATOM_TYPES.join(', ')}.
+
+concepts are kebab-case English TOPIC labels used to cluster atoms into
+concept pages (e.g. "captive-portal", "channel-pricing-strategy") — never
+entity or brand names. Use the same label for the same topic across atoms;
+prefer a label you already used over coining a near-synonym.
+
+Output ONLY the JSON array, no prose.`;
+
+export interface AtomExtractionProfile {
+  page_type: string;
+  pack_identity: string;
+  declaring_pack: string | null;
+  prompt_sha256: string;
+  model: string;
+  output_contract_version: typeof ATOM_OUTPUT_CONTRACT_VERSION;
+  source_input_profile_sha256: string | null;
+  input_selector: string | null;
+  window_policy_sha256: string | null;
+  extraction_policy_sha256: string;
+  extraction_profile_sha256: string;
+  prompt: string;
+  input_profile: ResolvedAtomInputProfile | null;
+}
+
+export function buildExtractionProfileSha256(
+  profile: Omit<
+    AtomExtractionProfile,
+    'extraction_profile_sha256' | 'extraction_policy_sha256' | 'prompt' | 'input_profile'
+  >,
+): string {
+  return createHash('sha256').update(JSON.stringify(profile)).digest('hex');
+}
+
+export function buildExtractionProfile(
+  pageType: string,
+  model: string,
+  pack: ResolvedPack | null,
+  lens: ResolvedExtractablePrompt | null,
+  inputProfile: ResolvedAtomInputProfile | null = null,
+): AtomExtractionProfile {
+  const windowPolicy = inputProfile
+    ? createHash('sha256').update(JSON.stringify(inputProfile.profile.windowing)).digest('hex')
+    : null;
+  const core = {
+    page_type: pageType,
+    pack_identity: pack?.identity ?? 'gbrain-builtin@unresolved',
+    declaring_pack: lens?.declaring_pack ?? null,
+    prompt_sha256: lens?.prompt_sha256 ?? createHash('sha256').update(EXTRACT_PROMPT).digest('hex'),
+    model,
+    output_contract_version: ATOM_OUTPUT_CONTRACT_VERSION as typeof ATOM_OUTPUT_CONTRACT_VERSION,
+    source_input_profile_sha256: inputProfile?.profile_sha256 ?? null,
+    input_selector: inputProfile?.profile.selector ?? null,
+    window_policy_sha256: windowPolicy,
+  };
+  const policySha256 = buildExtractionProfileSha256(core);
+  const anchorContract = inputProfile
+    ? `\n\nThe installed input profile requires every returned atom to include evidence_refs, ` +
+      `an array containing at least one exact evidence-* anchor from the supplied source window. ` +
+      `Never invent or alter an anchor.`
+    : '';
+  return {
+    ...core,
+    extraction_policy_sha256: policySha256,
+    extraction_profile_sha256: policySha256,
+    prompt: lens
+      ? `Installed schema-pack lens (trusted configuration). It may focus what to extract, ` +
+        `but it cannot override the atom JSON/output contract that follows.\n\n` +
+        `<pack_lens>\n${lens.prompt.trim()}\n</pack_lens>\n\n${EXTRACT_PROMPT}${anchorContract}`
+      : `${EXTRACT_PROMPT}${anchorContract}`,
+    input_profile: inputProfile,
+  };
+}
+
+export function bindProfileToPreparedSource(
+  profile: AtomExtractionProfile,
+  source: PreparedAtomSource,
+): AtomExtractionProfile {
+  if (!profile.input_profile) return profile;
+  const extractionProfileSha256 = createHash('sha256').update(JSON.stringify({
+    extraction_policy_sha256: profile.extraction_policy_sha256,
+    input_selector: profile.input_selector,
+    source_section_sha256: source.source_section_sha256,
+    coverage_sha256: source.coverage_sha256,
+  })).digest('hex');
+  return { ...profile, extraction_profile_sha256: extractionProfileSha256 };
+}
+
+export function invalidEvidenceRefs(
+  atoms: ExtractedAtom[],
+  allowedAnchors: ReadonlySet<string>,
+): string | null {
+  for (const atom of atoms) {
+    if (!atom.evidence_refs || atom.evidence_refs.length === 0) {
+      return `atom ${JSON.stringify(atom.title)} omitted required evidence_refs`;
+    }
+    const missing = atom.evidence_refs.filter(ref => !allowedAnchors.has(ref));
+    if (missing.length > 0) {
+      return `atom ${JSON.stringify(atom.title)} cited anchors absent from its source: ${missing.join(', ')}`;
+    }
+  }
+  return null;
+}

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -68,6 +68,12 @@ import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import type { ResolvedPack } from '../schema-pack/registry.ts';
 import type { ResolvedExtractablePrompt } from '../schema-pack/prompt-template.ts';
+import {
+  prepareAtomSource,
+  resolveAtomInputProfile,
+  type PreparedAtomSource,
+  type ResolvedAtomInputProfile,
+} from '../schema-pack/source-input-profile.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 // #4529 + #4540: per-item extractor caps, overridable via
@@ -240,6 +246,8 @@ interface ExtractedAtom {
   concepts?: string[];
   virality_score?: number;
   emotional_register?: string;
+  /** Exact source anchors required by source-complete input profiles. */
+  evidence_refs?: string[];
 }
 
 /** kebab-case validator for concept labels ("captive-portal", "channel-pricing"). */
@@ -275,12 +283,22 @@ export interface AtomExtractionProfile {
   prompt_sha256: string;
   model: string;
   output_contract_version: typeof ATOM_OUTPUT_CONTRACT_VERSION;
+  source_input_profile_sha256: string | null;
+  input_selector: string | null;
+  window_policy_sha256: string | null;
+  /** Stable pack/prompt/model/input-policy identity used by discovery. */
+  extraction_policy_sha256: string;
+  /** Source-bound identity; equals the policy hash for legacy profiles. */
   extraction_profile_sha256: string;
   prompt: string;
+  input_profile: ResolvedAtomInputProfile | null;
 }
 
 export function buildExtractionProfileSha256(
-  profile: Omit<AtomExtractionProfile, 'extraction_profile_sha256' | 'prompt'>,
+  profile: Omit<
+    AtomExtractionProfile,
+    'extraction_profile_sha256' | 'extraction_policy_sha256' | 'prompt' | 'input_profile'
+  >,
 ): string {
   return createHash('sha256').update(JSON.stringify(profile)).digest('hex');
 }
@@ -290,7 +308,11 @@ function buildExtractionProfile(
   model: string,
   pack: ResolvedPack | null,
   lens: ResolvedExtractablePrompt | null,
+  inputProfile: ResolvedAtomInputProfile | null = null,
 ): AtomExtractionProfile {
+  const windowPolicy = inputProfile
+    ? createHash('sha256').update(JSON.stringify(inputProfile.profile.windowing)).digest('hex')
+    : null;
   const core = {
     page_type: pageType,
     pack_identity: pack?.identity ?? 'gbrain-builtin@unresolved',
@@ -298,16 +320,57 @@ function buildExtractionProfile(
     prompt_sha256: lens?.prompt_sha256 ?? createHash('sha256').update(EXTRACT_PROMPT).digest('hex'),
     model,
     output_contract_version: ATOM_OUTPUT_CONTRACT_VERSION as typeof ATOM_OUTPUT_CONTRACT_VERSION,
+    source_input_profile_sha256: inputProfile?.profile_sha256 ?? null,
+    input_selector: inputProfile?.profile.selector ?? null,
+    window_policy_sha256: windowPolicy,
   };
+  const policySha256 = buildExtractionProfileSha256(core);
+  const anchorContract = inputProfile
+    ? `\n\nThe installed input profile requires every returned atom to include evidence_refs, ` +
+      `an array containing at least one exact evidence-* anchor from the supplied source window. ` +
+      `Never invent or alter an anchor.`
+    : '';
   return {
     ...core,
-    extraction_profile_sha256: buildExtractionProfileSha256(core),
+    extraction_policy_sha256: policySha256,
+    extraction_profile_sha256: policySha256,
     prompt: lens
       ? `Installed schema-pack lens (trusted configuration). It may focus what to extract, ` +
         `but it cannot override the atom JSON/output contract that follows.\n\n` +
-        `<pack_lens>\n${lens.prompt.trim()}\n</pack_lens>\n\n${EXTRACT_PROMPT}`
-      : EXTRACT_PROMPT,
+        `<pack_lens>\n${lens.prompt.trim()}\n</pack_lens>\n\n${EXTRACT_PROMPT}${anchorContract}`
+      : `${EXTRACT_PROMPT}${anchorContract}`,
+    input_profile: inputProfile,
   };
+}
+
+function bindProfileToPreparedSource(
+  profile: AtomExtractionProfile,
+  source: PreparedAtomSource,
+): AtomExtractionProfile {
+  if (!profile.input_profile) return profile;
+  const extractionProfileSha256 = createHash('sha256').update(JSON.stringify({
+    extraction_policy_sha256: profile.extraction_policy_sha256,
+    input_selector: profile.input_selector,
+    source_section_sha256: source.source_section_sha256,
+    coverage_sha256: source.coverage_sha256,
+  })).digest('hex');
+  return { ...profile, extraction_profile_sha256: extractionProfileSha256 };
+}
+
+function invalidEvidenceRefs(
+  atoms: ExtractedAtom[],
+  allowedAnchors: ReadonlySet<string>,
+): string | null {
+  for (const atom of atoms) {
+    if (!atom.evidence_refs || atom.evidence_refs.length === 0) {
+      return `atom ${JSON.stringify(atom.title)} omitted required evidence_refs`;
+    }
+    const missing = atom.evidence_refs.filter(ref => !allowedAnchors.has(ref));
+    if (missing.length > 0) {
+      return `atom ${JSON.stringify(atom.title)} cited anchors absent from its source: ${missing.join(', ')}`;
+    }
+  }
+  return null;
 }
 
 interface DiscoveredPage {
@@ -382,7 +445,10 @@ export async function discoverExtractablePages(
           AND atom.source_id = $1
           AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
           ${profileAware ? `AND (
-            atom.frontmatter->>'extraction_profile_sha256' = COALESCE((${profileParam}::jsonb)->>p.type, '')
+            COALESCE(
+              atom.frontmatter->>'extraction_policy_sha256',
+              atom.frontmatter->>'extraction_profile_sha256'
+            ) = COALESCE((${profileParam}::jsonb)->>p.type, '')
             OR (p.type = ANY($6::text[]) AND NOT (atom.frontmatter ? 'extraction_profile_sha256'))
           )` : ''}
           AND atom.deleted_at IS NULL
@@ -463,15 +529,16 @@ export async function countExtractAtomsBacklog(
       const { resolveExtractablePrompt } = await import('../schema-pack/prompt-template.ts');
       for (const pageType of types) {
         const lens = resolveExtractablePrompt(pack, pageType);
+        const inputProfile = resolveAtomInputProfile(pack, pageType);
         profileHashes[pageType] = buildExtractionProfile(
-          pageType, model, pack, lens,
-        ).extraction_profile_sha256;
-        if (!lens) legacyCompatibleTypes.push(pageType);
+          pageType, model, pack, lens, inputProfile,
+        ).extraction_policy_sha256;
+        if (!lens && !inputProfile) legacyCompatibleTypes.push(pageType);
       }
     } else {
       for (const pageType of types) {
         profileHashes[pageType] = buildExtractionProfile(pageType, model, null, null)
-          .extraction_profile_sha256;
+          .extraction_policy_sha256;
         legacyCompatibleTypes.push(pageType);
       }
     }
@@ -500,7 +567,10 @@ export async function countExtractAtomsBacklog(
              WHERE atom.type = 'atom' AND atom.source_id = $1
                AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
                AND (
-                 atom.frontmatter->>'extraction_profile_sha256' = COALESCE(($4::jsonb)->>p.type, '')
+                 COALESCE(
+                   atom.frontmatter->>'extraction_policy_sha256',
+                   atom.frontmatter->>'extraction_profile_sha256'
+                 ) = COALESCE(($4::jsonb)->>p.type, '')
                  OR (p.type = ANY($5::text[]) AND NOT (atom.frontmatter ? 'extraction_profile_sha256'))
                )
                AND atom.deleted_at IS NULL
@@ -665,16 +735,17 @@ export async function runPhaseExtractAtoms(
     const { resolveExtractablePrompt } = await import('../schema-pack/prompt-template.ts');
     for (const pageType of extractableTypes) {
       const lens = resolveExtractablePrompt(resolvedPack, pageType);
-      const profile = buildExtractionProfile(pageType, extractModel, resolvedPack, lens);
+      const inputProfile = resolveAtomInputProfile(resolvedPack, pageType);
+      const profile = buildExtractionProfile(pageType, extractModel, resolvedPack, lens, inputProfile);
       profileByType.set(pageType, profile);
-      profileHashesByType[pageType] = profile.extraction_profile_sha256;
-      if (!lens) legacyCompatibleTypes.push(pageType);
+      profileHashesByType[pageType] = profile.extraction_policy_sha256;
+      if (!lens && !inputProfile) legacyCompatibleTypes.push(pageType);
     }
   } else {
     for (const pageType of extractableTypes) {
       const profile = buildExtractionProfile(pageType, extractModel, null, null);
       profileByType.set(pageType, profile);
-      profileHashesByType[pageType] = profile.extraction_profile_sha256;
+      profileHashesByType[pageType] = profile.extraction_policy_sha256;
       legacyCompatibleTypes.push(pageType);
     }
   }
@@ -894,6 +965,72 @@ export async function runPhaseExtractAtoms(
   // say are "retryable, never counted" — see that regex's doc comment.
   let hardFailureCount = 0;
 
+  async function callAtoms(system: string, content: string): Promise<AtomsParseOutcome> {
+    const result = await chat({
+      model: extractModel,
+      system,
+      messages: [{ role: 'user', content }],
+      maxTokens: maxOutputTokens,
+    });
+    await maybeYield();
+    llmHalt.reset();
+    if (pacingMs > 0) await new Promise<void>((resolve) => setTimeout(resolve, pacingMs));
+    return parseAtomsOutcome(result.text);
+  }
+
+  async function extractItemAtoms(
+    item: WorkItem,
+    originLabel: string,
+    prepared: PreparedAtomSource | null,
+  ): Promise<AtomsParseOutcome> {
+    if (!prepared) {
+      return callAtoms(
+        item.profile.prompt,
+        `Source: ${originLabel}\n\n---\n\n${truncateUtf8(item.content, maxInputChars)}`,
+      );
+    }
+    const candidates: ExtractedAtom[] = [];
+    for (const window of prepared.windows) {
+      const outcome = await callAtoms(
+        item.profile.prompt,
+        `Source: ${originLabel}\n` +
+          `Selected source SHA-256: ${prepared.source_section_sha256}\n` +
+          `Window: ${window.index + 1}/${prepared.windows.length}\n` +
+          `Source character range: [${window.start}, ${window.end})\n` +
+          `Window SHA-256: ${window.sha256}\n` +
+          `Available evidence anchors: ${window.evidence_anchors.join(', ') || '(none)'}\n\n---\n\n` +
+          window.text,
+      );
+      if (!outcome.ok) {
+        return { ok: false, reason: `window ${window.index + 1}/${prepared.windows.length}: ${outcome.reason}` };
+      }
+      const invalid = invalidEvidenceRefs(outcome.atoms, new Set(window.evidence_anchors));
+      if (invalid) return { ok: false, reason: `window ${window.index + 1}: ${invalid}` };
+      candidates.push(...outcome.atoms);
+    }
+    if (prepared.windows.length === 1 || candidates.length === 0) {
+      return { ok: true, atoms: candidates };
+    }
+    const reconciliationSystem =
+      `${item.profile.prompt}\n\nYou are reconciling leads extracted from complete, overlapping windows ` +
+      `of one parent page. Return only the strongest non-duplicative 1-3 atoms. Preserve literal ` +
+      `chronology and exact evidence_refs from the candidates; do not add evidence or claims.`;
+    const reconciliation = await callAtoms(
+      reconciliationSystem,
+      `Parent source: ${originLabel}\n` +
+        `Selected source SHA-256: ${prepared.source_section_sha256}\n` +
+        `Coverage manifest SHA-256: ${prepared.coverage_sha256}\n` +
+        `Allowed evidence anchors: ${prepared.evidence_anchors.join(', ')}\n\n` +
+        `Window candidates:\n${JSON.stringify(candidates)}`,
+    );
+    if (!reconciliation.ok) {
+      return { ok: false, reason: `parent reconciliation: ${reconciliation.reason}` };
+    }
+    const invalid = invalidEvidenceRefs(reconciliation.atoms, new Set(prepared.evidence_anchors));
+    if (invalid) return { ok: false, reason: `parent reconciliation: ${invalid}` };
+    return reconciliation;
+  }
+
   /** Stamp the zero-yield/complete tombstone (hash-keyed; edits re-eligibilize). */
   async function stampAtomsScanHash(item: { slug: string; contentHash: string; profile: AtomExtractionProfile }): Promise<void> {
     try {
@@ -903,7 +1040,7 @@ export async function runPhaseExtractAtoms(
               || jsonb_build_object('atoms_scan_hash', $1::text)
               || jsonb_build_object('atoms_scan_profile', $2::text)
           WHERE source_id = $3 AND slug = $4 AND deleted_at IS NULL`,
-        [item.contentHash.slice(0, 16), item.profile.extraction_profile_sha256, sourceId, item.slug],
+        [item.contentHash.slice(0, 16), item.profile.extraction_policy_sha256, sourceId, item.slug],
       );
     } catch { /* fail-soft: page stays rediscoverable */ }
   }
@@ -933,7 +1070,7 @@ export async function runPhaseExtractAtoms(
                         ELSE 1 END)
           WHERE source_id = $3 AND slug = $4 AND deleted_at IS NULL
           RETURNING (frontmatter->>'atoms_fail_count')::int AS cnt`,
-        [item.contentHash.slice(0, 16), item.profile.extraction_profile_sha256, sourceId, item.slug],
+        [item.contentHash.slice(0, 16), item.profile.extraction_policy_sha256, sourceId, item.slug],
       );
       const cnt = rows[0]?.cnt;
       return cnt == null ? null : Number(cnt);
@@ -954,33 +1091,16 @@ export async function runPhaseExtractAtoms(
     const originLabel = item.kind === 'transcript' ? item.filePath : item.slug;
     const pendingSlugs: string[] = [];
     try {
-      const result = await chat({
-        model: extractModel,
-        system: item.profile.prompt,
-        messages: [
-          {
-            role: 'user',
-            // #4529/#4540: configurable input cap, cut UTF-8-safely (a bare
-            // .slice() can split a surrogate pair at the boundary).
-            content: `Source: ${originLabel}\n\n---\n\n${truncateUtf8(item.content, maxInputChars)}`,
-          },
-        ],
-        maxTokens: maxOutputTokens,
-      });
-      // Post-await yield: closes the "long LLM call past TTL" hazard
-      // codex flagged. The 30s throttle inside maybeYield bounds the
-      // actual refresh rate so this is cheap when calls are fast.
-      await maybeYield();
-      llmHalt.reset();
-      // #4540: optional per-item pacing between successful LLM calls.
-      // setTimeout (not setImmediate) so the lock-refresh interval fires.
-      if (pacingMs > 0) await new Promise<void>((r) => setTimeout(r, pacingMs));
+      const prepared = item.profile.input_profile
+        ? prepareAtomSource(item.content, item.profile.input_profile)
+        : null;
+      if (prepared) item.profile = bindProfileToPreparedSource(item.profile, prepared);
+      const parseOutcome = await extractItemAtoms(item, originLabel, prepared);
 
       estimatedSpendUsd = budgetTracker.totalSpent;
 
       // gbrain#4148: typed outcome — malformed output is a FAILURE (counted
       // toward the bounded tombstone below), never a zero-yield success.
-      const parseOutcome = parseAtomsOutcome(result.text);
       if (!parseOutcome.ok) {
         malformedOutputs++;
         hardFailureCount++;
@@ -1068,6 +1188,7 @@ export async function runPhaseExtractAtoms(
               // Provisional until the whole item's atoms persist (see above).
               source_hash: `pending:${hash16}`,
               extraction_profile_sha256: item.profile.extraction_profile_sha256,
+              extraction_policy_sha256: item.profile.extraction_policy_sha256,
               extraction_profile_state: 'pending',
               extraction_page_type: item.profile.page_type,
               extraction_pack_identity: item.profile.pack_identity,
@@ -1075,11 +1196,29 @@ export async function runPhaseExtractAtoms(
               extraction_prompt_sha256: item.profile.prompt_sha256,
               extraction_model: item.profile.model,
               extraction_output_contract_version: item.profile.output_contract_version,
+              ...(item.profile.source_input_profile_sha256 && {
+                extraction_input_profile_sha256: item.profile.source_input_profile_sha256,
+              }),
+              ...(item.profile.input_selector && {
+                extraction_input_selector: item.profile.input_selector,
+              }),
+              ...(item.profile.window_policy_sha256 && {
+                extraction_window_policy_sha256: item.profile.window_policy_sha256,
+              }),
+              ...(prepared && {
+                extraction_source_section_sha256: prepared.source_section_sha256,
+                extraction_source_range_start: prepared.source_start,
+                extraction_source_range_end: prepared.source_end,
+                extraction_source_window_count: prepared.windows.length,
+                extraction_source_coverage: 'complete',
+                extraction_source_coverage_sha256: prepared.coverage_sha256,
+              }),
               ...(atom.source_quote && { source_quote: atom.source_quote }),
               ...(atom.lesson && { lesson: atom.lesson }),
               ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
               ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
               ...(atom.emotional_register && { emotional_register: atom.emotional_register }),
+              ...(atom.evidence_refs && atom.evidence_refs.length > 0 && { evidence_refs: atom.evidence_refs }),
               extracted_at: new Date().toISOString(),
               extracted_by: 'extract_atoms-v0.41.2.1',
             },
@@ -1296,6 +1435,10 @@ export async function runPhaseExtractAtoms(
         model: profile.model,
         output_contract_version: profile.output_contract_version,
         extraction_profile_sha256: profile.extraction_profile_sha256,
+        extraction_policy_sha256: profile.extraction_policy_sha256,
+        source_input_profile_sha256: profile.source_input_profile_sha256,
+        input_selector: profile.input_selector,
+        window_policy_sha256: profile.window_policy_sha256,
       })),
     },
   };
@@ -1402,6 +1545,13 @@ function atomsFromParsedArray(parsed: unknown[]): ExtractedAtom[] {
           : undefined,
       emotional_register:
         typeof obj.emotional_register === 'string' ? obj.emotional_register : undefined,
+      evidence_refs: (() => {
+        if (!Array.isArray(obj.evidence_refs)) return undefined;
+        const refs = obj.evidence_refs
+          .filter((ref): ref is string => typeof ref === 'string' && /^evidence-[^\s]+$/u.test(ref))
+          .slice(0, 20);
+        return refs.length > 0 ? [...new Set(refs)] : undefined;
+      })(),
     });
   }
   return atoms;

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -66,6 +66,8 @@ import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
+import type { ResolvedPack } from '../schema-pack/registry.ts';
+import type { ResolvedExtractablePrompt } from '../schema-pack/prompt-template.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 // #4529 + #4540: per-item extractor caps, overridable via
@@ -74,6 +76,7 @@ const DEFAULT_BUDGET_USD = 0.3;
 // Exported so tests pin the defaults instead of re-hardcoding the literals.
 export const DEFAULT_EXTRACT_MAX_INPUT_CHARS = 50_000;
 export const DEFAULT_EXTRACT_MAX_OUTPUT_TOKENS = 4096;
+export const ATOM_OUTPUT_CONTRACT_VERSION = 'gbrain.extract_atoms.output.v1';
 
 /**
  * gbrain#4148: consecutive same-content failures of a content-deterministic
@@ -141,14 +144,38 @@ export function unionExtractableTypes(packExtractable: Iterable<string>): string
  * gbrain-base via the legacy-floor union. Fail-soft: any pack-load error falls
  * back to the legacy floor.
  */
-async function resolveExtractableTypes(): Promise<string[]> {
-  let packExtractable: Iterable<string> = [];
+async function resolveExtractionPack(
+  engine?: BrainEngine,
+  sourceId = 'default',
+): Promise<ResolvedPack | null> {
   try {
     const { loadConfig } = await import('../config.ts');
     const { loadActivePack } = await import('../schema-pack/load-active.ts');
+    const perSourceName = engine
+      ? await engine.getConfig(`schema_pack.source.${sourceId}`)
+      : null;
+    const dbConfig = engine ? await engine.getConfig('schema_pack') : null;
+    const perSourceDb = perSourceName
+      ? new Map<string, string>([[sourceId, perSourceName]])
+      : undefined;
+    return await loadActivePack({
+      cfg: loadConfig(),
+      remote: false,
+      sourceId,
+      perSourceDb,
+      dbConfig: dbConfig ?? undefined,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function resolveExtractableTypes(pack?: ResolvedPack | null): Promise<string[]> {
+  let packExtractable: Iterable<string> = [];
+  try {
     const { extractableTypesFromPack } = await import('../schema-pack/extractable.ts');
-    const resolved = await loadActivePack({ cfg: loadConfig(), remote: false });
-    packExtractable = extractableTypesFromPack(resolved.manifest);
+    const resolved = pack ?? await resolveExtractionPack();
+    if (resolved) packExtractable = extractableTypesFromPack(resolved.manifest);
   } catch {
     // Pack unavailable (test seams, bootstrap) — legacy floor only.
   }
@@ -174,7 +201,9 @@ export interface ExtractAtomsOpts {
    * Mirrors _transcripts shape. `undefined` triggers discovery; `[]`
    * explicitly suppresses page discovery (for transcript-only tests).
    */
-  _pages?: Array<{ slug: string; content: string; contentHash: string }>;
+  _pages?: Array<{ slug: string; content: string; contentHash: string; pageType?: string }>;
+  /** Test seam: pre-resolved active pack, including declaration origins. */
+  _resolvedPack?: ResolvedPack | null;
   /**
    * v0.41.19.0 (T3): cooperative yield hook fired from inside the work
    * loop on a 30s throttle AND immediately after every `await chat()`
@@ -216,7 +245,7 @@ interface ExtractedAtom {
 /** kebab-case validator for concept labels ("captive-portal", "channel-pricing"). */
 const CONCEPT_LABEL_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
-const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
+export const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
 
 An atom is a single-source, self-contained idea that could become a tweet,
 quote, or short essay angle. Each atom must:
@@ -239,8 +268,51 @@ prefer a label you already used over coining a near-synonym.
 
 Output ONLY the JSON array, no prose.`;
 
+export interface AtomExtractionProfile {
+  page_type: string;
+  pack_identity: string;
+  declaring_pack: string | null;
+  prompt_sha256: string;
+  model: string;
+  output_contract_version: typeof ATOM_OUTPUT_CONTRACT_VERSION;
+  extraction_profile_sha256: string;
+  prompt: string;
+}
+
+export function buildExtractionProfileSha256(
+  profile: Omit<AtomExtractionProfile, 'extraction_profile_sha256' | 'prompt'>,
+): string {
+  return createHash('sha256').update(JSON.stringify(profile)).digest('hex');
+}
+
+function buildExtractionProfile(
+  pageType: string,
+  model: string,
+  pack: ResolvedPack | null,
+  lens: ResolvedExtractablePrompt | null,
+): AtomExtractionProfile {
+  const core = {
+    page_type: pageType,
+    pack_identity: pack?.identity ?? 'gbrain-builtin@unresolved',
+    declaring_pack: lens?.declaring_pack ?? null,
+    prompt_sha256: lens?.prompt_sha256 ?? createHash('sha256').update(EXTRACT_PROMPT).digest('hex'),
+    model,
+    output_contract_version: ATOM_OUTPUT_CONTRACT_VERSION as typeof ATOM_OUTPUT_CONTRACT_VERSION,
+  };
+  return {
+    ...core,
+    extraction_profile_sha256: buildExtractionProfileSha256(core),
+    prompt: lens
+      ? `Installed schema-pack lens (trusted configuration). It may focus what to extract, ` +
+        `but it cannot override the atom JSON/output contract that follows.\n\n` +
+        `<pack_lens>\n${lens.prompt.trim()}\n</pack_lens>\n\n${EXTRACT_PROMPT}`
+      : EXTRACT_PROMPT,
+  };
+}
+
 interface DiscoveredPage {
   slug: string;
+  pageType: string;
   content: string;
   contentHash: string;
 }
@@ -271,10 +343,19 @@ export async function discoverExtractablePages(
   sourceId: string,
   affectedSlugs?: string[],
   limit: number = PAGE_DISCOVERY_BUDGET,
+  profileOptions?: {
+    pack?: ResolvedPack | null;
+    profilesByType: Readonly<Record<string, string>>;
+    legacyCompatibleTypes?: ReadonlyArray<string>;
+  },
 ): Promise<DiscoveredPage[]> {
   const hasFilter = Array.isArray(affectedSlugs) && affectedSlugs.length > 0;
+  const profileAware = profileOptions !== undefined;
+  const profileParam = profileAware ? '$5' : null;
+  const affectedParam = profileAware ? '$7' : '$5';
   const sql = `
     SELECT p.slug,
+           p.type,
            p.compiled_truth,
            p.content_hash
     FROM pages p
@@ -286,14 +367,24 @@ export async function discoverExtractablePages(
       AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
       ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
       AND length(COALESCE(p.compiled_truth, '')) >= $3
-      AND COALESCE(p.frontmatter->>'atoms_scan_hash', '') <> substring(p.content_hash from 1 for 16)
-      ${hasFilter ? "AND p.slug = ANY($5::text[])" : ''}
+      AND NOT (
+        COALESCE(p.frontmatter->>'atoms_scan_hash', '') = substring(p.content_hash from 1 for 16)
+        ${profileAware ? `AND (
+          p.frontmatter->>'atoms_scan_profile' = COALESCE((${profileParam}::jsonb)->>p.type, '')
+          OR (p.type = ANY($6::text[]) AND NOT (p.frontmatter ? 'atoms_scan_profile'))
+        )` : ''}
+      )
+      ${hasFilter ? `AND p.slug = ANY(${affectedParam}::text[])` : ''}
       AND NOT EXISTS (
         SELECT 1
         FROM pages atom
         WHERE atom.type = 'atom'
           AND atom.source_id = $1
           AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
+          ${profileAware ? `AND (
+            atom.frontmatter->>'extraction_profile_sha256' = COALESCE((${profileParam}::jsonb)->>p.type, '')
+            OR (p.type = ANY($6::text[]) AND NOT (atom.frontmatter ? 'extraction_profile_sha256'))
+          )` : ''}
           AND atom.deleted_at IS NULL
       )
     ORDER BY p.updated_at DESC
@@ -301,20 +392,26 @@ export async function discoverExtractablePages(
   `;
   const params: unknown[] = [
     sourceId,
-    await resolveExtractableTypes(),
+    await resolveExtractableTypes(profileOptions?.pack),
     MIN_PAGE_CHARS_FOR_EXTRACTION,
     limit,
   ];
+  if (profileAware) {
+    params.push(JSON.stringify(profileOptions.profilesByType));
+    params.push([...(profileOptions.legacyCompatibleTypes ?? [])]);
+  }
   if (hasFilter) params.push(affectedSlugs);
 
   try {
     const rows = await engine.executeRaw<{
       slug: string;
+      type: string;
       compiled_truth: string;
       content_hash: string;
     }>(sql, params);
     return rows.map((r) => ({
       slug: r.slug,
+      pageType: r.type,
       content: r.compiled_truth,
       contentHash: r.content_hash,
     }));
@@ -345,13 +442,44 @@ export async function countExtractAtomsBacklog(
   sourceId?: string,
 ): Promise<number | null> {
   try {
+    if (sourceId === undefined) {
+      const sources = await engine.executeRaw<{ id: string }>(
+        `SELECT id FROM sources ORDER BY id`,
+      );
+      let total = 0;
+      for (const source of sources) {
+        const count = await countExtractAtomsBacklog(engine, source.id);
+        if (count === null) return null;
+        total += count;
+      }
+      return total;
+    }
+    const model = await resolveExtractAtomsModel(engine);
+    const pack = await resolveExtractionPack(engine, sourceId);
+    const types = await resolveExtractableTypes(pack);
+    const profileHashes: Record<string, string> = {};
+    const legacyCompatibleTypes: string[] = [];
+    if (pack) {
+      const { resolveExtractablePrompt } = await import('../schema-pack/prompt-template.ts');
+      for (const pageType of types) {
+        const lens = resolveExtractablePrompt(pack, pageType);
+        profileHashes[pageType] = buildExtractionProfile(
+          pageType, model, pack, lens,
+        ).extraction_profile_sha256;
+        if (!lens) legacyCompatibleTypes.push(pageType);
+      }
+    } else {
+      for (const pageType of types) {
+        profileHashes[pageType] = buildExtractionProfile(pageType, model, null, null)
+          .extraction_profile_sha256;
+        legacyCompatibleTypes.push(pageType);
+      }
+    }
     // Two modes: scoped (the phase's per-source `remaining`) vs brain-wide
     // (doctor — matches the conversation-facts check's cross-source posture).
     // The atom must live in the SAME source as the page either way, so the
     // brain-wide form keys the NOT EXISTS on `atom.source_id = p.source_id`.
-    const scoped = sourceId !== undefined;
-    const sql = scoped
-      ? `SELECT COUNT(*) AS cnt FROM pages p
+    const sql = `SELECT COUNT(*) AS cnt FROM pages p
          WHERE p.source_id = $1
            AND p.type = ANY($2::text[])
            AND p.deleted_at IS NULL
@@ -360,33 +488,26 @@ export async function countExtractAtomsBacklog(
            AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
            ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
            AND length(COALESCE(p.compiled_truth, '')) >= $3
-           AND COALESCE(p.frontmatter->>'atoms_scan_hash', '') <> substring(p.content_hash from 1 for 16)
+           AND NOT (
+             COALESCE(p.frontmatter->>'atoms_scan_hash', '') = substring(p.content_hash from 1 for 16)
+             AND (
+               p.frontmatter->>'atoms_scan_profile' = COALESCE(($4::jsonb)->>p.type, '')
+               OR (p.type = ANY($5::text[]) AND NOT (p.frontmatter ? 'atoms_scan_profile'))
+             )
+           )
            AND NOT EXISTS (
              SELECT 1 FROM pages atom
              WHERE atom.type = 'atom' AND atom.source_id = $1
                AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
-               AND atom.deleted_at IS NULL
-           )`
-      : `SELECT COUNT(*) AS cnt FROM pages p
-         WHERE p.type = ANY($1::text[])
-           AND p.deleted_at IS NULL
-           AND p.content_hash IS NOT NULL
-           AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
-           AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
-           ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
-           AND length(COALESCE(p.compiled_truth, '')) >= $2
-           AND COALESCE(p.frontmatter->>'atoms_scan_hash', '') <> substring(p.content_hash from 1 for 16)
-           AND NOT EXISTS (
-             SELECT 1 FROM pages atom
-             WHERE atom.type = 'atom' AND atom.source_id = p.source_id
-               AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
+               AND (
+                 atom.frontmatter->>'extraction_profile_sha256' = COALESCE(($4::jsonb)->>p.type, '')
+                 OR (p.type = ANY($5::text[]) AND NOT (atom.frontmatter ? 'extraction_profile_sha256'))
+               )
                AND atom.deleted_at IS NULL
            )`;
-    const extractableTypes = await resolveExtractableTypes();
-    const params = scoped
-      ? [sourceId, extractableTypes, MIN_PAGE_CHARS_FOR_EXTRACTION]
-      : [extractableTypes, MIN_PAGE_CHARS_FOR_EXTRACTION];
-    const rows = await engine.executeRaw<{ cnt: string | number }>(sql, params);
+    const rows = await engine.executeRaw<{ cnt: string | number }>(sql, [
+      sourceId, types, MIN_PAGE_CHARS_FOR_EXTRACTION, JSON.stringify(profileHashes), legacyCompatibleTypes,
+    ]);
     return Number(rows[0]?.cnt ?? 0);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -497,6 +618,68 @@ export async function runPhaseExtractAtoms(
   const sourceId = opts.sourceId ?? 'default';
   const chat = opts._chat ?? gatewayChat;
 
+  let extractModel = resolveTierDefault('utility');
+  let budgetCap = DEFAULT_BUDGET_USD;
+  let maxInputChars = DEFAULT_EXTRACT_MAX_INPUT_CHARS;
+  let maxOutputTokens = DEFAULT_EXTRACT_MAX_OUTPUT_TOKENS;
+  let pacingMs = 0;
+  try {
+    extractModel = await resolveExtractAtomsModel(engine);
+    const configuredBudget = await engine.getConfig('cycle.extract_atoms.budget_usd');
+    if (configuredBudget) {
+      const n = Number(configuredBudget);
+      if (Number.isFinite(n) && n > 0) budgetCap = n;
+    }
+    const configuredMaxSourceChars = await engine.getConfig('cycle.extract_atoms.max_source_chars');
+    if (configuredMaxSourceChars) {
+      const n = Number(configuredMaxSourceChars);
+      if (Number.isFinite(n) && n >= 500) maxInputChars = Math.floor(n);
+    }
+    const configuredMaxInput = await engine.getConfig('cycle.extract_atoms.max_input_chars');
+    if (configuredMaxInput) {
+      const n = Number(configuredMaxInput);
+      if (Number.isFinite(n) && n >= 1_000) maxInputChars = Math.floor(n);
+    }
+    const configuredMaxOutput = await engine.getConfig('cycle.extract_atoms.max_output_tokens');
+    if (configuredMaxOutput) {
+      const n = Number(configuredMaxOutput);
+      if (Number.isFinite(n) && n >= 256) maxOutputTokens = Math.floor(n);
+    }
+    const configuredPacing = await engine.getConfig('cycle.extract_atoms.pacing_ms');
+    if (configuredPacing) {
+      const n = Number(configuredPacing);
+      if (Number.isFinite(n) && n > 0) pacingMs = Math.min(60_000, Math.floor(n));
+    }
+  } catch {
+    // Keep key-aware utility model and safe extraction defaults.
+  }
+
+  const resolvedPack = opts._resolvedPack === undefined
+    ? await resolveExtractionPack(engine, sourceId)
+    : opts._resolvedPack;
+  const profileByType = new Map<string, AtomExtractionProfile>();
+  const profileHashesByType: Record<string, string> = {};
+  const legacyCompatibleTypes: string[] = [];
+  const extractableTypes = await resolveExtractableTypes(resolvedPack);
+  if (resolvedPack) {
+    const { resolveExtractablePrompt } = await import('../schema-pack/prompt-template.ts');
+    for (const pageType of extractableTypes) {
+      const lens = resolveExtractablePrompt(resolvedPack, pageType);
+      const profile = buildExtractionProfile(pageType, extractModel, resolvedPack, lens);
+      profileByType.set(pageType, profile);
+      profileHashesByType[pageType] = profile.extraction_profile_sha256;
+      if (!lens) legacyCompatibleTypes.push(pageType);
+    }
+  } else {
+    for (const pageType of extractableTypes) {
+      const profile = buildExtractionProfile(pageType, extractModel, null, null);
+      profileByType.set(pageType, profile);
+      profileHashesByType[pageType] = profile.extraction_profile_sha256;
+      legacyCompatibleTypes.push(pageType);
+    }
+  }
+  const transcriptProfile = buildExtractionProfile('transcript', extractModel, null, null);
+
   // 1a. Get transcripts (test seam OR production discovery).
   //     v0.41.2.1: config loader switched to loadConfigWithEngine() so the
   //     dream.* DB-plane merge from Phase 1 reaches this phase.
@@ -539,7 +722,7 @@ export async function runPhaseExtractAtoms(
   // 1b. Get pages (test seam OR production discovery).
   //     _pages === undefined triggers discovery; _pages: [] suppresses it
   //     deliberately (transcript-only regression tests).
-  let pages: Array<{ slug: string; content: string; contentHash: string }>;
+  let pages: Array<{ slug: string; content: string; contentHash: string; pageType?: string }>;
   if (opts._pages !== undefined) {
     pages = opts._pages;
   } else {
@@ -548,6 +731,7 @@ export async function runPhaseExtractAtoms(
       sourceId,
       opts.affectedSlugs,
       await resolvePageDiscoveryLimit(engine),
+      { pack: resolvedPack, profilesByType: profileHashesByType, legacyCompatibleTypes },
     );
   }
 
@@ -595,21 +779,24 @@ export async function runPhaseExtractAtoms(
   //    the cap — `--drain` can no longer report the same backlog number
   //    forever while atoms keep getting extracted from transcripts.
   type WorkItem =
-    | { kind: 'transcript'; filePath: string; content: string; contentHash: string }
-    | { kind: 'page'; slug: string; content: string; contentHash: string };
+    | { kind: 'transcript'; filePath: string; content: string; contentHash: string; profile: AtomExtractionProfile }
+    | { kind: 'page'; slug: string; content: string; contentHash: string; pageType: string; profile: AtomExtractionProfile };
 
   const seenHashes = new Set<string>();
   const transcriptItems: WorkItem[] = [];
   for (const t of transcriptsLive) {
     if (seenHashes.has(t.contentHash)) { duplicatesSkipped++; continue; }
     seenHashes.add(t.contentHash);
-    transcriptItems.push({ kind: 'transcript', ...t });
+    transcriptItems.push({ kind: 'transcript', ...t, profile: transcriptProfile });
   }
   const pageItems: WorkItem[] = [];
   for (const p of pages) {
     if (seenHashes.has(p.contentHash)) { duplicatesSkipped++; continue; }
     seenHashes.add(p.contentHash);
-    pageItems.push({ kind: 'page', ...p });
+    const pageType = p.pageType ?? 'unknown-page';
+    const profile = profileByType.get(pageType)
+      ?? buildExtractionProfile(pageType, extractModel, resolvedPack, null);
+    pageItems.push({ kind: 'page', ...p, pageType, profile });
   }
   const work: WorkItem[] = [];
   const maxPoolLen = Math.max(transcriptItems.length, pageItems.length);
@@ -652,59 +839,6 @@ export async function runPhaseExtractAtoms(
   const failures: Array<{ source: string; error: string }> = [];
   let estimatedSpendUsd = 0;
   let budgetExhausted = false;
-  // #3813: key-aware tier default, not a hardcoded Anthropic model — an
-  // OPENAI_API_KEY-only install must not route to an unservable provider.
-  // Pre-computed so a config-read failure inside the try below (caught, see
-  // "Keep safe defaults" comment) still leaves extractModel on this default,
-  // matching the pre-refactor fail-soft behavior exactly.
-  let extractModel = resolveTierDefault('utility');
-  let budgetCap = DEFAULT_BUDGET_USD;
-  // #4529/#4540: the per-item input/output caps were hardcoded (slice(0, 50_000) +
-  // maxTokens: 4096). Operators on small-context or thinking models need to
-  // shrink/grow both without a code change; defaults are unchanged.
-  let maxInputChars = DEFAULT_EXTRACT_MAX_INPUT_CHARS;
-  let maxOutputTokens = DEFAULT_EXTRACT_MAX_OUTPUT_TOKENS;
-  let pacingMs = 0;
-  try {
-    extractModel = await resolveExtractAtomsModel(engine);
-    const configuredBudget = await engine.getConfig('cycle.extract_atoms.budget_usd');
-    if (configuredBudget) {
-      const n = Number(configuredBudget);
-      if (Number.isFinite(n) && n > 0) budgetCap = n;
-    }
-    // #4529: legacy input-cap key (its own floor of 500 chars, as landed).
-    // Read FIRST so the newer #4540 max_input_chars key below wins when
-    // both are set — they name the same knob.
-    const configuredMaxSourceChars = await engine.getConfig('cycle.extract_atoms.max_source_chars');
-    if (configuredMaxSourceChars) {
-      const n = Number(configuredMaxSourceChars);
-      if (Number.isFinite(n) && n >= 500) maxInputChars = Math.floor(n);
-    }
-    const configuredMaxInput = await engine.getConfig('cycle.extract_atoms.max_input_chars');
-    if (configuredMaxInput) {
-      const n = Number(configuredMaxInput);
-      // Floor of 1000 chars: below that the extractor sees a fragment too
-      // small to yield atoms and every page burns budget for nothing.
-      if (Number.isFinite(n) && n >= 1_000) maxInputChars = Math.floor(n);
-    }
-    const configuredMaxOutput = await engine.getConfig('cycle.extract_atoms.max_output_tokens');
-    if (configuredMaxOutput) {
-      const n = Number(configuredMaxOutput);
-      // Floor of 256 tokens mirrors dream.triage.max_tokens: a smaller cap
-      // truncates every response into the malformed-output failure path.
-      if (Number.isFinite(n) && n >= 256) maxOutputTokens = Math.floor(n);
-    }
-    // Optional per-item pacing sleep (ms) so a large backlog doesn't hammer
-    // a local/self-hosted provider back-to-back. 0 (default) = no pacing.
-    const configuredPacing = await engine.getConfig('cycle.extract_atoms.pacing_ms');
-    if (configuredPacing) {
-      const n = Number(configuredPacing);
-      if (Number.isFinite(n) && n > 0) pacingMs = Math.min(60_000, Math.floor(n));
-    }
-  } catch {
-    // Keep safe defaults on any config-read failure: key-aware utility-tier
-    // model, $0.30 cap, default input cap (max_input_chars).
-  }
   // A cost cap is only meaningful for a model the tracker can price.
   // BudgetTracker.reserve() hard-fails with BudgetExhausted(reason:'no_pricing')
   // when the model is absent from the pricing maps AND a cap is set; with no cap
@@ -761,13 +895,15 @@ export async function runPhaseExtractAtoms(
   let hardFailureCount = 0;
 
   /** Stamp the zero-yield/complete tombstone (hash-keyed; edits re-eligibilize). */
-  async function stampAtomsScanHash(item: { slug: string; contentHash: string }): Promise<void> {
+  async function stampAtomsScanHash(item: { slug: string; contentHash: string; profile: AtomExtractionProfile }): Promise<void> {
     try {
       await engine.executeRaw(
         `UPDATE pages
-            SET frontmatter = frontmatter || jsonb_build_object('atoms_scan_hash', $1::text)
-          WHERE source_id = $2 AND slug = $3 AND deleted_at IS NULL`,
-        [item.contentHash.slice(0, 16), sourceId, item.slug],
+            SET frontmatter = frontmatter
+              || jsonb_build_object('atoms_scan_hash', $1::text)
+              || jsonb_build_object('atoms_scan_profile', $2::text)
+          WHERE source_id = $3 AND slug = $4 AND deleted_at IS NULL`,
+        [item.contentHash.slice(0, 16), item.profile.extraction_profile_sha256, sourceId, item.slug],
       );
     } catch { /* fail-soft: page stays rediscoverable */ }
   }
@@ -777,20 +913,27 @@ export async function runPhaseExtractAtoms(
    * content edit resets the streak. Returns the new consecutive count, or
    * null for transcripts / on write failure (never blocks the phase).
    */
-  async function recordPageFailureCount(item: { kind: string; slug?: string; contentHash: string }): Promise<number | null> {
+  async function recordPageFailureCount(item: {
+    kind: string;
+    slug?: string;
+    contentHash: string;
+    profile: AtomExtractionProfile;
+  }): Promise<number | null> {
     if (item.kind !== 'page' || !item.slug || opts.dryRun) return null;
     try {
       const rows = await engine.executeRaw<{ cnt: number | string }>(
         `UPDATE pages
             SET frontmatter = frontmatter
               || jsonb_build_object('atoms_fail_hash', $1::text)
+              || jsonb_build_object('atoms_fail_profile', $2::text)
               || jsonb_build_object('atoms_fail_count',
                    CASE WHEN COALESCE(frontmatter->>'atoms_fail_hash', '') = $1::text
+                         AND COALESCE(frontmatter->>'atoms_fail_profile', '') = $2::text
                         THEN COALESCE((frontmatter->>'atoms_fail_count')::int, 0) + 1
                         ELSE 1 END)
-          WHERE source_id = $2 AND slug = $3 AND deleted_at IS NULL
+          WHERE source_id = $3 AND slug = $4 AND deleted_at IS NULL
           RETURNING (frontmatter->>'atoms_fail_count')::int AS cnt`,
-        [item.contentHash.slice(0, 16), sourceId, item.slug],
+        [item.contentHash.slice(0, 16), item.profile.extraction_profile_sha256, sourceId, item.slug],
       );
       const cnt = rows[0]?.cnt;
       return cnt == null ? null : Number(cnt);
@@ -809,10 +952,11 @@ export async function runPhaseExtractAtoms(
     }
 
     const originLabel = item.kind === 'transcript' ? item.filePath : item.slug;
+    const pendingSlugs: string[] = [];
     try {
       const result = await chat({
         model: extractModel,
-        system: EXTRACT_PROMPT,
+        system: item.profile.prompt,
         messages: [
           {
             role: 'user',
@@ -897,7 +1041,11 @@ export async function runPhaseExtractAtoms(
         const provenanceLinks: LinkBatchInput[] = [];
         for (const atom of atoms) {
           const srcRef = item.kind === 'transcript' ? item.filePath : item.slug;
-          const slug = atomSlug(atom.title, srcRef);
+          const slug = atomSlug(
+            atom.title,
+            srcRef,
+            item.kind === 'page' ? item.profile.extraction_profile_sha256 : undefined,
+          );
           const originFrontmatter =
             item.kind === 'transcript'
               ? { source_path: item.filePath }
@@ -919,6 +1067,14 @@ export async function runPhaseExtractAtoms(
               ...originFrontmatter,
               // Provisional until the whole item's atoms persist (see above).
               source_hash: `pending:${hash16}`,
+              extraction_profile_sha256: item.profile.extraction_profile_sha256,
+              extraction_profile_state: 'pending',
+              extraction_page_type: item.profile.page_type,
+              extraction_pack_identity: item.profile.pack_identity,
+              extraction_declaring_pack: item.profile.declaring_pack ?? 'builtin',
+              extraction_prompt_sha256: item.profile.prompt_sha256,
+              extraction_model: item.profile.model,
+              extraction_output_contract_version: item.profile.output_contract_version,
               ...(atom.source_quote && { source_quote: atom.source_quote }),
               ...(atom.lesson && { lesson: atom.lesson }),
               ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
@@ -945,14 +1101,16 @@ export async function runPhaseExtractAtoms(
               to_source_id: sourceId,
             });
           }
-          totalAtomsExtracted++;
+          pendingSlugs.push(slug);
         }
         // Completion receipt: flip provisional → real in one statement, then
         // stamp the source page. A crash between flip and stamp degrades to
         // the legacy atom-rows-mean-done semantics — safe, not lossy.
         await engine.executeRaw(
           `UPDATE pages
-              SET frontmatter = frontmatter || jsonb_build_object('source_hash', $1::text)
+              SET frontmatter = frontmatter
+                || jsonb_build_object('source_hash', $1::text)
+                || jsonb_build_object('extraction_profile_state', 'active')
             WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
           [hash16, sourceId, importedSlugs],
         );
@@ -972,8 +1130,26 @@ export async function runPhaseExtractAtoms(
           }
         }
         if (item.kind === 'page') {
+          await engine.executeRaw(
+            `UPDATE pages
+                SET deleted_at = now(),
+                    frontmatter = frontmatter
+                      || jsonb_build_object('extraction_profile_state', 'superseded')
+                      || jsonb_build_object('superseded_by_extraction_profile_sha256', $1::text)
+              WHERE source_id = $2
+                AND type = 'atom'
+                AND deleted_at IS NULL
+                AND frontmatter->>'source_slug' = $3
+                AND frontmatter->>'source_hash' = $4
+                AND COALESCE(frontmatter->>'extraction_profile_sha256', '') <> $1
+                AND NOT (slug = ANY($5::text[]))`,
+            [item.profile.extraction_profile_sha256, sourceId, item.slug, hash16, importedSlugs],
+          );
+        }
+        if (item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
+        totalAtomsExtracted += atoms.length;
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
       }
@@ -983,6 +1159,16 @@ export async function runPhaseExtractAtoms(
       // Reporter rate-limits to ~1 line/sec; safe to tick every iter.
       opts.progress?.tick(1, `${totalAtomsExtracted} atoms / ${duplicatesSkipped} skipped`);
     } catch (err) {
+      if (!opts.dryRun && pendingSlugs.length > 0) {
+        try {
+          await engine.executeRaw(
+            `UPDATE pages SET deleted_at = now()
+              WHERE source_id = $1 AND type = 'atom' AND slug = ANY($2::text[])
+                AND frontmatter->>'extraction_profile_state' = 'pending'`,
+            [sourceId, pendingSlugs],
+          );
+        } catch { /* prior complete profile remains active */ }
+      }
       if (err instanceof BudgetExhausted) {
         budgetExhausted = true;
         if (item.kind === 'transcript') transcriptsSkipped++;
@@ -1102,6 +1288,15 @@ export async function runPhaseExtractAtoms(
       budget_exhausted: budgetExhausted,
       source_id: sourceId,
       dry_run: opts.dryRun ?? false,
+      extraction_profiles: [...profileByType.values()].map(profile => ({
+        page_type: profile.page_type,
+        pack_identity: profile.pack_identity,
+        declaring_pack: profile.declaring_pack,
+        prompt_sha256: profile.prompt_sha256,
+        model: profile.model,
+        output_contract_version: profile.output_contract_version,
+        extraction_profile_sha256: profile.extraction_profile_sha256,
+      })),
     },
   };
 }
@@ -1249,7 +1444,8 @@ function sourceDate(ref: string): string {
  *   clobbers a *different* atom. Hash is over the title only (not body) so an
  *   LLM rewording the body on re-extraction still upserts rather than dupes.
  */
-function atomSlug(title: string, srcRef: string): string {
+function atomSlug(title: string, srcRef: string, extractionProfile?: string): string {
   const hash = createHash('sha256').update(title).digest('hex').slice(0, 6);
-  return `atoms/${sourceDate(srcRef)}/${atomSlugStem(title)}-${hash}`;
+  const profileSuffix = extractionProfile ? `-p${extractionProfile.slice(0, 8)}` : '';
+  return `atoms/${sourceDate(srcRef)}/${atomSlugStem(title)}-${hash}${profileSuffix}`;
 }

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -67,13 +67,20 @@ import { createHash } from 'crypto';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import type { ResolvedPack } from '../schema-pack/registry.ts';
-import type { ResolvedExtractablePrompt } from '../schema-pack/prompt-template.ts';
 import {
   prepareAtomSource,
   resolveAtomInputProfile,
   type PreparedAtomSource,
-  type ResolvedAtomInputProfile,
 } from '../schema-pack/source-input-profile.ts';
+import {
+  ATOM_TYPES,
+  CONCEPT_LABEL_RE,
+  bindProfileToPreparedSource,
+  buildExtractionProfile,
+  invalidEvidenceRefs,
+  type AtomExtractionProfile,
+  type ExtractedAtom,
+} from './atom-extraction-profile.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 // #4529 + #4540: per-item extractor caps, overridable via
@@ -98,13 +105,6 @@ export const MAX_DETERMINISTIC_FAILURES = 3;
  */
 const TRANSIENT_EXTRACT_ERROR_RE =
   /timeout|timed out|\b429\b|rate.?limit|\b5\d\d\b|ECONN|ETIMEDOUT|EPIPE|ENOTFOUND|fetch failed|\bnetwork\b|socket|overloaded/i;
-
-// v0.42+ TODO: read atom_type enum from active pack manifest at runtime.
-const ATOM_TYPES = [
-  'insight', 'anecdote', 'quote', 'framework', 'statistic',
-  'story_angle', 'strategy_angle', 'strategy', 'endorsement',
-  'critique', 'collection',
-] as const;
 
 // v0.41.2.1 (D2): brain-page discovery constants.
 //
@@ -229,148 +229,6 @@ export interface ExtractAtomsOpts {
    * `heartbeat()` on the passed reporter.
    */
   progress?: ProgressReporter;
-}
-
-interface ExtractedAtom {
-  title: string;
-  atom_type: typeof ATOM_TYPES[number];
-  body: string;
-  source_quote?: string;
-  lesson?: string;
-  /**
-   * 1-3 kebab-case topic labels for concept clustering. Consumed by
-   * synthesize_concepts (groups atoms by `frontmatter.concepts`; only
-   * labels shared by >=2 atoms materialize a concept page, so the prompt
-   * biases reuse-over-coinage). #2123.
-   */
-  concepts?: string[];
-  virality_score?: number;
-  emotional_register?: string;
-  /** Exact source anchors required by source-complete input profiles. */
-  evidence_refs?: string[];
-}
-
-/** kebab-case validator for concept labels ("captive-portal", "channel-pricing"). */
-const CONCEPT_LABEL_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-export const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
-
-An atom is a single-source, self-contained idea that could become a tweet,
-quote, or short essay angle. Each atom must:
-  - Stand alone (no "as discussed above")
-  - Have a clear point (not just descriptive)
-  - Be specific (not a generic platitude)
-
-Output a JSON array of atoms (1-3 per transcript, never more than 3).
-Each atom: {title (≤80 chars), atom_type, body (2-4 sentences),
-source_quote (verbatim ≤200 chars), lesson (one sentence), concepts
-(1-3 topic labels), virality_score (0-100), emotional_register (one of:
-shocking, inspiring, funny, sobering, practical, controversial)}.
-
-atom_type MUST be one of: ${ATOM_TYPES.join(', ')}.
-
-concepts are kebab-case English TOPIC labels used to cluster atoms into
-concept pages (e.g. "captive-portal", "channel-pricing-strategy") — never
-entity or brand names. Use the same label for the same topic across atoms;
-prefer a label you already used over coining a near-synonym.
-
-Output ONLY the JSON array, no prose.`;
-
-export interface AtomExtractionProfile {
-  page_type: string;
-  pack_identity: string;
-  declaring_pack: string | null;
-  prompt_sha256: string;
-  model: string;
-  output_contract_version: typeof ATOM_OUTPUT_CONTRACT_VERSION;
-  source_input_profile_sha256: string | null;
-  input_selector: string | null;
-  window_policy_sha256: string | null;
-  /** Stable pack/prompt/model/input-policy identity used by discovery. */
-  extraction_policy_sha256: string;
-  /** Source-bound identity; equals the policy hash for legacy profiles. */
-  extraction_profile_sha256: string;
-  prompt: string;
-  input_profile: ResolvedAtomInputProfile | null;
-}
-
-export function buildExtractionProfileSha256(
-  profile: Omit<
-    AtomExtractionProfile,
-    'extraction_profile_sha256' | 'extraction_policy_sha256' | 'prompt' | 'input_profile'
-  >,
-): string {
-  return createHash('sha256').update(JSON.stringify(profile)).digest('hex');
-}
-
-function buildExtractionProfile(
-  pageType: string,
-  model: string,
-  pack: ResolvedPack | null,
-  lens: ResolvedExtractablePrompt | null,
-  inputProfile: ResolvedAtomInputProfile | null = null,
-): AtomExtractionProfile {
-  const windowPolicy = inputProfile
-    ? createHash('sha256').update(JSON.stringify(inputProfile.profile.windowing)).digest('hex')
-    : null;
-  const core = {
-    page_type: pageType,
-    pack_identity: pack?.identity ?? 'gbrain-builtin@unresolved',
-    declaring_pack: lens?.declaring_pack ?? null,
-    prompt_sha256: lens?.prompt_sha256 ?? createHash('sha256').update(EXTRACT_PROMPT).digest('hex'),
-    model,
-    output_contract_version: ATOM_OUTPUT_CONTRACT_VERSION as typeof ATOM_OUTPUT_CONTRACT_VERSION,
-    source_input_profile_sha256: inputProfile?.profile_sha256 ?? null,
-    input_selector: inputProfile?.profile.selector ?? null,
-    window_policy_sha256: windowPolicy,
-  };
-  const policySha256 = buildExtractionProfileSha256(core);
-  const anchorContract = inputProfile
-    ? `\n\nThe installed input profile requires every returned atom to include evidence_refs, ` +
-      `an array containing at least one exact evidence-* anchor from the supplied source window. ` +
-      `Never invent or alter an anchor.`
-    : '';
-  return {
-    ...core,
-    extraction_policy_sha256: policySha256,
-    extraction_profile_sha256: policySha256,
-    prompt: lens
-      ? `Installed schema-pack lens (trusted configuration). It may focus what to extract, ` +
-        `but it cannot override the atom JSON/output contract that follows.\n\n` +
-        `<pack_lens>\n${lens.prompt.trim()}\n</pack_lens>\n\n${EXTRACT_PROMPT}${anchorContract}`
-      : `${EXTRACT_PROMPT}${anchorContract}`,
-    input_profile: inputProfile,
-  };
-}
-
-function bindProfileToPreparedSource(
-  profile: AtomExtractionProfile,
-  source: PreparedAtomSource,
-): AtomExtractionProfile {
-  if (!profile.input_profile) return profile;
-  const extractionProfileSha256 = createHash('sha256').update(JSON.stringify({
-    extraction_policy_sha256: profile.extraction_policy_sha256,
-    input_selector: profile.input_selector,
-    source_section_sha256: source.source_section_sha256,
-    coverage_sha256: source.coverage_sha256,
-  })).digest('hex');
-  return { ...profile, extraction_profile_sha256: extractionProfileSha256 };
-}
-
-function invalidEvidenceRefs(
-  atoms: ExtractedAtom[],
-  allowedAnchors: ReadonlySet<string>,
-): string | null {
-  for (const atom of atoms) {
-    if (!atom.evidence_refs || atom.evidence_refs.length === 0) {
-      return `atom ${JSON.stringify(atom.title)} omitted required evidence_refs`;
-    }
-    const missing = atom.evidence_refs.filter(ref => !allowedAnchors.has(ref));
-    if (missing.length > 0) {
-      return `atom ${JSON.stringify(atom.title)} cited anchors absent from its source: ${missing.join(', ')}`;
-    }
-  }
-  return null;
 }
 
 interface DiscoveredPage {

--- a/src/core/schema-pack/manifest-v1.ts
+++ b/src/core/schema-pack/manifest-v1.ts
@@ -63,6 +63,10 @@ const ExtractableSpecSchema = z.object({
   /** Relative path to a pack-supplied LLM prompt template. The runtime loads
    * it only from the pack that supplied the winning page-type declaration. */
   prompt_template: z.string().optional(),
+  /** Relative path to a declarative source-selection/windowing contract.
+   * The file is trusted pack data, never executable code. Packs that omit it
+   * retain the legacy whole-page prefix behavior. */
+  input_profile: z.string().optional(),
   /** Relative path within pack root to a JSONL fixture corpus. Validated
    * against path traversal at parse + load time. */
   fixture_corpus: z.string().optional(),

--- a/src/core/schema-pack/manifest-v1.ts
+++ b/src/core/schema-pack/manifest-v1.ts
@@ -60,8 +60,8 @@ const LinkTypeSchema = z.object({
  * See plan D-EXTRACT-17/19/21/37/42/47 for the load-bearing decisions.
  */
 const ExtractableSpecSchema = z.object({
-  /** Pack-supplied LLM prompt template. Plain text; sent to gateway.chat()
-   * with NO conversation context per the v0.41.23 threat model. */
+  /** Relative path to a pack-supplied LLM prompt template. The runtime loads
+   * it only from the pack that supplied the winning page-type declaration. */
   prompt_template: z.string().optional(),
   /** Relative path within pack root to a JSONL fixture corpus. Validated
    * against path traversal at parse + load time. */

--- a/src/core/schema-pack/prompt-template.ts
+++ b/src/core/schema-pack/prompt-template.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import type { ResolvedPack } from './registry.ts';
+import { getExtractableSpec } from './extractable.ts';
+
+export interface ResolvedExtractablePrompt {
+  page_type: string;
+  pack_identity: string;
+  declaring_pack: string;
+  prompt_path: string;
+  prompt_sha256: string;
+  prompt: string;
+}
+
+function assertSafeRelativePath(value: string): void {
+  if (isAbsolute(value)) throw new Error('extractable.prompt_template must be relative');
+  const segments = value.split(/[\\/]+/u);
+  if (segments.length === 0 || segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error('extractable.prompt_template contains an unsafe path segment');
+  }
+}
+
+/**
+ * Resolve a pack lens from the pack that supplied the winning page-type
+ * declaration. The file is data, never executable code, and every path
+ * component must remain a regular, non-symlink descendant of that pack root.
+ */
+export function resolveExtractablePrompt(
+  pack: ResolvedPack,
+  pageType: string,
+): ResolvedExtractablePrompt | null {
+  const spec = getExtractableSpec(pack.manifest, pageType);
+  const template = spec?.prompt_template;
+  if (!template) return null;
+  assertSafeRelativePath(template);
+
+  const origin = pack.page_type_declaration_origins[pageType];
+  if (!origin?.manifest_path) {
+    throw new Error(`cannot locate declaring pack for extractable page type: ${pageType}`);
+  }
+  const packRoot = dirname(origin.manifest_path);
+  const candidate = resolve(packRoot, template);
+  const lexicalRelative = relative(packRoot, candidate);
+  if (lexicalRelative.startsWith(`..${sep}`) || lexicalRelative === '..' || isAbsolute(lexicalRelative)) {
+    throw new Error('extractable.prompt_template escapes its declaring pack');
+  }
+
+  let cursor = packRoot;
+  for (const segment of template.split(/[\\/]+/u)) {
+    cursor = resolve(cursor, segment);
+    if (lstatSync(cursor).isSymbolicLink()) {
+      throw new Error('extractable.prompt_template may not traverse symlinks');
+    }
+  }
+  if (!lstatSync(candidate).isFile()) {
+    throw new Error('extractable.prompt_template must name a regular file');
+  }
+  const realRoot = realpathSync(packRoot);
+  const realCandidate = realpathSync(candidate);
+  const realRelative = relative(realRoot, realCandidate);
+  if (realRelative.startsWith(`..${sep}`) || realRelative === '..' || isAbsolute(realRelative)) {
+    throw new Error('extractable.prompt_template resolves outside its declaring pack');
+  }
+  const prompt = readFileSync(realCandidate, 'utf8');
+  if (prompt.trim().length === 0) throw new Error('extractable.prompt_template is empty');
+  return {
+    page_type: pageType,
+    pack_identity: pack.identity,
+    declaring_pack: origin.pack_name,
+    prompt_path: template,
+    prompt_sha256: createHash('sha256').update(prompt).digest('hex'),
+    prompt,
+  };
+}

--- a/src/core/schema-pack/registry.ts
+++ b/src/core/schema-pack/registry.ts
@@ -52,7 +52,7 @@
 //     inside the registry.
 
 import { statSync } from 'node:fs';
-import type { SchemaPackManifest } from './manifest-v1.ts';
+import type { PackPageType, SchemaPackManifest } from './manifest-v1.ts';
 import { computeManifestSha8, packIdentity } from './manifest-v1.ts';
 import { computeAliasClosureHash, buildAliasGraph, type AliasGraph } from './closure.ts';
 import { mergeInheritedManifest, type BorrowedTypes } from './merge.ts';
@@ -87,6 +87,11 @@ export interface ResolvedPack {
   manifest_sha8: string;
   alias_closure_hash: string;
   alias_graph: AliasGraph;
+  /** Winning declaration provenance for each merged page type. */
+  page_type_declaration_origins: Readonly<Record<string, {
+    pack_name: string;
+    manifest_path: string | null;
+  }>>;
 }
 
 export interface ResolutionInput {
@@ -287,12 +292,21 @@ export async function resolvePack(
   // declared types only — not its inherited/merged ones.
   const borrowed: BorrowedTypes = { page_types: [], link_types: [] };
   const borrowedNames: string[] = [];
+  const pageTypeOwners = new Map<PackPageType, string>();
+  for (const ancestor of ancestorsNearestFirst) {
+    for (const pageType of ancestor.page_types) pageTypeOwners.set(pageType, ancestor.name);
+  }
+  for (const pageType of manifest.page_types) pageTypeOwners.set(pageType, manifest.name);
   for (const entry of manifest.borrow_from) {
     const src = await loadByName(entry.pack);
     borrowedNames.push(entry.pack);
     const wantTypes = new Set(entry.types ?? []);
     const wantLinks = new Set(entry.link_types ?? []);
-    for (const pt of src.page_types) if (wantTypes.has(pt.name)) borrowed.page_types.push(pt);
+    for (const pt of src.page_types) {
+      if (!wantTypes.has(pt.name)) continue;
+      borrowed.page_types.push(pt);
+      pageTypeOwners.set(pt, entry.pack);
+    }
     for (const lt of src.link_types) if (wantLinks.has(lt.name)) borrowed.link_types.push(lt);
   }
 
@@ -303,6 +317,20 @@ export async function resolvePack(
   const merged = mergeInheritedManifest(ancestorsBaseFirst, manifest, borrowed);
   const alias_graph = buildAliasGraph(merged);
   const alias_closure_hash = await computeAliasClosureHash(merged);
+  const page_type_declaration_origins: Record<string, {
+    pack_name: string;
+    manifest_path: string | null;
+  }> = {};
+  for (const pageType of merged.page_types) {
+    const packName = pageTypeOwners.get(pageType);
+    if (!packName) {
+      throw new Error(`cannot resolve declaration origin for page type: ${pageType.name}`);
+    }
+    page_type_declaration_origins[pageType.name] = {
+      pack_name: packName,
+      manifest_path: opts.loadByPath?.(packName) ?? null,
+    };
+  }
 
   const resolved: ResolvedPack = {
     manifest: merged,
@@ -310,6 +338,7 @@ export async function resolvePack(
     manifest_sha8: sha8,
     alias_closure_hash,
     alias_graph,
+    page_type_declaration_origins,
   };
 
   // Capture file-stat snapshot for the stat-TTL gate over EVERY file that

--- a/src/core/schema-pack/source-input-profile.ts
+++ b/src/core/schema-pack/source-input-profile.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { z } from 'zod';
+import type { ResolvedPack } from './registry.ts';
+import { getExtractableSpec } from './extractable.ts';
+
+export const ATOM_INPUT_PROFILE_VERSION = 'gbrain.extract_atoms.input_profile.v1' as const;
+
+const AtomInputProfileSchema = z.object({
+  schema_version: z.literal(ATOM_INPUT_PROFILE_VERSION),
+  source: z.literal('compiled_truth'),
+  selector: z.string().regex(/^heading:[^\r\n]+$/u),
+  prior_interpretation: z.literal('exclude'),
+  windowing: z.object({
+    mode: z.literal('markdown_heading_and_turn_aware'),
+    max_chars: z.number().int().min(1_000).max(200_000),
+    overlap_chars: z.number().int().min(0),
+    coverage: z.literal('complete'),
+  }).strict(),
+  reconciliation_grain: z.literal('parent_page'),
+  evidence_anchor_validation: z.literal('exact_source_anchor_required'),
+  /** Pack-owned governance/audit labels. Runtime behavior never branches on
+   * these values, but the exact file bytes remain profile-hashed. */
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.windowing.overlap_chars >= value.windowing.max_chars) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['windowing', 'overlap_chars'],
+      message: 'overlap_chars must be smaller than max_chars',
+    });
+  }
+});
+
+export type AtomInputProfile = z.infer<typeof AtomInputProfileSchema>;
+
+export interface ResolvedAtomInputProfile {
+  page_type: string;
+  pack_identity: string;
+  declaring_pack: string;
+  profile_path: string;
+  profile_sha256: string;
+  profile: AtomInputProfile;
+}
+
+export interface AtomSourceWindow {
+  index: number;
+  start: number;
+  end: number;
+  text: string;
+  sha256: string;
+  evidence_anchors: string[];
+}
+
+export interface PreparedAtomSource {
+  selected_source: string;
+  source_section_sha256: string;
+  source_start: number;
+  source_end: number;
+  windows: AtomSourceWindow[];
+  evidence_anchors: string[];
+  coverage_sha256: string;
+}
+
+const EVIDENCE_ANCHOR_RE = /<a id="(evidence-[^"]+)"><\/a>/gu;
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function assertSafePackFile(pack: ResolvedPack, pageType: string, value: string): string {
+  if (isAbsolute(value)) throw new Error('extractable.input_profile must be relative');
+  const segments = value.split(/[\\/]+/u);
+  if (segments.length === 0 || segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error('extractable.input_profile contains an unsafe path segment');
+  }
+  const origin = pack.page_type_declaration_origins[pageType];
+  if (!origin?.manifest_path) {
+    throw new Error(`cannot locate declaring pack for extractable page type: ${pageType}`);
+  }
+  const packRoot = dirname(origin.manifest_path);
+  const candidate = resolve(packRoot, value);
+  const lexicalRelative = relative(packRoot, candidate);
+  if (lexicalRelative.startsWith(`..${sep}`) || lexicalRelative === '..' || isAbsolute(lexicalRelative)) {
+    throw new Error('extractable.input_profile escapes its declaring pack');
+  }
+  let cursor = packRoot;
+  for (const segment of segments) {
+    cursor = resolve(cursor, segment);
+    if (lstatSync(cursor).isSymbolicLink()) {
+      throw new Error('extractable.input_profile may not traverse symlinks');
+    }
+  }
+  if (!lstatSync(candidate).isFile()) {
+    throw new Error('extractable.input_profile must name a regular file');
+  }
+  const realRoot = realpathSync(packRoot);
+  const realCandidate = realpathSync(candidate);
+  const realRelative = relative(realRoot, realCandidate);
+  if (realRelative.startsWith(`..${sep}`) || realRelative === '..' || isAbsolute(realRelative)) {
+    throw new Error('extractable.input_profile resolves outside its declaring pack');
+  }
+  return realCandidate;
+}
+
+export function resolveAtomInputProfile(
+  pack: ResolvedPack,
+  pageType: string,
+): ResolvedAtomInputProfile | null {
+  const path = getExtractableSpec(pack.manifest, pageType)?.input_profile;
+  if (!path) return null;
+  const resolvedPath = assertSafePackFile(pack, pageType, path);
+  const bytes = readFileSync(resolvedPath, 'utf8');
+  let raw: unknown;
+  try {
+    raw = JSON.parse(bytes);
+  } catch {
+    throw new Error(`extractable.input_profile is not valid JSON: ${path}`);
+  }
+  const profile = AtomInputProfileSchema.parse(raw);
+  const origin = pack.page_type_declaration_origins[pageType];
+  return {
+    page_type: pageType,
+    pack_identity: pack.identity,
+    declaring_pack: origin.pack_name,
+    profile_path: path,
+    profile_sha256: sha256(bytes),
+    profile,
+  };
+}
+
+function selectedHeading(profile: AtomInputProfile): string {
+  return profile.selector.slice('heading:'.length).trim();
+}
+
+function selectHeadingSection(content: string, profile: AtomInputProfile): {
+  text: string;
+  start: number;
+  end: number;
+} {
+  const heading = `## ${selectedHeading(profile)}`;
+  const candidates = content.startsWith(`${heading}\n`) ? [0] : [];
+  let cursor = content.indexOf(`\n${heading}\n`);
+  while (cursor >= 0) {
+    candidates.push(cursor + 1);
+    cursor = content.indexOf(`\n${heading}\n`, cursor + heading.length + 2);
+  }
+  if (candidates.length !== 1) {
+    throw new Error(
+      `extract_atoms input selector expected exactly one ${JSON.stringify(heading)} section; found ${candidates.length}`,
+    );
+  }
+  const start = candidates[0];
+  const nextHeading = content.indexOf('\n## ', start + heading.length);
+  const end = nextHeading < 0 ? content.length : nextHeading + 1;
+  const text = content.slice(start, end).trimEnd();
+  if (text.length === 0) throw new Error('extract_atoms selected source section is empty');
+  return { text, start, end: start + text.length };
+}
+
+function windowEnd(text: string, start: number, maxChars: number): number {
+  const hardEnd = Math.min(text.length, start + maxChars);
+  if (hardEnd === text.length) return hardEnd;
+  const minimum = start + Math.floor(maxChars * 0.7);
+  for (const boundary of ['\n#### ', '\n### ', '\n<a id="evidence-', '\n\n', '\n']) {
+    const found = text.lastIndexOf(boundary, hardEnd);
+    if (found >= minimum) return found + (boundary === '\n\n' ? 2 : 1);
+  }
+  return hardEnd;
+}
+
+export function prepareAtomSource(
+  content: string,
+  resolved: ResolvedAtomInputProfile,
+): PreparedAtomSource {
+  const selected = selectHeadingSection(content, resolved.profile);
+  const { max_chars: maxChars, overlap_chars: overlapChars } = resolved.profile.windowing;
+  const windows: AtomSourceWindow[] = [];
+  let start = 0;
+  while (start < selected.text.length) {
+    const end = windowEnd(selected.text, start, maxChars);
+    const text = selected.text.slice(start, end);
+    const evidenceAnchors = [...text.matchAll(EVIDENCE_ANCHOR_RE)].map(match => match[1]);
+    windows.push({
+      index: windows.length,
+      start,
+      end,
+      text,
+      sha256: sha256(text),
+      evidence_anchors: [...new Set(evidenceAnchors)],
+    });
+    if (end === selected.text.length) break;
+    const desiredStart = Math.max(start + 1, end - overlapChars);
+    const paragraph = selected.text.lastIndexOf('\n\n', end - 1);
+    start = paragraph >= desiredStart ? paragraph + 2 : desiredStart;
+  }
+  let coveredThrough = 0;
+  for (const window of windows) {
+    if (window.start > coveredThrough) throw new Error('extract_atoms source windows contain a gap');
+    coveredThrough = Math.max(coveredThrough, window.end);
+  }
+  if (coveredThrough !== selected.text.length) {
+    throw new Error('extract_atoms source windows do not cover the complete selected source');
+  }
+  const evidenceAnchors = [...new Set(windows.flatMap(window => window.evidence_anchors))];
+  const coverage = windows.map(window => ({
+    index: window.index,
+    start: window.start,
+    end: window.end,
+    sha256: window.sha256,
+  }));
+  return {
+    selected_source: selected.text,
+    source_section_sha256: sha256(selected.text),
+    source_start: selected.start,
+    source_end: selected.end,
+    windows,
+    evidence_anchors: evidenceAnchors,
+    coverage_sha256: sha256(JSON.stringify(coverage)),
+  };
+}

--- a/test/extract-atoms-pack-prompt.test.ts
+++ b/test/extract-atoms-pack-prompt.test.ts
@@ -7,6 +7,10 @@ import { runPhaseExtractAtoms } from '../src/core/cycle/extract-atoms.ts';
 import { SchemaPackManifestSchema, type SchemaPackManifest } from '../src/core/schema-pack/manifest-v1.ts';
 import { _resetPackCacheForTests, resolvePack } from '../src/core/schema-pack/registry.ts';
 import { resolveExtractablePrompt } from '../src/core/schema-pack/prompt-template.ts';
+import {
+  prepareAtomSource,
+  resolveAtomInputProfile,
+} from '../src/core/schema-pack/source-input-profile.ts';
 import type { ChatOpts, ChatResult } from '../src/core/ai/gateway.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 
@@ -46,21 +50,35 @@ async function inheritedPack(
   promptPath = 'prompts/experience.md',
   prompt = 'Find bounded visible change.',
   childVersion = '1.0.0',
+  inputProfile?: unknown,
 ) {
   const root = mkdtempSync(join(tmpdir(), 'gbrain-pack-prompt-'));
   roots.push(root);
   const parentRoot = join(root, 'parent');
   const childRoot = join(root, 'child');
   mkdirSync(join(parentRoot, 'prompts'), { recursive: true });
+  mkdirSync(join(parentRoot, 'input-profiles'), { recursive: true });
   mkdirSync(childRoot, { recursive: true });
   const parentPath = join(parentRoot, 'pack.json');
   const childPath = join(childRoot, 'pack.json');
   writeFileSync(parentPath, '{}');
   writeFileSync(childPath, '{}');
   writeFileSync(join(parentRoot, 'prompts', 'experience.md'), prompt);
+  if (inputProfile) {
+    writeFileSync(
+      join(parentRoot, 'input-profiles', 'complete-source.json'),
+      JSON.stringify(inputProfile),
+    );
+  }
   const parent = manifest('parent-pack', '1.0.0', null, [{
     name: 'experience', primitive: 'entity', path_prefixes: ['experiences/'], aliases: [],
-    extractable: { prompt_template: promptPath, eval_dimensions: ['source-closure'] },
+    extractable: {
+      prompt_template: promptPath,
+      ...(inputProfile !== undefined
+        ? { input_profile: 'input-profiles/complete-source.json' }
+        : {}),
+      eval_dimensions: ['source-closure'],
+    },
   }]);
   const child = manifest('child-pack', childVersion, 'parent-pack', []);
   const byName = new Map([[parent.name, parent], [child.name, child]]);
@@ -69,6 +87,23 @@ async function inheritedPack(
     loadByPath: name => paths.get(name) ?? null,
   });
   return { root, parentRoot, resolved };
+}
+
+function completeSourceProfile() {
+  return {
+    schema_version: 'gbrain.extract_atoms.input_profile.v1',
+    source: 'compiled_truth',
+    selector: 'heading:Complete bounded source evidence',
+    prior_interpretation: 'exclude',
+    windowing: {
+      mode: 'markdown_heading_and_turn_aware',
+      max_chars: 1_000,
+      overlap_chars: 100,
+      coverage: 'complete',
+    },
+    reconciliation_grain: 'parent_page',
+    evidence_anchor_validation: 'exact_source_anchor_required',
+  };
 }
 
 describe('pack-owned extract_atoms prompt', () => {
@@ -90,6 +125,36 @@ describe('pack-owned extract_atoms prompt', () => {
     const fixture = await inheritedPack('prompts/link.md');
     symlinkSync(join(fixture.parentRoot, 'prompts', 'experience.md'), join(fixture.parentRoot, 'prompts', 'link.md'));
     expect(() => resolveExtractablePrompt(fixture.resolved, 'experience')).toThrow(/symlink/i);
+  });
+
+  test('resolves and completely windows a pack-declared source input profile', async () => {
+    const { resolved } = await inheritedPack(
+      'prompts/experience.md',
+      'Find bounded visible change.',
+      '1.0.0',
+      completeSourceProfile(),
+    );
+    const input = resolveAtomInputProfile(resolved, 'experience');
+    expect(input?.declaring_pack).toBe('parent-pack');
+    expect(input?.profile_sha256).toHaveLength(64);
+    const content =
+      '## Prior interpretation\nSYNTHESIS_MUST_NOT_ENTER_EXTRACTION\n\n' +
+      '## Complete bounded source evidence\n' +
+      Array.from({ length: 8 }, (_, index) =>
+        `<a id="evidence-turn-${index}"></a>\n#### Turn ${index}\n${String(index).repeat(420)}\n\n`,
+      ).join('') +
+      '<a id="evidence-tail"></a>\n#### Counterevidence\nUNIQUE_TAIL_COUNTEREXAMPLE';
+    const prepared = prepareAtomSource(content, input!);
+    expect(prepared.windows.length).toBeGreaterThan(1);
+    expect(prepared.selected_source).not.toContain('SYNTHESIS_MUST_NOT_ENTER_EXTRACTION');
+    expect(prepared.selected_source).toContain('UNIQUE_TAIL_COUNTEREXAMPLE');
+    expect(prepared.evidence_anchors).toContain('evidence-tail');
+    let covered = 0;
+    for (const window of prepared.windows) {
+      expect(window.start).toBeLessThanOrEqual(covered);
+      covered = Math.max(covered, window.end);
+    }
+    expect(covered).toBe(prepared.selected_source.length);
   });
 
   test('keeps source content in the user message and composes the lens with the fixed output contract', async () => {
@@ -158,5 +223,69 @@ describe('pack-owned extract_atoms prompt', () => {
       expect(rows).toHaveLength(2);
       expect(rows.filter(row => row.deleted_at === null).map(row => row.state)).toEqual(['active']);
     expect(rows.filter(row => row.deleted_at !== null).map(row => row.state)).toEqual(['superseded']);
+  }, 60_000);
+
+  test('processes every source window once, excludes synthesis, and reconciles tail evidence at parent grain', async () => {
+    const { resolved } = await inheritedPack(
+      'prompts/experience.md',
+      'Find bounded visible change.',
+      '1.1.0',
+      completeSourceProfile(),
+    );
+    const source = Array.from({ length: 9 }, (_, index) =>
+      `<a id="evidence-turn-${index}"></a>\n#### Turn ${index}\n${`turn-${index} `.repeat(75)}\n\n`,
+    ).join('') + '<a id="evidence-tail"></a>\n#### Tail\nUNIQUE_TAIL_COUNTEREXAMPLE';
+    const content =
+      '## Prior interpretation\nSYNTHESIS_MUST_NOT_ENTER_EXTRACTION\n\n' +
+      `## Complete bounded source evidence\n${source}`;
+    const windowCalls: string[] = [];
+    let reconciliationCalls = 0;
+    const chat = async (opts: ChatOpts): Promise<ChatResult> => {
+      const body = String(opts.messages[0]?.content ?? '');
+      let text: string;
+      if (body.includes('Window candidates:')) {
+        reconciliationCalls++;
+        const tailCandidate = body.includes('evidence-tail')
+          ? { title: 'Tail counterevidence', atom_type: 'critique', body: 'The tail changes the interpretation.', evidence_refs: ['evidence-tail'] }
+          : { title: 'Visible response', atom_type: 'insight', body: 'A response was visible.', evidence_refs: ['evidence-turn-0'] };
+        text = JSON.stringify([tailCandidate]);
+      } else {
+        windowCalls.push(body);
+        const anchors: string[] = body.match(/evidence-[a-z0-9-]+/gu) ?? [];
+        const anchor = anchors.includes('evidence-tail') ? 'evidence-tail' : anchors[0];
+        text = JSON.stringify(anchor ? [{
+          title: anchor === 'evidence-tail' ? 'Tail counterevidence' : `Lead ${windowCalls.length}`,
+          atom_type: anchor === 'evidence-tail' ? 'critique' : 'insight',
+          body: anchor === 'evidence-tail' ? 'The tail changes the interpretation.' : 'A bounded response was visible.',
+          evidence_refs: [anchor],
+        }] : []);
+      }
+      return {
+        text,
+        blocks: [{ type: 'text', text: '' }], stopReason: 'end',
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'anthropic:claude-haiku-4-5', providerId: 'anthropic',
+      };
+    };
+    const result = await runPhaseExtractAtoms(engine, {
+      sourceId: 'default', _resolvedPack: resolved, _transcripts: [],
+      _pages: [{ slug: 'experiences/long', pageType: 'experience', content, contentHash: 'long-source-hash-1234' }],
+      _chat: chat,
+    });
+    expect(result.status).toBe('ok');
+    expect(windowCalls.length).toBeGreaterThan(1);
+    expect(reconciliationCalls).toBe(1);
+    expect(windowCalls.every(call => !call.includes('SYNTHESIS_MUST_NOT_ENTER_EXTRACTION'))).toBe(true);
+    expect(windowCalls.filter(call => call.includes('UNIQUE_TAIL_COUNTEREXAMPLE'))).toHaveLength(1);
+    const rows = await engine.executeRaw<{ frontmatter: Record<string, unknown> }>(
+      `SELECT frontmatter FROM pages WHERE type='atom' AND deleted_at IS NULL`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].frontmatter.evidence_refs).toEqual(['evidence-tail']);
+    expect(rows[0].frontmatter.extraction_source_coverage).toBe('complete');
+    expect(rows[0].frontmatter.extraction_source_window_count).toBe(windowCalls.length);
+    expect(rows[0].frontmatter.extraction_profile_sha256).not.toBe(
+      rows[0].frontmatter.extraction_policy_sha256,
+    );
   }, 60_000);
 });

--- a/test/extract-atoms-pack-prompt.test.ts
+++ b/test/extract-atoms-pack-prompt.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runPhaseExtractAtoms } from '../src/core/cycle/extract-atoms.ts';
+import { SchemaPackManifestSchema, type SchemaPackManifest } from '../src/core/schema-pack/manifest-v1.ts';
+import { _resetPackCacheForTests, resolvePack } from '../src/core/schema-pack/registry.ts';
+import { resolveExtractablePrompt } from '../src/core/schema-pack/prompt-template.ts';
+import type { ChatOpts, ChatResult } from '../src/core/ai/gateway.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+const roots: string[] = [];
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+afterEach(() => {
+  _resetPackCacheForTests();
+  while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function manifest(name: string, version: string, extendsName: string | null, pageTypes: unknown[]): SchemaPackManifest {
+  return SchemaPackManifestSchema.parse({
+    api_version: 'gbrain-schema-pack-v1',
+    name,
+    version,
+    extends: extendsName,
+    page_types: pageTypes,
+  });
+}
+
+async function inheritedPack(
+  promptPath = 'prompts/experience.md',
+  prompt = 'Find bounded visible change.',
+  childVersion = '1.0.0',
+) {
+  const root = mkdtempSync(join(tmpdir(), 'gbrain-pack-prompt-'));
+  roots.push(root);
+  const parentRoot = join(root, 'parent');
+  const childRoot = join(root, 'child');
+  mkdirSync(join(parentRoot, 'prompts'), { recursive: true });
+  mkdirSync(childRoot, { recursive: true });
+  const parentPath = join(parentRoot, 'pack.json');
+  const childPath = join(childRoot, 'pack.json');
+  writeFileSync(parentPath, '{}');
+  writeFileSync(childPath, '{}');
+  writeFileSync(join(parentRoot, 'prompts', 'experience.md'), prompt);
+  const parent = manifest('parent-pack', '1.0.0', null, [{
+    name: 'experience', primitive: 'entity', path_prefixes: ['experiences/'], aliases: [],
+    extractable: { prompt_template: promptPath, eval_dimensions: ['source-closure'] },
+  }]);
+  const child = manifest('child-pack', childVersion, 'parent-pack', []);
+  const byName = new Map([[parent.name, parent], [child.name, child]]);
+  const paths = new Map([[parent.name, parentPath], [child.name, childPath]]);
+  const resolved = await resolvePack(child, async name => byName.get(name)!, {
+    loadByPath: name => paths.get(name) ?? null,
+  });
+  return { root, parentRoot, resolved };
+}
+
+describe('pack-owned extract_atoms prompt', () => {
+  test('resolves an inherited winning declaration inside the declaring pack', async () => {
+    const { resolved } = await inheritedPack();
+    expect(resolved.page_type_declaration_origins.experience.pack_name).toBe('parent-pack');
+    const lens = resolveExtractablePrompt(resolved, 'experience');
+    expect(lens?.prompt).toBe('Find bounded visible change.');
+    expect(lens?.declaring_pack).toBe('parent-pack');
+    expect(lens?.prompt_sha256).toHaveLength(64);
+  });
+
+  test('rejects absolute paths, traversal, symlinks, and missing files', async () => {
+    for (const unsafe of ['/tmp/prompt.md', '../prompt.md', 'prompts/missing.md']) {
+      const { resolved } = await inheritedPack(unsafe);
+      expect(() => resolveExtractablePrompt(resolved, 'experience')).toThrow();
+      _resetPackCacheForTests();
+    }
+    const fixture = await inheritedPack('prompts/link.md');
+    symlinkSync(join(fixture.parentRoot, 'prompts', 'experience.md'), join(fixture.parentRoot, 'prompts', 'link.md'));
+    expect(() => resolveExtractablePrompt(fixture.resolved, 'experience')).toThrow(/symlink/i);
+  });
+
+  test('keeps source content in the user message and composes the lens with the fixed output contract', async () => {
+    const { resolved } = await inheritedPack();
+    const captured: { value?: ChatOpts } = {};
+    const chat = async (opts: ChatOpts): Promise<ChatResult> => {
+      captured.value = opts;
+      return {
+        text: '[{"title":"Visible retry","atom_type":"insight","body":"The response changed."}]',
+        blocks: [{ type: 'text', text: '' }], stopReason: 'end',
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'anthropic:claude-haiku-4-5', providerId: 'anthropic',
+      };
+    };
+    await runPhaseExtractAtoms(engine, {
+        sourceId: 'default', _resolvedPack: resolved, _transcripts: [],
+        _pages: [{ slug: 'experiences/one', pageType: 'experience', content: 'UNTRUSTED_SOURCE_BODY', contentHash: '1234567890abcdef' }],
+        _chat: chat,
+      });
+      expect(captured.value).toBeDefined();
+      const call = captured.value!;
+      expect(call.system).toContain('Find bounded visible change.');
+      expect(call.system).toContain('Output ONLY the JSON array');
+      expect(call.system).not.toContain('UNTRUSTED_SOURCE_BODY');
+      expect(call.messages[0]?.content).toContain('UNTRUSTED_SOURCE_BODY');
+      const rows = await engine.executeRaw<{ frontmatter: Record<string, unknown> }>(
+        `SELECT frontmatter FROM pages WHERE type='atom' AND deleted_at IS NULL`,
+      );
+      expect(rows[0].frontmatter.extraction_profile_sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(rows[0].frontmatter.extraction_declaring_pack).toBe('parent-pack');
+    expect(rows[0].frontmatter.extraction_profile_state).toBe('active');
+  }, 60_000);
+
+  test('a changed prompt profile re-extracts and supersedes only after the replacement is complete', async () => {
+    const first = await inheritedPack('prompts/experience.md', 'Find the initial state.', '1.0.0');
+    _resetPackCacheForTests();
+    const second = await inheritedPack('prompts/experience.md', 'Find the later visible state.', '1.0.1');
+    await engine.putPage('experiences/replay', {
+      type: 'experience' as never, title: 'Replay', compiled_truth: 'e'.repeat(800),
+      timeline: '', frontmatter: {}, content_hash: 'profile-source-hash-1234',
+    });
+    let title = 'Initial atom';
+    const chat = async (_opts: ChatOpts): Promise<ChatResult> => ({
+      text: `[{"title":"${title}","atom_type":"insight","body":"A bounded observation."}]`,
+      blocks: [{ type: 'text', text: '' }], stopReason: 'end',
+      usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'anthropic:claude-haiku-4-5', providerId: 'anthropic',
+    });
+    const firstRun = await runPhaseExtractAtoms(engine, {
+        _resolvedPack: first.resolved, _transcripts: [], _chat: chat,
+      });
+      expect(firstRun.details?.pages_processed).toBe(1);
+      const replay = await runPhaseExtractAtoms(engine, {
+        _resolvedPack: first.resolved, _transcripts: [], _chat: chat,
+      });
+      expect(replay.details?.pages_processed).toBe(0);
+      title = 'Replacement atom';
+      const replacement = await runPhaseExtractAtoms(engine, {
+        _resolvedPack: second.resolved, _transcripts: [], _chat: chat,
+      });
+      expect(replacement.details?.pages_processed).toBe(1);
+      const rows = await engine.executeRaw<{ slug: string; deleted_at: string | null; state: string }>(
+        `SELECT slug, deleted_at, frontmatter->>'extraction_profile_state' AS state
+           FROM pages WHERE type='atom' ORDER BY slug`,
+      );
+      expect(rows).toHaveLength(2);
+      expect(rows.filter(row => row.deleted_at === null).map(row => row.state)).toEqual(['active']);
+    expect(rows.filter(row => row.deleted_at !== null).map(row => row.state)).toEqual(['superseded']);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- resolve the winning `extractable.prompt_template` declaration through inherited schema packs
- load pack prompt and input-profile data only from the declaring pack with absolute, traversal, symlink, and cross-pack rejection
- add opt-in `extractable.input_profile` contracts that select a named Markdown source section and exclude preceding synthesis
- cover long selected sections with deterministic heading, evidence-anchor, paragraph, and line-aware windows instead of a 50,000-character prefix
- extract every window once, reconcile candidates once at the parent-page grain, and require exact source evidence anchors
- bind pack, prompt, model, output contract, selector, window policy, selected-source hash, and coverage manifest into durable policy/profile identities
- keep page discovery and replay policy-aware; replacement atoms remain provisional until the complete profile persists, then older complete profiles are soft-superseded
- preserve legacy pack behavior, current configurable caps/model routing, atom provenance links, and atomic completion semantics

## Verification

- `bun run typecheck`
- 184 focused extraction/schema-pack tests passed across 15 files
- `bun run build`; compiled binary reports `gbrain 0.47.9.0`
- `bun run ci:local:diff` could not start selected E2E because Docker is not installed in this host environment; the focused full unit surface above passed

Fixtures are synthetic and generic. This PR contains no SchoolAI, New Brunswick, Jordan, or other customer data.