### PR TITLE
fix: harden dream oneshot JSON contract

### DIFF
--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -8,6 +8,11 @@ lives in `CHANGELOG.md` + `git log` / `git blame`, NOT here. Do not append
 per-release `**vX.Y.Z:**` narration — CI enforces this
 (`scripts/check-key-files-current-state.sh`).
 
+- `src/core/ai/gateway.ts` (chat sampling contract) — `ChatOpts.temperature` is provider-neutral and reaches the AI SDK's `generateText` call only when explicitly set, so existing callers retain provider defaults while contract-sensitive callers can pin deterministic sampling. Pinned by `test/ai/gateway-chat.test.ts`.
+- `src/core/config.ts` (dream oneshot headroom) — `dream.synthesize.oneshot_max_tokens` is a known, merged file/DB-plane setting. The synthesis loader owns runtime validation: default 32000, floor 8192 for finite zero/negative/small values, and default fallback for non-numeric values.
+- `src/core/cycle/synthesize.ts` (oneshot JSON prompt contract) — `buildSynthesisPrompt` is mode-aware: explicit agentic children retain search-tool and final-summary guidance; tool-less oneshot children receive neither. Oneshot children alone carry the resolved `oneshot_max_tokens` through `SubagentHandlerData.max_tokens`, leaving explicit agentic children on the generic cap.
+- `src/core/minions/handlers/subagent-oneshot.ts` (deterministic completion contract) — the single gateway call pins temperature 0 and reinforces JSON string escaping. A parse failure at reported output usage greater than or equal to the requested cap falls back as `length` even for normalized `end`/`other`; below-cap malformed output remains `unparseable`, and valid JSON at the cap proceeds normally. The existing paid agentic fallback policy is unchanged.
+
 - `docs/operations/conversation-parser-llm-fallback.md` — operator and maintainer contract for the default-off LLM parse fallback: exact config key, deterministic-first dispatch boundary, sampled data surface, untrusted-content prompt handling, page-date/cache-key coupling, timestamp validation, cache/checkpoint behavior, observability, limitations, and focused test commands.
 
 

--- a/docs/guides/cron-schedule.md
+++ b/docs/guides/cron-schedule.md
@@ -198,9 +198,18 @@ Above the triage cascade sit the execution dials:
   backfilled at phase end by a bounded pass over just the pages the phase
   wrote — never a source-wide sweep). A response that fails any check automatically
   falls back to the classic agentic loop **in the same job** — no lost work,
-  no resubmission. Typical effect: 10+ provider round-trips per transcript
+  no resubmission. The oneshot attempt and its fallback calls are both paid
+  provider work and both are included in synthesis token/spend telemetry.
+  Typical effect: 10+ provider round-trips per transcript
   (up to the 16-turn default cap, more on raised `max_turns`) → 1. Revert
   dial: `gbrain config set dream.synthesize.mode agentic`.
+- `dream.synthesize.oneshot_max_tokens` (default 32000, floor 8192) — output
+  headroom for the JSON-only completion. It is attached only to oneshot-mode
+  children; explicit agentic children keep the generic subagent cap. Oneshot
+  sampling is pinned to temperature 0 for byte-identical prompts. A malformed
+  reply whose reported output usage reaches this cap is classified as
+  `length`, even when a provider reports `end` or `other`; valid JSON at the
+  cap is still accepted.
 - `dream.synthesize.link_manifest` (default on) — the zero-embed
   pre-retrieval manifest (built from the triage verdict's cached entities +
   segment notes). Benefits BOTH modes: agentic children stop burning turns
@@ -214,7 +223,9 @@ Above the triage cascade sit the execution dials:
 Reading the phase report (`details.synthesis`): `mode`, `oneshot_jobs` /
 `fallback_jobs` / `agentic_jobs` + a `fallback_reasons` histogram (a rising
 fallback rate means the model is failing the output contract — check the
-top reason before considering the agentic revert), `queue_wait_ms_p50/p95`
+top reason before considering the agentic revert; `length` includes malformed
+responses whose output usage reached the configured oneshot cap even when the
+provider stop reason was ambiguous), `queue_wait_ms_p50/p95`
 and `child_runtime_ms_p50/p95` (a slow-but-healthy drain is visible instead
 of indistinguishable from a stuck one), and `dead_jobs`/`degraded`. A run
 with any non-completed child does NOT stamp the cooldown, so the next

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -3418,6 +3418,8 @@ export interface ChatOpts {
   messages: ChatMessage[];
   tools?: ChatToolDef[];
   maxTokens?: number;
+  /** Provider-neutral sampling temperature. Omitted preserves the provider default. */
+  temperature?: number;
   abortSignal?: AbortSignal;
   /**
    * Per-call provider options keyed by recipe id, deep-merged LAST — after
@@ -3992,6 +3994,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
       messages: toModelMessages(repairToolPairing(opts.messages)) as any,
       tools: opts.tools && opts.tools.length > 0 ? tools : undefined,
       maxOutputTokens: opts.maxTokens ?? defaultMaxOutputTokens(modelStr),
+      ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
       // v0.42.20.0 — default a chat timeout (composes with the caller's signal,
       // shorter wins). Covers native-anthropic (the default provider + facts Haiku).
       abortSignal: withDefaultTimeout(opts.abortSignal, AI_CHAT_TIMEOUT_MS),

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -434,6 +434,7 @@ export interface GBrainConfig {
       verdict_model?: string;
       max_prompt_tokens?: number;
       max_chunks_per_transcript?: number;
+      oneshot_max_tokens?: number;
       subagent_timeout_ms?: number;
       subagent_wait_timeout_ms?: number;
     };
@@ -1092,6 +1093,7 @@ export async function loadConfigWithEngine(
   const dbVerdictModel = await dbStr('dream.synthesize.verdict_model');
   const dbMaxPromptTokens = await dbInt('dream.synthesize.max_prompt_tokens');
   const dbMaxChunksPerTranscript = await dbInt('dream.synthesize.max_chunks_per_transcript');
+  const dbOneshotMaxTokens = await dbInt('dream.synthesize.oneshot_max_tokens');
   const dbSubagentTimeoutMs = await dbNum('dream.synthesize.subagent_timeout_ms');
   const dbSubagentWaitTimeoutMs = await dbNum('dream.synthesize.subagent_wait_timeout_ms');
   const dbLookbackDays = await dbInt('dream.patterns.lookback_days');
@@ -1117,6 +1119,9 @@ export async function loadConfigWithEngine(
   }
   if (mergedSynth.max_chunks_per_transcript === undefined && dbMaxChunksPerTranscript !== undefined) {
     mergedSynth.max_chunks_per_transcript = dbMaxChunksPerTranscript;
+  }
+  if (mergedSynth.oneshot_max_tokens === undefined && dbOneshotMaxTokens !== undefined) {
+    mergedSynth.oneshot_max_tokens = dbOneshotMaxTokens;
   }
   if (mergedSynth.subagent_timeout_ms === undefined && dbSubagentTimeoutMs !== undefined) {
     mergedSynth.subagent_timeout_ms = dbSubagentTimeoutMs;
@@ -1425,6 +1430,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'dream.synthesize.verdict_model',
   'dream.synthesize.max_prompt_tokens',
   'dream.synthesize.max_chunks_per_transcript',
+  'dream.synthesize.oneshot_max_tokens',
   // #2415: top-level namespace for synthesize/patterns output (default 'wiki').
   'dream.synthesize.output_root',
   'dream.synthesize.subagent_timeout_ms',

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -142,6 +142,9 @@ const DEFAULT_TRIAGE_CONCURRENCY = 4;
  * page counts drop; `details.synthesis.avg_turns` telemetry shows cap pressure.
  */
 const DEFAULT_MAX_TURNS = 16;
+/** One completion may carry several full markdown pages; keep headroom above the generic 8192 cap. */
+export const DEFAULT_ONESHOT_MAX_TOKENS = 32_000;
+const MIN_ONESHOT_MAX_TOKENS = 8192;
 
 /**
  * Compute per-chunk character budget for the resolved model + config override.
@@ -795,9 +798,11 @@ async function runPhaseSynthesizeInner(
             // #4117: validated per-lane namespaces.
             config.reflectionsPrefix,
             config.originalsPrefix,
+            config.mode,
           ),
           model: subagentModel,
           max_turns: config.maxTurns,
+          ...(config.mode === 'oneshot' ? { max_tokens: config.oneshotMaxTokens } : {}),
           allowed_slug_prefixes: allowedSlugPrefixes,
           // #4216: execution mode + the structural slug-suffix contract
           // (CDX-9) + #4217 write requirement — a synthesis child whose every
@@ -1356,6 +1361,8 @@ export interface SynthConfig {
   triage: SynthTriageConfig;
   /** dream.synthesize.max_turns, default 16 (see DEFAULT_MAX_TURNS rationale), floor 1. */
   maxTurns: number;
+  /** dream.synthesize.oneshot_max_tokens, default 32000, floor 8192. */
+  oneshotMaxTokens: number;
   /** dream.synthesize.max_submissions_per_source_per_day, default 0 = disabled (D2D). Docs recommend 200 for busy deployments. */
   maxSubmissionsPerSourcePerDay: number;
   cooldownHours: number;
@@ -1535,6 +1542,13 @@ export async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig>
     ? rescueContentTypesRaw.split(',').map(s => s.trim().toLowerCase()).filter(s => s.length > 0)
     : DEFAULT_RESCUE_CONTENT_TYPES;
   const maxTurns = Math.max(1, Math.floor(await getNumberConfig(engine, 'dream.synthesize.max_turns', DEFAULT_MAX_TURNS)) || 1);
+  const oneshotMaxTokensRaw = await engine.getConfig('dream.synthesize.oneshot_max_tokens');
+  const parsedOneshotMaxTokens = oneshotMaxTokensRaw === undefined || oneshotMaxTokensRaw === null
+    ? DEFAULT_ONESHOT_MAX_TOKENS
+    : Number(oneshotMaxTokensRaw);
+  const oneshotMaxTokens = Number.isFinite(parsedOneshotMaxTokens)
+    ? Math.max(MIN_ONESHOT_MAX_TOKENS, Math.floor(parsedOneshotMaxTokens))
+    : DEFAULT_ONESHOT_MAX_TOKENS;
   const maxSubmissionsPerSourcePerDay = Math.max(0,
     Math.floor(await getNumberConfig(engine, 'dream.synthesize.max_submissions_per_source_per_day', 0)));
   // getNumberConfig (not `parseInt(str, 10) || N`) so a configured 0 is honored — a bare
@@ -1620,6 +1634,7 @@ export async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig>
       rescueContentTypes,
     },
     maxTurns,
+    oneshotMaxTokens,
     maxSubmissionsPerSourcePerDay,
     cooldownHours,
     maxPromptTokens,
@@ -2613,6 +2628,7 @@ function buildSynthesisPrompt(
   // config-resolved values.
   reflectionsPrefix = `${outputRoot}/personal/reflections`,
   originalsPrefix = `${outputRoot}/originals/ideas`,
+  mode: 'agentic' | 'oneshot' = 'agentic',
 ): string {
   // #4348: UTC projection retained here on purpose — this is a slug-name
   // hint for undated sources, not calendar provenance.
@@ -2628,13 +2644,15 @@ function buildSynthesisPrompt(
   const transcriptHeader = isChunked
     ? `${t.filePath} (chunk ${chunkIdx + 1}/${chunkTotal})`
     : t.filePath;
-  // #4216 rule-2 wording: with a manifest present, the model is pointed at the
-  // pre-resolved candidates FIRST (the search tool stays available on the
-  // agentic path; the oneshot path has no tools, and this same prompt must be
-  // byte-identical across a oneshot attempt and its agentic fallback).
-  const crossRefRule = linkManifestBlock
-    ? 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`) to existing brain content. Pick targets from the LINK CANDIDATES above (or another page you write in this response); use the search tool, if available, only when no candidate fits.'
-    : 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`) to existing brain content. Use the search tool to find existing pages first.';
+  // The agentic prompt retains its search guidance. Oneshot has no tools, so
+  // it may use only pre-resolved candidates or pages in the same JSON batch.
+  const crossRefRule = mode === 'agentic'
+    ? (linkManifestBlock
+      ? 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`) to existing brain content. Pick targets from the LINK CANDIDATES above (or another page you write in this response); use the search tool, if available, only when no candidate fits.'
+      : 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`) to existing brain content. Use the search tool to find existing pages first.')
+    : (linkManifestBlock
+      ? 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`). Pick its target from the LINK CANDIDATES above or another page in this response.'
+      : 'Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., `[ref](people/jane-doe)` or `[[people/jane-doe]]`) to another page in this response.');
   // OV-7: the write allow-list must live in the PROMPT, not only in the
   // put_page tool schema — the oneshot path never sees a tool schema.
   const allowedPathsBlock = allowedSlugPrefixes.length > 0
@@ -2650,7 +2668,7 @@ CONTEXT
 OUTPUT POLICY (ALL of these are required)
 1. Quote the user verbatim. Quotation marks are ONLY for spans reproducible EXACTLY from the transcript below — if you cannot reproduce a span exactly, paraphrase it WITHOUT quotation marks. Do not paraphrase memorable phrasings you can quote exactly.
 2. ${crossRefRule}
-3. Do NOT write to any path outside the ALLOWED WRITE PATHS above${allowedSlugPrefixes.length > 0 ? '' : ' (shown in the put_page schema)'}.
+3. Do NOT write to any path outside the ALLOWED WRITE PATHS above${allowedSlugPrefixes.length > 0 ? '' : mode === 'agentic' ? ' (shown in the put_page schema)' : '; if none are listed, return the Task D skip response'}.
 4. Slug discipline: lowercase alphanumeric and hyphens only, slash-separated segments. NO underscores, NO file extensions.
 5. Self-contained opening: begin every new page's body with a 2-3 sentence summary that a reader unfamiliar with this transcript could understand on its own, before any quotes or detail. Do not assume the reader has the source conversation for context.
 6. Preserve concrete facts: carry the specific numbers, dates, dollar amounts, names, and who-decided-what OF the salient content you write about, exactly as the transcript states them. Do not add routine logistics for their own sake.
@@ -2663,16 +2681,18 @@ A. Reflections (self-knowledge, pattern recognition, emotional processing):
 B. Originals (new ideas, frames, theses, mental models):
    slug: \`${originalsPrefix}/${dateHint}-<idea-slug>-${hashSuffix}\`
 
-C. People mentions: ${linkManifestBlock ? 'check LINK CANDIDATES (and the search tool, when available) first' : 'search first, when a search tool is available'}; never write over an existing person page (the orchestrator handles people enrichment via timeline entries — your job is the reflection/original synthesis, NOT modifying existing person pages).
+C. People mentions: ${mode === 'agentic'
+    ? (linkManifestBlock ? 'check LINK CANDIDATES (and the search tool, when available) first' : 'search first, when a search tool is available')
+    : (linkManifestBlock ? 'check LINK CANDIDATES first' : 'do not create or modify person pages')}; never write over an existing person page (the orchestrator handles people enrichment via timeline entries — your job is the reflection/original synthesis, NOT modifying existing person pages).
 
 D. If nothing in this transcript meets the bar (significance filter already passed but the content is still routine), return without writing anything.
 
 TRANSCRIPT (${transcriptHeader})
 ---
 ${chunkText}
----
-
-When done, briefly list the slugs you wrote in your final message so the orchestrator can audit.`;
+---${mode === 'agentic'
+    ? '\n\nWhen done, briefly list the slugs you wrote in your final message so the orchestrator can audit.'
+    : ''}`;
 }
 
 function sanitizeForSlug(s: string): string {

--- a/src/core/minions/handlers/subagent-oneshot.ts
+++ b/src/core/minions/handlers/subagent-oneshot.ts
@@ -99,7 +99,7 @@ export const ONESHOT_SYSTEM = `You are a knowledge-synthesis engine. You have NO
 If nothing in the transcript meets the bar (Task D), respond with:
 {"pages": [], "skipped": true, "skip_reason": "<one line>"}
 
-Hard rules: at most ${MAX_PAGES_PER_RESPONSE} pages; slugs are lowercase, hyphen-separated, slash-delimited, no underscores, no file extensions; never invent wikilink targets that are not in LINK CANDIDATES or this response.`;
+Hard rules: at most ${MAX_PAGES_PER_RESPONSE} pages; slugs are lowercase, hyphen-separated, slash-delimited, no underscores, no file extensions; never invent wikilink targets that are not in LINK CANDIDATES or this response. Every field, especially body, must be a valid JSON string: escape quotes, backslashes, and line breaks; never place unescaped quotes or literal newlines inside a string.`;
 
 export interface OneshotPage {
   slug: string;
@@ -341,6 +341,7 @@ export async function runSubagentOneshot(args: OneshotArgs): Promise<OneshotOutc
       system: ONESHOT_SYSTEM,
       messages: [{ role: 'user', content: data.prompt }],
       maxTokens: args.maxOutputTokens,
+      temperature: 0,
       abortSignal: callSignal,
       // cacheSystem marks the system block as a cache breakpoint. Note:
       // ONESHOT_SYSTEM alone is under Anthropic's ~1024-token cache minimum,
@@ -401,7 +402,12 @@ export async function runSubagentOneshot(args: OneshotArgs): Promise<OneshotOutc
   }
 
   const parsed = parseOneshotResponse(chatResult.text ?? '');
-  if (!parsed) return fb('unparseable');
+  if (!parsed) {
+    // Some providers normalize an output-cap stop to end/other. Usage at the
+    // requested ceiling is the provider-neutral truncation signal, but only
+    // for invalid JSON — a complete valid response at the cap still succeeds.
+    return fb(chatResult.usage.output_tokens >= args.maxOutputTokens ? 'length' : 'unparseable');
+  }
   if (parsed.pages.length === 0) {
     if (!parsed.skipped) return fb('empty_no_skip');
     // Task-D skip: a legitimate zero-write completion.

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -386,6 +386,33 @@ describe('chat touchpoint — provider_chat_options passthrough', () => {
     expect(providerOptions).toBeUndefined();
   });
 
+  test('temperature is provider-neutral and omitted unless explicitly set', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    __setGenerateTextTransportForTests(async (args: any) => {
+      calls.push(args);
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      } as any;
+    });
+    configureGateway({
+      chat_model: 'anthropic:claude-sonnet-4-6',
+      env: { ANTHROPIC_API_KEY: 'fake' },
+    });
+
+    await chat({
+      messages: [{ role: 'user', content: 'deterministic' }],
+      temperature: 0,
+    });
+    await chat({
+      messages: [{ role: 'user', content: 'provider default' }],
+    });
+
+    expect(calls[0]!.temperature).toBe(0);
+    expect('temperature' in calls[1]!).toBe(false);
+  });
+
   test('call-scoped providerOptions merge last without dropping configured siblings', async () => {
     const providerOptions = await captureProviderOptions({
       chat_model: 'deepseek:deepseek-v4-flash',

--- a/test/cycle-dream-output-root.test.ts
+++ b/test/cycle-dream-output-root.test.ts
@@ -317,6 +317,24 @@ describe('#4216: buildSynthesisPrompt manifest + allow-list blocks', () => {
     expect(prompt).toContain('Use the search tool to find existing pages first.');
   });
 
+  test('oneshot prompt removes tool-use and final-prose instructions; agentic keeps them', () => {
+    const manifest = '\nLINK CANDIDATES\n- [[people/alice-example]] — Alice Example is a founder.';
+    const oneshot = buildSynthesisPrompt(
+      transcript, 'chunk', 0, 1, '', 'wiki', '', manifest,
+      ['wiki/personal/reflections/*'], undefined, undefined, 'oneshot',
+    );
+    const agentic = buildSynthesisPrompt(
+      transcript, 'chunk', 0, 1, '', 'wiki', '', manifest,
+      ['wiki/personal/reflections/*'], undefined, undefined, 'agentic',
+    );
+
+    expect(oneshot).not.toContain('search tool');
+    expect(oneshot).not.toContain('put_page schema');
+    expect(oneshot).not.toContain('final message');
+    expect(agentic).toContain('use the search tool, if available');
+    expect(agentic).toContain('final message');
+  });
+
   test('ALLOWED WRITE PATHS block renders from prefixes (OV-7: oneshot never sees a tool schema)', () => {
     const prompt = buildSynthesisPrompt(
       transcript, 'chunk', 0, 1, '', 'wiki', '', '',

--- a/test/cycle-synthesize-inline-concurrency.test.ts
+++ b/test/cycle-synthesize-inline-concurrency.test.ts
@@ -202,6 +202,19 @@ describe('loadSynthConfig knob validation (#4194/#4216)', () => {
     await engine.unsetConfig('dream.synthesize.mode');
   });
 
+  test('oneshot_max_tokens defaults high, honors overrides, and validates invalid values', async () => {
+    expect((await loadSynthConfig(engine)).oneshotMaxTokens).toBe(32_000);
+    await engine.setConfig('dream.synthesize.oneshot_max_tokens', '48000');
+    expect((await loadSynthConfig(engine)).oneshotMaxTokens).toBe(48_000);
+    await engine.setConfig('dream.synthesize.oneshot_max_tokens', '0');
+    expect((await loadSynthConfig(engine)).oneshotMaxTokens).toBe(8192);
+    await engine.setConfig('dream.synthesize.oneshot_max_tokens', '-50');
+    expect((await loadSynthConfig(engine)).oneshotMaxTokens).toBe(8192);
+    await engine.setConfig('dream.synthesize.oneshot_max_tokens', 'garbage');
+    expect((await loadSynthConfig(engine)).oneshotMaxTokens).toBe(32_000);
+    await engine.unsetConfig('dream.synthesize.oneshot_max_tokens');
+  });
+
   test("link_manifest: default ON; only explicit false/0/off disables (case/space-insensitive)", async () => {
     expect((await loadSynthConfig(engine)).linkManifest).toBe(true);
     for (const off of ['false', ' OFF ', '0']) {

--- a/test/e2e/dream-synthesize-chunking.test.ts
+++ b/test/e2e/dream-synthesize-chunking.test.ts
@@ -455,11 +455,11 @@ function escapeRe(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-describe('E2E synthesize — max_turns (#4152 REGRESSION pin) + triage map injection', () => {
+describe('E2E synthesize — child budgets (#4152/#4785 REGRESSION pins) + triage map injection', () => {
   // IRON-RULE REGRESSION TEST: the default turn budget dropped 30 → 16 with
   // the two-stage cascade. Pin BOTH the new default AND the config path that
   // restores the old behavior.
-  test('submitted subagent jobs carry max_turns=16 by default; dream.synthesize.max_turns=30 restores 30', async () => {
+  test('oneshot children carry their output cap; explicit agentic children keep the generic cap', async () => {
     const rig = await setupRig();
     try {
       await rig.engine.setConfig('dream.synthesize.enabled', 'true');
@@ -467,6 +467,7 @@ describe('E2E synthesize — max_turns (#4152 REGRESSION pin) + triage map injec
       // Two back-to-back runs in this test — disable the cooldown so the
       // second run isn't skipped (configured 0 is honored).
       await rig.engine.setConfig('dream.synthesize.cooldown_hours', '0');
+      await rig.engine.setConfig('dream.synthesize.oneshot_max_tokens', '48000');
       const basename = '2026-08-14-turns.txt';
       const filePath = corpusPath(rig.corpusDir, basename);
       const content = 'a substantive conversation line\n'.repeat(200);
@@ -478,23 +479,26 @@ describe('E2E synthesize — max_turns (#4152 REGRESSION pin) + triage map injec
           await runPhaseSynthesize(rig.engine, { brainDir: rig.brainDir, dryRun: false });
         });
       });
-      let rows = await rig.engine.executeRaw<{ data: { max_turns?: number; prompt?: string } }>(
+      let rows = await rig.engine.executeRaw<{ data: { max_turns?: number; max_tokens?: number; prompt?: string } }>(
         `SELECT data FROM minion_jobs WHERE name = 'subagent' ORDER BY id DESC LIMIT 1`,
       );
       expect(rows[0].data.max_turns).toBe(16);
+      expect(rows[0].data.max_tokens).toBe(48_000);
 
       // Restore path: config override back to the pre-#4152 value. Cancelled
       // rows release the idempotency key, so a re-run resubmits fresh.
       await rig.engine.setConfig('dream.synthesize.max_turns', '30');
+      await rig.engine.setConfig('dream.synthesize.mode', 'agentic');
       await withoutAnthropicKey(async () => {
         await withSubagentAutoCancel(rig.engine, async () => {
           await runPhaseSynthesize(rig.engine, { brainDir: rig.brainDir, dryRun: false });
         });
       });
-      rows = await rig.engine.executeRaw<{ data: { max_turns?: number } }>(
+      rows = await rig.engine.executeRaw<{ data: { max_turns?: number; max_tokens?: number } }>(
         `SELECT data FROM minion_jobs WHERE name = 'subagent' ORDER BY id DESC LIMIT 1`,
       );
       expect(rows[0].data.max_turns).toBe(30);
+      expect(rows[0].data.max_tokens).toBeUndefined();
     } finally {
       await rig.cleanup();
     }

--- a/test/minions/subagent-oneshot.test.ts
+++ b/test/minions/subagent-oneshot.test.ts
@@ -21,6 +21,7 @@ import {
   runSubagentOneshot,
   parseOneshotResponse,
   extractWikilinkTargets,
+  ONESHOT_SYSTEM,
   type OneshotArgs,
 } from '../../src/core/minions/handlers/subagent-oneshot.ts';
 import type { ChatResult } from '../../src/core/ai/gateway.ts';
@@ -51,12 +52,16 @@ const SUFFIX = 'abc123';
 const GOOD_SLUG_A = `wiki/personal/reflections/2026-08-16-topic-${SUFFIX}`;
 const GOOD_SLUG_B = `wiki/originals/ideas/2026-08-16-idea-${SUFFIX}`;
 
-function chatStub(text: string, stopReason: ChatResult['stopReason'] = 'end'): OneshotArgs['_chat'] {
+function chatStub(
+  text: string,
+  stopReason: ChatResult['stopReason'] = 'end',
+  outputTokens = 50,
+): OneshotArgs['_chat'] {
   return (async () => ({
     text,
     blocks: [{ type: 'text', text }],
     stopReason,
-    usage: { input_tokens: 100, output_tokens: 50, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    usage: { input_tokens: 100, output_tokens: outputTokens, cache_read_tokens: 0, cache_creation_tokens: 0 },
     model: 'anthropic:claude-sonnet-4-6',
     providerId: 'anthropic',
   })) as OneshotArgs['_chat'];
@@ -82,7 +87,13 @@ async function makeCtx(data: SubagentHandlerData): Promise<MinionJobContext> {
   };
 }
 
-function makeArgs(ctx: MinionJobContext, data: SubagentHandlerData, chatText: string, stop: ChatResult['stopReason'] = 'end'): OneshotArgs {
+function makeArgs(
+  ctx: MinionJobContext,
+  data: SubagentHandlerData,
+  chatText: string,
+  stop: ChatResult['stopReason'] = 'end',
+  outputTokens = 50,
+): OneshotArgs {
   const tools = buildBrainTools({
     subagentId: ctx.id,
     engine,
@@ -101,7 +112,7 @@ function makeArgs(ctx: MinionJobContext, data: SubagentHandlerData, chatText: st
     leaseKey: 'anthropic:messages',
     maxConcurrent: 32,
     leaseTtlMs: 120_000,
-    _chat: chatStub(chatText, stop),
+    _chat: chatStub(chatText, stop, outputTokens),
   };
 }
 
@@ -126,6 +137,12 @@ const VALID_RESPONSE = JSON.stringify({
 });
 
 describe('parseOneshotResponse', () => {
+  test('system contract requires JSON string escaping', () => {
+    expect(ONESHOT_SYSTEM).toContain('valid JSON string');
+    expect(ONESHOT_SYSTEM).toContain('unescaped quotes');
+    expect(ONESHOT_SYSTEM).toContain('literal newlines');
+  });
+
   test('parses the contract, applies title/type defaults', () => {
     const p = parseOneshotResponse('```json\n{"pages":[{"slug":"a/b","body":"text"}],"skipped":false}\n```');
     expect(p).not.toBeNull();
@@ -167,6 +184,21 @@ describe('extractWikilinkTargets', () => {
 });
 
 describe('runSubagentOneshot', () => {
+  test('pins deterministic sampling and the configured output cap on the gateway call', async () => {
+    const ctx = await makeCtx(DATA);
+    const args = makeArgs(ctx, DATA, '{"pages":[],"skipped":true,"skip_reason":"routine"}');
+    args.maxOutputTokens = 32_000;
+    const baseChat = args._chat!;
+    args._chat = (async (opts) => {
+      expect(opts.temperature).toBe(0);
+      expect(opts.maxTokens).toBe(32_000);
+      return baseChat(opts);
+    }) as OneshotArgs['_chat'];
+
+    const outcome = await runSubagentOneshot(args);
+    expect(outcome.kind).toBe('done');
+  });
+
   test('happy path: validates, writes both pages via put_page, ledger rows land, transcript persisted', async () => {
     const ctx = await makeCtx(DATA);
     const outcome = await runSubagentOneshot(makeArgs(ctx, DATA, VALID_RESPONSE));
@@ -323,6 +355,40 @@ describe('runSubagentOneshot', () => {
     const ctx = await makeCtx(DATA);
     const outcome = await runSubagentOneshot(makeArgs(ctx, DATA, VALID_RESPONSE.slice(0, 50), 'length'));
     expect(outcome).toEqual({ kind: 'fallback', reason: 'length', tokens: FB_TOKENS });
+  });
+
+  test("malformed output at the cap → length fallback for ambiguous 'end'/'other' reasons", async () => {
+    for (const stop of ['end', 'other'] as const) {
+      const ctx = await makeCtx(DATA);
+      const outcome = await runSubagentOneshot(
+        makeArgs(ctx, DATA, VALID_RESPONSE.slice(0, 50), stop, 8192),
+      );
+      expect(outcome).toEqual({
+        kind: 'fallback',
+        reason: 'length',
+        tokens: { ...FB_TOKENS, out: 8192 },
+      });
+    }
+  });
+
+  test('malformed output below the cap remains unparseable', async () => {
+    const ctx = await makeCtx(DATA);
+    const outcome = await runSubagentOneshot(
+      makeArgs(ctx, DATA, VALID_RESPONSE.slice(0, 50), 'end', 8191),
+    );
+    expect(outcome).toEqual({
+      kind: 'fallback',
+      reason: 'unparseable',
+      tokens: { ...FB_TOKENS, out: 8191 },
+    });
+  });
+
+  test('valid JSON at the cap is accepted', async () => {
+    const ctx = await makeCtx(DATA);
+    const outcome = await runSubagentOneshot(
+      makeArgs(ctx, DATA, '{"pages":[],"skipped":true,"skip_reason":"routine"}', 'end', 8192),
+    );
+    expect(outcome.kind).toBe('done');
   });
 
   test('duplicate slugs within one batch → bad_slug (second write would silently overwrite the first)', async () => {


### PR DESCRIPTION
## What

Extend the existing provider-neutral chat options with an optional temperature that is forwarded to the AI SDK, then pin only the dream oneshot call to temperature zero while leaving all other callers unchanged. Make `buildSynthesisPrompt` mode-aware: preserve the current agentic prompt for explicit agentic jobs, but remove tool-use and final-prose instructions from the oneshot prompt and reinforce JSON string escaping in `ONESHOT_SYSTEM`. Add a validated `dream.synthesize.oneshot_max_tokens` setting with a larger default and pass it through the existing `SubagentHandlerData.max_tokens` field only for oneshot-mode children, preserving the current agentic-mode default.

Dream synthesis defaults to a tool-less oneshot completion, but the shared prompt still asks the model to use search and append a prose slug summary despite the system contract requiring JSON only. The gateway also lacks a provider-neutral temperature option, so oneshot responses use each provider's sampling default and can vary for byte-identical prompts. Synthesis children inherit the generic 8,192-token output ceiling, and parse failures at that ceiling can be recorded as `unparseable` when the provider reports an ambiguous stop reason. These defects raise the JSON-contract failure rate and cause a paid oneshot attempt to be followed by the more expensive agentic loop.

Closes #4785

## Why

Extend the existing provider-neutral chat options with an optional temperature that is forwarded to the AI SDK, then pin only the dream oneshot call to temperature zero while leaving all other callers unchanged. Make `buildSynthesisPrompt` mode-aware: preserve the current agentic prompt for explicit agentic jobs, but remove tool-use and final-prose instructions from the oneshot prompt and reinforce JSON string escaping in `ONESHOT_SYSTEM`. Add a validated `dream.synthesize.oneshot_max_tokens` setting with a larger default and pass it through the existing `SubagentHandlerData.max_tokens` field only for oneshot-mode children, preserving the current agentic-mode default.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `<source file(s)>` to `<ref>`, ran `<test file>` → `N pass / M fail`. Restored → all pass.

## Verification

A gateway chat request with an explicit temperature forwards that value to the production transport, while an omitted temperature leaves the transport option unset.
A oneshot child calls the gateway with temperature zero and its configured output cap; a normal agentic child retains the existing generic cap and prompt behavior.
The oneshot synthesis prompt contains no search-tool instruction and no request for prose after JSON, while the explicitly configured agentic prompt retains its existing tool-oriented wording.
The oneshot output-token setting uses the documented default, honors a valid override, and safely floors or falls back for zero, negative, or non-numeric values; the queued child data carries the resolved value only in oneshot mode.
An invalid response whose output usage reaches the cap is reported as `length` for `end` and `other` stop reasons, while a below-cap malformed response remains `unparseable` and a valid at-cap JSON response is accepted.
Existing refusal, slug, wikilink, skip, write-ledger, crash-recovery, token-accounting, and agentic-fallback tests remain unchanged, proving the hardening does not weaken validation or alter fallback policy.

## Tests

Covered in the summary above.

AI was used for assistance.
