### PR TITLE
v0.48.2.1 fix(minions): derive worker start time from ps etime instead of lstart

### DIFF
--- a/src/core/minions/worker-registry.ts
+++ b/src/core/minions/worker-registry.ts
@@ -142,22 +142,51 @@ function processLiveness(pid: number): 'alive' | 'dead' | 'unknown' {
   }
 }
 
+/** Parses portable `ps -o etime=` output (`[[dd-]hh:]mm:ss`) to milliseconds. */
+export function parseEtimeToMs(etime: string): number | null {
+  const raw = etime.trim();
+  if (!raw) return null;
+
+  let days = 0;
+  let rest = raw;
+  const dash = rest.indexOf('-');
+  if (dash !== -1) {
+    days = Number(rest.slice(0, dash));
+    rest = rest.slice(dash + 1);
+    if (!Number.isInteger(days) || days < 0) return null;
+  }
+
+  const parts = rest.split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+  if (!parts.every(part => part.length > 0 && /^\d+$/.test(part))) return null;
+
+  const numbers = parts.map(Number);
+  const [hours, minutes, seconds] =
+    numbers.length === 3 ? numbers : [0, numbers[0]!, numbers[1]!];
+
+  return (((days * 24 + hours!) * 60 + minutes!) * 60 + seconds!) * 1000;
+}
+
 /**
  * Best-effort process start time (epoch ms) via `ps`. Used for the PID-reuse
  * guard: a stale `worker-<pid>.json` plus an OS-reused pid would otherwise make
  * us report an unrelated process's niceness (Codex #8). Returns null when
  * undeterminable — callers must NOT treat null as "reused".
+ *
+ * Elapsed time avoids `lstart`'s timezone-less local timestamp, which
+ * `Date.parse` interprets as UTC and shifts worker starts on non-UTC hosts.
+ * `etime` is used instead of Linux-only `etimes` so this also works on macOS.
  */
 function processStartMs(pid: number): number | null {
   try {
-    const out = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+    const out = execFileSync('ps', ['-o', 'etime=', '-p', String(pid)], {
       encoding: 'utf8',
       timeout: 2000,
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     if (!out) return null;
-    const t = Date.parse(out);
-    return Number.isNaN(t) ? null : t;
+    const elapsedMs = parseEtimeToMs(out);
+    return elapsedMs === null ? null : Date.now() - elapsedMs;
   } catch {
     return null;
   }

--- a/test/worker-registry.serial.test.ts
+++ b/test/worker-registry.serial.test.ts
@@ -43,6 +43,25 @@ describe('classifyLiveness (Codex #9)', () => {
   });
 });
 
+describe('parseEtimeToMs (PID-reuse guard, timezone-free)', () => {
+  test('parses every portable ps etime shape', async () => {
+    const { parseEtimeToMs } = await reg();
+    expect(parseEtimeToMs('00:00')).toBe(0);
+    expect(parseEtimeToMs('00:42')).toBe(42_000);
+    expect(parseEtimeToMs('01:23')).toBe(83_000);
+    expect(parseEtimeToMs('12:34:56')).toBe(((12 * 3600) + (34 * 60) + 56) * 1000);
+    expect(parseEtimeToMs('3-04:05:06')).toBe(((3 * 86400) + (4 * 3600) + (5 * 60) + 6) * 1000);
+    expect(parseEtimeToMs('  01:00  ')).toBe(60_000);
+  });
+
+  test('returns null when elapsed time cannot be determined', async () => {
+    const { parseEtimeToMs } = await reg();
+    expect(parseEtimeToMs('')).toBeNull();
+    expect(parseEtimeToMs('garbage')).toBeNull();
+    expect(parseEtimeToMs('not:a:number:at:all')).toBeNull();
+  });
+});
+
 describe('register + read round trip', () => {
   test('registerWorker writes under gbrainPath; readWorkers returns the live worker', async () => {
     const { registerWorker, readWorkers, workerRegistryDir } = await reg();


### PR DESCRIPTION
## What

The minions worker registry's PID-reuse guard now derives a process start time from `ps -o etime=` (elapsed time) instead of `ps -o lstart=`. `parseEtimeToMs` is exported and handles every portable `etime` shape (`mm:ss`, `hh:mm:ss`, `dd-hh:mm:ss`); anything unparseable still yields `null`, which callers already treat as "undeterminable", never as "reused".

## Why

`lstart` prints a local-time timestamp with no zone, and `Date.parse` reads that as UTC. On any non-UTC host the computed start time was shifted by the zone offset, so whether a live worker was classified as a reused pid depended on the machine's timezone. `etime` is timezone-free and works on both macOS and Linux (`etimes` is Linux-only).

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/minions/worker-registry.ts` to merge-base, ran `test/worker-registry.serial.test.ts` → 5 pass / 3 fail. Restored → all pass.

## Tests

- `test/worker-registry.serial.test.ts` — new `parseEtimeToMs` cases (every portable shape, whitespace, garbage, empty).
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/worker-registry.serial.test.ts` → 8 pass / 0 fail (exit 0).
- `bun run typecheck` → exit 0. `bun run verify` → 54 checks green (exit 0).
