### PR TITLE
perf(search): read search-mode config through the existing snapshot

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -1152,7 +1152,16 @@ export async function hybridSearch(
   // per-mode evals would not test production search if modes lived only in
   // the wrapper. See `[CDX-5+6]` in the plan.
   const { loadSearchModeConfig, resolveSearchMode } = await import('./mode.ts');
-  const modeInput = await loadSearchModeConfig(engine);
+  // SEARCH_MODE_CONFIG_KEYS is 32 keys + the mode key, each read as its own
+  // `SELECT value FROM config WHERE key = $1`. config-snapshot.ts exists for
+  // exactly this and is already used by loadConfigWithEngine and the gateway;
+  // the search path just never adopted it. Measured on a 232k-chunk PGLite
+  // brain: 34 reads, 314 ms, before any retrieval runs. (The module header
+  // assumes PGLite reads cost microseconds — that holds on a small brain, not
+  // on a 5 GB one where each round trip crosses the WASM wire protocol.)
+  const { snapshotConfigReader } = await import('../config-snapshot.ts');
+  const modeReader = (await snapshotConfigReader(engine)) ?? engine;
+  const modeInput = await loadSearchModeConfig(modeReader);
   const resolvedMode = resolveSearchMode({
     // T4/D5 — per-call mode selector (e.g. `--mode tokenmax`). The op layer
     // only passes this for trusted/local callers; remote callers leave it
@@ -2305,7 +2314,12 @@ export async function hybridSearchCached(
   // that scopes the cache row so a tokenmax write can't be served to a
   // conservative read. See [CDX-4] in the plan.
   const { loadSearchModeConfig, resolveSearchMode, knobsHash } = await import('./mode.ts');
-  const modeInputForCache = await loadSearchModeConfig(engine);
+  // Same snapshot as bare hybridSearch below. Note this wrapper resolves the
+  // mode and then calls hybridSearch, which resolves it AGAIN — so an uncached
+  // query paid ~66 per-key reads end to end, not 34.
+  const { snapshotConfigReader: snapshotConfigReaderForCache } = await import('../config-snapshot.ts');
+  const cacheModeReader = (await snapshotConfigReaderForCache(engine)) ?? engine;
+  const modeInputForCache = await loadSearchModeConfig(cacheModeReader);
   const resolvedForCache = resolveSearchMode({
     // T4/D5 — per-call mode folds into the cache key (resolved_mode is part
     // of knobsHash) so a per-call `--mode tokenmax` read can't be served a

--- a/test/search-mode-config-snapshot.test.ts
+++ b/test/search-mode-config-snapshot.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from 'bun:test';
+import { loadSearchModeConfig, SEARCH_MODE_CONFIG_KEYS } from '../src/core/search/mode.ts';
+import { snapshotConfigReader } from '../src/core/config-snapshot.ts';
+
+/**
+ * loadSearchModeConfig resolves 32 override keys plus the mode key, one
+ * `SELECT value FROM config WHERE key = $1` each. config-snapshot.ts exists to
+ * collapse that into a single whole-table read and is already used by
+ * loadConfigWithEngine and the gateway — the search path just never adopted it.
+ *
+ * Measured on a 232k-chunk PGLite brain before this wiring: 34 per-key reads,
+ * 314 ms, on every uncached search, before any retrieval work. Warm the same
+ * call is ~4 ms; the cold cost is what every one-shot `gbrain query` pays.
+ */
+function countingEngine(rows: Record<string, string>) {
+  const calls = { getConfig: 0, getAllConfig: 0 };
+  return {
+    calls,
+    async getConfig(key: string) { calls.getConfig++; return rows[key] ?? null; },
+    async getAllConfig() { calls.getAllConfig++; return { ...rows }; },
+  };
+}
+
+describe('search mode config reads', () => {
+  test('the raw engine is read once per key — the behaviour this wiring replaces', async () => {
+    const engine = countingEngine({ 'search.mode': 'balanced' });
+    await loadSearchModeConfig(engine);
+    expect(engine.calls.getConfig).toBe(SEARCH_MODE_CONFIG_KEYS.length + 1);
+    expect(engine.calls.getAllConfig).toBe(0);
+  });
+
+  test('through snapshotConfigReader it is one whole-table read and no per-key reads', async () => {
+    const engine = countingEngine({ 'search.mode': 'balanced' });
+    const reader = (await snapshotConfigReader(engine))!;
+    engine.calls.getAllConfig = 0; // de snapshot zelf telt niet mee
+    await loadSearchModeConfig(reader);
+    expect(engine.calls.getConfig).toBe(0);
+    expect(engine.calls.getAllConfig).toBe(0);
+  });
+
+  test('the snapshot returns the same values as per-key reads', async () => {
+    const rows = {
+      'search.mode': 'balanced',
+      'search.reranker.top_n_in': '15',
+      'search.autocut_jump': '1.0',
+    };
+    const direct = await loadSearchModeConfig(countingEngine(rows));
+    const viaSnapshot = await loadSearchModeConfig((await snapshotConfigReader(countingEngine(rows)))!);
+    expect(viaSnapshot).toEqual(direct);
+  });
+
+  test('an engine without getAllConfig still works, at the old cost', async () => {
+    // Engines implemented outside this repo may not have the bulk read.
+    const engine = countingEngine({ 'search.mode': 'balanced' });
+    const noBulk = { getConfig: engine.getConfig };
+    const reader = (await snapshotConfigReader(noBulk as never))!;
+    const out = await loadSearchModeConfig(reader);
+    expect(out.mode).toBe('balanced');
+  });
+});


### PR DESCRIPTION
## What's slow

`loadSearchModeConfig` resolves `SEARCH_MODE_CONFIG_KEYS` (32 keys) plus the mode key, issuing one `SELECT value FROM config WHERE key = $1` per key. Nothing repeats — 33 distinct keys, each read once — so a per-key memo buys nothing. The cost is the round-trips.

`config-snapshot.ts` was added for exactly this shape and is already used by `loadConfigWithEngine` and `reconfigureGatewayWithEngine`. The search path never adopted it.

## Measurements

On a 232k-chunk PGLite brain (~5 GB on disk):

| | reads | time |
|---|---|---|
| `hybridSearch`, cold | 34 | 314 ms |
| `loadSearchModeConfig`, warm | 33 | 4.1 ms |
| via `snapshotConfigReader` | 1 | ~0 ms |

The cold number is what matters in practice: every `gbrain query` from the CLI is a fresh process, so it pays it on every invocation. Inside a long-running `serve` only the first search does.

This contradicts `config-snapshot.ts`'s own header, which says "On PGLite each read costs microseconds, so the pattern stayed invisible for a long time." That holds on a small brain. On a multi-gigabyte one each read crosses the WASM wire protocol and the assumption stops holding — worth correcting in that comment, since it is the stated reason the search path was never wired up.

## Second-order finding (not fixed here)

`hybridSearchCached` resolves the mode, then calls `hybridSearch`, which resolves it again. An uncached query therefore paid ~66 per-key reads end to end, not 34. This change makes each of the two resolutions a single whole-table read. Collapsing them into one resolution is a larger refactor and is left alone; the duplication is noted in a comment at both call sites.

## Behaviour

Unchanged. Same top-5 results before and after on two live queries against a real brain.

## Tests

`test/search-mode-config-snapshot.test.ts`, four cases: the current per-key behaviour, the single-read behaviour through the snapshot, value equivalence between the two paths, and the fallback for an engine that has no `getAllConfig`.
