### PR TITLE
fix(ai/ollama): real pullable embedding tags + bare-id colon-parse fix (#3904)

### DIFF
--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -139,9 +139,12 @@ export function knownProviderIds(): string[] {
  * user-provided-model recipes declare `default_dims: 0` to force an explicit
  * `--embedding-dimensions`), so callers keep their existing falsy checks.
  *
- * Accepts a bare model id (`bge-m3`) or a qualified one (`ollama:bge-m3`);
- * the provider prefix is stripped before lookup so call sites can pass
- * whichever they hold.
+ * Accepts a bare model id (`bge-m3`, or one that itself contains a colon
+ * like Ollama's pullable tag `qwen3-embedding:8b`) or a qualified one
+ * (`ollama:bge-m3`, `ollama:qwen3-embedding:8b`); the id is tried as-is
+ * first, then with a leading `provider:` prefix stripped, so call sites can
+ * pass whichever they hold without a bare model-internal colon being
+ * mistaken for the provider separator.
  *
  * Fixes #2051: a recipe-wide default silently picked 768 for every Ollama
  * model, so `init --embedding-model ollama:bge-m3` built a 768-wide column
@@ -154,22 +157,37 @@ export function embeddingDimsForModel(
   const tp = recipe.touchpoints.embedding;
   if (!tp) return 0;
   if (!modelId) return tp.default_dims ?? 0;
-  // Strip a leading `provider:` so both forms resolve. Slash-form ids
-  // (openrouter nested) are left intact — they're the model id.
-  const colon = modelId.indexOf(':');
-  const bare = colon === -1 ? modelId : modelId.slice(colon + 1);
-  // #4123: fold BOTH sides — configured ids arrive cased (`ollama:Qwen3-Embed-8B`)
-  // and user-editable recipe model_dims tables can carry cased keys too.
-  // Exact match first (zero behavior change for today's all-lowercase
-  // tables), then a case-insensitive scan. Without this, a cased id fell
-  // through to default_dims and `gbrain init` built a wrong-width column.
-  let declared = tp.model_dims?.[bare];
-  if (typeof declared !== 'number' && tp.model_dims) {
-    const bareFolded = bare.toLowerCase();
-    for (const [k, v] of Object.entries(tp.model_dims)) {
-      if (k.toLowerCase() === bareFolded) { declared = v; break; }
-    }
+  // Try the id exactly as given first. This covers bare model ids that
+  // themselves contain a colon (e.g. Ollama's `qwen3-embedding:8b` pullable
+  // tag) — stripping the FIRST colon unconditionally would mistake the
+  // model's own colon for a `provider:` separator and truncate it.
+  let declared = lookupDims(tp.model_dims, modelId);
+  if (typeof declared !== 'number') {
+    // Strip a leading `provider:` so the qualified form also resolves.
+    // Slash-form ids (openrouter nested) are left intact — they're the model id.
+    const colon = modelId.indexOf(':');
+    const bare = colon === -1 ? modelId : modelId.slice(colon + 1);
+    declared = lookupDims(tp.model_dims, bare);
   }
   if (typeof declared === 'number' && declared > 0) return declared;
   return tp.default_dims ?? 0;
+}
+
+// #4123: fold BOTH sides — configured ids arrive cased (`ollama:Qwen3-Embed-8B`)
+// and user-editable recipe model_dims tables can carry cased keys too.
+// Exact match first (zero behavior change for today's all-lowercase
+// tables), then a case-insensitive scan. Without this, a cased id fell
+// through to default_dims and `gbrain init` built a wrong-width column.
+function lookupDims(
+  table: Record<string, number> | undefined,
+  key: string,
+): number | undefined {
+  if (!table) return undefined;
+  const exact = table[key];
+  if (typeof exact === 'number') return exact;
+  const keyFolded = key.toLowerCase();
+  for (const [k, v] of Object.entries(table)) {
+    if (k.toLowerCase() === keyFolded) return v;
+  }
+  return undefined;
 }

--- a/test/ai/ollama-library-tag-dims.test.ts
+++ b/test/ai/ollama-library-tag-dims.test.ts
@@ -9,17 +9,23 @@
  * `embeddingDimsForModel()`'s strip-the-leading-`provider:`-prefix logic with
  * a colon INSIDE the model id.
  *
- * Contract pinned here:
+ * Contract pinned here (both forms now resolve to the true 4096):
  *   - Qualified form (`ollama:qwen3-embedding:8b`) strips only the FIRST
- *     colon, so the tag survives and resolves to its declared 4096. This is
- *     the form every live caller passes (init verbose path, `gbrain
- *     embedding-migrate --to ...` — which rejects non-qualified input).
- *   - Bare colon-bearing form (`qwen3-embedding:8b`) has its `qwen3-embedding`
- *     head eaten by the prefix strip and falls back to default_dims (768).
- *     That is the documented strip-first-colon contract, NOT the tag's native
- *     width — colon-bearing library tags MUST be passed provider-qualified.
- *     If this pin ever fails because the strip became provider-aware, update
- *     it to 4096 and delete the caveat.
+ *     colon, so the tag survives and resolves to its declared 4096.
+ *   - Bare colon-bearing form (`qwen3-embedding:8b`) is tried as-given
+ *     FIRST (an exact `model_dims` lookup) before any provider-prefix strip
+ *     is attempted, so it also resolves to 4096 instead of the earlier
+ *     naive first-colon strip eating the `qwen3-embedding` head and falling
+ *     through to default_dims (768).
+ *
+ *   The bare form is not a theoretical caller: `parseModelId('ollama:
+ *   qwen3-embedding:8b')` (model-resolver.ts) splits on the FIRST colon
+ *   only, so its `.modelId` is exactly the bare `qwen3-embedding:8b` — and
+ *   `src/core/ai/gateway.ts` passes that already-parsed `.modelId` straight
+ *   into `embeddingDimsForModel()` at both its preflight dim-check
+ *   (line ~959) and its per-call dim lookup (line ~2384). A brain configured
+ *   with the standard qualified `ollama:qwen3-embedding:8b` embedding model
+ *   hit the bare-form path on every gateway dim check before this fix.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -39,12 +45,14 @@ describe('ollama library-tag dims — new pullable tags', () => {
     expect(embeddingDimsForModel(ollama, 'ollama:qwen3-embedding:8b')).toBe(4096);
   });
 
-  test('CAVEAT: bare qwen3-embedding:8b falls back to default_dims — colon tags require the qualified form', () => {
-    // The strip-first-colon contract treats `qwen3-embedding` as a provider
-    // prefix and looks up `8b`, which is unlisted → default_dims (768).
-    // Live callers never hit this: init's verbose path passes the full
-    // `ollama:...` string and resolveMigrationTarget() requires it.
-    expect(embeddingDimsForModel(ollama, 'qwen3-embedding:8b')).toBe(768);
+  test('bare qwen3-embedding:8b resolves to its true 4096 (the gateway.ts:959/:2384 call shape)', () => {
+    // embeddingDimsForModel() now tries the id exactly as given (an exact
+    // model_dims lookup) before assuming a leading `provider:` separator,
+    // so the bare colon-bearing form — exactly what parseModelId('ollama:
+    // qwen3-embedding:8b').modelId produces, and what gateway.ts passes
+    // straight through — resolves correctly instead of silently falling
+    // back to default_dims (768).
+    expect(embeddingDimsForModel(ollama, 'qwen3-embedding:8b')).toBe(4096);
   });
 
   test('legacy spellings keep validating at their declared dims', () => {

--- a/test/ai/ollama-library-tag-dims.test.ts
+++ b/test/ai/ollama-library-tag-dims.test.ts
@@ -18,19 +18,25 @@
  *     naive first-colon strip eating the `qwen3-embedding` head and falling
  *     through to default_dims (768).
  *
- *   The bare form is not a theoretical caller: `parseModelId('ollama:
+ *   The bare form is not a purely theoretical input: `parseModelId('ollama:
  *   qwen3-embedding:8b')` (model-resolver.ts) splits on the FIRST colon
  *   only, so its `.modelId` is exactly the bare `qwen3-embedding:8b` — and
- *   `src/core/ai/gateway.ts` passes that already-parsed `.modelId` straight
- *   into `embeddingDimsForModel()` at both its preflight dim-check
- *   (line ~959) and its per-call dim lookup (line ~2384). A brain configured
- *   with the standard qualified `ollama:qwen3-embedding:8b` embedding model
- *   hit the bare-form path on every gateway dim check before this fix.
+ *   `src/core/ai/gateway.ts`'s preflight dim-check (`~959`) passes that
+ *   already-parsed `.modelId` straight into `embeddingDimsForModel()`. Today
+ *   that one call site only branches on zero-vs-nonzero (both the old wrong
+ *   768 and the correct 4096 are nonzero, so its outcome doesn't currently
+ *   change), and the ollama recipe doesn't declare `supports_multimodal` so
+ *   it never reaches the OTHER embeddingDimsForModel() call site
+ *   (`~2384`, multimodal-only). So this fix is not closing an
+ *   observed-broken production path today — it's closing the actual parse
+ *   gap for the one real caller that already exists (proven below) and for
+ *   any future caller (dim mismatch errors, migration planning, etc.) that
+ *   depends on the correct declared width rather than a zero check.
  */
 
 import { describe, expect, test } from 'bun:test';
 import { getRecipe } from '../../src/core/ai/recipes/index.ts';
-import { embeddingDimsForModel } from '../../src/core/ai/model-resolver.ts';
+import { embeddingDimsForModel, resolveRecipe } from '../../src/core/ai/model-resolver.ts';
 import { resolveMigrationTarget } from '../../src/core/embedding-migration.ts';
 
 describe('ollama library-tag dims — new pullable tags', () => {
@@ -45,14 +51,18 @@ describe('ollama library-tag dims — new pullable tags', () => {
     expect(embeddingDimsForModel(ollama, 'ollama:qwen3-embedding:8b')).toBe(4096);
   });
 
-  test('bare qwen3-embedding:8b resolves to its true 4096 (the gateway.ts:959/:2384 call shape)', () => {
+  test('bare qwen3-embedding:8b resolves to its true 4096', () => {
     // embeddingDimsForModel() now tries the id exactly as given (an exact
     // model_dims lookup) before assuming a leading `provider:` separator,
-    // so the bare colon-bearing form — exactly what parseModelId('ollama:
-    // qwen3-embedding:8b').modelId produces, and what gateway.ts passes
-    // straight through — resolves correctly instead of silently falling
-    // back to default_dims (768).
+    // so the bare colon-bearing form resolves correctly instead of silently
+    // falling back to default_dims (768).
     expect(embeddingDimsForModel(ollama, 'qwen3-embedding:8b')).toBe(4096);
+  });
+
+  test('resolveRecipe("ollama:qwen3-embedding:8b").parsed.modelId is the bare colon-bearing form, and feeding it straight to embeddingDimsForModel() resolves correctly — the exact shape gateway.ts:959 passes', () => {
+    const { parsed, recipe } = resolveRecipe('ollama:qwen3-embedding:8b');
+    expect(parsed.modelId).toBe('qwen3-embedding:8b');
+    expect(embeddingDimsForModel(recipe, parsed.modelId)).toBe(4096);
   });
 
   test('legacy spellings keep validating at their declared dims', () => {

--- a/test/ai/ollama-library-tag-dims.test.ts
+++ b/test/ai/ollama-library-tag-dims.test.ts
@@ -1,37 +1,13 @@
 /**
  * Ollama library-tag dims — coverage for the pullable-tag catalog refresh.
  *
- * The ollama recipe gained the REAL Ollama library spellings
- * (`qwen3-embedding:8b`, `snowflake-arctic-embed2`) alongside the legacy
- * never-pullable spellings (`qwen3-embed-8b`, `snowflake-arctic-embed-l-v2`).
  * `qwen3-embedding:8b` is the first colon-bearing model tag in any recipe's
  * models list, which makes it the first tag to exercise
  * `embeddingDimsForModel()`'s strip-the-leading-`provider:`-prefix logic with
- * a colon INSIDE the model id.
- *
- * Contract pinned here (both forms now resolve to the true 4096):
- *   - Qualified form (`ollama:qwen3-embedding:8b`) strips only the FIRST
- *     colon, so the tag survives and resolves to its declared 4096.
- *   - Bare colon-bearing form (`qwen3-embedding:8b`) is tried as-given
- *     FIRST (an exact `model_dims` lookup) before any provider-prefix strip
- *     is attempted, so it also resolves to 4096 instead of the earlier
- *     naive first-colon strip eating the `qwen3-embedding` head and falling
- *     through to default_dims (768).
- *
- *   The bare form is not a purely theoretical input: `parseModelId('ollama:
- *   qwen3-embedding:8b')` (model-resolver.ts) splits on the FIRST colon
- *   only, so its `.modelId` is exactly the bare `qwen3-embedding:8b` — and
- *   `src/core/ai/gateway.ts`'s preflight dim-check (`~959`) passes that
- *   already-parsed `.modelId` straight into `embeddingDimsForModel()`. Today
- *   that one call site only branches on zero-vs-nonzero (both the old wrong
- *   768 and the correct 4096 are nonzero, so its outcome doesn't currently
- *   change), and the ollama recipe doesn't declare `supports_multimodal` so
- *   it never reaches the OTHER embeddingDimsForModel() call site
- *   (`~2384`, multimodal-only). So this fix is not closing an
- *   observed-broken production path today — it's closing the actual parse
- *   gap for the one real caller that already exists (proven below) and for
- *   any future caller (dim mismatch errors, migration planning, etc.) that
- *   depends on the correct declared width rather than a zero check.
+ * a colon INSIDE the model id. Both the qualified form
+ * (`ollama:qwen3-embedding:8b`) and the bare form (`qwen3-embedding:8b`)
+ * resolve to the declared 4096 — see the PR description for the reachability
+ * analysis of who calls `embeddingDimsForModel()` with which form.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -59,7 +35,7 @@ describe('ollama library-tag dims — new pullable tags', () => {
     expect(embeddingDimsForModel(ollama, 'qwen3-embedding:8b')).toBe(4096);
   });
 
-  test('resolveRecipe("ollama:qwen3-embedding:8b").parsed.modelId is the bare colon-bearing form, and feeding it straight to embeddingDimsForModel() resolves correctly — the exact shape gateway.ts:959 passes', () => {
+  test('resolver output preserves the colon-bearing tag for dimension lookup', () => {
     const { parsed, recipe } = resolveRecipe('ollama:qwen3-embedding:8b');
     expect(parsed.modelId).toBe('qwen3-embedding:8b');
     expect(embeddingDimsForModel(recipe, parsed.modelId)).toBe(4096);

--- a/test/embedding-model-dims.test.ts
+++ b/test/embedding-model-dims.test.ts
@@ -30,12 +30,26 @@ describe('embeddingDimsForModel — per-model dims (#2051)', () => {
     expect(embeddingDimsForModel(ollama, 'ollama:bge-m3')).toBe(1024);
   });
 
+  // #3904/#4650 — `qwen3-embedding:8b` (landed in v0.46.35.0) is the first
+  // model_dims key in any recipe carrying its own embedded colon.
+  // embeddingDimsForModel() now tries the id exactly as given before
+  // assuming a leading `provider:` separator, so both the qualified form
+  // (`ollama:qwen3-embedding:8b`) and the bare form (`qwen3-embedding:8b`,
+  // which itself contains a colon) resolve to the model's true 4096 dims
+  // instead of the earlier naive first-colon strip truncating the bare form
+  // down to `8b` and silently falling back to default_dims (768).
+  test('qualified id with an embedded colon in the model tag resolves correctly', () => {
+    expect(embeddingDimsForModel(ollama, 'ollama:qwen3-embedding:8b')).toBe(4096);
+  });
+
   test.each([
     ['nomic-embed-text', 768],
     ['mxbai-embed-large', 1024],
     ['all-minilm', 384],
-    ['qwen3-embed-8b', 4096],
-    ['snowflake-arctic-embed-l-v2', 1024],
+    ['qwen3-embed-8b', 4096], // legacy spelling — never a pullable ollama tag; kept for back-compat
+    ['snowflake-arctic-embed-l-v2', 1024], // legacy spelling — never a pullable ollama tag; kept for back-compat
+    ['snowflake-arctic-embed2', 1024], // real pullable tag, landed v0.46.35.0
+    ['qwen3-embedding:8b', 4096], // real pullable tag, bare form with its own embedded colon, landed v0.46.35.0
   ])('%s resolves to %i', (model, dims) => {
     expect(embeddingDimsForModel(ollama, model as string)).toBe(dims as number);
   });


### PR DESCRIPTION
## Summary

Originally extracted the "Ollama pullable tags" piece of #3904 as a standalone fix. **Update:** #3904 itself has since been closed — its direction landed via the maintainer's own reimplementation in v0.46.35.0 (wave-k maintainer train, #4650), which added the real pullable tags (`qwen3-embedding:8b`, `snowflake-arctic-embed2`) to the `ollama` recipe. This PR is now rebased onto that and narrowed to the one piece that reimplementation didn't cover.

**What's left:** `#4650`'s own test suite pinned a known caveat — `embeddingDimsForModel()` (`src/core/ai/model-resolver.ts`) strips everything before the *first* colon assuming it's a `provider:` separator, which breaks a bare (unqualified) model id that itself contains a colon (exactly what the new `qwen3-embedding:8b` tag is). The test comment claimed "live callers never hit this" and explicitly invited a fix: *"If this pin ever fails because the strip became provider-aware, update it to 4096 and delete the caveat."*

This PR does that — and traces the one real caller shape that already exists: `parseModelId('ollama:qwen3-embedding:8b')` splits on the first colon only, so its `.modelId` comes out as the bare `qwen3-embedding:8b`, and `src/core/ai/gateway.ts`'s preflight dim-check (`~959`) passes that already-parsed `.modelId` straight into `embeddingDimsForModel()`. **Caveat on impact:** today that specific call site only branches on zero-vs-nonzero (both the old wrong `768` and the correct `4096` are nonzero, so its outcome is unaffected), and the *other* `embeddingDimsForModel()` call site (`~2384`) is multimodal-only — unreachable for `ollama` since its recipe doesn't declare `supports_multimodal`. So this isn't closing an observed-broken production path today; it's closing the actual parsing gap for the one caller that already exists, and for any future caller (dim-mismatch errors, migration planning) that depends on the correct declared width rather than a zero check.

Fix: `embeddingDimsForModel()` now tries the model id exactly as given (an exact `model_dims` lookup, case-folded) before assuming a leading `provider:` prefix needs stripping. Both the qualified form (`ollama:qwen3-embedding:8b`) and the bare form (`qwen3-embedding:8b`) now resolve to the correct `4096`; existing single-colon-free ids and the `#4123` cased-id fold are unaffected.

## Test plan

- [x] `bun test test/ai/ollama-library-tag-dims.test.ts test/embedding-model-dims.test.ts test/embedding-dim-check.test.ts test/ai/ test/embedding-pricing.test.ts` — 753 pass / 0 fail
- [x] `bun test test/embedding-migration* test/init*` — 143 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] Direct regression added: `resolveRecipe('ollama:qwen3-embedding:8b').parsed.modelId` → `embeddingDimsForModel()` pinned as the real existing caller shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
