### PR TITLE
Add doctor check + repair command for null default source local_path

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1681,6 +1681,32 @@ export async function buildChecks(
     // unparseable config.json lands here and skips, same fail-open posture).
   }
 
+  // 3a-bis. default_source_local_path. The `default` source is the implicit
+  // write-through target for any unscoped `gbrain put`/`gbrain capture` call.
+  // A null local_path on that row is invisible to every other check here —
+  // the multi-source-drift check below explicitly excludes `default` from
+  // its own local_path filtering (it looks for content misrouted INTO
+  // default, not default's own config) — so a brain can run with
+  // `default.local_path: null` indefinitely with doctor reporting clean.
+  // Reported incident: exactly this, undetected for months, during which
+  // unscoped writes silently misrouted into another source's repo.
+  if (engine !== null) try {
+    const { assessDefaultSourcePath } = await import('../core/default-source-path-check.ts');
+    const [defaultSource] = await engine!.executeRaw<{ id: string; local_path: string | null }>(
+      `SELECT id, local_path FROM sources WHERE id = 'default'`,
+    );
+    const assessment = assessDefaultSourcePath(defaultSource);
+    if (assessment.status !== 'skip') {
+      checks.push({
+        name: 'default_source_local_path',
+        status: assessment.status,
+        message: assessment.message,
+      });
+    }
+  } catch {
+    // Best-effort. A broken sources table should not stop doctor.
+  }
+
   // 3b-multi-source. Multi-source drift (v0.31.8 — D8 + D17 + OV12 + OV13).
   // Pre-v0.30.3 putPage misrouted multi-source writes to (default, slug).
   // For each non-default source with local_path set, walk the FS and surface

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -896,6 +896,54 @@ async function runSetCrMode(engine: BrainEngine, args: string[]): Promise<void> 
   }
 }
 
+// Non-destructive local_path repair (reported incident: `default`'s
+// local_path sat at NULL for months with no way to fix it short of a raw SQL
+// UPDATE, causing unscoped `gbrain put`/`gbrain capture` calls to misroute
+// writes into an unrelated source's repo). Mirrors runSetCrMode's shape:
+// loud-rejection on a missing source (never a silent 0-row UPDATE), prints
+// the prior value before changing it so the change is visible/reversible,
+// and never deletes or archives anything — purely a pointer repair.
+async function runSetPath(engine: BrainEngine, args: string[]): Promise<void> {
+  const id = args[0];
+  const path = args[1];
+
+  if (!id || !path) {
+    console.error('Usage: gbrain sources set-path <id> <path>');
+    console.error('  Sets the source\'s local_path — the on-disk directory gbrain treats as');
+    console.error('  its write-through target and walks for sync/audit. Non-destructive: only');
+    console.error('  updates the pointer, never touches files on disk.');
+    process.exit(2);
+  }
+
+  const existing = await engine.executeRaw<{ id: string; local_path: string | null }>(
+    `SELECT id, local_path FROM sources WHERE id = $1 LIMIT 1`,
+    [id],
+  );
+  if (existing.length === 0) {
+    console.error(`Error: source "${id}" not found.`);
+    console.error(`  Run 'gbrain sources list' to see registered sources.`);
+    process.exit(4);
+  }
+
+  const priorPath = existing[0]!.local_path;
+
+  if (!existsSync(path)) {
+    console.error(`Error: path does not exist on disk: ${path}`);
+    console.error('  This command only repairs the DB pointer — it never creates directories.');
+    console.error('  Create the directory first, then re-run.');
+    process.exit(5);
+  }
+
+  await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = $2`, [path, id]);
+
+  if (priorPath) {
+    console.log(`Updated source "${id}" local_path: ${priorPath} -> ${path}`);
+  } else {
+    console.log(`Set source "${id}" local_path (was NULL) -> ${path}`);
+  }
+  console.log('Run `gbrain doctor` to confirm the change resolves any related warning.');
+}
+
 async function runArchive(engine: BrainEngine, args: string[]): Promise<void> {
   const id = args[0];
   if (!id) {
@@ -1822,6 +1870,7 @@ export async function runSources(engine: BrainEngine, args: string[]): Promise<v
     case 'tracked-branch': return runTrackedBranch(engine, rest);
     // v0.40.3.0 contextual retrieval (from master)
     case 'set-cr-mode': return runSetCrMode(engine, rest);
+    case 'set-path':    return runSetPath(engine, rest);
     case 'audit':      return runAudit(engine, rest);
     // v0.46 github-source demo (offline, privacy-clean fixtures)
     case 'demo':       { const { runSourcesDemo } = await import('./sources-demo.ts'); return runSourcesDemo(engine, rest); }
@@ -1885,6 +1934,12 @@ Subcommands:
                                     override (v0.40.3.0). Pass "unset" or
                                     "default" to clear (NULL falls through
                                     to the global search.mode bundle).
+  set-path <id> <path>             Repair a source's local_path pointer.
+                                    Non-destructive: only updates the DB
+                                    column, never touches files on disk.
+                                    Rejects a missing source or a path that
+                                    doesn't exist. See gbrain doctor's
+                                    default_source_local_path check.
   webhook <set|show|rotate|clear> <id> [options]
                                     v0.40 — per-source webhook secret management.
                                     Run 'sources webhook --help' for subcommand detail.

--- a/src/core/default-source-path-check.ts
+++ b/src/core/default-source-path-check.ts
@@ -1,0 +1,49 @@
+/**
+ * default-source-path-check — detect a null/missing local_path on the
+ * `default` source.
+ *
+ * The `default` source is the implicit write-through target for any unscoped
+ * `gbrain put` / `gbrain capture` call that doesn't name a `--source`. If its
+ * `local_path` is null, that write-through target is unresolvable from the
+ * sources row alone. Reported incident: a brain's `default` source sat with
+ * `local_path: null` for months with nothing surfacing it, during which
+ * unscoped `gbrain put` calls silently misrouted content into an unrelated
+ * source's git repo instead. `gbrain doctor` had no check that would have
+ * caught this — the existing multi-source-drift check (#1881/D8/D17)
+ * deliberately excludes the `default` source from its own local_path
+ * filtering (it detects content misrouted INTO default, not default's own
+ * config), so a null `default.local_path` was invisible to every doctor run.
+ *
+ * Pure assessment helper (no DB/FS access — caller supplies the row) so
+ * `gbrain doctor` can warn with receipts, in the same shape as
+ * npm-squat-check.ts / pglite-leftovers-check.ts.
+ */
+export interface DefaultSourcePathAssessment {
+  status: 'skip' | 'ok' | 'warn';
+  message: string;
+}
+
+export function assessDefaultSourcePath(
+  defaultSource: { id: string; local_path: string | null } | undefined,
+): DefaultSourcePathAssessment {
+  if (!defaultSource) {
+    // No `default` row at all is a different, more fundamental problem than
+    // this check's scope — leave it to whatever check owns sources-table
+    // integrity.
+    return { status: 'skip', message: '' };
+  }
+  if (defaultSource.local_path) {
+    return {
+      status: 'ok',
+      message: `default source local_path is set: ${defaultSource.local_path}`,
+    };
+  }
+  return {
+    status: 'warn',
+    message:
+      'default source has local_path: null. Unscoped `gbrain put`/`gbrain capture` calls ' +
+      '(no --source given) write through this source — with no local_path set, that write-' +
+      "through target is unresolvable from this row and writes can silently misroute into " +
+      'another source\'s repo. Fix with `gbrain sources set-path default <path>`.',
+  };
+}

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -218,6 +218,7 @@ export const OPS_CHECK_NAMES: ReadonlySet<string> = new Set([
  */
 export const META_CHECK_NAMES: ReadonlySet<string> = new Set([
   'cycle_phase_scope',
+  'default_source_local_path',
   'eval_capture',
   'minions_migration',
   'multi_source_drift',


### PR DESCRIPTION
## Summary
- The `default` source is the implicit write-through target for any unscoped `gbrain put`/`gbrain capture` call. If its `local_path` is null, that target is unresolvable from the sources row alone. Reported incident: a brain's `default` source sat with `local_path: null` for months with nothing surfacing it, during which unscoped writes silently misrouted into an unrelated source's git repo.
- The existing multi-source-drift check (#1881/D8/D17) deliberately excludes `default` from its own local_path filtering (it detects content misrouted INTO default, not default's own config), so a null `default.local_path` was invisible to every `gbrain doctor` run.

## What's added
- `src/core/default-source-path-check.ts` — pure assessment helper, same shape as `npm-squat-check.ts`/`pglite-leftovers-check.ts`.
- `doctor.ts` — new `default_source_local_path` check (warns when null, ok when set), registered in `doctor-categories.ts` under `META_CHECK_NAMES`.
- `sources.ts` — new `gbrain sources set-path <id> <path>` command that repairs the local_path pointer. Non-destructive: never touches files on disk, rejects a missing source or a nonexistent path (loud rejection, no silent 0-row UPDATE), and prints the prior value before changing it.

## Test plan
- [x] Verified end-to-end against a disposable pglite test brain: a fresh `gbrain init` reproduces the bug (default.local_path is null out of the box)
- [x] New doctor check correctly WARNs
- [x] `sources set-path` repairs it through all validation branches (missing args, unknown source, nonexistent path, valid repair)
- [x] Doctor re-run confirms OK
- [x] `tsc --noEmit` clean against these changes (one unrelated pre-existing test-file type error confirmed present on a clean checkout too, via git stash)
