### PR TITLE
fix(minions): release the synopsis rate lease on Postgres (bigint id arrives as a string)

### DIFF
--- a/src/core/minions/handlers/contextual-reindex-per-chunk.ts
+++ b/src/core/minions/handlers/contextual-reindex-per-chunk.ts
@@ -206,8 +206,10 @@ export function makeContextualReindexHandler(opts: MakeContextualReindexHandlerO
         );
       },
       releaseSynopsisLease: async (lease) => {
-        if (typeof lease === 'number') {
-          await releaseLease(engine, lease);
+        // Postgres returns the bigint lease id as a string; a strict number
+        // check never released the lease and each slot idled to its TTL.
+        if (lease != null && lease !== '') {
+          await releaseLease(engine, Number(lease));
         }
       },
     });

--- a/test/contextual-reindex-lease-release.test.ts
+++ b/test/contextual-reindex-lease-release.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'bun:test';
+import { makeContextualReindexHandler } from '../src/core/minions/handlers/contextual-reindex-per-chunk.ts';
+
+test('releases a Postgres string synopsis lease id', async () => {
+  const deletes: Array<{ sql: string; params?: unknown[] }> = [];
+  const engine = {
+    async getPage() {
+      return { source_id: 'default' };
+    },
+    async getConfig() {
+      return null;
+    },
+    async executeRaw(sql: string, params?: unknown[]) {
+      deletes.push({ sql, params });
+      return [];
+    },
+  };
+  const handler = makeContextualReindexHandler({
+    engine: engine as never,
+    reembedPage: async (args) => {
+      await args.releaseSynopsisLease?.('26016');
+      return {
+        kind: 'success',
+        mode_applied: 'per_chunk_synopsis',
+        chunks_embedded: 1,
+        corpus_generation: 'test-generation',
+      };
+    },
+  });
+  await handler({
+    id: 42,
+    data: { page_slug: 'wiki/example' },
+    signal: new AbortController().signal,
+  } as never);
+  expect(deletes).toEqual([{
+    sql: 'DELETE FROM subagent_rate_leases WHERE id = $1',
+    params: [26016],
+  }]);
+});


### PR DESCRIPTION
On a Postgres brain every `contextual_reindex_per_chunk` job dies with

    Failed to acquire contextual-synopsis:<model> lease after 60 attempts; Synopsis rate limit pile-up too deep.

even when a single job is running alone.

The handler's release hook only frees a lease when the id is a number:

```ts
releaseSynopsisLease: async (lease) => {
  if (typeof lease === 'number') {
    await releaseLease(engine, lease);
  }
},
```

`subagent_rate_leases.id` is a bigint, and the Postgres driver hands bigint back as a string, so the check never passes and no lease is ever released. Each slot then idles until the 60 s TTL. Throughput collapses to `maxConcurrent` calls per minute (`chat_usage_log` shows exactly two calls a minute at the default of 2), and every other chunk of the page burns through the 60 attempt acquire loop and fails the job.

Before the handler was rewritten around the lease hooks it released on `currentLeaseId != null`. This restores that: release whenever an id came back, coerced with `Number()` so the SQL parameter keeps its type.

Verified on a 4.5k page Postgres brain: with this change 942 reindex jobs (13k chunks) drained at about 50 synopsis calls a minute with zero failures. Without it, every job died.
