### PR TITLE
fix(google-loops): calendar system mail neither opens nor closes reply loops

### DIFF
--- a/docs/guides/open-loops.md
+++ b/docs/guides/open-loops.md
@@ -33,6 +33,20 @@ self-threads, and muted senders/threads never open loops. Sent-mail
 ingestion is what makes "unanswered" honest — your own replies are the
 negative filter.
 
+**Google Calendar system mail is excluded structurally.** `Invitation:`,
+`Updated invitation:`, `Accepted:`, `Declined:`, `Tentative:` and
+`Canceled event:` notices are sent by Calendar ON BEHALF OF a human, so they
+arrive from your colleague's real address — `isNoiseSender` cannot see them
+and `loops mute sender` would silence that person's genuine email along with
+them. They are identified by the `text/calendar` part (or `.ics` attachment)
+Gmail carries on every one of them and on no ordinary human mail; the subject
+prefix is a fallback for messages whose MIME was not captured, anchored to
+the start of the subject and refusing anything with a Re:/Fwd: prefix so a
+human forward of an invite thread still opens a loop. These notices neither
+OPEN nor CLOSE a loop — an invite is not a reply, and letting it flip the
+turn would silently answer a real outbound loop. They still ingest as normal
+searchable pages and still feed calendar/meeting context.
+
 **2. The LLM commitment extractor** (`src/core/google/loops-extract.ts`, one
 model call per recent thread, default ON for google sources). Extracts
 commitments with direction ("I'll send the deck by Friday" →

--- a/src/core/google/google-clients.ts
+++ b/src/core/google/google-clients.ts
@@ -156,6 +156,7 @@ interface RawGmailHeader {
 
 interface RawGmailPart {
   mimeType?: string;
+  filename?: string;
   body?: { data?: string; size?: number };
   parts?: RawGmailPart[];
 }
@@ -206,6 +207,31 @@ export function extractBody(part: RawGmailPart | undefined): { text: string; isH
   // Single-part messages sometimes carry data at the top level with no mimeType match.
   if (part.body?.data) return { text: decodeB64Url(part.body.data), isHtml: false };
   return { text: '', isHtml: false };
+}
+
+/**
+ * iCalendar method for a message, or null when it carries no calendar part.
+ *
+ * Structural, not textual: Google Calendar attaches a `text/calendar` part
+ * (`method=REQUEST|REPLY|CANCEL`) to every invitation, update, response and
+ * cancellation, so this identifies calendar system mail without matching on
+ * subject wording or sender address — both of which are wrong signals, since
+ * the mail arrives FROM the colleague's real address.
+ */
+export function extractCalendarMethod(part: RawGmailPart | undefined): string | null {
+  if (!part) return null;
+  const stack: RawGmailPart[] = [part];
+  while (stack.length > 0) {
+    const p = stack.shift()!;
+    const mime = (p.mimeType ?? '').toLowerCase();
+    if (mime.startsWith('text/calendar') || mime === 'application/ics') {
+      const m = /method\s*=\s*"?([a-z]+)"?/i.exec(p.mimeType ?? '');
+      return (m?.[1] ?? '').toUpperCase();
+    }
+    if ((p.filename ?? '').toLowerCase().endsWith('.ics')) return '';
+    if (p.parts) stack.push(...p.parts);
+  }
+  return null;
 }
 
 export class GmailClient extends GoogleApiClient {
@@ -298,6 +324,7 @@ export class GmailClient extends GoogleApiClient {
         internalDateMs,
         labelIds: m.labelIds ?? [],
         listUnsubscribe: header(m, 'List-Unsubscribe') !== '',
+        calendarMethod: extractCalendarMethod(m.payload),
         bodyText,
       };
     });

--- a/src/core/google/google-render.ts
+++ b/src/core/google/google-render.ts
@@ -34,6 +34,52 @@ export function isNoiseSender(fromAddress: string): boolean {
   return NOISE_SENDER_SUBSTRINGS.some((p) => f.includes(p));
 }
 
+/**
+ * Google Calendar system mail — the invitation/response/cancellation notices
+ * Calendar sends ON BEHALF OF a human organiser or attendee.
+ *
+ * Why this needs its own predicate: the mail arrives FROM the colleague's real
+ * address, so neither isNoiseSender nor `loops mute sender` can exclude it —
+ * muting the address would also silence that person's genuine email. In a
+ * measured audit these notices were 72 of 237 open loops (30%), every one of
+ * them a "reply owed" that no human ever expected an answer to.
+ *
+ * PRIMARY signal is structural: `calendarMethod` is non-null when the message
+ * carries a `text/calendar` part or an `.ics` attachment, which Calendar
+ * attaches to all of these and which ordinary human mail never has.
+ *
+ * The subject prefix is a deliberate FALLBACK, reached only when no MIME
+ * information was captured for the message. It is anchored to the start of the
+ * subject and refuses anything carrying a Re:/Fwd: prefix, so a human forward
+ * that happens to begin "Invitation: ..." still opens a loop.
+ */
+const CALENDAR_SUBJECT_PREFIXES = [
+  // en
+  'invitation:', 'updated invitation:', 'invitation with note:',
+  'updated invitation with note:', 'accepted:', 'declined:', 'tentative:',
+  'canceled event:', 'cancelled event:', 'notification:',
+  // ru
+  'приглашение:', 'обновлённое приглашение:', 'обновленное приглашение:',
+  'принято:', 'отклонено:', 'под вопросом:', 'отменено:', 'отмена мероприятия:',
+  // es / fr / de — the locales Calendar localises these headers into
+  'invitación:', 'invitación actualizada:', 'aceptada:', 'rechazada:',
+  'invitation mise à jour:', 'acceptée:', 'refusée:',
+  'einladung:', 'aktualisierte einladung:', 'zugesagt:', 'abgesagt:',
+];
+
+const REPLY_OR_FORWARD_PREFIX = /^\s*((re|fwd?|aw|sv|vs)\s*:\s*)+/i;
+
+export function isCalendarSystemMail(
+  msg: { calendarMethod?: string | null; subject?: string },
+): boolean {
+  if (msg.calendarMethod !== null && msg.calendarMethod !== undefined) return true;
+  const subject = (msg.subject ?? '').trim();
+  // A human reply/forward is never Calendar system mail, whatever it is titled.
+  if (REPLY_OR_FORWARD_PREFIX.test(subject)) return false;
+  const lowered = subject.toLowerCase();
+  return CALENDAR_SUBJECT_PREFIXES.some((p) => lowered.startsWith(p));
+}
+
 const SIGNATURE_PATTERNS = [
   /docusign/i,
   /dropbox sign/i,

--- a/src/core/google/loop-detect.ts
+++ b/src/core/google/loop-detect.ts
@@ -11,6 +11,9 @@
  * pinned by the labeled fixture corpus in test/google-loop-detect.test.ts —
  * every new false-positive class gets a fixture before its fix.
  *  - noise senders never open loops (noreply/notifications/…)
+ *  - Google Calendar system mail (text/calendar part) neither opens nor
+ *    closes loops — it comes FROM a real colleague, so no mute could
+ *    exclude it without silencing that person's genuine email
  *  - list mail (List-Unsubscribe) never opens loops
  *  - self-threads (all participants are my addresses) never open loops
  *  - CC-only inbound does not owe a reply (must be in To:)
@@ -31,7 +34,7 @@ import {
   type LoopEvidence,
   type SuppressionSet,
 } from '../loops/loops-store.ts';
-import { isNoiseSender } from './google-render.ts';
+import { isCalendarSystemMail, isNoiseSender } from './google-render.ts';
 import type { GmailMessageMeta, GmailThreadData } from './types.ts';
 
 export const INBOUND_GRACE_HOURS = 24;
@@ -86,9 +89,20 @@ export function detectThreadLoop(
   const messages = thread.messages.filter((m) => m.internalDateMs > 0);
   if (messages.length === 0) return { open: [], close: [] };
 
-  // Substantive = not from a noise sender. Noise threads carry no loops —
-  // and can't close any either (no turn flip is observable).
-  const substantive = messages.filter((m) => !isNoiseSender(m.fromAddress));
+  // Substantive = not from a noise sender, and not Google Calendar system
+  // mail. Noise threads carry no loops — and can't close any either (no turn
+  // flip is observable).
+  //
+  // Calendar notices are excluded HERE, alongside noise, rather than at the
+  // open gates, for two reasons. They must not open a loop: an
+  // `Invitation:`/`Accepted:` notice is machine mail nobody expects a reply
+  // to, and it arrives from the colleague's real address so no sender mute
+  // could exclude it without silencing that person entirely. And they must
+  // not CLOSE one either: a calendar invite is not a reply, so letting it
+  // flip the turn would silently answer a real outbound loop.
+  const substantive = messages.filter(
+    (m) => !isNoiseSender(m.fromAddress) && !isCalendarSystemMail(m),
+  );
   if (substantive.length === 0) return { open: [], close: [] };
 
   const last = substantive[substantive.length - 1];

--- a/src/core/google/types.ts
+++ b/src/core/google/types.ts
@@ -87,6 +87,15 @@ export interface GmailMessageMeta {
   internalDateMs: number;
   labelIds: string[];
   listUnsubscribe: boolean;
+  /**
+   * iCalendar method when the message carries a `text/calendar` part or an
+   * `.ics` attachment — 'REQUEST' | 'REPLY' | 'CANCEL' | 'COUNTER' | '' when a
+   * calendar part is present without an explicit method. `null`/absent means
+   * no calendar part was seen. Google Calendar attaches one to every
+   * invitation, update, response and cancellation, which is what makes this a
+   * structural signal rather than a subject guess.
+   */
+  calendarMethod?: string | null;
   /** Extracted, HTML-stripped, quote-trimmed, capped body text. */
   bodyText: string;
 }

--- a/test/google-loop-detect.test.ts
+++ b/test/google-loop-detect.test.ts
@@ -40,6 +40,8 @@ interface MsgSpec {
   body?: string;
   subject?: string;
   listUnsub?: boolean;
+  /** iCalendar method — non-null marks Google Calendar system mail. */
+  calendarMethod?: string | null;
   /** Explicit internalDateMs override (0 = the all-zero-date case). */
   dateMs?: number;
 }
@@ -58,6 +60,7 @@ function msg(spec: MsgSpec): GmailMessageMeta {
     subject: spec.subject ?? 'Quarterly plan',
     dateIso: new Date(Math.max(internalDateMs, 0)).toISOString(),
     internalDateMs,
+    calendarMethod: spec.calendarMethod ?? null,
     labelIds: spec.sent ? ['SENT'] : ['INBOX'],
     listUnsubscribe: spec.listUnsub ?? false,
     bodyText: spec.body ?? 'Can you review the plan?',
@@ -484,5 +487,151 @@ describe('detectThreadLoop precision corpus', () => {
       NOW,
     );
     expect(verdict.open[0].evidence[0].quote?.length).toBe(200);
+  });
+});
+
+describe('google calendar system mail', () => {
+  const detect = (messages: GmailMessageMeta[]): ThreadLoopVerdict =>
+    detectThreadLoop(thread(messages), MY, NOW);
+
+  // Structural: Calendar attaches a text/calendar part to every one of these.
+  // The address is the colleague's REAL address in each case — that is the
+  // whole point, and why a sender mute is not an available fix.
+  const CAL = [
+    { method: 'REQUEST', subject: 'Invitation: Team sync @ Fri Aug 21, 2026 1pm' },
+    { method: 'REQUEST', subject: 'Updated invitation: Team sync @ Fri Aug 21, 2026 1pm' },
+    { method: 'REPLY', subject: 'Accepted: 1:1 Alice / Bob' },
+    { method: 'REPLY', subject: 'Declined: 1:1 Alice / Bob' },
+    { method: 'REPLY', subject: 'Tentative: 1:1 Alice / Bob' },
+    { method: 'CANCEL', subject: 'Canceled event: Alice / Bob @ Fri Jun 26' },
+  ];
+
+  for (const c of CAL) {
+    test(`${c.subject.split(':')[0]} (method=${c.method}) opens no inbound loop`, () => {
+      const v = detect([
+        msg({
+          from: 'alice@example.com',
+          to: ['me@example.com'],
+          ageHours: 100,
+          subject: c.subject,
+          calendarMethod: c.method,
+        }),
+      ]);
+      expect(v.open).toEqual([]);
+    });
+  }
+
+  test('my own calendar response opens no outbound loop even with a question mark', () => {
+    const v = detect([
+      msg({
+        from: 'me@example.com',
+        to: ['alice@example.com'],
+        ageHours: 200,
+        sent: true,
+        subject: 'Accepted: Team sync',
+        body: 'Does this time still work?',
+        calendarMethod: 'REPLY',
+      }),
+    ]);
+    expect(v.open).toEqual([]);
+  });
+
+  test('a calendar invite does NOT close a real outbound loop', () => {
+    // A colleague sending an invite has not answered my question. If the
+    // invite were treated as their turn, it would silently close the loop.
+    const v = detect([
+      msg({
+        from: 'me@example.com',
+        to: ['alice@example.com'],
+        ageHours: 200,
+        sent: true,
+        body: 'Can you confirm the budget?',
+      }),
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Invitation: Budget sync',
+        calendarMethod: 'REQUEST',
+      }),
+    ]);
+    expect(v.open.map((o) => o.loopType)).toEqual(['unanswered_outbound']);
+    expect(v.close).toEqual(['unanswered_inbound']);
+  });
+
+  test('a real human email from the SAME colleague still opens a loop', () => {
+    const v = detect([
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Invitation: Team sync',
+        calendarMethod: 'REQUEST',
+      }),
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 50,
+        subject: 'Budget question',
+        body: 'Can you approve the Q3 number?',
+      }),
+    ]);
+    expect(v.open.map((o) => o.loopType)).toEqual(['unanswered_inbound']);
+    expect(v.open[0].counterpartyEmail).toBe('alice@example.com');
+  });
+
+  test('subject fallback applies when MIME was not captured', () => {
+    const v = detect([
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Updated invitation: Team sync @ Fri Aug 21',
+        calendarMethod: null,
+      }),
+    ]);
+    expect(v.open).toEqual([]);
+  });
+
+  test('a localized calendar subject is covered by the fallback', () => {
+    const v = detect([
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Приглашение: Team sync',
+        calendarMethod: null,
+      }),
+    ]);
+    expect(v.open).toEqual([]);
+  });
+
+  test('a forwarded human question is NOT lost just because it says Invitation', () => {
+    // The fallback refuses anything carrying a Re:/Fwd: prefix, so a human
+    // forward of an invite thread still owes a reply.
+    const v = detect([
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Fwd: Invitation: Team sync',
+        body: 'Should I accept this on your behalf?',
+        calendarMethod: null,
+      }),
+    ]);
+    expect(v.open.map((o) => o.loopType)).toEqual(['unanswered_inbound']);
+  });
+
+  test('a human subject merely containing the word invitation still opens a loop', () => {
+    const v = detect([
+      msg({
+        from: 'alice@example.com',
+        to: ['me@example.com'],
+        ageHours: 100,
+        subject: 'Your invitation: what should we do about the venue?',
+        calendarMethod: null,
+      }),
+    ]);
+    expect(v.open.map((o) => o.loopType)).toEqual(['unanswered_inbound']);
   });
 });


### PR DESCRIPTION
## Problem

Google Calendar sends invitation / update / response / cancellation notices **on behalf of a human**, so they arrive FROM the colleague's real address. The deterministic detector sees an inbound message from a real person and opens `unanswered_inbound` for each one.

Measured on a live two-account brain: **72 of 237 open loops (30%) were Calendar notices** — every one a "reply owed" that nobody ever expected an answer to. Worst cases: 18 of one colleague's 19 loops, 10 of another's 10, 5 of 5 for two more.

Neither existing gate can reach them:

- `isNoiseSender` matches on the address, and these come from a person;
- `gbrain loops mute sender` would silence that colleague's **genuine** email along with the notices.

## Change

Detect them **structurally**. Gmail's payload carries a `text/calendar` part (`method=REQUEST|REPLY|CANCEL`) or an `.ics` attachment on every one of these and on no ordinary human mail, so `extractCalendarMethod` reads it during the MIME walk the client already performs and stores it on `GmailMessageMeta`.

The subject prefix is a deliberate **fallback** for messages whose MIME was not captured: anchored to the start of the subject, covering localized forms, and refusing anything with a `Re:`/`Fwd:` prefix so a human forward of an invite thread still opens a loop.

Excluded alongside noise senders rather than at the open gates, because these notices must also never **close** a loop: an invite is not a reply, and letting it flip the turn would silently answer a real outbound loop. That bug is covered by its own test.

Ingestion is untouched — calendar mail still materializes as a normal searchable page and still feeds calendar/meeting context. It only stops opening and closing reply loops.

## Tests

13 new rows in `test/google-loop-detect.test.ts` (the existing labeled precision corpus): all six notice types with a calendar part; my own calendar response; the does-not-close case; a real human email from the same colleague still opening a loop; the MIME-absent subject fallback; a localized subject; and two negative cases — a `Fwd:` of an invite thread and a human subject merely containing the word "invitation" — both of which must still open loops.

`bun run verify` → **55/55 green**. google suites → **141/141**. Toolchain bun 1.3.13.

Independent of PR A. **PR C in this series is stacked on this branch** (its eligibility gate reuses `isCalendarSystemMail`).