### PR TITLE
v0.46.32.1 fix(parser): report generic chat unavailability (#4635)

### DIFF
--- a/src/core/conversation-parser/nightly-probe.ts
+++ b/src/core/conversation-parser/nightly-probe.ts
@@ -132,7 +132,10 @@ export async function runConversationParserNightlyProbe(
     return {
       ...baseResult,
       outcome: 'no_embedding_key',
-      reason: 'no Anthropic key configured (polish/fallback would be no-ops)',
+      // Autopilot passes provider-generic chat availability here, and parser
+      // polish/fallback route through the AI Gateway. Keep the historical
+      // outcome value for compatibility, but do not diagnose one provider.
+      reason: 'no chat model available (polish/fallback would be no-ops)',
     };
   }
 

--- a/test/conversation-parser/nightly-probe.test.ts
+++ b/test/conversation-parser/nightly-probe.test.ts
@@ -74,6 +74,8 @@ describe('runConversationParserNightlyProbe', () => {
       baseDeps({ hasLlmKey: () => false }),
     );
     expect(r.outcome).toBe('no_embedding_key');
+    expect(r.reason).toContain('no chat model available');
+    expect(r.reason).not.toContain('Anthropic');
   });
 
   test('happy path: all pass', async () => {


### PR DESCRIPTION
## What

Makes the Conversation Parser nightly-probe failure reason provider-neutral: `no chat model available` instead of `no Anthropic key configured`. The historical `no_embedding_key` outcome value remains unchanged for audit/schema compatibility.

## Why

Fixes #4635. Autopilot supplies a generic `isAvailable('chat')` result, and parser polish/fallback route through the provider-generic AI Gateway. The previous message diagnosed an Anthropic credential problem even for OpenAI-compatible, OpenRouter, Ollama, and other provider configurations.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/conversation-parser/nightly-probe.ts` to merge-base, ran `test/conversation-parser/nightly-probe.test.ts` → 6 pass / 1 fail. Restored → all pass.

## Verification

The dependency-injected nightly-probe test now pins both sides of the contract: the reason names generic chat availability and does not mention Anthropic.

## Tests

- `bun test test/conversation-parser/nightly-probe.test.ts` → 7 pass / 0 fail
- `bun run verify` → 54 pass / 0 fail
- `git diff --check` → pass
