### PR TITLE
v0.47.3.1 fix(sync): honor the persisted exclude scope on every sync path

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -374,6 +374,13 @@ export interface SyncOpts {
    * the full-sync and incremental paths. Excluded files are never imported;
    * exclusion does NOT delete previously-imported pages (conservative,
    * matching the #1433 metafile posture).
+   *
+   * Unioned with the persisted `sync.exclude` config key (comma- or
+   * newline-separated; a trailing `/` is normalized to a `/**` subtree glob),
+   * so callers that never touch the CLI — autopilot, minion sync jobs, the
+   * dream cycle — inherit the same indexing scope. Union, not override: an
+   * ad-hoc flag narrows further but never silently re-opens a scope the
+   * operator persisted. Best-effort read, as with `sync.include_working_tree`.
    */
   exclude?: string[];
   /**
@@ -1796,6 +1803,41 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     } catch { workingTreeResolved = false; }
   }
   const importWorkingTree = detachedHead || workingTreeResolved === true;
+
+  // Same reasoning as `sync.include_working_tree` directly above, applied to
+  // the indexing scope: `--exclude` is a per-invocation flag, so only callers
+  // that go through the CLI can narrow what gets indexed. autopilot, minion
+  // sync jobs and the dream cycle call sync internally with no place to put
+  // exclusions — a repo whose indexing scope is narrower than its git tree is
+  // honored on one path and silently ignored on the others.
+  //
+  // Silently is the operative word: not excluding something is not an error
+  // for an indexer, so the gap surfaces as content quietly reappearing in the
+  // index, never as a failure. Resolving the config HERE gives every caller
+  // the same scope. The read is best-effort, exactly like the one above.
+  //
+  // UNION rather than flag-wins, which is where this departs from the boolean
+  // above: a persisted scope is a property of the repo ("this is not indexable
+  // material"), and an ad-hoc `--exclude tmp/` must not silently re-open it —
+  // that would reintroduce the very failure this closes. A boolean has no
+  // union; a pattern list does. Narrowing further always works; widening is
+  // deliberate, by editing the config.
+  //
+  // Directory prefixes are normalized to subtree globs (`raw/` → `raw/**`):
+  // without the `**` the pattern matches the directory entry and none of the
+  // files inside it, which is the same gap wearing a different shape.
+  try {
+    const stored = await engine.getConfig('sync.exclude');
+    const storedPatterns = (stored ?? '')
+      .split(/[\n,]/)
+      .map(p => p.trim())
+      .filter(Boolean)
+      .map(p => (p.endsWith('/') ? `${p}**` : p));
+    if (storedPatterns.length > 0) {
+      opts = { ...opts, exclude: [...new Set([...(opts.exclude ?? []), ...storedPatterns])] };
+    }
+  } catch { /* config unreadable — never break a sync over the scope read */ }
+
   // Fail-open guard: the manifest builder shells out under a 30s/100MiB git
   // budget and THROWS on breach; a monster untracked dir must not convert
   // every previously-working up-to-date sync into a hard error. Drift

--- a/test/sync-exclude-config.test.ts
+++ b/test/sync-exclude-config.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Indexing scope must reach callers that never touch the CLI.
+ *
+ * `--exclude` is a per-invocation flag, so before this only CLI callers could
+ * narrow what gets indexed. autopilot, minion sync jobs and the dream cycle
+ * call sync internally with nowhere to put exclusions, so a repo whose
+ * indexing scope is narrower than its git tree was honored on one path and
+ * ignored on the others — and ignored silently, because failing to exclude
+ * something is not an error for an indexer.
+ *
+ * Under test:
+ *   1. `sync.exclude` config is honored with NO flag passed (the internal-caller
+ *      path, on the incremental diff — which is what runs in production).
+ *   2. A per-call flag UNIONS with the persisted scope instead of replacing it:
+ *      an ad-hoc `--exclude` narrows further, never re-opens what the operator
+ *      persisted.
+ *   3. A directory prefix (`raw/`) is normalized to a subtree glob (`raw/**`).
+ *      Without the `**` the pattern matches the directory entry and none of
+ *      the files inside it — the same gap in a different shape, and equally
+ *      silent.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { performSync } from '../src/commands/sync.ts';
+import { runSources } from '../src/commands/sources.ts';
+
+let engine: PGLiteEngine;
+let repoPath: string;
+const SOURCE_ID = 'testsrc-excl-cfg';
+
+function commitAll(msg: string): void {
+  execSync('git add -A', { cwd: repoPath, stdio: 'pipe' });
+  execSync(`git commit -m "${msg}"`, { cwd: repoPath, stdio: 'pipe' });
+}
+
+async function pageExists(slug: string): Promise<boolean> {
+  const rows = await engine.executeRaw<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM pages WHERE slug = $1 AND source_id = $2 AND deleted_at IS NULL`,
+    [slug, SOURCE_ID],
+  );
+  return Number(rows[0]?.n ?? 0) > 0;
+}
+
+/** No `exclude` key: this is exactly what an internal caller passes. */
+const baseOpts = () => ({
+  repoPath,
+  sourceId: SOURCE_ID,
+  noPull: true,
+  noEmbed: true,
+  noExtract: true,
+});
+
+describe('sync.exclude config reaches non-CLI callers', () => {
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    await runSources(engine, ['add', SOURCE_ID, '--no-federated']);
+
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-excl-cfg-'));
+    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'notes'), { recursive: true });
+    writeFileSync(join(repoPath, 'notes/base.md'), '# Base\n\ncommitted\n');
+    commitAll('base');
+
+    // First sync = full walk; establishes last_commit so later runs are incremental.
+    const first = await performSync(engine, baseOpts());
+    expect(first.status).toBe('first_sync');
+    expect(await pageExists('notes/base')).toBe(true);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (engine) await engine.disconnect();
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  }, 60_000);
+
+  test('with no config and no flag, everything in the tree is indexed', async () => {
+    // Baseline: without it, a passing exclusion test could just mean the file
+    // never made it into the repo.
+    mkdirSync(join(repoPath, 'raw'), { recursive: true });
+    writeFileSync(join(repoPath, 'raw/first.md'), '# Raw one\n\nbaseline\n');
+    commitAll('raw baseline');
+
+    await performSync(engine, baseOpts());
+    expect(await pageExists('raw/first')).toBe(true);
+  }, 60_000);
+
+  test('persisted sync.exclude is honored with no flag passed', async () => {
+    await engine.setConfig('sync.exclude', 'raw/');
+
+    writeFileSync(join(repoPath, 'raw/second.md'), '# Raw two\n\nmust not be indexed\n');
+    writeFileSync(join(repoPath, 'notes/kept.md'), '# Kept\n\nmust be indexed\n');
+    commitAll('raw two + kept');
+
+    await performSync(engine, baseOpts());
+
+    // The whole point: no caller passed --exclude, and the scope still held.
+    expect(await pageExists('raw/second')).toBe(false);
+    expect(await pageExists('notes/kept')).toBe(true);
+  }, 60_000);
+
+  test('a trailing slash covers the files inside, not just the directory entry', async () => {
+    // `raw/` without the `**` normalization matches the directory and nothing
+    // in it, so this asserts the normalization rather than the config plumbing.
+    writeFileSync(join(repoPath, 'raw/nested.md'), '# Nested\n\nstill excluded\n');
+    mkdirSync(join(repoPath, 'raw/deeper'), { recursive: true });
+    writeFileSync(join(repoPath, 'raw/deeper/leaf.md'), '# Leaf\n\nexcluded too\n');
+    commitAll('nested raw');
+
+    await performSync(engine, baseOpts());
+
+    expect(await pageExists('raw/nested')).toBe(false);
+    expect(await pageExists('raw/deeper/leaf')).toBe(false);
+  }, 60_000);
+
+  test('a per-call flag narrows further without re-opening the persisted scope', async () => {
+    writeFileSync(join(repoPath, 'raw/third.md'), '# Raw three\n\nstill excluded by config\n');
+    writeFileSync(join(repoPath, 'notes/adhoc.md'), '# Ad hoc\n\nexcluded by the flag\n');
+    writeFileSync(join(repoPath, 'notes/plain.md'), '# Plain\n\nindexed\n');
+    commitAll('flag union case');
+
+    await performSync(engine, { ...baseOpts(), exclude: ['notes/adhoc.md'] });
+
+    expect(await pageExists('notes/adhoc')).toBe(false);  // the flag applies
+    expect(await pageExists('raw/third')).toBe(false);    // the config still applies
+    expect(await pageExists('notes/plain')).toBe(true);   // neither matches
+  }, 60_000);
+
+  test('an unreadable scope never breaks a sync', async () => {
+    // Best-effort read, same posture as sync.include_working_tree: a config
+    // problem must degrade to "no persisted scope", not to a failed sync.
+    await engine.setConfig('sync.exclude', '');
+
+    writeFileSync(join(repoPath, 'notes/after-empty.md'), '# After\n\nindexed\n');
+    commitAll('empty scope');
+
+    const result = await performSync(engine, baseOpts());
+    expect(result.status).toBe('synced');
+    expect(await pageExists('notes/after-empty')).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
## What

`--exclude` is a per-invocation flag, so only callers that reach sync through the CLI can narrow what a repo indexes. `autopilot`, minion sync jobs and the dream cycle call sync internally and have nowhere to put exclusions, so a repo whose indexing scope is narrower than its git tree is honored on one path and ignored on the others.

`performSyncInner` now unions `opts.exclude` with a persisted `sync.exclude` config key, so every caller inherits the same scope.

## Why

The gap is silent by construction: **failing to exclude something is not an error for an indexer.** It surfaces as content quietly reappearing in the index, never as a failure — no exit code, no warning, nothing for a healthcheck to catch.

What it looked like in my install, in anonymized numbers:

- **2,723 of 5,405 atoms were duplicates.** 2,656 of the 2,675 repeated titles had exactly two pages each — same source, same `source_hash`, same extractor version. Only the path prefix differed.
- The cause was a **derivative→source loop**: `gbrain export` writes atoms and concepts back into the repo as markdown (kept version-controlled so humans and agents can read them), `sync` re-ingests them, and each derived item gets a second page.
- The diagnostic that isolates it: **only what gets exported duplicated.** My pipeline exports concepts at tier T1/T2 only, and 100% of duplicated concepts were T1/T2 — the T3 concepts, never written to the repo, never duplicated once.
- Collapsing the path prefix and date reduced 5,405 atoms to 2,682, exactly the number of distinct titles.

I had the exclusions declared and they were correct. They just never reached the caller doing the indexing, because that caller has no CLI in front of it.

### Why `--respect-gitignore` doesn't cover this (#1159 / #1483)

`#1483` asked for repo-local indexing exclusions and was answered with `--respect-gitignore` (`#1159`), enumerating via `git ls-files`. That's the right fix for the case it targets — a code repo where `vendor/`, `storage/` and `public/build/` are git-ignored and shouldn't be walked.

It doesn't reach this case, and the difference is not cosmetic: **the directories here are deliberately version-controlled.** They hold exported derivatives and raw intake that are kept in git on purpose — for review, for provenance, for reconstructing the brain from the repo. `git ls-files` includes them by definition.

The distinction needed is "tracked by git" vs "should be indexed", and today those are the same thing. This PR doesn't add a new concept for that — `exclude` already expresses it. It only lets the expression reach the callers that can't pass flags.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/sync.ts` to merge-base, ran `test/sync-exclude-config.test.ts` → 2 pass / 3 fail. Restored → all pass.

Produced by `bash scripts/check-test-discriminates.sh test/sync-exclude-config.test.ts src/commands/sync.ts`. The 2 that pass either way are deliberate baselines (everything indexed with no scope set; an empty scope never breaking a sync) — they exist so a passing exclusion assertion can't be an artifact of the file never reaching the repo.

## Tests

Added `test/sync-exclude-config.test.ts` (5 tests, PGLite + a real git repo, following `test/sync-working-tree.test.ts`):

1. baseline — with no config and no flag, everything in the tree is indexed
2. persisted `sync.exclude` is honored **with no flag passed**, on the incremental diff path (what runs in production)
3. a trailing slash covers the files inside, not just the directory entry
4. a per-call flag narrows further **without re-opening** the persisted scope
5. an empty/unreadable scope never breaks a sync

```
bun test test/sync-exclude-config.test.ts   → 5 pass / 0 fail
bun run typecheck                            → clean
bun run test                                 → 8223 pass / 0 fail (3 shards, 511 files)
bun run test:serial                          → exit 0
bun test test/sync-working-tree.test.ts test/sync-baseline-guard.test.ts \
         test/performfullsync-source-id.test.ts test/sync-all-missing-path.test.ts
                                             → 23 pass / 0 fail
bun test --max-concurrency=1 test/serve-sync-runner.serial.test.ts \
         test/config-db-plane.serial.test.ts test/config-set-unknown-flag.serial.test.ts \
         test/cycle/cycle-sync-uncommitted-warn.serial.test.ts
                                             → 28 pass / 0 fail
```

## Design notes for review

**Union, not flag-wins.** This is the one place it departs from the `sync.include_working_tree` fallback it otherwise mirrors. A persisted scope is a property of the repo ("this material is not indexable"), so an ad-hoc `--exclude tmp/` should narrow further, never silently re-open it — re-opening would reintroduce exactly the failure this closes. A boolean has no union; a pattern list does. Widening stays possible, but deliberate: edit the config.

**Directory prefixes normalize to subtree globs** (`raw/` → `raw/**`). Without the `**` the pattern matches the directory entry and none of the files inside it — the same gap in a different shape, and just as silent. Test 3 pins this.

**Scope of the key.** `sync.exclude` is global, matching `sync.include_working_tree`. A per-source column on `sources` would be the natural extension for multi-source installs; I left it out to keep the change small and would happily follow up if you'd prefer that shape instead.

**Not addressed here:** the derivative→source loop itself. `export` writing pages that `sync` re-ingests is arguably worth closing at the source — the exporter knows what it wrote, so a marker in the frontmatter could let sync upsert instead of duplicate, with no user configuration at all. That's a design decision rather than a bug fix, so I kept it out of this PR. Happy to open an issue if it's of interest.
