### PR TITLE
fix(chunker): CJK overlap uses whitespace tokens and can split UTF-16 surrogate pairs

### DIFF
--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -20,7 +20,13 @@
  * Lossless invariant: non-overlapping portions reassemble to original.
  */
 
-import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } from '../cjk.ts';
+import {
+  countCJKAwareWords,
+  CJK_SENTENCE_DELIMITERS,
+  CJK_CLAUSE_DELIMITERS,
+  CJK_SLUG_CHARS,
+  CJK_DENSITY_THRESHOLD,
+} from '../cjk.ts';
 import { estimateEmbedTokens, DEFAULT_MAX_CHUNK_TOKENS } from './token-estimate.ts';
 import { safeSplitIndex } from '../text-safe.ts';
 
@@ -38,8 +44,14 @@ import { safeSplitIndex } from '../text-safe.ts';
  * re-embed (not re-chunk) so existing pages pick up the wrapper on the
  * post-upgrade reembed sweep. See
  * `src/core/contextual-retrieval-service.ts`.
+ *
+ * v4: CJK overlap uses the same char-as-word counting as countCJKAwareWords,
+ * aligns to 。！？ sentence boundaries, and refuses to split UTF-16 surrogate
+ * pairs in capByChars / extractTrailingContext / splitOnWhitespace.
+ * English-dominant paths are byte-identical to v3. Boundaries change for
+ * CJK-dominant text, so `reindex --markdown` rebuilds those pages.
  */
-export const MARKDOWN_CHUNKER_VERSION = 3;
+export const MARKDOWN_CHUNKER_VERSION = 4;
 
 const DELIMITERS: string[][] = [
   ['\n\n'],                          // L0: paragraphs
@@ -201,7 +213,22 @@ function capByChars(
       }
     }
     if (end >= text.length) break;
-    const next = safeSplitIndex(text, Math.min(text.length, i + stride));
+    // For CJK-dominant text, try to start the next window at a sentence/
+    // clause boundary instead of a raw char index, but only within the
+    // intended overlap region so no characters are lost.
+    let next = safeSplitIndex(text, Math.min(text.length, i + stride));
+    if (isCJKDominant(text)) {
+      // The raw semantic boundary can land inside a UTF-16 surrogate pair
+      // (an astral emoji like 🚀 sits on two code units), which would split
+      // the pair across two chunks. Correct the index through safeSplitIndex
+      // so no pair is ever cut, but keep the semantic constraint intact:
+      // only keep the corrected index if it stays above `next` (the region's
+      // min); a correction that backs up to ≤ next would leave the window
+      // empty, so fall back to the min value.
+      const rawBoundary = findSemanticBoundaryStart(text, next, end);
+      const corrected = safeSplitIndex(text, rawBoundary);
+      next = corrected > next ? corrected : rawBoundary;
+    }
     i = next > i ? next : i + 1;
   }
   return out;
@@ -317,7 +344,19 @@ function splitOnWhitespace(text: string, target: number): string[] {
     const pieces: string[] = [];
     const charsPerPiece = Math.max(1, target);
     for (let i = 0; i < text.length; i += charsPerPiece) {
-      const slice = text.slice(i, i + charsPerPiece);
+      // Never cut a UTF-16 surrogate pair. If the stride landed i on a low
+      // surrogate (the previous end rounded down), back up to the pair start
+      // so no half is emitted and the pair itself is not lost (the previous
+      // slice stopped before it).
+      let start = i;
+      if (start > 0 && text.charCodeAt(start) >= 0xdc00 && text.charCodeAt(start) <= 0xdfff) {
+        start--;
+      }
+      // If the rounded end backs up all the way to start (tiny charsPerPiece
+      // over an astral char), advance past the pair so no chars are skipped.
+      let end = safeSplitIndex(text, start + charsPerPiece);
+      if (end <= start) end = Math.min(text.length, start + 2);
+      const slice = text.slice(start, end);
       if (slice.trim().length > 0) pieces.push(slice);
     }
     return pieces;
@@ -382,6 +421,12 @@ function applyOverlap(chunks: string[], overlapWords: number): string[] {
  * If a sentence boundary exists within the last N words, start there.
  */
 function extractTrailingContext(text: string, targetWords: number): string {
+  // CJK-dominant text needs char-aware tokenization and CJK sentence
+  // delimiters; keep the English path identical.
+  if (isCJKDominant(text)) {
+    return extractTrailingContextCJK(text, targetWords);
+  }
+
   const words = text.match(/\S+\s*/g) || [];
   if (words.length <= targetWords) return '';
 
@@ -401,6 +446,66 @@ function extractTrailingContext(text: string, targetWords: number): string {
 }
 
 /**
+ * CJK-aware trailing context. Matches the word-count semantics of
+ * countCJKAwareWords (one non-whitespace char = one word when CJK-dominant)
+ * and recognizes CJK sentence delimiters 。！？ as well as ASCII .!?
+ */
+function extractTrailingContextCJK(text: string, targetWords: number): string {
+  // Walk back targetWords non-whitespace chars so overlap spans line up with
+  // the density-based word count used everywhere else.
+  let count = 0;
+  let i = text.length;
+  while (i > 0 && count < targetWords) {
+    i--;
+    if (!/\s/.test(text[i])) count++;
+  }
+  // The walk-back counts code units, so i can land between the two units of
+  // an astral emoji (e.g. 🚀). Back up one more unit to keep the pair whole:
+  // an overlap prefix carrying one extra char is harmless; a lone surrogate
+  // sanitizes to U+FFFD and loses the glyph.
+  if (i > 0 && i < text.length && text.charCodeAt(i) >= 0xdc00 && text.charCodeAt(i) <= 0xdfff) {
+    i--;
+  }
+  const trailing = text.slice(i);
+
+  // Try to align the overlap start to a sentence boundary; CJK sentence
+  // delimiters may be followed by zero or more whitespace chars.
+  const sentenceStart = trailing.search(/[.!?。！？]\s*/);
+  if (sentenceStart !== -1 && sentenceStart < trailing.length / 2) {
+    const afterSentence = trailing.slice(sentenceStart).replace(/^[.!?。！？]\s*/, '');
+    if (afterSentence.trim().length > 0) {
+      return afterSentence;
+    }
+  }
+
+  return trailing;
+}
+
+/**
+ * Return the first semantic boundary index in [min, max) (sentence preferred,
+ * clause fallback), or min if none is found. Keeps the cut inside the intended
+ * overlap window so no characters are skipped.
+ */
+function findSemanticBoundaryStart(text: string, min: number, max: number): number {
+  if (min >= max) return min;
+  const segment = text.slice(min, max);
+
+  const sentenceMatch = segment.match(/[.!?。！？]\s*/);
+  if (sentenceMatch && sentenceMatch.index !== undefined) {
+    const boundary = min + sentenceMatch.index + sentenceMatch[0].length;
+    if (boundary > min && boundary < max) return boundary;
+  }
+
+  const clauseMatch = segment.match(/[；：，、;:,\n]\s*/);
+  if (clauseMatch && clauseMatch.index !== undefined) {
+    const boundary = min + clauseMatch.index + clauseMatch[0].length;
+    if (boundary > min && boundary < max) return boundary;
+  }
+
+  return min;
+}
+
+/**
  * Word count, CJK-aware (v0.32.7). For Latin-dominant text this behaves
  * exactly like the historical `text.match(/\S+/g).length`. When CJK char
  * density exceeds CJK_DENSITY_THRESHOLD (30%), each non-whitespace char is
@@ -414,4 +519,16 @@ function extractTrailingContext(text: string, targetWords: number): string {
  */
 function countWords(text: string): number {
   return countCJKAwareWords(text);
+}
+
+/**
+ * Mirror of countCJKAwareWords's density heuristic: true when non-whitespace
+ * CJK density reaches the threshold where each char is treated as a word.
+ */
+function isCJKDominant(text: string): boolean {
+  const cjkMatches = text.match(new RegExp(`[${CJK_SLUG_CHARS}]`, 'g'));
+  const cjkCount = cjkMatches ? cjkMatches.length : 0;
+  const nonWhitespace = text.replace(/\s/g, '').length;
+  if (nonWhitespace === 0) return false;
+  return cjkCount / nonWhitespace >= CJK_DENSITY_THRESHOLD;
 }

--- a/test/chunkers/recursive-cjk-overlap.test.ts
+++ b/test/chunkers/recursive-cjk-overlap.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect } from 'bun:test';
+import { chunkText } from '../../src/core/chunkers/recursive.ts';
+
+describe('CJK chunk overlap & boundary fixes', () => {
+  test('Chinese sentences align overlap to CJK sentence boundaries', () => {
+    // 40 short Chinese sentences, each 9-10 chars. Old ASCII tokenization
+    // treated each sentence as one "word"; overlap either vanished or
+    // spanned whole sentences. New path counts chars and splits on 。！？
+    const sentences = Array.from(
+      { length: 40 },
+      (_, i) => `第${i + 1}句中文测试句子。`,
+    );
+    const text = sentences.join('');
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Lossless reconstruction for whitespace-free CJK text.
+    const reconstructed = reconstructFromChunks(chunks);
+    expect(reconstructed).toBe(text);
+
+    // Each chunk after the first should start at a CJK sentence boundary.
+    for (let i = 1; i < chunks.length; i++) {
+      const curr = chunks[i].text;
+      expect(curr[0]).toMatch(/[一-鿿぀-ゟ゠-ヿ가-힯0-9]/);
+      // The first char should be the start of a sentence number, and the
+      // character just before the overlap in the previous chunk should be 。
+      const prev = chunks[i - 1].text;
+      const startInPrev = prev.lastIndexOf(curr.slice(0, Math.min(3, curr.length)));
+      if (startInPrev > 0) {
+        expect(prev[startInPrev - 1]).toBe('。');
+      }
+    }
+  });
+
+  test('mixed CJK + English preserves every non-whitespace character', () => {
+    // Use non-periodic, numbered fragments so any loss or reorder is visible.
+    const blocks: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      blocks.push(`Step ${i + 1} begins here. `);
+      blocks.push(`这是第${i + 1}步中文说明。`);
+    }
+    const text = blocks.join('');
+    const chunks = chunkText(text, { chunkSize: 60, chunkOverlap: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Whitespace may be normalized at chunk boundaries by trimming, so compare
+    // non-whitespace content only.
+    const strip = (s: string) => s.replace(/\s+/g, '');
+    const reconstructed = reconstructFromChunks(chunks);
+    expect(strip(reconstructed)).toBe(strip(text));
+
+    // Spot-check ordering: each step number appears in order.
+    let cursor = 0;
+    for (let n = 1; n <= 40; n++) {
+      const idx = reconstructed.indexOf(`Step ${n}`, cursor);
+      expect(idx).toBeGreaterThanOrEqual(cursor);
+      cursor = idx + 1;
+    }
+  });
+
+  test('overlap span is bounded on varied CJK-dominant text', () => {
+    const sentences: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      sentences.push(`第${i + 1}段混合文本，包含一些英文词汇如${i + 1}number。`);
+    }
+    const text = sentences.join('');
+    const overlapChars = 20;
+    const chunks = chunkText(text, { chunkSize: 60, chunkOverlap: overlapChars });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // No chunk should be a pure duplicate of its predecessor on varied text,
+    // and the actual overlap must be a suffix of the previous chunk.
+    for (let i = 1; i < chunks.length; i++) {
+      const prev = chunks[i - 1].text;
+      const curr = chunks[i].text;
+      // Find the actual overlap length.
+      let actualOverlap = 0;
+      for (let k = 1; k <= Math.min(prev.length, curr.length); k++) {
+        if (prev.endsWith(curr.slice(0, k))) actualOverlap = k;
+      }
+      expect(actualOverlap).toBeGreaterThan(0);
+      // Overlap should not swallow the whole previous chunk.
+      expect(actualOverlap).toBeLessThan(prev.length);
+      // Overlap should be bounded by a small multiple of target overlap chars.
+      expect(actualOverlap).toBeLessThanOrEqual(Math.max(overlapChars, 30) * 3);
+    }
+
+    const strip = (s: string) => s.replace(/\s+/g, '');
+    expect(strip(reconstructFromChunks(chunks))).toBe(strip(text));
+  });
+
+  test('emoji survive overlap path at production chunk params', () => {
+    // Production ingest calls chunkText with ONLY { maxTokens } — chunkSize
+    // 300 / overlap 50 / maxChars 6000 defaults apply, and the overlap is
+    // prepended via extractTrailingContext, not the capByChars path. A
+    // regression here ships to the DB even when the maxChars-forced test
+    // above passes (that exact miss happened with the 🚀 boundary).
+    const parts: string[] = [];
+    for (let i = 0; i < 120; i++) {
+      parts.push(`第${i + 1}段中文说明文字，这里有一枚火箭🚀用于测试代理对完整性。`);
+    }
+    const text = parts.join('\n');
+    const chunks = chunkText(text, { maxTokens: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const c of chunks) {
+      expect(hasOrphanedSurrogate(c.text)).toBe(false);
+    }
+
+    // Lossless reconstruction (whitespace-normalized) — no glyph dropped,
+    // no glyph duplicated outside designed overlap.
+    const strip = (s: string) => s.replace(/\s+/g, '');
+    expect(strip(reconstructFromChunks(chunks))).toBe(strip(text));
+  });
+
+  test('byte-identical English fixture path is unchanged', () => {
+    // Pure ASCII text must stay on the original code path, so chunking should
+    // match the historical behavior. We hard-code the expected chunks for a
+    // fixture that exercises paragraph, sentence, word, and overlap logic.
+    const sentences = Array.from(
+      { length: 20 },
+      (_, i) => `Sentence ${i + 1} has exactly eight words in it here.`,
+    );
+    const text = sentences.join(' ');
+    const chunks = chunkText(text, { chunkSize: 40, chunkOverlap: 8 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Reconstruction with overlap removed must equal the original.
+    const reconstructed = reconstructFromChunks(chunks);
+    expect(reconstructed).toBe(text);
+
+    // Each non-final chunk should end near an English sentence boundary.
+    for (let i = 0; i < chunks.length - 1; i++) {
+      const trimmed = chunks[i].text.trimEnd();
+      expect(trimmed).toMatch(/[.!?]$/);
+    }
+
+    // Indices should be sequential.
+    chunks.forEach((c, i) => expect(c.index).toBe(i));
+  });
+
+  test('emoji surrogate pairs survive CJK chunk boundaries whole', () => {
+    // Emoji such as 🚀 are astral: each is a UTF-16 surrogate PAIR (2 code
+    // units). A CJK-dominant chunk cutting a sentence/clause boundary inside
+    // such a pair would split the emoji across two chunks (the capByChars
+    // regression where the boundary was not routed through safeSplitIndex).
+    // Build a long, emoji-laced CJK string and force the char-window path
+    // with a small maxChars so every cut passes through the corrected boundary.
+    const parts: string[] = [];
+    for (let i = 0; i < 80; i++) {
+      parts.push(`第${i + 1}段中文测试文本，包含一个火箭标志🚀来测试代理对。`);
+    }
+    const text = parts.join('');
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 20, maxChars: 120 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // No chunk may contain a lone (orphaned) surrogate — a split 🚀 would
+    // leave a high surrogate at one chunk's end and a low surrogate at the
+    // next chunk's start.
+    for (const c of chunks) {
+      expect(hasOrphanedSurrogate(c.text)).toBe(false);
+    }
+
+    // Every 🚀 must survive in full (not dropped, not half). Chunks overlap by
+    // design, so an 🚀 inside an overlap region legitimately appears in two
+    // adjacent chunks — count against the overlap-free reconstruction, not
+    // the raw chunks.
+    const strip = (s: string) => s.replace(/\s+/g, '');
+    const reconstructedEmojis = strip(reconstructFromChunks(chunks)).split('🚀').length - 1;
+    expect(reconstructedEmojis).toBe(text.split('🚀').length - 1);
+
+    // Lossless reconstruction (whitespace-normalized).
+    expect(strip(reconstructFromChunks(chunks))).toBe(strip(text));
+  });
+});
+
+/**
+ * Reconstruct the original text from overlapped chunks by taking each chunk's
+ * prefix up to where the next chunk's overlap begins. For a sequence of chunks
+ * [C0, C1, C2, ...] where C_{i+1} starts with the trailing overlap of C_i,
+ * this returns C0 + (C1 without its overlap prefix) + (C2 without its overlap
+ * prefix) + ...
+ */
+function reconstructFromChunks(chunks: { text: string; index: number }[]): string {
+  if (chunks.length === 0) return '';
+  let out = chunks[0].text;
+  for (let i = 1; i < chunks.length; i++) {
+    const prev = chunks[i - 1].text;
+    const curr = chunks[i].text;
+    // Find how much of curr is a suffix of prev (the overlap).
+    let overlap = 0;
+    for (let k = 1; k <= Math.min(prev.length, curr.length); k++) {
+      if (prev.endsWith(curr.slice(0, k))) overlap = k;
+    }
+    out += curr.slice(overlap);
+  }
+  return out;
+}
+
+/**
+ * True if `s` contains a UTF-16 surrogate that is not paired (a lone high or
+ * low surrogate). Used to assert no astral emoji (e.g. 🚀) was split across a
+ * chunk boundary.
+ */
+function hasOrphanedSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const isHigh = code >= 0xD800 && code <= 0xDBFF;
+    const isLow = code >= 0xDC00 && code <= 0xDFFF;
+    if (isHigh) {
+      const next = i + 1 >= s.length ? -1 : s.charCodeAt(i + 1);
+      if (!(next >= 0xDC00 && next <= 0xDFFF)) return true;
+    } else if (isLow) {
+      const prev = i === 0 ? -1 : s.charCodeAt(i - 1);
+      if (!(prev >= 0xD800 && prev <= 0xDBFF)) return true;
+    }
+  }
+  return false;
+}

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -135,13 +135,14 @@ describe('Recursive Text Chunker', () => {
 });
 
 describe('CJK chunking (v0.32.7)', () => {
-  test('MARKDOWN_CHUNKER_VERSION is 3', async () => {
+  test('MARKDOWN_CHUNKER_VERSION is 4', async () => {
     // v0.40.3.0: bumped 2→3 to signal the post-upgrade reembed sweep that
-    // contextual retrieval wrapping is now applied at embed time. Chunk
-    // boundaries themselves are unchanged; the bump forces re-embed for
-    // pages where chunker_version < 3.
+    // contextual retrieval wrapping is now applied at embed time.
+    // v4: CJK overlap tokenization + UTF-16 surrogate-pair safety changes
+    // chunk boundaries for CJK-dominant text; English path is unchanged.
+    // `reindex --markdown` rebuilds pages where chunker_version < 4.
     const mod = await import('../../src/core/chunkers/recursive.ts');
-    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(3);
+    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(4);
   });
 
   test('long pure-Chinese paragraph splits into multiple chunks', () => {


### PR DESCRIPTION
## What

CJK-dominant markdown was chunked with inconsistent word units: `countCJKAwareWords`
treats each CJK character as a word, but `extractTrailingContext` still tokenized on
`/\S+\s*/g`, so a Chinese paragraph counted as one overlap token. Overlap then
swallowed, reordered, or duplicated whole sentences. Sentence alignment only
matched `[.!?]\s+` (not `。！？`). Three `slice` paths (`capByChars`,
`extractTrailingContextCJK` exit, `splitOnWhitespace` hard split) could also cut
UTF-16 surrogate pairs (e.g. 🚀 → lone surrogate → U+FFFD).

This PR:

- Walks non-whitespace chars for CJK overlap (same unit as `countCJKAwareWords`)
- Aligns overlap to `。！？` as well as ASCII `.!?`
- Refuses to split UTF-16 surrogate pairs on those three slice paths
- Leaves the English-dominant path byte-identical
- Bumps `MARKDOWN_CHUNKER_VERSION` 3→4 so `reindex --markdown` rebuilds affected pages

## Why

The mismatch has existed since the recursive chunker landed in v0.42.66.0.
v0.46.29.0 (#4530, `maxTokens` via `capByChars`) made it visible.

Related but not covering this:

- #648 — CJK-aware split of whitespace-less paragraphs (does not fix overlap counting)
- #2826 — URL-dense CJK token undercount
- #4528 / #2011 / #4199 — surrogate splits in extract_atoms / excerpt / gatherReflections, not these three chunker slice paths

On a 2173-page CJK-heavy markdown corpus, 59 pages changed chunk boundaries after
this fix; 0 purely-English pages changed.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted src/core/chunkers/recursive.ts to merge-base, ran test/chunkers/recursive-cjk-overlap.test.ts → 5 pass / 1 fail. Restored → all pass.

The failing pre-fix case is `overlap span is bounded on varied CJK-dominant text`
(`actualOverlap` expected >0, received 0). The English byte-identical case is
supposed to pass without the fix. Surrogate-pair cases on this fixture do not
always hit the old cut; lossless reconstruction can still succeed when the old
overlap path swallows/reorders, so those cases are guards rather than
discriminators.

## Tests

- `test/chunkers/recursive-cjk-overlap.test.ts` (new; 6 cases, including production
  ingest params `chunkText(text, { maxTokens: 2000 })` emoji path)
- `test/chunkers/recursive.test.ts` (version pin 3→4)

Local: `bun test test/chunkers/` → 113 pass / 0 fail.
