### PR TITLE
v0.47.4.0 fix(doctor): extract_health WARN message surfaces staleness per kind

### DIFF
--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -740,10 +740,24 @@ export async function computeExtractHealthCheck(
     const highHaltKinds = kinds.filter(k => k.halt_rate > 0.10);
 
     if (highHaltKinds.length > 0) {
+      // Each row's halt_count/round_completed_count are 7-day SUMS (the
+      // rollup table is one row per kind per day), so a kind whose most
+      // recent activity is near the edge of the 7-day window can show a
+      // high halt rate from entirely historical failures with nothing
+      // currently wrong — the operator has no way to tell "actively
+      // failing" from "hasn't run since a bug that's already fixed" without
+      // this. last_updated_at is already computed (MAX(updated_at) above)
+      // but wasn't surfaced in the message text, only in `details`.
       const top3 = [...highHaltKinds]
         .sort((a, b) => b.halt_rate - a.halt_rate)
         .slice(0, 3)
-        .map(k => `${k.kind}=${(k.halt_rate * 100).toFixed(1)}%`)
+        .map(k => {
+          const ageDays = k.last_updated_at
+            ? Math.floor((Date.now() - new Date(k.last_updated_at).getTime()) / 86_400_000)
+            : null;
+          const ageSuffix = ageDays === null ? '' : ageDays <= 0 ? ', today' : `, ${ageDays}d ago`;
+          return `${k.kind}=${(k.halt_rate * 100).toFixed(1)}%${ageSuffix}`;
+        })
         .join(', ');
       return {
         name,

--- a/test/doctor-extract-health.test.ts
+++ b/test/doctor-extract-health.test.ts
@@ -73,6 +73,35 @@ describe('computeExtractHealthCheck — WARN paths', () => {
     expect((check.details as any)?.kinds[0].halt_rate).toBe(0.5);
   });
 
+  test('a stale high-halt-rate kind (no activity in 6 days) shows its age in the message', async () => {
+    await clearRollup();
+    // day/updated_at 6 days ago, still inside the 7-day rolling window (day
+    // >= CURRENT_DATE - 7) — the historical halts still sum into the
+    // reported rate even though nothing has run since.
+    await engine.executeRaw(
+      `INSERT INTO extract_rollup_7d (kind, source_id, day, cost_usd, eval_pass_count, eval_fail_count, halt_count, round_completed_count, rollup_write_failures, updated_at)
+       VALUES ('atoms', 'chatgpt', CURRENT_DATE - 6, 5.00, 0, 0, 90, 5, 0, NOW() - INTERVAL '6 days')`,
+      [],
+    );
+    const check = await computeExtractHealthCheck(engine);
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('atoms');
+    expect(check.message).toContain('6d ago');
+  });
+
+  test("today's activity shows 'today', not '0d ago'", async () => {
+    await clearRollup();
+    await engine.executeRaw(
+      `INSERT INTO extract_rollup_7d (kind, source_id, day, cost_usd, eval_pass_count, eval_fail_count, halt_count, round_completed_count, rollup_write_failures, updated_at)
+       VALUES ('atoms', 'default', CURRENT_DATE, 5.00, 0, 0, 90, 5, 0, NOW())`,
+      [],
+    );
+    const check = await computeExtractHealthCheck(engine);
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('today');
+    expect(check.message).not.toContain('0d ago');
+  });
+
   test('multiple kinds with high halt rate: top-3 listed in message', async () => {
     await clearRollup();
     await engine.executeRaw(


### PR DESCRIPTION
## Problem

`extract_rollup_7d` is a 7-day rolling-window sum (one row per kind per day, per `WHERE day >= CURRENT_DATE - 7`). A kind whose most recent activity is near the edge of that window can show a high halt rate from entirely historical failures — the message gives no way to distinguish "actively failing right now" from "hasn't run since a bug that's already fixed."

`last_updated_at` (`MAX(updated_at)` per kind) is already computed and present in `details.kinds[]`, but the human-readable WARN message text never surfaces it.

## Fix

Adds a `Nd ago` / `today` suffix to each kind in the existing top-3 summary line (e.g. `atoms=85.2%, 6d ago`). Pure message-text formatting using data the query already returns — no new query, no threshold/status-logic change.

## Tests

Two new cases in `test/doctor-extract-health.test.ts`: a 6-day-stale row shows `6d ago`, a same-day row shows `today` (not `0d ago`). Full file: 10 pass / 0 fail.
