### PR TITLE
fix(secret-scan): redact gbrain's own bearer tokens

### DIFF
--- a/src/core/secret-scan.ts
+++ b/src/core/secret-scan.ts
@@ -90,11 +90,14 @@ const CORE_PATTERNS: ReadonlyArray<{ name: string; source: string }> = [
   { name: 'github_token', source: 'gh[pousr]_[A-Za-z0-9]{36,}' },
   { name: 'slack', source: 'xox[baprs]-[A-Za-z0-9-]{10,}' },
   { name: 'aws_access_key', source: 'AKIA[0-9A-Z]{16}' },
-  // gbrain's own bearer token: `auth create` mints 'gbrain_' + 32 random bytes
-  // hex (commands/auth.ts). Without this entry the scanner redacts every
-  // vendor's keys but ships its own live token — MCP client tooling prints it
-  // verbatim into session logs, and transcript ingest carries it into pages.
-  { name: 'gbrain_token', source: 'gbrain_[0-9a-f]{64}' },
+  // gbrain's own tokens: generateToken (core/utils.ts) mints 'gbrain_' plus an
+  // optional OAuth infix (at_ access / rt_ refresh / cs_ client secret /
+  // code_ auth code) plus 32 random bytes hex. Without this entry the scanner
+  // redacts every vendor's keys but ships its own live tokens — MCP client
+  // tooling prints the Authorization header verbatim into session logs, and
+  // transcript ingest carries it into pages. gbrain_cl_ client ids are public
+  // identifiers, deliberately not listed here.
+  { name: 'gbrain_token', source: 'gbrain_(?:at_|rt_|cs_|code_)?[0-9a-f]{64}' },
   // NOTE: private_key_pem is NOT here — a PEM key spans multiple lines and the
   // per-line scanner below cannot see the base64 body. It is matched over the
   // WHOLE text by PEM_BLOCK_RE (see scanPemBlocks) so redaction covers the

--- a/src/core/secret-scan.ts
+++ b/src/core/secret-scan.ts
@@ -90,6 +90,11 @@ const CORE_PATTERNS: ReadonlyArray<{ name: string; source: string }> = [
   { name: 'github_token', source: 'gh[pousr]_[A-Za-z0-9]{36,}' },
   { name: 'slack', source: 'xox[baprs]-[A-Za-z0-9-]{10,}' },
   { name: 'aws_access_key', source: 'AKIA[0-9A-Z]{16}' },
+  // gbrain's own bearer token: `auth create` mints 'gbrain_' + 32 random bytes
+  // hex (commands/auth.ts). Without this entry the scanner redacts every
+  // vendor's keys but ships its own live token — MCP client tooling prints it
+  // verbatim into session logs, and transcript ingest carries it into pages.
+  { name: 'gbrain_token', source: 'gbrain_[0-9a-f]{64}' },
   // NOTE: private_key_pem is NOT here — a PEM key spans multiple lines and the
   // per-line scanner below cannot see the base64 body. It is matched over the
   // WHOLE text by PEM_BLOCK_RE (see scanPemBlocks) so redaction covers the

--- a/test/secret-scan.test.ts
+++ b/test/secret-scan.test.ts
@@ -29,6 +29,7 @@ const GHO = 'gho_' + 'B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9';
 const GH_PAT = 'github_pat_' + '11AAAAAAA0aaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbb';
 const SLACK = 'xoxb-' + '123456789012-abcdefABCDEF';
 const AWS = 'AKIA' + 'IOSFODNN7EXAMPLE';
+const GBRAIN = 'gbrain_' + '0123456789abcdef'.repeat(4);
 const PEM = '-----BEGIN RSA PRIVATE KEY-----';
 
 let tmp: string | null = null;
@@ -76,6 +77,11 @@ describe('scanText — pattern classes', () => {
     }
   });
 
+  test("gbrain's own bearer token (auth create shape) fires as gbrain_token", () => {
+    const findings = scanText(`claude mcp list printed: Authorization: Bearer ${GBRAIN}`);
+    expect(findings.map((f) => f.pattern)).toEqual(['gbrain_token']);
+  });
+
   test('a Voyage key (pa-…, PROVIDER_KEY_SHAPES shape) fires as voyage', () => {
     const findings = scanText(`voyage_api_key: ${VOYAGE}`);
     expect(findings.map((f) => f.pattern)).toEqual(['voyage']);
@@ -96,6 +102,8 @@ describe('scanText — pattern classes', () => {
       'task-management-systems-for-founders-and-agents',
       'xoxo love, the changelog',                            // not xox[baprs]-
       'AKIAXX',                                              // too short
+      `gbrain_${'ab'.repeat(16)} is a 32-hex config id`,     // token body is 64 hex
+      'the gbrain_token pattern name itself',                // identifier, no hex body
       '-----BEGIN CERTIFICATE-----',                         // not a private key
     ].join('\n');
     expect(scanText(text)).toEqual([]);

--- a/test/secret-scan.test.ts
+++ b/test/secret-scan.test.ts
@@ -29,7 +29,7 @@ const GHO = 'gho_' + 'B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9';
 const GH_PAT = 'github_pat_' + '11AAAAAAA0aaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbb';
 const SLACK = 'xoxb-' + '123456789012-abcdefABCDEF';
 const AWS = 'AKIA' + 'IOSFODNN7EXAMPLE';
-const GBRAIN = 'gbrain_' + '0123456789abcdef'.repeat(4);
+const GBRAIN_HEX = '0123456789abcdef'.repeat(4);
 const PEM = '-----BEGIN RSA PRIVATE KEY-----';
 
 let tmp: string | null = null;
@@ -77,9 +77,17 @@ describe('scanText — pattern classes', () => {
     }
   });
 
-  test("gbrain's own bearer token (auth create shape) fires as gbrain_token", () => {
-    const findings = scanText(`claude mcp list printed: Authorization: Bearer ${GBRAIN}`);
-    expect(findings.map((f) => f.pattern)).toEqual(['gbrain_token']);
+  test("gbrain's own tokens (generateToken prefix family) fire as gbrain_token", () => {
+    // '' = legacy bearer (auth create / token-mint / serve-http); the rest are
+    // the OAuth forms from oauth-provider.ts, gbrain_at_ being the /mcp bearer.
+    for (const infix of ['', 'at_', 'rt_', 'cs_', 'code_']) {
+      const findings = scanText(`Authorization: Bearer gbrain_${infix}${GBRAIN_HEX}`);
+      expect(findings.map((f) => f.pattern)).toEqual(['gbrain_token']);
+    }
+  });
+
+  test('a gbrain_cl_ client id (public identifier) does not fire', () => {
+    expect(scanText(`client_id=gbrain_cl_${GBRAIN_HEX}`)).toEqual([]);
   });
 
   test('a Voyage key (pa-…, PROVIDER_KEY_SHAPES shape) fires as voyage', () => {


### PR DESCRIPTION
## Problem

`CORE_PATTERNS` covers Anthropic, OpenAI, Voyage, GitHub, Slack and AWS keys, but not the tokens gbrain itself mints: `generateToken(prefix)` in `src/core/utils.ts` returns `prefix + randomBytes(32).toString('hex')`, called with `gbrain_` (legacy bearer) and the OAuth forms `gbrain_at_` / `gbrain_rt_` / `gbrain_cs_` / `gbrain_code_` / `gbrain_cl_`.

This leaks through ordinary use of the HTTP serve. MCP client tooling prints the `Authorization` header verbatim into session logs (`claude mcp list` does, for one), and transcript ingest then carries the live token into conversation pages — from where it reaches exports and any git remote the workspace pushes to. We hit exactly this chain on our install: the only thing the scanner did not redact from an imported transcript was gbrain's own bearer token.

## Fix

Add the token family to `CORE_PATTERNS`:

```ts
{ name: 'gbrain_token', source: 'gbrain_(?:at_|rt_|cs_|code_)?[0-9a-f]{64}' }
```

with a comment pointing at the minting site, ordered with the other single-line patterns (PEM handling untouched). `gbrain_cl_` client ids are public identifiers and are deliberately not listed, pending the maintainer call raised in triage; a test pins that choice.

## Tests

- positive: an `Authorization: Bearer` line fires as `gbrain_token` (and only that) for each minted shape — bare, `at_`, `rt_`, `cs_`, `code_`
- `gbrain_cl_` does not fire (public identifier)
- benign lookalikes extended: a 32-hex `gbrain_` config id and the literal pattern name `gbrain_token` do not fire

`bun test` over all seven suites that import `secret-scan` (incl. the sources-push and workspace-push serial suites): 210 pass, 0 fail.