### PR TITLE
feat(loops): let loops_close name its source, like loops_mute already can

### DIFF
--- a/docs/guides/open-loops.md
+++ b/docs/guides/open-loops.md
@@ -166,9 +166,12 @@ served to remote callers with **fail-closed evidence redaction** — counts,
 counterparty, summary, due date; verbatim quotes, deep links, and the
 injectable `text` digest are trusted-local only. Remote callers also need a
 resolved source scope: an unscoped remote read is refused outright rather
-than spanning the brain, and the write ops require a single-source scope
-that matches the caller's grants (`loops_unmute` included — lifting another
-source's suppression is as much a targeted write as planting one). `open_loops` takes per-call scope params —
+than spanning the brain, and the write ops resolve to a single source that
+sits inside the caller's grants (`loops_unmute` included — lifting another
+source's suppression is as much a targeted write as planting one). A caller
+whose grant names exactly one source gets that one for free; a caller granted
+several must say which, via the `source_id` param on `loops_close` and
+`loops_mute`, and a source outside the grant is refused. `open_loops` takes per-call scope params —
 `source_id` (an MCP client whose transport is bound to another source can
 point the read at the google source, grant-checked for remote callers) and
 `all_sources` (trusted local spans the brain; remote stays in-grant).

--- a/src/core/ops/loops.ts
+++ b/src/core/ops/loops.ts
@@ -402,23 +402,46 @@ const loops_close: Operation = {
     id: { type: 'number', required: true, description: 'Loop id (from open_loops).' },
     status: { type: 'string', required: true, enum: ['done', 'dropped'], description: 'Terminal state.' },
     note: { type: 'string', description: 'Optional closed_by note (default: manual).' },
+    source_id: {
+      type: 'string',
+      description:
+        'Source the loop belongs to (default: routed source). A remote caller whose grant spans ' +
+        'several sources must name one, and it must sit inside the grant.',
+    },
   },
   mutating: true,
   scope: 'write',
   handler: async (ctx, p) => {
     const scope = sourceScopeOpts(ctx);
+    const requested = p.source_id as string | undefined;
+    if (requested) validateSourceId(requested);
     // Remote callers stay inside their granted source scope; trusted local
-    // closes across sources (null = unscoped).
-    let sourceId: string | null = null;
+    // closes across sources (null = unscoped) unless it names one.
+    let sourceId: string | null = requested ?? null;
     if (ctx.remote !== false) {
-      sourceId = scope.sourceId ?? (scope.sourceIds && scope.sourceIds.length === 1 ? scope.sourceIds[0] : null);
-      if (!sourceId) {
-        // Enumerated error envelope (dispatch classifies + request-logs it),
-        // never a success-shaped { closed:false } payload.
-        throw new OperationError(
-          'permission_denied',
-          'loops_close: remote callers need a single-source scope',
-        );
+      if (requested) {
+        // Mirrors loops_mute: an explicit source is honoured only when the
+        // grant covers it. Trusting p.source_id unchecked on a remote WRITE
+        // would let any client close loops in sources it cannot even read.
+        const granted =
+          (scope.sourceId && scope.sourceId === requested) ||
+          (scope.sourceIds?.includes(requested) ?? false);
+        if (!granted) {
+          throw new OperationError(
+            'permission_denied',
+            `loops_close: source "${requested}" is outside the caller's scope`,
+          );
+        }
+      } else {
+        sourceId = scope.sourceId ?? (scope.sourceIds && scope.sourceIds.length === 1 ? scope.sourceIds[0] : null);
+        if (!sourceId) {
+          // Enumerated error envelope (dispatch classifies + request-logs it),
+          // never a success-shaped { closed:false } payload.
+          throw new OperationError(
+            'permission_denied',
+            'loops_close: remote callers need a single-source scope, or an explicit source_id inside their grant',
+          );
+        }
       }
     }
     if (ctx.dryRun) return { dry_run: true, action: 'loops_close', id: p.id, status: p.status };

--- a/test/ops-loops.test.ts
+++ b/test/ops-loops.test.ts
@@ -677,6 +677,63 @@ describe('loops_close', () => {
     expect(res.status).toBe('dropped');
   });
 
+  test('multi-source grant + explicit in-grant source_id may close', async () => {
+    const { id } = await upsertOpenLoop(engine, loop());
+    const res = (await loopsCloseOp.handler(
+      ctx({
+        remote: true,
+        auth: {
+          token: 't',
+          clientId: 'c',
+          scopes: ['write'],
+          allowedSources: ['g1', 'g2'],
+        },
+      }),
+      { id, status: 'done', source_id: 'g1' },
+    )) as { closed: boolean; status: string };
+    expect(res.closed).toBe(true);
+    expect(res.status).toBe('done');
+    expect(await listOpenLoops(engine, { sourceIds: ['g1'], status: 'open' })).toHaveLength(0);
+  });
+
+  test('explicit source_id outside the grant → permission_denied, loop untouched', async () => {
+    const { id } = await upsertOpenLoop(engine, loop());
+    await expect(
+      loopsCloseOp.handler(
+        ctx({
+          remote: true,
+          auth: {
+            token: 't',
+            clientId: 'c',
+            scopes: ['write'],
+            allowedSources: ['g2', 'g3'], // g1 is not readable by this caller
+          },
+        }),
+        { id, status: 'done', source_id: 'g1' },
+      ),
+    ).rejects.toThrow(/permission_denied|outside the caller/);
+    expect(await listOpenLoops(engine, { sourceIds: ['g1'], status: 'open' })).toHaveLength(1);
+  });
+
+  test('source_id naming another source leaves the loop alone', async () => {
+    const { id } = await upsertOpenLoop(engine, loop());
+    const res = (await loopsCloseOp.handler(
+      ctx({
+        remote: true,
+        auth: {
+          token: 't',
+          clientId: 'c',
+          scopes: ['write'],
+          allowedSources: ['g1', 'g2'],
+        },
+      }),
+      { id, status: 'done', source_id: 'g2' },
+    )) as { closed: boolean; reason?: string };
+    expect(res.closed).toBe(false);
+    expect(res.reason).toBe('not_found_or_already_closed');
+    expect(await listOpenLoops(engine, { sourceIds: ['g1'], status: 'open' })).toHaveLength(1);
+  });
+
   test('dry_run returns the action without closing', async () => {
     const { id } = await upsertOpenLoop(engine, loop());
     const res = (await loopsCloseOp.handler(ctx({ dryRun: true }), { id, status: 'done' })) as {


### PR DESCRIPTION
## The gap

`loops_close` refuses every remote caller whose grant spans more than one source:

```
permission_denied: loops_close: remote callers need a single-source scope
```

The requirement is deliberate and documented (`docs/guides/open-loops.md`), and I am not proposing to relax it. Loop ids are global integers, so closing from a grant that spans several realms would be ambiguous, and that matters most for exactly the brains that separate realms on purpose.

The problem is narrower: the op gave the caller no way to satisfy it. `open_loops` takes `source_id`. `loops_mute` takes `source_id`. `loops_close` took none, so a federated read grant was a dead end rather than a choice. The comment in `loops_mute` even says it mirrors `loops_close`, but the mirror only went one way.

I hit this on a brain with several sources (one federated, two isolated realms, plus a Google source). Reading loops over MCP works fine; closing one is impossible without dropping to the CLI on the server, which is a worse answer than naming the source.

## The change

`loops_close` now takes an optional `source_id`, validated exactly the way `loops_mute` validates it: honoured only when the grant covers it, `permission_denied` when it does not.

- Single-source grant: unchanged, still resolves for free.
- Multi-source grant, no `source_id`: unchanged, still refused, with the error now naming the way out.
- Multi-source grant, in-grant `source_id`: closes.
- Any grant, out-of-grant `source_id`: refused.
- Trusted local: unchanged, unscoped unless it names a source.

No change to the security property. A remote caller still cannot close a loop in a source it was not granted. It can now say which of its granted sources it means.

## Tests

Three added to `test/ops-loops.test.ts`, alongside the existing scope tests:

- multi-source grant + in-grant `source_id` closes
- out-of-grant `source_id` throws `permission_denied`, loop untouched
- `source_id` naming a different granted source leaves the loop alone (`not_found_or_already_closed`), so the param narrows and never widens

Green locally on Bun 1.4.0: `ops-loops` 45 pass, `parity` 10 pass, and `operations-coverage-ledger` + `loops-extract-wiring` + `remote-privacy-sweep` 282 pass. `tsc --noEmit` clean.

`docs/guides/open-loops.md` updated to describe the resolved behaviour.