### PR TITLE
v0.48.2.0 fix(search): reuse cache lookup query embedding (#4839)

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -990,6 +990,13 @@ export interface HybridSearchOpts extends SearchOpts {
   _queryEmbedDeadline?: QueryEmbedDeadline;
 
   /**
+   * INTERNAL — query embedding already computed by `hybridSearchCached` for
+   * the semantic-cache lookup. Reuse it for the original query on a cache
+   * miss instead of charging the provider twice for identical work.
+   */
+  _queryEmbedding?: Float32Array;
+
+  /**
    * Hermetic eval canaries/CI — non-semantic embeddings. When set, the query
    * embedding for the TEXT vector arm comes from this function (e.g. qrels
    * basis vectors) INSTEAD of the gateway's query-embed path, and the
@@ -1778,7 +1785,9 @@ export async function hybridSearch(
     // No deadline needed — it's a synchronous-ish local computation with no
     // network. Absent queryEmbedFn, the bounded gateway path is unchanged.
     const embedOneQuery = (q: string): Promise<Float32Array> =>
-      opts?.queryEmbedFn
+      q === query && opts?._queryEmbedding
+        ? Promise.resolve(opts._queryEmbedding)
+        : opts?.queryEmbedFn
         ? Promise.resolve(opts.queryEmbedFn(q))
         : embedQueryBounded(q, embedOpts, embedDl);
     if (!searchSalvageEnabled()) {
@@ -2738,6 +2747,9 @@ export async function hybridSearchCached(
     // v0.42.20.0 (Fix 3) — share the query-embed deadline so the inner embed
     // doesn't start a fresh 6s budget after the cache-lookup already spent it.
     _queryEmbedDeadline: queryEmbedDl,
+    // The cache lookup already embedded the original query. Reuse that exact
+    // vector on a miss; expansion variants, if any, are still embedded here.
+    _queryEmbedding: queryEmbedding ?? undefined,
     // #2952 — classify this search's telemetry record (emitted by the inner
     // function) with the cache-consult outcome. 'hit' already returned above,
     // so only miss/disabled reach this call.

--- a/test/search-telemetry-cache-wiring.serial.test.ts
+++ b/test/search-telemetry-cache-wiring.serial.test.ts
@@ -40,14 +40,21 @@ function fixedEmbedding(): Float32Array {
 // Pluggable behavior so individual tests can simulate an embed-provider
 // failure (the 'disabled'-via-catch flavor). null → deterministic vector.
 let embedBehavior: (() => Promise<Float32Array>) | null = null;
+let embedCalls = 0;
 
 // Mock the embedding seam BEFORE importing hybrid.ts so both the cache-lookup
 // embed and the inner vector-arm embed resolve without a provider call. Spread
 // the real module so every other export stays live.
 mock.module('../src/core/embedding.ts', () => ({
   ...realEmbedding,
-  embed: async () => (embedBehavior ? embedBehavior() : fixedEmbedding()),
-  embedQuery: async () => (embedBehavior ? embedBehavior() : fixedEmbedding()),
+  embed: async () => {
+    embedCalls += 1;
+    return embedBehavior ? embedBehavior() : fixedEmbedding();
+  },
+  embedQuery: async () => {
+    embedCalls += 1;
+    return embedBehavior ? embedBehavior() : fixedEmbedding();
+  },
 }));
 
 // Import AFTER mocking.
@@ -139,6 +146,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   embedBehavior = null;
+  embedCalls = 0;
   _resetTelemetryWriterForTest();
   _resetPendingSearchCacheWritesForTests();
   await engine.executeRaw('DELETE FROM search_telemetry');
@@ -150,6 +158,9 @@ describe('hybridSearchCached — telemetry carries the cache outcome', () => {
     // Call 1 — cache consulted, empty → miss.
     const first = await hybridSearchCached(engine, 'alice telemetry fixtures', { limit: 5 });
     expect(first.length).toBeGreaterThan(0);
+    // A cache miss must reuse its lookup vector for the search arm. Calling
+    // the provider twice here can immediately trip a per-request rate limit.
+    expect(embedCalls).toBe(1);
     await awaitPendingSearchCacheWrites();
 
     // Sanity: the writeback actually landed, so call 2 exercises a REAL hit
@@ -174,6 +185,7 @@ describe('hybridSearchCached — telemetry carries the cache outcome', () => {
     });
     expect(meta?.cache?.status).toBe('hit');
     expect(second.length).toBeGreaterThan(0);
+    expect(embedCalls).toBe(2);
 
     const afterHit = await readCounters();
     // Pre-fix both sides of this were wrong: hit stayed 0 forever AND the hit


### PR DESCRIPTION
## What

Reuse the query embedding already computed by `hybridSearchCached` for the semantic-cache lookup when a cache miss continues into `hybridSearch`. The original query now consumes one provider embedding request; query-expansion variants still receive their own vectors.

## Why

On a semantic-cache miss the same original query was embedded twice: once for cache lookup and again for the vector search arm. That adds latency and cost and can make one search trip a provider rate limit. Closes #4839.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/search/hybrid.ts` to `v0.48.2.0`, ran `test/search-telemetry-cache-wiring.serial.test.ts` → `0 pass / 1 fail` for the new behavioral assertion. Restored → all pass.

## Tests

- `bun test test/search-telemetry-cache-wiring.serial.test.ts` on the exact v0.48.2.0 candidate: `4 pass / 33 expect() calls`.
- Current patch changes only `src/core/search/hybrid.ts` and the existing serial cache-wiring regression test.