### PR TITLE
fix(ai): OpenRouter DeepSeek thinking_by_default + triage thinking-off (#4758)

### DIFF
--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -47,6 +47,11 @@ export function openrouterRequiresExplicitPromptCache(modelId: string): boolean 
   return modelId.trim().toLowerCase().startsWith('anthropic/claude-');
 }
 
+/** Native DeepSeek v4 thinks by default; OpenRouter DeepSeek hosts do too. */
+export function openrouterThinkingByDefault(modelId: string): boolean {
+  return modelId.trim().toLowerCase().startsWith('deepseek/');
+}
+
 /**
  * OpenRouter Anthropic routes share Anthropic's tool-call envelope (and the
  * gateway loop already keys replay on gbrain_tool_use_id, not the raw
@@ -252,6 +257,9 @@ export const openrouter: Recipe = {
       // Family-scoped: OpenAI routes cache automatically; Anthropic routes
       // cache via the compat fetch shim's cache_control rewrite.
       supports_prompt_cache: openrouterSupportsPromptCache,
+      // DeepSeek v4 via OpenRouter thinks by default (same as native
+      // deepseek:). Other OR families stay default-off.
+      thinking_by_default: openrouterThinkingByDefault,
       // No max_context_tokens: catalog spans 128K to 1M+; a single recipe-wide
       // value is either unsafe for smaller models or wasteful for larger ones.
       // Let upstream errors surface per-model.

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -1770,7 +1770,9 @@ export function makeJudgeClient(verdictModel: string): JudgeClient | null {
         // the openai-compatible adapter spreads providerOptions[recipe.id]
         // into the wire body, where `thinking` is DeepSeek's documented knob.
         ...(v.parsed.providerId === 'deepseek'
-          ? { providerOptions: { deepseek: { thinking: { type: 'disabled' } } } }
+          || (v.parsed.providerId === 'openrouter'
+            && v.parsed.modelId.trim().toLowerCase().startsWith('deepseek/'))
+          ? { providerOptions: { [v.parsed.providerId]: { thinking: { type: 'disabled' } } } }
           : {}),
         // #4077: a cancelled cycle tears down the in-flight judge call too.
         abortSignal: options?.signal,

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -63,6 +63,13 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.supportsPromptCaching).toBe(false);
   });
 
+  it('marks OpenRouter DeepSeek routes as thinking-by-default (native deepseek: parity)', () => {
+    expect(getProviderCapabilities('deepseek:deepseek-v4-flash').supportsThinking).toBe(true);
+    expect(getProviderCapabilities('openrouter:deepseek/deepseek-v4-flash-0731').supportsThinking).toBe(true);
+    expect(getProviderCapabilities('openrouter:openai/gpt-5.2').supportsThinking).toBe(false);
+    expect(getProviderCapabilities('openrouter:anthropic/claude-sonnet-4.6').supportsThinking).toBe(false);
+  });
+
   it('returns local chat capabilities for Ollama without tool-loop support', () => {
     const caps = getProviderCapabilities('ollama:qwen2.5-coder:14b');
     expect(caps.supportsToolCalling).toBe(false);

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -215,6 +215,35 @@ describe('JudgeClient.create — gateway routing + shape adapter', () => {
     });
   });
 
+  test('A3c: OpenRouter DeepSeek verdict judge disables thinking for its own call only', async () => {
+    const judge = makeJudgeClient('openrouter:deepseek/deepseek-v4-flash-0731');
+    expect(judge).not.toBeNull();
+
+    let receivedProviderOptions: Record<string, Record<string, unknown>> | undefined;
+    __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+      receivedProviderOptions = opts.providerOptions;
+      return {
+        text: WORTH_PROCESSING_JSON,
+        blocks: [],
+        stopReason: 'end',
+        usage: { input_tokens: 10, output_tokens: 20, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'openrouter:deepseek/deepseek-v4-flash-0731',
+        providerId: 'openrouter',
+      };
+    });
+
+    await judge!.create({
+      model: 'openrouter:deepseek/deepseek-v4-flash-0731',
+      max_tokens: 1024,
+      system: 'judge system prompt',
+      messages: [{ role: 'user', content: 'judge this' }],
+    });
+
+    expect(receivedProviderOptions).toEqual({
+      openrouter: { thinking: { type: 'disabled' } },
+    });
+  });
+
   test('A4: ChatResult.text → Anthropic.Message.content[0].text mapping', async () => {
     await withEnv({ ANTHROPIC_API_KEY: 'sk-test-A4' }, async () => {
       const judge = makeJudgeClient('claude-haiku-4-5-20251001');

--- a/test/think-max-output-tokens.test.ts
+++ b/test/think-max-output-tokens.test.ts
@@ -78,6 +78,8 @@ describe('maxOutputTokensFor — thinking-default headroom', () => {
     // model-name regex, so provider renames keep the headroom.
     expect(maxOutputTokensFor('deepseek:deepseek-v4-flash')).toBe(16000);
     expect(maxOutputTokensFor('deepseek:deepseek-v4-pro')).toBe(16000);
+    expect(maxOutputTokensFor('openrouter:deepseek/deepseek-v4-flash')).toBe(16000);
+    expect(maxOutputTokensFor('openrouter:deepseek/deepseek-v4-flash-0731')).toBe(16000);
     // Retired alias still routes to a thinking v4 model at the provider.
     expect(maxOutputTokensFor('deepseek:deepseek-reasoner')).toBe(16000);
     // Recipes without the capability keep the conservative default.


### PR DESCRIPTION
## What

OpenRouter DeepSeek (`openrouter:deepseek/…`) now declares `thinking_by_default` like native `deepseek:`, so `maxOutputTokensFor` grants 16k headroom (#4172). Dream triage also pins `thinking: { type: 'disabled' }` on OpenRouter DeepSeek judges, not only `providerId === 'deepseek'`.

Fixes #4758

## Why

Without the flag, OpenRouter DeepSeek stays at the 4000-token default and the judge still thinks, so JSON verdicts truncate. Native DeepSeek already had both.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted src/core/ai/recipes/openrouter.ts to merge-base, ran test/think-max-output-tokens.test.ts → 6 pass / 1 fail. Restored → all pass.

Discrimination test: reverted src/core/cycle/synthesize.ts to merge-base, ran test/cycle/synthesize-gateway-adapter.test.ts → 15 pass / 1 fail. Restored → all pass.

## Tests

- `test/think-max-output-tokens.test.ts`
- `test/cycle/synthesize-gateway-adapter.test.ts` (A3c)
- `test/ai/capabilities.test.ts`

Local: `bun test test/think-max-output-tokens.test.ts test/cycle/synthesize-gateway-adapter.test.ts test/ai/capabilities.test.ts` → 51 pass / 0 fail.

## Risk Assessment

Low. Non-DeepSeek OpenRouter models unchanged. Thinking-off is per-call on the triage judge only. Does not enable Hangzhou `deepseek:`.
