### PR TITLE
fix(recall): honor the federated source set in the page-search arm (#4707)

### DIFF
--- a/src/core/ops/facts.ts
+++ b/src/core/ops/facts.ts
@@ -14,7 +14,7 @@
 
 import type { Operation } from './contract.ts';
 import { OperationError, verbError } from './contract.ts';
-import { sourceScopeOpts, stampEvidenceSafe } from './context.ts';
+import { federatedSearchScope, sourceScopeOpts, stampEvidenceSafe } from './context.ts';
 import { markKeywordHits } from '../search/evidence.ts';
 import { hybridSearchCached, stampContentFlags } from '../search/hybrid.ts';
 import { dedupResults } from '../search/dedup.ts';
@@ -369,7 +369,12 @@ const recall: Operation = {
     let searchResults: SearchResult[] = [];
     let searchDegraded: string | undefined;
     if (queryText) {
-      const searchScope = sourceScopeOpts(ctx);
+      // #3242 parity: the page-search arm widens an unqualified no-grant
+      // caller across the transport-computed federated set, exactly like
+      // search/query/get_page/list_pages/resolve_slugs. sourceScopeOpts alone
+      // pinned this arm to the scalar source, so a `federated: true` source
+      // was invisible to recall while visible to every sibling read op.
+      const searchScope = federatedSearchScope(ctx);
       // #4352 — recall's page-search arm enforces `visibility: private` for
       // untrusted callers (matches the facts arms' world-only filter above).
       const { resolveExcludePrivatePages } = await import('../search/private-visibility.ts');

--- a/test/recall-federated-search-scope.test.ts
+++ b/test/recall-federated-search-scope.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #3242 parity for `recall`'s page-search arm.
+ *
+ * #3242 taught the unqualified read surface to widen a no-grant caller across
+ * the transport-computed federated set (`ctx.localFederatedSourceIds`):
+ * `search` / `query` / `get_page` / `list_pages` / `resolve_slugs` all resolve
+ * their scope through `federatedSearchScope`. `recall`'s query arm was missed
+ * — it resolved through `sourceScopeOpts`, which only understands an ACL grant
+ * (`ctx.auth.allowedSources`) or the scalar `ctx.sourceId`, and never consults
+ * the federated set.
+ *
+ * Effect: a remote MCP caller with no source grant stayed pinned to its scalar
+ * source, so pages in a `federated: true` source were invisible to `recall`
+ * while visible to every sibling read op through the same context.
+ *
+ * The existing `test/recall-federated.test.ts` covers the FACTS arms fanning
+ * out across an `allowedSources` GRANT — a different axis. Nothing covered the
+ * query arm's federated widening, which is how the gap survived.
+ *
+ * The parity assertion (recall's slug set === search's slug set for one ctx
+ * and query) is the load-bearing one: it fails if either op drifts.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  federatedSearchScope,
+  sourceScopeOpts,
+  operations,
+  type OperationContext,
+} from '../src/core/operations.ts';
+
+let engine: PGLiteEngine;
+const recall = operations.find((o) => o.name === 'recall')!;
+const search = operations.find((o) => o.name === 'search')!;
+
+function ctxOf(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine: engine as any,
+    config: {} as any,
+    logger: console as any,
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+    ...overrides,
+  };
+}
+
+/**
+ * The exact context `gbrain serve --http` builds for a legacy bearer token
+ * with no operator source grant: remote, scalar 'default', and the federated
+ * set populated by the transport (never by caller params).
+ */
+const remoteNoGrant = () =>
+  ctxOf({ remote: true, sourceId: 'default', localFederatedSourceIds: ['default', 'wiki'] });
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  // Seeded 'default' is federated. Add a federated peer ('wiki') that an
+  // unqualified no-grant caller must see, and a NON-federated one ('private')
+  // that must stay invisible — the fix must widen, not unscope.
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ('wiki', 'wiki', '/tmp/wiki', '{"federated": true}'::jsonb)`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config) VALUES ('private', 'private', '/tmp/private', '{}'::jsonb)`,
+  );
+  const pages: Array<[slug: string, sourceId: string, where: string]> = [
+    ['notes/home', 'default', 'default'],
+    ['wiki/topic', 'wiki', 'wiki'],
+    ['private/topic', 'private', 'private'],
+  ];
+  for (const [slug, sourceId, where] of pages) {
+    await engine.putPage(
+      slug,
+      { type: 'note', title: `Topic in ${where}`, compiled_truth: `the zebra telescope in ${where}`, frontmatter: {} },
+      { sourceId },
+    );
+    await engine.upsertChunks(
+      slug,
+      [{ chunk_index: 0, chunk_text: `the zebra telescope in ${where}`, chunk_source: 'compiled_truth' }],
+      { sourceId },
+    );
+  }
+  // Keyword-only search path: no embedding provider needed in tests.
+  await engine.setConfig('search.mcp_keyword_only', 'true');
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+/** `recall` returns `{facts, results}`; `search` returns a bare result array. */
+const recallSlugs = (res: any): string[] => (res?.results ?? []).map((r: any) => r.slug);
+const searchSlugs = (res: any): string[] => (res ?? []).map((r: any) => r.slug);
+
+describe("recall's page-search arm honors the federated set (#3242 parity)", () => {
+  test('the two scope helpers differ for a no-grant remote ctx — recall must use the widening one', () => {
+    const ctx = remoteNoGrant();
+    expect(sourceScopeOpts(ctx)).toEqual({ sourceId: 'default' });
+    expect(federatedSearchScope(ctx)).toEqual({ sourceIds: ['default', 'wiki'] });
+  });
+
+  test('a no-grant remote caller sees pages from a federated peer source', async () => {
+    const slugs = recallSlugs(await recall.handler(remoteNoGrant(), { query: 'zebra telescope' }));
+    expect(slugs).toContain('wiki/topic');
+    expect(slugs).toContain('notes/home');
+  });
+
+  test('widening stops at the federated set — a non-federated source stays invisible', async () => {
+    const slugs = recallSlugs(await recall.handler(remoteNoGrant(), { query: 'zebra telescope' }));
+    expect(slugs).not.toContain('private/topic');
+  });
+
+  test('recall and search resolve the SAME slug set for one ctx (op parity)', async () => {
+    const ctx = remoteNoGrant();
+    const recalled = recallSlugs(await recall.handler(ctx, { query: 'zebra telescope' })).sort();
+    const searched = searchSlugs(await search.handler(ctx, { query: 'zebra telescope' })).sort();
+    expect(recalled).toEqual(searched);
+  });
+
+  test('fail-closed: a remote caller whose transport did NOT populate the set stays scalar', async () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'default' });
+    const slugs = recallSlugs(await recall.handler(ctx, { query: 'zebra telescope' }));
+    expect(slugs).toEqual(['notes/home']);
+  });
+
+  test('an ACL grant still governs — the federated set never widens past it', async () => {
+    const ctx = ctxOf({
+      remote: true,
+      sourceId: 'default',
+      localFederatedSourceIds: ['default', 'wiki'],
+      auth: { allowedSources: ['default'] } as any,
+    });
+    const slugs = recallSlugs(await recall.handler(ctx, { query: 'zebra telescope' }));
+    expect(slugs).toEqual(['notes/home']);
+  });
+});


### PR DESCRIPTION
Fixes #4707.

<!-- Title deliberately carries no version: this PR does not bump VERSION,
     since which release absorbs it is the maintainer's call. Happy to
     re-title with a version if the wave process wants one. -->

## What

`recall`'s page-search arm (the `results[]` arm, triggered by passing `query`) now resolves its source scope through `federatedSearchScope(ctx)` instead of `sourceScopeOpts(ctx)`, so a remote MCP caller with no source grant sees pages in `federated: true` peer sources — consistent with every sibling read op.

## Why

`sourceScopeOpts` only understands an ACL grant (`ctx.auth.allowedSources`) or the scalar `ctx.sourceId`. It never consults `ctx.localFederatedSourceIds`, the transport-computed federated set. So a no-grant caller stayed pinned to its scalar source (usually `default`), and pages ingested into a federated peer source were invisible to `recall` — while visible through the *same context* to `search`, `query`, `get_page`, `list_pages`, and `resolve_slugs`, all of which route through `federatedSearchScope`.

This is the #3242 bug class, with `recall`'s query arm missed at the time. The coverage gap is why it survived: `test/recall-federated.test.ts` covers the **facts** arms fanning out across an `allowedSources` grant — a different axis — and nothing covered the query arm's federated widening.

A differential test isolates it. Same context, same query, same corpus, one federated peer (`wiki`):

```
sourceScopeOpts      → {"sourceId":"default"}
federatedSearchScope → {"sourceIds":["default","wiki"]}

search slugs → ["notes/home","wiki/topic"]
recall slugs → ["notes/home"]            ← federated peer missing
```

The control op rules out corpus, context, and query; the only difference is the scope helper.

`recall` exposes no `source_id` param, so the no-argument call is the designed shape (mirrors the `resolve_slugs` usage in `src/core/ops/chunks.ts`). The widening stays fail-closed: it applies only when the transport itself populated `localFederatedSourceIds`, and an ACL grant continues to govern. Both are pinned by tests below.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/ops/facts.ts` to merge-base, ran `test/recall-federated-search-scope.test.ts` → `4 pass / 2 fail`. Restored → all pass.

## Verification

Confirmed end-to-end against a compiled binary (`bun build --compile --outfile <path> src/cli.ts`) serving `--http --surface verbs` over a real Postgres brain — same bearer token, same query, unfixed binary vs fixed:

```
=== unfixed ===
results: []
=== fixed ===
results: ['<page-a>', '<page-b>', '<page-c>', '<page-d>', '<page-e>']
```

## Tests

Added `test/recall-federated-search-scope.test.ts` (6 cases):

- the two scope helpers differ for a no-grant remote ctx (pins the root cause)
- a no-grant remote caller sees pages from a federated peer source
- widening stops at the federated set — a **non**-federated source stays invisible
- **parity**: `recall` and `search` resolve the same slug set for one ctx (load-bearing — fails if either op drifts)
- fail-closed: a remote caller whose transport did NOT populate the set stays scalar
- an ACL grant still governs — the federated set never widens past it

Local runs (redirected to file, exit code checked):

- `bun test test/recall-federated-search-scope.test.ts` → 6 pass / 0 fail
- `bun run typecheck` → clean
- `bun run test` (full unit suite) → **22496 pass / 2 fail / 31 skip**. Both failures (`test/backup-invalidation.serial.test.ts`, `test/worker-registry.serial.test.ts`) reproduce identically on a clean checkout with this change stashed — pre-existing, unrelated to this PR.
- `bun run verify` → 53/55, with `check:privacy` and `check:test-isolation` hitting the 120s cap under load; both pass when run standalone (`check-test-isolation: OK (1583 non-serial unit files scanned)`).
