### PR TITLE
fix(think): wire embedQuestion into remaining runThink call sites

### DIFF
--- a/src/core/ops/search.ts
+++ b/src/core/ops/search.ts
@@ -577,6 +577,7 @@ const query: Operation = {
         if (thinkCfg === 'true' && ctx.remote === false) {
           try {
             const { runThink } = await import('../think/index.ts');
+            const { embedQuery } = await import('../embedding.ts');
             const thinkScope = thinkSourceScopeOpts(ctx);
             const t = await runThink(ctx.engine, {
               question: queryText,
@@ -584,6 +585,8 @@ const query: Operation = {
               until: typeof p.until === 'string' ? p.until : undefined,
               ...thinkScope,
               remote: false,
+              // #3734: activate takes' vector retrieval arm for CRAG think escalation.
+              embedQuestion: (q) => embedQuery(q),
             });
             crag.think = {
               answer: t.answer,

--- a/src/core/verbs.ts
+++ b/src/core/verbs.ts
@@ -253,6 +253,7 @@ const synthesize: Operation = {
     }
     const scope = sourceScopeOpts(ctx);
     const { runThink } = await import('./think/index.ts');
+    const { embedQuery } = await import('./embedding.ts');
     // Remote-safe delegation: save/take are NEVER offered through this verb,
     // for any caller — the verb is a pure read.
     const result = await runThink(ctx.engine, {
@@ -264,6 +265,8 @@ const synthesize: Operation = {
       ...(scope.sourceIds !== undefined ? { allowedSources: scope.sourceIds } : {}),
       // Fail-closed: only a context that explicitly says local gets local.
       remote: ctx.remote !== false,
+      // #3734: activate takes' vector retrieval arm for the synthesize verb.
+      embedQuestion: (q) => embedQuery(q),
     });
 
     // [c10] runThink degrades gracefully to a no-LLM stub RESULT; the protocol


### PR DESCRIPTION
## Summary

#3734 activated the takes vector-retrieval arm for `gbrain think` (CLI), `auto-think` (dream cycle), and the MCP `think` op by passing an `embedQuestion` callback into `runThink()`. Two more call sites reach the same `runThink()` and were left without it, so their `takes_vec` arm stays silently empty (RRF fuses over an all-empty stream rather than erroring — no visible symptom other than `Takes(vec): 0`):

- the `synthesize` memory verb (`src/core/verbs.ts`)
- the CRAG think escalation inside `search`/`recall` (`src/core/ops/search.ts`)

This applies the exact same fix already used at the other 3 sites: `embedQuestion: (q) => embedQuery(q)`.

Found via dogfooding — a personal-brain operator had "gbrain think takes/graph returns 0" open as a recurring todo, traced to this gap after the CLI-side fix landed but two call sites were missed.

## Test plan

- [x] `bun run typecheck` clean
- [x] Before/after test run proving the fix is live: `bun test test/memory-verbs-conformance.test.ts test/search/crag-query-op.test.ts` — before this change, the log never shows `[think] question embed failed`; after, it logs multiple times (the callback is invoked and fails gracefully with the expected message in the no-`OPENAI_API_KEY` test environment, exactly matching the already-wired CLI path's behavior)
- [x] 36/36 tests pass unchanged in both before/after states