### PR TITLE
fix(ai): allow OpenRouter DeepSeek on the subagent loop (#4757)

### DIFF
--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -50,11 +50,14 @@ export function openrouterRequiresExplicitPromptCache(modelId: string): boolean 
 /**
  * OpenRouter Anthropic routes share Anthropic's tool-call envelope (and the
  * gateway loop already keys replay on gbrain_tool_use_id, not the raw
- * provider id). Other proxied families stay refused until they get their
- * own live abort/retry evidence (TODOS.md OpenRouter follow-up).
+ * provider id). DeepSeek routes share the native `deepseek:` openai-compat
+ * tool_call_id shape (`supports_subagent_loop: true` on that recipe). Other
+ * proxied families stay refused until they get their own live abort/retry
+ * evidence (TODOS.md OpenRouter follow-up).
  */
 export function openrouterSupportsSubagentLoop(modelId: string): boolean {
-  return modelId.trim().toLowerCase().startsWith('anthropic/');
+  const normalized = modelId.trim().toLowerCase();
+  return normalized.startsWith('anthropic/') || normalized.startsWith('deepseek/');
 }
 
 /**
@@ -161,8 +164,9 @@ export const openrouterCompatFetch = (async (
  * `supports_subagent_loop` so classifyCapabilities() allows them. The
  * handler still refuses the Anthropic-direct SDK for `openrouter:*` and
  * auto-routes those jobs through `gateway.toolLoop()` — OR is not a native
- * Anthropic provider. Other OR families stay refused until they get a live
- * abort/retry pin (TODOS.md).
+ * Anthropic provider. DeepSeek routes (`deepseek/…`) match the native
+ * `deepseek:` recipe (openai-compat tool_call ids). Other OR families stay
+ * refused until they get a live abort/retry pin (TODOS.md).
  */
 export const openrouter: Recipe = {
   id: 'openrouter',

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -93,6 +93,8 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     // Declared true — loop-capable.
     expect(getProviderCapabilities('anthropic:claude-sonnet-4-6').supportsSubagentLoop).toBe(true);
     expect(getProviderCapabilities('deepseek:deepseek-v4-flash').supportsSubagentLoop).toBe(true);
+    expect(getProviderCapabilities('openrouter:deepseek/deepseek-v4-flash').supportsSubagentLoop).toBe(true);
+    expect(getProviderCapabilities('openrouter:deepseek/deepseek-v4-flash-0731').supportsSubagentLoop).toBe(true);
     // Declared false — tools work, but tool_call_ids aren't replay-stable.
     expect(getProviderCapabilities('moonshot:kimi-k2.5').supportsSubagentLoop).toBe(false);
     expect(getProviderCapabilities('mistral:mistral-large-latest').supportsSubagentLoop).toBe(false);
@@ -126,14 +128,15 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
     expect(classifyCapabilities('google:gemini-1.5-pro')).toBe('degraded:no_caching');
   });
 
-  it('allows OpenRouter Anthropic routes for the subagent loop and refuses other OR families', () => {
-    // Anthropic-via-OR shares the Anthropic tool envelope; replay keys off
-    // gbrain_tool_use_id. Other proxied families stay refused until they get
-    // their own live abort/retry pin.
+  it('allows OpenRouter Anthropic and DeepSeek routes for the subagent loop and refuses other OR families', () => {
+    // Anthropic-via-OR shares the Anthropic tool envelope; DeepSeek-via-OR
+    // shares the native deepseek: openai-compat tool_call_id shape. Other
+    // proxied families stay refused until they get their own live abort/retry pin.
     expect(classifyCapabilities('openrouter:anthropic/claude-sonnet-4.6')).toBe('ok');
     expect(classifyCapabilities('openrouter:anthropic/claude-haiku-4.5')).toBe('ok');
+    expect(classifyCapabilities('openrouter:deepseek/deepseek-chat')).toBe('ok');
+    expect(classifyCapabilities('openrouter:deepseek/deepseek-v4-flash-0731')).toBe('ok');
     expect(classifyCapabilities('openrouter:openai/gpt-5.2')).toBe('unusable:no_subagent_loop');
-    expect(classifyCapabilities('openrouter:deepseek/deepseek-chat')).toBe('unusable:no_subagent_loop');
   });
 
   it('returns unusable:no_subagent_loop when tools work but the recipe declares the loop unsupported', () => {

--- a/test/ai/recipe-openrouter.test.ts
+++ b/test/ai/recipe-openrouter.test.ts
@@ -16,6 +16,7 @@ import {
   openrouterCompatFetch,
   openrouterRequiresExplicitPromptCache,
   openrouterSupportsPromptCache,
+  openrouterSupportsSubagentLoop,
 } from '../../src/core/ai/recipes/openrouter.ts';
 import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
 import { assertTouchpoint, embeddingDimsForModel } from '../../src/core/ai/model-resolver.ts';
@@ -75,7 +76,7 @@ describe('recipe: openrouter', () => {
       expect(loop('anthropic/claude-haiku-4.5')).toBe(true);
       expect(loop('anthropic/claude-sonnet-4.6')).toBe(true);
       expect(loop('openai/gpt-5.2')).toBe(false);
-      expect(loop('deepseek/deepseek-chat')).toBe(false);
+      expect(loop('deepseek/deepseek-chat')).toBe(true);
     }
     expect(() =>
       assertTouchpoint(r, 'chat', 'some/provider-model'),
@@ -205,6 +206,15 @@ describe('recipe: openrouter', () => {
     expect(openrouterRequiresExplicitPromptCache('anthropic/claude-sonnet-4.6')).toBe(true);
     expect(openrouterRequiresExplicitPromptCache('openai/gpt-5.2')).toBe(false);
     expect(openrouterRequiresExplicitPromptCache('deepseek/deepseek-chat')).toBe(false);
+  });
+
+  test('13b. subagent loop is allowed for Anthropic and DeepSeek routes only', () => {
+    expect(openrouterSupportsSubagentLoop('anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(openrouterSupportsSubagentLoop('deepseek/deepseek-v4-flash')).toBe(true);
+    expect(openrouterSupportsSubagentLoop('deepseek/deepseek-v4-flash-0731')).toBe(true);
+    expect(openrouterSupportsSubagentLoop('deepseek/deepseek-chat:free')).toBe(true);
+    expect(openrouterSupportsSubagentLoop('openai/gpt-5.2')).toBe(false);
+    expect(openrouterSupportsSubagentLoop('google/gemini-3-flash-preview')).toBe(false);
   });
 
   test('14. recipe installs the cache compat fetch shim', () => {

--- a/test/e2e/openrouter-deepseek-subagent-replay.live.test.ts
+++ b/test/e2e/openrouter-deepseek-subagent-replay.live.test.ts
@@ -1,0 +1,165 @@
+/**
+ * LIVE e2e — OpenRouter DeepSeek subagent abort/retry.
+ *
+ * Skip-gated on OPENROUTER_API_KEY. Same abort/resume contract as
+ * openrouter-anthropic-subagent-replay.live.test.ts: first turn hits real OR
+ * DeepSeek, persists the tool-call, completes the observation, then aborts
+ * before the follow-up model turn. Resume must keep those persisted
+ * tool-call ids byte-identical and must not re-dispatch the completed tool.
+ *
+ * Run (keep-keys required — unit preload strips OPENROUTER_API_KEY):
+ *   GBRAIN_TEST_KEEP_PROVIDER_KEYS=1 OPENROUTER_API_KEY=... \
+ *     bun test test/e2e/openrouter-deepseek-subagent-replay.live.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import { makeSubagentHandler } from '../../src/core/minions/handlers/subagent.ts';
+import type { MinionJobContext, ToolDef, ToolCtx } from '../../src/core/minions/types.ts';
+import { configureGateway, resetGateway } from '../../src/core/ai/gateway.ts';
+
+const MODEL = 'openrouter:deepseek/deepseek-v4-flash-0731';
+const API_KEY = process.env.OPENROUTER_API_KEY;
+const skipAll = !API_KEY;
+const SYSTEM =
+  'You are a tool-using intern. You MUST call ping before you say anything else. Never answer in prose first.';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  resetGateway();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('version', '85');
+  // Flag OFF on purpose: OR Anthropic must auto-route through the gateway.
+  await engine.unsetConfig('agent.use_gateway_loop');
+  if (skipAll) return;
+  configureGateway({
+    chat_model: MODEL,
+    embedding_model: 'openrouter:openai/text-embedding-3-small',
+    embedding_dimensions: 1024,
+    expansion_model: MODEL,
+    env: { OPENROUTER_API_KEY: API_KEY! },
+  });
+});
+
+function makeCtx(
+  jobId: number,
+  prompt: string,
+  signal: AbortSignal,
+): MinionJobContext {
+  return {
+    id: jobId,
+    name: 'subagent',
+    data: { prompt, model: MODEL, max_turns: 4, system: SYSTEM },
+    attempts_made: 0,
+    signal,
+    deadlineAtMs: null,
+    shutdownSignal: new AbortController().signal,
+    updateProgress: async () => {},
+    updateTokens: async () => {},
+    log: async () => {},
+    isActive: async () => true,
+    readInbox: async () => [],
+  };
+}
+
+async function makeJob(prompt: string): Promise<{ jobId: number }> {
+  const rows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO minion_jobs (name, status, data, queue, priority, created_at)
+     VALUES ('subagent', 'active', $1::jsonb, 'default', 0, now())
+     RETURNING id`,
+    [JSON.stringify({ prompt, model: MODEL, max_turns: 4, system: SYSTEM })],
+  );
+  return { jobId: rows[0]!.id };
+}
+
+describe('OpenRouter DeepSeek live — abort mid-loop and resume', () => {
+  test('persisted tool-call ids stay byte-identical across resume', async () => {
+    if (skipAll) {
+      console.warn('[skip] OPENROUTER_API_KEY not set');
+      return;
+    }
+
+    let pingCalls = 0;
+    const firstAbort = new AbortController();
+    const tools: ToolDef[] = [
+      {
+        name: 'ping',
+        description: 'Mandatory ping. Call this tool once with {"who":"gbrain"} before answering.',
+        input_schema: {
+          type: 'object',
+          properties: { who: { type: 'string' } },
+          required: ['who'],
+        },
+        idempotent: true,
+        async execute(_input: unknown, _ctx: ToolCtx) {
+          pingCalls += 1;
+          if (pingCalls === 1) {
+            // Observation is complete; abort before the follow-up model turn.
+            firstAbort.abort();
+          }
+          return { pong: true };
+        },
+      },
+    ];
+
+    const handler = makeSubagentHandler({
+      engine,
+      config: {} as never,
+      toolRegistry: tools,
+      makeAnthropic: () => ({
+        messages: {
+          create: async () => {
+            throw new Error('legacy Anthropic SDK must not run for openrouter:*');
+          },
+        },
+      }) as never,
+    });
+
+    const prompt = 'Call the ping tool exactly once with who=gbrain, then say done. Do not skip the tool.';
+    const { jobId } = await makeJob(prompt);
+
+    const first = await handler(makeCtx(jobId, prompt, firstAbort.signal));
+    expect(pingCalls).toBe(1);
+    expect(first.stop_reason).toBe('error');
+
+    const firstRows = await engine.executeRaw<{ content_blocks: unknown }>(
+      `SELECT content_blocks FROM subagent_messages
+        WHERE job_id = $1 AND role = 'assistant'
+        ORDER BY message_idx ASC LIMIT 1`,
+      [jobId],
+    );
+    expect(firstRows.length).toBe(1);
+    const firstBlocks = typeof firstRows[0]!.content_blocks === 'string'
+      ? firstRows[0]!.content_blocks
+      : JSON.stringify(firstRows[0]!.content_blocks);
+    expect(firstBlocks).toMatch(/tool-call|tool_use/);
+
+    const resume = await handler(makeCtx(jobId, prompt, new AbortController().signal));
+    expect(resume.stop_reason).toBe('end_turn');
+    // First observation already completed; resume must not re-execute it.
+    expect(pingCalls).toBe(1);
+
+    const secondRows = await engine.executeRaw<{ content_blocks: unknown }>(
+      `SELECT content_blocks FROM subagent_messages
+        WHERE job_id = $1 AND role = 'assistant'
+        ORDER BY message_idx ASC LIMIT 1`,
+      [jobId],
+    );
+    const secondBlocks = typeof secondRows[0]!.content_blocks === 'string'
+      ? secondRows[0]!.content_blocks
+      : JSON.stringify(secondRows[0]!.content_blocks);
+    expect(secondBlocks).toBe(firstBlocks);
+  }, 90_000);
+});


### PR DESCRIPTION
## What

Allow `openrouter:deepseek/…` on the Minions subagent loop, matching native `deepseek:` (`supports_subagent_loop: true`). Other OpenRouter families stay refused.

Fixes #4757

## Why

`classifyCapabilities('openrouter:deepseek/deepseek-v4-flash-0731')` was `unusable:no_subagent_loop` because `openrouterSupportsSubagentLoop` only allowed `anthropic/`. Native DeepSeek already drives the loop through openai-compat tool_call ids; OpenRouter DeepSeek uses the same wire.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted src/core/ai/recipes/openrouter.ts to merge-base, ran test/ai/capabilities.test.ts → 25 pass / 2 fail. Restored → all pass.

## Tests

- `test/ai/recipe-openrouter.test.ts`
- `test/ai/capabilities.test.ts`
- skip-gated live pin: `test/e2e/openrouter-deepseek-subagent-replay.live.test.ts`

Local: `bun test test/ai/recipe-openrouter.test.ts test/ai/capabilities.test.ts` → 45 pass / 0 fail.

## Risk Assessment

Low for capability declaration. Does not change default `models.subagent`. Live abort/retry is skip-gated on OPENROUTER_API_KEY (same pattern as the Anthropic OR pin).
