### PR TITLE
v0.48.2.1 fix(autopilot): skip missing source checkouts (#4729)

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -14,7 +14,7 @@ test/auto-link-targeted-probe-2544.test.ts	#2544 — auto-link behavior through 
 test/autopilot-auto-drain-wiring.test.ts	autopilot auto-drain wiring	8	readFileSync
 test/autopilot-cycle-failure-classification.test.ts	autopilot cycle-failure classification — only 'failed' trips the circuit breaker	2	readFileSync
 test/autopilot-cycle-failure-classification.test.ts	runPhaseOrphans ratio threshold — no more absolute count > 20	3	readFileSync
-test/autopilot-fanout-wiring.test.ts	autopilot.ts ↔ dispatchPerSource wiring	13	readFileSync
+test/autopilot-fanout-wiring.test.ts	autopilot.ts ↔ dispatchPerSource wiring	14	readFileSync
 test/autopilot-install.test.ts	autopilot install — reload-safety (#2608)	1	readFileSync
 test/autopilot-install.test.ts	autopilot showStatus — wrapper-path detection	1	readFileSync
 test/autopilot-install.test.ts	autopilot wiring: chat-unavailable boot warning (#2608)	1	readFileSync

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -94,6 +94,8 @@ export interface FanoutResult {
   legacy_fallback: boolean;
   /** True when every enumerated source is inside the freshness window. */
   all_sources_fresh: boolean;
+  /** True when every enumerated source is either fresh or skipped locally. */
+  all_sources_handled: boolean;
 }
 
 /**
@@ -355,7 +357,7 @@ export function selectSourcesForDispatch(
   const cooldown: SourceRow[] = [];
   const unavailablePath: SourceRow[] = [];
   for (const s of sources) {
-    if (s.local_path && sourceLocalPathSkipWarning(s.id, s.local_path, pathExists)) {
+    if (s.local_path && sourceLocalPathSkipWarning(s.id, s.local_path, pathExists, s.config)) {
       unavailablePath.push(s);
       continue;
     }
@@ -450,6 +452,7 @@ export async function dispatchPerSource(
       skipped_unavailable_path: [],
       legacy_fallback: true,
       all_sources_fresh: false,
+      all_sources_handled: false,
     };
   }
 
@@ -482,7 +485,7 @@ export async function dispatchPerSource(
     );
 
   for (const src of skippedUnavailablePath) {
-    const warning = src.local_path ? sourceLocalPathSkipWarning(src.id, src.local_path, pathExists) : null;
+    const warning = src.local_path ? sourceLocalPathSkipWarning(src.id, src.local_path, pathExists, src.config) : null;
     if (!warning) continue;
     if (opts.jsonMode) {
       emit(JSON.stringify({ event: 'fanout_source_path_skipped', source_id: src.id, reason: warning }));
@@ -592,6 +595,7 @@ export async function dispatchPerSource(
     skipped_unavailable_path: skippedUnavailablePath.map(s => s.id),
     legacy_fallback: false,
     all_sources_fresh: skippedFresh.length === sources.length,
+    all_sources_handled: skippedFresh.length + skippedUnavailablePath.length === sources.length,
   };
 }
 

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -20,6 +20,8 @@
  *   - P1-5: archive recheck happens in the handler (jobs.ts:1146), not
  *     here, so a source archived between fan-out and worker claim still
  *     skips cleanly.
+ *   - Missing checkout paths are skipped at dispatch time; sources.local_path
+ *     is machine-specific shared state and can legitimately point elsewhere.
  *
  * Phase-scope caveat (codex r1 P0-1): per-source cycle LOCKS let two cycles
  * RUN concurrently, but several phases (embed, orphans, purge,
@@ -30,10 +32,11 @@
  * row layer; cost duplication is the visible tradeoff).
  */
 
+import { existsSync } from 'fs';
 import type { BrainEngine, SourceRow } from '../core/engine.ts';
 import type { MinionQueue } from '../core/minions/queue.ts';
 import { SOURCE_FRESHNESS_PHASES, MAINTENANCE_PHASES, LAST_GLOBAL_AT_KEY } from '../core/cycle.ts';
-import { sourceConfigHasRemoteUrl } from '../core/sources-load.ts';
+import { sourceConfigHasRemoteUrl, sourceLocalPathSkipWarning } from '../core/sources-load.ts';
 import { AUTOPILOT_FULL_CYCLE_FLOOR_MINUTES } from './autopilot-remediation-policy.ts';
 
 // #2194 fix #2: failure cooldown. A source whose autopilot-cycle keeps
@@ -66,6 +69,8 @@ export interface FanoutOpts {
   emit?: (line: string) => void;
   /** Sink for non-JSON human log lines; defaults to console.log. */
   log?: (line: string) => void;
+  /** Test seam for source checkout availability. */
+  pathExists?: (path: string) => boolean;
 }
 
 export interface FanoutResult {
@@ -82,6 +87,8 @@ export interface FanoutResult {
   skipped_cap: string[];
   /** Source ids skipped because they're in failure cooldown (#2194 fix #2). */
   skipped_cooldown: string[];
+  /** Source ids skipped because local_path is unavailable from this machine. */
+  skipped_unavailable_path: string[];
   /** True when this tick fell back to the legacy single-job path
    *  (no sources rows / engine empty). */
   legacy_fallback: boolean;
@@ -341,11 +348,17 @@ export function selectSourcesForDispatch(
   floorMin = AUTOPILOT_FULL_CYCLE_FLOOR_MINUTES,
   recentFailures: Map<string, SourceFailure> = new Map(),
   cooldownOpts: CooldownOpts = { baseMin: FAILURE_COOLDOWN_BASE_MIN, capMin: FAILURE_COOLDOWN_CAP_MIN },
-): { dispatch: SourceRow[]; skippedFresh: SourceRow[]; skippedCap: SourceRow[]; skippedCooldown: SourceRow[] } {
+  pathExists: (path: string) => boolean = () => true,
+): { dispatch: SourceRow[]; skippedFresh: SourceRow[]; skippedCap: SourceRow[]; skippedCooldown: SourceRow[]; skippedUnavailablePath: SourceRow[] } {
   const stale: SourceRow[] = [];
   const fresh: SourceRow[] = [];
   const cooldown: SourceRow[] = [];
+  const unavailablePath: SourceRow[] = [];
   for (const s of sources) {
+    if (s.local_path && sourceLocalPathSkipWarning(s.id, s.local_path, pathExists)) {
+      unavailablePath.push(s);
+      continue;
+    }
     if (!isSourceStale(s, now, floorMin)) { fresh.push(s); continue; }
     // #2194 fix #2: a stale source that recently failed is held in cooldown so
     // it can't re-dispatch every tick (the storm). Success clears it.
@@ -364,7 +377,7 @@ export function selectSourcesForDispatch(
   });
   const dispatch = stale.slice(0, fanoutMax);
   const skippedCap = stale.slice(fanoutMax);
-  return { dispatch, skippedFresh: fresh, skippedCap, skippedCooldown: cooldown };
+  return { dispatch, skippedFresh: fresh, skippedCap, skippedCooldown: cooldown, skippedUnavailablePath: unavailablePath };
 }
 
 /**
@@ -434,6 +447,7 @@ export async function dispatchPerSource(
       skipped_fresh: [],
       skipped_cap: [],
       skipped_cooldown: [],
+      skipped_unavailable_path: [],
       legacy_fallback: true,
       all_sources_fresh: false,
     };
@@ -455,7 +469,8 @@ export async function dispatchPerSource(
     cooldownOpts = { baseMin: 0, capMin: FAILURE_COOLDOWN_CAP_MIN };
   }
 
-  const { dispatch, skippedFresh, skippedCap, skippedCooldown } =
+  const pathExists = opts.pathExists ?? existsSync;
+  const { dispatch, skippedFresh, skippedCap, skippedCooldown, skippedUnavailablePath } =
     selectSourcesForDispatch(
       sources,
       opts.fanoutMax,
@@ -463,7 +478,18 @@ export async function dispatchPerSource(
       AUTOPILOT_FULL_CYCLE_FLOOR_MINUTES,
       recentFailures,
       cooldownOpts,
+      pathExists,
     );
+
+  for (const src of skippedUnavailablePath) {
+    const warning = src.local_path ? sourceLocalPathSkipWarning(src.id, src.local_path, pathExists) : null;
+    if (!warning) continue;
+    if (opts.jsonMode) {
+      emit(JSON.stringify({ event: 'fanout_source_path_skipped', source_id: src.id, reason: warning }));
+    } else {
+      log(warning);
+    }
+  }
 
   const dispatched: string[] = [];
   const coalesced: string[] = [];
@@ -563,6 +589,7 @@ export async function dispatchPerSource(
     skipped_fresh: skippedFresh.map(s => s.id),
     skipped_cap: skippedCap.map(s => s.id),
     skipped_cooldown: skippedCooldown.map(s => s.id),
+    skipped_unavailable_path: skippedUnavailablePath.map(s => s.id),
     legacy_fallback: false,
     all_sources_fresh: skippedFresh.length === sources.length,
   };

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -1092,7 +1092,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               // it would sync a phantom path. Skip loudly; the fix is
               // re-registering with an absolute path (sources add now
               // resolves) or one successful `gbrain sync` (anchor self-heal).
-              const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path);
+              const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path, undefined, src.config);
               if (skipWarn) {
                 process.stderr.write(skipWarn + '\n');
                 continue;
@@ -1191,7 +1191,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
                     if (submittedToday >= maxJobsToday) break; // brain-wide daily cap (fairness)
                     if (!src.local_path) continue;
                     // #3696: same relative-path skip as the freshness loop.
-                    const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path);
+                    const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path, undefined, src.config);
                     if (skipWarn) {
                       process.stderr.write(skipWarn + '\n');
                       continue;
@@ -1391,7 +1391,13 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           // keep that behavior, or an all-coalesced tick (single-flight
           // suppression) would retake the full-cycle branch every tick and
           // starve the targeted-plan path for the whole in-flight window.
-          if (result.dispatched.length > 0 || result.coalesced.length > 0 || result.legacy_fallback || result.all_sources_fresh) {
+          if (
+            result.dispatched.length > 0 ||
+            result.coalesced.length > 0 ||
+            result.legacy_fallback ||
+            result.all_sources_fresh ||
+            result.all_sources_handled
+          ) {
             lastFullCycleAt = Date.now();
           }
           if (jsonMode) {
@@ -1402,6 +1408,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               skipped_fresh: result.skipped_fresh,
               skipped_cap: result.skipped_cap,
               skipped_cooldown: result.skipped_cooldown,
+              skipped_unavailable_path: result.skipped_unavailable_path,
               legacy_fallback: result.legacy_fallback,
               fanout_max: fanoutMax,
               score,
@@ -1411,7 +1418,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               `[dispatch] fanout: ${result.dispatched.length} dispatched` +
               `${result.coalesced.length > 0 ? ` (${result.coalesced.length} coalesced onto in-flight)` : ''}, ` +
               `${result.skipped_fresh.length} fresh, ${result.skipped_cap.length} capped, ` +
-              `${result.skipped_cooldown.length} cooldown ` +
+              `${result.skipped_cooldown.length} cooldown, ` +
+              `${result.skipped_unavailable_path.length} unavailable-path ` +
               `(score=${score}, max=${fanoutMax})`,
             );
           }

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -45,6 +45,7 @@ import { detectInstallMethod } from './upgrade.ts';
 import { evaluateQuietHours } from '../core/minions/quiet-hours.ts';
 import { inspectLock } from '../core/db-lock.ts';
 import { registerCleanup } from '../core/process-cleanup.ts';
+import { sourceLocalPathSkipWarning, relativeSourceLocalPathSkipWarning } from '../core/sources-load.ts';
 import { resolveAutopilotDispatchTimeoutMs } from './autopilot-timeout.ts';
 import {
   autopilotRemediationIdempotencyKey,
@@ -65,6 +66,7 @@ import {
   MIGRATE_PAUSE_MARKER_PREFIX,
 } from '../core/autopilot-paths.ts';
 export { autopilotLockPath, autopilotDisabledMarkerPath, autopilotPausedMarkerPath, autopilotLaunchdLabel };
+export { relativeSourceLocalPathSkipWarning as relativeLocalPathSkipWarning };
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -1090,9 +1092,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               // it would sync a phantom path. Skip loudly; the fix is
               // re-registering with an absolute path (sources add now
               // resolves) or one successful `gbrain sync` (anchor self-heal).
-              const relWarn = relativeLocalPathSkipWarning(src.id, src.local_path);
-              if (relWarn) {
-                process.stderr.write(relWarn + '\n');
+              const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path);
+              if (skipWarn) {
+                process.stderr.write(skipWarn + '\n');
                 continue;
               }
               const lastSyncMs = src.last_sync_at ? new Date(src.last_sync_at).getTime() : 0;
@@ -1189,9 +1191,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
                     if (submittedToday >= maxJobsToday) break; // brain-wide daily cap (fairness)
                     if (!src.local_path) continue;
                     // #3696: same relative-path skip as the freshness loop.
-                    const relWarn = relativeLocalPathSkipWarning(src.id, src.local_path);
-                    if (relWarn) {
-                      process.stderr.write(relWarn + '\n');
+                    const skipWarn = sourceLocalPathSkipWarning(src.id, src.local_path);
+                    if (skipWarn) {
+                      process.stderr.write(skipWarn + '\n');
                       continue;
                     }
                     const backlog = await countExtractAtomsBacklog(engine, src.id);
@@ -1974,23 +1976,6 @@ export function pgliteDaemonGuardMessage(engineKind: string, force: boolean): st
     `maintenance sweep, and delegates \`gbrain sync\`/\`gbrain sweep --once\` through its ` +
     `IPC socket.\n` +
     `  To install the daemon anyway (dedicated-brain setups), re-run with --force.`
-  );
-}
-
-/**
- * #3696 — the autopilot dispatch loops refuse to enqueue work for a source
- * whose local_path is RELATIVE: the daemon's cwd is launchd's (typically `/`),
- * not the shell that registered the source, so the path would resolve to a
- * phantom directory and the sync/extract job would fail (or worse, walk the
- * wrong tree). Returns the stderr warning line when the path must be skipped,
- * or null when it is dispatchable. Pure — the unit-test surface.
- */
-export function relativeLocalPathSkipWarning(sourceId: string, localPath: string): string | null {
-  if (isAbsolute(localPath)) return null;
-  return (
-    `[autopilot] skipping source '${sourceId}': relative local_path ` +
-    `'${localPath}' cannot be resolved from a daemon. Re-register with an ` +
-    `absolute --path or run 'gbrain sync --source ${sourceId}' once to self-heal.`
   );
 }
 

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -17,9 +17,8 @@
  * A shared helper hits the bar at lower cost.
  */
 import { existsSync } from 'fs';
-import { isAbsolute, resolve as resolvePath } from 'path';
+import { isAbsolute } from 'path';
 import type { BrainEngine } from './engine.ts';
-import { gbrainPath } from './config.ts';
 
 export interface SourceRow {
   id: string;
@@ -157,12 +156,11 @@ export function sourceConfigHasRemoteUrl(config: unknown): boolean {
   return typeof remoteUrl === 'string' && remoteUrl.trim().length > 0;
 }
 
-function sourceHasRecoverableManagedClone(sourceId: string, localPath: string, config: unknown): boolean {
+function sourceHasRecoverableManagedClone(config: unknown): boolean {
   const cfg = parseSourceConfig(config);
   const remoteUrl = cfg.remote_url;
   if (typeof remoteUrl !== 'string' || remoteUrl.trim().length === 0) return false;
-  if (cfg.managed_clone === true) return true;
-  return resolvePath(localPath) === resolvePath(gbrainPath('clones', sourceId));
+  return cfg.managed_clone === true;
 }
 
 /**
@@ -180,7 +178,7 @@ export function sourceLocalPathSkipWarning(
   const relative = relativeSourceLocalPathSkipWarning(sourceId, localPath);
   if (relative) return relative;
   if (pathExists(localPath)) return null;
-  if (sourceHasRecoverableManagedClone(sourceId, localPath, config)) return null;
+  if (sourceHasRecoverableManagedClone(config)) return null;
   return (
     `[autopilot] skipping source '${sourceId}': local_path ` +
     `'${localPath}' does not exist on this machine. Clone/register this ` +

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -16,6 +16,8 @@
  * implementations even though both run identical SQL through `executeRaw`.
  * A shared helper hits the bar at lower cost.
  */
+import { existsSync } from 'fs';
+import { isAbsolute } from 'path';
 import type { BrainEngine } from './engine.ts';
 
 export interface SourceRow {
@@ -152,6 +154,35 @@ export function parseSourceConfig(config: unknown): Record<string, unknown> {
 export function sourceConfigHasRemoteUrl(config: unknown): boolean {
   const remoteUrl = parseSourceConfig(config).remote_url;
   return typeof remoteUrl === 'string' && remoteUrl.trim().length > 0;
+}
+
+/**
+ * Warning for a legacy source path that cannot be interpreted safely from a
+ * daemon context. Relative paths are ambiguous; absent absolute paths belong to
+ * another machine or an unmounted checkout.
+ */
+export function sourceLocalPathSkipWarning(
+  sourceId: string,
+  localPath: string,
+  pathExists: (path: string) => boolean = existsSync,
+): string | null {
+  const relative = relativeSourceLocalPathSkipWarning(sourceId, localPath);
+  if (relative) return relative;
+  if (pathExists(localPath)) return null;
+  return (
+    `[autopilot] skipping source '${sourceId}': local_path ` +
+    `'${localPath}' does not exist on this machine. Clone/register this ` +
+    `source locally, or let the machine that owns that checkout sync it.`
+  );
+}
+
+export function relativeSourceLocalPathSkipWarning(sourceId: string, localPath: string): string | null {
+  if (isAbsolute(localPath)) return null;
+  return (
+    `[autopilot] skipping source '${sourceId}': relative local_path ` +
+    `'${localPath}' cannot be resolved from a daemon. Re-register with an ` +
+    `absolute --path or run 'gbrain sync --source ${sourceId}' once to self-heal.`
+  );
 }
 
 /** True iff the source's config.federated field is the literal boolean true. */

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -17,8 +17,9 @@
  * A shared helper hits the bar at lower cost.
  */
 import { existsSync } from 'fs';
-import { isAbsolute } from 'path';
+import { isAbsolute, resolve as resolvePath } from 'path';
 import type { BrainEngine } from './engine.ts';
+import { gbrainPath } from './config.ts';
 
 export interface SourceRow {
   id: string;
@@ -156,19 +157,30 @@ export function sourceConfigHasRemoteUrl(config: unknown): boolean {
   return typeof remoteUrl === 'string' && remoteUrl.trim().length > 0;
 }
 
+function sourceHasRecoverableManagedClone(sourceId: string, localPath: string, config: unknown): boolean {
+  const cfg = parseSourceConfig(config);
+  const remoteUrl = cfg.remote_url;
+  if (typeof remoteUrl !== 'string' || remoteUrl.trim().length === 0) return false;
+  if (cfg.managed_clone === true) return true;
+  return resolvePath(localPath) === resolvePath(gbrainPath('clones', sourceId));
+}
+
 /**
  * Warning for a legacy source path that cannot be interpreted safely from a
  * daemon context. Relative paths are ambiguous; absent absolute paths belong to
- * another machine or an unmounted checkout.
+ * another machine or an unmounted checkout unless the row is an owned remote
+ * clone that sync can safely recover by re-cloning.
  */
 export function sourceLocalPathSkipWarning(
   sourceId: string,
   localPath: string,
   pathExists: (path: string) => boolean = existsSync,
+  config: unknown = {},
 ): string | null {
   const relative = relativeSourceLocalPathSkipWarning(sourceId, localPath);
   if (relative) return relative;
   if (pathExists(localPath)) return null;
+  if (sourceHasRecoverableManagedClone(sourceId, localPath, config)) return null;
   return (
     `[autopilot] skipping source '${sourceId}': local_path ` +
     `'${localPath}' does not exist on this machine. Clone/register this ` +

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -79,13 +79,17 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     // all-coalesced tick (maxPending single-flight suppression) retakes the
     // full-cycle branch every tick and starves the targeted-plan path for the
     // whole in-flight window.
-    expect(AUTOPILOT_SRC).toMatch(
-      /result\.dispatched\.length > 0 \|\| result\.coalesced\.length > 0 \|\| result\.legacy_fallback \|\| result\.all_sources_fresh/,
-    );
+    const updateIdx = AUTOPILOT_SRC.indexOf('lastFullCycleAt = Date.now()');
+    expect(updateIdx).toBeGreaterThan(-1);
+    const advanceGate = AUTOPILOT_SRC.slice(Math.max(0, updateIdx - 400), updateIdx + 80);
+    expect(advanceGate).toContain('result.coalesced.length > 0');
+    expect(advanceGate).toContain('result.all_sources_fresh');
+    expect(advanceGate).toContain('result.all_sources_handled');
   });
 
   test('fanout_summary reports coalesced separately from dispatched (honest surfaces)', () => {
     expect(AUTOPILOT_SRC).toMatch(/event: 'fanout_summary',[\s\S]{0,200}coalesced: result\.coalesced/);
+    expect(AUTOPILOT_SRC).toMatch(/event: 'fanout_summary',[\s\S]{0,400}skipped_unavailable_path: result\.skipped_unavailable_path/);
   });
 
   test('targeted-plan dispatch honors the honest-dispatch contract (red-team finding)', () => {
@@ -106,7 +110,7 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     const freshnessIdx = AUTOPILOT_SRC.indexOf('idempotency_key: `autopilot-sync:');
     expect(freshnessIdx).toBeGreaterThan(-1);
     const freshnessBlock = AUTOPILOT_SRC.slice(Math.max(0, freshnessIdx - 900), freshnessIdx + 100);
-    expect(freshnessBlock).toContain('sourceLocalPathSkipWarning(src.id, src.local_path)');
+    expect(freshnessBlock).toContain('sourceLocalPathSkipWarning(src.id, src.local_path, undefined, src.config)');
   });
 
   test('#4046: targeted dispatch scopes stable recommendation keys to the interval', () => {
@@ -142,9 +146,7 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     // must update so the next tick doesn't immediately re-fan-out.
     // Coalesced counts as work-in-flight (see the dedicated advance-gate
     // test below for the full condition).
-    expect(AUTOPILOT_SRC).toMatch(
-      /result\.dispatched\.length > 0 \|\| result\.coalesced\.length > 0 \|\| result\.legacy_fallback \|\| result\.all_sources_fresh/,
-    );
+    expect(AUTOPILOT_SRC).toContain('result.all_sources_handled');
     expect(AUTOPILOT_SRC).toMatch(/lastFullCycleAt\s*=\s*Date\.now\(\)/);
   });
 

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -102,6 +102,13 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     expect(freshnessBlock).toContain('pull: sourceConfigHasRemoteUrl(src.config)');
   });
 
+  test('freshness sync dispatch skips unavailable source paths before enqueueing', () => {
+    const freshnessIdx = AUTOPILOT_SRC.indexOf('idempotency_key: `autopilot-sync:');
+    expect(freshnessIdx).toBeGreaterThan(-1);
+    const freshnessBlock = AUTOPILOT_SRC.slice(Math.max(0, freshnessIdx - 900), freshnessIdx + 100);
+    expect(freshnessBlock).toContain('sourceLocalPathSkipWarning(src.id, src.local_path)');
+  });
+
   test('#4046: targeted dispatch scopes stable recommendation keys to the interval', () => {
     expect(AUTOPILOT_SRC).toContain(
       'idempotency_key: autopilotRemediationIdempotencyKey(step.idempotency_key, slot)',

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -308,6 +308,54 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     expect(JSON.parse(skipped!).source_id).toBe('foreign');
   });
 
+  test('missing managed remote clones still dispatch so sync can re-clone them', async () => {
+    const managed = src('managed', undefined, {
+      remote_url: 'https://github.com/example/repo',
+      managed_clone: true,
+    });
+    managed.local_path = '/missing/managed';
+    const { engine, queue, added, fanoutOpts } = makeStubs([managed]);
+    fanoutOpts.pathExists = () => false;
+
+    const result = await dispatchPerSource(engine, queue, fanoutOpts);
+
+    expect(result.dispatched).toEqual(['managed']);
+    expect(result.skipped_unavailable_path).toEqual([]);
+    expect(added.length).toBe(1);
+  });
+
+  test('all unavailable non-managed sources are handled but not called fresh', async () => {
+    const missing = src('foreign');
+    missing.local_path = '/foreign/brain';
+    const { engine, queue, added, fanoutOpts } = makeStubs([missing]);
+    fanoutOpts.pathExists = () => false;
+
+    const result = await dispatchPerSource(engine, queue, fanoutOpts);
+
+    expect(result.dispatched).toEqual([]);
+    expect(result.skipped_unavailable_path).toEqual(['foreign']);
+    expect(result.all_sources_fresh).toBe(false);
+    expect(result.all_sources_handled).toBe(true);
+    expect(added.length).toBe(0);
+  });
+
+  test('fresh plus unavailable sources are handled without implying every source is fresh', async () => {
+    const NOW = Date.now();
+    const fresh = src('fresh', new Date(NOW - 5 * 60_000).toISOString());
+    const missing = src('foreign');
+    missing.local_path = '/foreign/brain';
+    const { engine, queue, added, fanoutOpts } = makeStubs([fresh, missing]);
+    fanoutOpts.pathExists = (p) => p === fresh.local_path;
+
+    const result = await dispatchPerSource(engine, queue, fanoutOpts);
+
+    expect(result.skipped_fresh).toEqual(['fresh']);
+    expect(result.skipped_unavailable_path).toEqual(['foreign']);
+    expect(result.all_sources_fresh).toBe(false);
+    expect(result.all_sources_handled).toBe(true);
+    expect(added.length).toBe(0);
+  });
+
   test('relative local_path rows are skipped by the same fan-out guard', () => {
     const relative = src('legacy');
     relative.local_path = 'notes/brain';
@@ -458,6 +506,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     expect(result.dispatched.length).toBe(0);
     expect(result.skipped_fresh.length).toBe(2);
     expect(result.all_sources_fresh).toBe(true);
+    expect(result.all_sources_handled).toBe(true);
     expect(added.length).toBe(0);
   });
 
@@ -471,5 +520,6 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
 
     expect(result.dispatched).toEqual([]);
     expect(result.all_sources_fresh).toBe(false);
+    expect(result.all_sources_handled).toBe(false);
   });
 });

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -250,7 +250,9 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
       emit: (line: string) => events.push(line),
       log: (line: string) => logs.push(line),
     };
-    return { engine, queue, added, events, logs, fanoutOpts };
+    const optsWithPathSeam = fanoutOpts as Parameters<typeof dispatchPerSource>[2];
+    optsWithPathSeam.pathExists = (_path: string) => true;
+    return { engine, queue, added, events, logs, fanoutOpts: optsWithPathSeam };
   }
 
   test('empty sources list falls back to legacy single-job dispatch', async () => {
@@ -285,6 +287,42 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     // source_id threaded through job data
     const sourceIds = added.map(j => (j.data as Record<string, unknown>).source_id).sort();
     expect(sourceIds).toEqual(['alpha', 'beta']);
+  });
+
+  test('sources whose local_path is missing on this machine are skipped before dispatch', async () => {
+    const present = src('present');
+    present.local_path = '/present/brain';
+    const missing = src('foreign');
+    missing.local_path = '/foreign/brain';
+    const { engine, queue, added, events, fanoutOpts } = makeStubs([present, missing]);
+    fanoutOpts.pathExists = (p) => p === '/present/brain';
+
+    const result = await dispatchPerSource(engine, queue, fanoutOpts);
+
+    expect(result.dispatched).toEqual(['present']);
+    expect(result.skipped_unavailable_path).toEqual(['foreign']);
+    expect(added.length).toBe(1);
+    expect((added[0].data as Record<string, unknown>).source_id).toBe('present');
+    const skipped = events.find(e => e.includes('fanout_source_path_skipped'));
+    expect(skipped).toBeDefined();
+    expect(JSON.parse(skipped!).source_id).toBe('foreign');
+  });
+
+  test('relative local_path rows are skipped by the same fan-out guard', () => {
+    const relative = src('legacy');
+    relative.local_path = 'notes/brain';
+    const result = selectSourcesForDispatch(
+      [src('present'), relative],
+      10,
+      Date.parse('2026-05-22T12:00:00.000Z'),
+      60,
+      new Map(),
+      { baseMin: 0, capMin: 120 },
+      () => true,
+    );
+
+    expect(result.dispatch.map(s => s.id)).toEqual(['present']);
+    expect(result.skippedUnavailablePath.map(s => s.id)).toEqual(['legacy']);
   });
 
   test('pull: true only when source.config.remote_url is set', async () => {
@@ -335,7 +373,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     } as unknown as Parameters<typeof dispatchPerSource>[1];
     const result = await dispatchPerSource(engine, queue, {
       repoPath: '/tmp', slot: 's', timeoutMs: 1, fanoutMax: 4, jsonMode: true,
-      emit: (l) => events.push(l), log: () => {},
+      emit: (l) => events.push(l), log: () => {}, pathExists: () => true,
     });
     // 2 of 3 dispatched (alpha + charlie); boom failed but didn't abort
     expect(result.dispatched.sort()).toEqual(['alpha', 'charlie']);
@@ -389,7 +427,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     let nextId = 200;
     const engine = {
       kind: 'postgres' as const,
-      listAllSources: async () => [src('a'), src('b')],
+      listAllSources: async () => [{ ...src('a'), local_path: null }, { ...src('b'), local_path: null }],
       getConfig: async () => null,
       executeRaw: async () => [],
     } as unknown as BrainEngine;

--- a/test/sources-load.test.ts
+++ b/test/sources-load.test.ts
@@ -13,6 +13,7 @@ import {
   parseSourceConfig,
   normalizeSourceConfig,
   isSourceFederated,
+  sourceLocalPathSkipWarning,
 } from '../src/core/sources-load.ts';
 
 let engine: PGLiteEngine;
@@ -194,5 +195,29 @@ describe('isSourceFederated', () => {
     expect(isSourceFederated({})).toBe(false);
     expect(isSourceFederated(null)).toBe(false);
     expect(isSourceFederated(['{"remote_url":"x"}', { federated: true }])).toBe(true);
+  });
+});
+
+describe('sourceLocalPathSkipWarning', () => {
+  test('keeps existing absolute checkouts dispatchable', () => {
+    expect(sourceLocalPathSkipWarning('present', '/repos/brain', (p) => p === '/repos/brain')).toBeNull();
+  });
+
+  test('skips relative local_path rows before consulting the filesystem', () => {
+    const asked: string[] = [];
+    const warn = sourceLocalPathSkipWarning('legacy', 'notes/brain', (p) => {
+      asked.push(p);
+      return true;
+    });
+    expect(asked).toEqual([]);
+    expect(warn).toContain("source 'legacy'");
+    expect(warn).toContain('relative local_path');
+  });
+
+  test('skips absolute paths missing from this machine', () => {
+    const warn = sourceLocalPathSkipWarning('foreign', '/missing/brain', () => false);
+    expect(warn).toContain("source 'foreign'");
+    expect(warn).toContain('/missing/brain');
+    expect(warn).toContain('does not exist on this machine');
   });
 });

--- a/test/sources-load.test.ts
+++ b/test/sources-load.test.ts
@@ -220,4 +220,26 @@ describe('sourceLocalPathSkipWarning', () => {
     expect(warn).toContain('/missing/brain');
     expect(warn).toContain('does not exist on this machine');
   });
+
+  test('allows missing managed remote clones to reach sync recovery', () => {
+    expect(
+      sourceLocalPathSkipWarning(
+        'managed',
+        '/missing/managed',
+        () => false,
+        { remote_url: 'https://github.com/example/repo', managed_clone: true },
+      ),
+    ).toBeNull();
+  });
+
+  test('still skips missing unowned remote-url paths', () => {
+    const warn = sourceLocalPathSkipWarning(
+      'foreign',
+      '/Users/other/repo',
+      () => false,
+      { remote_url: 'https://github.com/example/repo' },
+    );
+    expect(warn).toContain("source 'foreign'");
+    expect(warn).toContain('does not exist on this machine');
+  });
 });


### PR DESCRIPTION
Fixes #4729

## Summary
- Add a shared `sources.local_path` daemon guard that skips relative paths and absolute checkouts missing from the current machine.
- Apply the guard before autopilot freshness `sync` jobs, auto-drain source scans, and per-source `autopilot-cycle` fan-out.
- Emit a structured `fanout_source_path_skipped` event for skipped per-source fan-out rows, while preserving the existing relative-path warning surface.

## Verification
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/sources-load.test.ts test/autopilot-fanout.test.ts test/autopilot-fanout-wiring.test.ts test/sources-abs-path-3696.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL GBRAIN_TEST_ALLOW_DATABASE_URL=1 bash scripts/gbrain-gate.sh <worktree> test/sources-load.test.ts test/autopilot-fanout.test.ts test/autopilot-fanout-wiring.test.ts test/sources-abs-path-3696.test.ts`

Gate evidence: `RESULT: GREEN`; `verify` green; focused unit set reported 82 pass / 0 fail; diff-selected E2E `test/e2e/autopilot-linux-lifecycle.serial.test.ts` reported 7 pass / 0 fail.
