### PR TITLE
fix(doctor): atom_provenance_drift stops counting pre-binding-era atoms as source_gone

### DIFF
--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -813,11 +813,20 @@ export async function computeAtomProvenanceDriftCheck(
        SELECT count(*) AS total,
               count(*) FILTER (WHERE drifted) AS drifted,
               count(*) FILTER (WHERE drifted AND src_alive) AS source_changed,
-              -- "gone" needs a slug binding to have failed. A pre-binding-era
+              -- "gone" needs a slug binding to have failed. A slug-unbound
               -- atom (source_path only, no source_slug — see
               -- isCompatibleAtomBinding in extract-atoms.ts) can never match
-              -- p.slug, so counting it here reported every legacy atom as an
-              -- orphan even when its source page is alive.
+              -- p.slug, so counting it here reported every one of them as an
+              -- orphan even when its source page is alive. This is NOT a
+              -- closed legacy set: every transcript-kind atom is minted this
+              -- way today (extract-atoms.ts:994 sets source_path only,
+              -- never source_slug, for transcript origins) -- it is an
+              -- actively growing, structurally distinct binding kind, not a
+              -- shrinking cohort from before slug binding existed. Doctor
+              -- runs as a DB-only query and has no filesystem access to the
+              -- transcript corpus a source_path points at, so liveness for
+              -- this bucket genuinely cannot be resolved here (unlike
+              -- source_slug, which resolves against the pages table).
               count(*) FILTER (WHERE drifted AND NOT src_alive AND ss IS NOT NULL) AS source_gone,
               count(*) FILTER (WHERE drifted AND ss IS NULL) AS legacy_unbound,
               -- lexicographic min of ISO-shaped strings ≈ chronological min
@@ -865,7 +874,7 @@ export async function computeAtomProvenanceDriftCheck(
           `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
           `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
           (legacyUnbound > 0
-            ? `, ${legacyUnbound} pre-binding-era (source_path only, no source_slug — liveness not resolvable by slug)`
+            ? `, ${legacyUnbound} slug-unbound (source_path only, typically transcript-origin — liveness not resolvable against \`pages\` by slug)`
             : '') +
           (oldestDays != null ? `; oldest ${oldestDays}d` : '') +
           `. These still surface in search with a source_quote that no current page contains. Fix: ${fix}`,

--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -774,6 +774,7 @@ export async function computeAtomProvenanceDriftCheck(
     const rows = await engine.executeRaw<{
       total: string | number; drifted: string | number;
       source_changed: string | number; source_gone: string | number;
+      legacy_unbound: string | number;
       oldest_ext: string | null;
     }>(
       // extracted_at stays TEXT end to end (review fix): an unguarded
@@ -786,7 +787,7 @@ export async function computeAtomProvenanceDriftCheck(
       `WITH atom AS (
          SELECT a.source_id,
                 a.frontmatter->>'source_hash' AS sh,
-                a.frontmatter->>'source_slug' AS ss,
+                NULLIF(a.frontmatter->>'source_slug', '') AS ss,
                 CASE WHEN a.frontmatter->>'extracted_at' ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
                      THEN a.frontmatter->>'extracted_at' END AS ext
            FROM pages a
@@ -812,7 +813,13 @@ export async function computeAtomProvenanceDriftCheck(
        SELECT count(*) AS total,
               count(*) FILTER (WHERE drifted) AS drifted,
               count(*) FILTER (WHERE drifted AND src_alive) AS source_changed,
-              count(*) FILTER (WHERE drifted AND NOT src_alive) AS source_gone,
+              -- "gone" needs a slug binding to have failed. A pre-binding-era
+              -- atom (source_path only, no source_slug — see
+              -- isCompatibleAtomBinding in extract-atoms.ts) can never match
+              -- p.slug, so counting it here reported every legacy atom as an
+              -- orphan even when its source page is alive.
+              count(*) FILTER (WHERE drifted AND NOT src_alive AND ss IS NOT NULL) AS source_gone,
+              count(*) FILTER (WHERE drifted AND ss IS NULL) AS legacy_unbound,
               -- lexicographic min of ISO-shaped strings ≈ chronological min
               -- (oldest); informational only, never verdict-bearing
               min(ext) FILTER (WHERE drifted) AS oldest_ext
@@ -827,6 +834,7 @@ export async function computeAtomProvenanceDriftCheck(
     const drifted = num(r.drifted);
     const sourceChanged = num(r.source_changed);
     const sourceGone = num(r.source_gone);
+    const legacyUnbound = num(r.legacy_unbound);
     const oldestExtMs = r.oldest_ext ? new Date(String(r.oldest_ext)).getTime() : NaN;
     const oldestDays = Number.isFinite(oldestExtMs)
       ? Math.round(((Date.now() - oldestExtMs) / 86_400_000) * 10) / 10
@@ -837,6 +845,7 @@ export async function computeAtomProvenanceDriftCheck(
       drifted,
       source_changed: sourceChanged,
       source_gone: sourceGone,
+      legacy_unbound: legacyUnbound,
       drift_pct: total > 0 ? Math.round(ratio * 1000) / 10 : 0,
       oldest_drifted_days: oldestDays ?? undefined,
     };
@@ -855,6 +864,9 @@ export async function computeAtomProvenanceDriftCheck(
         message:
           `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
           `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
+          (legacyUnbound > 0
+            ? `, ${legacyUnbound} pre-binding-era (source_path only, no source_slug — liveness not resolvable by slug)`
+            : '') +
           (oldestDays != null ? `; oldest ${oldestDays}d` : '') +
           `. These still surface in search with a source_quote that no current page contains. Fix: ${fix}`,
         details,

--- a/test/doctor-atom-provenance-drift.test.ts
+++ b/test/doctor-atom-provenance-drift.test.ts
@@ -207,4 +207,69 @@ describe('computeAtomProvenanceDriftCheck', () => {
     expect(c.message).toContain('30/30');
     expect(c.message).toContain('source page is gone');
   });
+  it('does not count a pre-binding-era atom (source_path only, no source_slug) as source_gone', async () => {
+    // Legacy transcript-origin atoms carry `source_path` but no `source_slug`
+    // (isCompatibleAtomBinding in extract-atoms.ts). They can never match
+    // p.slug, so the slug-only liveness probe reported every one of them as
+    // an orphan even while the source page was alive — measured on a real
+    // brain as 702 "gone" atoms whose source pages all still existed.
+    await seedSource('src-l', 'original body');
+    await engine.putPage('atoms/2026-01-01/l-000000', {
+      type: 'atom', title: 'l', compiled_truth: 'claim body',
+      frontmatter: {
+        type: 'atom',
+        source_path: '/imports/src-l.md',
+        source_hash: await hashOf('src-l'),
+        extracted_at: new Date().toISOString(),
+      },
+    });
+    await seedSource('src-l', 'rewritten body'); // hash moves → drifted
+    const d = (await computeAtomProvenanceDriftCheck(engine)).details as Record<string, number>;
+    expect(d.drifted).toBe(1);
+    expect(d.source_gone).toBe(0);
+    expect(d.source_changed).toBe(0);
+    expect(d.legacy_unbound).toBe(1);
+  });
+
+  it('treats an empty-string source_slug like a missing one', async () => {
+    await seedSource('src-k', 'original body');
+    await engine.putPage('atoms/2026-01-01/k-000000', {
+      type: 'atom', title: 'k', compiled_truth: 'claim body',
+      frontmatter: {
+        type: 'atom', source_slug: '', source_path: '/imports/src-k.md',
+        source_hash: 'deadbeefdeadbeef', extracted_at: new Date().toISOString(),
+      },
+    });
+    const d = (await computeAtomProvenanceDriftCheck(engine)).details as Record<string, number>;
+    expect(d.source_gone).toBe(0);
+    expect(d.legacy_unbound).toBe(1);
+  });
+
+  it('omits the pre-binding-era bucket from the warn message when every drifted atom is slug-bound', async () => {
+    await seedSource('src-q', 'original body');
+    for (let i = 0; i < 30; i++) {
+      await seedAtom(`atoms/2026-01-01/q-${String(i).padStart(6, '0')}`, 'src-q', 'deadbeefdeadbeef');
+    }
+    const c = await computeAtomProvenanceDriftCheck(engine);
+    expect(c.status).toBe('warn');
+    expect((c.details as Record<string, number>).legacy_unbound).toBe(0);
+    expect(c.message).not.toContain('pre-binding-era');
+  }, 60_000);
+
+  it('names the pre-binding-era bucket in the warn message only when it is non-empty', async () => {
+    await seedSource('src-p', 'original body');
+    for (let i = 0; i < 30; i++) {
+      await engine.putPage(`atoms/2026-01-01/p-${String(i).padStart(6, '0')}`, {
+        type: 'atom', title: `p${i}`, compiled_truth: 'claim body',
+        frontmatter: {
+          type: 'atom', source_path: '/imports/src-p.md',
+          source_hash: 'deadbeefdeadbeef', extracted_at: new Date().toISOString(),
+        },
+      });
+    }
+    const c = await computeAtomProvenanceDriftCheck(engine);
+    expect(c.status).toBe('warn');
+    expect(c.message).toContain('0 whose source page is gone');
+    expect(c.message).toContain('30 pre-binding-era');
+  }, 60_000);
 });

--- a/test/doctor-atom-provenance-drift.test.ts
+++ b/test/doctor-atom-provenance-drift.test.ts
@@ -207,12 +207,14 @@ describe('computeAtomProvenanceDriftCheck', () => {
     expect(c.message).toContain('30/30');
     expect(c.message).toContain('source page is gone');
   });
-  it('does not count a pre-binding-era atom (source_path only, no source_slug) as source_gone', async () => {
-    // Legacy transcript-origin atoms carry `source_path` but no `source_slug`
-    // (isCompatibleAtomBinding in extract-atoms.ts). They can never match
-    // p.slug, so the slug-only liveness probe reported every one of them as
-    // an orphan even while the source page was alive — measured on a real
-    // brain as 702 "gone" atoms whose source pages all still existed.
+  it('does not count a slug-unbound atom (source_path only, no source_slug) as source_gone', async () => {
+    // Transcript-origin atoms carry `source_path` but no `source_slug`
+    // (isCompatibleAtomBinding in extract-atoms.ts) -- this is the CURRENT,
+    // ongoing binding kind for every transcript-kind atom, not a shrinking
+    // legacy cohort. They can never match p.slug, so the slug-only liveness
+    // probe reported every one of them as an orphan even while the source
+    // page was alive — measured on a real brain as 702 "gone" atoms whose
+    // source pages all still existed.
     await seedSource('src-l', 'original body');
     await engine.putPage('atoms/2026-01-01/l-000000', {
       type: 'atom', title: 'l', compiled_truth: 'claim body',
@@ -245,7 +247,7 @@ describe('computeAtomProvenanceDriftCheck', () => {
     expect(d.legacy_unbound).toBe(1);
   });
 
-  it('omits the pre-binding-era bucket from the warn message when every drifted atom is slug-bound', async () => {
+  it('omits the slug-unbound bucket from the warn message when every drifted atom is slug-bound', async () => {
     await seedSource('src-q', 'original body');
     for (let i = 0; i < 30; i++) {
       await seedAtom(`atoms/2026-01-01/q-${String(i).padStart(6, '0')}`, 'src-q', 'deadbeefdeadbeef');
@@ -253,10 +255,10 @@ describe('computeAtomProvenanceDriftCheck', () => {
     const c = await computeAtomProvenanceDriftCheck(engine);
     expect(c.status).toBe('warn');
     expect((c.details as Record<string, number>).legacy_unbound).toBe(0);
-    expect(c.message).not.toContain('pre-binding-era');
+    expect(c.message).not.toContain('slug-unbound');
   }, 60_000);
 
-  it('names the pre-binding-era bucket in the warn message only when it is non-empty', async () => {
+  it('names the slug-unbound bucket in the warn message only when it is non-empty', async () => {
     await seedSource('src-p', 'original body');
     for (let i = 0; i < 30; i++) {
       await engine.putPage(`atoms/2026-01-01/p-${String(i).padStart(6, '0')}`, {
@@ -270,6 +272,6 @@ describe('computeAtomProvenanceDriftCheck', () => {
     const c = await computeAtomProvenanceDriftCheck(engine);
     expect(c.status).toBe('warn');
     expect(c.message).toContain('0 whose source page is gone');
-    expect(c.message).toContain('30 pre-binding-era');
+    expect(c.message).toContain('30 slug-unbound');
   }, 60_000);
 });


### PR DESCRIPTION
## Summary

`atom_provenance_drift` (#4566, shipped in v0.48.1.0) resolves source-page liveness by `source_slug` only. Pre-binding-era atoms carry `source_path` and no `source_slug` — a binding kind `extract-atoms.ts` already recognises (`isCompatibleAtomBinding`) — so they can never match `p.slug`, and every drifted one of them was reported as "source page is gone" even when the source page is alive.

## Change

- `source_gone` now requires a slug binding that failed to resolve (`ss IS NOT NULL`).
- New `legacy_unbound` details bucket counts drifted atoms with no `source_slug`; the warn message names it only when non-empty.
- Empty-string `source_slug` is treated like a missing one (`NULLIF`).
- Thresholds (`MIN_DRIFTED`, `WARN_RATIO`), the `drifted` total, and the diagnostic-only nature are unchanged. No resolver by `source_path`, no GC — those are design calls I did not want to make in a defect fix.

## Evidence

On a Postgres brain (31,779 pages, 12,469 atoms) the check reported `702 whose source page is gone`. All 702 were `source_path`-only atoms (no `source_slug` key at all, extracted 2026-07-25 … 2026-08-22), and for all 702 a live page whose `source_path` basename matches the atom's `source_path` exists. After this change the same brain reports `source_gone = 0`, `legacy_unbound = 702`.

## Tests

`test/doctor-atom-provenance-drift.test.ts`: 4 new cases (source_path-only atom → `legacy_unbound`, empty-string `source_slug`, message omits the bucket when every drifted atom is slug-bound, message names the bucket when non-empty). All four fail on master (4 fail / 11 pass — the negative case because `details.legacy_unbound` is undefined there); on this branch all 15 pass. `bun run typecheck`, `check:privacy` and the rest of `bun run verify` pass.

## Scope note

Whether legacy atoms should be resolved through `source_path` (absolute import path vs the page's relative `source_path` — the two do not join directly) is left to the maintainer; this PR only stops calling them "gone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)