### PR TITLE
fix(routing-eval): don't strip non-Latin scripts in normalizeText

### DIFF
--- a/src/core/routing-eval.ts
+++ b/src/core/routing-eval.ts
@@ -84,7 +84,7 @@ export interface RoutingCaseResult {
 /**
  * Normalize a string for routing comparison:
  *   - lowercase
- *   - replace any non-alphanumeric char with a space
+ *   - replace any non-letter/non-number char with a space
  *   - collapse whitespace
  *   - trim
  *
@@ -94,10 +94,21 @@ export interface RoutingCaseResult {
  * a routing match should do. The cost is slightly over-permissive
  * matching; the benefit is reliable matches across quote/punctuation
  * variants that agents emit in practice.
+ *
+ * The character class is `\p{L}\p{N}` (any Unicode letter or number),
+ * not `a-z0-9`. An ASCII-only class silently drops every non-Latin
+ * script — Korean, Chinese, Japanese, Cyrillic, etc. all collapse to an
+ * empty string, so a skill with only non-English triggers can never
+ * match any intent through this checker, no matter how the trigger is
+ * worded. GBrain otherwise treats CJK/multi-language support as a first-
+ * class concern (see docs/guides/multi-language-fts.md and the CJK
+ * chunking/extraction work), so routing was the one place that support
+ * didn't reach. `\p{L}`/`\p{N}` need the `u` (unicode) flag to be
+ * interpreted as Unicode property escapes rather than literal `p{L}`.
  */
 export function normalizeText(s: string): string {
   if (!s) return '';
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+  return s.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').trim();
 }
 
 /**

--- a/test/routing-eval.test.ts
+++ b/test/routing-eval.test.ts
@@ -72,6 +72,21 @@ describe('normalizeText', () => {
     expect(normalizeText('')).toBe('');
     expect(normalizeText('   !!  ')).toBe('');
   });
+  it('preserves Korean text instead of stripping it to nothing', () => {
+    expect(normalizeText('한국어 문장 다듬어줘')).toBe('한국어 문장 다듬어줘');
+  });
+  it('preserves Chinese and Japanese text', () => {
+    expect(normalizeText('中文测试')).toBe('中文测试');
+    expect(normalizeText('日本語のテスト')).toBe('日本語のテスト');
+  });
+  it('still strips punctuation from non-Latin scripts', () => {
+    expect(normalizeText('한국어, 다듬어줘!')).toBe('한국어 다듬어줘');
+  });
+  it('a non-English trigger still substring-matches a non-English intent', () => {
+    const index = { skillPhrases: new Map([['fluent-korean', ['한국어 다듬']]]) };
+    const result = structuralRouteMatch('이거 한국어 다듬어줄 수 있어?', index);
+    expect(result.matched).toEqual(['fluent-korean']);
+  });
 });
 
 describe('extractTriggerPhrases', () => {


### PR DESCRIPTION
## Summary

- `normalizeText()` in `src/core/routing-eval.ts` stripped anything outside `[a-z0-9]` when normalizing text for trigger/intent comparison. Korean, Chinese, Japanese, Cyrillic, etc. all collapse to an empty string under that regex, so a skill with non-English triggers can never match any intent through `check-resolvable`'s routing-eval checker — no amount of trigger rewording fixes it, since the normalization itself discards the text before comparison ever happens.
- Swapped the character class to `\p{L}\p{N}` (Unicode letter/number properties, `u` flag) — same punctuation/whitespace stripping behavior, but preserves any script.
- Found this while building a Korean-language gbrain skill: every English routing-eval fixture matched fine, every Korean one silently reported "no matches" even with the exact trigger substring present in the intent.
- GBrain already treats CJK/multi-language as a first-class concern elsewhere (`docs/guides/multi-language-fts.md`, CJK-aware chunking (#3477, #3564, #2847, #114) and entity extraction (#1637)) — this brings the routing-eval checker in line with that rather than leaving it as an unintentional gap.

## Test plan

- [x] Added regression tests to `test/routing-eval.test.ts`: Korean/Chinese/Japanese text is preserved by `normalizeText`, punctuation is still stripped from non-Latin scripts, and `structuralRouteMatch` now correctly matches a Korean trigger against a Korean intent.
- [x] `bun test test/routing-eval.test.ts` — 39 pass, 0 fail (existing ASCII/punctuation-stripping behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)