### PR TITLE
feat(exports): expose gbrain/core/skillopt and gbrain/version subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "./extract": "./src/commands/extract.ts",
     "./ingestion": "./src/core/ingestion/index.ts",
     "./ingestion/test-harness": "./src/core/ingestion/test-harness.ts",
-    "./core/guardrails": "./src/core/guardrails.ts"
+    "./core/guardrails": "./src/core/guardrails.ts",
+    "./core/skillopt": "./src/core/skillopt/orchestrator.ts",
+    "./version": "./src/version.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/scripts/check-exports-count.sh
+++ b/scripts/check-exports-count.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=22
+EXPECTED_COUNT=24
 
 # Count top-level keys in the exports object. `node -e` parses JSON
 # reliably without needing jq (which isn't in every CI environment).

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -55,6 +55,8 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/ingestion', canary: ['INGESTION_SOURCE_API_VERSION', 'validateIngestionEvent', 'computeContentHash'] },
   { subpath: 'gbrain/ingestion/test-harness', canary: ['IngestionTestHarness', 'expectEvent'] },
   { subpath: 'gbrain/core/guardrails', canary: ['registerGuardrailProvider', 'runGuardrails', 'loadGuardrailProvidersFromEnv'] },
+  { subpath: 'gbrain/core/skillopt', canary: ['runSkillOpt', 'parseSplit'] },
+  { subpath: 'gbrain/version', canary: ['VERSION'] },
 ];
 
 function readPackageExports(): Record<string, string> {
@@ -70,7 +72,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(22);
+    expect(count).toBe(24);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## What

Adds two subpaths to gbrain's public `exports` map:

- `./core/skillopt` -> `src/core/skillopt/orchestrator.ts` (`runSkillOpt`, `parseSplit`)
- `./version` -> `src/version.ts` (`VERSION`)

## Why

Both gaps are named in the sibling `gbrain-evals` repo's TODOS.md ("Upstream gbrain"
P3 section, https://github.com/garrytan/gbrain-evals/blob/main/TODOS.md):

> export the `./core/skillopt` subpath (audit skillopt-cats-11): cat30-33 deep-import
> gbrain's skillopt orchestrator via node_modules paths that work on flat bun installs
> but break under isolated layouts. One export-map line upstream removes the last four
> deep imports.

> export a `gbrain/version` subpath so eval repos don't need the resolve-and-walk
> helper in `eval/runner/gbrain-version.ts` (works fine, just inelegant).

`docs/architecture/KEY_FILES.md`'s own `src/core/skillopt/` entry already says the
module "Drives the Track B SkillOpt benchmark suite in the sibling `gbrain-evals`
repo," so this is closing a gap between an already-acknowledged consumer and the
package's public surface, not opening a new one.

## Precedent

Follows PR #3427 ("expose runThink synthesis via gbrain/think subpath") exactly:
a single `package.json` exports-map line per subpath pointing straight at the
existing internal module (no re-export shim file), plus the matching
`test/public-exports.test.ts` `EXPECTED_EXPORTS` entry (with runtime canary
symbols) and the locked export-count bump in both the test and
`scripts/check-exports-count.sh`.

## Changes

- `package.json` — add `"./core/skillopt": "./src/core/skillopt/orchestrator.ts"`
  and `"./version": "./src/version.ts"`.
- `scripts/check-exports-count.sh` — `EXPECTED_COUNT` 22 -> 24.
- `test/public-exports.test.ts` — bump the locked export count 22 -> 24 and add
  two `EXPECTED_EXPORTS` rows:
  - `gbrain/core/skillopt` canaries `runSkillOpt`, `parseSplit`
  - `gbrain/version` canary `VERSION`

## Bundling both in one PR

Both are the same class of fix (a missing subpath export), requested in the same
TODOS.md section for the same underlying reason (downstream eval-repo ergonomics),
so this reads as one coherent change rather than two unrelated ones. Happy to split
into two PRs if you'd prefer to review/land them independently.

## Trust-boundary note on `./core/skillopt`

`runSkillOpt` in `orchestrator.ts` is the raw orchestration function — it does
**not** include the guardrails that wrap it at the MCP `run_skillopt` operation
layer (`src/core/ops/skillopt.ts`): the admin-scope + `skillopt.allowed_skills`
allowlist check, the `skill_name` kebab-case validation, and the remote-caller
path confinement for `benchmark_path`/`held_out_path` under the skills directory
(all gated on `ctx.remote !== false`, i.e. only enforced for untrusted MCP
callers). A library consumer importing `gbrain/core/skillopt` calls it exactly
the way the local CLI does (`ctx.remote === false`) — supplying its own trusted
`engine`, `skillsDir`, and paths — and is responsible for the same input hygiene
the CLI already assumes. This mirrors the existing `./think`, `./ingestion`, and
`./search/hybrid` exports, which are likewise raw functions without an
operation-layer wrapper; this PR doesn't introduce a new trust-boundary pattern,
just extends the existing "trusted library embedding" surface to one more module
that a real downstream consumer (gbrain-evals) already needs. `runSkillOpt` is
`mutating: true` (it can rewrite `SKILL.md`) and DB-lock-gated
(`tryAcquireDbLock('skillopt:<name>', ...)`) — callers should know it writes
files and expects a connected `engine`, same as calling it from the CLI.

## Verification

```
bun test test/public-exports.test.ts
44 pass / 0 fail

bash scripts/check-exports-count.sh
✓ public-exports guard: 24 entries (matches baseline 24)

bun run typecheck
(clean)
```

## Notes

- No new code — this only widens the public surface to modules that already
  exist, matching the precedent PR's framing.
- Did not touch `VERSION`, the `package.json` version, `CHANGELOG.md`, or the
  `llms` bundles, for the same reason PR #3427 didn't — avoiding collision with
  the `/ship` version-queue allocator. Happy to fold those in if preferred.
