### PR TITLE
v0.48.1.1 fix(storage): scope status pages to repo source (#4763)

### DIFF
--- a/src/commands/storage.ts
+++ b/src/commands/storage.ts
@@ -3,7 +3,7 @@ import type { BrainEngine } from '../core/engine.ts';
 import { loadStorageConfig, validateStorageConfig, getStorageTier } from '../core/storage-config.ts';
 import type { StorageConfig, StorageTier } from '../core/storage-config.ts';
 import { walkBrainRepo, type DiskFileEntry } from '../core/disk-walk.ts';
-import { getDefaultSourcePath } from '../core/source-resolver.ts';
+import { getDefaultSourcePath, resolveSourceForRepoPath } from '../core/source-resolver.ts';
 
 /**
  * Distinct nominal types for the two tier-keyed numeric maps. Both shapes
@@ -146,7 +146,11 @@ export async function getStorageStatus(
   // per directory + one stat per .md file, plus O(1) lookups below.
   const fileMap: Map<string, DiskFileEntry> = repoPath ? walkBrainRepo(repoPath) : new Map();
 
-  const pages = await engine.listPages({ limit: 1_000_000 });
+  const source = repoPath ? await resolveSourceForRepoPath(engine, repoPath) : null;
+  const pages = await engine.listPages({
+    limit: 1_000_000,
+    ...(source ? { sourceId: source.source_id } : {}),
+  });
 
   for (const page of pages) {
     const tier = config ? getStorageTier(page.slug, config) : 'unspecified';

--- a/test/storage-pglite.test.ts
+++ b/test/storage-pglite.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -98,6 +98,44 @@ describe('Storage tiering on PGLite — full lifecycle (D8 + D4)', () => {
       expect(result.pagesByTier.db_only).toBe(2);
       expect(result.pagesByTier.unspecified).toBe(1);
       expect(result.config!.db_only).toEqual(['media/x/']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('getStorageStatus scopes page checks to the source that owns the repo path (#4763)', async () => {
+    try {
+      writeGbrainYml();
+      mkdirSync(join(tmp, 'media', 'x'), { recursive: true });
+      writeFileSync(join(tmp, 'media', 'x', 'default-db-only.md'), 'file-backed default page');
+
+      const otherRepo = join(tmp, 'other-repo');
+      mkdirSync(otherRepo, { recursive: true });
+      await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [tmp]);
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config)
+           VALUES ('media-corpus', 'media-corpus', $1, '{}'::jsonb)
+           ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+        [otherRepo],
+      );
+
+      await engine.putPage('media/x/default-db-only', {
+        type: 'concept',
+        title: 'Default source page',
+        compiled_truth: '',
+        timeline: '',
+      }, { sourceId: 'default' });
+      await engine.putPage('media/x/foreign-db-only', {
+        type: 'concept',
+        title: 'Foreign source page',
+        compiled_truth: '',
+        timeline: '',
+      }, { sourceId: 'media-corpus' });
+
+      const result = await getStorageStatus(engine, tmp);
+      expect(result.totalPages).toBe(1);
+      expect(result.pagesByTier.db_only).toBe(1);
+      expect(result.missingFiles).toEqual([]);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
Fixes #4763

## Summary
- Resolve the source that owns the selected `storage status --repo` path before listing pages.
- Scope the status page scan with that source id so a single repo is not compared against every page in a multi-source brain.
- Add a PGLite regression covering a foreign-source `db_only` page that must not appear as missing from the selected repo.

## Verification
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/storage-pglite.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/storage-pglite.test.ts`

Gate evidence: `RESULT: GREEN`; `verify` green; `test/storage-pglite.test.ts` reported 7 pass / 0 fail; diff-selected E2E returned the fail-closed all-file set and was skipped locally per the gate script, with CI retaining full E2E coverage.
