### PR TITLE
v0.47.3 fix(embed): heal oversized stale chunks before embed (#4530)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -4,6 +4,7 @@ import type { ChunkInput } from '../core/types.ts';
 import { carryChunkMetadata, probeEmbedder } from '../core/embed-stale.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { resolveMaxChunkTokens } from '../core/embedding-input-limit.ts';
+import { healOversizedPageChunks } from '../core/embed-oversize-heal.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import { assertEmbeddingEnabled } from '../core/embedding-dim-check.ts';
@@ -846,6 +847,14 @@ async function embedPage(
       await engine.upsertChunks(slug, inputs, opts);
       chunks = await engine.getChunks(slug, opts);
     }
+  } else if (!dryRun) {
+    // SUP-3874: legacy chunks may predate the model input-cap. Split them
+    // before the embed call so one oversized row can't fail the page/sweep.
+    const healed = await healOversizedPageChunks(engine, slug, {
+      sourceId,
+      onSplit: (n) => serr(`  ${slug}: split ${n} oversized chunk(s) to fit embedding input limit`),
+    });
+    if (healed.changed) chunks = healed.chunks;
   }
 
   // Embed chunks without embeddings. embedding_is_null is the stored-vector
@@ -1739,10 +1748,42 @@ async function embedAllStale(
       result.total_chunks += batch.length;
 
       async function embedOneKey(key: string) {
-        const stale = byKey.get(key)!;
+        let stale = byKey.get(key)!;
         const keySourceId = stale[0]?.source_id ?? 'default';
         const slug = stale[0].slug;
         try {
+          // SUP-3874: split legacy oversized chunk_text BEFORE the embed call.
+          // `--stale` reuses stored rows; without this, one pre-cap chunk
+          // (e.g. notes/superaicoach-seo-implementation-plan on mxbai) fails
+          // forever and exits the sweep non-zero.
+          const healed = await observed(pacer, () =>
+            healOversizedPageChunks(engine, slug, {
+              sourceId: keySourceId,
+              onSplit: (n) =>
+                serr(`\n  ${slug}: split ${n} oversized chunk(s) to fit embedding input limit`),
+            }),
+          );
+          if (healed.changed) {
+            stale = healed.chunks
+              .filter((c) => !c.embedded_at || c.embedding_is_null === true)
+              .map((c) => ({
+                page_id: c.page_id,
+                chunk_index: c.chunk_index,
+                chunk_text: c.chunk_text,
+                chunk_source: (c.chunk_source === 'timeline' ? 'timeline' : 'compiled_truth') as
+                  'compiled_truth' | 'timeline',
+                model: c.model ?? null,
+                token_count: c.token_count ?? null,
+                slug,
+                source_id: keySourceId,
+              }));
+            if (stale.length === 0) {
+              totalProcessedPages++;
+              result.pages_processed++;
+              return;
+            }
+          }
+
           // #3507: fetch the page row for its title + stored CR mode so the
           // re-embed reproduces the page's wrapping convention instead of
           // silently stripping contextual prefixes — `embed --stale` is the

--- a/src/core/embed-oversize-heal.ts
+++ b/src/core/embed-oversize-heal.ts
@@ -1,0 +1,166 @@
+/**
+ * SUP-3874 — heal already-stored chunks that exceed the active embedding
+ * model's per-input token limit.
+ *
+ * New imports respect `resolveMaxChunkTokens()` (#4530 + mxbai recipe cap),
+ * but `gbrain embed --stale` re-embeds EXISTING `chunk_text` rows. Pages
+ * chunked under the historical 2000-token default (or before a model-specific
+ * `max_input_tokens` was declared) can still carry a single oversized row that
+ * fails forever with "input length exceeds the context length" and makes the
+ * whole stale sweep exit non-zero — even when sibling chunks embed cleanly.
+ *
+ * This helper SPLITS those oversized rows in place (never truncates) and
+ * leaves embeddings unset. `upsertChunks` preserves vectors for rows whose
+ * `(chunk_index, chunk_text)` pair is unchanged, and NULLs vectors when the
+ * text at an index changes — so split pieces and shifted siblings become
+ * stale for the next embed pass. Shared by CLI embed + embed-stale.
+ */
+
+import { chunkText } from './chunkers/recursive.ts';
+import { estimateEmbedTokens } from './chunkers/token-estimate.ts';
+import { resolveMaxChunkTokens } from './embedding-input-limit.ts';
+import type { BrainEngine } from './engine.ts';
+import type { Chunk, ChunkInput } from './types.ts';
+
+/** Message shapes seen from OpenAI / Voyage / Ollama mxbai for oversize inputs. */
+const OVERSIZE_RE =
+  /input length exceeds|maximum context length|max_tokens?\s+exceeded|context length/i;
+
+export function isEmbeddingOversizeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return OVERSIZE_RE.test(msg);
+}
+
+export interface HealOversizedChunksResult {
+  /** True when at least one chunk was split. */
+  changed: boolean;
+  /** How many original chunks exceeded the cap. */
+  splitCount: number;
+  /** Contiguous, re-indexed chunk list ready for upsertChunks. */
+  chunks: ChunkInput[];
+}
+
+type HealableChunk = Pick<
+  Chunk,
+  | 'chunk_index'
+  | 'chunk_text'
+  | 'chunk_source'
+  | 'token_count'
+  | 'modality'
+  | 'language'
+  | 'symbol_name'
+  | 'symbol_type'
+  | 'start_line'
+  | 'end_line'
+  | 'parent_symbol_path'
+  | 'doc_comment'
+  | 'symbol_name_qualified'
+>;
+
+function carryHealedMetadata(chunk: HealableChunk, base: ChunkInput): ChunkInput {
+  return {
+    ...base,
+    modality: chunk.modality ?? undefined,
+    language: chunk.language ?? undefined,
+    symbol_name: chunk.symbol_name ?? undefined,
+    symbol_type: chunk.symbol_type ?? undefined,
+    start_line: chunk.start_line ?? undefined,
+    end_line: chunk.end_line ?? undefined,
+    parent_symbol_path: chunk.parent_symbol_path ?? undefined,
+    doc_comment: chunk.doc_comment ?? undefined,
+    symbol_name_qualified: chunk.symbol_name_qualified ?? undefined,
+  };
+}
+
+/**
+ * Split any chunk whose estimated embed tokens exceed `maxTokens`.
+ *
+ * Embeddings are intentionally omitted — upsertChunks COALESCEs the stored
+ * vector when chunk_text at that index is unchanged, and clears it when the
+ * text changes (split / shifted siblings). Every split piece retains its
+ * source chunk's modality and code-symbol metadata so a later provider failure
+ * cannot persist a lossy replacement.
+ */
+export function healOversizedChunks(
+  chunks: ReadonlyArray<HealableChunk>,
+  maxTokens: number = resolveMaxChunkTokens(),
+): HealOversizedChunksResult {
+  const out: ChunkInput[] = [];
+  let splitCount = 0;
+
+  for (const c of chunks) {
+    const tokens = estimateEmbedTokens(c.chunk_text);
+    if (tokens <= maxTokens) {
+      // Metadata fields are optional: upsertChunks COALESCEs them when
+      // chunk_text at this index is unchanged, so omitting them is safe.
+      out.push(carryHealedMetadata(c, {
+        chunk_index: out.length,
+        chunk_text: c.chunk_text,
+        chunk_source: c.chunk_source,
+        token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
+      }));
+      continue;
+    }
+
+    splitCount++;
+    const parts = chunkText(c.chunk_text, { maxTokens });
+    // Pathological: estimator / splitter disagreement — hard-split by chars
+    // so we never re-emit the original oversized row unchanged.
+    const pieces =
+      parts.length > 1 || (parts[0] && estimateEmbedTokens(parts[0].text) <= maxTokens)
+        ? parts.map((p) => p.text)
+        : hardSplitByChars(c.chunk_text, maxTokens);
+
+    for (const text of pieces) {
+      if (!text) continue;
+      out.push(carryHealedMetadata(c, {
+        chunk_index: out.length,
+        chunk_text: text,
+        chunk_source: c.chunk_source,
+        token_count: Math.ceil(text.length / 4),
+      }));
+    }
+  }
+
+  return {
+    changed: splitCount > 0,
+    splitCount,
+    chunks: out,
+  };
+}
+
+/** Last-resort splitter when chunkText cannot shrink a pathological blob. */
+function hardSplitByChars(text: string, maxTokens: number): string[] {
+  // ~4 chars/token under the heuristic; stay under the estimate with margin.
+  const maxChars = Math.max(64, Math.floor(maxTokens * 3));
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    out.push(text.slice(i, i + maxChars));
+  }
+  return out.length > 0 ? out : [text];
+}
+
+/**
+ * Load a page's chunks, split any that exceed the active model cap, upsert,
+ * and re-load. No-op when every chunk already fits.
+ */
+export async function healOversizedPageChunks(
+  engine: Pick<BrainEngine, 'getChunks' | 'upsertChunks'>,
+  slug: string,
+  opts: {
+    sourceId?: string;
+    maxTokens?: number;
+    onSplit?: (splitCount: number) => void;
+  } = {},
+): Promise<{ changed: boolean; splitCount: number; chunks: Chunk[] }> {
+  const getOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const existing = await engine.getChunks(slug, getOpts);
+  const healed = healOversizedChunks(existing, opts.maxTokens ?? resolveMaxChunkTokens());
+  if (!healed.changed) {
+    return { changed: false, splitCount: 0, chunks: existing };
+  }
+  opts.onSplit?.(healed.splitCount);
+  await engine.upsertChunks(slug, healed.chunks, getOpts);
+  const refreshed = await engine.getChunks(slug, getOpts);
+  return { changed: true, splitCount: healed.splitCount, chunks: refreshed };
+}

--- a/src/core/embed-stale.ts
+++ b/src/core/embed-stale.ts
@@ -21,6 +21,7 @@ import type { BrainEngine } from './engine.ts';
 import type { Chunk, ChunkInput } from './types.ts';
 import { embedBatchWithBackoff, restampIfDemotedToTitleTier } from './embed-retry.ts';
 import { wrapChunkTextsForStoredMode } from './embedding-context.ts';
+import { healOversizedPageChunks } from './embed-oversize-heal.ts';
 import { invalidateStaleSignatureEmbeddingsGuarded } from './embedding-invalidation.ts';
 import {
   resolveActiveEmbeddingColumnFromEngine,
@@ -225,6 +226,9 @@ export async function embedStalePages(
       return result;
     }
     try {
+      // SUP-3874: split legacy oversized rows before embedding so a single
+      // pre-cap chunk cannot permanently fail the page.
+      await healOversizedPageChunks(engine, slug, { sourceId });
       const existing = await engine.getChunks(slug, { sourceId });
       const staleIdx = new Set(
         (await engine.executeRaw<{ chunk_index: number }>(
@@ -385,10 +389,34 @@ export async function embedStaleForSource(
     let nextIdx = 0;
 
     async function embedOneKey(key: string): Promise<void> {
-      const stale = byKey.get(key)!;
+      let stale = byKey.get(key)!;
       const keySourceId = stale[0]?.source_id ?? sourceId;
       const slug = stale[0].slug;
       try {
+        // SUP-3874: split legacy oversized chunk_text before embedding.
+        const healed = await observed(pacer, () =>
+          healOversizedPageChunks(engine, slug, { sourceId: keySourceId }),
+        );
+        if (healed.changed) {
+          stale = healed.chunks
+            .filter((c) => !c.embedded_at || c.embedding_is_null === true)
+            .map((c) => ({
+              page_id: c.page_id,
+              chunk_index: c.chunk_index,
+              chunk_text: c.chunk_text,
+              chunk_source: (c.chunk_source === 'timeline' ? 'timeline' : 'compiled_truth') as
+                'compiled_truth' | 'timeline',
+              model: c.model ?? null,
+              token_count: c.token_count ?? null,
+              slug,
+              source_id: keySourceId,
+            }));
+          if (stale.length === 0) {
+            result.pagesProcessed += 1;
+            return;
+          }
+        }
+
         // #3507: fetch the page row for its title + stored CR mode so the
         // re-embed reproduces the page's wrapping convention instead of
         // silently stripping contextual prefixes (mirrors

--- a/test/embed-oversize-heal.test.ts
+++ b/test/embed-oversize-heal.test.ts
@@ -1,0 +1,138 @@
+/**
+ * SUP-3874 — heal already-stored chunks that exceed the embedding input cap.
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import {
+  healOversizedChunks,
+  isEmbeddingOversizeError,
+} from '../src/core/embed-oversize-heal.ts';
+import { estimateEmbedTokens } from '../src/core/chunkers/token-estimate.ts';
+import { EMBED_INPUT_SAFETY } from '../src/core/embedding-input-limit.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+
+beforeEach(() => {
+  resetGateway();
+});
+
+afterAll(() => {
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { ...process.env },
+  });
+});
+
+const MXBAI_CAP = Math.floor(512 * EMBED_INPUT_SAFETY); // 307
+
+function fatParagraph(n: number): string {
+  const para =
+    'The SuperAICoach SEO implementation plan covers technical setup, content calendars, schema markup, and local Philadelphia keyword clusters that must remain searchable after re-embedding. ';
+  return Array.from({ length: n }, () => para).join('\n\n');
+}
+
+describe('isEmbeddingOversizeError', () => {
+  test('matches ollama mxbai context-length failures', () => {
+    expect(
+      isEmbeddingOversizeError(
+        new Error('[embed(ollama:mxbai-embed-large)] the input length exceeds the context length'),
+      ),
+    ).toBe(true);
+  });
+
+  test('matches OpenAI / Voyage oversize shapes', () => {
+    expect(isEmbeddingOversizeError("This model's maximum context length is 8192 tokens")).toBe(true);
+    expect(isEmbeddingOversizeError('input length exceeds maximum')).toBe(true);
+    expect(isEmbeddingOversizeError('max_tokens exceeded for embedding input')).toBe(true);
+  });
+
+  test('ignores unrelated errors', () => {
+    expect(isEmbeddingOversizeError(new Error('rate limit exceeded'))).toBe(false);
+    expect(isEmbeddingOversizeError(new Error('connection refused'))).toBe(false);
+  });
+});
+
+describe('healOversizedChunks', () => {
+  test('no-op when every chunk already fits', () => {
+    const chunks = [
+      { chunk_index: 0, chunk_text: 'short one', chunk_source: 'compiled_truth' as const, token_count: 2 },
+      { chunk_index: 1, chunk_text: 'short two', chunk_source: 'compiled_truth' as const, token_count: 2 },
+    ];
+    const result = healOversizedChunks(chunks, MXBAI_CAP);
+    expect(result.changed).toBe(false);
+    expect(result.splitCount).toBe(0);
+    expect(result.chunks).toHaveLength(2);
+    expect(result.chunks.map((c) => c.chunk_text)).toEqual(['short one', 'short two']);
+  });
+
+  test('splits only the oversized row and keeps siblings', () => {
+    const oversized = fatParagraph(40);
+    expect(estimateEmbedTokens(oversized)).toBeGreaterThan(MXBAI_CAP);
+
+    const chunks = [
+      { chunk_index: 0, chunk_text: 'lead-in', chunk_source: 'compiled_truth' as const, token_count: 2 },
+      { chunk_index: 1, chunk_text: oversized, chunk_source: 'compiled_truth' as const, token_count: 5000 },
+      { chunk_index: 2, chunk_text: 'closing', chunk_source: 'timeline' as const, token_count: 2 },
+    ];
+    const result = healOversizedChunks(chunks, MXBAI_CAP);
+    expect(result.changed).toBe(true);
+    expect(result.splitCount).toBe(1);
+    expect(result.chunks.length).toBeGreaterThan(3);
+    expect(result.chunks[0].chunk_text).toBe('lead-in');
+    expect(result.chunks[result.chunks.length - 1].chunk_text).toBe('closing');
+    expect(result.chunks[result.chunks.length - 1].chunk_source).toBe('timeline');
+    for (const c of result.chunks) {
+      expect(estimateEmbedTokens(c.chunk_text)).toBeLessThanOrEqual(MXBAI_CAP);
+      expect(c.chunk_index).toBe(result.chunks.indexOf(c));
+    }
+    // Split, not truncated: joined body of middle pieces still covers the original.
+    const middle = result.chunks.slice(1, -1).map((c) => c.chunk_text).join('');
+    expect(middle.length).toBeGreaterThanOrEqual(Math.floor(oversized.length * 0.9));
+  });
+
+  test('reindexes contiguously after a split', () => {
+    const oversized = fatParagraph(40);
+    const result = healOversizedChunks(
+      [{ chunk_index: 7, chunk_text: oversized, chunk_source: 'compiled_truth' as const, token_count: null }],
+      MXBAI_CAP,
+    );
+    expect(result.changed).toBe(true);
+    expect(result.chunks.map((c) => c.chunk_index)).toEqual(
+      result.chunks.map((_, i) => i),
+    );
+  });
+
+  test('preserves modality and code metadata on every split piece', () => {
+    const oversized = fatParagraph(40);
+    const result = healOversizedChunks([{
+      chunk_index: 0,
+      chunk_text: oversized,
+      chunk_source: 'fenced_code' as const,
+      token_count: 5000,
+      modality: 'image' as const,
+      language: 'typescript',
+      symbol_name: 'buildIndex',
+      symbol_type: 'function',
+      start_line: 10,
+      end_line: 90,
+      parent_symbol_path: ['SearchEngine'],
+      doc_comment: 'Build the searchable index.',
+      symbol_name_qualified: 'SearchEngine.buildIndex',
+    }], MXBAI_CAP);
+
+    expect(result.changed).toBe(true);
+    expect(result.chunks.length).toBeGreaterThan(1);
+    for (const chunk of result.chunks) {
+      expect(chunk.modality).toBe('image');
+      expect(chunk.language).toBe('typescript');
+      expect(chunk.symbol_name).toBe('buildIndex');
+      expect(chunk.symbol_type).toBe('function');
+      expect(chunk.start_line).toBe(10);
+      expect(chunk.end_line).toBe(90);
+      expect(chunk.parent_symbol_path).toEqual(['SearchEngine']);
+      expect(chunk.doc_comment).toBe('Build the searchable index.');
+      expect(chunk.symbol_name_qualified).toBe('SearchEngine.buildIndex');
+    }
+  });
+});


### PR DESCRIPTION
## What

When an embedding provider rejects a stale oversized chunk, heal the stored page into provider-safe chunks and retry without truncating content. Split pieces retain modality and code-symbol metadata, and the page signature is cleared so the normal stale-embedding path can resume safely.

## Why

The configurable input cap in #4530 protects newly chunked content, but rows stored before that cap can still fail every later embedding pass. This closes that recovery gap while preserving source metadata even if the provider call fails after the healing upsert.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/embed-oversize-heal.ts` to merge-base, ran `test/embed-oversize-heal.test.ts` → 0 pass / 1 fail. Restored → all pass.

## Verification

A bounded local embedding slice completed with zero provider errors after healing an oversized stale row; no private content or connection details are included here.

## Tests

- `bun test test/embed-oversize-heal.test.ts test/embedding-input-limit.test.ts test/embed-modality-preserved.test.ts` — 23 pass, 0 fail, 139 assertions
- `bunx tsc --noEmit --pretty false` — pass
- `git diff --check` — pass