### PR TITLE
fix(llama-server): max_batch_tokens CJK-conservative chars_per_token embeddings

### DIFF
--- a/src/core/ai/recipes/llama-server.ts
+++ b/src/core/ai/recipes/llama-server.ts
@@ -43,6 +43,12 @@ export const llamaServer: Recipe = {
       // more inputs with `batch size N > maximum allowed batch size 32`.
       // The token-budget split can't bound item count, so cap it here. A
       // server launched with a larger `-b` can raise this. v0.32 (#779).
+      // Conservative token budget companion to max_batch_items:32 so the
+      // gateway pre-splits instead of sending one unsplit batch. A server
+      // launched with a larger `-b` can raise this.
+      max_batch_tokens: 4096,
+      // CJK ≈1 char/token on average; conservative for mixed content.
+      chars_per_token: 1,
       max_batch_items: 32,
     },
     chat: {

--- a/test/ai/recipe-llama-server.test.ts
+++ b/test/ai/recipe-llama-server.test.ts
@@ -38,6 +38,14 @@ describe('recipe: llama-server', () => {
     expect(r.touchpoints.embedding!.default_dims).toBe(0);
   });
 
+  test('embedding touchpoint declares max_batch_tokens + CJK-conservative chars_per_token', () => {
+    const r = getRecipe('llama-server')!;
+    const e = r.touchpoints.embedding!;
+    expect(e.max_batch_tokens).toBe(4096);
+    expect(e.chars_per_token).toBe(1);
+    expect(e.max_batch_items).toBe(32);
+  });
+
   test('chat touchpoint declares tool calling and native prefix caching', () => {
     const r = getRecipe('llama-server')!;
     const chat = r.touchpoints.chat;


### PR DESCRIPTION
## What

The llama-server embedding touchpoint declared `max_batch_items: 32` but
omitted `max_batch_tokens`. The gateway therefore took the fast path and
sent the whole batch as one unsplit `embedMany` call, with no token-budget
pre-split.

This PR declares `max_batch_tokens: 4096` as a conservative companion to
the existing `max_batch_items: 32` item cap, and `chars_per_token: 1`
(CJK ≈1 char/token; the gateway default of 4 matches tiktoken on English
and undercounts CJK tokens ~4×, packing oversized batches). With the
default `safety_factor` of 0.8 the effective budget is ~3276 tokens per
sub-batch. A server launched with a larger `-b` can raise the declared
budget. English batches split smaller than tiktoken density would;
correctness over packing.

## Why

llama-server is the recipe for user-hosted local servers, which commonly
run Qwen and other CJK-heavy models. Without `max_batch_tokens` there is
no pre-split: one oversized batch goes out whole, and an operator's only
remedy was the `GBRAIN_EMBED_MAX_BATCH_TOKENS` env cap (#3622). A
recipe-declared cap supersedes that env knob for llama-server and makes
the safe behavior the default.

Same density choice as voyage / perplexity / zeroentropyai
(`chars_per_token: 1`); dashscope uses 2 with a CJK note. 4096 is not
claimed as a universal optimum — it matches the existing item cap's
conservative stance (llama-server's launch default `--batch-size` is 32).

No tracking issue; spotted while running a local llama-server embedding
backend against a CJK corpus.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/ai/recipes/llama-server.ts` to merge-base (`8c70f6255`), ran `test/ai/recipe-llama-server.test.ts` → 8 pass / 1 fail. Restored → all pass.

## Tests

- `test/ai/recipe-llama-server.test.ts`: new test pins
  `max_batch_tokens = 4096`, `chars_per_token = 1`, `max_batch_items = 32`.

Local: `bun test test/ai/recipe-llama-server.test.ts` → 9 pass / 0 fail
(29 assertions).
