### PR TITLE
fix(cycle): drop since_date from the consolidate take-identity lookup

### DIFF
--- a/src/core/cycle/phases/consolidate.ts
+++ b/src/core/cycle/phases/consolidate.ts
@@ -164,13 +164,31 @@ export async function runPhaseConsolidate(
       // which clears `consolidated_at` on every fact. Without this lookup,
       // a second cycle run would re-INSERT a duplicate take via
       // `MAX(row_num)+1`, silently poisoning trajectory + scorecard data.
-      // Match on (page_id, claim, since_date) — the natural identity of a
-      // promoted take.
-      const existing = await engine.executeRaw<{ id: number }>(
-        `SELECT id FROM takes
-         WHERE page_id = $1 AND claim = $2 AND since_date = $3
+      // Match on (page_id, claim) restricted to the rows this phase authors.
+      //
+      // `since_date` is NOT part of the identity: it is derived from
+      // MIN(valid_from) of the cluster, so it describes the fact rows that
+      // happen to exist right now. When extract_facts re-inserts a claim with
+      // a fresh `valid_from` (the common case: an LLM extraction that defaults
+      // valid_from to now()), keying on since_date makes this lookup miss and
+      // the upsert degrades into the duplicate-INSERT path this block exists
+      // to prevent.
+      //
+      // `kind = 'fact' AND holder = 'self'` mirrors the INSERT below, so the
+      // lookup can only ever match a take this phase wrote. Without it the
+      // widened match reaches human-authored takes that share the claim text
+      // and the UPDATE below would overwrite their provenance.
+      //
+      // Deliberately NOT filtered on `active`: a superseded take still owns
+      // this claim. Skipping it would send us down the INSERT path and
+      // resurrect a claim the user retired. `ORDER BY id` keeps the choice
+      // deterministic if a page already holds more than one matching row.
+      const existing = await engine.executeRaw<{ id: number; resolved_at: Date | null }>(
+        `SELECT id, resolved_at FROM takes
+         WHERE page_id = $1 AND claim = $2 AND kind = 'fact' AND holder = 'self'
+         ORDER BY id
          LIMIT 1`,
-        [pageId, best.fact, sinceISO],
+        [pageId, best.fact],
       );
 
       let takeId: number;
@@ -180,10 +198,16 @@ export async function runPhaseConsolidate(
         // source_session values that the prior run didn't see); leave
         // row_num + weight untouched to keep the take's identity stable.
         takeId = existing[0].id;
-        await engine.executeRaw(
-          `UPDATE takes SET source = $1, updated_at = now() WHERE id = $2`,
-          [sources.slice(0, 200), takeId],
-        );
+        // A resolved take is immutable everywhere else (the engines throw
+        // TAKE_RESOLVED_IMMUTABLE / TAKE_ALREADY_RESOLVED); this raw UPDATE
+        // would bypass that guard. Reuse its id so the facts still consolidate
+        // into it, but leave the row untouched.
+        if (existing[0].resolved_at === null) {
+          await engine.executeRaw(
+            `UPDATE takes SET source = $1, updated_at = now() WHERE id = $2`,
+            [sources.slice(0, 200), takeId],
+          );
+        }
       } else {
         const inserted = await engine.addTakesBatch([{
           page_id: pageId,

--- a/test/consolidate-valid-until.test.ts
+++ b/test/consolidate-valid-until.test.ts
@@ -254,6 +254,169 @@ describe('R4b / R7 — cycle idempotency: re-run consolidate produces zero new t
     expect(facts.length).toBe(4);
   });
 
+  test('semantic upsert: a re-extracted claim with a newer valid_from reuses the take', async () => {
+    await seedPage('cdx4-idempo-3');
+    const day1 = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-idempo-3',
+        text: 'stable claim',
+        valid_from: new Date(day1.getTime() + i * 60 * 60 * 1000),
+      });
+    }
+
+    const r1 = await runPhaseConsolidate(engine, {});
+    expect(r1.details.takes_written).toBe(1);
+    const firstTake = await engine.executeRaw<{ id: number; since_date: string }>(
+      `SELECT id, since_date::text FROM takes WHERE page_id = (SELECT id FROM pages WHERE slug = 'cdx4-idempo-3')`,
+    );
+    expect(firstTake.length).toBe(1);
+
+    // Simulate the next cycle's extract_facts: it hard-deletes and re-inserts
+    // the page's facts. The claim text is unchanged, but the new rows carry a
+    // fresh valid_from (an LLM extraction that defaults valid_from to now()),
+    // so MIN(valid_from) — and therefore since_date — lands on a later day.
+    await engine.executeRaw(`DELETE FROM facts WHERE entity_slug = 'cdx4-idempo-3'`);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-idempo-3',
+        text: 'stable claim',
+        valid_from: new Date(day1.getTime() + 24 * 60 * 60 * 1000 + i * 60 * 60 * 1000),
+      });
+    }
+
+    const r2 = await runPhaseConsolidate(engine, {});
+    expect(r2.details.facts_consolidated).toBe(4);
+    expect(r2.details.takes_written).toBe(0);
+
+    const countAfter2 = await engine.executeRaw<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM takes WHERE page_id = (SELECT id FROM pages WHERE slug = 'cdx4-idempo-3')`,
+    );
+    expect(parseInt(countAfter2[0].n, 10)).toBe(1); // STILL 1 — no duplicate
+
+    // The take keeps its identity: same row, same since_date as first promotion.
+    const afterTake = await engine.executeRaw<{ id: number; since_date: string }>(
+      `SELECT id, since_date::text FROM takes WHERE page_id = (SELECT id FROM pages WHERE slug = 'cdx4-idempo-3')`,
+    );
+    expect(afterTake[0]).toEqual(firstTake[0]);
+  });
+
+  test('semantic upsert: a human-authored take with the same claim is not hijacked', async () => {
+    const pageId = await seedPage('cdx4-foreign');
+    await engine.executeRaw(
+      `INSERT INTO takes (page_id, row_num, claim, kind, holder, source, active)
+       VALUES ($1, 1, 'shared claim', 'bet', 'garry', 'human:garry', TRUE)`,
+      [pageId],
+    );
+    const day1 = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-foreign',
+        text: 'shared claim',
+        valid_from: new Date(day1.getTime() + i * 60 * 60 * 1000),
+      });
+    }
+
+    const r = await runPhaseConsolidate(engine, {});
+    expect(r.details.takes_written).toBe(1);
+
+    const rows = await engine.executeRaw<{ id: number; kind: string; holder: string; source: string }>(
+      `SELECT id, kind, holder, source FROM takes WHERE page_id = $1 ORDER BY id`,
+      [pageId],
+    );
+    // The bet keeps its provenance; consolidate appends its own take instead
+    // of adopting a row it did not author.
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toMatchObject({ kind: 'bet', holder: 'garry', source: 'human:garry' });
+    expect(rows[1]).toMatchObject({ kind: 'fact', holder: 'self' });
+  });
+
+  test('semantic upsert: a superseded take is not resurrected as a new active row', async () => {
+    const pageId = await seedPage('cdx4-supersede');
+    const day1 = new Date(Date.now() - 96 * 60 * 60 * 1000);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-supersede',
+        text: 'retired claim',
+        valid_from: new Date(day1.getTime() + i * 60 * 60 * 1000),
+      });
+    }
+    await runPhaseConsolidate(engine, {});
+
+    // The user retires the take.
+    await engine.executeRaw(
+      `UPDATE takes SET active = FALSE, superseded_by = 999 WHERE page_id = $1`,
+      [pageId],
+    );
+
+    // Next cycle re-extracts the same claim with a fresher valid_from.
+    await engine.executeRaw(`DELETE FROM facts WHERE entity_slug = 'cdx4-supersede'`);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-supersede',
+        text: 'retired claim',
+        valid_from: new Date(day1.getTime() + 24 * 60 * 60 * 1000 + i * 60 * 60 * 1000),
+      });
+    }
+
+    const r2 = await runPhaseConsolidate(engine, {});
+    expect(r2.details.takes_written).toBe(0);
+
+    const rows = await engine.executeRaw<{ active: boolean; claim: string }>(
+      `SELECT active, claim FROM takes WHERE page_id = $1`,
+      [pageId],
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].active).toBe(false); // retirement survives the dream cycle
+  });
+
+  test('semantic upsert: a resolved take is reused but never mutated', async () => {
+    const pageId = await seedPage('cdx4-resolved');
+    const day1 = new Date(Date.now() - 96 * 60 * 60 * 1000);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-resolved',
+        text: 'resolved claim',
+        valid_from: new Date(day1.getTime() + i * 60 * 60 * 1000),
+      });
+    }
+    await runPhaseConsolidate(engine, {});
+    await engine.executeRaw(
+      `UPDATE takes SET resolved_at = now(), source = 'frozen' WHERE page_id = $1`,
+      [pageId],
+    );
+    const before = await engine.executeRaw<{ id: number; source: string; updated_at: Date }>(
+      `SELECT id, source, updated_at FROM takes WHERE page_id = $1`,
+      [pageId],
+    );
+
+    await engine.executeRaw(`DELETE FROM facts WHERE entity_slug = 'cdx4-resolved'`);
+    for (let i = 0; i < 4; i++) {
+      await insertFact({
+        entity_slug: 'cdx4-resolved',
+        text: 'resolved claim',
+        valid_from: new Date(day1.getTime() + 24 * 60 * 60 * 1000 + i * 60 * 60 * 1000),
+      });
+    }
+    const r2 = await runPhaseConsolidate(engine, {});
+    expect(r2.details.takes_written).toBe(0);
+
+    const after = await engine.executeRaw<{ id: number; source: string; updated_at: Date }>(
+      `SELECT id, source, updated_at FROM takes WHERE page_id = $1`,
+      [pageId],
+    );
+    expect(after.length).toBe(1);
+    expect(after[0].source).toBe(before[0].source);
+    expect(new Date(after[0].updated_at).getTime()).toBe(new Date(before[0].updated_at).getTime());
+
+    // Facts still consolidate into it — reuse without mutation.
+    const facts = await engine.executeRaw<{ consolidated_into: number }>(
+      `SELECT consolidated_into FROM facts WHERE entity_slug = 'cdx4-resolved' AND consolidated_into IS NOT NULL`,
+    );
+    expect(facts.length).toBe(4);
+    expect(facts[0].consolidated_into).toBe(before[0].id);
+  });
+
   test('valid_until idempotency: second run leaves valid_until unchanged (no diff)', async () => {
     await seedPage('cdx4-idempo-2');
     const t1 = new Date('2026-01-15T00:00:00Z');


### PR DESCRIPTION
## What

`consolidate`'s semantic upsert looks up an existing take by `(page_id, claim, since_date)`. `since_date` is derived from `MIN(valid_from)` of the current cluster, so it is temporal metadata about the fact rows that happen to exist right now, not a stable identity of the promoted take. This PR drops it from the lookup and scopes the lookup to the rows the phase itself authors.

Three changes, all in the same lookup/upsert block:

1. **Drop `since_date` from the match** — the actual fix.
2. **Add `kind = 'fact' AND holder = 'self'`** — mirrors the INSERT a few lines below, so the widened `(page_id, claim)` match can only ever land on a take this phase wrote.
3. **Skip the `source` UPDATE when the matched take is resolved** — reuse its id so facts still consolidate into it, but leave the row untouched.

2 and 3 exist because 1 widens the match; without them the widened lookup reaches rows consolidate does not own. Each is pinned by its own test.

## Why

The block's own comment states the goal:

> Without this lookup, a second cycle run would re-INSERT a duplicate take via `MAX(row_num)+1`, silently poisoning trajectory + scorecard data.

Keying on `since_date` defeats that goal in the ordinary case. The full cycle runs `extract_facts` before `consolidate`, and `extract_facts` hard-deletes and re-inserts the page's facts. When the extraction assigns a fresh `valid_from` — which an LLM extraction defaulting to `now()` does every run — `MIN(valid_from)` moves to a new day, `sinceISO` changes, the lookup misses, and control falls through to the exact `MAX(row_num)+1` INSERT the block was written to prevent. The claim text is identical; only a timestamp moved.

The failure is silent and compounding: one duplicate take per claim per cycle, accumulating in `takes` and skewing trajectory and scorecard reads. On our deployment this produced multi-day clusters of byte-identical takes on the same page before we traced it here.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/phases/consolidate.ts` to merge-base, ran `test/consolidate-valid-until.test.ts` → 6 pass / 3 fail. Restored → all pass.

(Produced by `bash scripts/check-test-discriminates.sh test/consolidate-valid-until.test.ts src/core/cycle/phases/consolidate.ts`. The three failures are the three cases below — one per change.)

## Tests

`test/consolidate-valid-until.test.ts` — four cases added, none modified or removed:

- `semantic upsert: a re-extracted claim with a newer valid_from reuses the take` — pins change 1. Promotes a claim, then simulates the next cycle's `extract_facts` by deleting the facts and re-inserting the same claim text one day later. Asserts `takes_written === 0`, exactly 1 take, and the take row unchanged (same `id`, same `since_date` from first promotion).
- `semantic upsert: a human-authored take with the same claim is not hijacked` — pins change 2. A pre-existing `kind=bet, holder=garry, source=human:garry` take plus 4 matching facts: the bet keeps its provenance and consolidate appends its own `kind=fact` row (2 rows total).
- `semantic upsert: a superseded take is not resurrected as a new active row` — pins the absence of an `active` filter. Take is retired (`active=false, superseded_by=N`), the next cycle re-extracts the same claim with a fresher `valid_from`: `takes_written === 0` and the row stays `active=false`.
- `semantic upsert: a resolved take is reused but never mutated` — pins change 3. `source` and `updated_at` are byte-identical across the second run, and the facts still consolidate into that take.

The existing `R4b/R7` same-day case is untouched and still passes under the new lookup: same `page_id` + `claim` + `kind` + `holder`, so the upsert hits.

```
bun test test/consolidate-valid-until.test.ts   → 9 pass / 0 fail (exit 0)
bun test test/cycle-consolidate.test.ts         → 5 pass / 0 fail (exit 0)
bun run verify                                   → 55/55 checks green
```

## Notes

- **Deliberately not filtered on `active`.** A superseded take still owns its claim; skipping it would send the phase down the INSERT path and resurrect a claim the user retired. An earlier revision of this PR had `active IS TRUE` here and did exactly that — the third test above is that regression, pinned.
- `ORDER BY id` keeps the choice deterministic when a page already holds more than one matching row (rows written before this fix).
- `since_date` is still written on INSERT and left untouched on the upsert path, so a take keeps the date of its first promotion.
- **Out of scope:** a take that consolidate itself authored and that was later resolved is now reused without mutation, but `MAX(row_num)+1` INSERT is still the fallback whenever no owned row matches. Filtering resolved rows out of the lookup entirely would reintroduce the duplicate INSERT this PR fixes, so the immutability guard is applied at the UPDATE instead.
