### PR TITLE
fix(extract-atoms): stop re-mining every page that was already scanned

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -71,6 +71,18 @@ export const HASH_EPHEMERAL_FRONTMATTER_KEYS: readonly string[] = [
   QUARANTINE_KEY,
   CONTENT_FLAG_KEY,
   EMBED_SKIP_KEY,
+  // Same bug class as captured_at (v0.39.3.0 CV8) and the gate markers
+  // (v0.42 #1699): extract-atoms.ts:768 stamps `atoms_scan_hash` INTO the
+  // frontmatter, so without this the marker changes content_hash on the next
+  // import. Atom eligibility is `atoms_scan_hash <> substring(content_hash,1,16)`
+  // (extract-atoms.ts:289), so a page scanned once is eligible again after the
+  // very next export->sync, forever. Measured on BTree 2026-08-30: all 24
+  // ever-scanned pages were eligible again, and three drains in one day
+  // re-mined the SAME 23 sources into ~9 LLM-paraphrased near-duplicate atoms
+  // each (205 of 208 atoms that day). content_hash_duplicates cannot see them
+  // because the wording differs. The marker is re-derived deterministically
+  // from the body, so dropping it from the hash is safe.
+  'atoms_scan_hash',
 ];
 
 /**

--- a/test/atoms-scan-hash-rearm.test.ts
+++ b/test/atoms-scan-hash-rearm.test.ts
@@ -1,0 +1,101 @@
+/**
+ * extract_atoms re-arms every page it has already mined.
+ *
+ * `extract-atoms.ts` stamps `atoms_scan_hash` INTO the page's frontmatter
+ * (the completion marker), and eligibility is
+ *
+ *   COALESCE(frontmatter->>'atoms_scan_hash','') <> substring(content_hash from 1 for 16)
+ *
+ * `contentHash()` hashes frontmatter minus HASH_EPHEMERAL_FRONTMATTER_KEYS.
+ * `atoms_scan_hash` was NOT in that list, so writing the marker changed the
+ * very hash the marker is compared against: the page went eligible again on
+ * the next import, and stayed eligible forever.
+ *
+ * Same bug class as `captured_at`/`ingested_at` (v0.39.3.0 CV8) and the
+ * content-sanity gate markers (v0.42 #1699), both fixed by adding the key
+ * here. The #1699 comment describes the symptom as re-chunking and
+ * re-embedding "forever ... real, unbounded embedding spend"; this consumer
+ * instead re-runs an LLM extraction, so the cost lands as duplicate atoms.
+ *
+ * Measured on a live brain before the fix: all 24 pages that had ever been
+ * scanned were eligible again, and three drains in one day re-mined the SAME
+ * 23 sources, producing ~9 paraphrased atoms per source (205 of that day's
+ * 208 atoms sat on re-extracted sources). Paraphrases defeat
+ * `content_hash_duplicates`, so nothing surfaced it.
+ *
+ * The invariant asserted here is deliberately phrased without reference to
+ * the marker: a page mined once must not become eligible again unless its
+ * BODY changed. That also covers brains where the marker is never persisted,
+ * where excluding the key alone would be a no-op.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { contentHash, HASH_EPHEMERAL_FRONTMATTER_KEYS } from '../src/core/utils.ts';
+
+type Page = Parameters<typeof contentHash>[0];
+
+const basePage = (): Page => ({
+  title: 'Wedge product and first beachhead',
+  type: 'note',
+  compiled_truth: 'Pick the narrowest problem you can own completely.',
+  timeline: '',
+  frontmatter: { status: 'active' },
+  tags: ['strategy'],
+} as Page);
+
+/** The eligibility predicate, verbatim from extract-atoms.ts. */
+const isEligible = (page: Page): boolean => {
+  const marker = (page.frontmatter as Record<string, unknown>)?.atoms_scan_hash ?? '';
+  return String(marker) !== contentHash(page).slice(0, 16);
+};
+
+/** What the extract_atoms phase does on completion. */
+const stampScanned = (page: Page): Page => ({
+  ...page,
+  frontmatter: {
+    ...(page.frontmatter as Record<string, unknown>),
+    atoms_scan_hash: contentHash(page).slice(0, 16),
+  },
+} as Page);
+
+describe('extract_atoms completion marker', () => {
+  test('atoms_scan_hash is excluded from contentHash', () => {
+    expect(HASH_EPHEMERAL_FRONTMATTER_KEYS).toContain('atoms_scan_hash');
+  });
+
+  test('stamping the marker does not change the hash', () => {
+    const page = basePage();
+    expect(contentHash(stampScanned(page))).toBe(contentHash(page));
+  });
+
+  test('two different marker values hash identically', () => {
+    const a = { ...basePage(), frontmatter: { status: 'active', atoms_scan_hash: 'a'.repeat(16) } } as Page;
+    const b = { ...basePage(), frontmatter: { status: 'active', atoms_scan_hash: 'b'.repeat(16) } } as Page;
+    expect(contentHash(a)).toBe(contentHash(b));
+  });
+
+  // The regression itself: pre-fix this page is eligible again immediately,
+  // and stays eligible through every subsequent export -> sync cycle.
+  test('a page mined once is NOT eligible again', () => {
+    let page = basePage();
+    expect(isEligible(page)).toBe(true); // never scanned
+
+    page = stampScanned(page);
+    expect(isEligible(page)).toBe(false);
+
+    // Re-import the page as written (the export -> sync round trip). Pre-fix
+    // the recomputed hash differed from the stamped marker and this flipped
+    // back to true, which is what re-mined the same sources every cycle.
+    for (let cycle = 0; cycle < 5; cycle++) {
+      expect(isEligible(page)).toBe(false);
+    }
+  });
+
+  test('a page IS eligible again when its body actually changes', () => {
+    const scanned = stampScanned(basePage());
+    expect(isEligible(scanned)).toBe(false);
+
+    const edited = { ...scanned, compiled_truth: 'Rewritten body: start with a narrow beachhead.' } as Page;
+    expect(isEligible(edited)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

`extract-atoms.ts` stamps its completion marker `atoms_scan_hash` **into the page's frontmatter**, and eligibility is:

```sql
COALESCE(p.frontmatter->>'atoms_scan_hash', '') <> substring(p.content_hash from 1 for 16)
```

`contentHash()` hashes frontmatter minus `HASH_EPHEMERAL_FRONTMATTER_KEYS`, and `atoms_scan_hash` was not in that list. So writing the marker changed the very hash the marker is compared against: the page went eligible again on the next import, and stayed eligible for good.

Every `export -> sync` cycle re-armed every page that had ever been scanned. Each drain then re-ran the LLM extraction over sources it had already mined, producing paraphrases of the same ideas. Because the atoms are LLM-written, each paraphrase hashes differently, so `content_hash_duplicates` reports clean the whole time and nothing surfaces the growth.

This is the same bug class as `captured_at`/`ingested_at` (v0.39.3.0 CV8) and the content-sanity gate markers (v0.42 #1699) — both fixed by adding the key to this same list. The #1699 comment describes the symptom as re-chunking and re-embedding *"forever ... real, unbounded embedding spend"*. Here the consumer re-runs an LLM extraction instead, so the cost lands as duplicate atoms rather than duplicate embeddings.

## Measurements

Before, on a live brain (511 pages):

- All **24** pages that had ever been scanned were eligible again — `atoms_scan_hash` never equalled the `content_hash` prefix for a single one.
- Three drains in one day hit the **same 23 sources**, ~9 paraphrased atoms per source. **205 of that day's 208 atoms** sat on re-extracted sources.
- `content_hash_duplicates`: clean throughout.

Two atoms from one source page, different runs:

> Closed systems don't require a choice between 'real API integration' and 'periodic manual upload.' A coverage ladder exists between…

> There's no magic to open closed systems, but API integration and periodic manual uploads aren't the only options. A coverage ladder spans…

After:

- `gbrain sync --full` re-imported **exactly the 24** marker-carrying pages and nothing else — the exclusion does precisely what it should and no more.
- A full `export -> commit -> sync` cycle (the one that previously re-armed all 24) left **0** pages eligible; `doctor` reports `extract_atoms_backlog: no pages awaiting atom extraction`.
- Secondary: that sync reported `~23 modified, 0 chunks created` — the hash now matches, so the wasted re-chunk/re-embed the #1699 comment warns about stops too.

## Test

`test/atoms-scan-hash-rearm.test.ts` asserts the **invariant** rather than the mechanism: *a page mined once must not become eligible again unless its body changed.* It reproduces the eligibility predicate verbatim, stamps the marker the way the phase does, and re-checks across repeated import cycles. Reverting the one-line fix makes it fail (verified by mutation).

Phrasing it as an invariant is deliberate — see the open case below, which "the marker is excluded from the hash" would not cover.

## Migration note for existing brains

The stored marker holds a **pre-fix** hash, so after upgrading, already-scanned pages are still eligible once. A one-time backfill fixes it:

```sql
UPDATE pages SET frontmatter = frontmatter
  || jsonb_build_object('atoms_scan_hash', substring(content_hash from 1 for 16))
WHERE deleted_at IS NULL AND frontmatter->>'atoms_scan_hash' IS NOT NULL
  AND frontmatter->>'atoms_scan_hash' <> substring(content_hash from 1 for 16);
```

It must run **after** this change, or it is self-invalidating.

## An open second case, NOT fixed here

There is a second completion guard on the atom side:

```sql
AND NOT EXISTS (SELECT 1 FROM pages atom
  WHERE atom.type = 'atom'
    AND atom.frontmatter->>'source_hash' = substring(p.content_hash from 1 for 16)
    AND atom.deleted_at IS NULL)
```

`extract-atoms.ts` stamps `source_hash` onto the atoms it creates. **Both guards key off the source page's `content_hash` prefix**, so any hash movement orphans both at once.

On a second brain, `atoms_scan_hash` is never persisted at all (0 of 294 pages carry it), yet every page is permanently eligible. There, `content_hash` was measured **stable** across re-ingest, and the re-arm came from the atom-side guard holding stale values: 87 distinct `source_hash` values across 84 pages, none matching their source's current hash. That brain is unaffected by this PR, and the cause of its hash movement is not yet isolated.

Also worth noting for anyone cleaning up duplicates: the `atom.deleted_at IS NULL` clause means **deleting atoms re-arms every source page they came from**.

A useful detector for this class, which text-similarity cannot find because the duplicates are paraphrases:

```sql
SELECT frontmatter->>'source_slug', count(DISTINCT frontmatter->>'source_hash') AS hashes, count(*)
FROM pages WHERE type='atom' AND deleted_at IS NULL
GROUP BY 1 HAVING count(DISTINCT frontmatter->>'source_hash') > 1;
```

Atoms-per-source landing on exact multiples of the per-run yield is the fingerprint.
