### PR TITLE
v0.48.2.1 fix(ai): fold deepseek config API key (#4808)

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -121,6 +121,7 @@ export const FILE_PLANE_API_KEYS: readonly string[] = [
   'openrouter_api_key',
   'voyage_api_key',
   'dashscope_api_key',
+  'deepseek_api_key',
   'litellm_api_key',
   'together_api_key',
   'google_api_key',

--- a/src/core/ai/provider-env.ts
+++ b/src/core/ai/provider-env.ts
@@ -39,6 +39,7 @@ export function mergedProviderEnv(
   if (cfg?.openrouter_api_key) fromConfig.OPENROUTER_API_KEY = cfg.openrouter_api_key;
   if (cfg?.voyage_api_key) fromConfig.VOYAGE_API_KEY = cfg.voyage_api_key;
   if (cfg?.dashscope_api_key) fromConfig.DASHSCOPE_API_KEY = cfg.dashscope_api_key;
+  if (cfg?.deepseek_api_key) fromConfig.DEEPSEEK_API_KEY = cfg.deepseek_api_key;
   // Same seam for LiteLLM + Together, closed alongside litellm's chat
   // touchpoint (v0.42.61.0 made litellm a full chat provider, so the
   // config-plane gap started biting daemon/launchd/MCP contexts the same

--- a/src/core/config-db-merge.ts
+++ b/src/core/config-db-merge.ts
@@ -40,6 +40,7 @@ export const DB_MERGED_PROVIDER_KEY_FIELDS = [
   'openrouter_api_key',
   'voyage_api_key',
   'dashscope_api_key',
+  'deepseek_api_key',
   'litellm_api_key',
   'together_api_key',
   'google_api_key',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -65,8 +65,7 @@ export interface GBrainConfig {
    * memorableGateAllowed in core/context/hook-heartbeat.ts.
    */
   integrations?: { memorable?: { enabled?: boolean } };
-  /** Monthly backup-coverage check (src/core/backup/). File-plane: read by
-   * engine-free render sites (hook children, the cli.ts startup rail). */
+  /** Monthly backup-coverage check. File-plane for engine-free hook children. */
   backup?: { check_enabled?: boolean | string; check_interval_days?: number | string };
   database_url?: string;
   database_path?: string;
@@ -111,6 +110,7 @@ export interface GBrainConfig {
    * voyage_api_key above.
    */
   dashscope_api_key?: string;
+  deepseek_api_key?: string;
   /**
    * LiteLLM proxy API key. File-plane slot folded into the gateway env as
    * LITELLM_API_KEY (optional in the litellm recipe — proxies may run
@@ -142,9 +142,8 @@ export interface GBrainConfig {
    * auth alternative to the Entra flow below.
    */
   azure_openai_api_key?: string;
-  /** Azure OpenAI (keyless/Entra). Non-secret endpoint + deployment + Entra opt-in,
-   * folded into the gateway env so the azure-openai recipe works in any shell.
-   * The bearer token is minted at request time via `az` — no secret stored here. */
+  /** Azure OpenAI (keyless/Entra). Non-secret endpoint/deployment + Entra opt-in;
+   * bearer token is minted at request time via `az` — no secret stored here. */
   azure_openai_endpoint?: string;
   azure_openai_deployment?: string;
   azure_openai_use_entra?: string;
@@ -1242,6 +1241,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'openrouter_api_key',
   'voyage_api_key',
   'dashscope_api_key',
+  'deepseek_api_key',
   'litellm_api_key',
   'together_api_key',
   'google_api_key',

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -215,6 +215,15 @@ describe('buildGatewayConfig config-plane API-key folding', () => {
     );
   });
 
+  test('deepseek_api_key folds into gateway env as DEEPSEEK_API_KEY (#4808)', async () => {
+    await withEnv({ DEEPSEEK_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        deepseek_api_key: 'sk-deepseek-config-plane',
+      } as unknown as GBrainConfig);
+      expect(cfg.env.DEEPSEEK_API_KEY).toBe('sk-deepseek-config-plane');
+    });
+  });
+
   // Recurring-class guard: EVERY *_api_key field declared in
   // KNOWN_CONFIG_KEYS must reach the gateway env dict. Adding a new
   // provider key field to GBrainConfig without folding it in

--- a/test/config-db-merge.test.ts
+++ b/test/config-db-merge.test.ts
@@ -109,6 +109,7 @@ describe('applyDbPlaneReadSideMerge — batched read (D2)', () => {
     const { engine } = makeBatchEngine({
       openai_api_key: 'sk-db-example',
       voyage_api_key: 'vg-db-example',
+      deepseek_api_key: 'ds-db-example',
       expansion_model: 'openai:gpt-5-mini',
       chat_model: 'anthropic:claude-haiku-4-5',
       chat_fallback_chain: 'anthropic:claude-haiku-4-5, openai:gpt-5-mini',
@@ -120,6 +121,7 @@ describe('applyDbPlaneReadSideMerge — batched read (D2)', () => {
 
     expect(merged.openai_api_key).toBe('sk-db-example');
     expect(merged.voyage_api_key).toBe('vg-db-example');
+    expect(merged.deepseek_api_key).toBe('ds-db-example');
     expect(merged.expansion_model).toBe('openai:gpt-5-mini');
     expect(merged.chat_model).toBe('anthropic:claude-haiku-4-5');
     expect(merged.chat_fallback_chain).toEqual([

--- a/test/config-file-plane-keys.test.ts
+++ b/test/config-file-plane-keys.test.ts
@@ -201,6 +201,7 @@ const GATEWAY_MAPPED_KEYS = [
   'openrouter_api_key',
   'voyage_api_key',
   'dashscope_api_key',
+  'deepseek_api_key',
   'google_api_key',
 ] as const;
 

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -84,6 +84,7 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('agent.use_gateway_loop');
     expect(KNOWN_CONFIG_KEYS).toContain('openrouter_api_key');
     expect(KNOWN_CONFIG_KEYS).toContain('zeroentropy_api_key');
+    expect(KNOWN_CONFIG_KEYS).toContain('deepseek_api_key');
   });
 
   test('registers the provider_sunset suppression key (v0.46.3 documented command)', () => {

--- a/test/provider-env.test.ts
+++ b/test/provider-env.test.ts
@@ -18,6 +18,7 @@ describe('mergedProviderEnv', () => {
     const env = mergedProviderEnv(cfg({
       openai_api_key: 'sk-o', anthropic_api_key: 'sk-a', voyage_api_key: 'pa-v',
       zeroentropy_api_key: 'ze', openrouter_api_key: 'or', dashscope_api_key: 'ds',
+      deepseek_api_key: 'sk-deepseek',
       google_api_key: 'gg',
       azure_openai_api_key: 'az-secret',
       azure_openai_endpoint: 'https://x.openai.azure.com',
@@ -30,6 +31,7 @@ describe('mergedProviderEnv', () => {
     expect(env.ZEROENTROPY_API_KEY).toBe('ze');
     expect(env.OPENROUTER_API_KEY).toBe('or');
     expect(env.DASHSCOPE_API_KEY).toBe('ds');
+    expect(env.DEEPSEEK_API_KEY).toBe('sk-deepseek');
     expect(env.GOOGLE_GENERATIVE_AI_API_KEY).toBe('gg');
     // #4031: the key was the only member of the Azure group left unfolded —
     // config.json looked complete while every keyless-shell embed failed auth.


### PR DESCRIPTION
Fixes #4808

## Summary
- Register `deepseek_api_key` as a known provider credential and route `gbrain config set deepseek_api_key ...` to the file plane.
- Include the field in the DB-plane read-side provider-key merge for older or direct writes.
- Fold the merged config into `DEEPSEEK_API_KEY` through `mergedProviderEnv`, so gateway config, capability probes, and key-aware defaults share one path.

## Verification
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/provider-env.test.ts test/config-set.test.ts test/config-file-plane-keys.test.ts test/config-db-merge.test.ts test/ai/build-gateway-config.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/provider-env.test.ts test/config-set.test.ts test/config-file-plane-keys.test.ts test/config-db-merge.test.ts test/ai/build-gateway-config.test.ts`

Gate evidence: `RESULT: GREEN`; `verify` green; focused unit set reported 104 pass / 0 fail; diff-selected E2E returned the fail-closed all-file set and was skipped locally per the gate script, with CI retaining full E2E coverage.
