### PR TITLE
fix(import): report the resolved source_id in `import --json` output

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -693,6 +693,13 @@ export async function runImport(
       status: 'success', duration_s: parseFloat(totalTime),
       imported, skipped, errors, chunks: chunksCreated,
       total_files: allFiles.length,
+      // The payload reported how much was imported but never WHERE, so a
+      // programmatic caller could not tell a routed import from one that
+      // fell through the resolver to `default` — the tier chain above runs
+      // entirely inside this function and is invisible from outside. Same
+      // `sourceId ?? 'default'` effective-source expression the schema-warn
+      // block below already uses.
+      source_id: sourceId ?? 'default',
     }));
   } else {
     console.log(`\nImport complete (${totalTime}s):`);

--- a/test/import-source-id.test.ts
+++ b/test/import-source-id.test.ts
@@ -80,6 +80,35 @@ describe('import --source-id (#1167)', () => {
     }
   });
 
+  // The --json payload reports counts; without a destination field a caller
+  // (gstack's memory-ingest is the one in tree — see
+  // test/import-json-stdout.serial.test.ts) cannot tell a routed import from
+  // one that fell through the resolver to `default`. Both directions are
+  // pinned so the field can't be "fixed" by hardcoding either answer.
+  async function importPayload(args: string[]): Promise<Record<string, unknown>> {
+    const lines: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: unknown[]) => { lines.push(a.join(' ')); };
+    try {
+      await runImport(engine, args);
+    } finally {
+      console.log = origLog;
+    }
+    const jsonLine = lines.find((l) => l.trimStart().startsWith('{'));
+    expect(jsonLine).toBeDefined();
+    return JSON.parse(jsonLine!) as Record<string, unknown>;
+  }
+
+  test('--json payload names default as the destination when unrouted', async () => {
+    const payload = await importPayload([scratchDir, '--no-embed', '--json']);
+    expect(payload.source_id).toBe('default');
+  });
+
+  test('--json payload names the routed source', async () => {
+    const payload = await importPayload([scratchDir, '--source-id', 'dept-x', '--no-embed', '--json']);
+    expect(payload.source_id).toBe('dept-x');
+  });
+
   test('--source-id value is NOT treated as a positional dir arg', async () => {
     // Regression: flag-value-as-dirArg was a real bug class in early
     // CLI parsers. Pre-fix the parser at line 82-83 would have


### PR DESCRIPTION
## Summary

`gbrain import --json` reports how much was imported but never where. The payload carries `status`, `duration_s`, `imported`, `skipped`, `errors`, `chunks`, `total_files` — no destination — while the source it actually wrote to is decided by the seven-tier resolution chain inside `runImport` (flag → env → dotfile → local_path → brain_default → sole_non_default → seed_default, `src/commands/import.ts:284-313`). That chain runs entirely inside the function, so a programmatic caller gets no way to distinguish an import that routed to the source it intended from one that fell through to `default`.

That gap matters most on exactly the brains where the fall-through is most likely. `sole_non_default` only fires when the brain has exactly one non-default source with a `local_path`; on a two-or-more-source brain an unscoped import lands in `default`, silently, and the JSON says nothing either way.

## Fix

One field, using the effective-source expression already in the function:

- `src/commands/import.ts` — add `source_id: sourceId ?? 'default'` to the `--json` payload. This is the same expression the schema-mismatch warn block twenty lines below already uses (`:718` on this branch) to name the source it counted pages in, so there is one notion of "where this import went", not two.
- **Additive only**: no existing field changes name, type, or value. Human (non-`--json`) output is untouched.
- **Scoped to `--json` deliberately**: the consumer for this is programmatic. The human path already prints a schema warning naming the source when it fires, and widening the human summary is a separate cosmetic decision.

## Discrimination test

Reverted `src/commands/import.ts` to `origin/master` with the new tests in place, ran `test/import-source-id.test.ts`:

```
104 |     expect(payload.source_id).toBe('default');
error: expect(received).toBe(expected)
(fail) import --source-id (#1167) > --json payload names default as the destination when unrouted [22.22ms]

109 |     expect(payload.source_id).toBe('dept-x');
error: expect(received).toBe(expected)
(fail) import --source-id (#1167) > --json payload names the routed source [23.26ms]

 3 pass
 2 fail
```

Restored → `5 pass / 0 fail`. The two failing assertions pin opposite directions: one that the field reports `default` when the resolver falls through, one that it reports the routed id when `--source-id` wins. A hardcoded constant satisfies neither pair.

## Live evidence

Two-source brain, importing from an unregistered staging directory — the shape `gstack-memory-ingest` produces, and the case where `sole_non_default` cannot fire.

**Before** (`origin/master` @ `6bf8db908`):

```
$ gbrain import $H/staging --no-embed --json
{"status":"success","duration_s":0.1,"imported":1,"skipped":0,"errors":0,"chunks":1,"total_files":1}

$ gbrain sources list
  default               federated          1 pages  never synced
  source-a              unset              0 pages  never synced
```

The page landed in `default`. Nothing in the payload said so.

**After** (this branch), identical command and brain shape:

```
$ gbrain import $H/staging --no-embed --json
{"status":"success","duration_s":0.1,"imported":1,"skipped":0,"errors":0,"chunks":1,"total_files":1,"source_id":"default"}
```

And with the flag set, on the same brain:

```
$ gbrain import $H/notes --source-id source-a --no-embed --json
{"status":"success",...,"source_id":"source-a"}
```

Worth noting from the same session: on a brain where the import directory matched a registered `local_path`, an import with no flag reported `"source_id":"source-a"` — the `local_path` tier had fired. That is correct behavior and precisely the case a caller currently cannot observe.

## Tests

- Added 2 cases to `test/import-source-id.test.ts` (unrouted → `default`; `--source-id` → that id), reusing the file's existing hermetic PGLite fixture.
- `bun run typecheck`: clean.
- `bun test test/import-source-id.test.ts test/import-json-stdout.serial.test.ts test/import-source-id-bookkeeping.test.ts`: 7 pass / 0 fail.
- `bun run verify`: 54/54 green.
- `scripts/module-size-limits.tsv`: not touched — `src/commands/import.ts` has no row and is 1,118 lines, under the 1,500-line unlisted ceiling.

## Scope note

Deliberately not done:

- **No routing behavior changes.** Which source an import resolves to is untouched; this only reports the decision already made. Related but distinct: #4583 (open) adds an advisory guard warning when an unscoped write would land in `default` and names `gbrain import` as one of its two target surfaces — that PR decides *whether to warn*, this one makes the outcome *machine-readable*. They compose; neither needs the other.
- **No `tier` field.** Reporting which of the seven tiers won would be more informative, but `resolveSourceWithTier`'s result is only retained in one branch today (`:302-312`), so exposing it means restructuring the resolution block. Separate concern, separate PR if wanted.
- **Human output unchanged**, per the scoping note above.

Addresses the observability half of gstack's garrytan/gstack#2140 discussion, where an unsourced `gbrain import` spawn seeds `default` invisibly. The gstack-side routing fix is already in flight as garrytan/gstack#2232; this is the gbrain-side piece that lets any such caller *verify* where its pages went rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
