### PR TITLE
v0.46.32.1 fix(takes): normalize proposal bigint rows (#4634)

### DIFF
--- a/src/core/take-proposals.ts
+++ b/src/core/take-proposals.ts
@@ -36,6 +36,16 @@ export interface TakeProposalRow {
   promoted_row_num: number | null;
 }
 
+/** Normalize Postgres driver values to the public numeric row contract. */
+function normalizeTakeProposalRow(row: TakeProposalRow): TakeProposalRow {
+  return {
+    ...row,
+    id: Number(row.id),
+    weight: Number(row.weight),
+    promoted_row_num: row.promoted_row_num == null ? null : Number(row.promoted_row_num),
+  };
+}
+
 export type TakeProposalErrorCode = 'not_found' | 'not_pending';
 
 export class TakeProposalError extends Error {
@@ -82,7 +92,7 @@ export async function listPendingProposals(
     where.push(`source_id = $${params.length}`);
   }
   params.push(limit);
-  return engine.executeRaw<TakeProposalRow>(
+  const rows = await engine.executeRaw<TakeProposalRow>(
     `SELECT ${PROPOSAL_COLUMNS}
        FROM take_proposals
       WHERE ${where.join(' AND ')}
@@ -90,6 +100,7 @@ export async function listPendingProposals(
       LIMIT $${params.length}`,
     params,
   );
+  return rows.map(normalizeTakeProposalRow);
 }
 
 async function loadProposal(
@@ -110,7 +121,7 @@ async function loadProposal(
   if (rows.length === 0) {
     throw new TakeProposalError('not_found', `No take proposal #${id}${sourceId ? ` in source '${sourceId}'` : ''}.`);
   }
-  const row = rows[0];
+  const row = normalizeTakeProposalRow(rows[0]);
   if (row.status !== 'pending') {
     // wave-g (#4480 follow-up): a crash between the accept CAS and the fence
     // write (or a failed rollback) strands the row as status='accepted' with

--- a/test/take-proposals.test.ts
+++ b/test/take-proposals.test.ts
@@ -307,6 +307,43 @@ describe('CLI dispatcher (#2411 no-fallthrough)', () => {
     expect(parsed.some((r: { claim_text: string }) => r.claim_text === 'cli: pending list claim')).toBe(true);
   });
 
+  test('`takes propose --json` normalizes Postgres BigInt proposal rows (#4634)', async () => {
+    const id = await insertProposal({
+      slug: 'companies/acme-example',
+      claim: 'cli: bigint proposal row',
+    });
+    const originalExecuteRaw = engine.executeRaw;
+    engine.executeRaw = (async <T>(query: string, params?: unknown[]): Promise<T[]> => {
+      const rows = await originalExecuteRaw.call(engine, query, params) as T[];
+      if (!query.includes('FROM take_proposals') || !query.includes("status = 'pending'")) {
+        return rows;
+      }
+      return rows.map((row) => {
+        const record = row as Record<string, unknown>;
+        return {
+          ...record,
+          id: BigInt(Number(record.id)),
+          weight: String(record.weight),
+          promoted_row_num: record.promoted_row_num == null
+            ? null
+            : BigInt(Number(record.promoted_row_num)),
+        } as T;
+      });
+    }) as typeof engine.executeRaw;
+
+    try {
+      const out = await captureStdout(() =>
+        runTakes(engine, ['propose', '--json', '--limit', '100'])
+      );
+      const parsed = JSON.parse(out) as Array<{ id: number; claim_text: string }>;
+      const row = parsed.find((candidate) => candidate.claim_text === 'cli: bigint proposal row');
+      expect(row?.id).toBe(id);
+      expect(typeof row?.id).toBe('number');
+    } finally {
+      engine.executeRaw = originalExecuteRaw;
+    }
+  });
+
   test('`takes propose --accept <id>` promotes and reports the fence row', async () => {
     const id = await insertProposal({ slug: 'companies/acme-example', claim: 'cli: accept me' });
     const out = await captureStdout(() => runTakes(engine, ['propose', '--accept', String(id)]));


### PR DESCRIPTION
## What

Normalizes `take_proposals` driver rows to the public numeric `TakeProposalRow` contract before list and action consumers receive them. This makes `gbrain takes propose --json` safe when Postgres returns BIGSERIAL/numeric columns as BigInt or strings.

## Why

Fixes #4634. The CLI directly serializes the pending proposal array, so a native BigInt `id` throws before any JSON is printed. This is related to but distinct from #4625 / #4626, which cover the `listStaleTakes()` path used by `takes embed`.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/take-proposals.ts` to merge-base, ran `test/take-proposals.test.ts` → 15 pass / 1 fail. Restored → all pass.

## Verification

The CLI regression injects a Postgres-shaped pending proposal row with native BigInt IDs and a string numeric weight, then parses the emitted JSON and asserts the public ID is a number.

## Tests

- `bun test test/take-proposals.test.ts` → 16 pass / 0 fail
- `bun run verify` → 54 pass / 0 fail
- `git diff --check` → pass

