### PR TITLE
feat(synthesize_concepts): link member atoms instead of naming them

### DIFF
--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -80,6 +80,8 @@ export interface SynthesizeConceptsOpts {
 
 interface AtomGroup {
   conceptSlug: string;
+  /** Parallel to atomTitles — the member atoms' slugs, for body wikilinks. */
+  atomSlugs: string[];
   atomTitles: string[];
   atomBodies: string[];
   tier: 'T1' | 'T2' | 'T3' | 'T4';
@@ -144,10 +146,11 @@ export async function runPhaseSynthesizeConcepts(
   }
 
   // 2. Group atoms by concept slug
-  const groups = new Map<string, { titles: string[]; bodies: string[] }>();
+  const groups = new Map<string, { slugs: string[]; titles: string[]; bodies: string[] }>();
   for (const atom of atoms) {
     for (const conceptSlug of atom.concept_refs) {
-      const existing = groups.get(conceptSlug) ?? { titles: [], bodies: [] };
+      const existing = groups.get(conceptSlug) ?? { slugs: [], titles: [], bodies: [] };
+      existing.slugs.push(atom.slug);
       existing.titles.push(atom.title);
       existing.bodies.push(atom.body);
       groups.set(conceptSlug, existing);
@@ -163,6 +166,7 @@ export async function runPhaseSynthesizeConcepts(
       count >= TIER_T1_MIN ? 'T1' : count >= TIER_T2_MIN ? 'T2' : 'T3';
     atomGroups.push({
       conceptSlug,
+      atomSlugs: data.slugs,
       atomTitles: data.titles,
       atomBodies: data.bodies,
       tier,
@@ -318,6 +322,10 @@ export async function runPhaseSynthesizeConcepts(
       // #2163: serialize to markdown and import via the canonical pipeline so
       // the page is chunked (+ embedded when a provider is configured) —
       // mirrors put_page's isAvailable('embedding') → noEmbed gate.
+      // Every mode gets the member block — the LLM narrative is prose and
+      // never emits wikilinks of its own, so without this the LLM-written
+      // concepts would be the only ones left with no provenance edges.
+      const body = `${narrative}${memberAtomsBlock(group)}`;
       const md = serializeMarkdown(
         {
           tier: group.tier,
@@ -327,7 +335,7 @@ export async function runPhaseSynthesizeConcepts(
           synthesized_at: new Date().toISOString(),
           synthesized_by: 'synthesize_concepts-v0.41',
         },
-        narrative,
+        body,
         '',
         { type: 'concept', title: title.replace(/-/g, ' '), tags: [] },
       );
@@ -415,11 +423,48 @@ export async function runPhaseSynthesizeConcepts(
 function deterministicNarrative(group: AtomGroup): string {
   const tier = group.tier;
   const count = group.atomTitles.length;
-  return (
-    `${tier} concept. ${count} atom${count === 1 ? '' : 's'} reference this. ` +
-    `Top mentions:\n${group.atomTitles
-      .slice(0, 5)
-      .map((t) => `  - ${t}`)
-      .join('\n')}`
-  );
+  // The member list itself is appended for EVERY synthesis mode by
+  // memberAtomsBlock — as wikilinks, not the plain-text titles this used to
+  // inline. Repeating it here would duplicate it on the page.
+  return `${tier} concept. ${count} atom${count === 1 ? '' : 's'} reference this.`;
+}
+
+/**
+ * The atoms this concept was synthesized from, rendered as wikilinks.
+ *
+ * A concept is derived, not imported: it has no source_uri and no
+ * source_slug, so its provenance IS its member atoms. Emitting them as
+ * wikilinks means the canonical importFromContent pipeline extracts them into
+ * real link rows (link_source='markdown') at write time — no new link_source,
+ * no extra phase, and no waiting for a later pass. That matters because
+ * `concepts-ladder` runs separately and only records atom → concept; until it
+ * catches up a freshly synthesized concept has NO edges at all and reads as an
+ * orphan. This also supplies the missing direction: concept → member atom as
+ * provenance, where the only existing outbound edge is
+ * `atom-semantic-neighbor`, which is similarity rather than lineage.
+ *
+ * Capped: mention_count reaches 2,222 on this author's brain while p99 is 47,
+ * so an uncapped list would render a several-thousand-line body for a handful
+ * of hub concepts. Completeness is not lost — concepts-ladder still records
+ * every member on the inbound side.
+ */
+const MEMBER_ATOM_LINK_CAP = 50;
+
+function memberAtomsBlock(group: AtomGroup): string {
+  const rows: string[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < group.atomSlugs.length && rows.length < MEMBER_ATOM_LINK_CAP; i++) {
+    const slug = group.atomSlugs[i];
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    // `]`, `[` and `|` would terminate the wikilink early (see
+    // WIKILINK_GENERIC_RE); atom titles are model-authored and do contain
+    // punctuation, so strip those three and collapse the whitespace.
+    const display = (group.atomTitles[i] ?? '').replace(/[[\]|]/g, ' ').replace(/\s+/g, ' ').trim();
+    rows.push(display ? `- [[${slug}|${display}]]` : `- [[${slug}]]`);
+  }
+  if (rows.length === 0) return '';
+  const total = new Set(group.atomSlugs.filter(Boolean)).size;
+  const more = total > rows.length ? `\n\n_…and ${total - rows.length} more._` : '';
+  return `\n\n## Member atoms\n\n${rows.join('\n')}${more}\n`;
 }

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -18,6 +18,7 @@ import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-conc
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
 import { canonicalLookup } from '../../src/core/model-pricing.ts';
+import { extractPageLinks, makeResolver } from '../../src/core/link-extraction.ts';
 
 let engine: PGLiteEngine;
 
@@ -701,5 +702,87 @@ describe('#2123: extractor stamps concepts → synthesize_concepts consumes via 
       `SELECT slug FROM pages WHERE slug = 'concepts/captive-portal' AND type = 'concept'`,
     );
     expect(concept.length).toBe(1);
+  });
+});
+
+/**
+ * A concept is derived, not imported — it has no source_uri/source_slug, so
+ * its provenance is its member atoms. The phase already fetches each atom's
+ * slug and used to discard it at grouping time, rendering the member list as
+ * plain text that no extractor could ever turn into an edge. These pin that
+ * the list is now real wikilinks: clickable in a reading view immediately,
+ * and picked up as concept -> atom edges by the normal link-extraction pass
+ * (importFromContent itself only extracts code refs, so the DB rows still
+ * arrive with that pass, not at write time).
+ */
+describe('concept member atoms are wikilinked at synthesis time', () => {
+  const atomsFor = (n: number, concept: string) =>
+    Array.from({ length: n }, (_, i) => ({
+      slug: `atoms/2026-01-01/member-${i}`,
+      title: `Member atom ${i}`,
+      body: 'body text',
+      concept_refs: [concept],
+    }));
+
+  async function seedAtoms(atoms: Array<{ slug: string; title: string; body: string }>) {
+    for (const a of atoms) {
+      await engine.putPage(a.slug, { type: 'atom', title: a.title, compiled_truth: a.body, timeline: '' });
+    }
+  }
+
+  test('member atoms render as wikilinks the extractor resolves to the atom slugs', async () => {
+    const atoms = atomsFor(3, 'dive-entry-mechanics');
+    await seedAtoms(atoms);
+
+    const result = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
+    expect(result.status).toBe('ok');
+
+    const page = await engine.getPage('concepts/dive-entry-mechanics', { sourceId: 'default' });
+    expect(page?.compiled_truth).toContain('[[atoms/2026-01-01/member-0|Member atom 0]]');
+
+    // The claim that matters: these are extractable into real edges.
+    const { candidates } = await extractPageLinks(
+      'concepts/dive-entry-mechanics',
+      page!.compiled_truth,
+      page!.frontmatter ?? {},
+      'concept' as never,
+      makeResolver(engine, { mode: 'live', sourceId: 'default' }),
+    );
+    const targets = candidates.map((c) => c.targetSlug);
+    expect(targets).toContain('atoms/2026-01-01/member-0');
+    expect(targets).toContain('atoms/2026-01-01/member-2');
+  });
+
+  test('caps the rendered list and says how many were elided', async () => {
+    const atoms = atomsFor(60, 'big-hub');
+    await seedAtoms(atoms);
+    // 60 atoms is T1, which takes the LLM path — stub it so no network call.
+    await runPhaseSynthesizeConcepts(engine, { _atoms: atoms, _chat: stubChat('A hub concept.') });
+
+    const page = await engine.getPage('concepts/big-hub', { sourceId: 'default' });
+    const rendered = (page?.compiled_truth ?? '').match(/^- \[\[/gm) ?? [];
+    expect(rendered.length).toBe(50);
+    expect(page?.compiled_truth).toContain('and 10 more');
+  });
+
+  test('a title containing ]] or | cannot terminate the wikilink early', async () => {
+    const atoms = [
+      { slug: 'atoms/2026-01-01/tricky', title: 'Broken ]] title | with pipe', body: 'b', concept_refs: ['tricky-concept'] },
+      { slug: 'atoms/2026-01-01/tricky-2', title: 'Second atom', body: 'b', concept_refs: ['tricky-concept'] },
+    ];
+    await seedAtoms(atoms);
+    await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
+
+    const page = await engine.getPage('concepts/tricky-concept', { sourceId: 'default' });
+    const { candidates } = await extractPageLinks(
+      'concepts/tricky-concept',
+      page!.compiled_truth,
+      page!.frontmatter ?? {},
+      'concept' as never,
+      makeResolver(engine, { mode: 'live', sourceId: 'default' }),
+    );
+    const targets = candidates.map((c) => c.targetSlug);
+    expect(targets).toContain('atoms/2026-01-01/tricky');
+    expect(targets).toContain('atoms/2026-01-01/tricky-2');
   });
 });


### PR DESCRIPTION
## The information is fetched, then dropped

A concept is derived, not imported — no `source_uri`, no `source_slug` — so its provenance **is** the atoms it was synthesized from.

`synthesize_concepts` already has those atoms' slugs. The query selects `slug`, the atom loop carries it, and then grouping throws it away:

```ts
existing.titles.push(atom.title);   // slug discarded here
```

`AtomGroup` ends up with `atomTitles: string[]` and no slugs, so `deterministicNarrative` can only render:

```
Top mentions:
  - Why Most Swim Starts Fail: The "Pipes" Problem
```

Nothing downstream can turn a bare title into an edge. The result is that a concept's own membership is never navigable in that direction, and a freshly synthesized concept reads as an orphan with no indication of where it came from.

On my brain that's **9,990 of 10,645 concepts (94%)** — every `deterministic_tier`, `budget_fallback` and `error_fallback` page.

## Change

Carry the slugs through and render the members as wikilinks. Two things follow:

- a reading view resolves them immediately, so the page documents its own provenance
- the normal link-extraction pass turns them into **concept → atom** rows

That direction is currently missing. `concepts-ladder` records atom → concept; the only outbound edge a concept has today is `atom-semantic-neighbor`, which is *similarity, not lineage*. The two are complementary, not duplicative.

To be precise about scope: `importFromContent` extracts code refs only, so the DB rows still arrive with the regular extraction pass rather than at write time. The gain is that there is now something extractable at all.

## Decisions

**Every synthesis mode**, not just the deterministic one — the LLM writes prose and never emits wikilinks, so gating on mode would leave the 132 LLM-written concepts as the only ones with no provenance. `deterministicNarrative` drops its own inline list, which the block supersedes.

**Capped at 50.** `mention_count` reaches 2,222 on my brain against a p99 of 47, so an uncapped list renders a several-thousand-line body for a handful of hubs. The elided count is stated, and `concepts-ladder` still records every member inbound, so nothing is lost.

**`[`, `]` and `|` stripped from the display half.** Titles are model-authored and contain punctuation; `Broken ]] title | with pipe` would otherwise terminate the wikilink early per `WIKILINK_GENERIC_RE` and point the edge somewhere else.

## Tests

- member atoms render as wikilinks that `extractPageLinks` resolves to the right atom slugs
- the cap holds at 50 and reports the elided count
- a title containing `]]` or `|` cannot terminate the wikilink early

Discrimination-tested: detaching the member block fails exactly those three and leaves the other 37 green. 178 tests pass across the cycle, concept-routing, drain, budget and receipt suites.