### PR TITLE
v0.47.3.1 fix(embed): honor backfill pricing overrides (#4571)

### DIFF
--- a/src/core/minions/handlers/embed-backfill.ts
+++ b/src/core/minions/handlers/embed-backfill.ts
@@ -18,10 +18,13 @@
  *     If a second job claims while the first is mid-loop, it returns
  *     `already_in_progress` cleanly and the lock is the source of truth.
  *
- *   - D6: BudgetTracker enforces per-job spend cap (default $10/job). Goes
- *     through `withBudgetTracker` so `gateway.embed()` auto-composes via
- *     AsyncLocalStorage. On `BudgetExhausted` throw, partial progress is
- *     preserved (chunks already embedded stay embedded; remaining stays NULL).
+ *   - D6: BudgetTracker enforces per-job spend cap (default $10/job). The
+ *     default cap is skipped when the configured embedding model has no
+ *     built-in or operator-declared price; an explicit numeric cap stays
+ *     fail-closed. Goes through `withBudgetTracker` so `gateway.embed()`
+ *     auto-composes via AsyncLocalStorage. On `BudgetExhausted` throw, partial
+ *     progress is preserved (chunks already embedded stay embedded; remaining
+ *     stays NULL).
  *
  *   - D15.1: parent-job linkage is INTENTIONALLY OMITTED. The submit-side
  *     helper does not pass `parent_job_id` — the queue's parent-child
@@ -32,8 +35,14 @@
  *     the next call free to claim.
  */
 import { tryAcquireDbLock } from '../../db-lock.ts';
-import { BudgetTracker, BudgetExhausted } from '../../budget/budget-tracker.ts';
-import { withBudgetTracker } from '../../ai/gateway.ts';
+import {
+  BudgetTracker,
+  BudgetExhausted,
+  isModelPriceable,
+  loadPricingOverrides,
+  type PricingOverrides,
+} from '../../budget/budget-tracker.ts';
+import { getEmbeddingModel, withBudgetTracker } from '../../ai/gateway.ts';
 import { embedStaleForSource } from '../../embed-stale.ts';
 import { currentEmbeddingSignature } from '../../embedding.ts';
 import { type DbPacer, createDbPacer, createNoopPacer } from '../../db-pacer.ts';
@@ -115,11 +124,52 @@ async function resolveBackfillPacer(
  * ledgered by the tracker either way — posture removes the ceiling, not the
  * accounting. `0`/garbage fall back to the $10 default.
  */
-async function readMaxUsd(engine: BrainEngine): Promise<number | undefined> {
+interface BackfillBudgetCap {
+  maxCostUsd: number | undefined;
+  defaulted: boolean;
+}
+
+function isExplicitFiniteUsdLimit(raw: unknown): boolean {
+  if (raw === null || raw === undefined) return false;
+  if (typeof raw === 'string' && raw.trim() === '') return false;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0;
+}
+
+async function readMaxUsd(engine: BrainEngine): Promise<BackfillBudgetCap> {
   const posture = await resolveSpendPosture(engine);
-  if (posture === 'tokenmax') return undefined;
+  if (posture === 'tokenmax') return { maxCostUsd: undefined, defaulted: false };
   const raw = await engine.getConfig('embed.backfill_max_usd');
-  return usdLimitToCap(parseUsdLimit(raw, DEFAULT_MAX_USD_PER_JOB));
+  const parsed = parseUsdLimit(raw, DEFAULT_MAX_USD_PER_JOB);
+  return {
+    maxCostUsd: usdLimitToCap(parsed),
+    defaulted: parsed === DEFAULT_MAX_USD_PER_JOB && !isExplicitFiniteUsdLimit(raw),
+  };
+}
+
+function currentBackfillEmbeddingModel(): string | null {
+  try {
+    return getEmbeddingModel();
+  } catch {
+    return null;
+  }
+}
+
+function capForModel(
+  cap: BackfillBudgetCap,
+  modelId: string | null,
+  pricingOverrides: PricingOverrides | undefined,
+): number | undefined {
+  if (cap.maxCostUsd === undefined) return undefined;
+  if (cap.defaulted && modelId && !isModelPriceable(modelId, 'embed', pricingOverrides)) {
+    console.error(
+      `[embed-backfill] model "${modelId}" is not in the pricing maps; ` +
+        `running without the default per-job cost gate. Add pricing.overrides ` +
+        `or set embed.backfill_max_usd to an explicit numeric cap to fail closed.`,
+    );
+    return undefined;
+  }
+  return cap.maxCostUsd;
 }
 
 /** Validate + extract typed job params. Throws on malformed input. */
@@ -168,10 +218,13 @@ export function makeEmbedBackfillHandler(
     // D6: budget-tracked execution. Gateway calls inside withBudgetTracker
     // auto-compose via AsyncLocalStorage; if pricing pushes cumulative spend
     // past the cap, gateway throws BudgetExhausted BEFORE the next API call.
-    const capUsd = await readMaxUsd(engine);
+    const pricingOverrides = await loadPricingOverrides(engine);
+    const cap = await readMaxUsd(engine);
+    const capUsd = capForModel(cap, currentBackfillEmbeddingModel(), pricingOverrides);
     const tracker = new BudgetTracker({
       maxCostUsd: capUsd,
       label: `embed-backfill:${sourceId}`,
+      pricingOverrides,
     });
 
     // paced-backfill: resolve env > config > bundle (env = incident escape

--- a/test/handlers-embed-backfill.test.ts
+++ b/test/handlers-embed-backfill.test.ts
@@ -20,6 +20,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { makeEmbedBackfillHandler } from '../src/core/minions/handlers/embed-backfill.ts';
 import { tryAcquireDbLock } from '../src/core/db-lock.ts';
 import type { MinionJobContext } from '../src/core/minions/types.ts';
+import { configureGateway, getCurrentBudgetTracker, resetGateway } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 
@@ -31,12 +32,17 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await engine.disconnect();
+  resetGateway();
 });
 
 beforeEach(async () => {
   // Clean minion_jobs + lock rows. Preserve config (schema version + flags).
   await engine.executeRaw('DELETE FROM minion_jobs');
   await engine.executeRaw(`DELETE FROM gbrain_cycle_locks WHERE id LIKE 'gbrain-embed-backfill:%'`);
+  await engine.unsetConfig('pricing.overrides');
+  await engine.unsetConfig('embed.backfill_max_usd');
+  await engine.unsetConfig('spend.posture');
+  resetGateway();
 });
 
 /** Build a minimal MinionJobContext for testing. */
@@ -199,5 +205,80 @@ describe('embed-backfill handler — #4283 honesty gates', () => {
       invalidated: 3,
       invalidationSkipped: 'embedder_probe_failed',
     });
+  });
+});
+
+describe('embed-backfill handler — #4571 unpriced embedding models', () => {
+  const drainBase = { pagesProcessed: 1, lastCursor: null, done: true, aborted: false, invalidated: 0 };
+
+  function configureUnpricedEmbeddingModel(): void {
+    configureGateway({ embedding_model: 'openai:bge-m3', embedding_dimensions: 1024, env: {} });
+  }
+
+  test('default per-job cap is dropped when the configured embedding model cannot be priced', async () => {
+    configureUnpricedEmbeddingModel();
+    const handler = makeEmbedBackfillHandler(engine, {
+      runStale: async () => {
+        const tracker = getCurrentBudgetTracker();
+        if (!tracker) throw new Error('missing BudgetTracker scope');
+        tracker.reserve({
+          modelId: 'openai:bge-m3',
+          estimatedInputTokens: 1_000_000,
+          maxOutputTokens: 0,
+          kind: 'embed',
+        });
+        tracker.record({ modelId: 'openai:bge-m3', inputTokens: 1_000_000, kind: 'embed' });
+        return { ...drainBase, embedded: 1, chunksProcessed: 1 };
+      },
+    });
+
+    const result = await handler(fakeJob({ sourceId: 'default' }));
+    expect(result.status).toBe('success');
+    expect(result.embedded).toBe(1);
+    expect(result.spentUsd).toBe(0);
+  });
+
+  test('pricing.overrides keeps the default cap enforceable for proxy embedding models', async () => {
+    configureUnpricedEmbeddingModel();
+    await engine.setConfig('pricing.overrides', '{"openai:bge-m3":0.5}');
+    const handler = makeEmbedBackfillHandler(engine, {
+      runStale: async () => {
+        const tracker = getCurrentBudgetTracker();
+        if (!tracker) throw new Error('missing BudgetTracker scope');
+        tracker.reserve({
+          modelId: 'openai:bge-m3',
+          estimatedInputTokens: 1_000_000,
+          maxOutputTokens: 0,
+          kind: 'embed',
+        });
+        tracker.record({ modelId: 'openai:bge-m3', inputTokens: 1_000_000, kind: 'embed' });
+        return { ...drainBase, embedded: 1, chunksProcessed: 1 };
+      },
+    });
+
+    const result = await handler(fakeJob({ sourceId: 'default' }));
+    expect(result.status).toBe('success');
+    expect(result.spentUsd).toBeCloseTo(0.5);
+  });
+
+  test('off switch still maps to an uncapped tracker for unpriced models', async () => {
+    configureUnpricedEmbeddingModel();
+    await engine.setConfig('embed.backfill_max_usd', 'off');
+    const handler = makeEmbedBackfillHandler(engine, {
+      runStale: async () => {
+        const tracker = getCurrentBudgetTracker();
+        if (!tracker) throw new Error('missing BudgetTracker scope');
+        tracker.reserve({
+          modelId: 'openai:bge-m3',
+          estimatedInputTokens: 1_000_000,
+          maxOutputTokens: 0,
+          kind: 'embed',
+        });
+        return { ...drainBase, embedded: 1, chunksProcessed: 1 };
+      },
+    });
+
+    const result = await handler(fakeJob({ sourceId: 'default' }));
+    expect(result.status).toBe('success');
   });
 });


### PR DESCRIPTION
## Summary

- Load `pricing.overrides` inside the `embed-backfill` minion handler and pass the parsed rates into its `BudgetTracker`.
- Keep the default per-job cap enforceable when an operator override prices a proxy/custom embedding model.
- Drop only the default cap for embedding models that remain unpriced, so queued backfill jobs can still make progress; explicit numeric caps remain fail-closed.

Fixes #4571.

## Tests

- **Red:** `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/handlers-embed-backfill.test.ts` failed the new default-cap and `pricing.overrides` cases with `budget_exhausted`.
- **Green:** `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/handlers-embed-backfill.test.ts` -> 15 pass, 0 fail.
- `bash scripts/gbrain-gate.sh <worktree> test/handlers-embed-backfill.test.ts` -> RESULT: GREEN.
- Gate verify: green.
- Gate unit: `test/handlers-embed-backfill.test.ts` -> 15 pass, 0 fail.
- Gate diff-selected E2E: `test/e2e/minions-concurrency.test.ts`, `test/e2e/minions-resilience.test.ts`, `test/e2e/minions-shell-pglite.test.ts`, `test/e2e/minions-shell.test.ts`, `test/e2e/worker-abort-recovery.test.ts` -> 9 pass, 16 skip, 0 fail.
