### PR TITLE
feat(content-sanity): disable individual junk patterns without the kill-switch

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -258,6 +258,12 @@ export function lintContent(content: string, filePath: string, opts: LintContent
       prose_check_enabled: cs.prose_check_enabled,
       page_kind: parsed.type,
       extra_literals: operator_literals,
+      // Same resolution as import: lint and import disagreeing about which
+      // patterns are live would make lint report a page as junk that import
+      // is configured to let through.
+      disabled_patterns: Array.isArray(cs.disabled_patterns)
+        ? (cs.disabled_patterns as string[])
+        : undefined,
     });
     // Rule: huge-page fires for both oversize_warn (over warn threshold)
     // AND oversize_block (over block threshold). Operator sees the same

--- a/src/core/content-sanity.ts
+++ b/src/core/content-sanity.ts
@@ -357,6 +357,25 @@ export function assessContentSanity(opts: {
    *  `~/.gbrain/junk-substrings.txt` via `src/core/content-sanity-literals.ts`.
    *  Empty array (default) means built-ins only. */
   extra_literals?: ReadonlyArray<OperatorLiteral>;
+  /** Built-in junk patterns to skip, by `name`. Resolved by the caller from
+   *  `content_sanity.disabled_patterns`.
+   *
+   *  Why one pattern rather than the kill-switch: the patterns are aimed at
+   *  scraped web content, and a brain built from mail, chat or transcripts
+   *  holds none of it — but it does hold people *writing about* the things
+   *  the patterns name. `access_denied` is `/^\s*access denied\b/im`, so a
+   *  page that quotes "Access Denied when I open the staging dashboard" at the start of
+   *  a line is hidden from search, and the comment on the error-title pattern
+   *  already anticipates the shape ("a thoughtful page ABOUT 404 errors won't
+   *  trip") — it is the line-anchored body match that reaches further than
+   *  the title one. Today the only escape is `content_sanity.disabled: true`,
+   *  which also turns off the size gates; those are load-bearing (they are
+   *  what catches a page past `bytes_block` before it silently stops being
+   *  searchable), so an operator who needs one pattern off has to give up
+   *  the rest. Unknown names are ignored rather than rejected: the built-in
+   *  set changes between releases and a config that names a retired pattern
+   *  should not fail an import. */
+  disabled_patterns?: ReadonlyArray<string>;
 }): ContentSanityResult {
   const bytes_warn = opts.bytes_warn ?? DEFAULT_BYTES_WARN;
   const bytes_block = opts.bytes_block ?? DEFAULT_BYTES_BLOCK;
@@ -382,8 +401,10 @@ export function assessContentSanity(opts: {
   const title = String(opts.title ?? '');
   const titleLower = title.toLowerCase();
 
+  const disabledPatterns = new Set(opts.disabled_patterns ?? []);
   const junk_pattern_matches: string[] = [];
   for (const p of BUILT_IN_JUNK_PATTERNS) {
+    if (disabledPatterns.has(p.name)) continue;
     const scope = p.applies_to ?? 'both';
     let matched = false;
     if (scope === 'title' || scope === 'both') {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -510,6 +510,12 @@ export async function importFromContent(
       prose_check_enabled: cs.prose_check_enabled,
       page_kind: parsed.type,
       extra_literals,
+      // `content_sanity.disabled_patterns`: turn off individual built-in
+      // junk patterns without reaching for the kill-switch, which would also
+      // disable the size gates.
+      disabled_patterns: Array.isArray(cs.disabled_patterns)
+        ? (cs.disabled_patterns as string[])
+        : undefined,
     });
 
     if (sanityDisabled) {

--- a/test/content-sanity.test.ts
+++ b/test/content-sanity.test.ts
@@ -665,3 +665,67 @@ describe('issue #1939 — non-string title defensive coercion', () => {
     expect(typeof r.shouldQuarantine).toBe('boolean');
   });
 });
+
+// ─── DISABLED PATTERNS ────────────────────────────────────────
+
+describe('assessContentSanity — content_sanity.disabled_patterns', () => {
+  // The built-in patterns target scraped web content. A brain built from
+  // mail, chat or transcripts holds none of that, but does hold people
+  // writing ABOUT the things the patterns name — and `access_denied` is a
+  // line-anchored body match, so a page whose body has a line starting
+  // "Access Denied …" is hidden from search even when the page is a
+  // discussion of that error rather than an instance of it. Before this
+  // option the only escape was `content_sanity.disabled`, which also turns
+  // off the size gates.
+  const page = {
+    compiled_truth: 'Could we get access to the staging environment?\nAccess Denied when I open the staging dashboard.\n',
+    timeline: '',
+    title: 'Re: staging access',
+  };
+
+  test('the pattern trips by default', () => {
+    const r = assessContentSanity(page);
+    expect(r.junk_pattern_matches).toContain('access_denied');
+    expect(r.shouldQuarantine).toBe(true);
+  });
+
+  test('naming it in disabled_patterns lets the page through', () => {
+    const r = assessContentSanity({ ...page, disabled_patterns: ['access_denied'] });
+    expect(r.junk_pattern_matches).not.toContain('access_denied');
+    expect(r.shouldQuarantine).toBe(false);
+  });
+
+  test('disabling one pattern leaves the others live', () => {
+    const captcha = {
+      compiled_truth: 'Please complete the security check to continue.',
+      timeline: '',
+      title: 'Verify you are human',
+    };
+    const r = assessContentSanity({ ...captcha, disabled_patterns: ['access_denied'] });
+    expect(r.junk_pattern_matches.length).toBeGreaterThan(0);
+  });
+
+  test('the size gates are untouched — this is not the kill-switch', () => {
+    const r = assessContentSanity({
+      compiled_truth: 'x'.repeat(DEFAULT_BYTES_BLOCK + 1),
+      timeline: '',
+      title: 'big',
+      disabled_patterns: ['access_denied'],
+    });
+    expect(r.oversize).toBe(true);
+    expect(r.shouldSkipEmbed).toBe(true);
+  });
+
+  test('an unknown name is ignored, not rejected', () => {
+    // The built-in set changes between releases; a config naming a pattern
+    // that has since been retired must not fail an import.
+    const r = assessContentSanity({ ...page, disabled_patterns: ['no_such_pattern'] });
+    expect(r.junk_pattern_matches).toContain('access_denied');
+  });
+
+  test('every built-in name can be disabled', () => {
+    const all = BUILT_IN_JUNK_PATTERNS.map((p) => p.name);
+    const r = assessContentSanity({ ...page, disabled_patterns: all });
+    expect(r.junk_pattern_matches).toEqual([]);
+  });
+});


### PR DESCRIPTION
`content_sanity.disabled_patterns: string[]` skips built-in junk patterns by
name. Resolved by the callers (`import-file`, `lint`) and passed into the pure
assessor alongside the existing thresholds, so both surfaces agree on which
patterns are live — lint reporting a page as junk that import is configured to
let through would be its own bug.

### Why

The patterns target scraped web content. A brain built from mail, chat or
transcripts holds none of that, but it does hold people writing *about* the
things the patterns name, and `access_denied` is a line-anchored body match:

```ts
pattern: /^\s*access denied\b/im,
applies_to: 'both',
```

A page whose body has a line starting `Access Denied …` is quarantined — hidden
from search — even when the page is a discussion of that error rather than an
instance of one. The comment on the error-title pattern already anticipates the
shape:

> Anchored so the title is exclusively the error phrase — a thoughtful page
> ABOUT 404 errors or one titled "How to Handle Access Denied Errors" won't
> trip.

That reasoning holds for the title match. The body match reaches further.

Today the only escape is `content_sanity.disabled: true`, which also turns off
the size gates. Those are load-bearing: `bytes_block` is what catches a page
before it silently stops being embedded, so an operator who needs one pattern
off has to give up the check that keeps pages searchable. This narrows the
choice to the pattern at fault.

Unknown names are ignored rather than rejected, since the built-in set changes
between releases and a config naming a retired pattern should not fail an
import.

### Tests

Six cases in `test/content-sanity.test.ts`: the pattern trips by default,
naming it lets the page through, other patterns stay live, the size gates are
untouched, an unknown name is ignored, and every built-in name can be disabled.

Found while running a brain over an e-mail archive, where one real thread was
hidden for five days because someone in it wrote a line beginning "Access
Denied". Nothing from that archive appears in this patch.