### PR TITLE
fix(upgrade): prevent stale migration recovery nags

### DIFF
--- a/src/commands/skillpack-check.ts
+++ b/src/commands/skillpack-check.ts
@@ -77,6 +77,47 @@ interface SkillpackReport {
   } | { error: string };
 }
 
+function parseSchemaStatus(stdout: string): 'current' | 'stale' | 'unknown' {
+  const match = stdout.match(/Database:\s*connected,\s*schema v(\d+)\s*\(latest (\d+)\)/i);
+  if (!match) return 'unknown';
+  return Number(match[1]) >= Number(match[2]) ? 'current' : 'stale';
+}
+
+function parseMigrationsOutput(stdout: string): Exclude<SkillpackReport['migrations'], { error: string }> {
+  const lines = stdout.split('\n');
+  let applied = 0;
+  let pending = 0;
+  let partial = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('Status') || trimmed.startsWith('---')) continue;
+    const first = trimmed.split(/\s+/)[0];
+    if (first === 'applied') applied++;
+    else if (first === 'pending') pending++;
+    else if (first === 'partial') partial++;
+  }
+
+  return {
+    applied_count: applied,
+    pending_count: pending,
+    partial_count: partial,
+    stdout,
+  };
+}
+
+function isProvenRedundantMigrationAction(
+  check: DoctorCheck,
+  action: string,
+  migrations: SkillpackReport['migrations'],
+): boolean {
+  return check.name === 'upgrade_errors'
+    && action === 'gbrain apply-migrations --yes'
+    && 'stdout' in migrations
+    && parseSchemaStatus(migrations.stdout) === 'current'
+    && migrations.pending_count === 0
+    && migrations.partial_count === 0;
+}
+
 function runDoctor(): SkillpackReport['doctor'] {
   const { cmd, prefix } = gbrainSpawn();
   try {
@@ -120,19 +161,7 @@ function runMigrationsList(): SkillpackReport['migrations'] {
     //     applied  0.11.0    ...
     //     pending  0.11.1    ...
     //     partial  0.10.0    ...
-    const lines = stdout.split('\n');
-    let applied = 0;
-    let pending = 0;
-    let partial = 0;
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('Status') || trimmed.startsWith('---')) continue;
-      const first = trimmed.split(/\s+/)[0];
-      if (first === 'applied') applied++;
-      else if (first === 'pending') pending++;
-      else if (first === 'partial') partial++;
-    }
-    return { applied_count: applied, pending_count: pending, partial_count: partial, stdout };
+    return parseMigrationsOutput(stdout);
   } catch (err: any) {
     return { error: `apply-migrations --list failed: ${err.message ?? String(err)}` };
   }
@@ -154,13 +183,21 @@ function buildReport(): SkillpackReport {
         // the `... Run: <cmd>` convention. Otherwise include the whole
         // message so the agent has enough to reason.
         const runMatch = check.message.match(/Run:\s*(.+)$/);
-        if (runMatch) actions.push(runMatch[1].trim());
+        if (runMatch) {
+          const action = runMatch[1].trim();
+          if (!isProvenRedundantMigrationAction(check, action, migrations)) actions.push(action);
+        }
         else actions.push(`[${check.name}] ${check.message}`);
       } else if (check.status === 'warn') {
         // Warnings don't fail the report but surface as informational
         // actions the agent can decide about.
         const runMatch = check.message.match(/Run:\s*(.+)$/);
-        if (runMatch && !actions.includes(runMatch[1].trim())) actions.push(runMatch[1].trim());
+        if (runMatch) {
+          const action = runMatch[1].trim();
+          if (!isProvenRedundantMigrationAction(check, action, migrations) && !actions.includes(action)) {
+            actions.push(action);
+          }
+        }
       }
     }
   } else {
@@ -268,4 +305,12 @@ function isSkillpackCheckSubcommand(): boolean {
 }
 
 /** Exported for unit tests. */
-export const __testing = { buildReport, runDoctor, runMigrationsList, gbrainSpawn };
+export const __testing = {
+  buildReport,
+  runDoctor,
+  runMigrationsList,
+  gbrainSpawn,
+  parseMigrationsOutput,
+  parseSchemaStatus,
+  isProvenRedundantMigrationAction,
+};

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -109,7 +109,7 @@ export async function runUpgrade(args: string[], opts: { targetVersion?: string 
         recordUpgradeError({
           phase: 'binary-self-update',
           fromVersion: oldVersion,
-          toVersion: '',
+          toVersion: opts.targetVersion ?? result.targetVersion ?? 'unknown',
           error: result.reason,
           hint: 'Integrity check failed; existing binary retained. Retry or download manually.',
         });
@@ -120,7 +120,7 @@ export async function runUpgrade(args: string[], opts: { targetVersion?: string 
         recordUpgradeError({
           phase: 'binary-self-update',
           fromVersion: oldVersion,
-          toVersion: '',
+          toVersion: opts.targetVersion ?? result.targetVersion ?? 'unknown',
           error: `${result.reason}${result.error ? `: ${result.error}` : ''}`,
           hint: 'Download from https://github.com/garrytan/gbrain/releases',
         });
@@ -286,7 +286,7 @@ function verifyUpgrade(): string {
 export function recordUpgradeError(record: {
   phase: string;
   fromVersion: string;
-  toVersion: string;
+  toVersion?: string;
   error: string;
   hint: string;
 }): void {
@@ -294,11 +294,12 @@ export function recordUpgradeError(record: {
     const dir = join(process.env.HOME || '', '.gbrain');
     mkdirSync(dir, { recursive: true });
     const path = join(dir, 'upgrade-errors.jsonl');
+    const targetVersion = normalizeUpgradeTargetVersion(record.toVersion);
     const line = JSON.stringify({
       ts: new Date().toISOString(),
       phase: record.phase,
       from_version: record.fromVersion,
-      to_version: record.toVersion,
+      to_version: targetVersion,
       error: record.error,
       hint: record.hint,
     }) + '\n';
@@ -307,6 +308,12 @@ export function recordUpgradeError(record: {
     // Recording errors is itself best-effort. The user will still see the
     // underlying failure in stdout/stderr from the original command.
   }
+}
+
+/** A missing/malformed target stays explicit and can never auto-resolve. */
+export function normalizeUpgradeTargetVersion(value?: string | null): string {
+  const clean = typeof value === 'string' ? value.trim().replace(/^v/, '') : '';
+  return parseSemver(clean) ? clean : 'unknown';
 }
 
 function saveUpgradeState(oldVersion: string, newVersion: string) {

--- a/src/core/binary-self-update.ts
+++ b/src/core/binary-self-update.ts
@@ -100,6 +100,8 @@ export interface BinarySelfUpdateResult {
   error?: string;
   /** Asset name resolved (when applicable). */
   asset?: string;
+  /** Release version resolved from GitHub, even when a later step fails. */
+  targetVersion?: string;
 }
 
 /** The release asset basename gbrain publishes for this platform/arch, or null
@@ -342,10 +344,11 @@ export async function runBinarySelfUpdate(
   if (!release) {
     return { ok: false, reason: 'fetch_failed', asset: assetName };
   }
+  const targetVersion = release.tag.replace(/^v/, '').trim();
 
   const url = resolvePlatformAsset(release.assets, platform, arch);
   if (!url) {
-    return { ok: false, reason: 'no_asset', asset: assetName };
+    return { ok: false, reason: 'no_asset', asset: assetName, targetVersion };
   }
 
   // Stage in a temp sibling so the rename is same-filesystem (atomic).
@@ -354,7 +357,7 @@ export async function runBinarySelfUpdate(
     await download(url, staged);
   } catch (e) {
     safeUnlink(staged);
-    return { ok: false, reason: 'download_failed', error: errMsg(e), asset: assetName };
+    return { ok: false, reason: 'download_failed', error: errMsg(e), asset: assetName, targetVersion };
   }
 
   // Integrity BEFORE chmod/exec: never make an unverified binary executable and
@@ -362,38 +365,38 @@ export async function runBinarySelfUpdate(
   const integrityFailure = await verifyIntegrity(staged, assetName, computeDigest, fetchAttestation);
   if (integrityFailure) {
     safeUnlink(staged);
-    return { ok: false, reason: integrityFailure, asset: assetName };
+    return { ok: false, reason: integrityFailure, asset: assetName, targetVersion };
   }
 
   try {
     chmodSync(staged, 0o755);
   } catch (e) {
     safeUnlink(staged);
-    return { ok: false, reason: 'download_failed', error: errMsg(e), asset: assetName };
+    return { ok: false, reason: 'download_failed', error: errMsg(e), asset: assetName, targetVersion };
   }
 
   if (!smoke(staged)) {
     safeUnlink(staged);
-    return { ok: false, reason: 'smoke_failed', asset: assetName };
+    return { ok: false, reason: 'smoke_failed', asset: assetName, targetVersion };
   }
 
   // Downgrade-replay guard: the staged binary must actually be the release it
   // claims. A swapped asset serving an older, still-validly-attested binary
   // clears digest+builder but reports the wrong version here.
-  const expectedVersion = release.tag.replace(/^v/, '').trim();
+  const expectedVersion = targetVersion;
   if (expectedVersion && !checkVersion(staged, expectedVersion)) {
     safeUnlink(staged);
-    return { ok: false, reason: 'version_mismatch', asset: assetName };
+    return { ok: false, reason: 'version_mismatch', asset: assetName, targetVersion };
   }
 
   try {
     renameSync(staged, targetPath); // atomic on same fs; old binary intact if this throws
   } catch (e) {
     safeUnlink(staged);
-    return { ok: false, reason: 'replace_failed', error: errMsg(e), asset: assetName };
+    return { ok: false, reason: 'replace_failed', error: errMsg(e), asset: assetName, targetVersion };
   }
 
-  return { ok: true, asset: assetName };
+  return { ok: true, asset: assetName, targetVersion };
 }
 
 function safeUnlink(path: string): void {

--- a/test/binary-self-update.test.ts
+++ b/test/binary-self-update.test.ts
@@ -81,6 +81,7 @@ describe('runBinarySelfUpdate', () => {
       });
       expect(res.ok).toBe(true);
       expect(res.asset).toBe('gbrain-darwin-arm64');
+      expect(res.targetVersion).toBe('9.9.9');
       expect(readFileSync(target, 'utf8')).toBe('NEW BINARY');
     });
   });
@@ -124,6 +125,7 @@ describe('runBinarySelfUpdate', () => {
         fetchRelease: async () => ({ tag: 'v9.9.9', assets: [] }),
       });
       expect(res.reason).toBe('no_asset');
+      expect(res.targetVersion).toBe('9.9.9');
       expect(readFileSync(target, 'utf8')).toBe('OLD');
     });
   });
@@ -141,6 +143,7 @@ describe('runBinarySelfUpdate', () => {
         },
       });
       expect(res.reason).toBe('download_failed');
+      expect(res.targetVersion).toBe('9.9.9');
       expect(res.error).toContain('disk full');
       expect(readFileSync(target, 'utf8')).toBe('OLD');
     });

--- a/test/doctor-upgrade-errors-stale.test.ts
+++ b/test/doctor-upgrade-errors-stale.test.ts
@@ -41,5 +41,7 @@ describe('upgradeErrorResolved (#4517)', () => {
     expect(upgradeErrorResolved('garbage', '0.46.28.0', true)).toBe(false);
     expect(upgradeErrorResolved('0.46.10.0', 'garbage', true)).toBe(false);
     expect(upgradeErrorResolved(undefined as unknown as string, '0.46.28.0', true)).toBe(false);
+    expect(upgradeErrorResolved('', '0.46.28.0', true)).toBe(false);
+    expect(upgradeErrorResolved('unknown', '0.46.28.0', true)).toBe(false);
   });
 });

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -171,3 +171,50 @@ describe('gbrainSpawn — argv[1] vs execPath resolution (#4094)', () => {
     expect(prefix).toEqual([]);
   });
 });
+
+describe('upgrade-error migration action reconciliation', () => {
+  const upgradeWarning = {
+    name: 'upgrade_errors',
+    status: 'warn' as const,
+    message: 'Recovery: Run: gbrain apply-migrations --yes',
+  };
+
+  test('suppresses duplicate migration action only when live DB proves schema current', () => {
+    const migrations = __testing.parseMigrationsOutput(
+      'Installed gbrain version: 0.48.1.0\nDatabase: connected, schema v145 (latest 145)\n\nAll migrations up to date.\n',
+    );
+    expect(__testing.parseSchemaStatus(migrations.stdout)).toBe('current');
+    expect(__testing.isProvenRedundantMigrationAction(
+      upgradeWarning,
+      'gbrain apply-migrations --yes',
+      migrations,
+    )).toBe(true);
+  });
+
+  test('unknown or stale schema remains fail-closed and actionable', () => {
+    const unknown = __testing.parseMigrationsOutput(
+      'Installed gbrain version: 0.48.1.0\nDatabase: UNREACHABLE (timeout)\n',
+    );
+    const stale = __testing.parseMigrationsOutput(
+      'Installed gbrain version: 0.48.1.0\nDatabase: connected, schema v144 (latest 145)\n',
+    );
+    for (const migrations of [unknown, stale]) {
+      expect(__testing.isProvenRedundantMigrationAction(
+        upgradeWarning,
+        'gbrain apply-migrations --yes',
+        migrations,
+      )).toBe(false);
+    }
+  });
+
+  test('pending or partial orchestrator work preserves the action even with current schema', () => {
+    const migrations = __testing.parseMigrationsOutput(
+      'Database: connected, schema v145 (latest 145)\npartial 0.48.1 Pending host work\n',
+    );
+    expect(__testing.isProvenRedundantMigrationAction(
+      upgradeWarning,
+      'gbrain apply-migrations --yes',
+      migrations,
+    )).toBe(false);
+  });
+});

--- a/test/upgrade.serial.test.ts
+++ b/test/upgrade.serial.test.ts
@@ -37,6 +37,18 @@ describe('upgrade command', () => {
   });
 });
 
+describe('upgrade error target normalization', () => {
+  test('blank and malformed targets become an explicit unknown sentinel', () => {
+    expect(upgradeModule.normalizeUpgradeTargetVersion('')).toBe('unknown');
+    expect(upgradeModule.normalizeUpgradeTargetVersion(undefined)).toBe('unknown');
+    expect(upgradeModule.normalizeUpgradeTargetVersion('garbage')).toBe('unknown');
+  });
+
+  test('valid targets are normalized without the v prefix', () => {
+    expect(upgradeModule.normalizeUpgradeTargetVersion('v0.48.1.0')).toBe('0.48.1.0');
+  });
+});
+
 describe('detectInstallMethod heuristic (source analysis)', () => {
   // Read the source and verify the detection order is correct
   const { readFileSync } = require('fs');


### PR DESCRIPTION
## Summary

- retain the resolved release target when a binary self-update fails after release discovery
- record unknown targets explicitly instead of a blank version
- suppress a stale apply-migrations recovery action only when live migration output proves the schema is current with no pending or partial work
- remain fail-closed when the database state is unavailable or stale

## Verification

- bun run typecheck
- bun run verify: 54/54 checks green
- focused upgrade, doctor, and skillpack tests green