### PR TITLE
fix(files): upload-raw rejects a filename resolving to '.' or '..'

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -140,7 +140,7 @@ test/facts-backstop-remedy-verb.test.ts	facts backstop thin-client-fallback reme
 test/features.test.ts	CLI routing	2	bun-file
 test/fence-extraction.test.ts	Layer 8 D2 — markdown fence extraction	18	readFileSync
 test/files.test.ts	collectFiles (production import)	9	readFileSync
-test/files.test.ts	files upload-raw git-storage branch (#2297)	3	readFileSync
+test/files.test.ts	files upload-raw git-storage branch (#2297)	5	readFileSync
 test/files.test.ts	files verify git lane (per-source root resolution)	1	readFileSync
 test/files.test.ts	storage precondition — the silent-no-op class (#4022)	3	readFileSync
 test/filing-rules-resolution.serial.test.ts	per-source filing-rules resolution	3	readFileSync

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -244,6 +244,18 @@ async function uploadRaw(engine: BrainEngine, args: string[]) {
 
   const stat = statSync(filePath);
   const filename = basename(filePath);
+  // A file argument like `.` or `..` (or a path resolving to one, e.g. the
+  // last path segment being empty) makes basename() return `.`/`..` itself
+  // rather than a real leaf filename. The git-storage branch below joins
+  // this value onto its sidecar dest dir (`destDir/${filename}`) — a `..`
+  // segment there walks the join back up OUT of the intended `.raw/<page>/`
+  // dir before the copy. Reject early with a clear error instead of letting
+  // it silently resolve to the parent dir and fail deep inside copyFileSync
+  // with an opaque EISDIR.
+  if (filename === '.' || filename === '..') {
+    console.error(`files upload-raw: "${filePath}" does not name a real file (resolves to "${filename}").`);
+    process.exit(1);
+  }
   const mimeType = getMimeType(filePath);
   const isMedia = mimeType?.startsWith('video/') || mimeType?.startsWith('audio/') || mimeType?.startsWith('image/');
   const needsCloud = stat.size >= SIZE_THRESHOLD || isMedia;

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -244,14 +244,17 @@ async function uploadRaw(engine: BrainEngine, args: string[]) {
 
   const stat = statSync(filePath);
   const filename = basename(filePath);
-  // A file argument like `.` or `..` (or a path resolving to one, e.g. the
-  // last path segment being empty) makes basename() return `.`/`..` itself
-  // rather than a real leaf filename. The git-storage branch below joins
-  // this value onto its sidecar dest dir (`destDir/${filename}`) — a `..`
-  // segment there walks the join back up OUT of the intended `.raw/<page>/`
-  // dir before the copy. Reject early with a clear error instead of letting
-  // it silently resolve to the parent dir and fail deep inside copyFileSync
-  // with an opaque EISDIR.
+  // A file argument that IS `.` or `..` makes basename() return that
+  // literal string back rather than a real leaf filename (a trailing
+  // separator, e.g. `foo/`, is stripped by basename() to `foo` — not
+  // affected). The git-storage branch below joins this value onto its
+  // sidecar dest dir (`destDir/${filename}`) — a `..` segment there walks
+  // the join back up OUT of the intended `.raw/<page>/` dir before the
+  // copy. Reject early with a clear error instead of letting it silently
+  // resolve to the parent dir and fail deep inside copyFileSync with a
+  // confusing OS-level error (observed on macOS: `ENOTSUP: operation not
+  // supported on socket, copyfile ...` — the target is a directory, not a
+  // normal file).
   if (filename === '.' || filename === '..') {
     console.error(`files upload-raw: "${filePath}" does not name a real file (resolves to "${filename}").`);
     process.exit(1);

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -383,7 +383,7 @@ describe('files upload-raw git-storage branch (#2297)', () => {
       cap.restore();
       exitSpy.mockRestore();
     }
-    expect(cap.errs.join('\n')).toContain('does not name a real file');
+    expect(cap.errs.join('\n')).toContain('resolves to "."');
   });
 
   test('file argument resolving to ".." exits 1 with a clear error, not a filesystem crash', async () => {
@@ -401,7 +401,7 @@ describe('files upload-raw git-storage branch (#2297)', () => {
       cap.restore();
       exitSpy.mockRestore();
     }
-    expect(cap.errs.join('\n')).toContain('does not name a real file');
+    expect(cap.errs.join('\n')).toContain('resolves to ".."');
   });
 });
 

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -362,6 +362,47 @@ describe('files upload-raw git-storage branch (#2297)', () => {
     }
     expect(cap.errs.join('\n')).toContain('--page');
   });
+
+  // A file argument whose basename() is exactly '.' or '..' (rather than a
+  // real leaf filename) would otherwise join onto the sidecar dest dir
+  // (`destDir/${filename}`) and walk the join back OUT of the intended
+  // `.raw/<page-name>/` dir before the copy — reject it early with a clear
+  // error instead of an opaque failure deep inside copyFileSync.
+  test('file argument resolving to "." exits 1 with a clear error, not a filesystem crash', async () => {
+    await engine.setConfig('sync.repo_path', repo);
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+    const cap = captureLogs();
+    try {
+      await runFiles(engine, ['upload-raw', '.', '--page', 'notes/small-doc']);
+      throw new Error('expected exit 1');
+    } catch (e) {
+      expect((e as Error).message).toBe('EXIT:1');
+    } finally {
+      cap.restore();
+      exitSpy.mockRestore();
+    }
+    expect(cap.errs.join('\n')).toContain('does not name a real file');
+  });
+
+  test('file argument resolving to ".." exits 1 with a clear error, not a filesystem crash', async () => {
+    await engine.setConfig('sync.repo_path', repo);
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+    const cap = captureLogs();
+    try {
+      await runFiles(engine, ['upload-raw', '..', '--page', 'notes/small-doc']);
+      throw new Error('expected exit 1');
+    } catch (e) {
+      expect((e as Error).message).toBe('EXIT:1');
+    } finally {
+      cap.restore();
+      exitSpy.mockRestore();
+    }
+    expect(cap.errs.join('\n')).toContain('does not name a real file');
+  });
 });
 
 // ---- verify git lane resolves each row via its OWNING source's local_path ----


### PR DESCRIPTION
## Problem

`gbrain files upload-raw <file> --page <slug>`'s small-file (git-storage) branch computes the sidecar destination as:

```ts
const filename = basename(filePath);
// ...
const dest = join(destDir, filename);
```

`basename()` strips directory separators from a normal filename, but if the *entire* `filePath` argument resolves to `.` or `..`, `basename()` returns that literal string back — not a real leaf filename. `join(destDir, '..')` then walks the join back out of the intended `.raw/<page-name>/` sidecar directory before the copy.

Live-verified: `gbrain files upload-raw .. --page notes/small-doc` reaches `copyFileSync('..', '<repo>/notes/.raw')` and crashes with an opaque OS-level error (`ENOTSUP: operation not supported on socket, copyfile '..' -> '.../notes/.raw'` on macOS) instead of a controlled validation error — `dest` resolves to `.raw` itself (a directory that was just created), which is why the copy fails rather than silently overwriting an arbitrary file: the join always lands exactly one level above the just-created page-specific sidecar dir, not on unrelated content elsewhere in the repo.

Narrow attack surface: `upload-raw` is explicitly a trusted-local CLI lane (`runFiles` is wired only from `cli.ts` with `remote: false`; the MCP `file_upload` op is a separate `localOnly` handler per the existing `nosemgrep` comments in this function), so this requires the operator to pass a crafted own file argument — not remote/untrusted input. This is a correctness/hardening fix, not a live overwrite vulnerability.

## Fix

Rejects `filename === '.' || filename === '..'` right after computing `basename(filePath)`, before either the cloud or git-storage branch runs, with a clear error naming the resolved value instead of letting it silently escape the sidecar dir and crash deep inside `copyFileSync` with a confusing OS error.

## Tests

2 new tests in the existing `files upload-raw git-storage branch (#2297)` describe block in `test/files.test.ts`, following that block's established `spyOn(process, 'exit')` pattern: `upload-raw .` and `upload-raw ..` both exit 1 with an error naming the problem, instead of throwing an uncaught filesystem error. Verified as a real regression, not a hypothetical: replaying against pristine `master` reproduces the exact `ENOTSUP ... copyfile '..' -> '.../notes/.raw'` crash quoted above.

Also regenerates `scripts/structural-suites.tsv` (`bun scripts/classify-tests.ts`) — required after the new test cases change that file's test-suite shape, per `check:structural-manifest`.

## Testing

`bun test test/files.test.ts`: 38/38 pass. `bun run typecheck`: clean. `bash scripts/check-module-size.sh`: clean. Full `bash scripts/run-verify-parallel.sh`: 55/55 checks green.
