### PR TITLE
fix(extract_atoms): link transcript-origin atoms to their conversation page

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -75,6 +75,7 @@ import { createHash } from 'crypto';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import { normalizeForGrounding } from './synthesize-verify.ts';
+import type { TranscriptPageIndex } from '../transcripts/discover.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
 // #4529 + #4540: per-item extractor caps, overridable via
@@ -699,6 +700,27 @@ export async function runPhaseExtractAtoms(
     if (i < transcriptItems.length) work.push(transcriptItems[i]);
   }
 
+  // #3961 follow-up: transcript-origin atoms get provenance edges too. The
+  // original implementation skipped them ("transcripts are files, not pages,
+  // so there is no from-endpoint to link") — but an imported transcript IS a
+  // page: the conversation page it was rendered into. Resolving it here (one
+  // frontmatter-only query, only when transcript work exists) gives those
+  // atoms the same source-page → atom edge that page-origin atoms get, so the
+  // graph can navigate from a conversation to what was learned from it.
+  let transcriptPageIndex: TranscriptPageIndex | null = null;
+  let resolveTranscriptPages: ((filePath: string, index: TranscriptPageIndex) => string[]) | null = null;
+  if (transcriptItems.length > 0) {
+    try {
+      const { indexTranscriptPages, resolveTranscriptPageSlugs } = await import('../transcripts/discover.ts');
+      transcriptPageIndex = await indexTranscriptPages(engine, sourceId);
+      resolveTranscriptPages = resolveTranscriptPageSlugs;
+    } catch {
+      // Index unavailable — atoms still import, they just carry no edge.
+      transcriptPageIndex = null;
+      resolveTranscriptPages = null;
+    }
+  }
+
   // Phase-level no-op: nothing to extract today.
   if (work.length === 0 && transcripts.length === 0 && pages.length === 0) {
     return {
@@ -1057,6 +1079,19 @@ export async function runPhaseExtractAtoms(
               from_source_id: sourceId,
               to_source_id: sourceId,
             });
+          } else if (transcriptPageIndex && resolveTranscriptPages) {
+            // A split session renders one page per part, all sharing a
+            // session id; without per-part offsets the honest attribution is
+            // the whole session, so every part gets the edge.
+            for (const fromSlug of resolveTranscriptPages(item.filePath, transcriptPageIndex)) {
+              provenanceLinks.push({
+                from_slug: fromSlug,
+                to_slug: slug,
+                link_source: 'atom-provenance',
+                from_source_id: sourceId,
+                to_source_id: sourceId,
+              });
+            }
           }
           totalAtomsExtracted++;
         }

--- a/src/core/transcripts/discover.ts
+++ b/src/core/transcripts/discover.ts
@@ -150,6 +150,79 @@ export async function indexImportedSessions(
 }
 
 /**
+ * Normalize a session identifier so the two names the pipeline gives the same
+ * session compare equal. The conversation page stamps
+ * `transcript_import.session_id` (`20260720_071844_e91dbe`); the corpus file
+ * on disk is named from the same parts with a different separator
+ * (`2026-07-20-071844-e91dbe.md`). Dropping separators and case makes them
+ * comparable without teaching this module either harness's naming scheme.
+ * Identity-safe for the JSONL harnesses too, where the basename stem already
+ * IS the session id (normalizing both sides is a no-op on a match).
+ */
+function sessionKey(raw: string): string {
+  return raw.toLowerCase().replace(/[-_]/g, '');
+}
+
+export interface TranscriptPageIndex {
+  /**
+   * normalized session key → conversation page slugs. A session that split
+   * across parts renders one page per part, all stamped with the same
+   * session_id, so this is one-to-many by design.
+   */
+  bySessionKey: Map<string, string[]>;
+  pagesScanned: number;
+}
+
+/**
+ * Reverse of `indexImportedSessions`: maps a session back to the conversation
+ * PAGE(S) it was rendered into, so a caller holding only a transcript file
+ * path can find the page to attribute it to. Same one-query, frontmatter-only
+ * discipline — conversation bodies run to ~300KB per part and must not be
+ * streamed to read two keys.
+ */
+export async function indexTranscriptPages(
+  engine: BrainEngine,
+  sourceId: string,
+): Promise<TranscriptPageIndex> {
+  const bySessionKey = new Map<string, string[]>();
+  let pagesScanned = 0;
+  const rows = await engine.executeRaw<{ slug: string; frontmatter: unknown }>(
+    `SELECT slug, frontmatter FROM pages
+     WHERE type = 'conversation' AND source_id = $1 AND deleted_at IS NULL`,
+    [sourceId],
+  );
+  for (const row of rows) {
+    pagesScanned++;
+    const fm = (typeof row.frontmatter === 'string' ? JSON.parse(row.frontmatter) : row.frontmatter) as
+      | Record<string, unknown>
+      | null;
+    const ti = fm?.transcript_import as { session_id?: string } | undefined;
+    if (!ti || typeof ti.session_id !== 'string' || ti.session_id === '') continue;
+    const key = sessionKey(ti.session_id);
+    if (key === '') continue;
+    const slugs = bySessionKey.get(key);
+    if (slugs) slugs.push(row.slug);
+    else bySessionKey.set(key, [row.slug]);
+  }
+  return { bySessionKey, pagesScanned };
+}
+
+/**
+ * The conversation page(s) a transcript file was rendered into, or [] when the
+ * transcript has not been imported as a page. Matches on the basename stem,
+ * which every supported harness derives from the session id.
+ */
+export function resolveTranscriptPageSlugs(
+  filePath: string,
+  index: TranscriptPageIndex,
+): string[] {
+  const base = filePath.split(/[/\\]/).pop() ?? '';
+  const stem = base.replace(/\.(md|markdown|jsonl|json)$/i, '');
+  if (stem === '') return [];
+  return index.bySessionKey.get(sessionKey(stem)) ?? [];
+}
+
+/**
  * JSONL harnesses name the session in the file basename (claude-code /
  * openclaw uuid.jsonl, codex rollout-<id>.jsonl). Grok does not: the
  * basename is always `chat_history.jsonl` and the session id is the parent

--- a/test/extract-atoms-provenance-links.test.ts
+++ b/test/extract-atoms-provenance-links.test.ts
@@ -8,8 +8,10 @@
  * (link_source='atom-provenance', both endpoints in the phase's source) and
  * flushes them BEFORE the completion-receipt flip (#4733: a failed provenance
  * write leaves the item discoverable for a normal retry instead of stranding
- * a completed page with no edges). Transcript items are skipped — a
- * transcript is a file, not a page, so there is no from-endpoint.
+ * a completed page with no edges). Transcript items resolve their from-endpoint
+ * through the conversation page the transcript was imported into (matched on
+ * the normalized session id); a transcript with no imported page still gets no
+ * edge, because there is genuinely nothing to link to.
  *
  * Also pins the #4733 atom-identity fix: page-derived atom slugs fold the
  * source-page slug into the identity hash so two same-date source pages
@@ -84,7 +86,7 @@ describe('atom provenance backlinks (#3961)', () => {
     expect(links.filter(l => l.link_source === 'atom-provenance')).toHaveLength(1);
   });
 
-  test('transcript items create NO provenance edges (files are not pages)', async () => {
+  test('an UNIMPORTED transcript creates no provenance edges (no page to link from)', async () => {
     const before = await engine.executeRaw<{ n: number }>(
       `SELECT COUNT(*)::int AS n FROM links WHERE link_source = 'atom-provenance'`,
     );
@@ -98,6 +100,58 @@ describe('atom provenance backlinks (#3961)', () => {
       `SELECT COUNT(*)::int AS n FROM links WHERE link_source = 'atom-provenance'`,
     );
     expect(after[0]!.n).toBe(before[0]!.n);
+  });
+
+  test('an IMPORTED transcript links its conversation page → atom', async () => {
+    // The conversation page the transcript was rendered into. The corpus file
+    // on disk names the same session with '-' separators; the page stamps it
+    // with '_' — the resolver normalizes both.
+    await engine.putPage('conversations/sessions/2026-07-20-hermes-e91dbe', {
+      type: 'conversation', title: 'Session', compiled_truth: 'turns', timeline: '',
+      frontmatter: { transcript_import: { harness: 'hermes', session_id: '20260720_071844_e91dbe', part: 1, of: 1 } },
+    });
+
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{
+        filePath: '/corpus/2026-07-20-071844-e91dbe.md',
+        content: 'a session worth distilling',
+        contentHash: 'bbbb111122223333',
+      }],
+      _pages: [],
+      _chat: stubChat('Session atom lands home'),
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_extracted).toBe(1);
+
+    const links = await engine.getLinks('conversations/sessions/2026-07-20-hermes-e91dbe');
+    const provenance = links.filter(l => l.link_source === 'atom-provenance');
+    expect(provenance).toHaveLength(1);
+    expect(provenance[0]!.to_slug).toContain('session-atom-lands-home');
+  });
+
+  test('a split session links EVERY part page to the atom', async () => {
+    for (const part of [1, 2]) {
+      await engine.putPage(`conversations/sessions/2026-07-22-hermes-split-p${part}`, {
+        type: 'conversation', title: `Split (part ${part} of 2)`, compiled_truth: 'turns', timeline: '',
+        frontmatter: { transcript_import: { harness: 'hermes', session_id: '20260722_090000_split', part, of: 2 } },
+      });
+    }
+
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{
+        filePath: '/corpus/2026-07-22-090000-split.md',
+        content: 'a long session split across two pages',
+        contentHash: 'cccc111122223333',
+      }],
+      _pages: [],
+      _chat: stubChat('Split session atom'),
+    });
+    expect(result.status).toBe('ok');
+
+    for (const part of [1, 2]) {
+      const links = await engine.getLinks(`conversations/sessions/2026-07-22-hermes-split-p${part}`);
+      expect(links.filter(l => l.link_source === 'atom-provenance')).toHaveLength(1);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

#3961 gave atoms a provenance edge (source-page → atom, `link_source='atom-provenance'`) but skipped transcript items, on the reasoning that *"transcripts are files, not pages, so there is no from-endpoint to link"* (`extract-atoms.ts`).

That is no longer true. An imported transcript **is** a page — the `conversation` page it was rendered into by `transcripts/render.ts`, stamped with `transcript_import.session_id`.

The consequence: every atom distilled from a session lands in the graph with no path back to the session it came from, and the conversation pages stay dead ends. You cannot navigate from a session to what was learned in it, in `backlinks` or any graph consumer.

On my brain that is 6,034 atoms across 413 conversations with no provenance edge.

## Fix

The two names for one session differ only in separator — the corpus file is `2026-07-20-071844-e91dbe.md`, the page stamps `20260720_071844_e91dbe`:

- `indexTranscriptPages` — the reverse of the existing `indexImportedSessions`, keeping the same one-query, frontmatter-only discipline (conversation bodies run ~300KB per part and must not be streamed to read two keys).
- `resolveTranscriptPageSlugs` — matches a corpus path against that index on a separator- and case-normalized key. The normalization is identity-safe for the JSONL harnesses, where the basename stem already *is* the session id.

Behaviour notes:

- A **split session** renders one page per part sharing a session id. Without per-part offsets the honest attribution is the whole session, so every part gets the edge.
- A transcript with **no imported page** still gets no edge — there is genuinely nothing to link to. That case keeps its test (renamed to say what it now pins).
- The index is built **once per phase run, only when transcript work exists**. If it fails to build, atoms import exactly as before, just without edges.

## Tests

`test/extract-atoms-provenance-links.test.ts`:

- an IMPORTED transcript links its conversation page → atom
- a split session links EVERY part page to the atom
- existing unimported-transcript test retained, renamed

Discrimination-tested: neutering `resolveTranscriptPageSlugs` to `return []` fails exactly the two new tests and leaves the other 13 passing.

182 tests green across the extract-atoms, provenance, doctor-drift and transcript suites.