### PR TITLE
Reject malformed put_page slugs

### DIFF
--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -343,6 +343,7 @@ const put_page: Operation = {
   scope: 'write',
   handler: async (ctx, p) => {
     const slug = p.slug as string;
+    validatePageSlug(slug);
 
     // v0.39.3.0 CV6 trust gate for provenance write-through (WARN-8).
     // Only trusted LOCAL callers (ctx.remote === false — capture CLI,

--- a/test/operations-allow-list.test.ts
+++ b/test/operations-allow-list.test.ts
@@ -98,6 +98,31 @@ describe('matchesSlugAllowList — glob semantics', () => {
 describe('put_page — trusted-workspace allow-list', () => {
   const put_page = findOp('put_page');
 
+  test('REJECTS malformed slugs before they reach the write path', async () => {
+    const ctx = makeCtx({
+      allowedSlugPrefixes: ['wiki/originals/*'],
+    });
+    await expect(put_page.handler(ctx, {
+      slug: 'wiki/originals/ideas/secrets-readonly- trusted-services',
+      content: '---\ntitle: x\n---\nbody',
+    })).rejects.toMatchObject({
+      code: 'invalid_params',
+    });
+  });
+
+  test('accepts a valid slug inside the allow-list in dry-run mode', async () => {
+    const ctx = makeCtx({
+      allowedSlugPrefixes: ['wiki/originals/*'],
+      dryRun: true,
+    });
+    await expect(put_page.handler(ctx, {
+      slug: 'wiki/originals/ideas/secrets-readonly-trusted-services',
+      content: '---\ntitle: x\n---\nbody',
+    })).resolves.toMatchObject({
+      dry_run: true,
+    });
+  });
+
   test('REJECTS when slug is outside the allow-list', async () => {
     const ctx = makeCtx({
       allowedSlugPrefixes: ['wiki/personal/reflections/*', 'wiki/originals/*'],
@@ -121,6 +146,26 @@ describe('put_page — trusted-workspace allow-list', () => {
       content: '---\ntitle: x\n---\nbody',
     })).rejects.toMatchObject({
       code: 'permission_denied',
+    });
+  });
+});
+
+describe('put_page — strict slug validation', () => {
+  const put_page = findOp('put_page');
+
+  test('REJECTS malformed slugs for trusted local callers too', async () => {
+    const ctx = makeCtx({
+      remote: false,
+      viaSubagent: false,
+      subagentId: undefined,
+      allowedSlugPrefixes: undefined,
+      dryRun: true,
+    });
+    await expect(put_page.handler(ctx, {
+      slug: 'notes/contains a space',
+      content: '---\ntitle: x\n---\nbody',
+    })).rejects.toMatchObject({
+      code: 'invalid_params',
     });
   });
 });


### PR DESCRIPTION
Malformed slugs from Dream could pass through `put_page`, enter the database, and only fail later during repository maintenance. This validates the slug at the operation boundary so the individual tool call fails before any write.

Main changes:

- Apply the existing strict page-slug validator before allow-list, dry-run, or write handling
- Cover the malformed Dream-style whitespace case for allow-listed and trusted local callers
- Keep valid allow-listed slugs working in dry-run mode

Reviewer notes:

- `bun run verify` passes all 54 checks
- Focused operation, Unicode slug, Dream allow-list, and allow-list serial tests pass (62 tests)
- `bun run typecheck` passes
- Full parallel test shards pass; two serial failures also reproduce unchanged on `origin/master` (`sync-rename-reconcile` and `worker-registry`)