### PR TITLE
fix(facts): flag bare-name entity resolution as unverified before fencing

### DIFF
--- a/src/core/entities/resolve-on-save.ts
+++ b/src/core/entities/resolve-on-save.ts
@@ -23,6 +23,7 @@ import {
 export const SAVE_TIME_RESOLUTION_SOURCES = [
   'exact_page',
   'alias_exact',
+  'prefix_expansion',
   'fuzzy_match',
   'fallback_slugify',
 ] as const satisfies readonly ResolutionSource[];

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -164,16 +164,32 @@ const PREFIX_EXPANSION_DIRS = ['people', 'companies', 'hosts', 'projects'] as co
  * v0.40.2.0 — resolution-source-tagged variant for trajectory routing.
  *
  * Same resolution chain as `resolveEntitySlug` but returns the source
- * (`exact_page` | `fuzzy_match` | `fallback_slugify`) alongside the slug
- * so trajectory callers can gate on `resolution_source !==
- * 'fallback_slugify'` — querying findTrajectory on an invented slug
- * always returns [] and wastes a SQL round-trip. Codex Problem 5 from
- * v0.40.2.0 outside-voice review.
+ * (`exact_page` | `alias_exact` | `prefix_expansion` | `fuzzy_match` |
+ * `fallback_slugify`) alongside the slug so trajectory callers can gate on
+ * `resolution_source !== 'fallback_slugify'` — querying findTrajectory on
+ * an invented slug always returns [] and wastes a SQL round-trip. Codex
+ * Problem 5 from v0.40.2.0 outside-voice review.
  *
  * The original `resolveEntitySlug` keeps its existing contract (returns
  * just the slug) for all pre-v0.40 call sites — no caller-side churn.
+ *
+ * `prefix_expansion` split out from `fuzzy_match` (previously the same tag)
+ * because the two branches carry very different confidence: `fuzzy_match`
+ * scores a multi-token phrase against existing slugs/titles, while
+ * `prefix_expansion` picks the sole `<dir>/<token>-*` page for a BARE
+ * single-token name purely because it's the only candidate sharing that
+ * token — cardinality, not identity. A bare "Victor" mentioned in an
+ * unrelated context silently resolves to the brain's one existing
+ * `people/victor-*` page even when it refers to someone else entirely
+ * (observed 2026-09-03: a Back-to-School-Night transcript's "Victor" —
+ * a classmate referred to by first name only — merged onto an unrelated
+ * `people/victor-wooten` page and wrote a fact about him that wasn't his).
+ * Both branches still verify a LIVE page (unlike `fallback_slugify`), so
+ * existing `!== 'fallback_slugify'` gates elsewhere are unaffected by this
+ * split; `facts/backstop.ts` uses the new tag specifically to flag
+ * fact-fence writes that land on an existing page through this weaker path.
  */
-export type ResolutionSource = 'exact_page' | 'alias_exact' | 'fuzzy_match' | 'fallback_slugify';
+export type ResolutionSource = 'exact_page' | 'alias_exact' | 'prefix_expansion' | 'fuzzy_match' | 'fallback_slugify';
 
 export interface ResolveResult {
   slug: string;
@@ -200,7 +216,7 @@ export async function resolveEntitySlugWithSource(
 
   if (isBareName(trimmed)) {
     const expanded = await tryUnambiguousPrefixExpansion(engine, source_id, slugify(trimmed));
-    if (expanded) return { slug: expanded, source: 'fuzzy_match' };
+    if (expanded) return { slug: expanded, source: 'prefix_expansion' };
   } else {
     const fuzzy = await tryFuzzyMatch(engine, source_id, trimmed);
     if (fuzzy) return { slug: fuzzy, source: 'fuzzy_match' };

--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -42,6 +42,38 @@ import type { ResolutionSource } from '../entities/resolve.ts';
 import { isFactsBackstopEligible } from './eligibility.ts';
 import type { PageType } from '../types.ts';
 
+/**
+ * Stamp the fact's context cell with a caution note when its entity_slug
+ * came from `resolveEntitySlugWithSource`'s `prefix_expansion` branch —
+ * a bare single-token name ("Victor") resolved to the ONLY existing
+ * `<dir>/<token>-*` page purely because it's the sole candidate, not
+ * because anything confirms this mention refers to that same person or
+ * company. Unlike `fallback_slugify` (an invented slug, caught by the
+ * #4108 stub guard on page CREATE), prefix_expansion always targets an
+ * already-existing, already-curated page — so a false match here silently
+ * corrupts real content instead of spawning an obviously-empty stub.
+ *
+ * Deliberately additive, not blocking: the fact still gets written (most
+ * prefix-expansion hits ARE correct, and dropping them would re-lose real
+ * facts the way the pre-2026-08-31 `daily-enrich.ts` bug did). The note
+ * just keeps the uncertainty visible in the fence/DB instead of the fact
+ * reading identically to a confirmed one — the same shape as an editor's
+ * "citation needed" rather than a silent revert.
+ *
+ * Observed in the wild 2026-09-03: a Back-to-School-Night meeting
+ * transcript's bare "Victor" (a classmate mentioned by first name only)
+ * resolved onto the brain's one unrelated `people/victor-wooten` page and
+ * wrote a fact about him that wasn't his, with no signal anything was off.
+ */
+function annotateUnverifiedResolution(
+  sourceSlug: string | null,
+  resolutionSource: ResolutionSource | null,
+): string | null {
+  if (resolutionSource !== 'prefix_expansion') return sourceSlug;
+  const note = 'entity matched by bare name only (prefix expansion) — unverified, please confirm';
+  return sourceSlug ? `${sourceSlug} — ${note}` : note;
+}
+
 export interface FactsBackstopCtx {
   engine: BrainEngine;
   /** Brain source identifier; default 'default'. */
@@ -700,7 +732,7 @@ async function runPipelineBodyInner(
     for (const s of unparented) legacyBucket.push(s);
   }
 
-  for (const { f, resolvedSlug } of legacyBucket) {
+  for (const { f, resolvedSlug, resolutionSource } of legacyBucket) {
     const newFact: NewFact = {
       fact: f.fact,
       kind: f.kind,
@@ -713,7 +745,7 @@ async function runPipelineBodyInner(
       embedding: f.embedding ?? null,
       // #4206: caller event-time fallback + provenance context.
       valid_from: f.valid_from ?? ctx.validFrom,
-      context: ctx.sourceSlug ?? null,
+      context: annotateUnverifiedResolution(ctx.sourceSlug ?? null, resolutionSource),
     };
     const result = await ctx.engine.insertFact(newFact, { source_id: ctx.sourceId }); // gbrain-allow-direct-insert: legacy DB-only fallback for unparented / thin-client facts (no entity page to fence onto)
     fact_ids.push(result.id);
@@ -734,14 +766,19 @@ async function runPipelineBodyInner(
   for (const [slug, group] of byEntity) {
     if (abortSignal?.aborted) break;
 
-    const inputFacts = group.map(({ f }) => ({
+    const inputFacts = group.map(({ f, resolutionSource }) => ({
       fact: f.fact,
       kind: f.kind,
       notability: f.notability,
       source: f.source,
       // #4206: the caller's source_slug (which page/transcript the turn came
       // from) lands in the fence context cell — visible in recall projections.
-      context: ctx.sourceSlug ?? null,
+      // Flagged when the entity_slug came from prefix_expansion (see
+      // annotateUnverifiedResolution below): that branch verifies A live
+      // page exists, but for a bare name it's picked purely because it's
+      // the ONLY `<dir>/<token>-*` page — not because anything confirms
+      // it's the SAME person/company as this mention.
+      context: annotateUnverifiedResolution(ctx.sourceSlug ?? null, resolutionSource),
       visibility,
       confidence: f.confidence,
       // #4206: extractor-derived date wins; then the caller's event time

--- a/test/entity-resolve.test.ts
+++ b/test/entity-resolve.test.ts
@@ -191,11 +191,17 @@ describe('slugify', () => {
 // ─────────────────────────────────────────────────────────────────────
 //
 // Same resolution chain as resolveEntitySlug, but returns the source
-// tag (`exact_page` | `fuzzy_match` | `fallback_slugify`) so trajectory
-// routing in `gbrain think` (Commit 2) can gate on
-// `resolution_source !== 'fallback_slugify'` and avoid querying invented
-// slugs in production. The longmemeval harness accepts fallback_slugify
-// because its extractor uses the same slugify fallback (they cohere).
+// tag (`exact_page` | `alias_exact` | `prefix_expansion` | `fuzzy_match` |
+// `fallback_slugify`) so trajectory routing in `gbrain think` (Commit 2)
+// can gate on `resolution_source !== 'fallback_slugify'` and avoid
+// querying invented slugs in production. The longmemeval harness accepts
+// fallback_slugify because its extractor uses the same slugify fallback
+// (they cohere).
+//
+// `prefix_expansion` split out from `fuzzy_match` so facts/backstop.ts can
+// flag fact-fence writes that land on an existing page through the weaker
+// bare-name-cardinality path — see the ResolutionSource doc comment in
+// src/core/entities/resolve.ts for the full rationale.
 //
 // These tests pin the source-tag contract per branch.
 
@@ -235,19 +241,25 @@ describe('resolveEntitySlugWithSource — fuzzy_match branch', () => {
     expect(result!.source).toBe<ResolutionSource>('fuzzy_match');
   });
 
-  it('returns fuzzy_match for prefix-expansion (bare first name "Alice")', async () => {
+});
+
+describe('resolveEntitySlugWithSource — prefix_expansion branch', () => {
+  it('returns prefix_expansion for a bare first name ("Alice")', async () => {
     // Bare name "Alice" doesn't exact-match any slug, fuzzy fails the
     // 0.4 threshold on short trigrams, so prefix expansion fires and
-    // resolves to people/alice-example. We tag this branch as
-    // fuzzy_match (not fallback_slugify) so trajectory routing knows
-    // it's a real-page resolution.
+    // resolves to people/alice-example. Tagged prefix_expansion (not
+    // fuzzy_match, not fallback_slugify) — it's a real-page resolution,
+    // but a lower-confidence one than fuzzy_match: it's picked purely
+    // because it's the ONLY people/alice-* page, not because anything
+    // confirms this "Alice" is the same Alice. facts/backstop.ts uses
+    // this tag to flag fact-fence writes made through this path.
     const result = await resolveEntitySlugWithSource(
       engine as unknown as BrainEngine,
       'default',
       'Alice',
     );
     expect(result!.slug).toBe('people/alice-example');
-    expect(result!.source).toBe<ResolutionSource>('fuzzy_match');
+    expect(result!.source).toBe<ResolutionSource>('prefix_expansion');
   });
 });
 

--- a/test/facts-backstop-unverified-resolution.test.ts
+++ b/test/facts-backstop-unverified-resolution.test.ts
@@ -1,0 +1,159 @@
+/**
+ * facts/backstop.ts — unverified-resolution context annotation.
+ *
+ * `resolveEntitySlugWithSource`'s `prefix_expansion` branch resolves a bare
+ * single-token name ("Victor") to the ONLY existing `<dir>/<token>-*` page
+ * purely because it's the sole candidate sharing that token — not because
+ * anything confirms the mention refers to that same person or company.
+ * Unlike `fallback_slugify` (an invented slug, blocked from spawning a
+ * canonical stub page by the #4108 stub guard), prefix_expansion always
+ * targets an already-existing, already-curated page, so a false match here
+ * silently corrupts real content instead of an obviously-empty stub.
+ *
+ * Observed in the wild 2026-09-03: a Back-to-School-Night meeting
+ * transcript's bare "Victor" (a classmate mentioned by first name only)
+ * resolved onto an unrelated pre-existing `people/victor-*` page and wrote
+ * a fact about him that wasn't his, with no signal anything was off.
+ *
+ * These tests pin that `runFactsBackstop` stamps the fact's context cell
+ * with a visible caution note when (and only when) the entity resolved via
+ * prefix_expansion — the fact is still written (dropping it would re-lose
+ * real facts the way the daily-enrich.ts died-job bug did), but the
+ * uncertainty is no longer indistinguishable from a confirmed fact.
+ *
+ * Real PGLite engine (in-memory, no DATABASE_URL). LLM is stubbed via
+ * __setChatTransportForTests. No sources.local_path configured, so writes
+ * take the legacy DB-only bucket — sufficient to exercise the annotation,
+ * which is applied identically on both the legacy and fence-write paths.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runFactsBackstop } from '../src/core/facts/backstop.ts';
+import type { FactsBackstopCtx } from '../src/core/facts/backstop.ts';
+import {
+  __setChatTransportForTests,
+  resetGateway,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
+import { __resetFactsQueueForTests } from '../src/core/facts/queue.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // Sole `people/victor-*` page — the only candidate prefix_expansion has
+  // to pick from for a bare "Victor" mention, whether or not it's the
+  // right one.
+  await engine.putPage('people/victor-example', {
+    type: 'person',
+    title: 'Victor Example',
+    compiled_truth: '# Victor Example',
+    frontmatter: {},
+  }, { sourceId: 'default' });
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+  resetGateway();
+  __resetFactsQueueForTests();
+});
+
+const LONG_BODY = 'this is a real meeting note longer than 80 chars '.repeat(3);
+
+function chatStub(facts: Array<{ fact: string; kind: string; notability?: string; entity?: string | null }>) {
+  __setChatTransportForTests(async (): Promise<ChatResult> => ({
+    text: JSON.stringify({
+      facts: facts.map(f => ({
+        fact: f.fact,
+        kind: f.kind,
+        entity: f.entity ?? null,
+        confidence: 1.0,
+        notability: f.notability,
+      })),
+    }),
+    blocks: [],
+    stopReason: 'end',
+    usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'test:stub',
+    providerId: 'test',
+  }));
+}
+
+function makeCtx(overrides: Partial<FactsBackstopCtx> = {}): FactsBackstopCtx {
+  return {
+    engine,
+    sourceId: 'default',
+    sessionId: null,
+    source: 'mcp:put_page',
+    ...overrides,
+  };
+}
+
+const meetingPage = (slug = 'meetings/test-' + Math.random().toString(36).slice(2, 9)) => ({
+  slug,
+  type: 'meeting' as const,
+  compiled_truth: LONG_BODY,
+  frontmatter: {} as Record<string, unknown>,
+});
+
+async function contextFor(id: number): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = await (engine as any).db.query('SELECT context FROM facts WHERE id = $1', [id]);
+  return rows.rows[0]?.context ?? null;
+}
+
+describe('runFactsBackstop — unverified prefix_expansion resolution', () => {
+  test('bare-name entity resolved via prefix_expansion gets a caution note in context', async () => {
+    chatStub([
+      { fact: 'Victor prefers design and tech over performing', kind: 'preference', notability: 'medium', entity: 'Victor' },
+    ]);
+    const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline' }));
+    expect(r.mode).toBe('inline');
+    if (r.mode !== 'inline') return;
+    expect(r.inserted).toBe(1);
+
+    const context = await contextFor(r.fact_ids[0]);
+    expect(context).toContain('unverified');
+    expect(context).toContain('prefix expansion');
+  });
+
+  test('exact-slug entity is NOT annotated', async () => {
+    chatStub([
+      { fact: 'Victor Example hosted an event', kind: 'event', notability: 'medium', entity: 'people/victor-example' },
+    ]);
+    const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline' }));
+    expect(r.mode).toBe('inline');
+    if (r.mode !== 'inline') return;
+    expect(r.inserted).toBe(1);
+
+    const context = await contextFor(r.fact_ids[0]);
+    // No sourceSlug is set on this ctx, so an unflagged resolution's
+    // context is null (unchanged pre-existing behavior) — assert against
+    // '' rather than null so `.not.toContain` doesn't choke on null.
+    expect(context ?? '').not.toContain('unverified');
+  });
+
+  test('multi-word fuzzy title match is NOT annotated (only bare-name prefix_expansion is)', async () => {
+    chatStub([
+      { fact: 'Victor Example hosted an event', kind: 'event', notability: 'medium', entity: 'Victor Example' },
+    ]);
+    const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline' }));
+    expect(r.mode).toBe('inline');
+    if (r.mode !== 'inline') return;
+    expect(r.inserted).toBe(1);
+
+    const context = await contextFor(r.fact_ids[0]);
+    // No sourceSlug is set on this ctx, so an unflagged resolution's
+    // context is null (unchanged pre-existing behavior) — assert against
+    // '' rather than null so `.not.toContain` doesn't choke on null.
+    expect(context ?? '').not.toContain('unverified');
+  });
+});

--- a/test/think-trajectory-injection.test.ts
+++ b/test/think-trajectory-injection.test.ts
@@ -340,7 +340,10 @@ describe('runThink — calibration-mode trajectory placement', () => {
 describe('runThink — resolution_source != fallback_slugify gate', () => {
   test('candidate that only matches via fallback_slugify is NOT trajectory-queried', async () => {
     // The test brain has people/marco-example seeded — questions about
-    // "marco" resolve via fuzzy_match → people/marco-example.
+    // "marco" resolve via prefix_expansion → people/marco-example (a bare
+    // single-token name; see entity-resolve.test.ts for the fuzzy_match
+    // vs. prefix_expansion split). The gate only excludes fallback_slugify,
+    // so behavior here is unchanged either way.
     // A question about an unseeded name ("zelda") would resolve via
     // fallback_slugify → "zelda". Pin: no trajectory block fires for
     // that candidate (even though there might happen to be facts under


### PR DESCRIPTION
## The bug

`resolveEntitySlugWithSource`'s bare-name branch resolves a single-token name (e.g. "Victor") to the sole existing `<dir>/<token>-*` page purely because it's the only candidate sharing that token — tagged identically to a true fuzzy title match (`'fuzzy_match'`). Nothing in that branch confirms the mention actually refers to the *same* person or company as the existing page; it's cardinality-based ("only one candidate"), not identity-based.

Unlike `fallback_slugify` (an invented slug, already blocked from spawning a canonical stub page by the #4108 stub guard), this branch always resolves to an already-existing, already-curated page. A false match silently attaches a fact to real content instead of an obviously-empty stub — with no error, no low-confidence signal, indistinguishable from a verified fact.

**Observed in the wild:** a meeting transcript's bare "Victor" (a person referred to by first name only, unrelated to any existing page) resolved onto the brain's one pre-existing `people/victor-*` page and wrote a fact about him onto that page.

## The fix

- `entities/resolve.ts`: split the bare-name prefix-expansion branch into its own `prefix_expansion` `ResolutionSource` tag, distinct from `fuzzy_match` (a real multi-token trigram match against slug/title, which carries actual specificity). Every existing `!== 'fallback_slugify'` gate elsewhere is unaffected — both branches still verify a live page, so nothing that only excluded `fallback_slugify` changes behavior.
- `facts/backstop.ts`: when a fact's entity resolved via `prefix_expansion`, stamp its `context` cell with a caution note (`"entity matched by bare name only (prefix expansion) — unverified, please confirm"`) on both the legacy DB-only and fence-write paths. The fact is still written — dropping it would lose real facts the same way the pre-existing died-job class of bug does elsewhere — but the uncertainty is now visible in the fence/DB instead of reading identically to a confirmed fact.

This is deliberately additive/non-blocking: most `prefix_expansion` hits ARE correct (that's why the heuristic exists), so this doesn't change write behavior or gate anything — it only makes the lower-confidence case visible to whoever reads the fact later.

## Tests

- New `test/facts-backstop-unverified-resolution.test.ts`: pins that the annotation fires only for `prefix_expansion`, not for `exact_page` or a genuine multi-word fuzzy title match.
- Updated `test/entity-resolve.test.ts` and a comment in `test/think-trajectory-injection.test.ts` that pinned the old `'fuzzy_match'` tag for bare-name resolution.
- Ran the full set of directly-affected test files locally (entity-resolve, entity-resolve-prefix-dirs, facts-backstop, facts-backstop-gating, facts-backstop-integration, facts-backstop-outcome, facts-fallback-stub-guard, track1-save-time-entity-resolution, think-trajectory-injection) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
