### PR TITLE
feat(cycle): fail extract_facts closed while an operator pause marker exists

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -53,6 +53,10 @@
  * backlog through the sanctioned removal path instead of raw SQL.
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveGbrainHome } from '../gbrain-home.ts';
+
 import type { BrainEngine } from '../engine.ts';
 import { resolveSupersededByRow, type SupersedeTarget } from '../facts/supersede-resolve.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
@@ -280,6 +284,21 @@ export async function runExtractFacts(
     phantomsLockBusy: false,
     phantomsMorePending: false,
   };
+
+  // Operator containment for the facts.fence reconciliation path. The marker
+  // is checked on every invocation so queued cycles, sweep, and direct callers
+  // all fail closed without pausing unrelated cycle phases or services.
+  const operatorPauseMarker = join(
+    resolveGbrainHome(),
+    'operator-pauses',
+    'facts-fence.pause',
+  );
+  if (existsSync(operatorPauseMarker)) {
+    result.warnings.push(
+      `operator_pause: extract_facts skipped while ${operatorPauseMarker} exists`,
+    );
+    return result;
+  }
 
   // ── Empty-fence guard (Codex R2-#7; #2484; #2646) ──────────────
   // Pre-check: if any genuinely-backfillable legacy fact rows exist,

--- a/test/extract-facts-operator-pause.test.ts
+++ b/test/extract-facts-operator-pause.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Operator pause marker for the facts.fence reconciliation path.
+ *
+ * While `<gbrain home>/operator-pauses/facts-fence.pause` exists,
+ * runExtractFacts must return before touching the engine, with a single
+ * operator_pause warning and zero page scans, inserts or deletes. The engine
+ * is a stub that throws on any access, which proves the early return.
+ */
+import { describe, test, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runExtractFacts } from '../src/core/cycle/extract-facts.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+const throwingEngine = new Proxy({}, {
+  get(_t, prop) {
+    throw new Error(`engine touched while paused: ${String(prop)}`);
+  },
+}) as any;
+
+describe('extract_facts operator pause marker', () => {
+  test('marker present: returns early with operator_pause warning and no engine access', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-pause-'));
+    try {
+      mkdirSync(join(home, '.gbrain', 'operator-pauses'), { recursive: true });
+      writeFileSync(join(home, '.gbrain', 'operator-pauses', 'facts-fence.pause'), 'paused by test\n');
+      await withEnv({ GBRAIN_HOME: home }, async () => {
+        const result = await runExtractFacts(throwingEngine, { sourceId: 'default' });
+        expect(result.pagesScanned).toBe(0);
+        expect(result.factsInserted).toBe(0);
+        expect(result.factsDeleted).toBe(0);
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0]).toStartWith('operator_pause: extract_facts skipped while ');
+        expect(result.warnings[0]).toContain('facts-fence.pause');
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('marker absent: the guard does not short-circuit (engine is reached)', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-nopause-'));
+    try {
+      await withEnv({ GBRAIN_HOME: home }, async () => {
+        await expect(runExtractFacts(throwingEngine, { sourceId: 'default' }))
+          .rejects.toThrow(/engine touched while paused/);
+      });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION

## What

If the file `<gbrain home>/operator-pauses/facts-fence.pause` exists, `runExtractFacts` returns immediately with one `operator_pause` warning and zero pages scanned, facts inserted or facts deleted, before it touches the engine. The check runs on every invocation, so the scheduled cycle, `gbrain sweep`, and direct callers all honor it; other cycle phases and the serve process are untouched. Delete the file to resume.

Two commits: the guard (`src/core/cycle/extract-facts.ts`, 18 lines) and its test (`test/extract-facts-operator-pause.test.ts`).

## Why

When the fact reconciliation phase is misbehaving (the case behind the companion "lock destructive fact reconciliation" fix), an operator needs to stop exactly that phase at once, across every process that can run it, without stopping the rest of the cycle and without writing config. Config writes go through the database, which may be the thing under repair, and a cycle already queued still runs with the settings it loaded. A marker file is the smallest lever that every process sees on its next call.

No existing upstream issue was found for this.

## Discrimination test

Discrimination test: reverted `src/core/cycle/extract-facts.ts` to merge-base, ran `test/extract-facts-operator-pause.test.ts` → 1 pass / 1 fail. Restored → all pass.

The test's engine is a Proxy that throws on any property access, so "returns before touching the engine" is asserted directly, and the second test proves the guard does not short-circuit when the marker is absent.

## Tests

Added: `test/extract-facts-operator-pause.test.ts` (uses `withEnv` from `test/helpers/with-env.ts` for `GBRAIN_HOME`; passes `scripts/check-test-isolation.sh`).

Local run (macOS, Bun 1.3.14, no DATABASE_URL):

`bun test test/extract-facts-operator-pause.test.ts test/extract-facts-phase.test.ts` → 50 pass / 0 fail (2 files). Exit 0.

Full unit suite (`bun run test`) on this branch versus a clean master at the same base commit:

Clean master (8c70f6255, one commit past v0.48.2.0): 23684 pass / 8 fail / 31 skip. The 8 failures are environment-bound on the machine used (a real `~/.gbrain` with a running supervisor): 3 in `test/smoke-test-worker-health` (#4175), 2 in the skills-resolver install-path tests, 2 serial (`test/backup-invalidation.serial.test.ts`, `test/worker-registry.serial.test.ts`), plus one flaky pass/fail in the per-source caps backfill test that passed on every branch run.

This branch: 23687 pass / 7 fail / 31 skip. The 7 failures are master's stable environment failures (the flaky one passed); none introduced.

`bun run typecheck`: clean. `bun run verify`: 54/54 checks green.

## Compatibility notes

- With no marker file present nothing changes. No config key, no schema migration, no new dependency.
- The marker path resolves through `resolveGbrainHome()`, so `GBRAIN_HOME` is respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
