### PR TITLE
feat(exports): expose gbrain/version subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "./ingestion/test-harness": "./src/core/ingestion/test-harness.ts",
     "./core/guardrails": "./src/core/guardrails.ts",
     "./core/skillopt": "./src/core/skillopt/index.ts",
-    "./pglite-lock": "./src/core/pglite-lock.ts"
+    "./pglite-lock": "./src/core/pglite-lock.ts",
+    "./version": "./src/version.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/scripts/check-exports-count.sh
+++ b/scripts/check-exports-count.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=24
+EXPECTED_COUNT=25
 
 # Count top-level keys in the exports object. `node -e` parses JSON
 # reliably without needing jq (which isn't in every CI environment).

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -59,6 +59,7 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   // cat30–33 consume, replacing physical node_modules deep imports.
   { subpath: 'gbrain/core/skillopt', canary: ['runSkillOpt', 'scoreSkillOnTasks', 'loadHeldOut'] },
   { subpath: 'gbrain/pglite-lock', canary: ['peekLock'] },
+  { subpath: 'gbrain/version', canary: ['VERSION'] },
 ];
 
 function readPackageExports(): Record<string, string> {
@@ -75,7 +76,8 @@ describe('public exports — package.json exports map', () => {
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
     // 23→24 (2026-08 fix wave): ./core/skillopt (audit skillopt-cats-11).
-    expect(count).toBe(24);
+    // 24→25: ./version (gbrain-evals TODOS P3 — direct VERSION import).
+    expect(count).toBe(25);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## Summary

Adds a single new `package.json` exports entry re-exporting `src/version.ts`'s `VERSION` constant.

## Why

Eval repos (e.g. `garrytan/gbrain-evals`) currently resolve the installed gbrain version via a resolve-and-walk helper (`eval/runner/gbrain-version.ts`) instead of importing it directly — works, just inelegant. Named as its own follow-up in `gbrain-evals`' `TODOS.md` (P3):

> **Upstream gbrain: export a `gbrain/version` subpath** so eval repos don't need the resolve-and-walk helper in `eval/runner/gbrain-version.ts` (works fine, just inelegant).

(https://github.com/garrytan/gbrain-evals/blob/main/TODOS.md)

## Design notes

- Follows the exact precedent set by the already-merged `./think` subpath export (PR #3427): a plain re-export of an existing, non-mutating module — one `package.json` line, one `EXPECTED_EXPORTS` test entry, the locked-count bump. No new operation-layer wrapper, no admin-scope/allowlist/path-confinement concerns, since `VERSION` is a side-effect-free string constant.
- **Split out of #4769** (closed): that PR combined this export with a `./core/skillopt` export in the same PR and got a WOULD-CLOSE review verdict for (1) combining two unrelated subpaths in one PR and (2) `./core/skillopt` exposing a mutating, guardrail-bypassing orchestrator (a real trust-boundary concern — `runSkillOpt` is `mutating: true` and its MCP operation wrapper's admin-scope/allowlist/path-confinement guardrails only apply when `ctx.remote !== false`, which a direct library import bypasses). This resubmission drops `./core/skillopt` entirely; it stays fork-local for now.

## Validation

- `bun run typecheck` — clean
- `bun test test/public-exports.test.ts` — 44/44 pass
- `bun run verify` — 54/54 checks pass
- Real runtime import check: `bun -e "const {VERSION} = await import('./src/version.ts'); ..."` → `0.47.9.0` (matches `package.json`'s version)
