### PR TITLE
fix(cycle): serialize destructive fact reconciliation under the page lock and refuse it on a stale page cache

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -53,6 +53,8 @@
  * backlog through the sanctioned removal path instead of raw SQL.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+
 import type { BrainEngine } from '../engine.ts';
 import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede-resolve.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
@@ -70,6 +72,9 @@ import {
 } from './phantom-redirect.ts';
 import { embed, isAvailable } from '../ai/gateway.ts';
 import { isAborted } from '../abort-check.ts';
+import { parseMarkdown } from '../markdown.ts';
+import { resolvePageWriteTarget } from '../write-through.ts';
+import { withPageLock } from '../page-lock.ts';
 
 interface ExistingPageFact {
   // v0.46 (#3014) — the row's own fact id. Read so the supersession-drift
@@ -100,6 +105,61 @@ function dedupeFactsByContentKey(facts: FenceExtractedFact[]): FenceExtractedFac
     deduped.push(fact);
   }
   return deduped;
+}
+
+/**
+ * Destructive reconciliation may only trust the pages-table body when it
+ * still matches the canonical Markdown file. The fact writer deliberately
+ * commits Markdown first and then stamps the facts index, while page sync is
+ * asynchronous. In that gap a sweep can observe the old pages.compiled_truth
+ * plus the new fact row and otherwise delete the new row as "stale".
+ *
+ * `unavailable` preserves the existing DB-only/thin-client behaviour. A local
+ * canonical file that exists but cannot be read is fail-closed: destructive
+ * cleanup waits for a healthy sync/read instead of guessing that the cache is
+ * authoritative.
+ */
+async function canonicalCacheState(
+  engine: BrainEngine,
+  slug: string,
+  sourceId: string,
+  cachedCompiledTruth: string,
+  cachedTimeline: string,
+): Promise<'fresh' | 'stale' | 'unavailable'> {
+  const target = await resolvePageWriteTarget(engine, slug, sourceId);
+  if (!target.ok || !existsSync(target.filePath)) return 'unavailable';
+  try {
+    const canonical = parseMarkdown(readFileSync(target.filePath, 'utf-8'), target.filePath);
+    return canonical.compiled_truth === cachedCompiledTruth.trim()
+      && canonical.timeline === cachedTimeline.trim()
+      ? 'fresh'
+      : 'stale';
+  } catch {
+    return 'stale';
+  }
+}
+
+async function refuseDestructiveReconcileOnStaleCache(
+  engine: BrainEngine,
+  slug: string,
+  sourceId: string,
+  cachedCompiledTruth: string,
+  cachedTimeline: string,
+  warnings: string[],
+): Promise<boolean> {
+  const state = await canonicalCacheState(
+    engine,
+    slug,
+    sourceId,
+    cachedCompiledTruth,
+    cachedTimeline,
+  );
+  if (state !== 'stale') return false;
+  warnings.push(
+    `${slug}: FACTS_PAGE_CACHE_STALE: canonical Markdown differs from the pages cache; ` +
+    'refusing destructive fact reconciliation until gbrain sync refreshes the page index.',
+  );
+  return true;
 }
 
 /**
@@ -167,6 +227,8 @@ export interface ExtractFactsOpts {
    * under the worker's 30s force-evict instead of running to completion.
    */
   signal?: AbortSignal;
+  /** Override the shared page-lock directory for deterministic tests. */
+  pageLockRoot?: string;
 }
 
 export interface ExtractFactsResult {
@@ -524,19 +586,34 @@ export async function runExtractFacts(
 
     if (extracted.length === 0) {
       if (existing.length > 0) {
-        // The delete targets source_markdown_slug = slug only, so
-        // NULL-source_markdown_slug legacy rows survive (the
-        // partial-UNIQUE-index keyspace). #1928: `cli:`-origin facts
-        // (conversation facts from extract-conversation-facts) are NOT
-        // fence-owned — the page carries no `## Facts` fence to recreate
-        // them — so they MUST survive this reconcile. #2646: soft-expired
-        // legacy rows (forget_fact's record of the forget) likewise
-        // survive via preserveExpiredLegacy.
-        const deleted = await engine.deleteFactsForPage(slug, sourceId, {
-          excludeSourcePrefixes: ['cli:'],
-          preserveExpiredLegacy: true,
-        });
-        result.factsDeleted += deleted.deleted;
+        const deletion = await withPageLock(slug, async () => {
+          if (await refuseDestructiveReconcileOnStaleCache(
+            engine,
+            slug,
+            sourceId,
+            page.compiled_truth ?? '',
+            page.timeline ?? '',
+            result.warnings,
+          )) {
+            return null;
+          }
+          // The delete targets source_markdown_slug = slug only, so
+          // NULL-source_markdown_slug legacy rows survive (the
+          // partial-UNIQUE-index keyspace). #1928: `cli:`-origin facts
+          // (conversation facts from extract-conversation-facts) are NOT
+          // fence-owned — the page carries no `## Facts` fence to recreate
+          // them — so they MUST survive this reconcile. #2646: soft-expired
+          // legacy rows (forget_fact's record of the forget) likewise
+          // survive via preserveExpiredLegacy.
+          return engine.deleteFactsForPage(slug, sourceId, {
+            excludeSourcePrefixes: ['cli:'],
+            preserveExpiredLegacy: true,
+          });
+        }, { lockRoot: opts.pageLockRoot });
+        if (!deletion) {
+          continue;
+        }
+        result.factsDeleted += deletion.deleted;
       }
       continue;
     }
@@ -670,11 +747,27 @@ export async function runExtractFacts(
 
     if (toInsert.length === 0) continue;
 
-    const inserted = await engine.insertFacts( // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
+    const insert = () => engine.insertFacts( // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
       toInsert,
       { source_id: sourceId },
       deleteForPageFirst ? { deleteForPageFirst } : undefined,
     );
+    const inserted = deleteForPageFirst
+      ? await withPageLock(slug, async () => {
+        if (await refuseDestructiveReconcileOnStaleCache(
+          engine,
+          slug,
+          sourceId,
+          page.compiled_truth ?? '',
+          page.timeline ?? '',
+          result.warnings,
+        )) {
+          return null;
+        }
+        return insert();
+      }, { lockRoot: opts.pageLockRoot })
+      : await insert();
+    if (!inserted) continue;
     result.factsInserted += inserted.inserted;
     // v0.46 (#3014) — the wipe (when needed) ran inside insertFacts' txn;
     // count it here from the atomic result rather than a separate delete.

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -10,10 +10,14 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExtractFacts } from '../src/core/cycle/extract-facts.ts';
 import { parseFactsFence } from '../src/core/facts-fence.ts';
 import { importFromContent } from '../src/core/import-file.ts';
+import { acquirePageLock } from '../src/core/page-lock.ts';
 
 let engine: PGLiteEngine;
 
@@ -204,6 +208,163 @@ describe('runExtractFacts — happy path', () => {
     );
     expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Existing', 'New']);
   });
+
+  test('refuses destructive reconcile when canonical Markdown is newer than the pages cache', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-facts-stale-cache-'));
+    try {
+      // Point the default source at a real canonical tree for this case.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+        [root],
+      );
+
+      const cachedBody = FACT_FENCE(
+        `| 1 | Existing | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+      );
+      const canonicalBody = FACT_FENCE(
+        `| 1 | Existing | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | Newly remembered | event | 1.0 | world | medium | 2026-09-02 |  | remember:test |  |`,
+      );
+      await putPage('people/alice', cachedBody);
+      await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+      // Reproduce the real ordering: remember writes canonical Markdown and
+      // stamps the new facts row before page sync refreshes compiled_truth.
+      mkdirSync(join(root, 'people'), { recursive: true });
+      writeFileSync(join(root, 'people', 'alice.md'), canonicalBody, 'utf-8');
+      await engine.insertFacts(
+        [{
+          fact: 'Newly remembered',
+          kind: 'event',
+          source: 'remember:test',
+          row_num: 2,
+          source_markdown_slug: 'people/alice',
+        }],
+        { source_id: 'default' },
+      );
+
+      const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+      expect(r.factsDeleted).toBe(0);
+      expect(r.factsInserted).toBe(0);
+      expect(r.warnings).toContainEqual(expect.stringContaining('FACTS_PAGE_CACHE_STALE'));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = await (engine as any).db.query(
+        `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+      );
+      expect(rows.rows.map((row: { fact: string }) => row.fact))
+        .toEqual(['Existing', 'Newly remembered']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('page lock closes the empty-fence delete race with a concurrent canonical writer', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-facts-empty-race-'));
+    const lockRoot = join(root, '.locks');
+    const slug = 'people/empty-race';
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+        [root],
+      );
+      await putPage(slug, '');
+      await engine.insertFacts(
+        [{ fact: 'Previously indexed', kind: 'fact', source: 'old', row_num: 1, source_markdown_slug: slug }],
+        { source_id: 'default' },
+      );
+
+      const held = await acquirePageLock(slug, { lockRoot });
+      expect(held).not.toBeNull();
+      let settled = false;
+      const reconcile = runExtractFacts(engine, { slugs: [slug], pageLockRoot: lockRoot })
+        .finally(() => { settled = true; });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settled).toBe(false);
+
+      const canonicalBody = FACT_FENCE(
+        `| 1 | Previously indexed | fact | 1.0 | world | medium | 2026-01-01 |  | old |  |\n` +
+        `| 2 | Concurrent remember | event | 1.0 | world | medium | 2026-09-02 |  | remember:test |  |`,
+      );
+      mkdirSync(join(root, 'people'), { recursive: true });
+      writeFileSync(join(root, 'people', 'empty-race.md'), canonicalBody, 'utf-8');
+      await engine.insertFacts(
+        [{ fact: 'Concurrent remember', kind: 'event', source: 'remember:test', row_num: 2, source_markdown_slug: slug }],
+        { source_id: 'default' },
+      );
+      await held!.release();
+
+      const r = await reconcile;
+      expect(r.factsDeleted).toBe(0);
+      expect(r.warnings).toContainEqual(expect.stringContaining('FACTS_PAGE_CACHE_STALE'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = await (engine as any).db.query(
+        `SELECT fact FROM facts WHERE source_markdown_slug = $1 ORDER BY row_num`,
+        [slug],
+      );
+      expect(rows.rows.map((row: { fact: string }) => row.fact))
+        .toEqual(['Previously indexed', 'Concurrent remember']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test('page lock closes the transactional drift-replace race with a concurrent canonical writer', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-facts-drift-race-'));
+    const lockRoot = join(root, '.locks');
+    const slug = 'people/drift-race';
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+        [root],
+      );
+      const cachedBody = FACT_FENCE(
+        `| 1 | Canonical cached | fact | 1.0 | world | medium | 2026-01-01 |  | cached |  |`,
+      );
+      await putPage(slug, cachedBody);
+      await engine.insertFacts(
+        [{ fact: 'Stale indexed row', kind: 'fact', source: 'stale', row_num: 1, source_markdown_slug: slug }],
+        { source_id: 'default' },
+      );
+
+      const held = await acquirePageLock(slug, { lockRoot });
+      expect(held).not.toBeNull();
+      let settled = false;
+      const reconcile = runExtractFacts(engine, { slugs: [slug], pageLockRoot: lockRoot })
+        .finally(() => { settled = true; });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settled).toBe(false);
+
+      const canonicalBody = FACT_FENCE(
+        `| 1 | Canonical cached | fact | 1.0 | world | medium | 2026-01-01 |  | cached |  |\n` +
+        `| 2 | Concurrent remember | event | 1.0 | world | medium | 2026-09-02 |  | remember:test |  |`,
+      );
+      mkdirSync(join(root, 'people'), { recursive: true });
+      writeFileSync(join(root, 'people', 'drift-race.md'), canonicalBody, 'utf-8');
+      await engine.insertFacts(
+        [{ fact: 'Concurrent remember', kind: 'event', source: 'remember:test', row_num: 2, source_markdown_slug: slug }],
+        { source_id: 'default' },
+      );
+      await held!.release();
+
+      const r = await reconcile;
+      expect(r.factsDeleted).toBe(0);
+      expect(r.factsInserted).toBe(0);
+      expect(r.warnings).toContainEqual(expect.stringContaining('FACTS_PAGE_CACHE_STALE'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rows = await (engine as any).db.query(
+        `SELECT fact FROM facts WHERE source_markdown_slug = $1 ORDER BY row_num, id`,
+        [slug],
+      );
+      expect(rows.rows.map((row: { fact: string }) => row.fact))
+        .toEqual(['Stale indexed row', 'Concurrent remember']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   test('cli:-origin conversation facts (#1928) neither break idempotency nor get wiped', async () => {
     await putPage('people/alice', FACT_FENCE(


### PR DESCRIPTION

## What

`extract_facts` reconciles a page's `## Facts` fence against the facts table by deleting the page's fence-owned rows and re-inserting them. This change makes that destructive step safe to run beside other writers:

- The delete plus re-insert now runs inside `withPageLock(slug, ...)`, the same per-page lock the fact writer, forget, takes and timeline writers already take, so a fence write and a reconcile of the same page can no longer interleave.
- Before deleting, the phase compares the pages-table copy of `compiled_truth` and `timeline` with the canonical Markdown file. If they differ, the page is skipped for this cycle with a `FACTS_PAGE_CACHE_STALE` warning instead of being reconciled against a body that is about to change. A page with no canonical file (DB-only or thin-client brains) is treated as before. A canonical file that exists but cannot be read is treated as stale (fail closed).
- `runExtractFacts` gains a `pageLockRoot` option so tests can point the lock directory at a temp dir.

One commit. Files: `src/core/cycle/extract-facts.ts`, `test/extract-facts-phase.test.ts`.

## Why

The fact writer commits Markdown first and then stamps the facts index, while page sync into the pages table is asynchronous. In that gap a running `extract_facts` sweep observed the old `compiled_truth` from the pages table together with the new fact row and deleted the new row as stale, or re-inserted rows that the fence had just removed. On a brain with a scheduled cycle and an agent writing facts at the same time this produced both missing facts and duplicated facts with nothing in the logs.

Related upstream context: #4756 (fence placement) touches the same phase but a different failure.

## Discrimination test

Discrimination test: reverted `src/core/cycle/extract-facts.ts` to merge-base, ran `test/extract-facts-phase.test.ts` → 48 pass / 3 fail. Restored → all pass.

The three failing tests hold the page lock from the test and assert the reconcile waits, and stage a stale pages-table body and assert the skip plus warning with no deletion.

## Tests

Updated: `test/extract-facts-phase.test.ts` (3 new tests: concurrent writer holding the lock, stale cache refusal, fresh cache proceeds).

Local run (macOS, Bun 1.3.14, no DATABASE_URL):

`bun test test/extract-facts-phase.test.ts test/page-lock.test.ts` → 64 pass / 0 fail (2 files). Exit 0.

Full unit suite (`bun run test`) on this branch versus a clean master at the same base commit:

Clean master (8c70f6255, one commit past v0.48.2.0): 23684 pass / 8 fail / 31 skip. The 8 failures are environment-bound on the machine used (a real `~/.gbrain` with a running supervisor): 3 in `test/smoke-test-worker-health` (#4175), 2 in the skills-resolver install-path tests, 2 serial (`test/backup-invalidation.serial.test.ts`, `test/worker-registry.serial.test.ts`), plus one flaky pass/fail in the per-source caps backfill test that passed on every branch run.

This branch: 23687 pass / 8 fail / 31 skip. Same 8 failures as master, none introduced.

`bun run typecheck`: clean. `bun run verify`: 54/54 checks green.

## Compatibility notes

- No config key, no schema migration, no new dependency.
- Behavior change only for pages whose pages-table body is stale relative to the canonical file: they are skipped that cycle with a warning and picked up once `gbrain sync` refreshes the index. Previously they were reconciled against stale data.
- The lock is the existing slug-keyed page lock on master. A companion PR (revision-guarded canonical page mutations) changes lock identity to (source, slug); this change works with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
