### PR TITLE
v0.47.6.1 fix(schema): enforce pack vocabulary at write surfaces (#4655)

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -47,8 +47,15 @@ import {
   detectBinarySignature,
   normalizeForHash,
   deriveTitle,
+  captureTypeFromContent,
   mergeCaptureFrontmatter,
 } from '../core/capture-content.ts';
+import {
+  loadActivePackForWriteVocabulary,
+  packDeclaresPageType,
+  undeclaredPageTypeMessage,
+  undeclaredPageTypeSuggestion,
+} from '../core/schema-pack/write-vocabulary.ts';
 
 export { detectBinaryNullByte, normalizeForHash, mergeCaptureFrontmatter } from '../core/capture-content.ts';
 
@@ -349,6 +356,26 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
     }
   }
 
+  let captureType: string;
+  try {
+    captureType = captureTypeFromContent(rawBody, parsed);
+  } catch (e) {
+    console.error(`gbrain capture: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+  if (!isThinClient(cfg) && engine) {
+    const activePack = await loadActivePackForWriteVocabulary({
+      engine,
+      remote: false,
+      sourceId: resolvedSourceId,
+    });
+    if (activePack && !packDeclaresPageType(activePack, captureType)) {
+      console.error(`gbrain capture: ${undeclaredPageTypeMessage(captureType, activePack, 'capture')}`);
+      console.error(`  ${undeclaredPageTypeSuggestion(activePack)}`);
+      process.exit(1);
+    }
+  }
+
   // CV8 (CLI side): content_hash for the RECEIPT comes from the normalized
   // rawBody, NOT the assembled fullContent which contains a timestamp.
   // The daemon's 24h LRU dedup keys on this hash; identical captures must
@@ -502,6 +529,7 @@ export const __testing = {
   buildContent,
   mergeCaptureFrontmatter,
   deriveTitle,
+  captureTypeFromContent,
   parseArgs,
   detectBinaryNullByte,
   detectBinarySignature,

--- a/src/core/capture-content.ts
+++ b/src/core/capture-content.ts
@@ -196,6 +196,28 @@ export function buildEventBlock(opts: CaptureFrontmatterOpts): Record<string, un
   return Object.keys(block).length ? block : undefined;
 }
 
+export function captureTypeFromContent(rawBody: string, opts: CaptureFrontmatterOpts): string {
+  const trimmedStart = rawBody.replace(/^﻿/, '');
+  if (!/^---\r?\n/.test(trimmedStart)) {
+    return opts.type ?? 'note';
+  }
+
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(rawBody);
+  } catch (e) {
+    throw new Error(
+      `malformed frontmatter in capture input: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  const userFm = (parsed.data ?? {}) as Record<string, unknown>;
+  const type = opts.type ?? userFm.type ?? 'note';
+  if (typeof type !== 'string' || type.length === 0) {
+    throw new Error('capture type must be a non-empty string');
+  }
+  return type;
+}
+
 /**
  * v0.39.3.0 (BUG-1): merge capture's auto-stamped fields with any existing
  * frontmatter in `rawBody`, rather than always prepending a second

--- a/src/core/ops/links.ts
+++ b/src/core/ops/links.ts
@@ -7,7 +7,7 @@
  * '../operations.ts' here (cycle).
  */
 
-import type { Operation } from './contract.ts';
+import { OperationError, type Operation } from './contract.ts';
 import {
   enforceClientSlugFence,
   linkReadScopeOpts,
@@ -21,6 +21,12 @@ import { unionLinksAcrossIdentity } from '../entity-identity.ts';
 import { findPrivateOnlySlugs, resolveExcludePrivatePages } from '../search/private-visibility.ts';
 import type { BrainEngine } from '../engine.ts';
 import type { Link } from '../types.ts';
+import {
+  loadActivePackForWriteVocabulary,
+  packDeclaresLinkType,
+  undeclaredLinkTypeMessage,
+  undeclaredLinkTypeSuggestion,
+} from '../schema-pack/write-vocabulary.ts';
 
 /**
  * #4352 remediation shared by get_links / get_backlinks: when the caller is
@@ -81,6 +87,17 @@ const add_link: Operation = {
     // (and renders on) the from page; linking TO a page outside the
     // binding is a reference, not a mutation of the target.
     enforceClientSlugFence(ctx, p.from as string, 'add_link');
+    const linkType = typeof p.link_type === 'string' ? p.link_type : '';
+    if (linkType.length > 0) {
+      const activePack = await loadActivePackForWriteVocabulary(ctx);
+      if (activePack && !packDeclaresLinkType(activePack, linkType)) {
+        throw new OperationError(
+          'invalid_params',
+          undeclaredLinkTypeMessage(linkType, activePack, 'add_link'),
+          undeclaredLinkTypeSuggestion(activePack),
+        );
+      }
+    }
     if (ctx.dryRun) return { dry_run: true, action: 'add_link', from: p.from, to: p.to };
     // v114 (#1941): default omitted provenance to 'manual' (NOT the engine's
     // 'markdown' default) so hand/tool-created CLI edges are honestly manual,
@@ -104,7 +121,7 @@ const add_link: Operation = {
     try {
       await ctx.engine.addLink( // gbrain-allow-direct-insert: add_link MCP op is the explicit canonical surface for manual link creation; auto-link reconciliation runs separately via auto_link post-hook
         p.from as string, p.to as string,
-        (p.context as string) || '', (p.link_type as string) || '',
+        (p.context as string) || '', linkType,
         linkSource, undefined, undefined,
         linkOpts,
       );

--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -24,6 +24,12 @@ import { getContentFlag } from '../quarantine.ts';
 import { bumpLastRetrievedAt } from '../last-retrieved.ts';
 import { resolveExcludePrivatePages, isPrivatePage, findPrivateOnlySlugs } from '../search/private-visibility.ts';
 import { LIST_PAGES_DESCRIPTION, CAPTURE_DESCRIPTION } from '../operations-descriptions.ts';
+import {
+  loadActivePackForWriteVocabulary,
+  packDeclaresPageType,
+  undeclaredPageTypeMessage,
+  undeclaredPageTypeSuggestion,
+} from '../schema-pack/write-vocabulary.ts';
 import { OperationError } from './contract.ts';
 import type { Operation, OperationContext } from './contract.ts';
 import {
@@ -1383,6 +1389,7 @@ const capture: Operation = {
   cliHints: { name: 'capture', hidden: true },
   handler: async (ctx, p) => {
     const {
+      captureTypeFromContent,
       detectBinaryNullByte, normalizeForHash, mergeCaptureFrontmatter,
       defaultSlug,
     } = await import('../capture-content.ts');
@@ -1398,7 +1405,25 @@ const capture: Operation = {
     if (normalized.length === 0) {
       throw new OperationError('invalid_params', 'Refusing to capture empty content.');
     }
-    const type = typeof p.type === 'string' && p.type.length > 0 ? p.type : 'note';
+    let type: string;
+    const explicitType = typeof p.type === 'string' && p.type.length > 0 ? p.type : undefined;
+    try {
+      type = captureTypeFromContent(content, explicitType ? { type: explicitType } : {});
+    } catch (e) {
+      throw new OperationError(
+        'invalid_params',
+        e instanceof Error ? e.message : String(e),
+        'Pass a string page type, or remove the type field to use the default note type.',
+      );
+    }
+    const activePack = await loadActivePackForWriteVocabulary(ctx);
+    if (activePack && !packDeclaresPageType(activePack, type)) {
+      throw new OperationError(
+        'invalid_params',
+        undeclaredPageTypeMessage(type, activePack, 'capture'),
+        undeclaredPageTypeSuggestion(activePack),
+      );
+    }
     let slug = typeof p.slug === 'string' && p.slug.length > 0 ? p.slug : undefined;
     if (slug) {
       // Defense-in-depth on the caller-supplied slug (matches the takes ops);
@@ -1424,7 +1449,7 @@ const capture: Operation = {
     // Remote MCP captures record `capture-mcp` provenance; local CLI callers
     // (ctx.remote === false) keep the neutral 'capture-cli' default.
     const capturedVia = ctx.remote !== false ? 'capture-mcp' : undefined;
-    const fullContent = mergeCaptureFrontmatter(content, { type, capturedVia });
+    const fullContent = mergeCaptureFrontmatter(content, { ...(explicitType ? { type: explicitType } : {}), capturedVia });
     if (ctx.dryRun) return { dry_run: true, action: 'capture', slug };
     // Delegate with the SAME ctx (the runCapture local-path precedent) —
     // put_page enforces the slug fence, validates the slug, dedupes, and

--- a/src/core/schema-pack/write-vocabulary.ts
+++ b/src/core/schema-pack/write-vocabulary.ts
@@ -1,0 +1,72 @@
+import { loadConfigFileOnly } from '../config.ts';
+import type { BrainEngine } from '../engine.ts';
+import { loadActivePack } from './load-active.ts';
+import type { ResolvedPack } from './registry.ts';
+
+export interface WriteVocabularyContext {
+  engine: Pick<BrainEngine, 'getConfig'>;
+  remote: boolean | undefined;
+  sourceId?: string;
+}
+
+/**
+ * Resolve the active pack for write-time vocabulary checks.
+ *
+ * This is deliberately best-effort: legacy write paths already tolerate a
+ * missing or broken pack, but when a pack resolves, explicit vocabulary values
+ * should not mint undeclared page types or link verbs.
+ */
+export async function loadActivePackForWriteVocabulary(
+  ctx: WriteVocabularyContext,
+): Promise<ResolvedPack | null> {
+  let dbConfig: string | undefined;
+  try {
+    dbConfig = (await ctx.engine.getConfig('schema_pack'))?.trim() || undefined;
+  } catch {
+    dbConfig = undefined;
+  }
+
+  try {
+    return await loadActivePack({
+      cfg: loadConfigFileOnly(),
+      remote: ctx.remote === false ? false : true,
+      sourceId: ctx.sourceId,
+      dbConfig,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function packDeclaresPageType(pack: ResolvedPack, typeName: string): boolean {
+  return pack.manifest.page_types.some((t) => t.name === typeName);
+}
+
+export function packDeclaresLinkType(pack: ResolvedPack, linkType: string): boolean {
+  return pack.manifest.link_types.some((t) => t.name === linkType);
+}
+
+function previewNames(names: readonly string[]): string {
+  if (names.length === 0) return 'none declared';
+  const shown = names.slice(0, 12);
+  const suffix = names.length > shown.length ? `, ... (${names.length} total)` : '';
+  return `${shown.join(', ')}${suffix}`;
+}
+
+export function undeclaredPageTypeMessage(typeName: string, pack: ResolvedPack, surface: string): string {
+  return `${surface}: page type '${typeName}' is not declared in active schema pack '${pack.manifest.name}'.`;
+}
+
+export function undeclaredPageTypeSuggestion(pack: ResolvedPack): string {
+  const names = pack.manifest.page_types.map((t) => t.name).sort();
+  return `Use a declared page type (${previewNames(names)}), or add this type to the active schema pack before writing.`;
+}
+
+export function undeclaredLinkTypeMessage(linkType: string, pack: ResolvedPack, surface: string): string {
+  return `${surface}: link type '${linkType}' is not declared in active schema pack '${pack.manifest.name}'.`;
+}
+
+export function undeclaredLinkTypeSuggestion(pack: ResolvedPack): string {
+  const names = pack.manifest.link_types.map((t) => t.name).sort();
+  return `Use a declared link type (${previewNames(names)}), or add this link type to the active schema pack before writing.`;
+}

--- a/test/capture-op.test.ts
+++ b/test/capture-op.test.ts
@@ -59,6 +59,29 @@ describe('capture op', () => {
     expect(body.slug).toMatch(/^life\/diary\/\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$/);
   });
 
+  test('rejects an undeclared explicit page type before writing', async () => {
+    const slug = 'inbox/capture-bad-explicit-type';
+    const body = parsed(await dispatchToolCall(engine, 'capture', {
+      content: 'This should not be written.',
+      slug,
+      type: 'definitely_not_a_type',
+    }, { ...STDIO }));
+    expect(body.error).toBe('invalid_params');
+    expect(body.message).toContain("page type 'definitely_not_a_type' is not declared");
+    expect(await engine.getPage(slug)).toBeNull();
+  });
+
+  test('rejects an undeclared frontmatter page type before writing', async () => {
+    const slug = 'inbox/capture-bad-frontmatter-type';
+    const body = parsed(await dispatchToolCall(engine, 'capture', {
+      content: '---\ntype: definitely_not_a_type\n---\n\nThis should not be written.',
+      slug,
+    }, { ...STDIO }));
+    expect(body.error).toBe('invalid_params');
+    expect(body.message).toContain("page type 'definitely_not_a_type' is not declared");
+    expect(await engine.getPage(slug)).toBeNull();
+  });
+
   test('NUL byte and empty content are refused with named errors', async () => {
     const nul = parsed(await dispatchToolCall(engine, 'capture', { content: 'ab\u0000cd' }, { ...STDIO }));
     expect(nul.error).toBe('invalid_params');

--- a/test/commands/capture.test.ts
+++ b/test/commands/capture.test.ts
@@ -45,6 +45,7 @@ beforeEach(async () => {
   brainDir = path.join(tmpRoot, 'brain');
   fs.mkdirSync(brainDir, { recursive: true });
   await engine.setConfig('sync.repo_path', brainDir);
+  await engine.setConfig('schema_pack', 'gbrain-base');
 });
 
 describe('capture — defaultSlug helper', () => {
@@ -213,6 +214,33 @@ describe('capture — local install integration', () => {
     const page = await engine.getPage('inbox/from-file');
     expect(page).not.toBeNull();
     expect(page?.compiled_truth).toContain('body content here');
+  });
+
+  test('--file rejects an undeclared frontmatter type before writing', async () => {
+    const file = path.join(tmpRoot, 'bad-type.md');
+    fs.writeFileSync(file, '---\ntype: definitely_not_a_type\n---\n\nbody content here');
+    const errCaptured: string[] = [];
+    const origErr = console.error;
+    const origExit = process.exit;
+    let exitCode: number | undefined;
+    console.error = (...args: unknown[]) => errCaptured.push(args.map(String).join(' '));
+    (process.exit as unknown as (code?: number) => never) = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error('__EXIT__');
+    });
+    try {
+      await runCapture(engine, ['--file', file, '--slug', 'inbox/bad-frontmatter-type', '--quiet']);
+      throw new Error('expected capture to exit');
+    } catch (e) {
+      if (!(e instanceof Error) || e.message !== '__EXIT__') throw e;
+    } finally {
+      console.error = origErr;
+      process.exit = origExit;
+    }
+    expect(exitCode).toBe(1);
+    expect(errCaptured.join('\n')).toContain("page type 'definitely_not_a_type' is not declared");
+    expect(await engine.getPage('inbox/bad-frontmatter-type')).toBeNull();
+    expect(fs.existsSync(path.join(brainDir, 'inbox/bad-frontmatter-type.md'))).toBe(false);
   });
 
   test('--json emits structured output', async () => {

--- a/test/link-source-namespaced-regex.test.ts
+++ b/test/link-source-namespaced-regex.test.ts
@@ -157,24 +157,33 @@ describe('add_link op — provenance + managed-built-in guard (OV4A)', () => {
 
   test('threads custom provenance through to the row', async () => {
     const op = operationsByName['add_link'];
-    await op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'cites', link_source: 'citation-graph' });
+    await op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'works_at', link_source: 'citation-graph' });
     const links = await engine.getLinks('lsrc-a');
-    expect(links.some(l => (l as any).to_slug === 'lsrc-b' && (l as any).link_source === 'citation-graph' && (l as any).link_type === 'cites')).toBe(true);
+    expect(links.some(l => (l as any).to_slug === 'lsrc-b' && (l as any).link_source === 'citation-graph' && (l as any).link_type === 'works_at')).toBe(true);
   });
 
   test("omitted link_source defaults to 'manual' (not 'markdown')", async () => {
     const op = operationsByName['add_link'];
-    await op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'default-prov' });
+    await op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'attended' });
     const links = await engine.getLinks('lsrc-a');
-    const row = links.find(l => (l as any).link_type === 'default-prov');
+    const row = links.find(l => (l as any).link_type === 'attended');
     expect((row as any)?.link_source).toBe('manual');
+  });
+
+  test('rejects undeclared link_type before inserting the row', async () => {
+    const op = operationsByName['add_link'];
+    await expect(
+      op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'definitely_not_a_verb' }),
+    ).rejects.toMatchObject({ code: 'invalid_params' });
+    const links = await engine.getLinks('lsrc-a');
+    expect(links.some(l => (l as any).link_type === 'definitely_not_a_verb')).toBe(false);
   });
 
   for (const managed of MANAGED_LINK_SOURCES) {
     test(`rejects managed built-in '${managed}'`, async () => {
       const op = operationsByName['add_link'];
       await expect(
-        op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'g', link_source: managed }),
+        op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'mentions', link_source: managed }),
       ).rejects.toThrow(/reconciliation-managed/);
     });
   }
@@ -182,7 +191,7 @@ describe('add_link op — provenance + managed-built-in guard (OV4A)', () => {
   test("'manual' is allowed (not in the managed set)", async () => {
     const op = operationsByName['add_link'];
     await expect(
-      op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'man', link_source: 'manual' }),
+      op.handler(makeCtx(), { from: 'lsrc-a', to: 'lsrc-b', link_type: 'related_to', link_source: 'manual' }),
     ).resolves.toMatchObject({ status: 'ok' });
   });
 });

--- a/test/source-boundary-mutation-errors.test.ts
+++ b/test/source-boundary-mutation-errors.test.ts
@@ -107,7 +107,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: FROM_SLUG,
       to: TO_FOREIGN,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, GRANTED);
 
     expect(result.isError).toBe(true);
@@ -122,7 +122,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: TO_FOREIGN,
       to: TO_SHARED,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, GRANTED);
 
     expect(result.isError).toBe(true);
@@ -135,7 +135,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: FROM_SLUG,
       to: TO_FOREIGN,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, UNGRANTED);
 
     expect(result.isError).toBe(true);
@@ -150,7 +150,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: FROM_SLUG,
       to: DELETED_FOREIGN,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, GRANTED);
 
     expect(result.isError).toBe(true);
@@ -162,7 +162,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: SD_FROM,
       to: SD_TO,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, GRANTED);
 
     expect(result.isError).toBeUndefined();
@@ -173,7 +173,7 @@ describe('add_link source-boundary diagnostics (#4109)', () => {
     const result = await dispatchToolCall(engine, 'add_link', {
       from: FROM_SLUG,
       to: TO_SHARED,
-      link_type: 'documents',
+      link_type: 'mentions',
     }, GRANTED);
 
     expect(result.isError).toBeUndefined();


### PR DESCRIPTION
Fixes #4655

## Summary
- Adds a best-effort active-pack vocabulary helper for write surfaces.
- Makes `capture` reject undeclared final page types from `--type` or input frontmatter before delegating to `put_page`.
- Makes `add_link` reject explicit undeclared `link_type` values before inserting manual edges, while preserving untyped links.
- Updates focused tests to use declared pack verbs in unrelated happy paths and adds negative regressions for capture/link writes.

## Verification
- `DATABASE_URL= GBRAIN_DATABASE_URL= bash scripts/gbrain-gate.sh <worktree> test/capture-op.test.ts test/commands/capture.test.ts test/link-source-namespaced-regex.test.ts test/source-boundary-mutation-errors.test.ts` -> RESULT: GREEN
