### PR TITLE
feat(loops): add stock `loops unmute` to reverse a suppression

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -4,7 +4,7 @@
 <!-- Regenerate: bun run scripts/generate-tool-catalog.ts -->
 <!-- Freshness-guarded by scripts/check-tool-catalog-fresh.sh (bun run verify). -->
 
-Every non-localOnly operation on the MCP surface: 121 tools across 23 areas. **Starter** marks membership in the ~27-op `starter` surface (`src/mcp/surface.ts`); **Gate** names the config key that must be true before remote callers see/call the op (`gbrain config set <key> true`). What a given token actually sees is further filtered per request by scope, bound-client fence, publish gates, and the per-client surface — see `docs/operations/mcp-surface-runbook.md`. Area names are non-contractual groupings.
+Every non-localOnly operation on the MCP surface: 122 tools across 23 areas. **Starter** marks membership in the ~27-op `starter` surface (`src/mcp/surface.ts`); **Gate** names the config key that must be true before remote callers see/call the op (`gbrain config set <key> true`). What a given token actually sees is further filtered per request by scope, bound-client fence, publish gates, and the per-client surface — see `docs/operations/mcp-surface-runbook.md`. Area names are non-contractual groupings.
 
 ## admin
 
@@ -122,6 +122,7 @@ Every non-localOnly operation on the MCP surface: 121 tools across 23 areas. **S
 |---|---|---|---|---|
 | `loops_close` | Close an open loop by id: status 'done' (handled) or 'dropped' (not going to). | write |  |  |
 | `loops_mute` | Suppress a sender (email address) or thread id from opening NEW loops — the detector feedback primitive behind "never track this sender". | write |  |  |
+| `loops_unmute` | Remove a sender/thread suppression added by loops_mute, so the detector can open NEW loops for it again. | write |  |  |
 | `open_loops` | The open-loop engine's killer output: who is waiting on you, what you promised, and the context needed to respond. | read |  |  |
 
 ## memory

--- a/docs/guides/open-loops.md
+++ b/docs/guides/open-loops.md
@@ -67,6 +67,8 @@ gbrain loops done <id> | drop <id>   close (a closed commitment expires its
 gbrain loops mute sender <email>     never open loops for this sender again
 gbrain loops mute thread <id>        ...or this thread (existing loops keep
                                      their state)
+gbrain loops unmute sender <email>   undo a mute — the detector may open new
+gbrain loops unmute thread <id>      loops for it again
 ```
 
 `gbrain waiting` and `gbrain loops list` read across **every source in the
@@ -74,15 +76,28 @@ brain** by default (loops live in google sources, not `default` — a
 default-scoped read would say "all clean" while people wait); `--source <id>`
 narrows explicitly. An unqualified `loops mute` resolves to the brain's
 google source automatically, and refuses with the exact fix when there is
-none or more than one (`--source` disambiguates).
+none or more than one (`--source` disambiguates). `loops unmute` resolves
+its source the same way, so an unmute cannot aim at a different source than
+the mute it reverses.
 
-MCP: the `open_loops`, `loops_close`, `loops_mute` ops. `open_loops` is
+**Unmute is exact and forward-only.** It deletes the one
+`(source_id, kind, value)` row the mute wrote — the same lower-casing, so
+`unmute sender BOB@Example.com` reverses `mute sender bob@example.com`, while
+a sibling source, the other `kind`, or a different value are untouched. It
+does **not** reopen loops: suppressions gate NEW detection only, so anything
+closed or never opened while the mute was in place stays that way; the
+detector simply resumes opening loops from the next sync. A repeated unmute
+is a no-op that reports `removed: false` and exits 0, so a script may call it
+unconditionally without special-casing "was not muted".
+
+MCP: the `open_loops`, `loops_close`, `loops_mute`, `loops_unmute` ops. `open_loops` is
 served to remote callers with **fail-closed evidence redaction** — counts,
 counterparty, summary, due date; verbatim quotes, deep links, and the
 injectable `text` digest are trusted-local only. Remote callers also need a
 resolved source scope: an unscoped remote read is refused outright rather
 than spanning the brain, and the two write ops require a single-source scope
-that matches the caller's grants. `open_loops` takes per-call scope params —
+that matches the caller's grants (`loops_unmute` included — lifting another
+source's suppression is as much a targeted write as planting one). `open_loops` takes per-call scope params —
 `source_id` (an MCP client whose transport is bound to another source can
 point the read at the google source, grant-checked for remote callers) and
 `all_sources` (trusted local spans the brain; remote stays in-grant).

--- a/src/commands/loops.ts
+++ b/src/commands/loops.ts
@@ -12,6 +12,7 @@
  *   gbrain loops show <id> [--json]
  *   gbrain loops done <id> / drop <id>
  *   gbrain loops mute <sender|thread> <value> [--source <id>]
+ *   gbrain loops unmute <sender|thread> <value> [--source <id>]
  *
  * All paths dispatch through the trusted-local op layer (handleToolCall,
  * remote:false) so CLI and MCP share one behavior. Reads default to the
@@ -145,6 +146,7 @@ export async function runLoops(engine: BrainEngine, args: string[]): Promise<voi
         '  done  <id>        mark handled',
         '  drop  <id>        not going to do it',
         '  mute  sender <email> | thread <thread-id>   [--source <id>]',
+        '  unmute sender <email> | thread <thread-id>  [--source <id>]   undo a mute',
         '',
         'The ranked digest lives at: gbrain waiting',
       ].join('\n') + '\n',
@@ -236,15 +238,17 @@ export async function runLoops(engine: BrainEngine, args: string[]): Promise<voi
     return;
   }
 
-  if (sub === 'mute') {
+  if (sub === 'mute' || sub === 'unmute') {
     const kind = rest[0];
     const value = rest[1];
     if ((kind !== 'sender' && kind !== 'thread') || !value) {
-      console.error('Usage: gbrain loops mute sender <email> | thread <thread-id> [--source <id>]');
+      console.error(`Usage: gbrain loops ${sub} sender <email> | thread <thread-id> [--source <id>]`);
       process.exit(2);
     }
     // A suppression row is only consulted by the detector inside ITS source —
-    // an unqualified mute must land in the google source, never 'default'.
+    // an unqualified mute/unmute must land in the google source, never
+    // 'default'. Both directions share this resolution so an unmute can never
+    // aim at a different source than the mute it is reversing.
     let sourceId = sourceFlag(rest);
     if (!sourceId) {
       const gs = await googleSourceIds(engine);
@@ -252,23 +256,42 @@ export async function runLoops(engine: BrainEngine, args: string[]): Promise<voi
       else {
         console.error(
           gs.length === 0
-            ? 'No google source found — pass --source <id> to scope the mute (gbrain sources list).'
+            ? `No google source found — pass --source <id> to scope the ${sub} (gbrain sources list).`
             : `Multiple google sources — pass --source <id> (one of: ${gs.join(', ')}).`,
         );
         process.exit(2);
       }
     }
-    const result = (await handleToolCall(engine, 'loops_mute', {
+    if (sub === 'mute') {
+      const result = (await handleToolCall(engine, 'loops_mute', {
+        kind,
+        value,
+        source_id: sourceId,
+      })) as { muted: boolean; reason?: string };
+      if (json) {
+        process.stdout.write(JSON.stringify({ ok: result.muted, status: result.muted ? 'muted' : 'not_muted', ...result }, null, 2) + '\n');
+      } else {
+        process.stdout.write(result.muted ? `Muted ${kind} ${value}. New loops won't open for it (existing loops keep their state).\n` : `Not muted: ${result.reason}\n`);
+      }
+      if (!result.muted) setCliExitVerdict(1);
+      return;
+    }
+    const result = (await handleToolCall(engine, 'loops_unmute', {
       kind,
       value,
       source_id: sourceId,
-    })) as { muted: boolean; reason?: string };
+    })) as { removed: boolean; reason?: string };
+    // A repeated unmute is a no-op, NOT a failure: removed:false exits 0 so
+    // scripts can call it unconditionally without special-casing.
     if (json) {
-      process.stdout.write(JSON.stringify({ ok: result.muted, status: result.muted ? 'muted' : 'not_muted', ...result }, null, 2) + '\n');
+      process.stdout.write(JSON.stringify({ ok: true, status: result.removed ? 'unmuted' : 'not_muted', ...result }, null, 2) + '\n');
     } else {
-      process.stdout.write(result.muted ? `Muted ${kind} ${value}. New loops won't open for it (existing loops keep their state).\n` : `Not muted: ${result.reason}\n`);
+      process.stdout.write(
+        result.removed
+          ? `Unmuted ${kind} ${value}. New loops can open for it again (loops closed meanwhile stay closed).\n`
+          : `Not muted: ${kind} ${value} had no suppression in ${sourceId}.\n`,
+      );
     }
-    if (!result.muted) setCliExitVerdict(1);
     return;
   }
 

--- a/src/core/loops/loops-store.ts
+++ b/src/core/loops/loops-store.ts
@@ -273,6 +273,34 @@ export async function addSuppression(
   );
 }
 
+/**
+ * Remove one exact suppression row (`gbrain loops unmute`).
+ *
+ * The symmetric counterpart to addSuppression, and deliberately narrow: it
+ * matches the SAME (source_id, kind, value) triple the insert wrote, with the
+ * same lower-casing, so an unmute can never remove a sibling source's row or a
+ * different kind. Returns the number of rows removed — 0 is the ordinary
+ * "already not muted" answer, not an error, which keeps a repeated unmute
+ * idempotent for callers that retry.
+ *
+ * Suppressions only gate NEW loop creation (see loop-detect), so removing one
+ * changes future detection only; it never reopens or mutates existing loops.
+ */
+export async function removeSuppression(
+  engine: BrainEngine,
+  sourceId: string,
+  kind: 'sender' | 'thread',
+  value: string,
+): Promise<number> {
+  const rows = await engine.executeRaw<{ value: string }>(
+    `DELETE FROM loop_suppressions
+      WHERE source_id = $1 AND kind = $2 AND value = $3
+      RETURNING value`,
+    [sourceId, kind, value.toLowerCase()],
+  );
+  return rows.length;
+}
+
 export interface SuppressionSet {
   senders: Set<string>;
   threads: Set<string>;

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -293,7 +293,7 @@ const OP_AREAS: Record<string, string> = {
   entity_identity_link: 'entities', entity_identity_unlink: 'entities',
   entity_identity_list: 'entities',
   // v0.47 open-loop engine (google source kind)
-  open_loops: 'loops', loops_close: 'loops', loops_mute: 'loops',
+  open_loops: 'loops', loops_close: 'loops', loops_mute: 'loops', loops_unmute: 'loops',
   // insight / signal reads
   get_recent_salience: 'insights', find_anomalies: 'insights',
   find_contradictions: 'insights', find_experts: 'insights',

--- a/src/core/ops/loops.ts
+++ b/src/core/ops/loops.ts
@@ -23,6 +23,7 @@ import { resolveRequestedScope, sourceScopeOpts } from './context.ts';
 import { validateSourceId } from '../utils.ts';
 import {
   addSuppression,
+  removeSuppression,
   closeOpenLoop,
   listOpenLoops,
   type LoopStatus,
@@ -480,4 +481,53 @@ const loops_mute: Operation = {
   },
 };
 
-export const loopsOperations: Operation[] = [open_loops, loops_close, loops_mute];
+const loops_unmute: Operation = {
+  name: 'loops_unmute',
+  description:
+    'Remove a sender/thread suppression added by loops_mute, so the detector can open NEW loops for ' +
+    'it again. Exact-match only. Does not reopen loops closed while the mute was in place.',
+  params: {
+    kind: { type: 'string', required: true, enum: ['sender', 'thread'], description: 'What to unmute.' },
+    value: { type: 'string', required: true, description: 'The sender email or Gmail thread id.' },
+    source_id: { type: 'string', description: 'Google source the mute was scoped to (default: routed source).' },
+  },
+  mutating: true,
+  scope: 'write',
+  handler: async (ctx, p) => {
+    const sourceId = (p.source_id as string | undefined) ?? ctx.sourceId ?? 'default';
+    validateSourceId(sourceId);
+    // Same grant check as loops_mute — an unmute is equally a targeted write:
+    // letting a remote caller lift another source's suppression would re-open
+    // the very noise channel its owner silenced.
+    if (ctx.remote !== false) {
+      const scope = sourceScopeOpts(ctx);
+      const granted =
+        (scope.sourceId && scope.sourceId === sourceId) ||
+        (scope.sourceIds?.includes(sourceId) ?? false);
+      if (!granted) {
+        throw new OperationError(
+          'permission_denied',
+          `loops_unmute: source "${sourceId}" is outside the caller's scope`,
+        );
+      }
+    }
+    if (ctx.dryRun) return { dry_run: true, action: 'loops_unmute', kind: p.kind, value: p.value };
+    const removed = await removeSuppression(
+      ctx.engine,
+      sourceId,
+      p.kind as 'sender' | 'thread',
+      p.value as string,
+    );
+    // removed:false is the ordinary "was not muted" answer, never an error —
+    // a retried unmute must be safe.
+    return {
+      removed: removed > 0,
+      kind: p.kind,
+      value: (p.value as string).toLowerCase(),
+      source_id: sourceId,
+      ...(removed > 0 ? {} : { reason: 'no matching suppression' }),
+    };
+  },
+};
+
+export const loopsOperations: Operation[] = [open_loops, loops_close, loops_mute, loops_unmute];

--- a/test/loops-cli.test.ts
+++ b/test/loops-cli.test.ts
@@ -27,6 +27,8 @@ import {
   _resetCliExitVerdictForTests,
 } from '../src/core/cli-force-exit.ts';
 import {
+  addSuppression,
+  listOpenLoops,
   loadSuppressions,
   upsertOpenLoop,
   type OpenLoopUpsert,
@@ -362,6 +364,55 @@ describe('runLoops', () => {
     expect(r.exitCalled).toBe(2);
   });
 
+  test('unmute removes the row the mute wrote, matching case-insensitively', async () => {
+    await captured(() => runLoops(engine, ['mute', 'sender', 'Bob@Example.com']));
+    const r = await captured(() => runLoops(engine, ['unmute', 'sender', 'BOB@example.COM']));
+    expect(r.out).toContain('Unmuted sender BOB@example.COM');
+    expect(r.verdict).toBe(0);
+    expect((await loadSuppressions(engine, 'default')).senders.has('bob@example.com')).toBe(false);
+  });
+
+  test('a repeated unmute is a no-op that still exits 0', async () => {
+    await captured(() => runLoops(engine, ['mute', 'sender', 'bob@example.com']));
+    const first = await captured(() => runLoops(engine, ['unmute', 'sender', 'bob@example.com']));
+    const second = await captured(() => runLoops(engine, ['unmute', 'sender', 'bob@example.com']));
+    expect(first.out).toContain('Unmuted');
+    expect(second.out).toContain('had no suppression');
+    // The idempotency contract: a retried unmute must not look like a failure.
+    expect(second.verdict).toBe(0);
+  });
+
+  test('unmute --json envelope reports ok:true with removed true then false', async () => {
+    await captured(() => runLoops(engine, ['mute', 'thread', '18C2F4A9B3D21E07']));
+    const hit = await captured(() => runLoops(engine, ['unmute', 'thread', '18C2F4A9B3D21E07', '--json']));
+    const a = JSON.parse(hit.out) as { ok: boolean; status: string; removed: boolean; value: string };
+    expect(a.ok).toBe(true);
+    expect(a.status).toBe('unmuted');
+    expect(a.removed).toBe(true);
+    expect(a.value).toBe('18c2f4a9b3d21e07');
+    const miss = await captured(() => runLoops(engine, ['unmute', 'thread', '18C2F4A9B3D21E07', '--json']));
+    const b = JSON.parse(miss.out) as { ok: boolean; status: string; removed: boolean };
+    expect(b.ok).toBe(true);
+    expect(b.status).toBe('not_muted');
+    expect(b.removed).toBe(false);
+  });
+
+  test('unmute leaves existing loops exactly as they were', async () => {
+    await upsertOpenLoop(engine, loop({ counterpartyEmail: 'bob@example.com' }));
+    await addSuppression(engine, 'default', 'sender', 'bob@example.com');
+    const before = await listOpenLoops(engine, { sourceIds: ['default'], status: 'open' });
+    await captured(() => runLoops(engine, ['unmute', 'sender', 'bob@example.com']));
+    const after = await listOpenLoops(engine, { sourceIds: ['default'], status: 'open' });
+    expect(after.length).toBe(before.length);
+    expect(after[0].id).toBe(before[0].id);
+    expect(after[0].status).toBe('open');
+  });
+
+  test('unmute without kind/value hard-exits with usage code 2', async () => {
+    const r = await captured(() => runLoops(engine, ['unmute', 'sender']));
+    expect(r.exitCalled).toBe(2);
+  });
+
   test('--help paths answer without touching loops', async () => {
     const w = await captured(() => runWaiting(engine, ['--help']));
     expect(w.out).toContain('gbrain waiting');
@@ -369,6 +420,7 @@ describe('runLoops', () => {
     const l = await captured(() => runLoops(engine, ['--help']));
     expect(l.out).toContain('gbrain loops');
     expect(l.out).toContain('mute');
+    expect(l.out).toContain('unmute');
     expect(w.verdict).toBe(0);
     expect(l.verdict).toBe(0);
   });

--- a/test/loops-store.test.ts
+++ b/test/loops-store.test.ts
@@ -16,6 +16,7 @@ import {
   closeThreadLoops,
   listOpenLoops,
   loadSuppressions,
+  removeSuppression,
   markStaleLoops,
   upsertOpenLoop,
   type OpenLoopUpsert,
@@ -502,5 +503,50 @@ describe('suppressions', () => {
       `SELECT COUNT(*) AS n FROM loop_suppressions WHERE source_id = 'g1'`,
     );
     expect(Number(raw[0].n)).toBe(2);
+  });
+
+  test('remove deletes exactly the matching row, with the same lowercasing', async () => {
+    await addSuppression(engine, 'g1', 'sender', 'Bob@Example.com');
+    await addSuppression(engine, 'g1', 'thread', '18C2F4A9B3D21E07');
+
+    // Mixed case on the way out must match the lower-cased row the insert wrote.
+    expect(await removeSuppression(engine, 'g1', 'sender', 'BOB@example.COM')).toBe(1);
+
+    const set = await loadSuppressions(engine, 'g1');
+    expect([...set.senders]).toEqual([]);
+    expect([...set.threads]).toEqual(['18c2f4a9b3d21e07']);
+  });
+
+  test('remove is exact: a sibling source, kind or value is untouched', async () => {
+    await addSuppression(engine, 'g1', 'sender', 'bob@example.com');
+    await addSuppression(engine, 'g2', 'sender', 'bob@example.com');
+    await addSuppression(engine, 'g1', 'thread', 'bob@example.com');
+    await addSuppression(engine, 'g1', 'sender', 'carol@example.com');
+
+    expect(await removeSuppression(engine, 'g1', 'sender', 'bob@example.com')).toBe(1);
+
+    // The same value under another source and under another kind both survive.
+    expect((await loadSuppressions(engine, 'g2')).senders.has('bob@example.com')).toBe(true);
+    const g1 = await loadSuppressions(engine, 'g1');
+    expect(g1.threads.has('bob@example.com')).toBe(true);
+    expect(g1.senders.has('carol@example.com')).toBe(true);
+    expect(g1.senders.has('bob@example.com')).toBe(false);
+  });
+
+  test('a repeated remove is idempotent and reports 0, not an error', async () => {
+    await addSuppression(engine, 'g1', 'sender', 'bob@example.com');
+    expect(await removeSuppression(engine, 'g1', 'sender', 'bob@example.com')).toBe(1);
+    expect(await removeSuppression(engine, 'g1', 'sender', 'bob@example.com')).toBe(0);
+    // Never muted at all is the same answer.
+    expect(await removeSuppression(engine, 'g1', 'sender', 'nobody@example.com')).toBe(0);
+  });
+
+  test('removing a suppression does not touch existing loops', async () => {
+    await upsertOpenLoop(engine, loop({ counterpartyEmail: 'bob@example.com' }));
+    await addSuppression(engine, 'g1', 'sender', 'bob@example.com');
+    await removeSuppression(engine, 'g1', 'sender', 'bob@example.com');
+    const open = await listOpenLoops(engine, { sourceIds: ['g1'], status: 'open' });
+    expect(open.length).toBe(1);
+    expect(open[0].counterparty_email).toBe('bob@example.com');
   });
 });

--- a/test/ops-loops.test.ts
+++ b/test/ops-loops.test.ts
@@ -52,6 +52,7 @@ beforeEach(async () => {
 const openLoopsOp = loopsOperations.find((o) => o.name === 'open_loops')!;
 const loopsCloseOp = loopsOperations.find((o) => o.name === 'loops_close')!;
 const loopsMuteOp = loopsOperations.find((o) => o.name === 'loops_mute')!;
+const loopsUnmuteOp = loopsOperations.find((o) => o.name === 'loops_unmute')!;
 
 function ctx(over: Partial<OperationContext> = {}): OperationContext {
   return {
@@ -102,6 +103,9 @@ describe('registration', () => {
     expect(operationsByName['loops_close'].mutating).toBe(true);
     expect(operationsByName['loops_mute']).toBeDefined();
     expect(operationsByName['loops_mute'].scope).toBe('write');
+    expect(operationsByName['loops_unmute']).toBeDefined();
+    expect(operationsByName['loops_unmute'].scope).toBe('write');
+    expect(operationsByName['loops_unmute'].mutating).toBe(true);
   });
 });
 
@@ -749,5 +753,83 @@ describe('loops_mute', () => {
       { kind: 'sender', value: 'bob@example.com' },
     )) as { muted: boolean };
     expect(ok.muted).toBe(true);
+  });
+});
+
+describe('loops_unmute', () => {
+  test('removes the row loops_mute wrote and reports removed:true', async () => {
+    await loopsMuteOp.handler(ctx(), { kind: 'sender', value: 'Bob@Example.com' });
+    const res = (await loopsUnmuteOp.handler(ctx(), {
+      kind: 'sender',
+      value: 'BOB@example.COM',
+    })) as { removed: boolean; value: string; source_id: string };
+    expect(res.removed).toBe(true);
+    expect(res.value).toBe('bob@example.com');
+    expect(res.source_id).toBe('g1');
+    expect((await loadSuppressions(engine, 'g1')).senders.size).toBe(0);
+  });
+
+  test('a second unmute reports removed:false with a reason, and does not throw', async () => {
+    await loopsMuteOp.handler(ctx(), { kind: 'sender', value: 'bob@example.com' });
+    await loopsUnmuteOp.handler(ctx(), { kind: 'sender', value: 'bob@example.com' });
+    const res = (await loopsUnmuteOp.handler(ctx(), {
+      kind: 'sender',
+      value: 'bob@example.com',
+    })) as { removed: boolean; reason?: string };
+    expect(res.removed).toBe(false);
+    expect(res.reason).toContain('no matching suppression');
+  });
+
+  test('dry_run returns the action without removing', async () => {
+    await loopsMuteOp.handler(ctx(), { kind: 'sender', value: 'bob@example.com' });
+    const res = (await loopsUnmuteOp.handler(ctx({ dryRun: true }), {
+      kind: 'sender',
+      value: 'bob@example.com',
+    })) as { dry_run: boolean; action: string };
+    expect(res.dry_run).toBe(true);
+    expect(res.action).toBe('loops_unmute');
+    expect((await loadSuppressions(engine, 'g1')).senders.has('bob@example.com')).toBe(true);
+  });
+
+  test('kind is exact: unmuting a sender leaves the same value muted as a thread', async () => {
+    await loopsMuteOp.handler(ctx(), { kind: 'sender', value: 'shared-value' });
+    await loopsMuteOp.handler(ctx(), { kind: 'thread', value: 'shared-value' });
+    await loopsUnmuteOp.handler(ctx(), { kind: 'sender', value: 'shared-value' });
+    const set = await loadSuppressions(engine, 'g1');
+    expect(set.senders.has('shared-value')).toBe(false);
+    expect(set.threads.has('shared-value')).toBe(true);
+  });
+
+  test('remote caller cannot unmute outside its granted scope (throws)', async () => {
+    await loopsMuteOp.handler(ctx(), { kind: 'sender', value: 'bob@example.com' });
+    await expect(
+      loopsUnmuteOp.handler(
+        ctx({
+          remote: true,
+          auth: { token: 't', clientId: 'c', scopes: ['write'], allowedSources: ['other-src'] },
+        }),
+        { kind: 'sender', value: 'bob@example.com' },
+      ),
+    ).rejects.toThrow(/permission_denied|outside the caller's scope/);
+    expect((await loadSuppressions(engine, 'g1')).senders.has('bob@example.com')).toBe(true);
+  });
+
+  test('REGRESSION: scalar-scoped remote caller cannot unmute a DIFFERENT source via p.source_id', async () => {
+    // Mirrors the loops_mute guard: lifting another source's suppression is
+    // just as much a targeted write as planting one — it re-opens the noise
+    // channel that source's owner deliberately silenced.
+    // This file's fixture seeds only g1; the sibling source is local to this test.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config) VALUES ('g2', 'g2', '{"kind":"google"}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    await loopsMuteOp.handler(ctx({ sourceId: 'g2' }), { kind: 'sender', value: 'bob@example.com' });
+    await expect(
+      loopsUnmuteOp.handler(
+        ctx({ remote: true, sourceId: 'g1' }),
+        { kind: 'sender', value: 'bob@example.com', source_id: 'g2' },
+      ),
+    ).rejects.toThrow(/permission_denied|outside the caller's scope/);
+    expect((await loadSuppressions(engine, 'g2')).senders.has('bob@example.com')).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`gbrain loops mute` inserts a row into `loop_suppressions`, but nothing removes one. `gbrain loops` implements only `mute`; `grep -rniE "unmute|removeSuppression|deleteSuppression|DELETE FROM loop_suppressions" src` returns nothing.

An accidental mute is therefore unrecoverable through the CLI — the only fix is manual SQL against the operator's own brain, which the open-loops guide has no answer for. It bit us: a mute applied to a sender that turned out to carry real signing/payment obligations could not be undone by any supported command.

## Change

Adds the symmetric half, reusing mute's identity normalisation and source scoping so the two cannot drift.

```
gbrain loops unmute sender <email> | thread <id> [--source <id>]
MCP: loops_unmute (scope: write, mutating)
```

Semantics, each pinned by a test:

- **exact match only** on `(source_id, kind, value)` with mute's lower-casing — a sibling source, the other `kind`, or a different value all survive;
- **forward-only** — suppressions gate NEW detection, so unmute never reopens or mutates existing loops;
- **idempotent** — a repeated unmute reports `removed: false` and exits 0 rather than failing, so a script can call it unconditionally;
- **same remote grant check as `loops_mute`** — lifting another source's suppression is as much a targeted write as planting one.

The CLI now shares one source-resolution block between `mute` and `unmute`, so an unmute cannot aim at a different source than the mute it reverses.

## Tests

16 new: 4 store (`test/loops-store.test.ts`), 6 CLI (`test/loops-cli.test.ts`), 6 MCP op (`test/ops-loops.test.ts`), including the scalar-scoped remote-caller regression mirroring the existing `loops_mute` one.

`bun run verify` → **55/55 green**. Targeted suites → **91/91**. Toolchain bun 1.3.13 (the CI pin).

`docs/TOOL_CATALOG.md` regenerated via `bun run scripts/generate-tool-catalog.ts`; `docs/guides/open-loops.md` documents the exact/forward-only/idempotent semantics.

Independent of the other two PRs in this series.