### PR TITLE
fix: make code graph misses trustworthy

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -500,6 +500,25 @@ export interface SyncOpts {
   onProgress?: (p: { phase: string; bankedFiles?: number }) => void;
 }
 
+/**
+ * Resolve the strategy for a single-source sync.
+ *
+ * An explicit CLI override wins. Otherwise the registered source owns its
+ * ingestion strategy, matching the existing `sync --all` and
+ * `syncOneSource` behavior. Invalid legacy config values fail safely to the
+ * normal default instead of being cast into SyncOpts.
+ */
+export function resolveSingleSourceSyncStrategy(
+  explicit: SyncOpts['strategy'] | undefined,
+  sourceConfig: Record<string, unknown> | null | undefined,
+): SyncOpts['strategy'] | undefined {
+  if (explicit) return explicit;
+  const configured = sourceConfig?.strategy;
+  return configured === 'markdown' || configured === 'code' || configured === 'auto'
+    ? configured
+    : undefined;
+}
+
 // The git-plumbing cluster (git(), discoverGitRoot, createSyncBaselineCommit,
 // path-containment guards, ...) was peeled to src/core/sync-git.ts (pure
 // move). Re-exported so existing importers keep working.
@@ -5142,9 +5161,23 @@ See also:
   // lock released by its own finally) instead of a hard cut.
   const singleSourceInterrupt = new AbortController();
   const onSingleSourceSigint = () => { try { singleSourceInterrupt.abort(new Error('SIGINT')); } catch { /* */ } };
+  // A registered source owns its default ingestion strategy. `sync --all`
+  // and syncOneSource already honor config.strategy; the explicit
+  // `sync --source <id>` path historically dropped it and silently fell back
+  // to markdown. That left code sources partially indexed and made graph
+  // queries report false zero-callers results. Keep an explicit CLI strategy
+  // authoritative, otherwise inherit the source's durable configuration.
+  const strategyRows = await engine.executeRaw<{ config: Record<string, unknown> }>(
+    `SELECT config FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  const singleSourceStrategy = resolveSingleSourceSyncStrategy(
+    strategyArg,
+    strategyRows[0]?.config,
+  );
   const opts: SyncOpts = {
     repoPath, dryRun, full, noPull, noEmbed, noExtract, skipFailed, retryFailed, noSchemaPack, includeGitignored, workingTree, sourceId,
-    strategy: strategyArg, concurrency,
+    strategy: singleSourceStrategy, concurrency,
     srcSubpath,
     exclude: excludePatterns.length > 0 ? excludePatterns : undefined,
     includeHidden: includeHiddenPatterns.length > 0 ? includeHiddenPatterns : undefined,

--- a/src/core/ops/code-intel.ts
+++ b/src/core/ops/code-intel.ts
@@ -156,7 +156,7 @@ const code_refs: Operation = {
 
 const code_blast: Operation = {
   name: 'code_blast',
-  description: 'BEFORE editing any function, run code_blast with the symbol name to surface every transitive caller grouped by depth (direct → 2-hop → 3-hop). Use this during plan-mode to size the change. Returns up to 200 nodes. Returns: {result, depth_groups?, truncation?, cycles_detected?, did_you_mean?, candidates?}. Example ok: {result:"ok", depth_groups:[{depth:1, nodes:[{symbol,chunk_id}], confidence:0.77}], truncation:"none"}.',
+  description: 'BEFORE editing any function, run code_blast with the symbol name to surface every transitive caller grouped by depth (direct → 2-hop → 3-hop). Use this during plan-mode to size the change. Returns up to 200 nodes. Trust an empty/not_found result only when ready=true; ready=false means impact is unknown and requires a safe fallback. Returns: {result, status, ready, depth_groups?, truncation?, cycles_detected?, did_you_mean?, candidates?}. Example ok: {result:"ok", status:"ready", ready:true, depth_groups:[{depth:1, nodes:[{symbol,chunk_id}], confidence:0.77}], truncation:"none"}.',
   params: {
     symbol: { type: 'string', required: true, description: 'Bare or qualified symbol name (e.g. "performSync" or "src/foo::performSync")' },
     depth: { type: 'number', description: 'Hop cap (default 5, max 8)' },
@@ -178,7 +178,7 @@ const code_blast: Operation = {
     // exactly preserving pre-fix local behavior.
     const { sourceId: scopedSourceId } = await routeCodeIntelScope(ctx, typeof p.source_id === 'string' ? p.source_id : undefined);
     const sourceId = scopedSourceId ?? ctx.sourceId;
-    return getCachedOrCompute(
+    const walk = await getCachedOrCompute(
       ctx.engine,
       { symbol_qualified: symbol, depth, source_id: sourceId },
       () => runRecursiveWalk(ctx.engine, symbol, {
@@ -189,6 +189,29 @@ const code_blast: Operation = {
         exact,
       }),
     );
+    // Recursive traversal must carry the same typed readiness contract as
+    // code_def/code_refs/code_callers/code_callees. Without it,
+    // `{result:"not_found"}` conflates a genuine miss with an unbuilt or
+    // still-indexing graph, causing agents to treat absence of evidence as
+    // evidence of no blast radius.
+    const resultCount = walk.result === 'ok'
+      ? walk.depth_groups.reduce((total, group) => total + group.nodes.length, 0)
+      : walk.result === 'ambiguous'
+        ? walk.candidates.length
+        : 0;
+    const { resolveCodeReadiness } = await import('../code-graph-readiness.ts');
+    const readiness = await resolveCodeReadiness(ctx.engine, {
+      kind: walk.result === 'not_found' ? 'symbol' : 'edge',
+      count: resultCount,
+      sourceId,
+      remote: ctx.remote,
+    });
+    return {
+      ...walk,
+      status: readiness.status,
+      ready: readiness.ready,
+      ...(readiness.scoped_source_id ? { scoped_source_id: readiness.scoped_source_id } : {}),
+    };
   },
   cliHints: { name: 'code_blast', hidden: true },
 };

--- a/test/code-intel-source-scope.test.ts
+++ b/test/code-intel-source-scope.test.ts
@@ -288,8 +288,14 @@ describe('A13 — code_blast / code_flow resolveCodeIntelScope fence', () => {
     const scoped = (await op.handler(remoteAlpha(), { symbol: 'betaSecretFn' })) as {
       result: string;
       did_you_mean: unknown[];
+      status: string;
+      ready: boolean;
     };
     expect(scoped.result).toBe('not_found');
+    // A miss is trustworthy only when the symbol index for this exact scope
+    // is ready. This keeps "not found" distinct from "index unavailable".
+    expect(scoped.status).toBe('ready');
+    expect(scoped.ready).toBe(true);
     // The did_you_mean suggestions are source-scoped too — no beta leak.
     expect(containsBeta(scoped.did_you_mean)).toBe(false);
     // Anti-vacuity control: beta scope resolves and walks the same symbol.

--- a/test/sync-source-strategy.test.ts
+++ b/test/sync-source-strategy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveSingleSourceSyncStrategy } from '../src/commands/sync.ts';
+
+describe('single-source sync strategy', () => {
+  test('inherits the registered code strategy when CLI does not override it', () => {
+    expect(resolveSingleSourceSyncStrategy(undefined, { strategy: 'code' })).toBe('code');
+  });
+
+  test('keeps an explicit CLI strategy authoritative', () => {
+    expect(resolveSingleSourceSyncStrategy('markdown', { strategy: 'code' })).toBe('markdown');
+  });
+
+  test('ignores invalid legacy configuration values', () => {
+    expect(resolveSingleSourceSyncStrategy(undefined, { strategy: 'invalid' })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- make single-source sync inherit the source's configured strategy when the CLI does not override it
- attach code-index readiness to `code_blast`, including trustworthy empty results
- add regressions for source strategy inheritance and ready `not_found` responses

## Why

A source configured with `strategy: code` could be indexed as Markdown through `sync --source`, leaving callers incomplete. `code_blast` then returned an unqualified `not_found`, collapsing an incomplete graph into a false claim of zero impact.

## Verification

- focused strategy/readiness tests: 15 passed
- related code-intel tests: 37 passed
- TypeScript: `bunx tsc --noEmit` passed
- physical Candor corpus: a known symbol returns 3 direct callers and 33 transitive nodes; an invented symbol returns `not_found` with `status: ready` and `ready: true`

Full Docker-backed local CI was unavailable because Docker Desktop was not running.