### PR TITLE
v0.47.4.0 fix(ci): wire sync-reconcile-postgres.test.ts into tier1 (#4568)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,7 +184,7 @@ jobs:
           # above already run this same workflow, plus live-key token
           # spenders (this job carries no provider keys, so they would
           # self-skip anyway — the list makes the spend guarantee explicit).
-          EXCLUDE='test/e2e/op-checkpoint-jsonb-parity.test.ts test/e2e/jsonb-roundtrip.test.ts test/e2e/mechanical.test.ts test/e2e/mcp.test.ts test/e2e/job-isolation.test.ts test/e2e/engine-parity.test.ts test/e2e/serve-http-multi-agent.test.ts test/e2e/postgres-bootstrap.test.ts test/e2e/sync-delegation-under-serve.serial.test.ts test/e2e/dream-synthesize-pglite.test.ts test/e2e/skills.test.ts test/e2e/zeroentropy-live.test.ts test/e2e/voyage-rerank-live.test.ts test/e2e/voyage-multimodal.test.ts'
+          EXCLUDE='test/e2e/op-checkpoint-jsonb-parity.test.ts test/e2e/jsonb-roundtrip.test.ts test/e2e/mechanical.test.ts test/e2e/mcp.test.ts test/e2e/job-isolation.test.ts test/e2e/sync-reconcile-postgres.test.ts test/e2e/engine-parity.test.ts test/e2e/serve-http-multi-agent.test.ts test/e2e/postgres-bootstrap.test.ts test/e2e/sync-delegation-under-serve.serial.test.ts test/e2e/dream-synthesize-pglite.test.ts test/e2e/skills.test.ts test/e2e/zeroentropy-live.test.ts test/e2e/voyage-rerank-live.test.ts test/e2e/voyage-multimodal.test.ts'
           : > /tmp/run.txt
           while IFS= read -r f; do
             [ -z "$f" ] && continue
@@ -235,7 +235,15 @@ jobs:
       - name: Run Tier 1 E2E tests
         # job-isolation rides tier1 deliberately: e2e.yml runs only explicitly
         # NAMED files (no glob) — an unwired e2e file is silent coverage loss.
-        run: bun test --timeout=60000 test/e2e/mechanical.test.ts test/e2e/mcp.test.ts test/e2e/job-isolation.test.ts
+        # sync-reconcile-postgres joins for the same reason: it only ran
+        # nightly via the coverage-full-e2e schedule-only glob, so a
+        # regression in the reconcile's real-Postgres array-parameter
+        # binding path could reach master with every PR lane green. It
+        # already uses the same setupDB/teardownDB TRUNCATE-reset pattern
+        # (test/e2e/helpers.ts) as the other DB-backed files on this line.
+        # Also added to the selected-e2e EXCLUDE list above so a PR
+        # touching sync.ts doesn't run it a second time there.
+        run: bun test --timeout=60000 test/e2e/mechanical.test.ts test/e2e/mcp.test.ts test/e2e/job-isolation.test.ts test/e2e/sync-reconcile-postgres.test.ts
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gbrain_test
           # #3485 preload guard: this job intentionally tests against a DB.


### PR DESCRIPTION
Fixes #4568.

## Context

I opened #4570 (and the tracking issue #4568) for this exact change stacked on #3583 (rename-sentinel operator exit). #4568 was closed with: "Folded the tier1 wiring ... directly into #3583's branch instead of tracking it separately ... Closing this and #4570 in favor of that" — i.e. the wiring commit (`19f98c326`) was expected to land as part of #3583 landing.

`test/e2e/sync-reconcile-postgres.test.ts` did land on master (via the wave-k community train, `77bb9d8c2`) — but checking current `.github/workflows/e2e.yml`, the tier1 named-file list still doesn't include it, so the specific wiring commit apparently didn't survive the wave's reimplementation even though the test file itself did. Re-filing standalone against current master since the closure's premise (that #3583 landing would carry the wiring too) didn't hold.

## What this does

`test/e2e/sync-reconcile-postgres.test.ts` only runs nightly via the `coverage-full-e2e` schedule-only glob — a regression in the reconcile's real-Postgres array-parameter binding path could reach master with every PR lane green.

Joins the existing "Run Tier 1 E2E tests" shared-process line (`mechanical.test.ts`, `mcp.test.ts`, `job-isolation.test.ts`) — it already uses the same `setupDB`/`teardownDB` TRUNCATE-reset pattern (`test/e2e/helpers.ts`) as the other DB-backed files there. Also added to the `selected-e2e` job's `EXCLUDE` list so a PR touching `sync.ts` doesn't run it a second time in that lane.

## Testing

Couldn't spin up a local Postgres container this session, so verification is indirect: the exact same test content passed 2/2 in the most recent nightly full-Postgres CI run (`gh run view 33158511370` → `=== sync-reconcile-postgres.test.ts === ... 2 pass`). `bun run verify`: 55/55 green. This PR's own tier1 CI run (which will execute this exact new command against a real Postgres service container) is the actual first-run confirmation.
