### PR TITLE
fix(ai): pass output dimensions for Gemini embeddings over OpenRouter

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -343,6 +343,18 @@ export function dimsProviderOptions(
       if (matchId === 'text-embedding-v3' || matchId === 'embedding-3') {
         return { openaiCompatible: { dimensions: dims } };
       }
+      // Gemini embedding models on OpenRouter return 3072 dimensions when
+      // the parameter is omitted, so reduced-width brains must send it.
+      if (bareModelId.startsWith('gemini-embedding')) {
+        if (!Number.isInteger(dims) || dims < 1 || dims > 3072) {
+          throw new AIConfigError(
+            `Gemini model "${modelId}" supports embedding_dimensions in 1..3072, got ${dims}.`,
+            `Set \`embedding_dimensions\` to a value between 1 and 3072 in your gbrain config.`,
+          );
+        }
+        if (dims === 3072) return undefined;
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // Qwen3-Embedding family on Ollama (and any other openai-compatible
       // provider serving it) supports Matryoshka truncation via `dimensions`.
       // Native sizes: 0.6B=1024, 4B=2560, 8B=4096. Without `dimensions`,

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -214,8 +214,23 @@ describe('dims.dimsProviderOptions', () => {
   });
 
   test('Google gemini-embedding returns outputDimensionality', () => {
-    const opts = dimsProviderOptions('native-google', 'gemini-embedding-001', 768);
-    expect(opts).toEqual({ google: { outputDimensionality: 768 } });
+    const opts = dimsProviderOptions('native-google', 'gemini-embedding-001', 1024);
+    expect(opts).toEqual({ google: { outputDimensionality: 1024 } });
+  });
+
+  test('OpenRouter Gemini embedding returns dimensions for a reduced width', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'google/gemini-embedding-001', 1024);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('OpenRouter Gemini embedding omits dimensions at the native width', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'google/gemini-embedding-001', 3072);
+    expect(opts).toBeUndefined();
+  });
+
+  test('OpenRouter Gemini embedding rejects dimensions outside 1..3072', () => {
+    expect(() => dimsProviderOptions('openai-compatible', 'google/gemini-embedding-001', 3073))
+      .toThrow(AIConfigError);
   });
 
   test('Anthropic returns undefined (no embedding model)', () => {


### PR DESCRIPTION
Gemini embedding models on OpenRouter return **3072 dimensions** when the
output-dimension parameter is omitted. A brain configured for a narrower
embedding width silently received 3072-wide vectors, which then fail to match
the column the brain actually stores.

**What this changes**

`src/core/ai/dims.ts` now forwards the configured embedding dimensions for
`gemini-embedding*` model ids, and validates the value up front: the supported
range is 1..3072, and anything outside it raises `AIConfigError` with the
model id and the offending value rather than failing later at insert time.

**Tests**

`test/ai/gateway.test.ts` — 41 pass / 0 fail. `bun run typecheck` clean.

This commit was previously bundled inside a larger branch; it is split out here
because it is an independent fix and reviews on its own.
