### PR TITLE
v0.47.7.1 fix(dream): run full cycle for implicit default sources (#4700)

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -31,7 +31,7 @@ import {
   type CyclePhase,
   type CycleReport,
 } from '../core/cycle.ts';
-import { resolveSourceId } from '../core/source-resolver.ts';
+import { resolveImplicitDefaultSourceId, resolveSourceId } from '../core/source-resolver.ts';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
 import { fetchSource } from '../core/sources-load.ts';
 import { existsSync } from 'fs';
@@ -419,11 +419,14 @@ Options:
                       cycle_freshness check sees a fresh stamp on
                       completion. When omitted, gbrain derives the
                       source from --dir / the configured checkout
-                      when it matches a source's local_path (#1869).
+                      when it matches a source's local_path (#1869),
+                      or from the default-like source selected by
+                      sources.default / sole-non-default routing.
                       A named non-default source runs the deterministic
                       freshness phases unless --phase is given
-                      (explicit phases are honored verbatim);
-                      --source default still runs the full cycle.
+                      (explicit phases are honored verbatim). A bare
+                      no --source dream against the default-like source,
+                      and --source default, still run the full cycle.
   --source-id <id>    Alias for --source. Matches the v0.37.7.0+
                       naming used by import/extract/graph-query.
 
@@ -706,6 +709,23 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
   //      last_full_cycle_at to an archived source would mask data
   //      staleness when the source is later restored)
   let resolvedSourceId: string | undefined;
+  let implicitDefaultSourceId: string | null = null;
+  let fullImplicitSourceCycle = false;
+  if (opts.source === null && engine !== null) {
+    try {
+      implicitDefaultSourceId = await resolveImplicitDefaultSourceId(engine);
+    } catch (e) {
+      if (isResolverUserError(e)) {
+        console.error((e as Error).message);
+        process.exit(1);
+      }
+      throw e;
+    }
+    if (opts.dir === null && implicitDefaultSourceId && implicitDefaultSourceId !== 'default') {
+      resolvedSourceId = implicitDefaultSourceId;
+      fullImplicitSourceCycle = true;
+    }
+  }
   if (opts.source !== null) {
     if (engine === null) {
       console.error(
@@ -767,7 +787,12 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     const derived = await resolveSourceForDir(engine, brainDir);
     if (derived !== undefined) {
       const src = await fetchSource(engine, derived);
-      if (src?.archived !== true) resolvedSourceId = derived;
+      if (src?.archived !== true) {
+        resolvedSourceId = derived;
+        fullImplicitSourceCycle = opts.source === null
+          && implicitDefaultSourceId === derived
+          && derived !== 'default';
+      }
     }
   }
   // ─── issue #1678: bounded single-hold extract_atoms drain ──────────
@@ -788,7 +813,10 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     dryRun: opts.dryRun,
     pull: opts.pull,
     phases,
-    sourceId: resolvedSourceId, // undefined when --source not set → legacy back-compat
+    // Undefined for legacy unscoped runs; set for explicit source cycles,
+    // path-derived cycles, and bare default-like non-default source cycles.
+    sourceId: resolvedSourceId,
+    fullImplicitSourceCycle,
     synthInputFile: opts.inputFile ?? undefined,
     synthDate: opts.date ?? undefined,
     synthFrom: opts.from ?? undefined,

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -243,15 +243,14 @@ export const SOURCE_BACKGROUND_PHASES: CyclePhase[] = SOURCE_PHASES.filter(
  * re-run mixed or background work once per source while human intent stays
  * authoritative.
  *
- * The canonical `default` cycle remains the one place where a full implicit
- * cycle (including mixed phases) is valid.
+ * Full implicit non-default source cycles are caller opt-in.
  */
 export function resolveCyclePhases(
   requested: CyclePhase[] | undefined,
-  sourceId: string | undefined,
+  sourceId: string | undefined, fullImplicitSourceCycle = false,
 ): CyclePhase[] {
   if (!sourceId || sourceId === 'default') return requested ?? ALL_PHASES;
-  if (requested === undefined) return SOURCE_FRESHNESS_PHASES;
+  if (requested === undefined) return fullImplicitSourceCycle ? ALL_PHASES : SOURCE_FRESHNESS_PHASES;
   return requested;
 }
 
@@ -529,6 +528,7 @@ export interface CycleOpts {
    * Validated via `assertValidSourceId` in `cycleLockIdFor` (defense-in-depth).
    */
   sourceId?: string;
+  fullImplicitSourceCycle?: boolean; // Bare dream may opt default-like sources into full phases.
   /**
    * issue #2860 — one-shot per-invocation bypass of a phase's own
    * `dream.<phase>.enabled` / `cycle.<phase>.enabled` config gate. Wired
@@ -1860,7 +1860,7 @@ export async function runCycle(
 ): Promise<CycleReport> {
   const start = performance.now();
   const requestedPhases = opts.phases ?? ALL_PHASES;
-  const phases = resolveCyclePhases(opts.phases, opts.sourceId);
+  const phases = resolveCyclePhases(opts.phases, opts.sourceId, opts.fullImplicitSourceCycle);
   const excludedPhases = requestedPhases.filter((phase) => !phases.includes(phase));
   const dryRun = !!opts.dryRun;
   const pull = !!opts.pull;

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -297,7 +297,10 @@ async function listRegisteredLocalPathSources(
   }
 }
 
-async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | null> {
+async function pickSoleNonDefaultSource(
+  engine: BrainEngine,
+  opts: { quiet?: boolean } = {},
+): Promise<string | null> {
   // archived column was added in v34 (v0.26.5). Older brains may not have
   // it — fall back to the un-archived query in that case via try/catch.
   let rows: Array<{ id: string }>;
@@ -321,7 +324,7 @@ async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | n
       // every bare command away from the sole side-source, and the user
       // hunts for "lost" writes. One stderr line names both sides so the
       // misroute is diagnosable; same suppression knob as the routing nudge.
-      if (process.env.GBRAIN_NO_SOLE_NON_DEFAULT_NUDGE !== '1') {
+      if (!opts.quiet && process.env.GBRAIN_NO_SOLE_NON_DEFAULT_NUDGE !== '1') {
         console.error(
           `[gbrain] sole non-default source '${rows[0].id}' exists, but 'default' is non-empty — routing to 'default' (#3070 emptiness guard). Pass --source ${rows[0].id} or set sources.default to target it.`,
         );
@@ -334,6 +337,21 @@ async function pickSoleNonDefaultSource(engine: BrainEngine): Promise<string | n
     // resolution outright.
   }
   return rows[0].id;
+}
+
+/**
+ * Source id that represents the brain's implicit default target for a bare
+ * local command. Unlike resolveSourceWithTier(), this deliberately ignores
+ * env, dotfile, cwd, and local_path tiers so callers can distinguish the
+ * canonical default-like source from an explicit/path-scoped source cycle.
+ */
+export async function resolveImplicitDefaultSourceId(engine: BrainEngine): Promise<string | null> {
+  const globalDefault = await engine.getConfig('sources.default');
+  if (globalDefault && isValidSourceId(globalDefault)) {
+    await assertSourceExists(engine, globalDefault);
+    return globalDefault;
+  }
+  return pickSoleNonDefaultSource(engine, { quiet: true });
 }
 
 /**

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -88,6 +88,11 @@ describe('cycle phase partition (#2194 fix #3)', () => {
     expect(resolveCyclePhases(['synthesize'], undefined)).toEqual(['synthesize']);
   });
 
+  test('default-like source opt-in runs a full implicit cycle without changing explicit phases', () => {
+    expect(resolveCyclePhases(undefined, 'repo-a', true)).toEqual(ALL_PHASES);
+    expect(resolveCyclePhases(['sync'], 'repo-a', true)).toEqual(['sync']);
+  });
+
   test('exclusion skip-records never dilute failure status into a stampable partial (#4250 ship-stage P1)', () => {
     // Pre-fix: six failed freshness phases + seventeen synthetic exclusion
     // skips made deriveStatus see "not every entry failed" → 'partial' →

--- a/test/dream.test.ts
+++ b/test/dream.test.ts
@@ -33,6 +33,7 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { makeGitFixture, type GitFixture } from './helpers/git-fixture.ts';
 import { runDream } from '../src/commands/dream.ts';
+import { ALL_PHASES, SOURCE_FRESHNESS_PHASES } from '../src/core/cycle.ts';
 
 // ─── Shared fixtures (built once; reset per test) ──────────────────
 
@@ -411,6 +412,17 @@ describe('runDream — --source / --source-id (v0.41.13)', () => {
     return typeof raw === 'string' ? raw : null;
   }
 
+  function phaseByName(report: any, name: string): any {
+    return report?.phases?.find((p: any) => p.phase === name);
+  }
+
+  function expectNoImplicitSourceExclusions(report: any): void {
+    expect(report?.phases.map((p: any) => p.phase)).toEqual(ALL_PHASES);
+    for (const p of report.phases) {
+      expect(p.details?.reason).not.toBe('excluded_from_implicit_source_cycle');
+    }
+  }
+
   // ─── parseArgs: --source missing / conflict / repetition ────────────
 
   test('--source with no value exits 2 with usage hint', async () => {
@@ -595,6 +607,38 @@ describe('runDream — --source / --source-id (v0.41.13)', () => {
     expect(report).toBeTruthy();
     expect(await readLastFullCycleAt('alpha')).not.toBeNull();
     expect(await readLastFullCycleAt('beta')).toBeNull();
+  }, 300_000);
+
+  test('bare dream runs the full cycle for a non-default sources.default target (#4700)', async () => {
+    await seedSource('primary');
+    await engine.setConfig('sources.default', 'primary');
+    await engine.setConfig('sync.repo_path', repo);
+
+    const report = await runDream(engine, ['--dry-run', '--json']);
+    expect(report).toBeTruthy();
+    expectNoImplicitSourceExclusions(report);
+  }, 300_000);
+
+  test('bare dream runs the full cycle for the sole non-default source (#4700)', async () => {
+    await seedSource('solo');
+    await engine.setConfig('sync.repo_path', repo);
+
+    const report = await runDream(engine, ['--dry-run', '--json']);
+    expect(report).toBeTruthy();
+    expectNoImplicitSourceExclusions(report);
+  }, 300_000);
+
+  test('explicit --source remains a freshness-only source cycle even when it is sources.default', async () => {
+    await seedSource('primary');
+    await engine.setConfig('sources.default', 'primary');
+
+    const report = await runDream(engine, ['--source', 'primary', '--dry-run', '--json']);
+    expect(report).toBeTruthy();
+    const synthesize = phaseByName(report, 'synthesize');
+    expect(synthesize?.details?.reason).toBe('excluded_from_implicit_source_cycle');
+    for (const phase of SOURCE_FRESHNESS_PHASES) {
+      expect(phaseByName(report, phase)?.details?.reason).not.toBe('excluded_from_implicit_source_cycle');
+    }
   }, 300_000);
 
   // ─── --source-id alias equivalence (D3) ─────────────────────────────


### PR DESCRIPTION
Fixes #4700

## Summary
- Adds a narrow `runCycle` opt-in for full implicit cycles on named non-default sources.
- Makes bare `gbrain dream` treat `sources.default` and sole-non-default routing as the canonical default cycle target.
- Keeps explicit `gbrain dream --source <id>` and autopilot per-source jobs on the existing freshness-only path.
- Adds focused regressions for `sources.default`, sole-non-default routing, and the explicit `--source` guardrail.

## Verification
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/dream.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/autopilot-global-maintenance.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/source-resolver-sole-non-default.test.ts test/source-resolver-with-tier.test.ts test/source-resolver.test.ts`
- `GBRAIN_TEST_ALLOW_DATABASE_URL=1 bash scripts/gbrain-gate.sh <worktree> test/dream.test.ts test/autopilot-global-maintenance.test.ts test/source-resolver-sole-non-default.test.ts test/source-resolver-with-tier.test.ts test/source-resolver.test.ts` -> RESULT: GREEN
