### PR TITLE
fix(serve-http): advertise /mcp as the OAuth protected resource (RFC 9728)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import { mcpAuthRouter, getOAuthProtectedResourceMetadataUrl } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import { OAuthTokenRevocationRequestSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { BrainEngine } from '../core/engine.ts';
@@ -1275,7 +1275,23 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // parameter, so MCP clients couldn't begin the OAuth flow from a fresh
   // 401 — they would silently fail to connect with a generic "couldn't
   // reach the MCP server" error.
-  const resourceMetadataUrl = `${issuerUrl.toString().replace(/\/$/, '')}/.well-known/oauth-protected-resource`;
+  // RFC 9728 §3.1 / MCP auth spec: the protected-resource metadata describes
+  // the RESOURCE the client actually connects to — our streamable-HTTP endpoint
+  // at /mcp — not the authorization server root. Pre-fix we passed no
+  // resourceServerUrl, so the SDK fell back to `issuerUrl` (AS=RS) and
+  // advertised `resource: "https://host/"` while the connector was pointed at
+  // "https://host/mcp". Clients that bind the grant to the canonical resource
+  // URI (RFC 8707) see `.../` != `.../mcp` and refuse to treat the connection
+  // as authorized, re-running discovery and re-registering a fresh DCR client
+  // on every attempt even though the issued bearer works fine on the wire.
+  const mcpResourceUrl = new URL('/mcp', issuerUrl);
+
+  // Metadata URL advertised in the 401 `WWW-Authenticate: Bearer
+  // resource_metadata="..."` challenge. MUST track mcpResourceUrl: with
+  // resourceServerUrl set, the SDK mounts the document at the path-inserted
+  // location (/.well-known/oauth-protected-resource/mcp) and no longer at the
+  // bare root, so a hardcoded root URL here would point 401s at a 404.
+  const resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(mcpResourceUrl);
 
   // F9: cookie `secure` flag honors both the request's TLS state (req.secure
   // is set when express trust-proxy lands an X-Forwarded-Proto: https) AND
@@ -1300,6 +1316,8 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     // ['read','write','admin'] list left those new scopes invisible.
     scopesSupported: [...ALLOWED_SCOPES_LIST],
     resourceName: 'GBrain MCP Server',
+    // Advertise /mcp as the protected resource (see mcpResourceUrl above).
+    resourceServerUrl: mcpResourceUrl,
   };
 
   // F12: DCR disable lives on the provider's constructor option above. The
@@ -1333,6 +1351,22 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       };
     }
     next();
+  });
+
+  // Back-compat alias: setting resourceServerUrl moves the SDK's document to
+  // /.well-known/oauth-protected-resource/mcp only. Clients that probe the bare
+  // root path (the pre-RFC-9728 convention, and what gbrain advertised until
+  // now) would start getting a 404 mid-flight. Serve the same document there so
+  // already-connected clients keep discovering us; both paths report the same
+  // `resource` value, which is the field that actually matters.
+  const legacyProtectedResourceMetadata = {
+    resource: mcpResourceUrl.href,
+    authorization_servers: [issuerUrl.href],
+    scopes_supported: [...ALLOWED_SCOPES_LIST],
+    resource_name: 'GBrain MCP Server',
+  };
+  app.get('/.well-known/oauth-protected-resource', (_req: Request, res: Response) => {
+    res.json(legacyProtectedResourceMetadata);
   });
 
   app.use(authRouter);

--- a/test/e2e/serve-http-oauth.test.ts
+++ b/test/e2e/serve-http-oauth.test.ts
@@ -358,6 +358,70 @@ describeE2E('serve-http OAuth 2.1 E2E (v0.26.1 + v0.26.2 + v0.26.3)', () => {
   });
 
   // =========================================================================
+  // RFC 9728: protected-resource metadata describes /mcp, not the issuer root
+  // =========================================================================
+
+  // The MCP auth spec layers RFC 9728 on top of AS metadata: the *protected
+  // resource* is the streamable-HTTP endpoint the client actually POSTs to
+  // (/mcp), not the authorization-server root. Passing no resourceServerUrl
+  // made the SDK fall back to issuerUrl (AS == RS) and advertise
+  // `resource: "https://host/"`. A client that binds its grant to the
+  // canonical resource URI (RFC 8707) compares that against the
+  // "https://host/mcp" it was configured with, sees a mismatch, and refuses to
+  // treat the connection as authorized — re-running discovery and registering
+  // a fresh DCR client on every attempt, even though the issued bearer works
+  // fine on the wire.
+
+  test('protected-resource metadata advertises /mcp as the resource', async () => {
+    const res = await fetch(`${BASE}/.well-known/oauth-protected-resource/mcp`);
+    expect(res.ok).toBe(true);
+    const meta = await res.json() as any;
+    // The resource is the MCP endpoint, NOT the issuer root.
+    expect(meta.resource).toBe(`${BASE}/mcp`);
+    expect(meta.resource).not.toBe(`${BASE}/`);
+    expect(meta.authorization_servers).toContain(`${BASE}/`);
+    expect(meta.scopes_supported).toEqual(
+      expect.arrayContaining(['admin', 'read', 'sources_admin', 'users_admin', 'write']),
+    );
+  });
+
+  // Setting resourceServerUrl moves the SDK's document to the path-inserted
+  // location only. Clients that probe the bare root (the pre-RFC-9728
+  // convention, and what gbrain advertised before this fix) must keep
+  // discovering us instead of getting a 404 mid-flight.
+  test('legacy root protected-resource path serves the same resource value', async () => {
+    const res = await fetch(`${BASE}/.well-known/oauth-protected-resource`);
+    expect(res.ok).toBe(true);
+    const meta = await res.json() as any;
+    expect(meta.resource).toBe(`${BASE}/mcp`);
+  });
+
+  // The 401 challenge must name a metadata URL that actually resolves: with
+  // resourceServerUrl set, the SDK mounts the document at the path-inserted
+  // location and no longer at the bare root, so a hardcoded root URL in the
+  // challenge would send clients to a 404. Advertised URL and mounted
+  // document have to move together.
+  test('401 challenge advertises a resource_metadata URL that resolves', async () => {
+    const res = await fetch(`${BASE}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(401);
+
+    const challenge = res.headers.get('www-authenticate') ?? '';
+    const advertised = challenge.match(/resource_metadata="([^"]+)"/)?.[1];
+    expect(advertised).toBeTruthy();
+
+    const meta = await fetch(advertised!);
+    expect(meta.ok).toBe(true);
+    expect((await meta.json() as any).resource).toBe(`${BASE}/mcp`);
+  });
+
+  // =========================================================================
   // Fix 3: Express 5 compatibility
   // =========================================================================
 


### PR DESCRIPTION
## What

The OAuth protected-resource metadata described the authorization-server root
instead of the streamable-HTTP endpoint MCP clients actually connect to.
`mcpAuthRouter` was called with no `resourceServerUrl`, so the SDK fell back to
`issuerUrl` (AS == RS) and published `resource: "https://host/"` while the
connector was pointed at `https://host/mcp`.

After this change the published `resource` is the `/mcp` endpoint, the 401
challenge names a metadata URL that actually resolves, and the bare-root
discovery path keeps working for already-connected clients.

## Why

A client that binds its grant to the canonical resource URI (RFC 8707) compares
the advertised `resource` against the URL it was configured with, sees
`.../` != `.../mcp`, and refuses to treat the connection as authorized. It then
re-runs discovery and registers a **fresh DCR client on every attempt** — even
though the bearer it was issued works fine on the wire.

The symptom is a remote MCP connector that appears to authorize successfully and
still never connects, while `oauth_clients` fills with duplicate registrations.
Nothing in the logs points at the metadata document, because the token exchange
itself succeeds.

Three parts:

- Pass `resourceServerUrl` (the `/mcp` endpoint) in the auth router options, so
  the published `resource` names the real protected resource.
- Derive the challenge's `resource_metadata` URL with the SDK's
  `getOAuthProtectedResourceMetadataUrl` instead of hardcoding the root. With
  `resourceServerUrl` set, the SDK mounts the document at the path-inserted
  location and no longer at the bare root, so a hardcoded root URL would point
  the 401 at a 404.
- Keep serving the same document at the bare root path. That is the
  pre-RFC-9728 convention and what gbrain advertised until now, so
  already-connected clients keep discovering the server rather than getting a
  404 mid-flight. Both paths report the same `resource`, which is the field
  that decides authorization.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/serve-http.ts` to `8c70f6255`
(merge-base with origin/master), ran `test/e2e/serve-http-oauth.test.ts` →
**45 pass / 3 fail**. Restored → **48 pass / 0 fail**.

The three failures are exactly the three tests added here:

```
(fail) protected-resource metadata advertises /mcp as the resource
(fail) legacy root protected-resource path serves the same resource value
(fail) 401 challenge advertises a resource_metadata URL that resolves
```

## Verification

Confirmed against a live Tailscale-fronted `gbrain serve --http --enable-dcr`
deployment before and after. After the fix, the challenge and both discovery
paths agree:

```
POST /mcp -> 401
WWW-Authenticate: Bearer error="invalid_token",
  resource_metadata=".../.well-known/oauth-protected-resource/mcp"

GET /.well-known/oauth-protected-resource/mcp
GET /.well-known/oauth-protected-resource        (legacy root)
  -> both: {"resource":".../mcp","authorization_servers":[".../"], ...}
```

## Tests

`test/e2e/serve-http-oauth.test.ts` — three tests added. No assertion covered
the protected-resource document before this PR, which is how the bug shipped.

Local run against `pgvector/pgvector:pg16`, output redirected to a file and the
exit code checked (not piped through `tail`):

```
48 pass / 0 fail / 268 expect() calls — Ran 48 tests across 1 file. [10.81s]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)