### PR TITLE
feat(volunteer): let ambient recall exclude a slug subtree

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -332,6 +332,8 @@ export interface GBrainConfig {
    * reverts on the next turn with a config edit, no redeploy.
    */
   retrieval_reflex_lexical_arms?: boolean;
+  /** Slug prefixes the volunteer stage never surfaces — see volunteerExcludeSlugPrefixes. */
+  retrieval_reflex_volunteer_exclude_slug_prefixes?: string[];
   /**
    * 2026-08 fix wave — kill switch for the reflex's volunteer arm (Arm 2:
    * confidence-gated volunteered pages fused after the pointer budget, parity

--- a/src/core/context/reflex.ts
+++ b/src/core/context/reflex.ts
@@ -181,6 +181,31 @@ export function lexicalArmsEnabled(cfg: GBrainConfig | null): boolean {
   return cfg?.retrieval_reflex_lexical_arms !== false;
 }
 
+/**
+ * Slug prefixes the volunteer stage must never surface. Ambient recall reaches
+ * for whatever a turn's words resolve to, which makes an imported subtree with
+ * prose-colliding aliases actively harmful: on this author's brain a flashcard
+ * vault aliased "Delivery", "Cell" and "Log" produced 96% of all alias-arm
+ * volunteers at 2.8% precision, and with only VOLUNTEER_DEFAULT_MAX_PAGES
+ * slots it crowded out every specific hit.
+ *
+ * A subtree, not a slug set: the vault's members change on every sync, so
+ * enumeration is not maintainable. Env-direct override matches
+ * volunteerEnabled/lexicalArmsEnabled so a config-less environment keeps the
+ * escape hatch; comma-separated, blanks dropped.
+ */
+export function volunteerExcludeSlugPrefixes(cfg: GBrainConfig | null): string[] {
+  const env = process.env.GBRAIN_VOLUNTEER_EXCLUDE_SLUG_PREFIXES;
+  const raw = env != null && env !== ''
+    ? env.split(',')
+    : cfg?.retrieval_reflex_volunteer_exclude_slug_prefixes;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+}
+
 function maxPointers(cfg: GBrainConfig | null): number {
   const n = cfg?.retrieval_reflex_max_pointers;
   return typeof n === 'number' && n > 0 ? n : DEFAULT_MAX_POINTERS;

--- a/src/core/context/turn-context.ts
+++ b/src/core/context/turn-context.ts
@@ -145,6 +145,8 @@ export interface AssembleTurnContextOpts {
   maxBytes?: number;
   /** v0.46.15: lexical-arms kill switch — see ResolvePointersOpts.lexicalArms. */
   lexicalArms?: boolean;
+  /** Slug prefixes the volunteer stage never surfaces — see GateOpts. */
+  excludeSlugPrefixes?: readonly string[];
   // ── v0.45.7 ambient recall ──────────────────────────────────────────────
   /** Assembly mode. Default 'turn' (existing behavior). */
   mode?: ContextMode;
@@ -249,6 +251,7 @@ export async function assembleTurnContext(
           // v0.46.15+ lexical-arms kill switch rides the same threading as the
           // pointer arm above (ResolvePointersOpts.lexicalArms).
           lexicalArms: opts.lexicalArms,
+          excludeSlugPrefixes: opts.excludeSlugPrefixes,
         });
       }
     } catch {

--- a/src/core/context/volunteer.ts
+++ b/src/core/context/volunteer.ts
@@ -67,6 +67,13 @@ export interface VolunteerOpts {
    * slots every turn and starve new pages behind it (red-team finding).
    */
   excludeSlugs?: ReadonlySet<string>;
+  /**
+   * Slug prefixes to skip on the same terms as excludeSlugs. Needed because a
+   * whole subtree (an imported flashcard vault whose one-word aliases collide
+   * with ordinary prose) cannot be enumerated as a set — its members change on
+   * every sync.
+   */
+  excludeSlugPrefixes?: readonly string[];
   maxPages?: number;
   minConfidence?: number;
   /** v0.46.15: lexical-arms kill switch — see ResolvePointersOpts.lexicalArms. */
@@ -132,6 +139,12 @@ export interface GateOpts {
   minConfidence?: number;
   /** Skipped BEFORE gate + cap — see VolunteerOpts.excludeSlugs. */
   excludeSlugs?: ReadonlySet<string>;
+  /**
+   * Slug prefixes skipped BEFORE gate + cap. The set form needs every slug
+   * enumerated up front, which is unusable for a whole subtree (an imported
+   * flashcard vault, a scratch inbox) whose members change on every sync.
+   */
+  excludeSlugPrefixes?: readonly string[];
   /** Turn count of the extraction window — feeds the rationale template. */
   windowSize: number;
 }
@@ -166,6 +179,7 @@ export function gateVolunteeredPointers(
   const out: VolunteeredPage[] = [];
   for (const p of block.pointers) {
     if (opts.excludeSlugs?.has(p.slug)) continue; // before gate + cap — see VolunteerOpts
+    if (opts.excludeSlugPrefixes?.some((prefix) => p.slug.startsWith(prefix))) continue;
     // matchedNorm is the resolver's provenance join-key (the candidate that
     // resolved the pointer); display-based lookup is the fallback for the
     // rare suffix rows where provenance couldn't be recovered.
@@ -225,6 +239,8 @@ export type VolunteerResolveFn = (
 export interface VolunteerStageOpts {
   /** Skipped BEFORE gate + cap — typically the turn's already-injected pointer slugs. */
   excludeSlugs?: ReadonlySet<string>;
+  /** Slug prefixes skipped BEFORE gate + cap — see GateOpts.excludeSlugPrefixes. */
+  excludeSlugPrefixes?: readonly string[];
   priorContextText?: string;
   lexicalArms?: boolean;
   maxPages?: number;
@@ -262,6 +278,7 @@ export async function volunteerStage(
     maxPages: opts.maxPages,
     minConfidence: opts.minConfidence,
     excludeSlugs: opts.excludeSlugs,
+    excludeSlugPrefixes: opts.excludeSlugPrefixes,
     windowSize,
   });
 }
@@ -292,6 +309,7 @@ export async function volunteerContext(
     turns.length,
     {
       excludeSlugs: opts.excludeSlugs,
+      excludeSlugPrefixes: opts.excludeSlugPrefixes,
       priorContextText: opts.priorContext,
       lexicalArms: opts.lexicalArms,
       maxPages: opts.maxPages,

--- a/src/core/ops/insights.ts
+++ b/src/core/ops/insights.ts
@@ -83,7 +83,7 @@ const volunteer_context: Operation = {
     }
     const turns = parseWindow(p.window);
     const { loadConfig: loadCfgForArms } = await import('../config.ts');
-    const { lexicalArmsEnabled } = await import('../context/reflex.ts');
+    const { lexicalArmsEnabled, volunteerExcludeSlugPrefixes } = await import('../context/reflex.ts');
     const pages = await volunteerContext(ctx.engine, turns, {
       sourceIds,
       priorContext: typeof p.prior_context === 'string' ? p.prior_context : undefined,
@@ -92,6 +92,7 @@ const volunteer_context: Operation = {
       // v0.46.15+ kill switch for the lexical recall arms (weak-alias +
       // surname) — file-plane gate, threaded per ResolvePointersOpts.
       lexicalArms: lexicalArmsEnabled(loadCfgForArms()),
+      excludeSlugPrefixes: volunteerExcludeSlugPrefixes(loadCfgForArms()),
     });
 
     // Feedback-loop logging: fire-and-forget batched INSERT through the

--- a/src/mcp/resolve-ipc-binding.ts
+++ b/src/mcp/resolve-ipc-binding.ts
@@ -29,7 +29,7 @@ import {
   type IpcHandlers,
 } from '../core/context/resolve-ipc.ts';
 import { resolveEntitiesToPointers, logDeliveredReflexPointers } from '../core/context/retrieval-reflex.ts';
-import { lexicalArmsEnabled } from '../core/context/reflex.ts';
+import { lexicalArmsEnabled, volunteerExcludeSlugPrefixes } from '../core/context/reflex.ts';
 import { VOLUNTEER_MAX_PAGES_CAP } from '../core/context/volunteer.ts';
 import { assembleTurnContext } from '../core/context/turn-context.ts';
 import { makeContextPackIpcHandler } from './context-pack-handler.ts';
@@ -184,6 +184,7 @@ export async function bindResolveIpcForServe(
             // Per-request config read — same next-turn-revert rationale as
             // the resolve handler above (adversarial F3).
             lexicalArms: lexicalArmsEnabled(loadConfig()),
+            excludeSlugPrefixes: volunteerExcludeSlugPrefixes(loadConfig()),
           }),
         // v0.45.7 ambient recall: boundary context pack. Extracted to
         // context-pack-handler.ts (directly testable against a real engine);

--- a/test/volunteer-context.test.ts
+++ b/test/volunteer-context.test.ts
@@ -254,6 +254,50 @@ describe('gateVolunteeredPointers — direct unit (the pure gate step)', () => {
     extractCandidatesFromWindow([{ role: 'user', text: 'Alice Example met Widget Co' }]),
   );
 
+  test('excludeSlugPrefixes drops a whole subtree, BEFORE the cap consumes a slot', () => {
+    // An imported flashcard vault: its one-word aliases ("Delivery", "Cell")
+    // collide with ordinary prose, and the subtree cannot be enumerated as a
+    // set because its members change on every sync. Two card pointers sit
+    // AHEAD of the real hit, so a post-cap filter would return nothing at
+    // maxPages: 1 — the exclusion has to happen before the cap.
+    const block: PointerBlock = {
+      pointers: [
+        { display: 'Delivery', slug: 'inbox/obsidian-cards/oratory-delivery', source_id: 'default', synopsis: 'x', arm: 'alias', confidence: 0.9 },
+        { display: 'Cell', slug: 'inbox/obsidian-cards/cells', source_id: 'default', synopsis: 'x', arm: 'alias', confidence: 0.9 },
+        { display: 'Alice Example', slug: 'people/alice-example', source_id: 'default', synopsis: 'x', arm: 'alias', confidence: 0.9 },
+      ],
+      text: 'BLOCK',
+    };
+    const cands = candidatesByNorm(
+      extractCandidatesFromWindow([{ role: 'user', text: 'Delivery Cell Alice Example' }]),
+    );
+
+    const unfiltered = gateVolunteeredPointers(block, cands, { windowSize: 1, maxPages: 1 });
+    expect(unfiltered.map((p) => p.slug)).toEqual(['inbox/obsidian-cards/oratory-delivery']);
+
+    const filtered = gateVolunteeredPointers(block, cands, {
+      windowSize: 1,
+      maxPages: 1,
+      excludeSlugPrefixes: ['inbox/obsidian-cards/'],
+    });
+    expect(filtered.map((p) => p.slug)).toEqual(['people/alice-example']);
+  });
+
+  test('excludeSlugPrefixes is prefix-anchored, not a substring match', () => {
+    const block: PointerBlock = {
+      pointers: [
+        { display: 'Alice Example', slug: 'people/inbox/obsidian-cards-note', source_id: 'default', synopsis: 'x', arm: 'alias', confidence: 0.9 },
+      ],
+      text: 'BLOCK',
+    };
+    const cands = candidatesByNorm(extractCandidatesFromWindow([{ role: 'user', text: 'Alice Example' }]));
+    const out = gateVolunteeredPointers(block, cands, {
+      windowSize: 1,
+      excludeSlugPrefixes: ['inbox/obsidian-cards/'],
+    });
+    expect(out.map((p) => p.slug)).toEqual(['people/inbox/obsidian-cards-note']);
+  });
+
   test('gates below-threshold arms out; passes alias arm with newest-turn boost', () => {
     const pages = gateVolunteeredPointers(BLOCK, CANDS, { windowSize: 1 });
     expect(pages.map((p) => p.slug)).toEqual(['people/alice-example']); // slug-suffix 0.6+0.05 < 0.7


### PR DESCRIPTION
## The lever that was never reachable

`gateVolunteeredPointers` has always had an `excludeSlugs` escape hatch, applied *before* the confidence gate and the `maxPages` cap. **Nothing outside `volunteer.ts` ever populated it** — no config key, no op parameter, no caller anywhere in `src/`. A brain with a noisy subtree had no way to quiet it.

## Why a set is the wrong shape

On my brain, an imported Obsidian flashcard vault carries one-word aliases — `Delivery`, `Cell`, `Log`, `Dreaming` — because that is how Obsidian resolves `[[Delivery]]` to a note. Those aliases are **correct in Obsidian and actively harmful in ambient recall**: the alias arm scores 0.9, above an exact title match, so any sentence containing that ordinary noun beat every specific hit.

Measured over 90 days on 69,742 pages:

| Arm | Volunteered | Precision |
|---|---|---|
| `alias` | 889 | **2.8%** |
| `title` | 2,078 | 87.5%\* |

852 of the 889 alias volunteers (96%) were **one flashcard about oratory**. With `VOLUNTEER_DEFAULT_MAX_PAGES = 3`, it took a slot every time it fired.

\* *the title figure is confounded — the precision proxy is `last_retrieved_at > volunteered_at`, which counts any later read, so a frequently-read page scores ~100% regardless of whether volunteering helped.*

Deleting the aliases is not the fix: it breaks the vault's own linking, and `page_aliases` is a projection that `import-file.ts` rebuilds from frontmatter on every sync, so the deletion silently reverts. The subtree also can't be enumerated as a set — its members change on every sync. Hence prefixes.

## Change

`excludeSlugPrefixes` threaded through the path `excludeSlugs` already takes (`GateOpts` → `VolunteerStageOpts` → `VolunteerOpts`), read by `volunteerExcludeSlugPrefixes` with the env-direct override `volunteerEnabled`/`lexicalArmsEnabled` already use, and wired into both production call sites (the insights op, and the per-turn hook via `turn-context`).

## Deliberately not included

Down-weighting single-token aliases. It looks like the obvious general fix and it is wrong — a one-word alias is usually a person's nickname (`Swami`), which is the main reason aliases exist. Telling a useful nickname from a colliding common noun needs **document frequency**, not token count, and that's a lookup on a hot path. I prototyped it, saw it break the existing nickname test, and dropped it rather than ship the collateral damage.

## Tests

- exclusion drops a whole subtree **before the cap consumes a slot** — the ordering that makes it useful rather than cosmetic
- matching is prefix-anchored, not substring

Discrimination-tested: removing the one-line guard fails the ordering test and leaves the rest green. 161 tests pass across the volunteer, reflex, turn-context and doctor suites.