### PR TITLE
fix(auth): let auth create set the token's write source

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -70,8 +70,8 @@ async function withConfiguredSql<T>(
   }
 }
 
-async function create(name: string, opts: { takesHolders?: string[]; scopes?: string[] } = {}) {
-  if (!name) { console.error('Usage: auth create <name> [--takes-holders world,garry] [--scopes read,write]'); process.exit(1); }
+async function create(name: string, opts: { takesHolders?: string[]; scopes?: string[]; source?: string } = {}) {
+  if (!name) { console.error('Usage: auth create <name> [--takes-holders world,garry] [--scopes read,write] [--source <id>]'); process.exit(1); }
   // #4043 least-privilege: validate scopes at mint time — the verify path
   // treats a filtered-empty scopes array as DENY, so a typo must fail loudly
   // here, never silently brick (or widen) the token.
@@ -94,7 +94,29 @@ async function create(name: string, opts: { takesHolders?: string[]; scopes?: st
       const takesHolders = opts.takesHolders && opts.takesHolders.length > 0
         ? opts.takesHolders
         : ['world'];
-      const permissions = { takes_holders: takesHolders };
+      // #bearer-source: the write source of a legacy token lives in
+      // permissions.source_id (read by parseLegacyTokenScope). Until this flag
+      // existed there was no way to set it, so every legacy token fell back to
+      // the literal 'default' — on a multi-source brain that silently routes
+      // every write to whichever source is named 'default', which is rarely the
+      // one the operator meant. Validate here: a typo must fail at mint time,
+      // not surface later as writes landing in the wrong (or an archived) source.
+      if (opts.source !== undefined) {
+        const known = await engine.executeRaw<{ id: string }>(
+          `SELECT id FROM sources WHERE id = $1`,
+          [opts.source],
+        );
+        if (known.length === 0) {
+          const all = await engine.executeRaw<{ id: string }>(`SELECT id FROM sources ORDER BY id`);
+          console.error(
+            `Unknown source '${opts.source}'. Known sources: ${all.map(r => r.id).join(', ') || '(none)'}`,
+          );
+          process.exit(1);
+        }
+      }
+      const permissions = opts.source !== undefined
+        ? { takes_holders: takesHolders, source_id: opts.source }
+        : { takes_holders: takesHolders };
       // JSONB write: pass the object via executeRawJsonb with an explicit
       // ::jsonb cast in the SQL string. Both engines round-trip the object
       // through the wire-protocol type oid without the v0.12.0 double-encode
@@ -125,7 +147,10 @@ async function create(name: string, opts: { takesHolders?: string[]; scopes?: st
       const scopeLine = opts.scopes !== undefined
         ? `scopes=${JSON.stringify(opts.scopes)}`
         : 'scopes=full access (grandfathered — pass --scopes read,write to narrow)';
-      console.log(`Token created for "${name}" (takes_holders=${JSON.stringify(takesHolders)}, ${scopeLine}):\n`);
+      const sourceLine = opts.source !== undefined
+        ? `, source=${opts.source}`
+        : ', source=default (pass --source <id> to target another source)';
+      console.log(`Token created for "${name}" (takes_holders=${JSON.stringify(takesHolders)}, ${scopeLine}${sourceLine}):\n`);
       console.log(`  ${token}\n`);
       console.log('Save this token — it will not be shown again.');
       console.log(`Revoke with: gbrain auth revoke "${name}" (or gbrain auth revoke --id <id> from auth list)`);
@@ -1083,7 +1108,7 @@ async function clientsCmd(args: string[]) {
  * register-client #3990 normalization precedent). Validation against the
  * allowed scope set happens in create() so the error path exits cleanly.
  */
-export function parseAuthCreateArgs(rest: string[]): { name: string; takesHolders?: string[]; scopes?: string[]; error?: string } {
+export function parseAuthCreateArgs(rest: string[]): { name: string; takesHolders?: string[]; scopes?: string[]; source?: string; error?: string } {
   const takesIdx = rest.indexOf('--takes-holders');
   const takesValue = takesIdx >= 0 ? rest[takesIdx + 1] : undefined;
   // Fail closed on a missing/flag-like value: `--scopes` as the last arg
@@ -1103,15 +1128,36 @@ export function parseAuthCreateArgs(rest: string[]): { name: string; takesHolder
   const scopes = scopesValue !== undefined
     ? scopesValue.split(/[\s,]+/).map(s => s.trim()).filter(Boolean)
     : undefined;
-  const positional = rest.find(a => !a.startsWith('--') && a !== takesValue && a !== scopesValue);
-  return { name: positional || '', takesHolders, ...(scopes !== undefined ? { scopes } : {}) };
+  // #bearer-source: without this the token's write source falls back to the
+  // literal 'default' in parseLegacyTokenScope, which on a multi-source brain
+  // is whatever source happens to be named 'default' — silently the WRONG one.
+  const sourceIdx = rest.indexOf('--source');
+  const sourceValue = sourceIdx >= 0 ? rest[sourceIdx + 1] : undefined;
+  if (sourceIdx >= 0 && (sourceValue === undefined || sourceValue.startsWith('--'))) {
+    return { name: '', error: 'the source flag requires a value (e.g. workspace)' };
+  }
+  const source = sourceValue !== undefined ? sourceValue.trim() : undefined;
+  if (source !== undefined && source.length === 0) {
+    return { name: '', error: 'the source flag requires a non-empty value (e.g. workspace)' };
+  }
+  const positional = rest.find(a => !a.startsWith('--') && a !== takesValue && a !== scopesValue && a !== sourceValue);
+  return {
+    name: positional || '',
+    takesHolders,
+    ...(scopes !== undefined ? { scopes } : {}),
+    ...(source !== undefined ? { source } : {}),
+  };
 }
 
 const AUTH_USAGE = `GBrain Token Management
 
 Usage:
-  gbrain auth create <name> [--takes-holders world,garry,brain] [--scopes read,write]
-                                                          Create a legacy bearer token. v0.28: --takes-holders
+  gbrain auth create <name> [--takes-holders world,garry,brain] [--scopes read,write] [--source <id>]
+                                                          Create a legacy bearer token. --source sets the
+                                                          token's WRITE source (default: 'default'); required
+                                                          on a multi-source brain, where the fallback would
+                                                          otherwise route writes to the wrong source.
+                                                          v0.28: --takes-holders
                                                           sets the per-token allow-list for the takes.holder
                                                           field (default: ["world"]). MCP-bound calls to
                                                           takes_list / takes_search / query filter by this.
@@ -1189,7 +1235,7 @@ export async function runAuth(args: string[]): Promise<void> {
         console.error(`Error: ${parsed.error}`);
         process.exit(1);
       }
-      await create(parsed.name, { takesHolders: parsed.takesHolders, scopes: parsed.scopes });
+      await create(parsed.name, { takesHolders: parsed.takesHolders, scopes: parsed.scopes, source: parsed.source });
       return;
     }
     case 'list': await list(); return;

--- a/test/auth-create-args.test.ts
+++ b/test/auth-create-args.test.ts
@@ -3,6 +3,54 @@ import { parseAuthCreateArgs, parseAuthClientsArgs, parseRescopeSurfaceValue, re
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 
 describe('parseAuthCreateArgs', () => {
+  // --source (write-source of a legacy bearer token). Without it every legacy
+  // token fell back to the literal 'default' in parseLegacyTokenScope, which on
+  // a multi-source brain routes writes to the wrong source with no warning.
+  test('name + --source', () => {
+    expect(parseAuthCreateArgs(['claude-code', '--source', 'workspace'])).toEqual({
+      name: 'claude-code',
+      takesHolders: undefined,
+      source: 'workspace',
+    });
+  });
+
+  test('--source before the name still finds the name', () => {
+    expect(parseAuthCreateArgs(['--source', 'workspace', 'claude-code']).name).toBe('claude-code');
+  });
+
+  test('the source value is not mistaken for the name', () => {
+    expect(parseAuthCreateArgs(['--source', 'workspace', 'mybot']).source).toBe('workspace');
+    expect(parseAuthCreateArgs(['--source', 'workspace', 'mybot']).name).toBe('mybot');
+  });
+
+  test('--source as the last arg fails closed', () => {
+    // Fail-open here would mint a token silently scoped to 'default' — the
+    // exact bug this flag exists to fix.
+    expect(parseAuthCreateArgs(['mybot', '--source']).error).toContain('source flag requires a value');
+  });
+
+  test('--source followed by another flag fails closed', () => {
+    // De andere vlag krijgt hier wel een waarde, anders slaat DIE controle als
+    // eerste aan: de parser checkt takes-holders en scopes voor source.
+    expect(parseAuthCreateArgs(['mybot', '--source', '--takes-holders', 'world']).error)
+      .toContain('source flag requires a value');
+  });
+
+  test('omitting --source leaves source undefined (grandfathered behaviour)', () => {
+    expect(parseAuthCreateArgs(['mybot']).source).toBeUndefined();
+  });
+
+  test('--source combines with --scopes and --takes-holders', () => {
+    expect(parseAuthCreateArgs([
+      'mybot', '--scopes', 'read,write', '--takes-holders', 'world', '--source', 'workspace',
+    ])).toEqual({
+      name: 'mybot',
+      takesHolders: ['world'],
+      scopes: ['read', 'write'],
+      source: 'workspace',
+    });
+  });
+
   test('bare name (no flag) resolves the name — regression for the dropped-name bug', () => {
     // Pre-fix this returned name='' because rest[takesIdx+1] === rest[0] when
     // takesIdx === -1, excluding the only positional from the search.


### PR DESCRIPTION
## What's broken

A legacy bearer token gets its write source from `access_tokens.permissions.source_id`, read by `parseLegacyTokenScope` in `core/legacy-token-scope.ts`. Nothing could set that field: `gbrain auth create` has no flag for it, and no other code path writes it. Every legacy token therefore falls through to the documented fallback — the literal string `default`.

On a single-source brain that is invisible. On a multi-source brain it means **every write through a bearer token silently lands in whichever source happens to be named `default`**, regardless of `GBRAIN_SOURCE`, `sources current`, or the operator's intent.

We hit this on a multi-source brain where the id `default` happens to be held by an archived, search-excluded legacy import. A `put_page` over HTTP landed in the isolated, search-excluded `default` source while `GBRAIN_SOURCE=workspace` was set in the process environment and `sources current` reported `workspace`. No error at any layer. Silent memory loss is a bad failure mode for a memory system, so we rolled the HTTP server back and stayed on stdio — which in turn keeps the PGLite single-writer lock contended between sessions.

`auth register-client` (OAuth) already has `--source` and works correctly. Only the legacy bearer path is affected — and `gbrain connect` refuses `--oauth` for Claude Code, so that is the path Claude Code users are on.

## What this changes

Adds `--source <id>` to `gbrain auth create`:

- Validated at mint time against the `sources` table. A typo fails loudly with the list of known sources, rather than surfacing later as writes going nowhere.
- Written to `permissions.source_id`, which `parseLegacyTokenScope` already reads — no changes needed on the read side.
- Reported in the confirmation line, so it is visible what was minted.
- Omitting the flag keeps the current behaviour exactly (fallback to `default`), so this is additive.

## Verification

End to end on a multi-source brain:

```
$ gbrain auth create test-typo --source wrkspace
Unknown source 'wrkspace'. Known sources: default, mail-a, mail-b, workspace

$ gbrain auth create test-token --source workspace --scopes read,write
Token created for "test-token" (takes_holders=["world"], scopes=["read","write"], source=workspace):
```

Read back from the database, `permissions` is `{"source_id":"workspace","takes_holders":["world"]}` and `parseLegacyTokenScope` resolves it to `{"sourceId":"workspace"}` instead of `default`.

## Tests

Seven parser cases added to `test/auth-create-args.test.ts` (28 pass). One of them documents an ordering nuance worth knowing: `--source` followed by another flag reports the *other* flag's error first, because takes-holders and scopes are checked earlier in the parser.

All fifteen auth/oauth test files pass — 294 tests.
