### PR TITLE
v0.48.2.2 fix(extract_atoms): gate the cost cap on the embedding model too and honor pricing.overrides (#4877)

### DIFF
--- a/src/core/cycle/extract-atoms-cost-gate.ts
+++ b/src/core/cycle/extract-atoms-cost-gate.ts
@@ -1,0 +1,61 @@
+/**
+ * Cost-gate decision for the extract_atoms BudgetTracker.
+ *
+ * Split out of extract-atoms.ts so the decision is a pure, unit-testable
+ * function and the phase file stays under the module-size cap. See the
+ * "cost cap" comment at the tracker construction site in extract-atoms.ts
+ * for the defect this closes.
+ */
+
+import { isAvailable, getEmbeddingModel } from '../ai/gateway.ts';
+import { isModelPriceable, type PricingOverrides } from '../budget/budget-tracker.ts';
+
+/**
+ * Cost-gate decision for the extract_atoms BudgetTracker.
+ *
+ * `enforceCap: true` → construct the tracker with `maxCostUsd`. `false` → run
+ * uncapped (the tracker then warns once on unpriced models instead of throwing)
+ * and `unpricedModel`/`unpricedKind` name the call that made the cap
+ * unenforceable. Pure: no config or gateway access, so it is unit-testable and
+ * the call site stays a one-liner.
+ */
+export interface ExtractAtomsCostGate {
+  enforceCap: boolean;
+  unpricedModel?: string;
+  unpricedKind?: 'chat' | 'embed';
+}
+
+/**
+ * Both models that bill under the extract_atoms tracker must be priceable for
+ * a cap to be enforceable: the extraction chat model AND the embedding model
+ * the atom import path calls (pass `null` when embedding is unavailable, in
+ * which case the import runs with `noEmbed` and nothing embeds). Operator
+ * `pricing.overrides` are consulted first, matching BudgetTracker.reserve().
+ */
+export function resolveExtractAtomsCostGate(
+  extractModel: string,
+  embedModel: string | null,
+  overrides?: PricingOverrides,
+): ExtractAtomsCostGate {
+  if (!isModelPriceable(extractModel, 'chat', overrides)) {
+    return { enforceCap: false, unpricedModel: extractModel, unpricedKind: 'chat' };
+  }
+  if (embedModel !== null && !isModelPriceable(embedModel, 'embed', overrides)) {
+    return { enforceCap: false, unpricedModel: embedModel, unpricedKind: 'embed' };
+  }
+  return { enforceCap: true };
+}
+
+/**
+ * The embedding model the atom import will bill under this phase's tracker,
+ * or `null` when embedding is unavailable (the write site then passes
+ * `noEmbed: true` and no embed call happens). Mirrors the write site's own
+ * `isAvailable('embedding')` check so the gate and the import agree.
+ */
+export function resolveEmbedModelForCostGate(): string | null {
+  try {
+    return isAvailable('embedding') ? getEmbeddingModel() : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -68,7 +68,8 @@ import { createGlobalLlmHaltTracker, haltedClassOf, type GlobalLlmErrorClass } f
 import { importFromContent } from '../import-file.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import { truncateUtf8 } from '../text-safe.ts';
-import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budget-tracker.ts';
+import { BudgetExhausted, BudgetTracker, loadPricingOverrides } from '../budget/budget-tracker.ts';
+import { resolveExtractAtomsCostGate, resolveEmbedModelForCostGate } from './extract-atoms-cost-gate.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
@@ -786,22 +787,42 @@ export async function runPhaseExtractAtoms(
     // Keep safe defaults on any config-read failure: key-aware utility-tier
     // model, $0.30 cap, default input cap (max_input_chars).
   }
-  // A cost cap is only meaningful for a model the tracker can price.
-  // BudgetTracker.reserve() hard-fails with BudgetExhausted(reason:'no_pricing')
-  // when the model is absent from the pricing maps AND a cap is set; with no cap
-  // it warns once and proceeds. Because this phase always set a cap, every
-  // non-Anthropic model tripped that hard-fail on the first item, latched
-  // `budgetExhausted`, and skipped the entire workload while reporting ok.
-  const priceable = isModelPriceable(extractModel, 'chat');
-  if (!priceable) {
+  // A cost cap is only meaningful when the tracker can price EVERY call made
+  // under it. BudgetTracker.reserve() hard-fails with
+  // BudgetExhausted(reason:'no_pricing') when a model is absent from the pricing
+  // maps AND a cap is set; with no cap it warns once and proceeds. Because this
+  // phase always set a cap, every non-Anthropic chat model tripped that
+  // hard-fail on the first item, latched `budgetExhausted`, and skipped the
+  // entire workload while reporting ok.
+  //
+  // The chat model is not the only call under this tracker: the atom write
+  // site below goes through importFromContent, which chunks AND embeds inside
+  // the same withBudgetTracker scope. So the embedding model must be priceable
+  // too. Pre-fix, a $0 local chat model (ollama/llama-server) kept the cap on
+  // while an unpriced embedding route (e.g. `litellm:*`, which is deliberately
+  // NOT assumed free because a proxy can front a paid provider) threw
+  // no_pricing on the FIRST atom import — 0 atoms, `budget_exhausted: true`,
+  // $0 spent, on every run. The operator escape hatch the error message
+  // advertises (`pricing.overrides`, #4312) was also never loaded here, unlike
+  // enrich / ingest-facts / extract-conversation-facts.
+  const pricingOverrides = await loadPricingOverrides(engine);
+  const costGate = resolveExtractAtomsCostGate(
+    extractModel,
+    resolveEmbedModelForCostGate(),
+    pricingOverrides,
+  );
+  if (!costGate.enforceCap) {
     console.error(
-      `[extract_atoms] model "${extractModel}" is not in the pricing maps; ` +
-        `running without a cost gate (a cap cannot be enforced on an unpriced model).`,
+      `[extract_atoms] ${costGate.unpricedKind} model "${costGate.unpricedModel}" is not in the pricing maps; ` +
+        `running without a cost gate (a cap cannot be enforced on an unpriced model). ` +
+        `Declare an operator rate to restore the cap: ` +
+        `gbrain config set pricing.overrides '{"${costGate.unpricedModel}": <usd-per-1M-tokens>}' (0 for local inference).`,
     );
   }
   const budgetTracker = new BudgetTracker({
-    maxCostUsd: priceable ? budgetCap : undefined,
+    maxCostUsd: costGate.enforceCap ? budgetCap : undefined,
     label: 'cycle.extract_atoms',
+    pricingOverrides,
   });
 
   // v0.41.19.0 (T3): throttled yield helper. Fires `opts.yieldDuringPhase`

--- a/test/extract-atoms-embed-cost-gate.test.ts
+++ b/test/extract-atoms-embed-cost-gate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression: extract_atoms gated its cost cap on the CHAT model alone, but
+ * the atom write site (importFromContent) also embeds inside the same
+ * withBudgetTracker scope. A $0 local chat model (ollama / llama-server) kept
+ * the cap on, and an unpriced embedding route — `litellm:*`, deliberately not
+ * assumed free because a proxy can front a paid provider — made
+ * BudgetTracker.reserve() throw BudgetExhausted(no_pricing) on the FIRST atom
+ * import. `budgetExhausted` latched, every remaining item was skipped, and the
+ * phase reported 0 atoms / `budget_exhausted: true` / $0 spent on every run.
+ *
+ * The phase also never loaded `pricing.overrides` (#4312), so the operator
+ * fix its own error message advertised did nothing here.
+ *
+ * Pure-helper cases first; the final describe is a PGLite round-trip that
+ * pins the actual defect (an unpriced embed model no longer zeroes the run).
+ * No model calls anywhere — chat is stubbed via the `_chat` seam and the embed
+ * transport via __setEmbedTransportForTests.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runPhaseExtractAtoms } from '../src/core/cycle/extract-atoms.ts';
+import { resolveExtractAtomsCostGate } from '../src/core/cycle/extract-atoms-cost-gate.ts';
+import { parsePricingOverrides } from '../src/core/budget/budget-tracker.ts';
+import {
+  configureGateway,
+  resetGateway,
+  isAvailable,
+  __setEmbedTransportForTests,
+} from '../src/core/ai/gateway.ts';
+import type { ChatResult, ChatOpts } from '../src/core/ai/gateway.ts';
+
+const FREE_CHAT = 'llama-server:local-27b';
+const UNPRICED_EMBED = 'litellm:nvidia/some-local-embedder';
+
+describe('resolveExtractAtomsCostGate', () => {
+  test('priced chat + priced embed → cap enforced', () => {
+    expect(resolveExtractAtomsCostGate('claude-haiku-4-5-20251001', 'openai:text-embedding-3-large'))
+      .toEqual({ enforceCap: true });
+  });
+
+  test('free local chat + no embedding configured → cap enforced (nothing unpriced bills)', () => {
+    expect(resolveExtractAtomsCostGate(FREE_CHAT, null)).toEqual({ enforceCap: true });
+  });
+
+  test('free local chat + free local embed → cap enforced at $0', () => {
+    expect(resolveExtractAtomsCostGate(FREE_CHAT, 'ollama:nomic-embed-text')).toEqual({ enforceCap: true });
+  });
+
+  test('unpriced chat model disables the cap and names the chat model', () => {
+    expect(resolveExtractAtomsCostGate('groq:llama-3.3-70b', 'openai:text-embedding-3-large')).toEqual({
+      enforceCap: false,
+      unpricedModel: 'groq:llama-3.3-70b',
+      unpricedKind: 'chat',
+    });
+  });
+
+  test('free local chat + UNPRICED embed disables the cap and names the embed model (the defect)', () => {
+    expect(resolveExtractAtomsCostGate(FREE_CHAT, UNPRICED_EMBED)).toEqual({
+      enforceCap: false,
+      unpricedModel: UNPRICED_EMBED,
+      unpricedKind: 'embed',
+    });
+  });
+
+  test('an operator pricing override for the embed model restores the cap', () => {
+    const overrides = parsePricingOverrides(JSON.stringify({ [UNPRICED_EMBED]: 0 }));
+    expect(overrides).toBeDefined();
+    expect(resolveExtractAtomsCostGate(FREE_CHAT, UNPRICED_EMBED, overrides)).toEqual({ enforceCap: true });
+  });
+
+  test('override lookup is case-insensitive, matching BudgetTracker.reserve()', () => {
+    const overrides = parsePricingOverrides(JSON.stringify({ [UNPRICED_EMBED.toUpperCase()]: 0 }));
+    expect(resolveExtractAtomsCostGate(FREE_CHAT, UNPRICED_EMBED, overrides)).toEqual({ enforceCap: true });
+  });
+});
+
+describe('extract_atoms with a $0 chat model and an unpriced embedding model (PGLite round-trip)', () => {
+  let engine: PGLiteEngine;
+  const DIMS = 1536; // matches the preload's schema width
+
+  beforeAll(async () => {
+    // Hermetic: keyless env, an embedding model with NO pricing entry, and a
+    // stubbed embed transport so isAvailable('embedding') is true and the atom
+    // import really embeds — under the phase's BudgetTracker — without a network.
+    configureGateway({
+      embedding_model: UNPRICED_EMBED,
+      embedding_dimensions: DIMS,
+      env: {},
+    });
+    // Same shape as the ai-sdk embedMany result the gateway consumes (see
+    // test/asymmetric-encoding-contract.test.ts).
+    __setEmbedTransportForTests((async (args: any) => ({
+      embeddings: (args.values as string[]).map(() => Array.from({ length: DIMS }, () => 0.01)),
+      usage: { tokens: 10 * (args.values as string[]).length },
+    })) as any);
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    await engine.setConfig('models.dream.extract_atoms', FREE_CHAT);
+  });
+  afterAll(async () => {
+    await engine.disconnect();
+    __setEmbedTransportForTests(null);
+    resetGateway();
+  });
+  afterEach(async () => {
+    await engine.unsetConfig('pricing.overrides');
+  });
+
+  const chat = async (_o: ChatOpts): Promise<ChatResult> => ({
+    text: `[{"title":"Embedded atom","atom_type":"insight","body":"Local inference costs electricity, not tokens."}]`,
+    blocks: [{ type: 'text', text: '' }],
+    stopReason: 'end',
+    usage: { input_tokens: 500, output_tokens: 200, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: FREE_CHAT,
+    providerId: 'llama-server',
+  });
+
+  test('the unpriced embed no longer zeroes the run: 1 atom, budget not exhausted', async () => {
+    expect(isAvailable('embedding')).toBe(true);
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/fake/meeting-a.txt', content: 'transcript content a', contentHash: 'a1b2c3d4e5f60718' }],
+      _pages: [],
+      _chat: chat,
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_extracted).toBe(1);
+    expect(result.details?.budget_exhausted).toBe(false);
+    expect(result.details?.transcripts_skipped_budget).toBe(0);
+  }, 60000);
+
+  test('with a $0 pricing override for the embed model the cap stays on and the run still extracts', async () => {
+    await engine.setConfig('pricing.overrides', JSON.stringify({ [UNPRICED_EMBED]: 0 }));
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/fake/meeting-b.txt', content: 'transcript content b', contentHash: 'b1b2c3d4e5f60718' }],
+      _pages: [],
+      _chat: chat,
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_extracted).toBe(1);
+    expect(result.details?.budget_exhausted).toBe(false);
+  }, 60000);
+});


### PR DESCRIPTION
## What

`extract_atoms` now decides its cost cap from **every** model billed under its BudgetTracker — the extraction chat model *and* the embedding model the atom import calls — and loads operator `pricing.overrides` into that tracker. With a $0 local chat model and an unpriced embedding route (`litellm:*`) the phase runs uncapped with a warning that names the model and the override that restores the cap, instead of silently extracting nothing. With a `pricing.overrides` entry for the embedding model the cap stays enforced. Fixes #4877.

## Why

The atom write site goes through `importFromContent`, which chunks **and embeds** inside the same `withBudgetTracker` scope, but the gate only checked `isModelPriceable(extractModel, 'chat')`. `llama-server`/`ollama` price at $0 so the cap stayed on; `litellm` is deliberately not assumed free, so `reserve()` threw `BudgetExhausted(no_pricing)` on the first atom import, `budgetExhausted` latched, and every item was budget-skipped: `atoms_extracted: 0`, `budget_exhausted: true`, `estimated_spend_usd: 0`, status `warn`, every run (audit trail in #4877). The phase also never passed `pricingOverrides` to its tracker, so the `gbrain config set pricing.overrides …` remedy in the error text did nothing here, unlike `enrich`, `ingest-facts` and `extract-conversation-facts`.

Implementation: `src/core/cycle/extract-atoms-cost-gate.ts` (new, keeps `extract-atoms.ts` under the 1500-line module cap) exports the pure `resolveExtractAtomsCostGate(extractModel, embedModel | null, overrides)` and `resolveEmbedModelForCostGate()` (mirrors the write site's `isAvailable('embedding')` so gate and import agree). The tracker construction site consumes both and passes `pricingOverrides`.

`test/extract-atoms-chunk-embed.test.ts` already describes this exact failure in a comment and works around it by pinning a keyless gateway; that test is unchanged and still passes.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/extract-atoms.ts` to merge-base, ran `test/extract-atoms-embed-cost-gate.test.ts` → 7 pass / 2 fail. Restored → all pass.

(`bash scripts/check-test-discriminates.sh test/extract-atoms-embed-cost-gate.test.ts src/core/cycle/extract-atoms.ts` → OK. The two failing cases are the PGLite round-trips; the seven helper cases exercise the new module directly and pass either way.)

## Verification

The new warning tells the operator to run `gbrain config set pricing.overrides '{"<model>": <usd-per-1M-tokens>}'`. Against the broken state (v0.48.2.0, `models.dream.extract_atoms = llama-server:…`, embedding `litellm:nvidia/Nemotron-3-Embed-8B-BF16`):

```
$ gbrain dream --phase extract_atoms --source default --json
  "summary": "extract_atoms: 0 atoms from 0/8 transcripts + 0/50 pages (58 budget-skipped)",
  "atoms_extracted": 0, "estimated_spend_usd": 0, "budget_usd": 0.3, "budget_exhausted": true
```

With this branch, same config, no override (PGLite round-trip in the test reproduces the same shape):

```
[extract_atoms] embed model "litellm:nvidia/some-local-embedder" is not in the pricing maps; running without a cost gate (a cap cannot be enforced on an unpriced model). Declare an operator rate to restore the cap: gbrain config set pricing.overrides '{"litellm:nvidia/some-local-embedder": <usd-per-1M-tokens>}' (0 for local inference).
→ status ok, atoms_extracted 1, budget_exhausted false
```

With `pricing.overrides '{"litellm:nvidia/some-local-embedder": 0}'`: no warning, cap enforced, atoms_extracted 1.

## Tests

- `test/extract-atoms-embed-cost-gate.test.ts` (new): 9 cases — priced/priced, free chat + no embedding, free chat + free embed, unpriced chat, free chat + unpriced embed (the defect), override restores the cap, override lookup is case-insensitive; plus two PGLite round-trips with a stubbed embed transport.
- `bun test test/extract-atoms-*.test.ts test/atoms-scan-hash-rearm.test.ts` → 130 pass / 0 fail. `bun test test/extract-atoms-embed-cost-gate.test.ts test/extract-atoms-unpriced-model.test.ts test/extract-atoms-chunk-embed.test.ts` → 24 pass / 0 fail. `bun run typecheck` clean. `check:privacy`, `check:fixture-privacy`, `check:test-isolation`, `check:test-names`, `check:exports-count`, `check:module-size`, `check:orphan-modules`, `check:engine-dynamic-import`, `check:structural-manifest`, `check:gateway-routed`, `check:progress`, `check:newlines` all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013srLURpYQaKijTSyAfPAdo
