### PR TITLE
fix(skillopt): BudgetExhausted misclassified as generic errored

### DIFF
--- a/src/core/skillopt/orchestrator.ts
+++ b/src/core/skillopt/orchestrator.ts
@@ -255,8 +255,9 @@ export async function runSkillOpt(opts: SkillOptOpts): Promise<RunSkillOptResult
  * catch-all string sniff it replaces (`msg.includes('BudgetExhausted') ||
  * msg.includes('budget_exhausted')`) could never match, because every
  * BudgetExhausted thrown by src/core/budget/budget-tracker.ts carries a
- * human-readable message ("projected cost $X exceeds --max-cost $Y", "N
- * exceeded --max-runtime Ns", ...) containing neither literal substring.
+ * human-readable message ("projected cost $X exceeds the configured cap
+ * $Y", "N exceeded --max-runtime Ns", ...) containing neither literal
+ * substring.
  * Every cost-cap / no-pricing / (unreachable from this tracker today,
  * since it's never constructed with maxRuntimeMs) runtime abort fell
  * through to the generic catch-all instead, misreporting outcome='errored'

--- a/src/core/skillopt/orchestrator.ts
+++ b/src/core/skillopt/orchestrator.ts
@@ -79,7 +79,7 @@
 
 import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
-import { BudgetTracker } from '../budget/budget-tracker.ts';
+import { BudgetExhausted, BudgetTracker } from '../budget/budget-tracker.ts';
 import { withBudgetTracker } from '../ai/gateway.ts';
 import { errorFor } from '../errors.ts';
 import { applyEditBatch, getWorkingTreeStatusForFile, splitFrontmatter } from './apply-edits.ts';
@@ -241,6 +241,56 @@ export async function runSkillOpt(opts: SkillOptOpts): Promise<RunSkillOptResult
   return await withSkilloptLock(engine, skillName, async () => {
     return runOptimizationLoop(opts, bench, split, bundledCtx, mutateDecision, heldOutTasks);
   });
+}
+
+/**
+ * Classifies a run-loop error into the abort taxonomy the receipt + audit
+ * trail surface. Pulled out of runOptimizationLoop's catch block so it's
+ * unit-testable without driving a full orchestrator run (engine, benchmark,
+ * lock, LLM calls) — the string-sniff bug this replaces went unexercised
+ * for exactly that reason: nothing could cheaply throw a real error deep
+ * inside the loop to catch it.
+ *
+ * `err instanceof BudgetExhausted` is the real classification signal — the
+ * catch-all string sniff it replaces (`msg.includes('BudgetExhausted') ||
+ * msg.includes('budget_exhausted')`) could never match, because every
+ * BudgetExhausted thrown by src/core/budget/budget-tracker.ts carries a
+ * human-readable message ("projected cost $X exceeds --max-cost $Y", "N
+ * exceeded --max-runtime Ns", ...) containing neither literal substring.
+ * Every cost-cap / no-pricing / (unreachable from this tracker today,
+ * since it's never constructed with maxRuntimeMs) runtime abort fell
+ * through to the generic catch-all instead, misreporting outcome='errored'
+ * / abortReason='error' on the receipt and audit trail.
+ */
+export function classifyAbortError(
+  err: unknown,
+  opts: { maxRuntimeMin: number },
+): {
+  outcome: 'aborted' | 'errored';
+  abortReason: 'budget_exhausted' | 'runtime_exceeded' | 'sigint' | 'error';
+  abortDetail: string;
+} {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (err instanceof BudgetExhausted) {
+    return {
+      outcome: 'aborted',
+      abortReason: err.reason === 'runtime' ? 'runtime_exceeded' : 'budget_exhausted',
+      abortDetail: msg,
+    };
+  } else if (msg.includes('skillopt_runtime_exceeded')) {
+    return {
+      outcome: 'aborted',
+      abortReason: 'runtime_exceeded',
+      abortDetail: `exceeded --max-runtime-min ${opts.maxRuntimeMin}`,
+    };
+  } else if (msg.includes('SIGINT')) {
+    return { outcome: 'aborted', abortReason: 'sigint', abortDetail: msg };
+  } else {
+    // #3516: truthful catch-all. Pre-fix this logged reason:'sigint' for
+    // EVERY unrecognized error (provider failures, no_pricing hard-fails),
+    // which made the audit trail lie about why the run died.
+    return { outcome: 'errored', abortReason: 'error', abortDetail: msg };
+  }
 }
 
 async function runOptimizationLoop(
@@ -692,27 +742,10 @@ async function runOptimizationLoop(
       }
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('BudgetExhausted') || msg.includes('budget_exhausted')) {
-      outcome = 'aborted';
-      abortReason = 'budget_exhausted';
-      abortDetail = msg;
-    } else if (msg.includes('skillopt_runtime_exceeded')) {
-      outcome = 'aborted';
-      abortReason = 'runtime_exceeded';
-      abortDetail = `exceeded --max-runtime-min ${opts.maxRuntimeMin}`;
-    } else if (msg.includes('SIGINT')) {
-      outcome = 'aborted';
-      abortReason = 'sigint';
-      abortDetail = msg;
-    } else {
-      // #3516: truthful catch-all. Pre-fix this logged reason:'sigint' for
-      // EVERY unrecognized error (provider failures, no_pricing hard-fails),
-      // which made the audit trail lie about why the run died.
-      outcome = 'errored';
-      abortReason = 'error';
-      abortDetail = msg;
-    }
+    const classified = classifyAbortError(err, opts);
+    outcome = classified.outcome;
+    abortReason = classified.abortReason;
+    abortDetail = classified.abortDetail;
     logEvent({
       kind: 'abort',
       run_id: runId,

--- a/test/skillopt/silent-abort-3516.test.ts
+++ b/test/skillopt/silent-abort-3516.test.ts
@@ -16,6 +16,11 @@
  *   - audit union: reason 'error' is a first-class abort reason (typed, no
  *     `as never`), so the catch-all no longer has to lie with 'sigint'.
  *   - RunReceipt carries abort_reason/abort_detail fields (type-level).
+ *   - classifyAbortError: a real (not string-faked) BudgetExhausted correctly
+ *     classifies as outcome='aborted'/abort_reason='budget_exhausted' — the
+ *     #3516-adjacent gap where the catch block's own string sniff could
+ *     never match any of budget-tracker.ts's actual throw messages, so every
+ *     cost-cap/no-pricing abort silently fell through to outcome='errored'.
  */
 
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
@@ -25,7 +30,9 @@ import * as path from 'node:path';
 import { withEnv } from '../helpers/with-env.ts';
 import { parseFlags } from '../../src/commands/skillopt.ts';
 import { estimateCost, formatPreflightReport, preflight } from '../../src/core/skillopt/preflight.ts';
-import { BudgetTracker, _resetBudgetTrackerWarningsForTest } from '../../src/core/budget/budget-tracker.ts';
+import { BudgetTracker, BudgetExhausted, _resetBudgetTrackerWarningsForTest } from '../../src/core/budget/budget-tracker.ts';
+import { BudgetExhausted as MinionsBudgetExhausted } from '../../src/core/minions/budget-tracker.ts';
+import { classifyAbortError } from '../../src/core/skillopt/orchestrator.ts';
 import {
   _resetAuditWriterForTests,
   currentAuditFilename,
@@ -185,5 +192,103 @@ describe('#3516 — RunReceipt carries abort_reason / abort_detail', () => {
     const parsed = JSON.parse(JSON.stringify(receipt));
     expect(parsed.abort_reason).toBe('error');
     expect(parsed.abort_detail).toBe('provider exploded: 500');
+  });
+});
+
+describe('classifyAbortError — real BudgetExhausted instances (not string-faked)', () => {
+  // Every message shape matches an ACTUAL throw site in budget-tracker.ts
+  // (reserve's cost-cap denial, reserve's no_pricing hard-fail, record's
+  // post-hoc cost overage) — none contain the literal substrings the old
+  // string sniff checked for, which is exactly why every real
+  // BudgetExhausted fell through to the generic catch-all pre-fix.
+  test('reason=cost classifies as aborted/budget_exhausted', () => {
+    const err = new BudgetExhausted(
+      'skillopt:widget: projected cost $1.5000 exceeds --max-cost $1.00 (cumulative $0.0000 + outstanding $0.0000 + this call $1.5000)',
+      { reason: 'cost', spent: 0, cap: 1.0, modelId: 'anthropic:claude-opus-4-7' },
+    );
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('aborted');
+    expect(r.abortReason).toBe('budget_exhausted');
+    expect(r.abortDetail).toBe(err.message);
+  });
+
+  test('reason=no_pricing classifies as aborted/budget_exhausted', () => {
+    const err = new BudgetExhausted('no pricing data available for openrouter:some-model', {
+      reason: 'no_pricing', spent: 0, cap: 1.0, modelId: 'openrouter:some-model',
+    });
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('aborted');
+    expect(r.abortReason).toBe('budget_exhausted');
+  });
+
+  test('reason=runtime classifies as aborted/runtime_exceeded (distinct from budget_exhausted)', () => {
+    // Not reachable from orchestrator.ts's own tracker today (constructed
+    // without maxRuntimeMs) — pinned anyway so the mapping stays correct if
+    // that ever changes, and so this reason isn't silently merged into
+    // budget_exhausted by a future edit.
+    const err = new BudgetExhausted('skillopt:widget: wall-clock 45.0s exceeded --max-runtime 30.0s', {
+      reason: 'runtime', spent: 45000, cap: 30000,
+    });
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('aborted');
+    expect(r.abortReason).toBe('runtime_exceeded');
+  });
+
+  test('a BudgetExhausted from the UNRELATED minions/budget-tracker.ts class is not misclassified as budget_exhausted', () => {
+    // Two distinct BudgetExhausted classes exist in this repo (core/budget,
+    // used here, and core/minions, a differently-shaped job-cost tracker
+    // with an unrelated (owner_id, balance_cents) constructor) — instanceof
+    // is nominal, not structural, so an instance of the wrong one must NOT
+    // satisfy this check. Guards against a future refactor importing the
+    // wrong one and silently reintroducing this exact bug class.
+    const wrongClassErr = new MinionsBudgetExhausted(42, 0);
+    const r = classifyAbortError(wrongClassErr, { maxRuntimeMin: 30 });
+    expect(r.abortReason).not.toBe('budget_exhausted');
+    expect(r.outcome).toBe('errored');
+  });
+
+  test('skillopt_runtime_exceeded (plain Error, the orchestrator wall-clock deadline) still classifies correctly', () => {
+    const err = new Error('skillopt_runtime_exceeded');
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('aborted');
+    expect(r.abortReason).toBe('runtime_exceeded');
+    expect(r.abortDetail).toBe('exceeded --max-runtime-min 30');
+  });
+
+  test('SIGINT (plain Error) still classifies correctly', () => {
+    const err = new Error('received SIGINT, aborting run');
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('aborted');
+    expect(r.abortReason).toBe('sigint');
+  });
+
+  test('an unrelated provider error still classifies as the truthful catch-all (#3516 behavior preserved)', () => {
+    const err = new Error('provider exploded: 500');
+    const r = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(r.outcome).toBe('errored');
+    expect(r.abortReason).toBe('error');
+    expect(r.abortDetail).toBe('provider exploded: 500');
+  });
+
+  test('negative control: replaying the exact pre-fix string-sniff against a real BudgetExhausted misclassifies it (proves this is a real regression, not a hypothetical)', () => {
+    function preFixClassify(err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('BudgetExhausted') || msg.includes('budget_exhausted')) {
+        return { outcome: 'aborted' as const, abortReason: 'budget_exhausted' as const };
+      } else if (msg.includes('skillopt_runtime_exceeded')) {
+        return { outcome: 'aborted' as const, abortReason: 'runtime_exceeded' as const };
+      } else if (msg.includes('SIGINT')) {
+        return { outcome: 'aborted' as const, abortReason: 'sigint' as const };
+      }
+      return { outcome: 'errored' as const, abortReason: 'error' as const };
+    }
+    const err = new BudgetExhausted('skillopt:widget: projected cost $1.5000 exceeds --max-cost $1.00', {
+      reason: 'cost', spent: 0, cap: 1.0,
+    });
+    const old = preFixClassify(err);
+    const fixed = classifyAbortError(err, { maxRuntimeMin: 30 });
+    expect(old.outcome).toBe('errored'); // the bug: pre-fix logic misses it
+    expect(fixed.outcome).toBe('aborted'); // this fix: correctly classified
+    expect(old).not.toEqual({ outcome: fixed.outcome, abortReason: fixed.abortReason });
   });
 });


### PR DESCRIPTION
## Problem

`skillopt`'s `runOptimizationLoop` catch block classifies aborted runs by string-sniffing the caught error's message:

```ts
if (msg.includes('BudgetExhausted') || msg.includes('budget_exhausted')) { ... }
```

Every actual `BudgetExhausted` thrown by `src/core/budget/budget-tracker.ts` (4 throw sites: `reserve()`'s cost-cap denial, `reserve()`'s `no_pricing` hard-fail, `record()`'s post-hoc cost overage, the runtime-cap check) carries a human-readable message like `"projected cost $1.50 exceeds --max-cost $1.00"` or `"wall-clock 30.0s exceeded --max-runtime 20.0s"` — none contain the literal substrings `'BudgetExhausted'` or `'budget_exhausted'`. `BudgetExhausted` itself is not even imported into `orchestrator.ts`.

Practical effect: every cost-cap and no-pricing abort falls through to the generic catch-all and gets `outcome='errored'`/`abort_reason='error'` on both the receipt and the audit trail, instead of `outcome='aborted'`/`abort_reason='budget_exhausted'` — a categorization bug (the message text itself is fine; only the machine-readable fields are wrong). This directly undermines #3516's own stated goal ("the audit trail no longer lies about why the run died") for the specific case it was arguably written to cover.

A dedicated test file (`test/skillopt/silent-abort-3516.test.ts`) exists for the surrounding #3516 work but only unit-tests `parseFlags`/`preflight`/`BudgetTracker.reserve()`/type shapes — it never drives the catch block itself, so this misclassification went unexercised.

## Fix

Imports `BudgetExhausted` alongside the already-imported `BudgetTracker` and classifies via `err instanceof BudgetExhausted` instead of the string sniff. `BudgetExhausted.reason` (`'cost' | 'runtime' | 'no_pricing'`) maps to `abort_reason`: `'runtime'` → `'runtime_exceeded'` (this repo's existing separate wall-clock-deadline mechanism already uses that reason), everything else → `'budget_exhausted'`. Note `orchestrator.ts`'s own `BudgetTracker` instance is never constructed with `maxRuntimeMs`, so `reason: 'runtime'` isn't reachable from it today — the mapping is there so it stays correct if that ever changes, rather than silently merging into `budget_exhausted`.

The classification logic (previously inline in the catch block) is extracted into an exported pure function, `classifyAbortError(err, opts)`. This is the change that also fixes the *un-exercised* half of the bug: `runOptimizationLoop` itself needs a full engine + benchmark + per-skill lock + LLM calls to invoke at all, so nothing could cheaply throw a real error deep inside it to test the catch block directly. Pulling the classification into its own function makes it testable with a real `new BudgetExhausted(...)` instance and zero orchestration machinery.

Two `BudgetExhausted` classes exist in this repo (`src/core/budget/budget-tracker.ts`, used here — and an unrelated `src/core/minions/budget-tracker.ts` job-cost tracker with a different `(owner_id, balance_cents)` constructor). `instanceof` is nominal, so importing the wrong one would silently reintroduce this exact bug; a test pins that a minions-side instance is *not* misclassified.

## Tests

8 new tests appended to `test/skillopt/silent-abort-3516.test.ts` (matching Codex's earlier explicit request during review: cover the recognized reasons plus a negative control, not every expensive orchestrator path):

- Real `BudgetExhausted` with `reason: 'cost'` and `reason: 'no_pricing'` → `aborted`/`budget_exhausted` (the two reasons actually reachable from this file's tracker).
- Real `BudgetExhausted` with `reason: 'runtime'` → `aborted`/`runtime_exceeded`, pinned distinct from `budget_exhausted` even though currently unreachable.
- A `BudgetExhausted` instance from the unrelated minions class is *not* classified as `budget_exhausted`.
- The pre-existing `skillopt_runtime_exceeded`, `SIGINT`, and generic-error branches are unchanged (regression coverage for #3516's own behavior).
- A negative control: replaying the exact pre-fix string-sniff logic against a real `BudgetExhausted` reproduces the bug (`outcome: 'errored'`) side-by-side with the fix (`outcome: 'aborted'`) in the same assertion, so the test suite itself proves this was a real, reachable regression rather than a hypothetical.

## Testing

`bun test test/skillopt/silent-abort-3516.test.ts`: 20/20 pass. `bun test test/skillopt/`: 254/254 pass (no regressions across the directory). `bun run typecheck`: clean. `bash scripts/check-module-size.sh`: clean. Full `bash scripts/run-verify-parallel.sh`: 55/55 checks green.
