### PR TITLE
fix(slug): strip trailing .md/.mdx in validateSlug to prevent .md.md write-through

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -54,7 +54,24 @@ export function validateSlug(slug: string): string {
   if (/%2e|%2f|%5c/i.test(slug)) {
     throw new Error(`Invalid slug: "${slug}". URL-encoded path separators are not allowed in slugs.`);
   }
-  return slug.toLowerCase();
+  // Storage convention: a slug never carries the markdown extension — the
+  // write-through sink appends `<slug>.md`. A slug that already ends in
+  // `.md`/`.mdx` (a caller that pasted a filename or a slug template that
+  // baked in the extension) would otherwise land a double-extension `foo.md.md`
+  // on disk: silently written (write_through.written:true, no error) and
+  // invisible to delete_page, which resolves by the DB slug `foo.md` and never
+  // touches the mis-named file (NOE-3172). Strip every trailing markdown
+  // extension so the canonical write slug matches how `slugifyPath` derives
+  // slugs from disk paths (`/\.mdx?$/i`), keeping the DB row and the `.md` file
+  // in agreement.
+  let normalized = slug;
+  while (/\.mdx?$/i.test(normalized)) {
+    normalized = normalized.replace(/\.mdx?$/i, '');
+  }
+  if (!normalized || /\/$/.test(normalized)) {
+    throw new Error(`Invalid slug: "${slug}". Stripping the markdown extension left an empty or malformed slug.`);
+  }
+  return normalized.toLowerCase();
 }
 
 /**

--- a/test/ingestion/put-page-write-through.test.ts
+++ b/test/ingestion/put-page-write-through.test.ts
@@ -100,6 +100,24 @@ describe('put_page write-through — happy path', () => {
     expect(onDisk).toContain('WT body');
   });
 
+  test('NOE-3172: a .md-suffixed slug writes a single-extension file, not foo.md.md', async () => {
+    const ctx = makeCtx();
+    const result = (await putPage.handler(ctx, {
+      slug: 'inbox/report.md',
+      content: '---\ntitle: Dbl\n---\n\ndouble-ext body',
+    })) as { slug: string; write_through?: { written: boolean; path?: string } };
+    expect(result.write_through?.written).toBe(true);
+    // Canonical slug carries no markdown extension; the sink adds exactly one.
+    expect(result.slug).toBe('inbox/report');
+    const goodPath = path.join(brainDir, 'inbox/report.md');
+    expect(result.write_through?.path).toBe(goodPath);
+    expect(fs.existsSync(goodPath)).toBe(true);
+    // The corrupt double-extension artifact must never appear.
+    expect(fs.existsSync(path.join(brainDir, 'inbox/report.md.md'))).toBe(false);
+    // The DB row is keyed by the stripped slug, so delete_page can find it.
+    expect(await engine.getPage('inbox/report')).not.toBeNull();
+  });
+
   test('stamps provenance frontmatter (ingested_via=put_page for local CLI)', async () => {
     const ctx = makeCtx({ remote: false });
     const result = (await putPage.handler(ctx, {

--- a/test/loops-extract-run.serial.test.ts
+++ b/test/loops-extract-run.serial.test.ts
@@ -57,8 +57,8 @@ const { normalizeAlias } = await import('../src/core/search/alias-normalize.ts')
 const { MinionQueue } = await import('../src/core/minions/queue.ts');
 
 const SRC = 'g1';
-const EMAIL_SLUG = 'emails/2026/08/2026-08-20-test-thread-abcd1234.md';
-const SUPPRESSED_SLUG = 'emails/2026/08/2026-08-20-suppressed-thread-efab5678.md';
+const EMAIL_SLUG = 'emails/2026/08/2026-08-20-test-thread-abcd1234';
+const SUPPRESSED_SLUG = 'emails/2026/08/2026-08-20-suppressed-thread-efab5678';
 const THREAD_ID = 'thread-abcd1234';
 const SUPPRESSED_THREAD_ID = 'thread-efab5678';
 const PERSON_SLUG = 'people/alice-example';
@@ -225,7 +225,7 @@ describe('runLoopsExtract', () => {
     // the extraction sail through to the model. The rendered thread page
     // carries every SENDER (`senders`, the message authors); all of them
     // gate the lane.
-    const slug = 'emails/2026/08/2026-08-24-earlier-muted-77665544.md';
+    const slug = 'emails/2026/08/2026-08-24-earlier-muted-77665544';
     await engine.putPage(
       slug,
       {
@@ -277,7 +277,7 @@ describe('runLoopsExtract', () => {
     // thread she was CC'd on, and an outside sender could dodge extraction by
     // CC'ing a known-muted address. Only addresses that AUTHORED a message
     // count.
-    const slug = 'emails/2026/08/2026-08-25-muted-cc-only-88776655.md';
+    const slug = 'emails/2026/08/2026-08-25-muted-cc-only-88776655';
     await engine.putPage(
       slug,
       {
@@ -479,7 +479,7 @@ describe('runLoopsExtract', () => {
   });
 
   test('prompt hardening: newest 12k is retained and sanitized; stale head is dropped', async () => {
-    const slug = 'emails/2026/08/2026-08-22-injection-thread-99887766.md';
+    const slug = 'emails/2026/08/2026-08-22-injection-thread-99887766';
     // 'ignore previous instructions' matches sanitize.ts's 'ignore-prior'
     // pattern (replacement '[redacted]'). The old head marker is pushed out
     // while the newest evidence remains inside the 12k payload.
@@ -519,7 +519,7 @@ describe('runLoopsExtract', () => {
   });
 
   test('counterparty without a person page: loop still lands, no edge is written', async () => {
-    const slug = 'emails/2026/08/2026-08-21-bob-thread-ef567890.md';
+    const slug = 'emails/2026/08/2026-08-21-bob-thread-ef567890';
     await engine.putPage(
       slug,
       {
@@ -578,7 +578,7 @@ describe('runLoopsExtract', () => {
   });
 
   test('verbatim evidence: a fabricated quote is BLANKED (loop lands, edge label falls back to text); a genuine quote survives whitespace-normalized', async () => {
-    const slug = 'emails/2026/08/2026-08-23-verbatim-thread-11223344.md';
+    const slug = 'emails/2026/08/2026-08-23-verbatim-thread-11223344';
     await engine.putPage(
       slug,
       {

--- a/test/ops-loops.test.ts
+++ b/test/ops-loops.test.ts
@@ -252,7 +252,7 @@ describe('open_loops grouped', () => {
 });
 
 describe('open_loops deep links + context (trusted local)', () => {
-  const EMAIL_SLUG = 'emails/2026/08/2026-08-20-plan-review-abcd1234.md';
+  const EMAIL_SLUG = 'emails/2026/08/2026-08-20-plan-review-abcd1234';
 
   test('deep_link regenerates from the page account + hex message-id evidence', async () => {
     // The thread page carries the account in frontmatter; the loop points at

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -25,6 +25,36 @@ describe('validateSlug', () => {
   test('rejects leading slash', () => {
     expect(() => validateSlug('/absolute/path')).toThrow('start with /');
   });
+
+  // NOE-3172: a slug that already carries the markdown extension would make the
+  // write-through sink append a second `.md` → a corrupt `foo.md.md` on disk,
+  // silently written and invisible to delete_page (which resolves by the DB
+  // slug). Slugs never carry the extension — the storage layer adds `<slug>.md`
+  // — so strip a trailing `.md`/`.mdx`, matching slugifyPath's disk-side rule.
+  test('strips a trailing .md extension', () => {
+    expect(validateSlug('notes/foo.md')).toBe('notes/foo');
+    expect(validateSlug('daily/2026-08-28.md')).toBe('daily/2026-08-28');
+  });
+
+  test('strips a trailing .md/.mdx case-insensitively', () => {
+    expect(validateSlug('Foo.MD')).toBe('foo');
+    expect(validateSlug('components/Hero.MDX')).toBe('components/hero');
+  });
+
+  test('dedupes a doubled markdown extension to none', () => {
+    expect(validateSlug('notes/foo.md.md')).toBe('notes/foo');
+    expect(validateSlug('notes/foo.mdx.md')).toBe('notes/foo');
+  });
+
+  test('only strips the trailing extension, preserving inner dots', () => {
+    expect(validateSlug('notes/v1.0.0')).toBe('notes/v1.0.0');
+    expect(validateSlug('notes/v1.0.0.md')).toBe('notes/v1.0.0');
+  });
+
+  test('rejects a slug that is only a markdown extension', () => {
+    expect(() => validateSlug('.md')).toThrow('Invalid slug');
+    expect(() => validateSlug('foo/.md')).toThrow('Invalid slug');
+  });
 });
 
 describe('contentHash', () => {


### PR DESCRIPTION
## What

A slug that already carries a markdown extension (`inbox/report.md`) passed
`validateSlug` unchanged — it only lowercased. The write-through sink then appends
its own `.md`, so the page lands on disk as `inbox/report.md.md` while the DB row is
keyed `inbox/report.md`.

`validateSlug` now strips a trailing `.md` / `.mdx` at the shared write chokepoint
(`putPage` + `updateSlug`, both engines), matching the disk→slug direction the
codebase already documents as the storage convention:

- `slugifyPath` strips `/\.mdx?$/i` (`src/core/sync.ts`)
- `disk-walk.ts`: *"the on-disk path relative to the brain repo, with the trailing
  `.md` stripped, matching how pages are stored"*
- `sync.ts` `srcSubpath`: *"`wiki/page1.md` → slug `wiki/page1`"*

A slug that reduces to empty or a trailing slash (`.md`, `foo/.md`) is rejected
instead of silently becoming a directory write.

## Why

The failure mode is silent and not recoverable through the normal surface:

- `put_page` reports success — `write_through.written: true`, no error.
- The file on disk is `foo.md.md`; nothing in the brain points at that name.
- `delete_page` resolves by the DB slug `foo.md` and appends `.md` the same way, so
  it never touches the mis-named file. The artifact needs a manual `rm`.
- A later `sync` re-imports `foo.md.md` under the slug `foo.md`, so the ghost row
  keeps coming back.

The two directions of one convention had drifted: disk→slug strips the extension,
slug→disk did not defend against one already being there.

## Test fixtures touched (please review this part first)

Eight slug constants in two existing test files stored their pages through
`engine.putPage()` with a `.md`-suffixed slug and then looked them up by that same
string — a shape no production path produces, because the Google lane writes through
`importRendered` → `importFile`, which derives the slug from the rel-path and strips
the extension (`src/core/google/google-source.ts:232`). With the chokepoint
normalizing, those fixtures wrote `emails/…-abcd1234` and read `emails/…-abcd1234.md`,
so `runLoopsExtract` returned `page_missing` / `skipped`.

Normalized in `test/loops-extract-run.serial.test.ts` (7 constants) and
`test/ops-loops.test.ts` (1). Deliberately left as-is: `emails/does-not-exist.md`
and `emails/never-imported.md`, which assert the not-found paths and never get
written.

If you would rather keep those fixtures verbatim, the alternative is to make the
write-through sink skip its own `.md` when the slug already ends in one — but that
leaves two spellings of the same page identity (`foo` from sync, `foo.md` from
put_page) and the duplicate-row problem that follows, so this PR normalizes the
identity instead.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/utils.ts` to merge-base, ran
`test/utils.test.ts` → 26 pass / 5 fail. Restored → all pass.

Discrimination test: reverted `src/core/utils.ts` to merge-base, ran
`test/ingestion/put-page-write-through.test.ts` → 10 pass / 1 fail. Restored → all pass.

## Tests

Added:

- `test/utils.test.ts` — 5 new `validateSlug` cases: strips `.md`; case-insensitive
  `.MD` / `.MDX`; doubled `foo.md.md` → `foo`; inner dots preserved (`notes/v1.0.0`
  survives, `notes/v1.0.0.md` → `notes/v1.0.0`); extension-only slugs rejected.
- `test/ingestion/put-page-write-through.test.ts` — end to end: a `.md`-suffixed slug
  yields a single-extension file, no `report.md.md` on disk, and the DB row is
  retrievable under the stripped slug (the property `delete_page` depends on).

Local runs (bun 1.3.10, macOS arm64, base e9a14c952):

- `bun test test/utils.test.ts test/ingestion/put-page-write-through.test.ts` → 42 pass / 0 fail
- `bun test test/loops-extract-run.serial.test.ts test/ops-loops.test.ts` → 58 pass / 0 fail
- Slug-adjacent sweep — `slug-validation`, `path-confine`, `client-slug-fence`,
  `export-import-slug-roundtrip`, `pglite-engine`, `skillpack-personas`,
  `sync-rename-reconcile.serial` → 370 pass / 0 fail
- `bun run verify` → 54/54 green
- `bun run test` → 23626 pass / 7 fail. The clean base (e9a14c952) produces 23621
  pass / 6 fail on the same machine and runner; those six are identical and
  environmental (postgres run-dir socket, smoke-test worker health ×3, template-door
  gh shim, workspace-push finish). The seventh is `cycle-conversation-facts-backfill`
  failing on "expected 1280 dimensions, not 1536" — cross-shard embedding-dimension
  pollution under parallel packing, unrelated to slugs; it passes 3/3 standalone.
