### PR TITLE
fix(cycle): reasoning-aware + configurable output cap for synthesize_concepts

### DIFF
--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -27,6 +27,7 @@ import type { ProgressReporter } from '../progress.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { chat as gatewayChat, isAvailable } from '../ai/gateway.ts';
+import { getProviderCapabilities } from '../ai/capabilities.ts';
 import { createGlobalLlmHaltTracker, haltedClassOf, type GlobalLlmErrorClass } from '../ai/errors.ts';
 // #2163: concept pages route through importFromContent (the same
 // parse→chunk→embed pipeline put_page uses) instead of a bare engine.putPage,
@@ -51,6 +52,46 @@ const FALLBACK_PRICING: ModelPricing = canonicalLookup('anthropic:claude-sonnet-
 const TIER_T1_MIN = 10;
 const TIER_T2_MIN = 5;
 const TIER_T3_MIN = 2;
+/**
+ * Output cap for the per-concept narrative. 500 sizes the *answer* (a 1-paragraph
+ * narrative) and is ample for a non-reasoning model. It is NOT ample for a
+ * thinking-by-default model: reasoning bills as output and counts against
+ * max_tokens, so the budget is spent before any answer text is emitted and the
+ * call returns empty content with finish_reason "length" — which lands in
+ * `deterministicNarrative` and silently ships a template stub. This phase
+ * resolves at `tier: 'reasoning'`, so a thinking model here is the expected
+ * case, not an edge case.
+ */
+const DEFAULT_SYNTH_MAX_OUTPUT_TOKENS = 500;
+/** Answer budget plus reasoning headroom, mirroring think's smaller-than-gateway cap. */
+const THINKING_SYNTH_MAX_OUTPUT_TOKENS = 8000;
+/** Floor mirrors cycle.extract_atoms.max_output_tokens: below this every
+ *  response truncates into the malformed-output path. */
+const MIN_SYNTH_MAX_OUTPUT_TOKENS = 256;
+
+/**
+ * Resolve the narrative output cap: explicit operator config wins, else
+ * reasoning-aware default. Keyed on the recipe-declared capability rather than
+ * a model-name regex so provider renames cannot silently drop the headroom.
+ */
+export async function resolveSynthMaxOutputTokens(
+  engine: BrainEngine,
+  modelStr: string,
+): Promise<number> {
+  const configured = await engine.getConfig('cycle.synthesize_concepts.max_output_tokens');
+  if (configured) {
+    const n = Number(configured);
+    if (Number.isFinite(n) && n >= MIN_SYNTH_MAX_OUTPUT_TOKENS) return Math.floor(n);
+  }
+  try {
+    if (getProviderCapabilities(modelStr).supportsThinking) {
+      return THINKING_SYNTH_MAX_OUTPUT_TOKENS;
+    }
+  } catch {
+    // Unknown provider / chat-less recipe — keep the conservative default.
+  }
+  return DEFAULT_SYNTH_MAX_OUTPUT_TOKENS;
+}
 
 export interface SynthesizeConceptsOpts {
   brainDir?: string;
@@ -234,6 +275,7 @@ export async function runPhaseSynthesizeConcepts(
     tier: 'reasoning',
     fallback: 'sonnet',
   });
+  const synthMaxOutputTokens = await resolveSynthMaxOutputTokens(engine, synthModel);
   for (const group of atomGroups) {
     tierCounts[group.tier]++;
     let narrative: string;
@@ -260,7 +302,7 @@ export async function runPhaseSynthesizeConcepts(
                     .join('\n\n')}`,
               },
             ],
-            maxTokens: 500,
+            maxTokens: synthMaxOutputTokens,
           });
           // Post-await yield (T3): the LLM call is the main TTL hazard
           // codex flagged. Throttle inside maybeYield bounds the actual

--- a/test/synthesize-concepts-token-cap.test.ts
+++ b/test/synthesize-concepts-token-cap.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveSynthMaxOutputTokens } from '../src/core/cycle/synthesize-concepts.ts';
+import { getProviderCapabilities } from '../src/core/ai/capabilities.ts';
+
+// Minimal engine stub: only getConfig is consulted by the resolver.
+const engineWith = (cfg: Record<string, string>) =>
+  ({ getConfig: async (k: string) => cfg[k] }) as any;
+
+// synthesize_concepts resolves its model at `tier: 'reasoning'`, yet capped the
+// narrative call at a hardcoded 500 output tokens. Reasoning bills as output and
+// counts against max_tokens, so a thinking-by-default model spends the budget
+// before emitting answer text, returns empty content with finish_reason
+// "length", and the phase silently falls back to `deterministicNarrative` —
+// shipping a template stub as if synthesis had succeeded.
+describe('resolveSynthMaxOutputTokens', () => {
+  it('grants reasoning headroom to a thinking-by-default model', async () => {
+    // Guard the premise: if the recipe drops the flag this fails here, loudly.
+    expect(getProviderCapabilities('deepseek:deepseek-v4-flash').supportsThinking).toBe(true);
+    expect(await resolveSynthMaxOutputTokens(engineWith({}), 'deepseek:deepseek-v4-flash'))
+      .toBe(8000);
+  });
+
+  it('keeps the 500 default for a non-thinking model', async () => {
+    expect(getProviderCapabilities('groq:qwen/qwen3.8-27b').supportsThinking).toBe(false);
+    expect(await resolveSynthMaxOutputTokens(engineWith({}), 'groq:qwen/qwen3.8-27b'))
+      .toBe(500);
+  });
+
+  it('lets explicit operator config win over both defaults', async () => {
+    const cfg = { 'cycle.synthesize_concepts.max_output_tokens': '1200' };
+    expect(await resolveSynthMaxOutputTokens(engineWith(cfg), 'groq:qwen/qwen3.8-27b')).toBe(1200);
+    expect(await resolveSynthMaxOutputTokens(engineWith(cfg), 'deepseek:deepseek-v4-flash')).toBe(1200);
+  });
+
+  it('ignores config below the floor that would truncate every response', async () => {
+    const cfg = { 'cycle.synthesize_concepts.max_output_tokens': '32' };
+    expect(await resolveSynthMaxOutputTokens(engineWith(cfg), 'groq:qwen/qwen3.8-27b')).toBe(500);
+  });
+
+  it('degrades to the default for an unknown provider instead of throwing', async () => {
+    expect(await resolveSynthMaxOutputTokens(engineWith({}), 'not-a-provider:nope')).toBe(500);
+  });
+});


### PR DESCRIPTION
## The contradiction

`synthesize_concepts` resolves its model at `tier: 'reasoning'` with `fallback: 'sonnet'`:

```ts
const synthModel = await resolveModel(engine, {
  configKey: 'models.dream.synthesize',
  tier: 'reasoning',
  fallback: 'sonnet',
});
```

…then caps the narrative call at a hardcoded **500** output tokens.

For a thinking-by-default model those two facts are incompatible. Reasoning bills as output and counts against `max_tokens`, so the budget is spent before any answer text is emitted.

## Why it's invisible

The call returns empty content with `finish_reason: "length"`. The phase catches that and calls `deterministicNarrative`, so the run **reports success** with an `(N LLM-failed → template fallback)` note — not an error. The visible symptom is a T1/T2 concept page whose body reads:

```
T3 concept. 3 atoms reference this. Top mentions:
```

…sitting in production search results, indistinguishable from a page that never qualified for synthesis at all.

Observed on 0.47.9.0 with `models.dream.synthesize` set to a DeepSeek v4 model: every T1/T2 group fell back. Reproduced directly against the API with the phase's own prompt shape — at `max_tokens=500`, `reasoning_tokens=500`, `content_len=0`, `finish_reason=length`.

## The change

**500 is correct for the answer** — a one-paragraph narrative, and existing concept bodies run 119–312 chars. It is not correct for answer *plus* reasoning. So:

- non-reasoning models keep **500** (no behavior change)
- models whose recipe declares `thinking_by_default` get **8000** (answer budget plus reasoning headroom, deliberately smaller than the gateway's 32000, mirroring how `think` keeps its own smaller cap)
- `cycle.synthesize_concepts.max_output_tokens` overrides either, mirroring the existing `cycle.extract_atoms.max_output_tokens` including its **256 floor** — below that every response truncates into the malformed-output path

Detection uses `getProviderCapabilities().supportsThinking` — the same recipe-declared capability `think`'s `maxOutputTokensFor` already keys on — rather than a model-name regex, so provider renames can't silently drop the headroom. Unknown or chat-less providers degrade to 500 rather than throwing.

## Scope note

This is **not** fixed by making the gateway default reasoning-aware (my #4847): this call site passes `maxTokens` explicitly, so it bypasses `defaultMaxOutputTokens` entirely. The two are independent, and this one is the more damaging of the pair — it degrades concept quality silently rather than surfacing a parse error.

Related but distinct: #4203 addressed synthesis *ordering* and *recording* which pages came from a fallback. This addresses the cap that causes the fallbacks.

## Tests

`test/synthesize-concepts-token-cap.test.ts`:
- thinking-by-default model gets headroom (with a guard asserting the recipe still declares the capability, so a recipe regression fails loudly rather than silently reverting to 500)
- non-thinking model keeps 500
- explicit config wins over both defaults
- sub-floor config is ignored
- unknown provider degrades instead of throwing

Verified the thinking assertion **fails without the capability branch and passes with it** (removing only that branch, keeping the export and config path, fails exactly that one test with `Expected: 8000`).

`bun test` 5 pass. `bun run verify` **54/54 green**. `tsc --noEmit` clean. Module-size ceilings unaffected.
