### PR TITLE
fix(cycle): commit lint repairs in hardened brains

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -505,6 +505,8 @@ export interface LintOpts {
    * CLI can size its progress bar without walking the tree a second time.
    */
   onPagesCollected?: (count: number) => void;
+  /** Hardened corpus root whose exact lint-fixed pages should be committed. */
+  durabilityRoot?: string;
 }
 
 export interface LintResult {
@@ -544,6 +546,17 @@ export async function runLintCore(opts: LintOpts): Promise<LintResult> {
   const contentSanity = opts.contentSanity ?? await resolveLintContentSanity(opts.engine);
   const lintOpts: LintContentOpts = { contentSanity };
 
+  let commitFixedPage: ((page: string) => void) | undefined;
+  if (opts.durabilityRoot && !opts.dryRun) {
+    const { commitWriteThroughFile, isDurabilityHardened } = await import('../core/brain-repo-durability.ts');
+    if (isDurabilityHardened(opts.durabilityRoot)) {
+      commitFixedPage = (page) => {
+        const slug = relative(opts.durabilityRoot!, page).replace(/\.md$/u, '');
+        commitWriteThroughFile(opts.durabilityRoot!, page, slug);
+      };
+    }
+  }
+
   let totalIssues = 0;
   let totalFixable = 0;
   let totalFixed = 0;
@@ -576,6 +589,7 @@ export async function runLintCore(opts: LintOpts): Promise<LintResult> {
         totalFixed += fixCount;
         if (!opts.dryRun) {
           writeFileSync(page, fixed);
+          commitFixedPage?.(page);
         }
       }
     }

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1052,7 +1052,7 @@ export async function runPhaseLint(brainDir: string, dryRun: boolean, engine?: B
     // competing module-style engine that nulls the shared db singleton
     // mid-cycle (which broke every phase after lint with a misleading
     // "connect() has not been called").
-    const result = await runLintCore({ target: brainDir, fix: true, dryRun, engine: engine ?? undefined, signal });
+    const result = await runLintCore({ target: brainDir, fix: true, dryRun, engine: engine ?? undefined, signal, durabilityRoot: brainDir });
     const issues = result.total_issues ?? 0;
     const fixed = result.total_fixed ?? 0;
     const remaining = Math.max(0, issues - fixed);

--- a/test/cycle-lint-durability.test.ts
+++ b/test/cycle-lint-durability.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { runPhaseLint } from '../src/core/cycle.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('cycle lint durability', () => {
+  test('a hardened corpus commits exactly the page lint fixed', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-cycle-lint-durability-'));
+    roots.push(root);
+    const page = join(root, 'note.md');
+    writeFileSync(
+      page,
+      `---\ntype: note\ntitle: Durable\nstatus: active\ningested_at: '2026-08-30T12:00:00Z'\n---\n\nBody.\n`,
+    );
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    execFileSync('git', ['add', '--', 'note.md'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'initial'], { cwd: root });
+
+    const hook = join(root, '.git', 'hooks', 'post-commit');
+    mkdirSync(join(root, '.git', 'hooks'), { recursive: true });
+    writeFileSync(
+      hook,
+      '#!/bin/sh\n# gbrain brain-durability post-commit hook (v0.42.44+)\nexit 0\n',
+    );
+    chmodSync(hook, 0o755);
+
+    const result = await runPhaseLint(root, false, null);
+
+    expect(result.status).toBe('ok');
+    expect(result.details?.fixed).toBe(1);
+    expect(execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' })).toBe('');
+    expect(execFileSync('git', ['log', '-1', '--format=%s'], { cwd: root, encoding: 'utf8' }).trim())
+      .toBe('gbrain: write-through note');
+  });
+});


### PR DESCRIPTION
## Summary

When the cycle repairs a page through lint --fix in a durability-hardened corpus, commit that exact repaired page through the existing write-through helper.

This closes the gap where the database reflected a repair but the protected Git corpus retained an uncommitted mutation. Dry runs and non-hardened corpora are unchanged.

## Verification

- cycle lint durability regression test green
- bun run typecheck green