### PR TITLE
feat(memory): let remember stamp session_id so recall{session_id} can find the fact

### DIFF
--- a/src/core/verbs.ts
+++ b/src/core/verbs.ts
@@ -95,6 +95,11 @@ const remember: Operation = {
       description:
         'world (default): readable by every agent connected to this brain — required for the remote remember→recall round-trip. private: local CLI reads only.',
     },
+    session_id: {
+      type: 'string',
+      description:
+        'Opaque id of the session that captured this fact. Later, recall{session_id} returns only facts captured in that session. Omit = null.',
+    },
   },
   mutating: true,
   scope: 'write',
@@ -158,6 +163,7 @@ const remember: Operation = {
     // subjectless statements, and resolving them would file the fact under
     // a non-existent entity_slug no lookup can reach.
     const entityParam = typeof p.entity === 'string' ? p.entity.trim() : null;
+    const sessionId = typeof p.session_id === 'string' ? p.session_id.trim() || null : null;
     const result = await writeSingleFact(ctx.engine, ctx.sourceId ?? 'default', {
       fact,
       provenance,
@@ -165,6 +171,7 @@ const remember: Operation = {
       entity: entityParam && !isNullLikeEntity(entityParam) ? entityParam : null,
       visibility,
       validUntil,
+      sessionId,
     });
 
     const statusText =

--- a/test/memory-verbs-conformance.test.ts
+++ b/test/memory-verbs-conformance.test.ts
@@ -9,7 +9,7 @@
  *   - query-arm keyword degradation (never an error without embeddings)
  *   - remember contract: provenance_required, ttl forms (P30D trap), enum
  *     kinds, world default + the remote remember→recall round-trip [F2],
- *     private facts hidden from remote readers
+ *     session-scoped writes, private facts hidden from remote readers
  *   - entity: card shape vs RESPONSE_SCHEMAS, three resolution arms,
  *     miss→suggestions, ZERO-LLM guard (chat transport rigged to throw)
  *   - synthesize: [EXPENSIVE prefix, annotations, clean `unavailable` with
@@ -267,6 +267,40 @@ describe('remember — contract behavior', () => {
     const texts = body.facts.map((f: { fact: string }) => f.fact).join('|');
     expect(texts).toContain('world-visible round-trip fact');
     expect(texts).not.toContain('PRIVATE-SENTINEL');
+  });
+
+  it('stamps session_id for session-scoped recall while omitted session_id stays null and excluded', async () => {
+    const sessionId = 'remember-session-positive';
+    const positiveFact = 'session-scoped remember positive fact';
+    const negativeFact = 'session-less remember negative control fact';
+
+    const positive = await callRemote('remember', {
+      fact: positiveFact,
+      provenance: 'session regression test',
+      session_id: `  ${sessionId}  `,
+    });
+    const negative = await callRemote('remember', {
+      fact: negativeFact,
+      provenance: 'session regression test',
+    });
+    expect(positive.isError).toBe(false);
+    expect(negative.isError).toBe(false);
+
+    const rows = await engine.executeRaw<{ fact: string; source_session: string | null }>(
+      `SELECT fact, source_session
+         FROM facts
+        WHERE fact IN ($1, $2)
+        ORDER BY fact`,
+      [positiveFact, negativeFact],
+    );
+    expect(rows).toContainEqual({ fact: positiveFact, source_session: sessionId });
+    expect(rows).toContainEqual({ fact: negativeFact, source_session: null });
+
+    const recalled = await callRemote('recall', { session_id: sessionId });
+    expect(recalled.isError).toBe(false);
+    const recalledFacts = recalled.body.facts.map((f: { fact: string }) => f.fact);
+    expect(recalledFacts).toContain(positiveFact);
+    expect(recalledFacts).not.toContain(negativeFact);
   });
 });
 


### PR DESCRIPTION
`recall` documents a `session_id` filter — *"Returns facts captured in that
session"* — and the plumbing behind it already exists: `facts.source_session`
is a column, and `writeSingleFact` accepts `sessionId` and writes it.

What was missing is the connection. The `remember` op exposed no `session_id`
param, so every fact written through it landed with `source_session` NULL and
could never be returned by `recall{session_id}`. The documented filter worked
only for facts created by the LLM extraction path.

**What this changes**

`src/core/verbs.ts`: `remember` gains an optional `session_id`, and the handler
forwards it to `writeSingleFact`. Empty strings are treated as omitted, matching
how the other optional params behave. Three lines of wiring — no new plumbing.

**Tests**

`test/memory-verbs-conformance.test.ts` — 37 pass / 0 fail. The new case covers
both directions:

- a fact remembered **with** `session_id` is stamped and comes back from
  `recall({ session_id })`
- a fact remembered **without** one is stamped NULL and is *excluded* from that
  same recall

The negative half matters: without it the test would pass even if `recall`
returned everything regardless of the filter.

`bun run typecheck` and `bun run check:module-size` clean.
