### PR TITLE
fix: recompute content_hash when timeline write-through mutates a page

### DIFF
--- a/src/core/timeline-write-through.ts
+++ b/src/core/timeline-write-through.ts
@@ -49,6 +49,7 @@ import { basename, dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { BrainEngine } from './engine.ts';
 import { sanitizeForJsonb } from './batch-rows.ts';
+import { contentHash } from './utils.ts';
 import {
   isWriteThroughDisabled,
   resolvePageWriteTarget,
@@ -404,10 +405,17 @@ export async function writeTimelineEntryThrough(
         const newTimeline = sanitizeForJsonb(
           spliceTimelineBlock(page.timeline ?? '', entry.date, rendered.block),
         );
+        // Invariant (#3694/#4654 — content_hash must always equal
+        // contentHash(current semantic columns)): timeline is in the hash
+        // shape, so mutating it MUST recompute the hash in the same write.
+        // Compute over the already-fetched page with the new timeline spliced
+        // in; page.tags is undefined on the DB row so contentHash falls back
+        // to frontmatter.tags, matching the importer's spelling.
+        const newHash = contentHash({ ...page, timeline: newTimeline });
         await engine.executeRaw(
-          `UPDATE pages SET timeline = $1, updated_at = now()
-            WHERE slug = $2 AND source_id = $3 AND deleted_at IS NULL`,
-          [newTimeline, slug, sourceId],
+          `UPDATE pages SET timeline = $1, content_hash = $2, updated_at = now()
+            WHERE slug = $3 AND source_id = $4 AND deleted_at IS NULL`,
+          [newTimeline, newHash, slug, sourceId],
         );
 
         // Store the tuple the FS extractor recovers from the bullet just

--- a/test/timeline-write-through.test.ts
+++ b/test/timeline-write-through.test.ts
@@ -22,6 +22,7 @@ import { resetGateway } from '../src/core/ai/gateway.ts';
 import { operations } from '../src/core/operations.ts';
 import type { Operation, OperationContext } from '../src/core/operations.ts';
 import { importFromContent } from '../src/core/import-file.ts';
+import { contentHash } from '../src/core/utils.ts';
 import { writePageThrough, _resetWriteThroughCacheForTest } from '../src/core/write-through.ts';
 import {
   renderTimelineEntry,
@@ -126,6 +127,32 @@ describe('add_timeline_entry on an FS-canonical brain (#1856)', () => {
     // The page row's timeline text gained the bullet (`gbrain get` shows it).
     const page = await engine.getPage(slug, { sourceId: 'default' });
     expect(page?.timeline ?? '').toContain('Manual milestone added via timeline-add');
+  });
+
+  test('#4654 invariant: writing a timeline entry recomputes content_hash', async () => {
+    // timeline is part of the contentHash shape. Pre-fix, the write-through's
+    // `UPDATE pages SET timeline = ...` left content_hash stale, drifting the
+    // identity domain (the 43.6% validate:false class). The stored hash must
+    // ALWAYS equal contentHash(current semantic columns) after the write.
+    await engine.setConfig('sync.repo_path', brainDir);
+    const slug = 'notes/hash-invariant-example';
+    await seedPage(slug);
+
+    // Baseline: a fresh import hashes to its own content.
+    const before = await engine.getPage(slug, { sourceId: 'default' });
+    expect(before?.content_hash).toBe(contentHash({ ...before!, timeline: before!.timeline ?? '' }));
+
+    await addTimelineEntryOp.handler(makeCtx(), {
+      slug,
+      date: '2026-07-15',
+      summary: 'Must not drift the content hash',
+      source: 'meetings/2026-07-15',
+    });
+
+    const after = await engine.getPage(slug, { sourceId: 'default' });
+    expect(after?.timeline ?? '').toContain('Must not drift the content hash');
+    // THE invariant: the stored hash recomputes over the MUTATED page.
+    expect(after?.content_hash).toBe(contentHash({ ...after!, timeline: after!.timeline ?? '' }));
   });
 
   test('FS→DB rebuild recovers the entry from the file (the P0 loss mode)', async () => {


### PR DESCRIPTION
# fix: recompute `content_hash` when timeline write-through mutates a page

## Problem

`pages.content_hash` is defined (in `src/core/utils.ts`) as the invariant
`sha256(JSON.stringify({title, type, compiled_truth, timeline||'', frontmatter*
, tags}))` — it must ALWAYS equal `contentHash(current semantic columns)`. It is
the identity key for import idempotency, cross-slug dedup, and query-cache
invalidation.

`timeline` is part of that hash shape. But `writeTimelineEntryThrough`
(`src/core/timeline-write-through.ts`) ran:

```sql
UPDATE pages SET timeline = $1, updated_at = now()
WHERE slug = $2 AND source_id = $3 AND deleted_at IS NULL
```

…leaving `content_hash` stale after every timeline write. On FS-canonical brains
(where the timeline write-through is the active path), adding a timeline entry
drifted the identity domain — the same class of post-write drift as the operator
`validate:false` key (43.6% of one large deployment's pages), which required a
one-off DB repair to refresh 6,577 hashes. A code invariant should prevent gbrain's
OWN writers from creating drift; it should not need a repair.

## Fix

Recompute `content_hash` in the same `UPDATE` as the timeline mutation, over the
already-fetched page with the new timeline spliced in:

- `page` is already fetched (`engine.getPage`) earlier in the function, so the
  hash is computed from current columns + the spliced timeline — no extra query.
- `page.tags` is `undefined` on the DB row, so `contentHash` falls back to
  `frontmatter.tags`, matching the importer's spelling (this is exactly the
  `page.tags ?? frontmatter.tags` parity #3694 established).
- Same-write recompute keeps it atomic with the mutation; the page never holds a
  hash that disagrees with its columns.

## Test

Adds `#4654 invariant: writing a timeline entry recomputes content_hash` to
`test/timeline-write-through.test.ts`:

- seeds a page, asserts a fresh import hashes to its own content;
- writes a timeline entry through the op;
- asserts the stored `content_hash` equals `contentHash(current semantic columns)`
  of the MUTATED page.

Verified RED→GREEN on this branch:
- pre-fix source: only this test fails (23 pass / 1 fail)
- post-fix: 24 pass / 0 fail

## Scope note

This makes gbrain's OWN writers drift-free. It does not (and cannot) prevent a
caller from mutating columns via direct SQL outside gbrain — that remains an
operator responsibility. Other non-hashed columns (slug, embedding_signature,
links_extracted_at, last_retrieved_at, deleted_at, effective_date) are correctly
excluded from the hash and untouched here.

## Verification

Scratch Postgres 16 verification against a full `pg_dump` restore of a live brain
(15,070 pages, pre-repair state with 59% historical drift):

- `gbrain sync` of a fresh git source (seed-bank, 68 md): **100% parity, 0 drift**
  on the freshly-imported pages.
- `add_timeline_entry` on a synced page (the write-through path fixed here):
  hash recomputed, **invariant holds after the write**.
- `put_page` adding a post-hash frontmatter key (`validate:false`): hash
  recomputed, **invariant holds**.
- `bunx tsc --noEmit`: clean.
