### PR TITLE
v0.48.2.1 fix(facts): use handler timeout for durable absorb jobs (#4864)

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -333,7 +333,6 @@ export async function runFactsBackstop(
             // re-runnable), never a silent consume.
             max_attempts: 5,
             backoff_delay: 60_000,
-            timeout_ms: 180_000,
           },
         );
         return { mode: 'queue', enqueued: true, queueDepth: 0 };

--- a/test/facts-backstop-outcome.serial.test.ts
+++ b/test/facts-backstop-outcome.serial.test.ts
@@ -164,7 +164,8 @@ describe('keyless vs keyed chat_unavailable', () => {
     // Global default would be Anthropic (unservable), but the DB-plane
     // extraction override IS servable with the OpenAI key — the engine-aware
     // gate must admit the work. Short-lived mode routes to the durable minion
-    // (no LLM call executes in-test) so we can also pin the retry policy.
+    // (no LLM call executes in-test) so we can also pin the retry policy and
+    // the handler-default timeout stamped on the submitted row.
     process.env.OPENAI_API_KEY = 'sk-test';
     await engine.setConfig('facts.extraction_model', 'openai:gpt-4o-mini');
     configureGateway({ env: { OPENAI_API_KEY: 'sk-test' } });
@@ -176,13 +177,14 @@ describe('keyless vs keyed chat_unavailable', () => {
     expect(r.mode).toBe('queue');
     expect((r as { enqueued: boolean }).enqueued).toBe(true);
     expect((r as { skipped?: string }).skipped).toBeUndefined();
-    const jobs = await engine.executeRaw<{ max_attempts: number; backoff_delay: number }>(
-      `SELECT max_attempts, backoff_delay FROM minion_jobs WHERE name = 'facts-absorb'`,
+    const jobs = await engine.executeRaw<{ max_attempts: number; backoff_delay: number; timeout_ms: number | string }>(
+      `SELECT max_attempts, backoff_delay, timeout_ms FROM minion_jobs WHERE name = 'facts-absorb'`,
     );
     expect(jobs).toHaveLength(1);
     // Slow-retry policy (R2-5): config drift is fixed on human timescales.
     expect(Number(jobs[0].max_attempts)).toBe(5);
     expect(Number(jobs[0].backoff_delay)).toBe(60_000);
+    expect(Number(jobs[0].timeout_ms)).toBe(10 * 60 * 1000);
   });
 });
 


### PR DESCRIPTION
Fixes #4864

## Summary
- Stop passing an explicit `timeout_ms: 180_000` when the durable facts backstop submits `facts-absorb`.
- Let `MinionQueue.add` stamp the `facts-absorb` handler default timeout while preserving the existing retry, backoff, and idempotency policy.
- Extend the durable-job regression coverage to assert the persisted row carries the 10-minute timeout along with the slow-retry settings.

## Verification
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bun test test/facts-backstop-outcome.serial.test.ts`
- `env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/facts-backstop-outcome.serial.test.ts`

Gate evidence: `RESULT: GREEN`; `verify` green; focused unit file reported 15 pass / 0 fail; diff-selected E2E was skipped as unrelated, with CI covering the full suite.
