### PR TITLE
fix(import): list per-file failures in the --json payload

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -748,10 +748,20 @@ export async function runImport(
 
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
   if (jsonOutput) {
+    // `skipped` includes every per-file failure importFile RETURNS (invalid
+    // frontmatter, oversize, symlink, slug mismatch) as well as content-hash
+    // no-ops, and `errors` counts only the thrown ones — so a caller cannot
+    // tell "unchanged" from "failed" by counts alone. The failure ledger is
+    // written only for git-repo dirs (see the gitHead gate below), so a caller
+    // importing a scratch directory has no other channel. Emit the per-file
+    // list so state can be gated per file.
     console.log(JSON.stringify({
       status: 'success', duration_s: parseFloat(totalTime),
       imported, skipped, errors, chunks: chunksCreated,
       total_files: allFiles.length,
+      unchanged: skipped - failures.length - malformedFileSkips,
+      malformed_skipped: malformedFileSkips,
+      failures,
     }));
   } else {
     console.log(`\nImport complete (${totalTime}s):`);

--- a/test/import-json-stdout.serial.test.ts
+++ b/test/import-json-stdout.serial.test.ts
@@ -72,7 +72,7 @@ function seedNotes(prefix: string): string {
   return dir;
 }
 
-describe('import --json stdout is parseable JSON (#3637)', () => {
+describe('import --json stdout is parseable JSON (#3637) and lists per-file failures', () => {
   test('--json puts one JSON document on stdout and the progress lines on stderr; human mode is unchanged', async () => {
     const home = mkdtempSync(join(tmpdir(), 'gbrain-3637-'));
     const jsonNotes = seedNotes('gbrain-3637-json-');
@@ -113,6 +113,35 @@ describe('import --json stdout is parseable JSON (#3637)', () => {
       // still sees it.
       expect(json.stdout).not.toContain('Found 2 markdown files');
       expect(json.stderr).toContain('Found 2 markdown files');
+
+      // Per-file failures are listed in the payload. Pre-fix, a file whose
+      // import returned status='skipped' with an error (invalid frontmatter
+      // here) was indistinguishable from a content-hash no-op: `skipped`
+      // counted both, `errors` counted neither, exit code was 0, and the
+      // failure ledger is only written for git-repo dirs. gstack's
+      // memory-ingest stamped such pages as ingested and never retried them.
+      const mixedNotes = mkdtempSync(join(tmpdir(), 'gbrain-import-failures-'));
+      writeFileSync(join(mixedNotes, 'good.md'), '# good\n\nbody\n');
+      writeFileSync(
+        join(mixedNotes, 'broken.md'),
+        '---\ntitle: a: b\ntags: [\n---\n\n# broken\n',
+      );
+      const mixed = await runCli(['import', mixedNotes, '--no-embed', '--json'], env, 120_000);
+      if (mixed.exitCode !== 0) {
+        console.error('--- import mixed stdout ---\n' + mixed.stdout);
+        console.error('--- import mixed stderr ---\n' + mixed.stderr);
+      }
+      expect(mixed.exitCode).toBe(0);
+      const mixedJson = JSON.parse(mixed.stdout);
+      expect(mixedJson.imported).toBe(1);
+      expect(mixedJson.skipped).toBe(1);
+      expect(mixedJson.errors).toBe(0);
+      expect(mixedJson.unchanged).toBe(0);
+      expect(mixedJson.malformed_skipped).toBe(0);
+      expect(mixedJson.failures).toHaveLength(1);
+      expect(mixedJson.failures[0].path).toBe('broken.md');
+      expect(mixedJson.failures[0].error).toContain('Invalid YAML frontmatter');
+      try { rmSync(mixedNotes, { recursive: true, force: true }); } catch { /* best effort */ }
 
       // Guard the other direction: without --json the human line stays on
       // stdout, so this fix cannot be "fixed" by deleting the output.


### PR DESCRIPTION
## Problem

`gbrain import --json` reports only counts. A per-file failure that `importFile` **returns** (invalid frontmatter, oversize, symlink, slug mismatch) is folded into `skipped` with exit 0, and `errors` counts only the thrown ones, so a caller cannot tell "unchanged" from "failed" by counts alone:

```
  Skipped notes/broken.md: Invalid YAML frontmatter: ...
{"status":"success","imported":1,"skipped":1,"errors":0,"chunks":1,"total_files":2}
```

The failure ledger (`sync-failures.jsonl`) is the intended channel ("so callers can gate state advances"), but `recordFailures` runs only inside `if (gitHead && !opts.managedBookmark)`, so a caller importing a scratch directory has no per-file signal at all.

**Field impact:** gstack's memory-ingest stages transcripts in a non-git directory, runs `gbrain import --no-embed --json`, and treated `imported + skipped` as "landed". Every transcript gbrain rejected for invalid frontmatter was stamped as ingested and never retried: 37 and 69 phantom state entries on two machines, found 2026-09-02. Companion PR on gstack reads the new field.

## Change

The `--json` payload now carries:

- `failures: [{ path, error }]` — the same list `runImport` already returns to programmatic callers
- `unchanged` — skips that were content-hash no-ops
- `malformed_skipped` — informational malformed-filename skips

Human output is unchanged. Additive only; existing fields keep their meaning.

## Test

`bun test test/import-json-stdout.serial.test.ts` (PGLite, spawn-level): a directory with one good note and one with broken YAML frontmatter yields `imported: 1, skipped: 1, errors: 0, unchanged: 0` and `failures[0].path === 'broken.md'` with the frontmatter error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6tUuiiAyoh8DGjsfnWgG
