### PR TITLE
v0.48.2.1 fix(mcp-stdio): refuse to serve a well-formed GBRAIN_SOURCE that no source row backs (#4850)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -173,6 +173,10 @@ export async function trackStdioRpc<T>(work: () => Promise<T>): Promise<T> {
 
 export async function startMcpServer(engine: BrainEngine, opts: { surface?: McpSurface; sourceGuard?: boolean } = {}) {
   const config = loadConfig();
+  // Refuse to serve a well-formed GBRAIN_SOURCE that no source row backs
+  // (see source-preflight.ts). Throws before any transport is attached.
+  const { assertStdioSourceBindable } = await import('./source-preflight.ts');
+  await assertStdioSourceBindable(engine);
   // MEMORY_VERBS v1 surface mode: 'full' (default — every op, byte-identical
   // to pre-surface behavior), 'starter' (WP4 daily-driver set), or 'verbs'
   // (exactly the 7 protocol verbs). Enforced BOTH on the advertised list and

--- a/src/mcp/source-preflight.ts
+++ b/src/mcp/source-preflight.ts
@@ -1,0 +1,42 @@
+import type { BrainEngine } from '../core/engine.ts';
+
+/**
+ * Stdio-lane preflight: a well-formed `GBRAIN_SOURCE` that names NO registered
+ * source must not serve.
+ *
+ * Why: `resolveMcpStdioSourceScope` deliberately
+ * passes a well-formed-but-unknown env value through as tier 'env' so the
+ * opt-in `--source-guard` can produce its actionable envelope. Without the
+ * flag, nothing catches it: every read scopes to a source that holds zero
+ * pages (search/query return `[]` even with `__all__`) and every write dies
+ * on `facts_source_id_fkey`. A stale `GBRAIN_SOURCE=workspace` in a harness
+ * MCP config blinded the Claude Code lane for a week while every health check
+ * stayed green. Fail loudly at startup instead.
+ *
+ * Scope: only the stdio server calls this. HTTP tokens carry their own
+ * source grant. `__all__` and malformed values keep their existing handling
+ * (malformed already falls back to the seed tier in the resolver).
+ * A transient engine error does NOT block startup — this guards config, not
+ * connectivity.
+ */
+export async function assertStdioSourceBindable(
+  engine: BrainEngine,
+  env: string | undefined = process.env.GBRAIN_SOURCE,
+): Promise<void> {
+  if (!env) return;
+  const { isValidSourceId, ALL_SOURCES } = await import('../core/source-id.ts');
+  if (env === ALL_SOURCES || !isValidSourceId(env)) return;
+  let rows: Array<{ id: string }>;
+  try {
+    rows = await engine.executeRaw<{ id: string }>(`SELECT id FROM sources WHERE id = $1`, [env]);
+  } catch {
+    return;
+  }
+  if (rows.length === 0) {
+    throw new Error(
+      `GBRAIN_SOURCE="${env}" is not a registered source; refusing to serve a phantom scope ` +
+      `(reads would return nothing, writes would fail on the sources foreign key). ` +
+      `Run \`gbrain sources list\`, then set GBRAIN_SOURCE to a listed id or unset it.`,
+    );
+  }
+}

--- a/test/mcp-stdio-source-preflight.test.ts
+++ b/test/mcp-stdio-source-preflight.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { assertStdioSourceBindable } from '../src/mcp/source-preflight.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+function makeEngine(registeredSources: string[], opts: { throwing?: boolean } = {}): BrainEngine {
+  return {
+    kind: 'postgres',
+    executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
+      if (opts.throwing) throw new Error('engine down');
+      if (sql.includes('SELECT id FROM sources WHERE id = $1')) {
+        const id = params?.[0];
+        return typeof id === 'string' && registeredSources.includes(id) ? [{ id } as T] : [];
+      }
+      return [];
+    },
+  } as unknown as BrainEngine;
+}
+
+describe('stdio MCP source preflight', () => {
+  test('no GBRAIN_SOURCE: nothing to check', async () => {
+    await expect(assertStdioSourceBindable(makeEngine(['default']), undefined)).resolves.toBeUndefined();
+    await expect(assertStdioSourceBindable(makeEngine(['default']), '')).resolves.toBeUndefined();
+  });
+
+  test('registered source passes', async () => {
+    await expect(assertStdioSourceBindable(makeEngine(['default', 'wiki']), 'wiki')).resolves.toBeUndefined();
+  });
+
+  test('well-formed but unregistered source refuses to serve, naming the value and the fix', async () => {
+    const p = assertStdioSourceBindable(makeEngine(['default']), 'workspace');
+    await expect(p).rejects.toThrow(/GBRAIN_SOURCE="workspace" is not a registered source/);
+    await expect(assertStdioSourceBindable(makeEngine(['default']), 'workspace')).rejects.toThrow(/gbrain sources list/);
+  });
+
+  test('__all__ sentinel and malformed values are left to the resolver', async () => {
+    await expect(assertStdioSourceBindable(makeEngine(['default']), '__all__')).resolves.toBeUndefined();
+    await expect(assertStdioSourceBindable(makeEngine(['default']), 'Not A Valid Id!')).resolves.toBeUndefined();
+  });
+
+  test('engine failure does not block startup (guards config, not connectivity)', async () => {
+    await expect(assertStdioSourceBindable(makeEngine([], { throwing: true }), 'workspace')).resolves.toBeUndefined();
+  });
+
+  // Integration: the guard is wired into startMcpServer and fires BEFORE any
+  // transport attaches. This is the discriminating case for the fix — without
+  // the server.ts wiring, startMcpServer proceeds and this expectation fails.
+  const scratch: string[] = [];
+  afterEach(() => { for (const d of scratch.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+  test('startMcpServer refuses a phantom GBRAIN_SOURCE before attaching a transport', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-preflight-home-'));
+    scratch.push(home);
+    const { startMcpServer } = await import('../src/mcp/server.ts');
+    await withEnv({ GBRAIN_HOME: home, GBRAIN_SOURCE: 'phantom-source' }, async () => {
+      await expect(startMcpServer(makeEngine(['default']))).rejects.toThrow(/GBRAIN_SOURCE="phantom-source" is not a registered source/);
+    });
+  });
+});


### PR DESCRIPTION
## What

`gbrain serve` (stdio) now refuses to start when `GBRAIN_SOURCE` is set to a well-formed id that no row in `sources` backs. The error names the value and points at `gbrain sources list`. `__all__` and malformed values keep their existing handling; a transient engine error does not block startup. The HTTP lane is untouched (tokens carry their own source grant). Fixes #4850.

## Why

`resolveMcpStdioSourceScope` deliberately passes a well-formed-but-unregistered env value through as tier `'env'` so the opt-in `--source-guard` can produce its envelope. Without the flag (the default) nothing catches it: every read scopes to an empty source (`search`/`query` return `[]` even with `__all__`), every write dies on `facts_source_id_fkey`, and `run_doctor`/`get_health` stay green. A stale `GBRAIN_SOURCE` left in a harness MCP config after a source is removed blinds that lane indefinitely with no signal. Fail loudly at startup instead.

Implementation: `src/mcp/source-preflight.ts` exports `assertStdioSourceBindable(engine, env)`; `startMcpServer` awaits it right after `loadConfig()`, before any transport is attached.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/mcp/server.ts` to merge-base, ran `test/mcp-stdio-source-preflight.test.ts` → 5 pass / 1 fail. Restored → all pass.

(The failing case is the integration test that calls the real `startMcpServer` with a phantom `GBRAIN_SOURCE` and a hermetic `GBRAIN_HOME`; the five unit cases exercise the helper directly.)

## Verification

The message tells the user to run `gbrain sources list`. Against a brain whose only source is `default`, with a stale `GBRAIN_SOURCE=workspace`:

```
$ GBRAIN_SOURCE=workspace gbrain serve --surface full </dev/null
GBRAIN_SOURCE="workspace" is not a registered source; refusing to serve a phantom scope (reads would return nothing, writes would fail on the sources foreign key). Run `gbrain sources list`, then set GBRAIN_SOURCE to a listed id or unset it.
$ echo $?
1
$ gbrain sources list
SOURCES
  default   federated   236 pages   ...
$ GBRAIN_SOURCE=default gbrain serve --surface full </dev/null ; echo $?
0
```

## Tests

- `test/mcp-stdio-source-preflight.test.ts` (new): 6 cases — no env, registered source, unregistered source refuses with the value and the fix in the message, `__all__` and malformed left to the resolver, engine failure does not block, and the `startMcpServer` integration case.
- `test/mcp-stdio-source-resolution.test.ts` (existing): unchanged, still 2 pass — the resolver's pass-through for `--source-guard` is preserved.
- `bun test test/mcp-stdio-source-preflight.test.ts test/mcp-stdio-source-resolution.test.ts` → 8 pass / 0 fail (exit 0). `bun run typecheck` clean. `check:privacy`, `check:test-isolation`, `check:test-names`, `check:exports-count`, `check:module-size`, `check:engine-dynamic-import`, `check:structural-manifest`, `check:newlines` all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013srLURpYQaKijTSyAfPAdo