### PR TITLE
feat(tasks): add optimistic concurrency and removal tombstones

### DIFF
--- a/plugin-variants/gbrain-daily/skills/daily-task-manager/SKILL.md
+++ b/plugin-variants/gbrain-daily/skills/daily-task-manager/SKILL.md
@@ -64,7 +64,7 @@ Map user intent deterministically before touching state:
    - **Add:** Require a description. Priority: use the user's stated/clearly-implied level; otherwise default to **P3 and say so in the reply + timeline entry**. Due date only if supplied or explicit in the user's words. Mint a new task ID (`t-YYYYMMDD-NN`, NN = next free ordinal that day). Add a timeline entry.
    - **Complete:** Mark `[x]`, move to Completed with `(completed: YYYY-MM-DD)`.
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
-   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
+   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Move the task to `Removed`, mark `[x]`, preserve its stable ID, origin/source metadata and visible description, and append `(removed: YYYY-MM-DD)`. Never delete the line: it is the durable tombstone that prevents source retries from recreating the task. If `Removed` is absent on an older page, add it immediately before `Completed`. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
 5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
@@ -73,6 +73,7 @@ Map user intent deterministically before touching state:
 - **First run:** page missing → create from template before acting; `status: ok`, note "initialized".
 - **Malformed page:** if `ops/tasks.md` exists but doesn't match the schema, do NOT rewrite it wholesale. Append/edit within it minimally, preserve unknown content verbatim, and flag the malformation in the reply.
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
+- **Removed source retry:** a matching ID, origin, source link or exact obligation in `Removed` is closed. Do not recreate or move it back to active unless the user explicitly asks to restore it as a new action.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
 - **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
@@ -100,6 +101,9 @@ Each task carries a stable ID so later actions can target it safely:
 
 ## Deferred
 - [ ] <!-- id: {task-id} --> {task description} (deferred until: {date}; reason: {reason})
+
+## Removed
+- [x] <!-- id: {task-id} --> {task description} (removed: {date})
 
 ## Completed
 - [x] <!-- id: {task-id} --> {task description} (completed: {date})

--- a/plugin-variants/gbrain-daily/skills/daily-task-manager/SKILL.md
+++ b/plugin-variants/gbrain-daily/skills/daily-task-manager/SKILL.md
@@ -44,7 +44,7 @@ For `review`, return the grouped active-task list instead of a single task_id. W
 
 ## Tool Interface
 
-Use ONLY the declared tools. `get_page("ops/tasks.md")` to read, `put_page("ops/tasks.md", …)` to write, `add_timeline_entry` for the audit trail, `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks` / `gbrain put ops/tasks` — equivalents only, not the skill's interface.)
+Use ONLY the declared tools. `get_page("ops/tasks.md", include_content=true)` to read the canonical markdown and its `content_hash`; `put_page("ops/tasks.md", content=…, expected_content_hash=…)` to write; `add_timeline_entry` for the audit trail; `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks --include-content --json` / `gbrain put ops/tasks --expected-content-hash HASH` — equivalents only, not the skill's interface.)
 
 ## Action Routing
 
@@ -57,7 +57,7 @@ Map user intent deterministically before touching state:
 
 ## Phases
 
-1. **Load.** `get_page("ops/tasks.md")`. **First run:** if the page does not exist, create it from the Output Format template, then proceed.
+1. **Load.** `get_page("ops/tasks.md", include_content=true)`. Preserve the returned canonical `content` and `content_hash`. **First run:** if the page does not exist, create it from the Output Format template with `expected_content_hash="absent"`, then proceed.
 2. **Validate.** Determine the action via Action Routing. If required fields are missing (see per-action rules), ask ONE concise clarification before mutating state. Never fabricate priorities, due dates, or defer reasons.
 3. **Identify the target task** (complete/defer/remove): match by `id` when given; otherwise fuzzy-match description against ACTIVE tasks only. Zero matches → return `not_found`, do not mutate. Multiple matches → list candidates with IDs, return `ambiguous`, do not mutate.
 4. **Execute:**
@@ -66,7 +66,7 @@ Map user intent deterministically before touching state:
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
    - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
-5. **Save.** `put_page("ops/tasks.md")` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize.
+5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
 ## Edge Cases
 
@@ -75,7 +75,7 @@ Map user intent deterministically before touching state:
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
-- **Single-writer assumption (concurrency limitation).** The task cycle is read-modify-write: `get_page("ops/tasks.md")` → edit → `put_page("ops/tasks.md")`. `put_page` replaces the WHOLE page and has no compare-and-swap, so two mutations that interleave are last-writer-wins: the second `put_page` overwrites the first's change (a completed task reappears, an added task vanishes), and the `t-YYYYMMDD-NN` minting can hand the same ordinal to two concurrent adds (duplicate IDs). Serialize task edits — never run parallel task mutations (multiple subagents, concurrent chat turns) against `ops/tasks.md`. If a mutation might race, re-`get_page` immediately before `put_page` and re-derive the next free ordinal from the freshly-read page.
+- **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
 
 ## Output Format
 
@@ -122,7 +122,7 @@ Each with its corrective action:
 - Fabricating due dates, priorities, or reasons → never invent required fields; ask.
 - Unbounded list growth → when Backlog exceeds ~20 items, prompt a weekly review.
 - Storing tasks outside the brain page → everything lives in `ops/tasks.md` (searchable).
-- Running parallel task mutations against `ops/tasks.md` → last-writer-wins whole-page `put_page` silently loses updates and mints duplicate IDs; serialize edits, re-read immediately before writing.
+- Writing `ops/tasks.md` without `expected_content_hash`, or retrying a stale body after `write_conflict` → silent lost-update risk; always re-read, reapply and retry with the new hash.
 
 ## Design Rationale (failure modes this version closes)
 

--- a/plugin/skills/daily-task-manager/SKILL.md
+++ b/plugin/skills/daily-task-manager/SKILL.md
@@ -64,7 +64,7 @@ Map user intent deterministically before touching state:
    - **Add:** Require a description. Priority: use the user's stated/clearly-implied level; otherwise default to **P3 and say so in the reply + timeline entry**. Due date only if supplied or explicit in the user's words. Mint a new task ID (`t-YYYYMMDD-NN`, NN = next free ordinal that day). Add a timeline entry.
    - **Complete:** Mark `[x]`, move to Completed with `(completed: YYYY-MM-DD)`.
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
-   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
+   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Move the task to `Removed`, mark `[x]`, preserve its stable ID, origin/source metadata and visible description, and append `(removed: YYYY-MM-DD)`. Never delete the line: it is the durable tombstone that prevents source retries from recreating the task. If `Removed` is absent on an older page, add it immediately before `Completed`. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
 5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
@@ -73,6 +73,7 @@ Map user intent deterministically before touching state:
 - **First run:** page missing → create from template before acting; `status: ok`, note "initialized".
 - **Malformed page:** if `ops/tasks.md` exists but doesn't match the schema, do NOT rewrite it wholesale. Append/edit within it minimally, preserve unknown content verbatim, and flag the malformation in the reply.
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
+- **Removed source retry:** a matching ID, origin, source link or exact obligation in `Removed` is closed. Do not recreate or move it back to active unless the user explicitly asks to restore it as a new action.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
 - **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
@@ -100,6 +101,9 @@ Each task carries a stable ID so later actions can target it safely:
 
 ## Deferred
 - [ ] <!-- id: {task-id} --> {task description} (deferred until: {date}; reason: {reason})
+
+## Removed
+- [x] <!-- id: {task-id} --> {task description} (removed: {date})
 
 ## Completed
 - [x] <!-- id: {task-id} --> {task description} (completed: {date})

--- a/plugin/skills/daily-task-manager/SKILL.md
+++ b/plugin/skills/daily-task-manager/SKILL.md
@@ -44,7 +44,7 @@ For `review`, return the grouped active-task list instead of a single task_id. W
 
 ## Tool Interface
 
-Use ONLY the declared tools. `get_page("ops/tasks.md")` to read, `put_page("ops/tasks.md", …)` to write, `add_timeline_entry` for the audit trail, `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks` / `gbrain put ops/tasks` — equivalents only, not the skill's interface.)
+Use ONLY the declared tools. `get_page("ops/tasks.md", include_content=true)` to read the canonical markdown and its `content_hash`; `put_page("ops/tasks.md", content=…, expected_content_hash=…)` to write; `add_timeline_entry` for the audit trail; `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks --include-content --json` / `gbrain put ops/tasks --expected-content-hash HASH` — equivalents only, not the skill's interface.)
 
 ## Action Routing
 
@@ -57,7 +57,7 @@ Map user intent deterministically before touching state:
 
 ## Phases
 
-1. **Load.** `get_page("ops/tasks.md")`. **First run:** if the page does not exist, create it from the Output Format template, then proceed.
+1. **Load.** `get_page("ops/tasks.md", include_content=true)`. Preserve the returned canonical `content` and `content_hash`. **First run:** if the page does not exist, create it from the Output Format template with `expected_content_hash="absent"`, then proceed.
 2. **Validate.** Determine the action via Action Routing. If required fields are missing (see per-action rules), ask ONE concise clarification before mutating state. Never fabricate priorities, due dates, or defer reasons.
 3. **Identify the target task** (complete/defer/remove): match by `id` when given; otherwise fuzzy-match description against ACTIVE tasks only. Zero matches → return `not_found`, do not mutate. Multiple matches → list candidates with IDs, return `ambiguous`, do not mutate.
 4. **Execute:**
@@ -66,7 +66,7 @@ Map user intent deterministically before touching state:
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
    - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
-5. **Save.** `put_page("ops/tasks.md")` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize.
+5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
 ## Edge Cases
 
@@ -75,7 +75,7 @@ Map user intent deterministically before touching state:
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
-- **Single-writer assumption (concurrency limitation).** The task cycle is read-modify-write: `get_page("ops/tasks.md")` → edit → `put_page("ops/tasks.md")`. `put_page` replaces the WHOLE page and has no compare-and-swap, so two mutations that interleave are last-writer-wins: the second `put_page` overwrites the first's change (a completed task reappears, an added task vanishes), and the `t-YYYYMMDD-NN` minting can hand the same ordinal to two concurrent adds (duplicate IDs). Serialize task edits — never run parallel task mutations (multiple subagents, concurrent chat turns) against `ops/tasks.md`. If a mutation might race, re-`get_page` immediately before `put_page` and re-derive the next free ordinal from the freshly-read page.
+- **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
 
 ## Output Format
 
@@ -122,7 +122,7 @@ Each with its corrective action:
 - Fabricating due dates, priorities, or reasons → never invent required fields; ask.
 - Unbounded list growth → when Backlog exceeds ~20 items, prompt a weekly review.
 - Storing tasks outside the brain page → everything lives in `ops/tasks.md` (searchable).
-- Running parallel task mutations against `ops/tasks.md` → last-writer-wins whole-page `put_page` silently loses updates and mints duplicate IDs; serialize edits, re-read immediately before writing.
+- Writing `ops/tasks.md` without `expected_content_hash`, or retrying a stale body after `write_conflict` → silent lost-update risk; always re-read, reapply and retry with the new hash.
 
 ## Design Rationale (failure modes this version closes)
 

--- a/skills/daily-task-manager/SKILL.md
+++ b/skills/daily-task-manager/SKILL.md
@@ -64,7 +64,7 @@ Map user intent deterministically before touching state:
    - **Add:** Require a description. Priority: use the user's stated/clearly-implied level; otherwise default to **P3 and say so in the reply + timeline entry**. Due date only if supplied or explicit in the user's words. Mint a new task ID (`t-YYYYMMDD-NN`, NN = next free ordinal that day). Add a timeline entry.
    - **Complete:** Mark `[x]`, move to Completed with `(completed: YYYY-MM-DD)`.
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
-   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
+   - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Move the task to `Removed`, mark `[x]`, preserve its stable ID, origin/source metadata and visible description, and append `(removed: YYYY-MM-DD)`. Never delete the line: it is the durable tombstone that prevents source retries from recreating the task. If `Removed` is absent on an older page, add it immediately before `Completed`. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
 5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
@@ -73,6 +73,7 @@ Map user intent deterministically before touching state:
 - **First run:** page missing → create from template before acting; `status: ok`, note "initialized".
 - **Malformed page:** if `ops/tasks.md` exists but doesn't match the schema, do NOT rewrite it wholesale. Append/edit within it minimally, preserve unknown content verbatim, and flag the malformation in the reply.
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
+- **Removed source retry:** a matching ID, origin, source link or exact obligation in `Removed` is closed. Do not recreate or move it back to active unless the user explicitly asks to restore it as a new action.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
 - **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
@@ -100,6 +101,9 @@ Each task carries a stable ID so later actions can target it safely:
 
 ## Deferred
 - [ ] <!-- id: {task-id} --> {task description} (deferred until: {date}; reason: {reason})
+
+## Removed
+- [x] <!-- id: {task-id} --> {task description} (removed: {date})
 
 ## Completed
 - [x] <!-- id: {task-id} --> {task description} (completed: {date})

--- a/skills/daily-task-manager/SKILL.md
+++ b/skills/daily-task-manager/SKILL.md
@@ -44,7 +44,7 @@ For `review`, return the grouped active-task list instead of a single task_id. W
 
 ## Tool Interface
 
-Use ONLY the declared tools. `get_page("ops/tasks.md")` to read, `put_page("ops/tasks.md", …)` to write, `add_timeline_entry` for the audit trail, `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks` / `gbrain put ops/tasks` — equivalents only, not the skill's interface.)
+Use ONLY the declared tools. `get_page("ops/tasks.md", include_content=true)` to read the canonical markdown and its `content_hash`; `put_page("ops/tasks.md", content=…, expected_content_hash=…)` to write; `add_timeline_entry` for the audit trail; `search` for cross-referencing. Do not shell out to `gbrain` CLI verbs from this skill; the tools are the interface. (When the user runs this manually outside an agent, the CLI equivalents are `gbrain get ops/tasks --include-content --json` / `gbrain put ops/tasks --expected-content-hash HASH` — equivalents only, not the skill's interface.)
 
 ## Action Routing
 
@@ -57,7 +57,7 @@ Map user intent deterministically before touching state:
 
 ## Phases
 
-1. **Load.** `get_page("ops/tasks.md")`. **First run:** if the page does not exist, create it from the Output Format template, then proceed.
+1. **Load.** `get_page("ops/tasks.md", include_content=true)`. Preserve the returned canonical `content` and `content_hash`. **First run:** if the page does not exist, create it from the Output Format template with `expected_content_hash="absent"`, then proceed.
 2. **Validate.** Determine the action via Action Routing. If required fields are missing (see per-action rules), ask ONE concise clarification before mutating state. Never fabricate priorities, due dates, or defer reasons.
 3. **Identify the target task** (complete/defer/remove): match by `id` when given; otherwise fuzzy-match description against ACTIVE tasks only. Zero matches → return `not_found`, do not mutate. Multiple matches → list candidates with IDs, return `ambiguous`, do not mutate.
 4. **Execute:**
@@ -66,7 +66,7 @@ Map user intent deterministically before touching state:
    - **Defer:** Require a target date/timeframe AND a reason; ask if missing. Move to Deferred preserving original text, ID, and priority unless the user changes them.
    - **Remove:** Destructive — require explicit confirmation unless the user's message already contains it. Prefer suggesting complete or defer.
    - **Review:** Read-only. Never mutates. Active tasks grouped by priority, IDs shown.
-5. **Save.** `put_page("ops/tasks.md")` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize.
+5. **Save.** `put_page("ops/tasks.md", content=<complete edited canonical content>, expected_content_hash=<hash from Load>)` after any mutation. Diff-mindset: touch only the affected lines; preserve all other content, including sections this skill doesn't recognize. On `write_conflict`, re-read the page, re-identify the same user-requested action, reapply it to the new canonical content, remint an add ID if necessary, and retry. Stop after three total write attempts and report the conflict; never fall back to an unguarded put.
 
 ## Edge Cases
 
@@ -75,7 +75,7 @@ Map user intent deterministically before touching state:
 - **Retry/duplicate add:** if an identical description already exists in active tasks, do not add a duplicate — report the existing task ID instead.
 - **Dates:** ISO 8601 (`YYYY-MM-DD`) everywhere. Compute "today"/"next week" with code/clock, never guess.
 - **Page identifier:** always `ops/tasks.md` (with extension) in tool calls; this is the single canonical location.
-- **Single-writer assumption (concurrency limitation).** The task cycle is read-modify-write: `get_page("ops/tasks.md")` → edit → `put_page("ops/tasks.md")`. `put_page` replaces the WHOLE page and has no compare-and-swap, so two mutations that interleave are last-writer-wins: the second `put_page` overwrites the first's change (a completed task reappears, an added task vanishes), and the `t-YYYYMMDD-NN` minting can hand the same ordinal to two concurrent adds (duplicate IDs). Serialize task edits — never run parallel task mutations (multiple subagents, concurrent chat turns) against `ops/tasks.md`. If a mutation might race, re-`get_page` immediately before `put_page` and re-derive the next free ordinal from the freshly-read page.
+- **Concurrent mutation.** `put_page` replaces the whole page, so every task mutation must carry the exact `content_hash` returned by its read. A conflict means another writer won; re-read and reapply the intended action. Never retry the stale body or omit `expected_content_hash`. Avoid parallel task mutations because repeated conflicts add latency, but correctness no longer depends on a single-writer assumption.
 
 ## Output Format
 
@@ -122,7 +122,7 @@ Each with its corrective action:
 - Fabricating due dates, priorities, or reasons → never invent required fields; ask.
 - Unbounded list growth → when Backlog exceeds ~20 items, prompt a weekly review.
 - Storing tasks outside the brain page → everything lives in `ops/tasks.md` (searchable).
-- Running parallel task mutations against `ops/tasks.md` → last-writer-wins whole-page `put_page` silently loses updates and mints duplicate IDs; serialize edits, re-read immediately before writing.
+- Writing `ops/tasks.md` without `expected_content_hash`, or retrying a stale body after `write_conflict` → silent lost-update risk; always re-read, reapply and retry with the new hash.
 
 ## Design Rationale (failure modes this version closes)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1731,6 +1731,7 @@ export function formatResult(
       if (r.error === 'ambiguous_slug') {
         return `Ambiguous slug. Did you mean:\n${r.candidates.map((c: string) => `  ${c}`).join('\n')}\n`;
       }
+      if (params.json === true) return JSON.stringify(r, null, 2) + '\n';
       return serializeMarkdown(r.frontmatter || {}, r.compiled_truth || '', r.timeline || '', {
         type: r.type, title: r.title, tags: r.tags || [],
       });

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -661,11 +661,15 @@ export async function importFromContent(
   // unscoped-check/scoped-write bug class).
   const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
 
-  if (opts.expectedContentHash !== undefined && !/^[a-f0-9]{64}$/i.test(opts.expectedContentHash)) {
+  if (
+    opts.expectedContentHash !== undefined
+    && opts.expectedContentHash !== 'absent'
+    && !/^[a-f0-9]{64}$/i.test(opts.expectedContentHash)
+  ) {
     throw new OperationError(
       'invalid_params',
-      'expected_content_hash must be a 64-character hexadecimal SHA-256 hash.',
-      'Read the page with get_page include_content:true and pass its content_hash unchanged.',
+      'expected_content_hash must be a 64-character hexadecimal SHA-256 hash or "absent".',
+      'Read the page with get_page include_content:true and pass its content_hash unchanged; use "absent" only when creating a page that must not already exist.',
     );
   }
 
@@ -987,7 +991,8 @@ export async function importFromContent(
 
       const current = await tx.getPage(slug, txOpts);
       const actualHash = current?.content_hash ?? null;
-      if (actualHash !== opts.expectedContentHash) {
+      const expectedHash = opts.expectedContentHash === 'absent' ? null : opts.expectedContentHash;
+      if (actualHash !== expectedHash) {
         throw new OperationError(
           'write_conflict',
           `Page '${slug}' changed after it was read; refusing to overwrite newer content.`,

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -50,6 +50,7 @@ import { DEFAULT_SYNOPSIS_MODEL } from './page-summary.ts';
 import { runGuardrails } from './guardrails.ts';
 import { FACTS_FENCE_BEGIN, FACTS_FENCE_END, parseFactsFence, renderFactsTable, restoreHiddenFactRows, factsGapWarning } from './facts-fence.ts';
 import { scanFencedBlocks, MAX_FENCES_PER_PAGE } from './fence-scan.ts';
+import { OperationError } from './ops/contract.ts';
 
 /**
  * v0.20.0 Cathedral II Layer 8 D2 — markdown fence extraction helper.
@@ -369,6 +370,15 @@ export async function importFromContent(
      * and reindex leave it unset so the guard stays armed.
      */
     allowEmptyOverwrite?: boolean;
+    /**
+     * Optimistic concurrency guard for whole-page writers. When supplied, the
+     * write succeeds only if the page still has this content hash after the
+     * transaction-scoped page lock is acquired. Callers obtain the hash from
+     * get_page and retry the full read -> modify -> put cycle on conflict.
+     *
+     * Undefined preserves the legacy unconditional replace behavior.
+     */
+    expectedContentHash?: string;
   } = {},
 ): Promise<ImportResult> {
   // Normalize BEFORE any tx write: putPage lowercases via validateSlug but
@@ -650,6 +660,14 @@ export async function importFromContent(
   // mirrors that default instead of matching the slug in ANY source (the
   // unscoped-check/scoped-write bug class).
   const existing = await engine.getPage(slug, { sourceId: sourceId ?? 'default' });
+
+  if (opts.expectedContentHash !== undefined && !/^[a-f0-9]{64}$/i.test(opts.expectedContentHash)) {
+    throw new OperationError(
+      'invalid_params',
+      'expected_content_hash must be a 64-character hexadecimal SHA-256 hash.',
+      'Read the page with get_page include_content:true and pass its content_hash unchanged.',
+    );
+  }
 
   // #2044 / #4548: remote get_page/fetch intentionally strip non-'world'
   // facts rows before an untrusted caller ever sees them. A documented
@@ -952,6 +970,32 @@ export async function importFromContent(
   // for single-source callers.
   const txOpts = { sourceId: sourceId ?? 'default' };
   await engine.transaction(async (tx) => {
+    // Serialize competing writers for the same source + slug before checking
+    // the caller's observed hash. Postgres holds this advisory lock until the
+    // transaction commits. PGLite is single-process and its transaction is
+    // already serialized; engines/test doubles without advisory locks fall
+    // through to the in-transaction re-read.
+    if (opts.expectedContentHash !== undefined) {
+      try {
+        await tx.executeRaw(
+          `SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`,
+          [`put_page_cas:${sourceId ?? 'default'}:${slug}`],
+        );
+      } catch {
+        // Embedded engines do not need a cross-process advisory lock.
+      }
+
+      const current = await tx.getPage(slug, txOpts);
+      const actualHash = current?.content_hash ?? null;
+      if (actualHash !== opts.expectedContentHash) {
+        throw new OperationError(
+          'write_conflict',
+          `Page '${slug}' changed after it was read; refusing to overwrite newer content.`,
+          'Read the page again, reapply the intended mutation, and retry with the new content_hash.',
+        );
+      }
+    }
+
     if (existing) await tx.createVersion(slug, txOpts);
 
     // v0.29.1 — compute effective_date from frontmatter precedence chain.

--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -364,6 +364,7 @@ const put_page: Operation = {
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Complete markdown content with YAML frontmatter. REPLACES the entire page; this is not a partial edit. Read the canonical page first with `get_page include_content:true` before modifying it.' },
+    expected_content_hash: { type: 'string', required: false, description: 'Optimistic concurrency guard. Pass the exact content_hash returned by get_page; the write fails with write_conflict if another writer changed the page first.' },
     allow_empty: { type: 'boolean', required: false, description: 'Allow overwriting an existing non-empty page with empty/whitespace-only content (default: false). Without it, put_page rejects the empty overwrite — the empty-stdin failure class.' },
     // v0.39.3.0 provenance write-through (WARN-8 + A1 + CV6). Optional fields
     // for trusted local callers (capture CLI, autopilot, dream cycle). Remote
@@ -494,6 +495,9 @@ const put_page: Operation = {
       // (including frontmatter-only content the raw-content check above
       // can't see — the parsed body is blank even though content isn't).
       ...(p.allow_empty === true ? { allowEmptyOverwrite: true } : {}),
+      ...(typeof p.expected_content_hash === 'string'
+        ? { expectedContentHash: p.expected_content_hash }
+        : {}),
     });
 
     // The dedup pre-check in importFromContent can resolve the write to a

--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -364,7 +364,7 @@ const put_page: Operation = {
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Complete markdown content with YAML frontmatter. REPLACES the entire page; this is not a partial edit. Read the canonical page first with `get_page include_content:true` before modifying it.' },
-    expected_content_hash: { type: 'string', required: false, description: 'Optimistic concurrency guard. Pass the exact content_hash returned by get_page; the write fails with write_conflict if another writer changed the page first.' },
+    expected_content_hash: { type: 'string', required: false, description: 'Optimistic concurrency guard. Pass the exact content_hash returned by get_page, or "absent" for create-if-missing; the write fails with write_conflict if the page state changed first.' },
     allow_empty: { type: 'boolean', required: false, description: 'Allow overwriting an existing non-empty page with empty/whitespace-only content (default: false). Without it, put_page rejects the empty overwrite — the empty-stdin failure class.' },
     // v0.39.3.0 provenance write-through (WARN-8 + A1 + CV6). Optional fields
     // for trusted local callers (capture CLI, autopilot, dream cycle). Remote

--- a/test/cli-format-get-page-json.test.ts
+++ b/test/cli-format-get-page-json.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { formatResult } from '../src/cli.ts';
+
+describe('formatResult - get_page --json', () => {
+  const page = {
+    slug: 'ops/tasks',
+    type: 'note',
+    title: 'Tasks',
+    compiled_truth: '# Tasks',
+    timeline: '',
+    frontmatter: { status: 'active' },
+    tags: [],
+    content_hash: 'a'.repeat(64),
+    content: '---\nstatus: active\n---\n\n# Tasks\n',
+  };
+
+  test('returns the full machine-readable page including hash and content', () => {
+    expect(JSON.parse(formatResult('get_page', page, { json: true }))).toEqual(page);
+  });
+
+  test('keeps markdown as the default human output', () => {
+    const output = formatResult('get_page', page, {});
+    expect(output).toContain('# Tasks');
+    expect(output).not.toContain('content_hash');
+  });
+});

--- a/test/put-page-cas.test.ts
+++ b/test/put-page-cas.test.ts
@@ -92,4 +92,20 @@ describe('put_page expected_content_hash', () => {
       expected_content_hash: 'not-a-hash',
     })).rejects.toMatchObject({ code: 'invalid_params' });
   });
+
+  test('supports create-if-missing and rejects a second creator', async () => {
+    const first = await putPage.handler(ctx(), {
+      slug: 'ops/new-tasks',
+      content: page('Tasks', 'first'),
+      expected_content_hash: 'absent',
+    }) as { status: string };
+    expect(first.status).toBe('created_or_updated');
+
+    await expect(putPage.handler(ctx(), {
+      slug: 'ops/new-tasks',
+      content: page('Tasks', 'second'),
+      expected_content_hash: 'absent',
+    })).rejects.toMatchObject({ code: 'write_conflict' });
+    expect((await engine.getPage('ops/new-tasks', { sourceId: 'default' }))!.compiled_truth).toContain('first');
+  });
 });

--- a/test/put-page-cas.test.ts
+++ b/test/put-page-cas.test.ts
@@ -1,0 +1,95 @@
+/**
+ * put_page optimistic concurrency guard.
+ *
+ * Whole-page writers must not silently overwrite a mutation committed after
+ * their read. The caller supplies get_page.content_hash and retries the whole
+ * read -> modify -> put sequence when it receives write_conflict.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { operations, OperationError } from '../src/core/operations.ts';
+import type { OperationContext } from '../src/core/operations.ts';
+import { resetGateway } from '../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  resetGateway();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  resetGateway();
+});
+
+function ctx(): OperationContext {
+  return {
+    engine,
+    config: { engine: 'pglite' as const },
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+  };
+}
+
+const putPage = operations.find((o) => o.name === 'put_page')!;
+
+function page(title: string, body: string): string {
+  return `---\ntitle: ${title}\n---\n\n# ${title}\n\n${body}`;
+}
+
+describe('put_page expected_content_hash', () => {
+  test('accepts the current hash and writes the replacement', async () => {
+    await putPage.handler(ctx(), { slug: 'ops/tasks', content: page('Tasks', 'one') });
+    const observed = await engine.getPage('ops/tasks', { sourceId: 'default' });
+
+    const result = await putPage.handler(ctx(), {
+      slug: 'ops/tasks',
+      content: page('Tasks', 'two'),
+      expected_content_hash: observed!.content_hash,
+    }) as { status: string };
+
+    expect(result.status).toBe('created_or_updated');
+    expect((await engine.getPage('ops/tasks', { sourceId: 'default' }))!.compiled_truth).toContain('two');
+  });
+
+  test('rejects a stale hash without changing the page', async () => {
+    await putPage.handler(ctx(), { slug: 'ops/tasks', content: page('Tasks', 'one') });
+    const stale = (await engine.getPage('ops/tasks', { sourceId: 'default' }))!.content_hash;
+    await putPage.handler(ctx(), { slug: 'ops/tasks', content: page('Tasks', 'newer') });
+
+    let error: unknown;
+    try {
+      await putPage.handler(ctx(), {
+        slug: 'ops/tasks',
+        content: page('Tasks', 'stale overwrite'),
+        expected_content_hash: stale,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(OperationError);
+    expect((error as OperationError).code).toBe('write_conflict');
+    expect((await engine.getPage('ops/tasks', { sourceId: 'default' }))!.compiled_truth).toContain('newer');
+    expect((await engine.getPage('ops/tasks', { sourceId: 'default' }))!.compiled_truth).not.toContain('stale overwrite');
+  });
+
+  test('rejects malformed hashes before writing', async () => {
+    await expect(putPage.handler(ctx(), {
+      slug: 'ops/tasks',
+      content: page('Tasks', 'one'),
+      expected_content_hash: 'not-a-hash',
+    })).rejects.toMatchObject({ code: 'invalid_params' });
+  });
+});


### PR DESCRIPTION
## Summary

- add an expected-content-hash guard for whole-page writes
- document the CAS contract for task-page writers
- preserve removed task origins as tombstones so deleted tasks cannot reappear

## Why

Multiple operational writers can update one task page. Without compare-and-swap, a stale writer can overwrite a newer change, and without tombstones a removed task can be recreated from recent source history.

## Verification

Focused page/task tests and typecheck passed on the branch.