### PR TITLE
feat(pricing): add Claude Fable 5.1 with its 0.025x cache-read rate

### DIFF
--- a/src/core/ai/recipes/anthropic.ts
+++ b/src/core/ai/recipes/anthropic.ts
@@ -24,6 +24,7 @@ export const anthropic: Recipe = {
     chat: {
       models: [
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-opus-5',
         'claude-opus-4-8',
         'claude-opus-4-7',
@@ -36,6 +37,7 @@ export const anthropic: Recipe = {
       supports_prompt_cache: true,
       model_context_tokens: {
         'claude-fable-5': 1_000_000,
+        'claude-fable-5-1': 1_000_000,
         'claude-opus-5': 1_000_000,
         'claude-sonnet-5': 1_000_000,
         'claude-opus-4-8': 1_000_000,

--- a/src/core/ai/recipes/claude-cli.ts
+++ b/src/core/ai/recipes/claude-cli.ts
@@ -36,6 +36,7 @@ export const claudeCli: Recipe = {
     chat: {
       models: [
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-opus-5',
         'claude-opus-4-8',
         'claude-opus-4-7',

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -62,6 +62,7 @@ export const MAX_OUTPUT_TOKENS_CEIL = 32_000;
  */
 export const ANTHROPIC_OUTPUT_CAPS: Record<string, number> = {
   'claude-fable-5': 64_000,
+  'claude-fable-5-1': 64_000,
   'claude-opus-5': 32_000,
   'claude-sonnet-5': 64_000,
   'claude-opus-4-8': 32_000,

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -44,8 +44,9 @@ export interface ModelPricing {
   /**
    * #4218 — USD per 1M prompt-cache-READ tokens. Optional: present only for
    * providers whose published cache pricing we've verified (Anthropic:
-   * 0.1x input). Consumers that price cache tokens fall back to the input
-   * rate when absent (conservative over-estimate for reads).
+   * 0.1x input by default; Fable 5.1 / Mythos 5.1: 0.025x). Consumers that
+   * price cache tokens fall back to the input rate when absent (conservative
+   * over-estimate for reads).
    */
   cache_read?: number;
   /**
@@ -63,15 +64,25 @@ export interface ModelPricing {
  * writes bill 1.25x. Exported so the drift guard can assert every
  * anthropic: row's cache fields stay derived from its input rate. */
 export const ANTHROPIC_CACHE_READ_MULT = 0.1;
+/** Fable 5.1 / Mythos 5.1 bill cache hits at 0.025x base input ($0.25/MTok on a
+ * $10 input rate) instead of the 0.1x every other Anthropic model uses. */
+export const ANTHROPIC_CACHE_READ_MULT_FABLE_5_1 = 0.025;
 export const ANTHROPIC_CACHE_WRITE_5M_MULT = 1.25;
-function anthro(input: number, output: number): ModelPricing {
+function anthro(input: number, output: number, cacheReadMult = ANTHROPIC_CACHE_READ_MULT): ModelPricing {
   return {
     input,
     output,
-    cache_read: input * ANTHROPIC_CACHE_READ_MULT,
+    cache_read: input * cacheReadMult,
     cache_write: input * ANTHROPIC_CACHE_WRITE_5M_MULT,
   };
 }
+
+/** Per-model cache-read multiplier overrides. Anthropic bills cache hits at
+ *  ANTHROPIC_CACHE_READ_MULT (0.1x) except where listed here. Keys match
+ *  CANONICAL_PRICING keys; the drift guard asserts both directions. */
+export const ANTHROPIC_CACHE_READ_MULT_OVERRIDES: Record<string, number> = {
+  'anthropic:claude-fable-5-1': ANTHROPIC_CACHE_READ_MULT_FABLE_5_1,
+};
 
 /**
  * Canonical price table. Keys are provider-prefixed (`provider:model`),
@@ -86,6 +97,9 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   // see the anthro() helper + multiplier constants above.
   // Fable 5: Anthropic's top tier, above Opus. $10 in / $50 out.
   'anthropic:claude-fable-5':             anthro(10.00, 50.00),
+  // Fable 5.1: same $10/$50 sticker as Fable 5, but cache hits bill 0.025x
+  // ($0.25/MTok) instead of 0.1x — the only rate that changed.
+  'anthropic:claude-fable-5-1':           anthro(10.00, 50.00, ANTHROPIC_CACHE_READ_MULT_FABLE_5_1),
   // Opus 4.x/5: $5 in / $25 out. Opus 5 (new generation) shares the same
   // per-token rate as 4.8 (released 2026-05-28) — closes gbrain#1819.
   'anthropic:claude-opus-5':              anthro( 5.00, 25.00),

--- a/test/anthropic-model-ids.test.ts
+++ b/test/anthropic-model-ids.test.ts
@@ -46,6 +46,12 @@ describe('Anthropic recipe model IDs', () => {
     expect(chatModels).toContain('claude-sonnet-5');
   });
 
+  it('Fable 5.1 is chat-only and carries its 1M context window', () => {
+    expect(anthropic.touchpoints?.chat?.models ?? []).toContain('claude-fable-5-1');
+    expect(anthropic.touchpoints?.chat?.model_context_tokens?.['claude-fable-5-1']).toBe(1_000_000);
+    expect(anthropic.touchpoints?.expansion?.models ?? []).not.toContain('claude-fable-5-1');
+  });
+
   it('Sonnet 5 is listed for expansion', () => {
     expect(anthropic.touchpoints?.expansion?.models ?? []).toContain('claude-sonnet-5');
   });

--- a/test/brainstorm/judges-maxtokens.test.ts
+++ b/test/brainstorm/judges-maxtokens.test.ts
@@ -59,6 +59,11 @@ describe('computeJudgeMaxTokens (pure formula)', () => {
     expect(computeJudgeMaxTokens(300, 'claude-sonnet-4-6')).toBe(300 * TOKEN_BUDGET_PER_IDEA + TOKEN_BUDGET_ENVELOPE);
   });
 
+  test('Fable 5.1 keeps the conservative 64K family cap', () => {
+    expect(ANTHROPIC_OUTPUT_CAPS['claude-fable-5-1']).toBe(64_000);
+    expect(computeJudgeMaxTokens(500, 'claude-fable-5-1')).toBe(64_000);
+  });
+
   test('96 ideas on legacy Haiku 3.5 (8K cap): CAP binds at 8192 (D11 codex fix)', () => {
     // 96 * 150 + 500 = 14_900 > 8192; legacy 3.5 caps at 8K — without
     // ANTHROPIC_OUTPUT_CAPS this would have been the next opaque HTTP 400.

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -17,6 +17,7 @@ import {
   CANONICAL_PRICING,
   canonicalLookup,
   ANTHROPIC_CACHE_READ_MULT,
+  ANTHROPIC_CACHE_READ_MULT_OVERRIDES,
   ANTHROPIC_CACHE_WRITE_5M_MULT,
 } from '../src/core/model-pricing.ts';
 import { ANTHROPIC_PRICING } from '../src/core/anthropic-pricing.ts';
@@ -57,6 +58,16 @@ describe('CANONICAL_PRICING — table integrity', () => {
     expect(CANONICAL_PRICING['anthropic:claude-fable-5']).toMatchObject({ input: 10.0, output: 50.0 });
   });
 
+  test('Fable 5.1 uses $0.25 cache reads while Fable 5 remains at $1.00', () => {
+    expect(CANONICAL_PRICING['anthropic:claude-fable-5-1']).toEqual({
+      input: 10.0,
+      output: 50.0,
+      cache_read: 0.25,
+      cache_write: 12.5,
+    });
+    expect(CANONICAL_PRICING['anthropic:claude-fable-5'].cache_read).toBe(1.0);
+  });
+
   test('Gemini 2.0 Flash reconciled to $0.10/$0.40; legacy alias agrees', () => {
     expect(CANONICAL_PRICING['google:gemini-2.0-flash']).toEqual({ input: 0.1, output: 0.4 });
     expect(CANONICAL_PRICING['google:gemini-2-flash']).toEqual(
@@ -74,11 +85,20 @@ describe('CANONICAL_PRICING — table integrity', () => {
   // #4218 drift guard extension: cache_read/cache_write are DERIVED from the
   // input rate via the exported multipliers — a hand-edited cache number that
   // drifts from input*mult fails here.
-  test('every anthropic: row carries cache_read = 0.1x input and cache_write = 1.25x input', () => {
+  test('every anthropic: row carries its declared cache-read multiplier and cache_write = 1.25x input', () => {
     for (const [key, p] of Object.entries(CANONICAL_PRICING)) {
       if (!key.startsWith('anthropic:')) continue;
-      expect(p.cache_read).toBeCloseTo(p.input * ANTHROPIC_CACHE_READ_MULT, 10);
+      const mult = ANTHROPIC_CACHE_READ_MULT_OVERRIDES[key] ?? ANTHROPIC_CACHE_READ_MULT;
+      expect(p.cache_read).toBeCloseTo(p.input * mult, 10);
       expect(p.cache_write).toBeCloseTo(p.input * ANTHROPIC_CACHE_WRITE_5M_MULT, 10);
+    }
+  });
+
+  test('every cache-read multiplier override names a canonical row with matching cache_read', () => {
+    for (const [key, mult] of Object.entries(ANTHROPIC_CACHE_READ_MULT_OVERRIDES)) {
+      const p = CANONICAL_PRICING[key];
+      expect(p).toBeDefined();
+      expect(p!.cache_read).toBeCloseTo(p!.input * mult, 10);
     }
   });
 


### PR DESCRIPTION
## What

Registers `claude-fable-5-1` across the Anthropic surfaces, and makes the cache-read multiplier per-model so the new rate can be expressed at all.

## Why the pricing row is not a one-liner

Fable 5.1 keeps Fable 5's $10/$50 sticker and the 1.25x cache-write, but **cache hits bill 0.025x base input** ($0.25/MTok) instead of the 0.1x every other Anthropic model uses. Anthropic's pricing page states it directly: *"Cache hits and refreshes on Claude Fable 5.1 and Claude Mythos 5.1 are priced at 0.025x the base input price."*

`anthro()` hardcoded `ANTHROPIC_CACHE_READ_MULT` (0.1), so adding a plain row would have overstated cache reads 4x and failed the #4218 drift guard.

## How

- `anthro()` takes an optional cache-read multiplier defaulting to the existing constant, so no other call site changes.
- The exception lives in **one exported table**, `ANTHROPIC_CACHE_READ_MULT_OVERRIDES`, which the drift guard reads. A test-local copy would have let `src` and the guard disagree silently — the guard exists precisely to prevent that class of drift.
- The guard gained the reverse assertion too: every override key must name a real `CANONICAL_PRICING` row whose `cache_read` equals `input x override`. Without it the table could accumulate dead or wrong entries unnoticed.
- `claude-fable-5-1` added to the anthropic `chat` touchpoint (1M context) and to `ANTHROPIC_OUTPUT_CAPS` at 64k — matching the existing Fable 5 entry, since that table is documented as a deliberate conservative bound rather than the provider maximum.

Existing `claude-fable-5` rows and tests are untouched.

## Verification

- 19 test files that reference `CANONICAL_PRICING`, the cache multipliers, `ANTHROPIC_OUTPUT_CAPS`, `model_context_tokens`, `canonicalLookup`, or `claude-fable-5`: **354 pass**.
- 2 failures in `think-max-output-tokens` and `think-pipeline.serial` reproduce identically with this change stashed — pre-existing `beforeEach/afterEach` hook timeouts, unrelated to pricing.
- `tsc --noEmit` clean.
- Negative controls, to show the guard actually bites: dropping the override makes it fail with `cache_read=1 != 10*0.025`; adding an override key with no canonical row fails the new reverse assertion.

I did not run the full 1638-file suite locally — it was on track for hours. Happy to if you'd like.