### PR TITLE
v0.47.6.1 fix(graph): default remote traversal to bidirectional edges (#4666)

### DIFF
--- a/src/core/ops/links.ts
+++ b/src/core/ops/links.ts
@@ -230,12 +230,12 @@ const TRAVERSE_DEPTH_CAP = 10;
 
 const traverse_graph: Operation = {
   name: 'traverse_graph',
-  description: 'Traverse link graph from a page. With link_type/direction, returns edges (GraphPath[]) instead of nodes.',
+  description: 'Traverse link graph from a page. Remote callers default to bidirectional edges (GraphPath[]); trusted local no-filter callers keep the legacy node shape.',
   params: {
     slug: { type: 'string', required: true, description: "Slug of the page to start the traversal from, e.g. 'people/alice-example'. This is the start-node param — there is no `start` or `root` param." },
     depth: { type: 'number', description: `Max traversal depth (default 5, capped at ${TRAVERSE_DEPTH_CAP})` },
     link_type: { type: 'string', description: 'Filter to one link type (per-edge filter, traversal only follows matching edges)' },
-    direction: { type: 'string', enum: ['in', 'out', 'both'], description: 'Traversal direction (default out)' },
+    direction: { type: 'string', enum: ['in', 'out', 'both'], description: 'Traversal direction. Defaults to both for remote callers; trusted local no-filter callers keep legacy outgoing-node output.' },
   },
   handler: async (ctx, p) => {
     const slug = p.slug as string;
@@ -245,7 +245,8 @@ const traverse_graph: Operation = {
     }
     const depth = Math.max(1, Math.min(requestedDepth, TRAVERSE_DEPTH_CAP));
     const linkType = p.link_type as string | undefined;
-    const direction = p.direction as 'in' | 'out' | 'both' | undefined;
+    const requestedDirection = p.direction as 'in' | 'out' | 'both' | undefined;
+    const direction = requestedDirection ?? (ctx.remote !== false ? 'both' : undefined);
     // v0.34.1 (#861 — P0 leak seal): thread caller's source scope so graph
     // walks stay within the auth'd client's accessible sources. Pre-fix,
     // traverseGraph / traversePaths happily followed edges into pages from
@@ -260,9 +261,11 @@ const traverse_graph: Operation = {
       const startHidden = await findPrivateOnlySlugs(ctx.engine, [slug], scope, { includeDeleted: true });
       if (startHidden.has(slug)) return [];
     }
-    // Backward compat: when neither link_type nor direction is provided, return
-    // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
-    if (linkType === undefined && direction === undefined) {
+    // Backward compat: trusted local no-filter callers keep the legacy
+    // GraphNode[] shape used by `gbrain graph`. Remote MCP callers need the
+    // natural no-filter invocation to surface inbound-only typed edges too, so
+    // they default to `direction=both` and return explicit GraphPath[] edges.
+    if (linkType === undefined && requestedDirection === undefined && ctx.remote === false) {
       const nodes = await ctx.engine.traverseGraph(slug, depth, scope);
       if (!excludePrivate) return nodes;
       const hidden = await findPrivateOnlySlugs(

--- a/test/private-visibility.test.ts
+++ b/test/private-visibility.test.ts
@@ -337,16 +337,15 @@ describe('sibling read ops (#4352 remediation — no bypass around get_page)', (
     expect(local.map((l) => l.from_slug)).toContain('notes/private-page');
   });
 
-  test('traverse_graph (node shape): private nodes + edges to them are stripped remotely', async () => {
+  test('traverse_graph (remote default path shape): private nodes + edges to them are stripped remotely', async () => {
     __resetPrivateVisibilityCacheForTests();
     const op = operationsByName['traverse_graph'];
     const remote = (await op.handler(mkCtx(true), { slug: 'notes/world-page' })) as Array<{
-      slug: string; links: Array<{ to_slug: string }>;
+      from_slug: string; to_slug: string;
     }>;
-    expect(remote.map((n) => n.slug)).not.toContain('notes/private-page');
-    for (const node of remote) {
-      expect(node.links.map((l) => l.to_slug)).not.toContain('notes/private-page');
-    }
+    const touched = remote.flatMap((e) => [e.from_slug, e.to_slug]);
+    expect(touched).not.toContain('notes/private-page');
+    expect(touched).toContain('notes/unmarked-page');
     const local = (await op.handler(mkCtx(false), { slug: 'notes/world-page' })) as Array<{ slug: string }>;
     expect(local.map((n) => n.slug)).toContain('notes/private-page');
   });

--- a/test/traverse-graph-op-default.test.ts
+++ b/test/traverse-graph-op-default.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #4666 — MCP traverse_graph defaults must not hide inbound-only edges.
+ *
+ * The engine's legacy GraphNode traversal is outgoing-only. That remains fine
+ * for trusted local compatibility, but the MCP/default operation call should
+ * surface explicit edges from both directions so an inbound-only graph does not
+ * look empty.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { operationsByName, type OperationContext } from '../src/core/operations.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  for (const t of ['content_chunks', 'links', 'tags', 'raw_data', 'timeline_entries', 'page_versions', 'ingest_log', 'pages']) {
+    await (engine as any).db.exec(`DELETE FROM ${t}`);
+  }
+});
+
+function ctx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine,
+    remote: true,
+    config: {},
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    dryRun: false,
+    sourceId: 'default',
+    ...overrides,
+  } as unknown as OperationContext;
+}
+
+async function seedInboundOnlyTarget() {
+  await engine.putPage('notes/evidence-a', {
+    type: 'note',
+    title: 'Evidence A',
+    compiled_truth: 'supports the target',
+    timeline: '',
+    frontmatter: {},
+  });
+  await engine.putPage('knowledge/kcs/target', {
+    type: 'concept',
+    title: 'Target',
+    compiled_truth: 'target page',
+    timeline: '',
+    frontmatter: {},
+  });
+  await engine.addLink(
+    'notes/evidence-a',
+    'knowledge/kcs/target',
+    'evidence supports target',
+    'supports',
+    'manual',
+  );
+}
+
+describe('#4666 traverse_graph operation defaults', () => {
+  test('remote default returns inbound typed edges as explicit GraphPath rows', async () => {
+    await seedInboundOnlyTarget();
+
+    const result = await operationsByName.traverse_graph.handler(ctx(), {
+      slug: 'knowledge/kcs/target',
+      depth: 2,
+    });
+
+    expect(result).toContainEqual(expect.objectContaining({
+      from_slug: 'notes/evidence-a',
+      to_slug: 'knowledge/kcs/target',
+      link_type: 'supports',
+      depth: 1,
+    }));
+  });
+
+  test('trusted local no-filter calls keep the legacy outgoing-node shape', async () => {
+    await seedInboundOnlyTarget();
+
+    const result = await operationsByName.traverse_graph.handler(ctx({ remote: false }), {
+      slug: 'knowledge/kcs/target',
+      depth: 2,
+    }) as Array<{ slug: string; links: Array<{ to_slug: string }> }>;
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        slug: 'knowledge/kcs/target',
+        links: [],
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #4666

## Summary
- Default remote traverse_graph calls now return bidirectional GraphPath edges when callers omit link_type and direction.
- Preserves the trusted local no-filter GraphNode path used by gbrain graph.
- Adds a focused PGLite operation regression for the inbound-only edge case and the local compatibility case.

## Verification
- `bash scripts/gbrain-gate.sh <worktree> test/traverse-graph-op-default.test.ts` -> RESULT: GREEN
