### PR TITLE
fix(ai): promote OpenRouter reasoning_content when content is empty (#4753)

### DIFF
--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -1,4 +1,5 @@
 import type { Recipe } from '../types.ts';
+import { deepseekReasoningContentCompatFetch } from './deepseek.ts';
 import { openaiModelSupportsPromptCache } from './openai.ts';
 
 /**
@@ -88,9 +89,13 @@ function withSystemCacheControl(body: unknown): unknown {
 }
 
 /**
- * Compat fetch: honors the OPENROUTER_CACHE_HEADER marker by splicing an
+ * Compat fetch: (1) honors the OPENROUTER_CACHE_HEADER marker by splicing an
  * Anthropic cache_control breakpoint onto the system block, then strips the
- * marker. Fail-open: any parse problem sends the original body unchanged.
+ * marker; (2) composes the native DeepSeek `reasoning_content` promote so
+ * OpenRouter-hosted thinking models (DeepSeek V4, etc.) do not arrive at the
+ * AI SDK adapter as empty `content`. Fail-open: any parse problem sends the
+ * original body unchanged. Tool-call turns are not promoted (that logic lives
+ * in `deepseekReasoningContentCompatFetch`).
  *
  * @internal exported for tests. Cast through `unknown` because TS's
  * `typeof fetch` includes a `preconnect` member (matches azure-openai.ts).
@@ -99,9 +104,11 @@ export const openrouterCompatFetch = (async (
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> => {
-  if (!init?.headers) return fetch(input as any, init as any);
+  const promote = (nextInit?: RequestInit) =>
+    deepseekReasoningContentCompatFetch(input, nextInit);
+  if (!init?.headers) return promote(init);
   const headers = new Headers(init.headers as any);
-  if (!headers.has(OPENROUTER_CACHE_HEADER)) return fetch(input as any, init as any);
+  if (!headers.has(OPENROUTER_CACHE_HEADER)) return promote(init);
   headers.delete(OPENROUTER_CACHE_HEADER);
   let body = init.body;
   if (typeof body === 'string') {
@@ -116,7 +123,7 @@ export const openrouterCompatFetch = (async (
       // Non-JSON body: let the provider surface the original problem.
     }
   }
-  return fetch(input as any, { ...init, headers, body } as any);
+  return promote({ ...init, headers, body } as any);
 }) as unknown as typeof fetch;
 
 /**

--- a/test/ai/recipe-openrouter.test.ts
+++ b/test/ai/recipe-openrouter.test.ts
@@ -258,4 +258,90 @@ describe('recipe: openrouter', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('16. fetch shim promotes reasoning_content when content is empty (DeepSeek-via-OpenRouter)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({
+        choices: [{ message: { role: 'assistant', content: '', reasoning_content: 'the answer' } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+    try {
+      const res = await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions');
+      const json = await res.json();
+      expect(json.choices[0].message.content).toBe('the answer');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('17. fetch shim does not promote on tool-call turns or non-empty content', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = typeof init?.body === 'string' ? init.body : '';
+      const kind = body.includes('tool') ? 'tool' : 'content';
+      if (kind === 'tool') {
+        return new Response(JSON.stringify({
+          choices: [{ finish_reason: 'tool_calls', message: {
+            content: null,
+            reasoning_content: 'INTERNAL CHAIN OF THOUGHT — must not leak',
+            tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'brain_search', arguments: '{}' } }],
+          } }],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'real content', reasoning_content: 'ignored' } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+    try {
+      const toolRes = await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'deepseek/deepseek-v4-flash-0731', kind: 'tool' }),
+      });
+      const toolJson = await toolRes.json();
+      expect(toolJson.choices[0].message.content).toBeNull();
+      expect(toolJson.choices[0].message.tool_calls).toHaveLength(1);
+
+      const textRes = await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'deepseek/deepseek-v4-flash-0731' }),
+      });
+      expect((await textRes.json()).choices[0].message.content).toBe('real content');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('18. cache_control rewrite still runs, then reasoning_content is promoted on the response', async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ init?: RequestInit }> = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ init });
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: '   ', reasoning_content: 'from ws' } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+    try {
+      const res = await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: { [OPENROUTER_CACHE_HEADER]: '1' },
+        body: JSON.stringify({
+          model: 'anthropic/claude-sonnet-4.6',
+          messages: [
+            { role: 'system', content: 'stable system prompt' },
+            { role: 'user', content: 'hello' },
+          ],
+        }),
+      });
+      const rewritten = JSON.parse(calls[0].init!.body as string);
+      expect(rewritten.messages[0].content).toEqual([
+        { type: 'text', text: 'stable system prompt', cache_control: { type: 'ephemeral' } },
+      ]);
+      expect(new Headers(calls[0].init!.headers as any).has(OPENROUTER_CACHE_HEADER)).toBe(false);
+      expect((await res.json()).choices[0].message.content).toBe('from ws');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
## What

OpenRouter-hosted thinking models (DeepSeek V4 via `openrouter:deepseek/...`) return the answer in `reasoning_content` and leave `content` empty. The native `deepseek:` recipe already promotes that field; `openrouterCompatFetch` did not, so dream triage / facts extract / expansion saw empty or unparseable text.

Fixes #4753

## Why

Same weights, different recipe. The AI SDK openai-compat adapter reads only `content`. Without the promote, OpenRouter DeepSeek thinking turns look empty even when the model answered.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted src/core/ai/recipes/openrouter.ts to merge-base, ran test/ai/recipe-openrouter.test.ts → 18 pass / 2 fail. Restored → all pass.

## Tests

- `test/ai/recipe-openrouter.test.ts` (tests 16–18)
- `test/ai/deepseek-reasoning-content.test.ts` (unchanged, still green)

Local: `bun test test/ai/recipe-openrouter.test.ts test/ai/deepseek-reasoning-content.test.ts` → 32 pass / 0 fail.

## Risk Assessment

Low. Request-side Anthropic cache rewrite is unchanged. Response-side promote is reused from `deepseekReasoningContentCompatFetch` (tool-call turns are not promoted; fail-open on non-JSON / non-ok). Does not enable Hangzhou `deepseek:` and does not change model routing.
