### PR TITLE
fix(backup): no_remote coverage hint also names bootstrap attach for out-of-band-adopted repos

### DIFF
--- a/src/core/advisor/collect-backup-coverage.ts
+++ b/src/core/advisor/collect-backup-coverage.ts
@@ -71,7 +71,13 @@ export const collectBackupCoverage: AdvisorCollector = {
           severity: 'warn',
           title: 'Your agent workspace has no private repo yet — a disk loss loses skills, memory, and identity.',
           detail: a.detail,
-          fix: { command_argv: a.fix_argv ?? ['gbrain', 'bootstrap', 'repo'] },
+          // No default fallback here (matches source_repo above): coverage.ts
+          // deliberately leaves fix_argv null for this kind since it can't
+          // tell an empty origin (bootstrap repo) from an already-pushed
+          // out-of-band one (bootstrap attach) without a git subprocess — a
+          // hardcoded ['gbrain','bootstrap','repo'] fallback would reintroduce
+          // the same wrong-command-in-the-out-of-band-case bug this exists to fix.
+          fix: { command_argv: a.fix_argv ?? null },
           collector: 'backup-coverage',
           ask_user: true,
         });

--- a/src/core/backup/coverage.ts
+++ b/src/core/backup/coverage.ts
@@ -166,10 +166,15 @@ export async function computeBackupCoverage(
           id: receipt.workspace_dir,
           state: 'no_remote',
           detail:
-            'bootstrap workspace has no private repo yet — run `gbrain bootstrap repo` to create one, ' +
-            'or `gbrain bootstrap attach` instead if this workspace already has a git origin configured ' +
-            '(e.g. it was pushed or adopted out-of-band).',
-          fix_argv: ['gbrain', 'bootstrap', 'repo'],
+            'bootstrap workspace has no private repo yet — run `gbrain bootstrap repo` to create one ' +
+            '(this is the right command for a truly empty/unconfigured origin). If this workspace was ' +
+            'already pushed to an existing repo out-of-band, `bootstrap repo` will refuse — run ' +
+            '`gbrain bootstrap attach` instead to reconcile the receipt.',
+          // No single command is correct here without a git subprocess (coverage.ts is deliberately
+          // file-plane only): an empty/unconfigured origin needs `bootstrap repo`, an already-pushed
+          // one needs `bootstrap attach`, and this check can't tell which case it's in. Leave fix_argv
+          // null rather than advertise a command that's wrong in the out-of-band-adopted case.
+          fix_argv: null,
         });
       } else {
         // THIS workspace's own push status only — a failing entry from some

--- a/src/core/backup/coverage.ts
+++ b/src/core/backup/coverage.ts
@@ -165,7 +165,10 @@ export async function computeBackupCoverage(
           kind: 'bootstrap_workspace',
           id: receipt.workspace_dir,
           state: 'no_remote',
-          detail: 'bootstrap workspace has no private repo yet',
+          detail:
+            'bootstrap workspace has no private repo yet — run `gbrain bootstrap repo` to create one, ' +
+            'or `gbrain bootstrap attach` instead if this workspace already has a git origin configured ' +
+            '(e.g. it was pushed or adopted out-of-band).',
           fix_argv: ['gbrain', 'bootstrap', 'repo'],
         });
       } else {

--- a/test/advisor-backup-coverage.serial.test.ts
+++ b/test/advisor-backup-coverage.serial.test.ts
@@ -359,7 +359,7 @@ function writeReceipt(ws: string, extra: Record<string, unknown> = {}): void {
 }
 
 describe('collectBackupCoverage local — workspace and db_only findings', () => {
-  test('receipt without repo_url → backup_workspace_no_repo warn with the bootstrap-repo fix', async () => {
+  test('receipt without repo_url → backup_workspace_no_repo warn, no single-command fix (ambiguous between repo/attach)', async () => {
     const ws = join(tmp, 'ws-no-repo');
     mkdirSync(ws, { recursive: true });
     writeReceipt(ws); // no repo_url → bootstrap_workspace no_remote asset
@@ -373,7 +373,10 @@ describe('collectBackupCoverage local — workspace and db_only findings', () =>
     expect(f.severity).toBe('warn');
     expect(f.title).toContain('workspace has no private repo');
     expect(f.detail).toContain('no private repo yet');
-    expect(f.fix.command_argv).toEqual(['gbrain', 'bootstrap', 'repo']);
+    // No default fallback: this check can't tell an empty origin (needs
+    // `bootstrap repo`) from an already-pushed out-of-band one (needs
+    // `bootstrap attach`) without a git subprocess — see coverage.ts.
+    expect(f.fix.command_argv).toBeNull();
     expect(f.ask_user).toBe(true);
     expect(f.collector).toBe('backup-coverage');
   });

--- a/test/backup-coverage.serial.test.ts
+++ b/test/backup-coverage.serial.test.ts
@@ -373,6 +373,12 @@ describe('computeBackupCoverage — bootstrap workspace', () => {
     expect(asset?.id).toBe(ws);
     expect(asset?.state).toBe('no_remote');
     expect(asset?.fix_argv).toEqual(['gbrain', 'bootstrap', 'repo']);
+    // The message also names `bootstrap attach` for the out-of-band-adopted
+    // case (a git origin already configured on this workspace) — otherwise
+    // the reader only discovers it after `bootstrap repo` guaranteed-fails
+    // with ORIGIN_NOT_EMPTY (see src/core/bootstrap/repo.ts).
+    expect(asset?.detail).toContain('no private repo yet');
+    expect(asset?.detail).toContain('bootstrap attach');
     expect(s.overall).toBe('warn');
     expect(s.totals.no_remote).toBe(1);
   });

--- a/test/backup-coverage.serial.test.ts
+++ b/test/backup-coverage.serial.test.ts
@@ -361,7 +361,7 @@ describe('computeBackupCoverage — db_content and empty brain', () => {
 // ── Bootstrap workspace via the receipt ─────────────────────────────────────
 
 describe('computeBackupCoverage — bootstrap workspace', () => {
-  test('receipt without repo_url → bootstrap_workspace no_remote with bootstrap repo fix', async () => {
+  test('receipt without repo_url → bootstrap_workspace no_remote names both bootstrap repo and attach, fix_argv null', async () => {
     const ws = join(tmp, 'ws');
     mkdirSync(ws, { recursive: true });
     writeReceipt(ws);
@@ -372,12 +372,15 @@ describe('computeBackupCoverage — bootstrap workspace', () => {
     expect(asset).toBeDefined();
     expect(asset?.id).toBe(ws);
     expect(asset?.state).toBe('no_remote');
-    expect(asset?.fix_argv).toEqual(['gbrain', 'bootstrap', 'repo']);
-    // The message also names `bootstrap attach` for the out-of-band-adopted
-    // case (a git origin already configured on this workspace) — otherwise
-    // the reader only discovers it after `bootstrap repo` guaranteed-fails
-    // with ORIGIN_NOT_EMPTY (see src/core/bootstrap/repo.ts).
+    // This check is file-plane only (no git subprocess) so it can't tell an
+    // empty/unconfigured origin (needs `bootstrap repo`) from an
+    // already-pushed out-of-band one (needs `bootstrap attach`, since
+    // `bootstrap repo` guaranteed-refuses with ORIGIN_NOT_EMPTY there — see
+    // src/core/bootstrap/repo.ts). fix_argv stays null rather than advertise
+    // a command that's wrong in the out-of-band case; the message names both.
+    expect(asset?.fix_argv).toBeNull();
     expect(asset?.detail).toContain('no private repo yet');
+    expect(asset?.detail).toContain('bootstrap repo');
     expect(asset?.detail).toContain('bootstrap attach');
     expect(s.overall).toBe('warn');
     expect(s.totals.no_remote).toBe(1);


### PR DESCRIPTION
## What

`computeBackupCoverage()`'s `bootstrap_workspace` `no_remote` verdict (in
`src/core/backup/coverage.ts`) always pointed the reader at `gbrain
bootstrap repo` when `receipt.repo_url` is unset. `bootstrap repo` is only
safe when there's truly no git origin yet. If this workspace was already
pushed to an existing repo out-of-band, `bootstrap repo` is guaranteed to
refuse with `ORIGIN_NOT_EMPTY` (`assertAdoptableOrigin` in
`src/core/bootstrap/repo.ts`) — whose own error text correctly points at
`gbrain bootstrap attach`, and `attachWorkspace`'s `sameWorkspace` branch
(`src/core/bootstrap/attach.ts`) already reconciles `receipt.repo_url` from
the actual git origin. So the fix already exists; the coverage hint just
never mentioned it.

This PR updates the `detail` message to name both `bootstrap repo` (empty
origin) and `bootstrap attach` (already-pushed/out-of-band), and sets
`fix_argv` to `null` instead of the previous `['gbrain', 'bootstrap',
'repo']` — `coverage.ts` is deliberately file-plane only (no git
subprocess), so it can't tell which case it's in, and a single suggested
command is wrong half the time. No new logic or subprocess added.

The advisor (`src/core/advisor/collect-backup-coverage.ts`) had its own
`a.fix_argv ?? ['gbrain', 'bootstrap', 'repo']` fallback for this same
finding, which would have silently reintroduced the bug regardless of the
coverage.ts fix. Removed it (now matches the `source_repo` finding just
above it, which already used `a.fix_argv ?? null`).

## Tests

- `test/backup-coverage.serial.test.ts` / `test/advisor-backup-coverage.serial.test.ts`
  updated: `fix_argv`/`command_argv` now asserted `null`; `detail` asserted
  to mention both `bootstrap repo` and `bootstrap attach`.
- Discrimination test (both touched source files reverted to the
  upstream/master merge-base, tests kept): 37 pass / 2 fail (exactly the
  two changed tests). Restored: 48 pass / 0 fail.
- Full targeted suite (8 files): 155 pass / 1 fail — pre-existing,
  unrelated `workspacePush` lock-race test, reproduces identically on the
  merge-base.
- `bun run typecheck` clean, `bun run verify` 54/54.

## Blast-radius audit

Grepped for the original detail string and all `no_remote`/`fix_argv`
consumers of this verdict — the advisor was the only other reader, fixed
above. Not a hot path (manual/monthly backup-coverage check).