### PR TITLE
fix: terminate cancelled test shards

### DIFF
--- a/scripts/run-unit-parallel.sh
+++ b/scripts/run-unit-parallel.sh
@@ -227,6 +227,64 @@ fi
 # so $? is recoverable per-shard (we never trust `wait`'s aggregate value).
 # ──────────────────────────────────────────────────────────────────────────
 SHARD_PIDS=()
+HB_PID=""
+CLEANUP_STARTED=0
+
+# An operator interrupt must stop the work, not only this wrapper. Without a
+# signal trap, bash exits while gtimeout/bun stay alive under launchd and can
+# retain gigabytes indefinitely. Each timeout process is normally its own
+# process-group leader; the direct-PID fallback covers platforms where it is
+# not. TERM gives cooperative children a moment to exit, then KILL guarantees
+# that a TERM-resistant test cannot outlive the cancelled suite.
+cleanup_children() {
+  local exit_code="${1:-0}"
+  [ "$CLEANUP_STARTED" = "1" ] && return
+  CLEANUP_STARTED=1
+
+  if [ -n "$HB_PID" ]; then
+    pkill -P "$HB_PID" 2>/dev/null || true
+    kill "$HB_PID" 2>/dev/null || true
+  fi
+
+  local pid descendants=""
+  collect_descendants() {
+    local parent="$1" child
+    for child in $(pgrep -P "$parent" 2>/dev/null); do
+      collect_descendants "$child"
+      printf '%s\n' "$child"
+    done
+  }
+
+  # Snapshot descendants before TERM can orphan them. Process-group teardown
+  # is not sufficient in non-interactive shells where gtimeout may share its
+  # caller's group rather than lead one of its own.
+  for pid in "${SHARD_PIDS[@]}"; do
+    descendants="$descendants $(collect_descendants "$pid")"
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  done
+  for pid in $descendants; do kill -TERM "$pid" 2>/dev/null || true; done
+  [ "${#SHARD_PIDS[@]}" -gt 0 ] && sleep 1
+  for pid in $descendants; do kill -KILL "$pid" 2>/dev/null || true; done
+  for pid in "${SHARD_PIDS[@]}"; do
+    kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  [ -n "$HB_PID" ] && wait "$HB_PID" 2>/dev/null || true
+
+  return "$exit_code"
+}
+
+handle_interrupt() {
+  local exit_code="$1"
+  trap - INT TERM EXIT
+  cleanup_children "$exit_code" || true
+  exit "$exit_code"
+}
+
+trap 'handle_interrupt 130' INT
+trap 'handle_interrupt 143' TERM
+trap 'cleanup_children $?' EXIT
+
 for i in $(seq 1 "$N"); do
   (
     SHARD_LOG="$LOG_DIR/shard-$i.log"
@@ -436,14 +494,10 @@ HB_PID=$!
 # process cleanup" at end-of-job reports them as (unnamed) test failures.
 # Seen on the garrytan/port-pr-1406 PR, 2 CI runs in a row, 6 orphans
 # matching the 6 invocations in test/scripts/run-unit-parallel.test.ts.
-trap 'pkill -P "$HB_PID" 2>/dev/null; kill "$HB_PID" 2>/dev/null; wait "$HB_PID" 2>/dev/null' EXIT
-
 # Wait for every shard. Don't care about wait's exit code.
 for pid in "${SHARD_PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
 
-pkill -P "$HB_PID" 2>/dev/null
-kill "$HB_PID" 2>/dev/null
-wait "$HB_PID" 2>/dev/null
+cleanup_children 0 || true
 trap - EXIT
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/test/scripts/run-unit-parallel.test.ts
+++ b/test/scripts/run-unit-parallel.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
-import { execFileSync, spawnSync } from 'child_process';
+import { execFileSync, spawn, spawnSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, copyFileSync, chmodSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
@@ -173,6 +173,71 @@ describe('run-unit-parallel.sh timeout escalation contract', () => {
     const source = readFileSync(PARALLEL_SH_SRC, 'utf-8');
     expect(source).toContain('[ "$rc" = "124" ] || [ "$rc" = "137" ]');
   });
+});
+
+describe('run-unit-parallel.sh operator-interrupt cleanup', () => {
+  it('kills an interrupt-resistant shard when its terminal group receives SIGINT', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-parallel-interrupt-'));
+    try {
+      mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
+      mkdirSync(join(root, 'test'), { recursive: true });
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      for (const s of ['run-unit-parallel.sh', 'run-unit-shard.sh', 'run-serial-tests.sh']) {
+        copyFileSync(resolve(REPO_ROOT, 'scripts', s), join(root, 'scripts', s));
+        chmodSync(join(root, 'scripts', s), 0o755);
+      }
+      copyFileSync(TESTENV_SH_SRC, join(root, 'scripts', 'lib', 'test-env.sh'));
+      writeFileSync(join(root, 'test', 'hang.test.ts'), '// discovered by the shard wrapper\n');
+
+      const fakeBun = join(root, 'bin', 'bun');
+      writeFileSync(fakeBun, `#!/usr/bin/env bash
+[ "${'$'}{1:-}" = "test" ] || exit 0
+echo "$$" > "${join(root, 'bun.pid')}"
+trap '' INT TERM
+while true; do sleep 1; done
+`);
+      chmodSync(fakeBun, 0o755);
+
+      const child = spawn('bash', [join(root, 'scripts', 'run-unit-parallel.sh'), '--shards', '1'], {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${join(root, 'bin')}:${process.env.PATH ?? ''}`,
+          GBRAIN_TEST_NO_MEM_ADAPT: '1',
+          GBRAIN_TEST_SHARD_TIMEOUT: '300',
+        },
+        detached: true,
+        stdio: 'ignore',
+      });
+
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(join(root, 'bun.pid')) && Date.now() < deadline) {
+        await Bun.sleep(25);
+      }
+      expect(existsSync(join(root, 'bun.pid'))).toBe(true);
+      const bunPid = Number(readFileSync(join(root, 'bun.pid'), 'utf8').trim());
+
+      const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+        child.once('exit', (code, signal) => resolveExit({ code, signal }));
+        process.kill(-child.pid!, 'SIGINT');
+      });
+      expect(exit.code === 130 || exit.signal === 'SIGINT').toBe(true);
+
+      const goneDeadline = Date.now() + 2_000;
+      let liveState = '';
+      do {
+        const probe = spawnSync('ps', ['-o', 'stat=', '-p', String(bunPid)], { encoding: 'utf8' });
+        liveState = (probe.stdout || '').trim();
+        if (!liveState || liveState.startsWith('Z')) break;
+        await Bun.sleep(25);
+      } while (Date.now() < goneDeadline);
+      // A zombie owns no memory and only awaits launchd reaping; any other
+      // state means the cancelled suite is still doing or retaining work.
+      expect(!liveState || liveState.startsWith('Z')).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 15_000);
 });
 
 describe('run-unit-parallel.sh no-timeout-binary fallback (rc from shard wait, not watchdog teardown)', () => {


### PR DESCRIPTION
## Summary

- trap operator `SIGINT` and `SIGTERM` in the parallel unit runner
- snapshot descendant PIDs before termination can orphan them
- escalate from TERM to KILL so interrupt-resistant Bun tests cannot survive cancellation
- add a behavioral regression using a fake Bun process that ignores both signals

## Why

Cancelling `run-unit-parallel.sh` could exit the wrapper while `gtimeout` / `bun test` survived under launchd. A reproduced orphan retained more than 2 GB of RAM after the calling Codex command had already reported cancellation.

## Verification

- exact interrupt regression: passed; stubborn child removed in about 1.45 s
- complete runner test file: 21 passed, 0 failed
- `bash -n scripts/run-unit-parallel.sh` passed
- TypeScript: `bunx tsc --noEmit` passed

Full Docker-backed local CI was unavailable because Docker Desktop was not running.