### PR TITLE
fix(entities,links): fold Latin stroke letters the accent strip cannot reach

### DIFF
--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -23,6 +23,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import { normalizeAlias } from '../search/alias-normalize.ts';
+import { foldNonDecomposingLatin } from '../latin-fold.ts';
 import { isUndefinedTableError } from '../utils.ts';
 
 /**
@@ -448,33 +449,6 @@ async function tryFuzzyMatch(
 }
 
 /**
- * Latin letters whose diacritic is drawn INSIDE the glyph — a stroke, bar, or
- * ligature rather than a floating accent. Unicode assigns them no
- * decomposition mapping, so the NFKD pass below leaves them untouched and the
- * `[^a-z0-9]+` sweep then DELETES them instead of folding them to a base
- * letter. Vietnamese is the common case: "Đăng Example" slugged to
- * "ang-example" — the leading d vanished, and every fact written under that
- * name landed on an entity slug no lookup by name could reach.
- *
- * Keys are lowercase: slugify() lowercases before it consults this table.
- */
-const NON_DECOMPOSING_LATIN: Record<string, string> = {
-  đ: 'd', // U+0111 Vietnamese, Croatian, Sami
-  ð: 'd', // U+00F0 Icelandic eth
-  ø: 'o', // U+00F8 Danish, Norwegian, Faroese
-  ł: 'l', // U+0142 Polish
-  ħ: 'h', // U+0127 Maltese
-  ŧ: 't', // U+0167 Northern Sami
-  ı: 'i', // U+0131 Turkish dotless i
-  ß: 'ss', // U+00DF German sharp s
-  æ: 'ae', // U+00E6 Danish, Norwegian, Icelandic
-  œ: 'oe', // U+0153 French
-  þ: 'th', // U+00FE Icelandic thorn
-};
-
-const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_LATIN).join('')}]`, 'g');
-
-/**
  * Deterministic slugify: lowercase, fold accents and stroke letters to their
  * base letter, replace non-alphanumerics with hyphens, collapse repeated
  * hyphens, trim leading/trailing hyphens.
@@ -482,16 +456,20 @@ const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_LATIN).joi
  * Exported for tests + callers who want the same fallback shape independently.
  */
 export function slugify(raw: string): string {
-  return raw
-    .toLowerCase()
-    .normalize('NFKD')
-    // NFKD decomposes accents into combining marks (U+0300..U+036F);
-    // strip them before replacing the rest with hyphens so "è" → "e",
-    // not "e" + "-".
-    .replace(/[̀-ͯ]/g, '')
-    // Runs AFTER the mark strip so composed forms reduce in one pass:
-    // "ǿ" → NFKD → "ø" + U+0301 → mark stripped → "ø" → "o".
-    .replace(NON_DECOMPOSING_RE, ch => NON_DECOMPOSING_LATIN[ch])
+  // Stroke letters carry no decomposition, so the mark strip cannot fold them
+  // and the sweep below would DELETE them: "Đăng Example" slugged to
+  // "ang-example". Fold after the strip so composed forms reduce in one pass
+  // ("ǿ" → "ø" → "o").
+  const folded = foldNonDecomposingLatin(
+    raw
+      .toLowerCase()
+      .normalize('NFKD')
+      // NFKD decomposes accents into combining marks (U+0300..U+036F);
+      // strip them before replacing the rest with hyphens so "è" → "e",
+      // not "e" + "-".
+      .replace(/[̀-ͯ]/g, ''),
+  );
+  return folded
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '');

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -448,8 +448,36 @@ async function tryFuzzyMatch(
 }
 
 /**
- * Deterministic slugify: lowercase, replace non-alphanumerics with hyphens,
- * collapse repeated hyphens, trim leading/trailing hyphens.
+ * Latin letters whose diacritic is drawn INSIDE the glyph — a stroke, bar, or
+ * ligature rather than a floating accent. Unicode assigns them no
+ * decomposition mapping, so the NFKD pass below leaves them untouched and the
+ * `[^a-z0-9]+` sweep then DELETES them instead of folding them to a base
+ * letter. Vietnamese is the common case: "Đăng Example" slugged to
+ * "ang-example" — the leading d vanished, and every fact written under that
+ * name landed on an entity slug no lookup by name could reach.
+ *
+ * Keys are lowercase: slugify() lowercases before it consults this table.
+ */
+const NON_DECOMPOSING_LATIN: Record<string, string> = {
+  đ: 'd', // U+0111 Vietnamese, Croatian, Sami
+  ð: 'd', // U+00F0 Icelandic eth
+  ø: 'o', // U+00F8 Danish, Norwegian, Faroese
+  ł: 'l', // U+0142 Polish
+  ħ: 'h', // U+0127 Maltese
+  ŧ: 't', // U+0167 Northern Sami
+  ı: 'i', // U+0131 Turkish dotless i
+  ß: 'ss', // U+00DF German sharp s
+  æ: 'ae', // U+00E6 Danish, Norwegian, Icelandic
+  œ: 'oe', // U+0153 French
+  þ: 'th', // U+00FE Icelandic thorn
+};
+
+const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_LATIN).join('')}]`, 'g');
+
+/**
+ * Deterministic slugify: lowercase, fold accents and stroke letters to their
+ * base letter, replace non-alphanumerics with hyphens, collapse repeated
+ * hyphens, trim leading/trailing hyphens.
  *
  * Exported for tests + callers who want the same fallback shape independently.
  */
@@ -461,6 +489,9 @@ export function slugify(raw: string): string {
     // strip them before replacing the rest with hyphens so "è" → "e",
     // not "e" + "-".
     .replace(/[̀-ͯ]/g, '')
+    // Runs AFTER the mark strip so composed forms reduce in one pass:
+    // "ǿ" → NFKD → "ø" + U+0301 → mark stripped → "ø" → "o".
+    .replace(NON_DECOMPOSING_RE, ch => NON_DECOMPOSING_LATIN[ch])
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '');

--- a/src/core/latin-fold.ts
+++ b/src/core/latin-fold.ts
@@ -1,0 +1,49 @@
+/**
+ * Latin letters whose diacritic is drawn INSIDE the glyph — a stroke, bar, or
+ * ligature rather than a floating accent.
+ *
+ * Unicode assigns these no decomposition mapping, so the usual fold (NFD/NFKD
+ * decompose, then strip combining marks U+0300–U+036F) turns "é" into "e" but
+ * leaves "đ" exactly as it was. What happens next depends on the grammar
+ * downstream, and both outcomes are wrong in the same way:
+ *
+ *   - a grammar that keeps only `[a-z0-9]` DELETES the letter
+ *     ("Đăng Example" → "ang-example");
+ *   - a grammar that keeps all letters KEEPS it unfolded
+ *     ("Đức Example" → "đuc-example").
+ *
+ * Neither matches the ASCII form the rest of the pipeline expects, and the
+ * mismatch is silent: a slug nothing resolves to, or a basename lookup that
+ * misses.
+ *
+ * Leaf module by design — text primitives only, no engine or graph imports —
+ * so every grammar that folds accents can share one table.
+ */
+
+/** Keys are lowercase: callers fold after their own lowercasing pass. */
+export const NON_DECOMPOSING_LATIN: Readonly<Record<string, string>> = {
+  đ: 'd', // U+0111 Vietnamese, Croatian, Sami
+  ð: 'd', // U+00F0 Icelandic eth
+  ø: 'o', // U+00F8 Danish, Norwegian, Faroese
+  ł: 'l', // U+0142 Polish
+  ħ: 'h', // U+0127 Maltese
+  ŧ: 't', // U+0167 Northern Sami
+  ı: 'i', // U+0131 Turkish dotless i
+  ß: 'ss', // U+00DF German sharp s
+  æ: 'ae', // U+00E6 Danish, Norwegian, Icelandic
+  œ: 'oe', // U+0153 French
+  þ: 'th', // U+00FE Icelandic thorn
+};
+
+const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_LATIN).join('')}]`, 'g');
+
+/**
+ * Fold stroke/bar/ligature letters to their base ASCII letters.
+ *
+ * Call AFTER lowercasing (the table is lowercase-keyed) and AFTER the
+ * combining-mark strip, so composed forms reduce in a single pass:
+ * "ǿ" → NFD → "ø" + U+0301 → mark stripped → "ø" → "o".
+ */
+export function foldNonDecomposingLatin(s: string): string {
+  return s.replace(NON_DECOMPOSING_RE, ch => NON_DECOMPOSING_LATIN[ch]);
+}

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -18,6 +18,7 @@ import { stripCodeBlocks } from './markdown-code.ts';
 import { parseInlineCitationTimelineEntries } from './timeline-citations.ts';
 import { slugifyPath } from './sync.ts';
 import { SLUG_WORD_CHARS } from './cjk.ts';
+import { foldNonDecomposingLatin } from './latin-fold.ts';
 // #3190: pack-aware link typing. link-inference imports only manifest-v1
 // (zod) + redos-guard (node:vm) — no cycle back into this module.
 import type { SchemaPackManifest } from './schema-pack/manifest-v1.ts';
@@ -1085,8 +1086,15 @@ export interface SlugResolver {
  */
 const BASENAME_KEEP_RE = new RegExp(`[^${SLUG_WORD_CHARS}\\s\\-]`, 'gu');
 export function normalizeBasename(s: string): string {
-  return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').normalize('NFC')
-    .toLowerCase().replace(BASENAME_KEEP_RE, '').trim().replace(/\s+/g, '-');
+  // The accent strip cannot fold stroke letters \u2014 Unicode gives them no
+  // decomposition \u2014 so the shared table runs after it, on both the index and
+  // the query side. Without it a display name keeps the unfolded letter while
+  // the ASCII page slug does not, and the lookup misses in silence:
+  // `[[\u0110\u1ee9c Example]]` keyed `\u0111uc-example` and never found `people/duc-example`.
+  const folded = foldNonDecomposingLatin(
+    s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').normalize('NFC').toLowerCase(),
+  );
+  return folded.replace(BASENAME_KEEP_RE, '').trim().replace(/\s+/g, '-');
 }
 
 /** Stable order: shorter slug first (likely closer to brain root), then lexical. */

--- a/test/entity-resolve.test.ts
+++ b/test/entity-resolve.test.ts
@@ -184,6 +184,32 @@ describe('slugify', () => {
   it('strips accents', () => {
     expect(slugify('José García')).toBe('jose-garcia');
   });
+
+  // Stroke/bar/ligature letters carry no Unicode decomposition, so the NFKD
+  // pass cannot fold them and the non-alphanumeric sweep used to delete them:
+  // "Đăng Example" slugged to "ang-example", filing facts under an entity slug
+  // that no lookup by name could ever resolve.
+  it('folds stroke letters that NFKD cannot decompose', () => {
+    expect(slugify('Đăng Example')).toBe('dang-example');
+    expect(slugify('Bảo Đào Example')).toBe('bao-dao-example');
+  });
+
+  it('folds the same class across other Latin scripts', () => {
+    expect(slugify('Łukasz Example')).toBe('lukasz-example');
+    expect(slugify('Søren Example')).toBe('soren-example');
+    expect(slugify('Weiß Example')).toBe('weiss-example');
+    expect(slugify('Þór Example')).toBe('thor-example');
+  });
+
+  it('folds a stroke letter that also carries a combining accent', () => {
+    // "ǿ" decomposes to "ø" + U+0301: the mark strips, then the table folds.
+    expect(slugify('Ǿrn Example')).toBe('orn-example');
+  });
+
+  it('keeps a name that is only stroke letters reachable', () => {
+    // Pre-fix this collapsed to the empty string.
+    expect(slugify('Đ')).toBe('d');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -1901,6 +1901,30 @@ describe('normalizeBasename — CJK + accent folding (#2367)', () => {
       .toEqual(['meetings/루카텍-올핸즈-미팅']);
   });
 
+  // Stroke letters (đ ł ø ß …) have no Unicode decomposition, so the accent
+  // strip leaves them unfolded and the key diverges from the ASCII page slug
+  // — the lookup then misses in silence. Each name here carries BOTH a
+  // decomposing accent (folded by the strip) and a stroke letter (folded by
+  // the shared table), so a half-fix handling only one class still fails.
+  test('stroke letters fold to the ASCII form the page slug uses', () => {
+    expect(normalizeBasename('Đức Example')).toBe('duc-example');
+    expect(normalizeBasename('Łukasz Example')).toBe('lukasz-example');
+    expect(normalizeBasename('Søren Example')).toBe('soren-example');
+  });
+
+  test('basename index: a stroke-letter display name hits its ASCII slug tail', () => {
+    const idx = buildBasenameIndex(['people/duc-example', 'people/lukasz-example']);
+    expect(queryBasenameIndex(idx, 'Đức Example')).toEqual(['people/duc-example']);
+    expect(queryBasenameIndex(idx, 'Łukasz Example')).toEqual(['people/lukasz-example']);
+  });
+
+  test('index side folds too, so a stroke-letter slug stays reachable', () => {
+    // Symmetry: both sides run through normalizeBasename, so a page whose own
+    // slug kept the stroke letter still answers to the ASCII display name.
+    const idx = buildBasenameIndex(['people/đuc-example']);
+    expect(queryBasenameIndex(idx, 'Duc Example')).toEqual(['people/đuc-example']);
+  });
+
   test('end-to-end: bare CJK wikilink resolves via the basename index', async () => {
     const idx = buildBasenameIndex(['meetings/루카텍-올핸즈-미팅']);
     const resolver: SlugResolver = {


### PR DESCRIPTION
## What

Two slug/basename grammars delete or keep-unfolded the Latin letters whose diacritic is drawn inside the glyph — a stroke, bar, or ligature — because Unicode assigns them no decomposition and the usual accent fold (decompose, then strip combining marks U+0300–U+036F) cannot touch them.

- `slugify()` in `src/core/entities/resolve.ts`, the holding fallback behind entity resolution, keeps only `[a-z0-9]` and so **deletes** the letter: `Đăng Example` → `ang-example`.
- `normalizeBasename()` in `src/core/link-extraction.ts` keeps all letters and so **keeps it unfolded**: `Đức Example` → `đuc-example`.

Both diverge from the ASCII form the rest of the pipeline uses, and both fail silently.

This PR adds `src/core/latin-fold.ts` — a leaf module with no engine or graph imports, holding one table (`đ ð ø ł ħ ŧ ı ß æ œ þ`) and one `foldNonDecomposingLatin()` helper — and points both grammars at it. The fold runs after the combining-mark strip, so composed forms reduce in a single pass (`ǿ` → `ø` + U+0301 → `ø` → `o`).

## Why

**Entity slugs.** `slugify` is the fallback behind `resolveEntitySlugWithSource`, so the failure only fires for an entity with **no page yet** — a name that already has one resolves on `exact_page` / `alias_exact` / fuzzy long before the fallback runs. On that first mention `remember` files the fact under a mangled `entity_slug`, nothing errors, and no later lookup by name reaches it. Spot-checking existing entities shows nothing wrong, which is what makes this easy to miss.

**Wikilinks.** `normalizeBasename` keys the basename index and the query that hits it. A page slug is ASCII (`people/duc-example`), the display name is not, so `[[Đức Example]]` keyed `đuc-example`, matched nothing, and produced **no edge at all** — no error, no `skippedMissingTarget` warning, just a link that silently isn't in the graph. Observed on v0.48.2.0: on one page, three bare wikilinks of identical shape, only the name without a stroke letter produced an edge.

Folding runs on both the index and the query side, so it is symmetric — it can only add matches, never break existing ones. A page whose own slug kept the stroke letter stays reachable by the ASCII display name; there is a test for that direction.

Same class as #3417 (`slugifySegment` dropping non-CJK scripts). One table rather than two copies, for the reason #972 keeps ONE basename matcher: duplicates drift.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/entities/resolve.ts src/core/link-extraction.ts src/core/latin-fold.ts` to merge-base, ran `test/entity-resolve.test.ts` → `32 pass / 4 fail`. Restored → all pass.

Discrimination test: reverted `src/core/entities/resolve.ts src/core/link-extraction.ts src/core/latin-fold.ts` to merge-base, ran `test/link-extraction.test.ts` → `194 pass / 3 fail`. Restored → all pass.

Both runs revert all three source files together. Reverting `latin-fold.ts` alone deletes a module the other two still import, which crashes the module graph and reports `0 pass / 1 fail` — the vacuous-failure shape the script's exit-code contract warns about, not an executed-test failure.

## Tests

`test/entity-resolve.test.ts` — 4 cases added to the existing `slugify` describe. `test/link-extraction.test.ts` — 3 cases added to the `#2367` describe, including two that go through `buildBasenameIndex` / `queryBasenameIndex` rather than asserting on the normalizer alone, plus the index-side symmetry case. All use the `*-example` placeholder pattern per the CLAUDE.md privacy rule.

```
bun test test/entity-resolve.test.ts test/link-extraction.test.ts   # 233 pass / 0 fail, exit 0
bun run typecheck                                                   # exit 0
```

Full `bun run test` on this branch: 23,691 pass / 5 fail. Four are pre-existing watchdog and lock-timing serial tests — verified failing identically with these changes reverted — and the fifth is a parallel-shard flake that passes when its file is run on its own.

End-to-end check on a live brain: a page carrying three bare wikilinks produced one edge before the change and three after, with no other edit and the same `gbrain sync` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
