### PR TITLE
fix(atoms): verify source_quote against the text the model saw

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -214,6 +214,106 @@ interface ExtractedAtom {
 /** kebab-case validator for concept labels ("captive-portal", "channel-pricing"). */
 const CONCEPT_LABEL_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+/**
+ * Fold typography and collapse whitespace, recording the ORIGINAL index of each
+ * emitted character.
+ *
+ * The map is what makes provenance real: matching has to tolerate a curly quote
+ * or a line wrap (the model returns one line; the page is wrapped markdown), but
+ * the offsets we persist must point into the ORIGINAL text or they are useless
+ * for later verification.
+ */
+function foldWithMap(s: string): { norm: string; map: number[] } {
+  const FOLD: Record<string, string> = {
+    '’': "'", '‘': "'", '“': '"', '”': '"',
+    '—': '-', '–': '-', '…': '...', ' ': ' ',
+  };
+  let norm = '';
+  const map: number[] = [];
+  let inSpace = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!;
+    if (/\s/.test(ch)) {
+      if (!inSpace && norm.length > 0) { norm += ' '; map.push(i); }
+      inSpace = true;
+      continue;
+    }
+    inSpace = false;
+    for (const c of (FOLD[ch] ?? ch.toLowerCase())) { norm += c; map.push(i); }
+  }
+  while (norm.endsWith(' ')) { norm = norm.slice(0, -1); map.pop(); }
+  return { norm, map };
+}
+
+/**
+ * Locate a model-returned quote inside the text it was extracted from.
+ *
+ * This is the provenance step, and it exists because the alternative — matching
+ * a stored quote back to its source LATER — is not solvable. A passage and its
+ * negation ("would not improve" vs "would improve") are ~99% similar, so no
+ * after-the-fact matcher can tell which one an atom came from, and picking wrong
+ * writes a reversed claim into the brain.
+ *
+ * At extraction there is no such ambiguity: we know exactly which text was sent
+ * to the model, so the question collapses from "which passage did it mean?" to
+ * "is this string in the text we just handed it?" — a fact rather than a guess.
+ *
+ * Returns ORIGINAL-text offsets, or null when the model paraphrased instead of
+ * quoting.
+ */
+export function locateQuote(
+  content: string, quote: string,
+): { start: number; end: number } | null {
+  if (!quote || !content) return null;
+
+  // Everything is decided in FOLDED space, including uniqueness. Short-circuiting
+  // on an exact match and checking uniqueness only among exact matches lets a
+  // typographic twin elsewhere ('“go now”' vs '"go now"') go unseen, and the
+  // offset can then name the wrong passage. Folded space is where twins are
+  // visible, so that is where ambiguity must be judged.
+  const c = foldWithMap(content);
+  const q = foldWithMap(quote);
+  if (!q.norm) return null;
+  // Enumerate every folded hit, then keep only those that survive the boundary
+  // check, THEN judge ambiguity. Order matters: rejecting on raw hit-count first
+  // lets an INVALID partial-character match veto a genuinely unique valid one —
+  // "No. First. No… not ever" has two folded hits for "No." but only the first
+  // is a real character-aligned quotation.
+  //
+  // Boundary check is a round-trip: folding is lossy and one-to-many (… -> ...),
+  // so a hit can land part-way through a single original character. Re-folding
+  // the slice we would store and requiring equality with the folded quote
+  // rejects exactly those.
+  const valid: Array<{ start: number; end: number }> = [];
+  const MAX_CANDIDATES = 8; // pathological input shouldn't scan a whole book
+  let at = c.norm.indexOf(q.norm);
+  let seen = 0;
+  while (at !== -1 && seen < MAX_CANDIDATES) {
+    seen++;
+    const start = c.map[at]!;
+    const end = c.map[at + q.norm.length - 1]! + 1;
+    if (foldWithMap(content.slice(start, end)).norm === q.norm
+        && !valid.some(v => v.start === start && v.end === end)) {
+      valid.push({ start, end });
+    }
+    // Step by one, not by length: overlapping hits are still distinct passages
+    // for ambiguity purposes.
+    at = c.norm.indexOf(q.norm, at + 1);
+  }
+
+  // Cap exhausted with hits still pending: the scan was truncated, so uniqueness
+  // is UNPROVEN and must fail closed. Otherwise a run of invalid partial matches
+  // could push a second valid span past the cap and the first would be certified
+  // unique when it is not.
+  if (at !== -1) return null;
+
+  // Exactly one surviving passage, or we cannot say which the atom used — and
+  // two candidates may differ in their ORIGINAL characters, so the text we
+  // persist could differ from what the model quoted. Drop it rather than guess.
+  if (valid.length !== 1) return null;
+  return valid[0]!;
+}
+
 const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
 
 An atom is a single-source, self-contained idea that could become a tweet,
@@ -775,6 +875,12 @@ export async function runPhaseExtractAtoms(
     }
 
     const originLabel = item.kind === 'transcript' ? item.filePath : item.slug;
+    // Bind the cut ONCE. This is the exact text the model receives, and quote
+    // provenance is resolved against THIS rather than the full item, so a quote
+    // can only verify against text the model actually saw.
+    // #4529/#4540: configurable input cap, cut UTF-8-safely (a bare .slice()
+    // can split a surrogate pair at the boundary).
+    const promptContent = truncateUtf8(item.content, maxInputChars);
     try {
       const result = await chat({
         model: extractModel,
@@ -782,9 +888,7 @@ export async function runPhaseExtractAtoms(
         messages: [
           {
             role: 'user',
-            // #4529/#4540: configurable input cap, cut UTF-8-safely (a bare
-            // .slice() can split a surrogate pair at the boundary).
-            content: `Source: ${originLabel}\n\n---\n\n${truncateUtf8(item.content, maxInputChars)}`,
+            content: `Source: ${originLabel}\n\n---\n\n${promptContent}`,
           },
         ],
         maxTokens: maxOutputTokens,
@@ -868,6 +972,29 @@ export async function runPhaseExtractAtoms(
             item.kind === 'transcript'
               ? { source_path: item.filePath }
               : { source_slug: item.slug };
+          // Pin the quote to its origin, or don't claim one. When located we
+          // store the ORIGINAL characters rather than the model's rendering, so
+          // the stored quote is verbatim by construction and typographic drift
+          // cannot accumulate. When not located the model paraphrased: drop the
+          // quote rather than store an unverifiable one. An atom without a
+          // quotation is honest; an atom with a fabricated one is not, and the
+          // body/lesson/concepts remain useful either way.
+          //
+          // Search ONLY what the model actually received. The prompt is capped
+          // at maxInputChars, so searching the whole item would let a
+          // hallucinated quote that happens to appear beyond the cap be stamped
+          // as verified provenance. Offsets stay valid against the full item
+          // because the cut is a prefix.
+          const loc = locateQuote(promptContent, atom.source_quote ?? '');
+          const quoteFields = atom.source_quote
+            ? (loc
+                ? {
+                    source_quote: promptContent.slice(loc.start, loc.end),
+                    source_quote_offset: [loc.start, loc.end],
+                    source_quote_verified: true,
+                  }
+                : { quote_unverified: 'model paraphrased; not present in source' })
+            : {};
           // Serialize to markdown and import via the canonical pipeline so
           // the atom is chunked (+ embedded when a provider is configured).
           // engine.putPage is a bare page-row upsert that never chunks, so
@@ -885,7 +1012,7 @@ export async function runPhaseExtractAtoms(
               ...originFrontmatter,
               // Provisional until the whole item's atoms persist (see above).
               source_hash: `pending:${hash16}`,
-              ...(atom.source_quote && { source_quote: atom.source_quote }),
+              ...quoteFields,
               ...(atom.lesson && { lesson: atom.lesson }),
               ...(atom.concepts && atom.concepts.length > 0 && { concepts: atom.concepts }),
               ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),

--- a/test/cycle/extract-atoms-quote-provenance.test.ts
+++ b/test/cycle/extract-atoms-quote-provenance.test.ts
@@ -1,0 +1,271 @@
+// extract_atoms — source_quote is verified against the text the model saw.
+//
+// EXTRACT_PROMPT asks the model for `source_quote (verbatim <=200 chars)`, and
+// the persist path stored whatever came back. Nothing checked the claim, so a
+// paraphrase — or an invented line — was written to the atom's frontmatter
+// indistinguishable from a real quotation.
+//
+// Measured on one production corpus (2026-08-29, 7,212 atoms): of the 7,202
+// atoms whose model supplied a quote, 694 (9.6%) were not a verbatim span of
+// the text the model had been given.
+//
+// The fix locates the quote in the exact text sent to the model. Located: store
+// the ORIGINAL characters plus [start, end] offsets and stamp
+// source_quote_verified. Not located: drop the quote and stamp
+// quote_unverified. An atom without a quotation is honest; an atom with a
+// fabricated one is not, and body/lesson/concepts stay useful either way.
+//
+// Verification happens at EXTRACTION on purpose. Matching a stored quote back
+// to its source later is not solvable: a passage and its negation ("would not
+// improve" / "would improve") are ~99% similar, so an after-the-fact matcher
+// cannot tell which one an atom came from, and picking wrong writes a reversed
+// claim into the brain. At extraction the question collapses to "is this string
+// in the text we just handed the model?" — a fact rather than a guess.
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { runPhaseExtractAtoms, locateQuote } from '../../src/core/cycle/extract-atoms.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+describe('locateQuote — offsets point into the ORIGINAL text', () => {
+  test('exact substring: the returned span round-trips to the quote', () => {
+    const content = 'Intro line.\nThe cap is the ceiling, not the target.\nOutro.';
+    const quote = 'The cap is the ceiling, not the target.';
+    const loc = locateQuote(content, quote);
+    expect(loc).not.toBeNull();
+    expect(content.slice(loc!.start, loc!.end)).toBe(quote);
+  });
+
+  test('typography folds, but the stored span is the ORIGINAL characters', () => {
+    // Model returns straight quotes and a plain hyphen; the page has curly
+    // quotes and an em dash. The match must succeed and the offsets must name
+    // the original glyphs, not the folded ones.
+    const content = 'He said “ship it” — then left.';
+    const loc = locateQuote(content, '"ship it" - then left.');
+    expect(loc).not.toBeNull();
+    expect(content.slice(loc!.start, loc!.end)).toBe('“ship it” — then left.');
+  });
+
+  test('a line-wrapped source still matches a single-line quote', () => {
+    const content = 'notes:\nthe budget is a\nceiling and not a target\nend';
+    const loc = locateQuote(content, 'the budget is a ceiling and not a target');
+    expect(loc).not.toBeNull();
+    expect(content.slice(loc!.start, loc!.end)).toBe('the budget is a\nceiling and not a target');
+  });
+
+  test('an ellipsis character matches its three-dot rendering', () => {
+    const content = 'She paused… then answered.';
+    const loc = locateQuote(content, 'She paused... then answered.');
+    expect(loc).not.toBeNull();
+    expect(content.slice(loc!.start, loc!.end)).toBe('She paused… then answered.');
+  });
+});
+
+describe('locateQuote — fails closed rather than guessing', () => {
+  test('a paraphrase returns null', () => {
+    const content = 'The cap is the ceiling, not the target.';
+    expect(locateQuote(content, 'the cap should be treated as a ceiling')).toBeNull();
+  });
+
+  test('two identical passages are ambiguous -> null', () => {
+    const content = 'ship it now.\n---\nship it now.';
+    expect(locateQuote(content, 'ship it now.')).toBeNull();
+  });
+
+  test('a TYPOGRAPHIC twin is ambiguous too', () => {
+    // The reason uniqueness is judged in folded space. Checking uniqueness only
+    // among EXACT matches sees one hit here and confidently returns the wrong
+    // passage; folded space sees both.
+    const content = 'A: “go now”\nB: "go now"';
+    expect(locateQuote(content, '"go now"')).toBeNull();
+  });
+
+  test('an invalid partial-character hit does not veto a valid unique one', () => {
+    // "No." has two folded hits here, but the second lands part-way through the
+    // ellipsis (… folds to "..."), so it is not a character-aligned
+    // quotation. Validate first, judge ambiguity second, or the real match is
+    // lost to a phantom.
+    const content = 'No. First. No… not ever.';
+    const loc = locateQuote(content, 'No.');
+    expect(loc).not.toBeNull();
+    expect(loc!.start).toBe(0);
+    expect(content.slice(loc!.start, loc!.end)).toBe('No.');
+  });
+
+  test('a truncated candidate scan is UNPROVEN uniqueness -> null', () => {
+    // More occurrences than the internal scan cap. Uniqueness cannot be
+    // established, so the only safe answer is null.
+    const content = Array.from({ length: 40 }, () => 'repeat me.').join(' ');
+    expect(locateQuote(content, 'repeat me.')).toBeNull();
+  });
+
+  test('empty quote or empty content returns null', () => {
+    expect(locateQuote('some content', '')).toBeNull();
+    expect(locateQuote('', 'some quote')).toBeNull();
+    expect(locateQuote('some content', '   ')).toBeNull();
+  });
+});
+
+function chatReturning(atoms: unknown[]): (o: ChatOpts) => Promise<ChatResult> {
+  const text = JSON.stringify(atoms);
+  return async () => ({
+    text,
+    blocks: [{ type: 'text', text }],
+    stopReason: 'end',
+    usage: { input_tokens: 100, output_tokens: 10, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'anthropic:claude-haiku-4-5',
+    providerId: 'anthropic',
+  });
+}
+
+async function onlyAtom() {
+  const pages = await engine.listPages({ type: 'atom', limit: 10 });
+  expect(pages.length).toBe(1);
+  return (await engine.getPage(pages[0]!.slug))!;
+}
+
+describe('extract_atoms persists provenance, not claims', () => {
+  const SOURCE = [
+    'Meeting notes, 12 March.',
+    'The budget is a ceiling and not a target.',
+    'We agreed to revisit in April.',
+  ].join('\n').padEnd(600, ' .');
+
+  test('a real quote is stored verbatim with offsets and verified', async () => {
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [{ filePath: '/tmp/q1.txt', content: SOURCE, contentHash: 'a1'.repeat(8) }],
+      _pages: [],
+      _chat: chatReturning([{
+        title: 'Budgets are ceilings',
+        atom_type: 'insight',
+        body: 'A budget caps spend; it is not a goal to reach.',
+        source_quote: 'The budget is a ceiling and not a target.',
+      }]),
+    });
+
+    const atom = await onlyAtom();
+    expect(atom.frontmatter.source_quote).toBe('The budget is a ceiling and not a target.');
+    expect(atom.frontmatter.source_quote_verified).toBe(true);
+    const [start, end] = atom.frontmatter.source_quote_offset as [number, number];
+    // The offsets are real indices into the source text.
+    expect(SOURCE.slice(start, end)).toBe('The budget is a ceiling and not a target.');
+    expect(atom.frontmatter.quote_unverified).toBeUndefined();
+  });
+
+  test('a paraphrase is flagged and NO source_quote is stored', async () => {
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [{ filePath: '/tmp/q2.txt', content: SOURCE, contentHash: 'b2'.repeat(8) }],
+      _pages: [],
+      _chat: chatReturning([{
+        title: 'Budgets are ceilings',
+        atom_type: 'insight',
+        body: 'A budget caps spend; it is not a goal to reach.',
+        // Plausible, close to the source, and never actually said.
+        source_quote: 'Treat the budget as a ceiling rather than a target.',
+      }]),
+    });
+
+    const atom = await onlyAtom();
+    expect(atom.frontmatter.source_quote).toBeUndefined();
+    expect(atom.frontmatter.source_quote_verified).toBeUndefined();
+    expect(atom.frontmatter.quote_unverified).toBe('model paraphrased; not present in source');
+    // The atom itself still lands — the body is unaffected by the missing quote.
+    expect(atom.frontmatter.atom_type).toBe('insight');
+  });
+
+  test('the stored quote is the SOURCE glyphs, not the model rendering', async () => {
+    // End-to-end guard for the fold: the page has curly quotes and an em dash,
+    // the model answers with straight quotes and a hyphen. What lands must be
+    // the page's own characters, or typographic drift accumulates in the brain
+    // one atom at a time.
+    const typographic = [
+      'Standup, 3 April.',
+      'She said “ship it now” — and nobody argued.',
+      'Then we moved on.',
+    ].join('\n').padEnd(600, ' .');
+
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [{ filePath: '/tmp/q4.txt', content: typographic, contentHash: 'd4'.repeat(8) }],
+      _pages: [],
+      _chat: chatReturning([{
+        title: 'Nobody argued',
+        atom_type: 'insight',
+        body: 'The decision met no resistance.',
+        source_quote: '"ship it now" - and nobody argued.',
+      }]),
+    });
+
+    const atom = await onlyAtom();
+    expect(atom.frontmatter.source_quote_verified).toBe(true);
+    // Curly quotes and the em dash survive; the model's ASCII rendering does not.
+    expect(atom.frontmatter.source_quote).toBe('“ship it now” — and nobody argued.');
+    const [start, end] = atom.frontmatter.source_quote_offset as [number, number];
+    expect(typographic.slice(start, end)).toBe('“ship it now” — and nobody argued.');
+  });
+
+  test('a quote past max_input_chars is NOT verified — only the sent prefix counts', async () => {
+    // The model never saw this text, so a "quote" matching it is not provenance.
+    // Verifying against the whole item instead of the sent prefix would stamp a
+    // hallucination that happens to collide with unsent text as verified.
+    await engine.setConfig('cycle.extract_atoms.max_input_chars', '1000');
+    const beyond = 'The quiet part nobody transmitted.';
+    const content = 'A'.repeat(1200) + '\n' + beyond;
+
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [{ filePath: '/tmp/q5.txt', content, contentHash: 'e5'.repeat(8) }],
+      _pages: [],
+      _chat: chatReturning([{
+        title: 'Beyond the cap',
+        atom_type: 'insight',
+        body: 'Something the model was never shown.',
+        source_quote: beyond,
+      }]),
+    });
+
+    // Present in the ITEM, absent from the PROMPT.
+    expect(content).toContain(beyond);
+    const atom = await onlyAtom();
+    expect(atom.frontmatter.source_quote).toBeUndefined();
+    expect(atom.frontmatter.source_quote_verified).toBeUndefined();
+    expect(atom.frontmatter.quote_unverified).toBe('model paraphrased; not present in source');
+  });
+
+  test('an atom that offered no quote is untouched', async () => {
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [{ filePath: '/tmp/q3.txt', content: SOURCE, contentHash: 'c3'.repeat(8) }],
+      _pages: [],
+      _chat: chatReturning([{
+        title: 'Revisit in April',
+        atom_type: 'insight',
+        body: 'The team deferred the decision by a month.',
+      }]),
+    });
+
+    const atom = await onlyAtom();
+    expect(atom.frontmatter.source_quote).toBeUndefined();
+    expect(atom.frontmatter.quote_unverified).toBeUndefined();
+    expect(atom.frontmatter.source_quote_verified).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The defect

`EXTRACT_PROMPT` asks the model for `source_quote (verbatim <=200 chars)`, and the persist path stores whatever comes back. Nothing verifies the claim, so a paraphrase — or an invented line — lands in an atom's frontmatter indistinguishable from a real quotation.

Measured on one production corpus (7,212 atoms): of the **7,202 atoms whose model supplied a quote, 694 (9.6%) were not a verbatim span of the text the model had been given.**

## Why verify at extraction rather than later

Matching a stored quote back to its source afterwards is not solvable. A passage and its negation ("would not improve" / "would improve") are ~99% similar, so no after-the-fact matcher can tell which one an atom came from — and picking wrong writes a reversed claim into the brain.

At extraction there is no ambiguity, because we know exactly which text was sent. The question collapses from "which passage did it mean?" to "is this string in the text we just handed it?" — a fact rather than a guess.

## The change

`locateQuote(content, quote)` folds typography and collapses whitespace while recording the **original** index of each emitted character, so a curly quote or a line wrap still matches but the offsets we persist point into the real text.

It fails closed. Ambiguous matches (including typographic twins — `“go now”` vs `"go now"`), matches straddling a one-to-many fold boundary (`…` → `...`), and a truncated candidate scan all return `null` rather than guess.

| Outcome | Persisted |
|---|---|
| Located | `source_quote` (the **source** characters, not the model's rendering), `source_quote_offset: [start, end]`, `source_quote_verified: true` |
| Not located | `quote_unverified`, and the quote is dropped |

Two properties worth calling out:

- **Strictly additive.** An atom always persists; only the quote is gated. An atom without a quotation is honest; one with a fabricated quotation is not, and `body` / `lesson` / `concepts` are unaffected either way.
- **Verified against the prompt prefix, not the whole item.** Content past `max_input_chars` was never shown to the model, so a "quote" matching it is a collision, not provenance. This required binding the truncated text once (`promptContent`) and reusing it for both the message and verification; the outgoing message content is byte-identical to before.

## Known limitation

A rejected quote is discarded, so the split between genuine model paraphrase and matcher strictness is **not** recoverable from stored data — the 9.6% above is the rejection rate, not a proven hallucination rate. Retaining the rejected string under a debug key would make that auditable; happy to add if you want it.

## Tests

`test/cycle/extract-atoms-quote-provenance.test.ts` — 15 tests.

Unit, on the matcher: exact match round-trips; typography folds while offsets stay original; line-wrapped source matches a single-line quote; ellipsis matches its three-dot rendering; paraphrase → null; duplicate passages → null; typographic twin → null; an invalid partial-character hit does not veto a valid unique one; truncated scan → null; empty inputs → null.

Integration, through `runPhaseExtractAtoms`: a real quote stores verbatim with working offsets; a paraphrase is flagged with no `source_quote`; the stored quote keeps the **source** glyphs when the model answers in ASCII; a quote sitting past `max_input_chars` is not verified; an atom offering no quote is untouched.

## Verification

- `tsc --noEmit` clean
- `bun run verify` — 55/55 gates
- All 20 existing atom-related test files: 191 pass, 0 fail
- New file: 15 pass, 0 fail

Happy to reshape this however suits the codebase — including if you'd rather take the idea and implement it your own way.
