### PR TITLE
v0.46.32.1 fix(takes): normalize stale take bigint rows (#4625)

### DIFF
--- a/src/core/pglite-engine/takes.ts
+++ b/src/core/pglite-engine/takes.ts
@@ -19,7 +19,7 @@ import type { SqlValue } from '../sql-query.ts';
 import { deriveResolutionTuple, finalizeScorecard } from '../takes-resolution.ts';
 import { normalizeWeightForStorage } from '../takes-fence.ts';
 import { buildTakeRows } from '../batch-rows.ts';
-import { takeRowToTake, takeHitRowToHit } from '../utils.ts';
+import { staleTakeRowToRow, takeRowToTake, takeHitRowToHit } from '../utils.ts';
 
 /** Narrow slice of PGLiteEngine the takes operations use. */
 export interface PgliteTakesDeps {
@@ -407,7 +407,7 @@ export async function listStaleTakes(deps: PgliteTakesDeps): Promise<StaleTakeRo
        ORDER BY t.id
        LIMIT 100000`
     );
-    return rows as unknown as StaleTakeRow[];
+    return rows.map((row) => staleTakeRowToRow(row as Record<string, unknown>));
   }
 
 export async function updateTakeEmbeddings(

--- a/src/core/postgres-engine/takes.ts
+++ b/src/core/postgres-engine/takes.ts
@@ -22,7 +22,7 @@ import type { SqlValue } from '../sql-query.ts';
 import { deriveResolutionTuple, finalizeScorecard } from '../takes-resolution.ts';
 import { normalizeWeightForStorage } from '../takes-fence.ts';
 import { buildTakeRows } from '../batch-rows.ts';
-import { takeRowToTake, takeHitRowToHit, tryParseEmbedding } from '../utils.ts';
+import { staleTakeRowToRow, takeRowToTake, takeHitRowToHit, tryParseEmbedding } from '../utils.ts';
 
 /** Narrow slice of PostgresEngine the takes operations use. */
 export interface PgTakesDeps {
@@ -420,7 +420,7 @@ export async function listStaleTakes(deps: PgTakesDeps): Promise<StaleTakeRow[]>
       ORDER BY t.id
       LIMIT 100000
     `;
-    return rows as unknown as StaleTakeRow[];
+    return rows.map((row) => staleTakeRowToRow(row as Record<string, unknown>));
   }
 
 export async function updateTakeEmbeddings(

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'crypto';
 import type { Page, PageInput, PageType, Chunk, SearchResult, StalePageRow } from './types.ts';
 import type { Take, TakeKind, TakeHit } from './engine.ts';
+import type { StaleTakeRow } from './takes-row-types.ts';
 // Leaf modules (no imports) — safe here without a cycle. Single source of
 // truth for the hash-ephemeral frontmatter keys shared with the importer.
 import { QUARANTINE_KEY, CONTENT_FLAG_KEY } from './quarantine.ts';
@@ -545,5 +546,19 @@ export function takeHitRowToHit(row: Record<string, unknown>): TakeHit {
     holder: String(row.holder),
     weight: Number(row.weight),
     score: Number(row.score),
+  };
+}
+
+/**
+ * Convert a stale-take SQL row to the numeric `StaleTakeRow` contract.
+ * Postgres returns BIGINT columns as BigInt/string values, while PGLite may
+ * already return numbers; normalize both engines at their shared boundary.
+ */
+export function staleTakeRowToRow(row: Record<string, unknown>): StaleTakeRow {
+  return {
+    take_id: Number(row.take_id),
+    page_slug: String(row.page_slug ?? ''),
+    row_num: Number(row.row_num),
+    claim: String(row.claim),
   };
 }

--- a/test/e2e/takes-postgres.test.ts
+++ b/test/e2e/takes-postgres.test.ts
@@ -179,6 +179,9 @@ d('v0.28 takes engine — Postgres', () => {
     const stale = await engine.listStaleTakes();
     expect(stale.length).toBe(count);
     expect(stale[0]).toHaveProperty('take_id');
+    expect(typeof stale[0]!.take_id).toBe('number');
+    expect(typeof stale[0]!.row_num).toBe('number');
+    expect(() => JSON.stringify(stale)).not.toThrow();
   });
 });
 

--- a/test/stale-takes-bigint.test.ts
+++ b/test/stale-takes-bigint.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { listStaleTakes as listPostgresStaleTakes } from '../src/core/postgres-engine/takes.ts';
+import { listStaleTakes as listPgliteStaleTakes } from '../src/core/pglite-engine/takes.ts';
+import type { PgTakesDeps } from '../src/core/postgres-engine/takes.ts';
+import type { PgliteTakesDeps } from '../src/core/pglite-engine/takes.ts';
+
+const rawRow = {
+  take_id: 42n,
+  page_slug: 'people/alice-example',
+  row_num: 3n,
+  claim: 'Strong DX intuition',
+};
+
+describe('listStaleTakes bigint normalization', () => {
+  test('Postgres rows match the numeric StaleTakeRow contract', async () => {
+    const sql = (async () => [rawRow]) as unknown as PgTakesDeps['sql'];
+    const rows = await listPostgresStaleTakes({ sql } as PgTakesDeps);
+
+    expect(rows).toEqual([{
+      take_id: 42,
+      page_slug: 'people/alice-example',
+      row_num: 3,
+      claim: 'Strong DX intuition',
+    }]);
+    expect(() => JSON.stringify(rows)).not.toThrow();
+  });
+
+  test('PGLite rows use the same normalized boundary', async () => {
+    const db = { query: async () => ({ rows: [rawRow] }) };
+    const rows = await listPgliteStaleTakes({ db } as unknown as PgliteTakesDeps);
+
+    expect(rows[0]?.take_id).toBe(42);
+    expect(rows[0]?.row_num).toBe(3);
+    expect(() => JSON.stringify(rows)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Normalizes stale-take SQL rows at the engine boundary so `take_id` and `row_num` satisfy the numeric `StaleTakeRow` contract on Postgres and PGLite. This lets `takes embed` pass Postgres BIGINT-backed IDs to the embedding writer instead of failing validation.

## Why

Closes #4625. `listStaleTakes()` previously used a TypeScript cast on driver rows. Postgres can return BIGINT-backed IDs as string/BigInt values, while `_updateTakeEmbeddingsOnce()` correctly requires integer numbers. The search-takes paths already perform the equivalent normalization.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/utils.ts src/core/postgres-engine/takes.ts src/core/pglite-engine/takes.ts` to merge-base, ran `test/stale-takes-bigint.test.ts` → 0 pass / 2 fail. Restored → all pass.

## Tests

- `bun test test/stale-takes-bigint.test.ts test/cli-bigint-normalize.test.ts test/takes-engine.test.ts` → 39 pass / 0 fail
- `bun run typecheck` → pass
- `bun run verify` → 54 pass / 0 fail
- `bun test test/e2e/takes-postgres.test.ts` → 23 skipped because local `DATABASE_URL` is unset; the E2E now asserts numeric IDs and JSON serialization when CI provides Postgres
- `git diff --check` → pass