### PR TITLE
v0.46.32.1 fix(facts): honor pricing overrides in conversation backfills (#4633)

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -73,7 +73,7 @@ import {
   type ExtractedFact,
 } from '../core/facts/extract.ts';
 import { configureGatewayIfUninitialized, isAvailable, withBudgetTracker } from '../core/ai/gateway.ts';
-import { BudgetTracker, BudgetExhausted } from '../core/budget/budget-tracker.ts';
+import { BudgetTracker, BudgetExhausted, loadPricingOverrides } from '../core/budget/budget-tracker.ts';
 import { listSources } from '../core/sources-ops.ts';
 import {
   loadOpCheckpoint,
@@ -1570,7 +1570,6 @@ export async function runExtractConversationFactsCore(
       await recordCompleted(engine, checkpointKey(sourceId), cpMapToEntries(state.cpMap));
     }
   };
-
   let ownedTracker: BudgetTracker | null = null;
   try {
     if (opts.budgetTracker) {
@@ -1581,6 +1580,7 @@ export async function runExtractConversationFactsCore(
       const tracker = new BudgetTracker({
         maxCostUsd: opts.maxCostUsd ?? DEFAULT_MAX_COST_USD,
         label: `extract-conversation-facts:${sourceId}`,
+        pricingOverrides: await loadPricingOverrides(engine),
       });
       ownedTracker = tracker;
       try {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1309,10 +1309,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // Link resolution (issue #972)
   'link_resolution',
   'link_resolution.global_basename',
-  // Spend controls (v0.42.42.0, issue #2139). Previously `--force`-only — the
-  // operator had to discover these by reading source. Registered so `config
-  // set` accepts them directly. See docs/operations/spend-controls.md.
+  // Spend controls (v0.42.42.0, issue #2139). Previously `--force`-only;
+  // registered so `config set` accepts them. See docs/operations/spend-controls.md.
   'spend.posture',
+  'pricing.overrides',
   // Life Chronicle (v0.42.56.0, #2390). The release notes' enable command is
   // `gbrain config set auto_chronicle true`, but the key was never registered
   // — so the documented command failed with "Unknown config key" and the

--- a/src/core/cycle/conversation-facts-backfill.ts
+++ b/src/core/cycle/conversation-facts-backfill.ts
@@ -43,7 +43,11 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
-import { BudgetTracker, BudgetExhausted } from '../budget/budget-tracker.ts';
+import {
+  BudgetTracker,
+  BudgetExhausted,
+  loadPricingOverrides,
+} from '../budget/budget-tracker.ts';
 import { withBudgetTracker } from '../ai/gateway.ts';
 import { listSources } from '../sources-ops.ts';
 import {
@@ -164,6 +168,7 @@ export async function runPhaseConversationFactsBackfill(
   opts: ConversationFactsBackfillPhaseOpts = {},
 ): Promise<ConversationFactsBackfillPhaseResult> {
   const cfg = await loadCfg(engine);
+  const pricingOverrides = await loadPricingOverrides(engine);
 
   if (!cfg.enabled) {
     if (!opts.once) {
@@ -268,6 +273,7 @@ export async function runPhaseConversationFactsBackfill(
         maxCostUsd: perSourceCapUsd,
         maxRuntimeMs: perSourceWallMs,
         label: `conversation_facts_backfill:${src.id}`,
+        pricingOverrides,
       });
 
       // Per-source deadline signal. The tracker's maxRuntimeMs fires at LLM

--- a/src/core/transcripts/ingest-facts.ts
+++ b/src/core/transcripts/ingest-facts.ts
@@ -17,7 +17,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import { isFactsExtractionEnabled } from '../facts/extract.ts';
-import { BudgetTracker } from '../budget/budget-tracker.ts';
+import { BudgetTracker, loadPricingOverrides } from '../budget/budget-tracker.ts';
 import { withBudgetTracker } from '../ai/gateway.ts';
 import {
   DEFAULT_MAX_COST_USD,
@@ -47,6 +47,7 @@ export async function runIngestFacts(
   const tracker = new BudgetTracker({
     maxCostUsd: opts.maxCostUsd ?? DEFAULT_MAX_COST_USD,
     label: 'transcripts-ingest-facts',
+    pricingOverrides: await loadPricingOverrides(engine),
   });
   await withBudgetTracker(tracker, () =>
     runExtractConversationFactsCore(engine, {

--- a/test/conversation-facts-pricing-wiring.test.ts
+++ b/test/conversation-facts-pricing-wiring.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #4633 — every capped Conversation Facts entry point must load the same
+ * DB-plane pricing.overrides map before constructing its BudgetTracker.
+ *
+ * Hermetic: one PGLite engine plus gateway test transports. No network, API
+ * keys, or production database.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  __setChatTransportForTests,
+  __setEmbedTransportForTests,
+  configureGateway,
+  resetGateway,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
+import { runExtractConversationFactsCore } from '../src/commands/extract-conversation-facts.ts';
+import { runPhaseConversationFactsBackfill } from '../src/core/cycle/conversation-facts-backfill.ts';
+import { runIngestFacts } from '../src/core/transcripts/ingest-facts.ts';
+import { KNOWN_CONFIG_KEYS } from '../src/core/config.ts';
+
+const MODEL = 'litellm:custom-chat';
+const SLUG = 'conversations/pricing-override-example';
+const BODY = [
+  '**Alice Example** (2026-08-27 9:00 AM): The example rollout is complete.',
+  '**Bob Demo** (2026-08-27 9:01 AM): Record the result.',
+].join('\n');
+
+let engine: PGLiteEngine;
+let chatCalls = 0;
+
+async function seedPage(): Promise<void> {
+  await engine.putPage(SLUG, {
+    type: 'conversation',
+    title: 'Pricing override example',
+    compiled_truth: BODY,
+    timeline: '',
+    frontmatter: {},
+  }, { sourceId: 'default' });
+}
+
+async function terminalCount(): Promise<number> {
+  const rows = await engine.executeRaw<{ count: number | string }>(
+    `SELECT COUNT(*) AS count FROM facts
+      WHERE source_id = 'default'
+        AND source_markdown_slug = $1
+        AND source = 'cli:extract-conversation-facts:terminal:v2'`,
+    [SLUG],
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  resetGateway();
+  configureGateway({
+    chat_model: MODEL,
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    base_urls: { litellm: 'http://localhost:4000' },
+    env: { LITELLM_BASE_URL: 'http://localhost:4000', OPENAI_API_KEY: 'test' },
+  });
+  __setChatTransportForTests(async (): Promise<ChatResult> => {
+    chatCalls++;
+    return {
+      text: JSON.stringify({
+        facts: [{
+          fact: 'the example rollout is complete',
+          kind: 'event',
+          entity: null,
+          confidence: 1,
+          notability: 'high',
+        }],
+      }),
+      blocks: [],
+      stopReason: 'end',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+      model: MODEL,
+      providerId: 'litellm',
+    };
+  });
+  __setEmbedTransportForTests(
+    (async ({ values }: { values: string[] }) => ({
+      embeddings: values.map(() => Array.from({ length: 1536 }, () => 0.1)),
+    })) as never,
+  );
+});
+
+afterAll(async () => {
+  __setChatTransportForTests(null);
+  __setEmbedTransportForTests(null);
+  resetGateway();
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  chatCalls = 0;
+  await engine.executeRaw(`DELETE FROM facts`);
+  await engine.executeRaw(`DELETE FROM pages WHERE slug = $1`, [SLUG]);
+  await engine.executeRaw(`DELETE FROM op_checkpoints WHERE op = 'extract-conversation-facts'`);
+  await engine.executeRaw(`DELETE FROM extract_rollup_7d`);
+  await engine.setConfig('facts.extraction_enabled', 'true');
+  await engine.setConfig('facts.extraction_model', MODEL);
+  await engine.setConfig('conversation_parser.llm_fallback_enabled', 'false');
+  await engine.setConfig('pricing.overrides', JSON.stringify({
+    [MODEL]: { input: 1, output: 2 },
+  }));
+  await engine.setConfig('cycle.conversation_facts_backfill.enabled', 'true');
+  await engine.setConfig('cycle.conversation_facts_backfill.max_cost_usd', '0.1');
+  await engine.setConfig('cycle.conversation_facts_backfill.max_total_cost_usd', '0.1');
+  await seedPage();
+});
+
+describe('Conversation Facts pricing override wiring', () => {
+  test('the documented config key is accepted by the strict config registry', () => {
+    expect(KNOWN_CONFIG_KEYS).toContain('pricing.overrides');
+  });
+
+  test('direct core extraction uses the configured operator price', async () => {
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: SLUG,
+      maxCostUsd: 0.1,
+      sleepMs: 0,
+    });
+
+    expect(result.budget_exhausted).not.toBe(true);
+    expect(chatCalls).toBeGreaterThan(0);
+    expect(await terminalCount()).toBe(1);
+  });
+
+  test('cycle backfill passes operator pricing to its external tracker', async () => {
+    const result = await runPhaseConversationFactsBackfill(engine, {});
+    const details = result.details as Record<string, unknown>;
+
+    expect(details.sources_budget_exhausted).toBe(0);
+    expect(chatCalls).toBeGreaterThan(0);
+    expect(await terminalCount()).toBe(1);
+  });
+
+  test('transcripts --facts passes operator pricing to its external tracker', async () => {
+    await runIngestFacts(engine, {
+      sourceId: 'default',
+      slugs: [SLUG],
+      maxCostUsd: 0.1,
+      quiet: true,
+    });
+
+    expect(chatCalls).toBeGreaterThan(0);
+    expect(await terminalCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Loads DB-plane `pricing.overrides` into every capped Conversation Facts tracker: direct CLI/core extraction, the Autopilot cycle backfill, and transcripts ingest with `--facts`. It also registers `pricing.overrides` in `KNOWN_CONFIG_KEYS`, so the BudgetTracker remediation command no longer requires `--force`.

## Why

Fixes #4633. Proxy-backed models with valid operator pricing were still rejected as `no_pricing` before the first provider call because these three tracker construction sites never received the configured override map.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/extract-conversation-facts.ts src/core/cycle/conversation-facts-backfill.ts src/core/transcripts/ingest-facts.ts src/core/config.ts` to merge-base, ran `test/conversation-facts-pricing-wiring.test.ts` → 0 pass / 4 fail. Restored → all pass.

## Verification

The new hermetic PGLite suite configures an unpriced `litellm:custom-chat` model plus an operator rate, then proves all three entry points reach the test transport and mint a durable terminal outcome instead of stopping at `no_pricing`.

## Tests

- `bun test test/conversation-facts-pricing-wiring.test.ts test/budget/pricing-overrides.test.ts` → 16 pass / 0 fail
- `bun run verify` → 54 pass / 0 fail
- `git diff --check` → pass

