### PR TITLE
fix(import): preserve machine-generated tags across re-import

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -231,7 +231,16 @@ export interface BrainEngine {
   // Tags
   addTag(slug: string, tag: string): Promise<void>;
   removeTag(slug: string, tag: string): Promise<void>;
-  getTags(slug: string): Promise<string[]>;
+  /**
+   * Tags for a page. By default every tag regardless of origin.
+   *
+   * Pass opts.fileOnly=true for tags the MARKDOWN FILE owns (tags.source IS NULL, which
+   * is what addTag writes). Tags generated outside the file — hermes (LLM tagger), rule
+   * (deterministic stub tagger), manual — carry an explicit source and are excluded.
+   * Import reconciliation must use this, or it deletes machine tags the file never knew
+   * about. See import-file.ts.
+   */
+  getTags(slug: string, opts?: { fileOnly?: boolean }): Promise<string[]>;
 
   // Timeline
   /**

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -278,8 +278,20 @@ export async function importFromContent(
       content_hash: hash,
     });
 
-    // Tag reconciliation: remove stale, add current
-    const existingTags = await tx.getTags(slug);
+    // Tag reconciliation: remove stale FILE tags, add current.
+    //
+    // fileOnly is essential. The file's frontmatter is authoritative ONLY over the tags the
+    // file itself wrote (tags.source IS NULL). Tags generated outside the file carry an
+    // explicit source — 'hermes' (LLM tagger), 'rule' (deterministic stub tagger),
+    // 'manual' — and live only in Postgres; they are never written back to the markdown.
+    // Reconciling against ALL tags therefore deleted every machine tag on any re-import,
+    // because none of them appear in the frontmatter.
+    //
+    // Measured damage before this fix (2026-09-02): a bulk re-import on 2026-08-28 wiped
+    // the tags off 5,640 `sources/email/*` pages, and 8,029 of 16,951 notes (47%) sat
+    // untagged. The page row survives the re-import, so the tagger's own ledger still said
+    // "done" and never revisited them — the loss was silent and permanent.
+    const existingTags = await tx.getTags(slug, { fileOnly: true });
     const newTags = new Set(parsed.tags);
     for (const old of existingTags) {
       if (!newTags.has(old)) await tx.removeTag(slug, old);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1030,10 +1030,11 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { fileOnly?: boolean }): Promise<string[]> {
     const { rows } = await this.db.query(
       `SELECT tag FROM tags
        WHERE page_id = (SELECT id FROM pages WHERE slug = $1)
+         ${opts?.fileOnly ? 'AND source IS NULL' : ''}
        ORDER BY tag`,
       [slug]
     );

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1177,11 +1177,12 @@ export class PostgresEngine implements BrainEngine {
     `;
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { fileOnly?: boolean }): Promise<string[]> {
     const sql = this.sql;
     const rows = await sql`
       SELECT tag FROM tags
       WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+        ${opts?.fileOnly ? sql`AND source IS NULL` : sql``}
       ORDER BY tag
     `;
     return rows.map((r) => r.tag as string);

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -243,6 +243,50 @@ Content here.
     expect(addCalls.length).toBe(2);
   });
 
+  test('reconciliation only removes tags the FILE owns, never machine-generated tags', async () => {
+    // Regression guard. Frontmatter is authoritative only over the tags the file wrote
+    // (tags.source IS NULL, which is what the importer's own addTag writes). Tags applied
+    // outside the file carry an explicit source and live only in the database — an LLM
+    // tagger, a rule-based tagger, a manual tag. Reconciling against ALL tags deleted every
+    // one of them on any re-import, because none appear in the frontmatter.
+    const filePath = join(TMP, 'machine-tags.md');
+    writeFileSync(filePath, `---
+type: concept
+title: Machine Tagged
+tags: [kept-tag]
+---
+
+Content here.
+`);
+
+    const fileTags = ['old-tag', 'kept-tag'];      // source IS NULL — the file's own
+    const machineTags = ['hermes-tag', 'rule-tag']; // source set — not the file's business
+    let askedForFileOnly = false;
+
+    const engine = mockEngine({
+      getTags: (_slug: string, opts?: { fileOnly?: boolean }) => {
+        if (opts?.fileOnly) {
+          askedForFileOnly = true;
+          return Promise.resolve(fileTags);
+        }
+        return Promise.resolve([...fileTags, ...machineTags]);
+      },
+      getPage: () => Promise.resolve(null),
+    });
+
+    await importFile(engine, filePath, 'concepts/machine-tags.md', { noEmbed: true });
+
+    const removed = (engine as any)._calls
+      .filter((c: any) => c.method === 'removeTag')
+      .map((c: any) => c.args[1]);
+
+    expect(askedForFileOnly).toBe(true);
+    // The file dropped 'old-tag', so it goes. Nothing else may.
+    expect(removed).toEqual(['old-tag']);
+    expect(removed).not.toContain('hermes-tag');
+    expect(removed).not.toContain('rule-tag');
+  });
+
   test('chunks compiled_truth and timeline separately', async () => {
     const filePath = join(TMP, 'chunked.md');
     writeFileSync(filePath, `---


### PR DESCRIPTION
## What breaks

Tag reconciliation in `importFromContent` treats markdown frontmatter as authoritative over
every tag on a page:

```ts
const existingTags = await tx.getTags(slug);
const newTags = new Set(parsed.tags);
for (const old of existingTags) {
  if (!newTags.has(old)) await tx.removeTag(slug, old);
}
```

`getTags` returns every tag regardless of origin. Any tag applied outside the file lives only
in the database and never appears in frontmatter, so it is deleted on the next import of that
file. That covers an LLM tagger writing `tags.source='hermes'`, a rule-based tagger, and a
manual `add_tag` call.

The page row survives the import, since `putPage` is an update rather than a delete. Nothing
downstream notices. A tagger that keeps its own "already processed" ledger keyed on page id
will treat the page as done forever and never revisit it, so the loss is silent and permanent
rather than merely temporary.

## Measured impact

On a production brain of roughly 29,700 pages with content:

- a bulk re-import stripped every tag from 5,640 pages in a single run
- 8,029 of 16,951 `note` pages (47%) sat with zero tags while the nightly tagger reported
  "queue drained" and exit 0 every night
- the tagger's ledger recorded 9,134 tags applied for pages that had none

The coverage metric that hid it was "pages processed", which stayed at 99%+ the whole time.
The honest metric is pages with content and zero tags.

## The fix

`getTags` gains an optional `{ fileOnly: true }` that filters `source IS NULL`, which is what
the importer's own `addTag` writes. Reconciliation uses it, so frontmatter stays authoritative
over the tags the file wrote and over nothing else.

The parameter is optional, so the other five `getTags` call sites are unchanged. Implemented
on the `BrainEngine` interface and both engines.

## Tests

New case in `test/import-file.test.ts`. A page whose database holds two file tags and two
machine tags, with frontmatter dropping one file tag. It asserts the dropped file tag is
removed, both machine tags survive, and the `fileOnly` read actually happened.

Verified to be a real regression guard, not a passing fixture: reverting the one-line change
in `import-file.ts` makes the new test fail while the other 16 keep passing.

Also verified end to end against live Postgres. With the fix, a re-import kept the machine
tags and correctly dropped the frontmatter tag that was removed. With the fix reverted, the
same re-import destroyed both machine tags.

## Notes

No `VERSION` or `CHANGELOG` bump. Those are yours to allocate at ship time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U15Z46NXAd9qhxcm3Lj7C
