### PR TITLE
fix: retry Bun DNS timeout embedding errors

### DIFF
--- a/src/core/embed-retry.ts
+++ b/src/core/embed-retry.ts
@@ -283,7 +283,8 @@ export function transientBackoffMs(attempt: number, rng: () => number = Math.ran
 
 /**
  * #3374 — transient NETWORK failures: socket timeouts, connection resets,
- * DNS blips. Structured detection first (error `code` / TimeoutError name
+ * DNS blips (including Bun's `DNS_ETIMEOUT` code and `ETIMEOUT` getaddrinfo
+ * message). Structured detection first (error `code` / TimeoutError name
  * through the cause chain, matching statusFromCause's walk), message-match
  * fallback for wrappers that strip the code. Deliberately does NOT match
  * caller-initiated aborts: the retry loop re-checks `signal.aborted` BEFORE
@@ -292,7 +293,7 @@ export function transientBackoffMs(attempt: number, rng: () => number = Math.ran
  * @internal exported for unit tests.
  */
 export function isTransientNetworkEmbedError(e: unknown): boolean {
-  const TRANSIENT_CODES = /^(ETIMEDOUT|ESOCKETTIMEDOUT|ECONNRESET|EPIPE|ECONNABORTED|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|UND_ERR_SOCKET)$/;
+  const TRANSIENT_CODES = /^(DNS_ETIMEOUT|ETIMEOUT|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNRESET|EPIPE|ECONNABORTED|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|UND_ERR_SOCKET)$/;
   let cur: unknown = e;
   for (let depth = 0; depth < 5 && cur !== undefined && cur !== null; depth++) {
     const obj = cur as { code?: unknown; name?: unknown; cause?: unknown };
@@ -301,5 +302,5 @@ export function isTransientNetworkEmbedError(e: unknown): boolean {
     cur = obj.cause;
   }
   const msg = e instanceof Error ? e.message : String(e);
-  return /\b(ETIMEDOUT|ESOCKETTIMEDOUT|ECONNRESET|EPIPE|EAI_AGAIN)\b|socket hang up|fetch failed|connect(ion)? timeout|connection (reset|closed)|network (error|timeout)|request timed out|timed out/i.test(msg);
+  return /\b(DNS_ETIMEOUT|ETIMEOUT|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNRESET|EPIPE|EAI_AGAIN)\b|socket hang up|fetch failed|connect(ion)? timeout|connection (reset|closed)|network (error|timeout)|request timed out|timed out/i.test(msg);
 }

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -830,6 +830,13 @@ describe('#3374 — transient network retry branch', () => {
     expect(isTransientNetworkEmbedError(new Error('socket hang up'))).toBe(true);
     expect(isTransientNetworkEmbedError(new Error('fetch failed'))).toBe(true);
     expect(isTransientNetworkEmbedError(new Error('request timed out'))).toBe(true);
+    // Bun's DNS resolver uses DNS_ETIMEOUT as its code and ETIMEOUT (without
+    // the D in ETIMEDOUT) in getaddrinfo messages.
+    expect(isTransientNetworkEmbedError(new Error('getaddrinfo ETIMEOUT api.voyageai.com'))).toBe(true);
+    expect(isTransientNetworkEmbedError({ code: 'ETIMEOUT' })).toBe(true);
+    expect(isTransientNetworkEmbedError({ code: 'DNS_ETIMEOUT' })).toBe(true);
+    expect(isTransientNetworkEmbedError({ cause: { code: 'DNS_ETIMEOUT' } })).toBe(true);
+    expect(isTransientNetworkEmbedError(new Error('DNS_ETIMEOUT'))).toBe(true);
     // NOT transient: plain 500, permanent 4xx, caller aborts.
     expect(isTransientNetworkEmbedError(new Error('500 internal server error'))).toBe(false);
     expect(isTransientNetworkEmbedError(new Error('400 invalid input'))).toBe(false);
@@ -859,6 +866,23 @@ describe('#3374 — transient network retry branch', () => {
       if (calls === 1) {
         const err = new Error('socket hang up');
         (err as any).code = 'ECONNRESET';
+        throw err;
+      }
+      return [new Float32Array(1536)];
+    };
+    const result = await embedBatchWithBackoff(['x']);
+    expect(calls).toBe(2);
+    expect(result).toHaveLength(1);
+  }, 10_000);
+
+  test('Bun DNS ETIMEOUT retries then succeeds', async () => {
+    const { embedBatchWithBackoff } = await import('../src/commands/embed.ts');
+    let calls = 0;
+    embedBatchBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        const err = new Error('getaddrinfo ETIMEOUT api.voyageai.com');
+        (err as any).code = 'DNS_ETIMEOUT';
         throw err;
       }
       return [new Float32Array(1536)];


### PR DESCRIPTION
## Problem

Bun can surface transient DNS failures as structured `DNS_ETIMEOUT` and/or the message `getaddrinfo ETIMEOUT ...`. GBrain 0.47.6.0 recognizes `ETIMEDOUT` and `EAI_AGAIN`, but neither Bun spelling, so these failures bypass the existing bounded embedding retry ladder.

Observed sanitized production error:

```text
[embed(voyage:voyage-4-large)] getaddrinfo ETIMEOUT api.voyageai.com
```

No request reached the provider; current DNS subsequently resolved normally.

## Fix

- classify exact `DNS_ETIMEOUT` and `ETIMEOUT` structured codes as transient
- recognize both exact word-bounded message variants
- add direct, nested-cause, message, and retry-then-success regressions

The match remains narrow and routes only through the existing bounded backoff.

## Validation

- `bun test test/embed.serial.test.ts`: 52 passed, 229 assertions
- focused `#3374` tests after rebasing on master: 6 passed
- `bun run typecheck`
- `git diff --check`

Related Bun behavior: https://github.com/oven-sh/bun/issues/18694