### PR TITLE
fix(google): retry Gmail rate limits patiently and never poison rate-limited threads

### DIFF
--- a/docs/guides/google-connect.md
+++ b/docs/guides/google-connect.md
@@ -155,6 +155,27 @@ consecutive failures instead of wedging the sync forever;
 `gbrain sync --source <id> --full` retries skipped threads with a fresh
 ledger.
 
+### Rate limits during backfill
+
+A large mailbox backfilling a wide `--history-days` window can trip Gmail's
+per-user rate limit in bursts — Google answers with HTTP 403
+(`rateLimitExceeded` / `userRateLimitExceeded`) or 429, and it clears on its
+own within seconds to low minutes. The client retries a rate-limited request
+patiently — 6 attempts by default, exponential backoff with jitter capped at
+60s, honoring `Retry-After` when Google sends one — before finally giving up
+and reporting `rate_limited`. That budget is deliberately much larger than
+the 2-attempt budget used for other retryable failures (like a 401 needing a
+token refresh): giving up too early used to mean a thread that would have
+succeeded a few seconds later was instead skipped for the rest of the sync.
+
+Tune it with `GBRAIN_GOOGLE_RATE_LIMIT_RETRIES` (a positive integer) if the
+default isn't enough for a very large, very rate-limited backfill. And even
+when a thread's retry budget IS exhausted, a rate-limit failure is never
+counted toward the poison-skip threshold — unlike a genuine per-thread
+failure (a malformed message, a permissions edge case), a rate limit says
+nothing about that specific thread, so the sweep keeps retrying it on every
+future run instead of silently giving up on it.
+
 ## Other ways to reach Google (no gbrain OAuth)
 
 If your stack already holds Google access another way — a Google CLI with its

--- a/src/core/google/google-clients.ts
+++ b/src/core/google/google-clients.ts
@@ -4,7 +4,14 @@
  * Hand-rolled (no googleapis dep, house style — see github-source.ts):
  *  - auth via GoogleTokenProvider (vault-backed, auto-refreshing)
  *  - 401 → forceRefresh() + single retry
- *  - 403/429 → Retry-After honored (delta-seconds AND http-date)
+ *  - 403/429 → Retry-After honored (delta-seconds AND http-date). A
+ *    rate-limit-class response (403 rateLimitExceeded/userRateLimitExceeded,
+ *    403 quota, or 429) gets a MUCH more patient retry budget than other
+ *    retryable failures — DEFAULT_RATE_LIMIT_RETRIES, exponential backoff
+ *    with jitter capped at 60s, GBRAIN_GOOGLE_RATE_LIMIT_RETRIES env
+ *    override — because Gmail's per-user rate limiting under backfill burst
+ *    load is common and self-clearing; giving up after two tries used to
+ *    poison threads that would have succeeded a few seconds later.
  *  - 403 accessNotConfigured → CredentialError 'api_not_enabled' with the
  *    exact enable deep link (project number extracted from the client id)
  *  - uniform pageToken pagination with a safety cap
@@ -34,6 +41,41 @@ const PEOPLE_BASE = 'https://people.googleapis.com/v1';
 
 const PAGINATION_CAP = 500;
 
+/** Retry budget for a 401 needing a token refresh-and-retry. */
+const DEFAULT_RETRIES = 2;
+
+/**
+ * Retry budget for a rate-limit-class response (403 rateLimitExceeded /
+ * userRateLimitExceeded / quota, or 429) — deliberately much larger than
+ * DEFAULT_RETRIES. Gmail's per-user rate limiting under backfill burst load
+ * clears on its own within seconds to low minutes; two tries (~6s total)
+ * gave up before it cleared and poisoned threads that would otherwise have
+ * succeeded.
+ */
+const DEFAULT_RATE_LIMIT_RETRIES = 6;
+
+/** Backoff ceiling for a rate-limit retry with no Retry-After header. */
+const RATE_LIMIT_BACKOFF_CAP_MS = 60_000;
+
+function resolveRateLimitRetries(): number {
+  const raw = process.env.GBRAIN_GOOGLE_RATE_LIMIT_RETRIES;
+  if (!raw) return DEFAULT_RATE_LIMIT_RETRIES;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_RATE_LIMIT_RETRIES;
+}
+
+/**
+ * Exponential backoff with EQUAL jitter (half fixed, half random), capped at
+ * RATE_LIMIT_BACKOFF_CAP_MS. Only used when Google didn't send Retry-After —
+ * jitter avoids many gbrain processes hitting the same per-user/per-project
+ * quota resynchronizing their retries in lockstep.
+ */
+export function rateLimitBackoffMs(attempt: number): number {
+  const base = Math.min(RATE_LIMIT_BACKOFF_CAP_MS, 2 ** attempt * 2_000);
+  const half = base / 2;
+  return Math.round(half + Math.random() * half);
+}
+
 interface GoogleErrorBody {
   error?: {
     code?: number;
@@ -58,10 +100,16 @@ export class GoogleApiClient {
   async fetchJSON<T>(
     url: string,
     apiHint: ApiHint,
-    opts: { signal?: AbortSignal; retries?: number } = {},
+    opts: { signal?: AbortSignal; retries?: number; rateLimitRetries?: number } = {},
   ): Promise<T> {
-    const retries = opts.retries ?? 2;
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    const retries = opts.retries ?? DEFAULT_RETRIES;
+    // Rate-limit-class failures get their OWN (larger) retry budget — see
+    // the class doc comment. The shared `attempt` counter is bounded by
+    // whichever budget is larger; each branch below still checks its own
+    // budget, so a plain 401 exhausts at `retries` exactly as before.
+    const rateLimitRetries = opts.rateLimitRetries ?? resolveRateLimitRetries();
+    const maxAttempt = Math.max(retries, rateLimitRetries);
+    for (let attempt = 0; attempt <= maxAttempt; attempt++) {
       const token = await this.tokens.getAccessToken();
       const res = await this.fetchImpl(url, {
         headers: { authorization: `Bearer ${token}` },
@@ -88,9 +136,12 @@ export class GoogleApiClient {
         }
       }
       if (res.status === 403 || res.status === 429) {
-        const waitMs = parseRetryAfterMs(res.headers.get('retry-after')) ?? Math.min(60_000, 2 ** attempt * 2_000);
-        if (attempt < retries) {
-          this.log(`[google] HTTP ${res.status}; retrying in ${Math.round(waitMs / 1000)}s`);
+        const waitMs = parseRetryAfterMs(res.headers.get('retry-after')) ?? rateLimitBackoffMs(attempt);
+        if (attempt < rateLimitRetries) {
+          this.log(
+            `[google] HTTP ${res.status}; retrying in ${Math.round(waitMs / 1000)}s ` +
+              `(rate limit, attempt ${attempt + 1}/${rateLimitRetries})`,
+          );
           await new Promise<void>((resolve) => {
             const t = setTimeout(resolve, waitMs);
             opts.signal?.addEventListener('abort', () => { clearTimeout(t); resolve(); }, { once: true });

--- a/src/core/google/google-source.ts
+++ b/src/core/google/google-source.ts
@@ -611,6 +611,18 @@ async function applyLoopDetection(
 const MAX_THREAD_FAILURES = 3;
 
 /**
+ * A rate-limit failure is transient and self-clearing (Google's own quota
+ * window, not a problem with this thread) — it must NOT count toward
+ * MAX_THREAD_FAILURES. The google-clients.ts retry loop already retries a
+ * rate-limited request patiently (DEFAULT_RATE_LIMIT_RETRIES, backoff +
+ * jitter) before giving up and throwing this; reaching here means the
+ * client's own retry budget was exhausted, not that the thread is bad.
+ */
+function isRateLimitFailure(e: unknown): boolean {
+  return isCredentialError(e) && e.code === 'rate_limited';
+}
+
+/**
  * Returns true when every gmail thread this run either imported or was
  * deliberately skipped (404-vanished, poison ledger). False = real failures
  * remain, and the caller must NOT stamp `last_sync_at` — a poison thread
@@ -698,11 +710,19 @@ async function sweepGmail(
               progressTick(`thread ${tid} gone`);
               continue;
             }
-            failCounts[tid] = (failCounts[tid] ?? 0) + 1;
+            // Rate-limited failures don't count toward the poison threshold
+            // (transient, self-clearing) — but they still fail the batch so
+            // the floor doesn't skip past a thread nothing has actually
+            // imported yet.
+            const rateLimited = isRateLimitFailure(e);
+            if (!rateLimited) failCounts[tid] = (failCounts[tid] ?? 0) + 1;
             batchFailed = true;
             summary.failedFiles++;
             summary.status = 'partial';
-            deps.log(`[google] thread ${tid} failed: ${e instanceof Error ? e.message : String(e)}`);
+            deps.log(
+              `[google] thread ${tid} failed${rateLimited ? ' (rate limited; not counted toward the poison threshold)' : ''}: ` +
+                `${e instanceof Error ? e.message : String(e)}`,
+            );
           }
         }
         // Monotone forward progress: the floor commits per FULLY-SUCCESSFUL
@@ -799,11 +819,18 @@ async function sweepGmail(
         progressTick(`thread ${tid} gone`);
         continue;
       }
-      failCounts[tid] = (failCounts[tid] ?? 0) + 1;
+      // Same rate-limit carve-out as the backfill batch loop above: transient,
+      // self-clearing, must not count toward the poison threshold — but it
+      // still holds the delta cursor back (failed++) so nothing is dropped.
+      const rateLimited = isRateLimitFailure(e);
+      if (!rateLimited) failCounts[tid] = (failCounts[tid] ?? 0) + 1;
       failed++;
       summary.failedFiles++;
       summary.status = 'partial';
-      deps.log(`[google] thread ${tid} failed: ${e instanceof Error ? e.message : String(e)}`);
+      deps.log(
+        `[google] thread ${tid} failed${rateLimited ? ' (rate limited; not counted toward the poison threshold)' : ''}: ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
   // The delta cursor advances only when every flagged thread landed —

--- a/test/google-clients.test.ts
+++ b/test/google-clients.test.ts
@@ -28,8 +28,10 @@ import {
   GoogleApiClient,
   GoogleCursorExpiredError,
   PeopleClient,
+  rateLimitBackoffMs,
   type FetchImpl,
 } from '../src/core/google/google-clients.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 // ── extractCalendarMethod (pure) ─────────────────────────────────────────────
 
@@ -231,6 +233,27 @@ function b64url(s: string): string {
   return Buffer.from(s, 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+// ── rateLimitBackoffMs (pure) ────────────────────────────────────────────────
+
+describe('rateLimitBackoffMs', () => {
+  test('stays within [half, base] of the exponential-backoff schedule and never exceeds the 60s cap', () => {
+    // attempt 0: base=2000, half=1000 → [1000, 2000]
+    // attempt 4: base=32000, half=16000 → [16000, 32000]
+    // attempt 10: base would exceed the cap, so base clamps to 60000 → [30000, 60000]
+    for (const [attempt, [lo, hi]] of [
+      [0, [1000, 2000]],
+      [4, [16000, 32000]],
+      [10, [30000, 60000]],
+    ] as const) {
+      for (let i = 0; i < 20; i++) {
+        const ms = rateLimitBackoffMs(attempt);
+        expect(ms).toBeGreaterThanOrEqual(lo);
+        expect(ms).toBeLessThanOrEqual(hi);
+      }
+    }
+  });
+});
+
 // ── GoogleApiClient core: auth, retry, error mapping ─────────────────────────
 
 describe('GoogleApiClient request core', () => {
@@ -348,7 +371,7 @@ describe('GoogleApiClient request core', () => {
 });
 
 describe('GoogleApiClient retry exhaustion + 403 mapping', () => {
-  test("always-429 (Retry-After: 0) exhausts the retries and maps to 'rate_limited'", async () => {
+  test("always-429 (Retry-After: 0) exhausts the RATE-LIMIT retry budget (bigger than the plain retry budget) and maps to 'rate_limited'", async () => {
     let apiCalls = 0;
     const h = makeHarness(() => {
       apiCalls++;
@@ -363,9 +386,113 @@ describe('GoogleApiClient retry exhaustion + 403 mapping', () => {
     }
     expect(thrown).toBeInstanceOf(CredentialError);
     expect((thrown as CredentialError).code).toBe('rate_limited');
-    // Default retries=2: attempts 0 and 1 are retried, attempt 2 throws.
-    expect(apiCalls).toBe(3);
+    // Default rate-limit retries=6 (bigger than the plain retries=2 used for
+    // 401): attempts 0-5 are retried, attempt 6 throws. This is deliberately
+    // MORE patient than a plain retryable failure — the whole point of this
+    // fix (a 403/429 used to give up after 3 calls and poison the thread).
+    expect(apiCalls).toBe(7);
     expect(h.tokenPosts()).toBe(0); // a rate limit never triggers a token refresh
+  });
+
+  test('always-429 (Retry-After: 0) honors an explicit smaller rateLimitRetries override', async () => {
+    let apiCalls = 0;
+    const h = makeHarness(() => {
+      apiCalls++;
+      return json({ error: { message: 'rate limit' } }, 429, { 'retry-after': '0' });
+    });
+    const client = new GoogleApiClient(h.tokens, h.fetchImpl);
+    let thrown: unknown;
+    try {
+      await client.fetchJSON('https://gmail.googleapis.com/gmail/v1/fake', 'gmail', {
+        rateLimitRetries: 1,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(CredentialError);
+    expect((thrown as CredentialError).code).toBe('rate_limited');
+    expect(apiCalls).toBe(2); // attempt 0 retried, attempt 1 throws
+  });
+
+  test('GBRAIN_GOOGLE_RATE_LIMIT_RETRIES env var raises the default rate-limit retry budget', async () => {
+    let apiCalls = 0;
+    const h = makeHarness(() => {
+      apiCalls++;
+      return json({ error: { message: 'rate limit' } }, 429, { 'retry-after': '0' });
+    });
+    const client = new GoogleApiClient(h.tokens, h.fetchImpl);
+    let thrown: unknown;
+    await withEnv({ GBRAIN_GOOGLE_RATE_LIMIT_RETRIES: '2' }, async () => {
+      try {
+        await client.fetchJSON('https://gmail.googleapis.com/gmail/v1/fake', 'gmail');
+      } catch (e) {
+        thrown = e;
+      }
+    });
+    expect(thrown).toBeInstanceOf(CredentialError);
+    expect((thrown as CredentialError).code).toBe('rate_limited');
+    expect(apiCalls).toBe(3); // attempts 0-1 retried (env override = 2), attempt 2 throws
+  });
+
+  test('GBRAIN_GOOGLE_RATE_LIMIT_RETRIES with an invalid value falls back to the default (6), not a crash', async () => {
+    let apiCalls = 0;
+    const h = makeHarness(() => {
+      apiCalls++;
+      return json({ error: { message: 'rate limit' } }, 429, { 'retry-after': '0' });
+    });
+    const client = new GoogleApiClient(h.tokens, h.fetchImpl);
+    let thrown: unknown;
+    await withEnv({ GBRAIN_GOOGLE_RATE_LIMIT_RETRIES: 'not-a-number' }, async () => {
+      try {
+        await client.fetchJSON('https://gmail.googleapis.com/gmail/v1/fake', 'gmail');
+      } catch (e) {
+        thrown = e;
+      }
+    });
+    expect((thrown as CredentialError).code).toBe('rate_limited');
+    expect(apiCalls).toBe(7); // falls back to the default budget (6 retries)
+  });
+
+  test('a 403 quota reason gets the same patient rate-limit retry budget as 429', async () => {
+    let apiCalls = 0;
+    const h = makeHarness(() => {
+      apiCalls++;
+      return json(
+        { error: { code: 403, message: 'Quota exceeded', errors: [{ reason: 'quotaExceeded' }] } },
+        403,
+        { 'retry-after': '0' },
+      );
+    });
+    const client = new GoogleApiClient(h.tokens, h.fetchImpl);
+    let thrown: unknown;
+    try {
+      await client.fetchJSON('https://gmail.googleapis.com/gmail/v1/fake', 'gmail');
+    } catch (e) {
+      thrown = e;
+    }
+    expect((thrown as CredentialError).code).toBe('rate_limited');
+    expect(apiCalls).toBe(7);
+  });
+
+  test('a 401 still exhausts at its OWN (unchanged, smaller) retry budget even though the rate-limit budget is larger', async () => {
+    let apiCalls = 0;
+    const h = makeHarness(() => {
+      apiCalls++;
+      return json({ error: { code: 401, message: 'Invalid Credentials' } }, 401);
+    });
+    const gmail = new GmailClient(h.tokens, h.fetchImpl, () => {}, CLIENT_ID);
+    let thrown: unknown;
+    try {
+      await gmail.getProfile();
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(CredentialError);
+    expect((thrown as CredentialError).code).toBe('upstream');
+    // Default retries=2 for 401 (unaffected by the bigger rate-limit budget):
+    // attempts 0 and 1 retried (with a forceRefresh each), attempt 2 throws.
+    expect(apiCalls).toBe(3);
+    expect(h.tokenPosts()).toBe(2);
   });
 
   test("403 with a non-rate, non-quota reason maps to 'upstream' WITHOUT a retry", async () => {

--- a/test/google-source-materialize.test.ts
+++ b/test/google-source-materialize.test.ts
@@ -91,6 +91,9 @@ interface FakeGoogle {
   historyResponseId: string;
   historyExpired: boolean;
   failThreads: Set<string>;
+  /** Threads that 429 (rate-limited) on every fetch — retry-after: 0 so tests
+   *  don't actually sleep through the client's real backoff schedule. */
+  rateLimitThreads: Set<string>;
   contacts: unknown[];
   contactsDelta: unknown[];
   calendarEvents: unknown[];
@@ -111,6 +114,7 @@ function emptyFx(): FakeGoogle {
     historyResponseId: '1000',
     historyExpired: false,
     failThreads: new Set(),
+    rateLimitThreads: new Set(),
     contacts: [],
     contactsDelta: [],
     calendarEvents: [],
@@ -127,8 +131,8 @@ function b64url(s: string): string {
 }
 
 function buildFetch(fx: FakeGoogle): FetchImpl {
-  const json = (body: unknown, status = 200): Response =>
-    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+  const json = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json', ...headers } });
 
   return async (url: string): Promise<Response> => {
     const u = new URL(url);
@@ -174,6 +178,11 @@ function buildFetch(fx: FakeGoogle): FetchImpl {
       fx.threadFetches++;
       fx.onThreadFetch?.();
       if (fx.failThreads.has(tid)) return json({ error: { code: 500, message: 'backend error' } }, 500);
+      if (fx.rateLimitThreads.has(tid)) {
+        // retry-after: 0 → the client's real (patient) retry loop still
+        // runs its full attempt budget, but with zero actual delay.
+        return json({ error: { message: 'rate limit' } }, 429, { 'retry-after': '0' });
+      }
       const msgs = fx.messages
         .filter((m) => m.threadId === tid)
         .sort((a, b) => b.internalDateMs - a.internalDateMs); // served newest-first
@@ -832,6 +841,54 @@ describe('google-source materialize', () => {
         expect(state5.gmail_fail_counts ?? {}).toEqual({}); // reset + success
         const slugs5 = await slugsWhere(`slug LIKE 'emails/%'`);
         expect(slugs5.some((s) => s.includes('contract-question'))).toBe(true);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('rate-limited thread: partial every run like a real failure, but NEVER poisoned — the ledger stays empty across many runs', async () => {
+    // The production bug this pins: a transient 429/403 rate-limit failure
+    // used to count toward MAX_THREAD_FAILURES exactly like a hard failure,
+    // so a burst of rate limiting during a big backfill would poison
+    // (silently skip, without --full) mail that was never actually bad.
+    const dir = mkdtempSync(join(tmpdir(), 'gsrc-ratelimit-'));
+    const fx = emptyFx();
+    gmailFixture(fx);
+    const vault = makeVault();
+    try {
+      await insertGoogleSource(dir);
+      await withHome(async () => {
+        fx.rateLimitThreads.add(T_B);
+        // Run this MORE times than MAX_THREAD_FAILURES (3) would take to
+        // poison a hard failure — if rate-limit failures were still counted,
+        // run 4 would already skip T_B instead of retrying it.
+        for (let run = 1; run <= 5; run++) {
+          const res = await sweep(dir, fx, vault, {}, 'gmail');
+          expect(res.status).toBe('partial');
+          expect(res.failedFiles).toBe(1);
+          const state = readGoogleState(dir);
+          // The ledger entry for T_B never appears — a rate-limit failure is
+          // never counted toward the poison threshold, no matter how many
+          // times it happens in a row.
+          expect(state.gmail_fail_counts?.[T_B]).toBeUndefined();
+          expect(state.gmail_backfill_done).toBe(false);
+        }
+
+        // The thread was actually FETCHED every run (never skipped as
+        // poisoned) — proof the loop kept retrying it, not silently giving up.
+        const fetchCalls = fx.calls.filter((c) => c.includes(`/threads/${T_B}`));
+        expect(fetchCalls.length).toBeGreaterThan(0);
+
+        // Once the rate limit clears, the thread imports normally and the
+        // backfill completes — nothing was permanently lost.
+        fx.rateLimitThreads.clear();
+        const resFinal = await sweep(dir, fx, vault, {}, 'gmail');
+        expect(resFinal.status).toBe('synced');
+        const stateFinal = readGoogleState(dir);
+        expect(stateFinal.gmail_backfill_done).toBe(true);
+        const slugsFinal = await slugsWhere(`slug LIKE 'emails/%'`);
+        expect(slugsFinal.some((s) => s.includes('contract-question'))).toBe(true);
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Two changes to the Gmail sync path in `src/core/google/google-clients.ts` and
`src/core/google/google-source.ts`:

1. A rate-limit-class response (403 `rateLimitExceeded`/`userRateLimitExceeded`/quota,
   or 429) now gets its own, much larger retry budget before the client gives
   up — separate from the budget used for a plain 401-needs-refresh retry.
2. A rate-limited thread failure never counts toward the per-thread poison
   threshold in `sweepGmail` (backfill batch loop and delta-lane loop) — it
   still fails the batch/drain (so forward progress stays safe), just never
   silently skips the thread forever.

## Observed (gbrain 0.48.2.0, real production sync)

A single `gbrain sync --source <google>` pass fetched 230 Gmail threads and
logged 69 `[google] HTTP 403; retrying in Ns`, 20 `thread X failed: Google
rate-limited the request…`, and 4 `thread X failed 3x; skipping it …
poisoned`. Result: `imported 0 of 0 file(s)` — the pass re-fetched the same
window as the previous pass. This repeated every pass for an hour;
`gmail_backfill_floor_ms` never moved. (Log shapes only — no thread ids,
account identifiers, or message content.)

## Root cause (two interacting pieces)

1. **`google-clients.ts`'s `fetchJSON`** retried a 403/429 only `retries ?? 2`
   times total (backoff `min(60_000, 2**attempt*2000)` unless `Retry-After`)
   — the *same* budget used for the 401-needs-token-refresh case. Under
   Gmail's per-user rate limiting during a burst, a thread failed
   permanently after ~3 calls (a few seconds), nowhere near long enough for
   the quota window to actually clear.
2. **`google-source.ts`'s `sweepGmail`**: the backfill floor advances only
   when a batch has zero failures — correct and load-bearing (a failed
   thread newer than a committed floor would fall outside the resume window
   forever, and the delta lane can't replay it either). But *every* failure,
   rate-limited or not, incremented `gmail_fail_counts[tid]` identically,
   and `MAX_THREAD_FAILURES = 3` poisons (silently skips, without `--full`)
   a thread that hit 3 failures. With per-thread rate-limit odds under burst
   load, and every batch's floor blocked by any single failure, a large
   backfill could spend an entire sync run re-fetching the same window while
   transient throttling quietly poisoned mail that was never actually bad.

## Fix

- **`google-clients.ts`**: rate-limit-class responses get
  `DEFAULT_RATE_LIMIT_RETRIES = 6` retries (vs. the unchanged `retries = 2`
  used for 401), with exponential backoff + equal jitter capped at 60s
  (jitter avoids multiple gbrain processes retrying in lockstep against the
  same quota), still honoring `Retry-After` when Google sends one. Env
  override `GBRAIN_GOOGLE_RATE_LIMIT_RETRIES` follows the same
  read-once/clamp/fall-back-to-default shape as the existing `GBRAIN_SYNC_*`
  knobs in `sync.ts`. Exhausting the budget still throws the pre-existing
  `CredentialError('rate_limited', …)` — that error code already existed
  and is already documented in `docs/guides/google-connect.md`'s
  troubleshooting table, so no catalog change was needed.
- **`google-source.ts`**: in both places `sweepGmail` catches a per-thread
  failure (the initial-backfill batch loop and the incremental delta-lane
  loop), a `CredentialError` with code `'rate_limited'` skips the
  `gmail_fail_counts[tid]++` — everything else (batch/drain marked failed,
  `summary.status = 'partial'`, the log line) is unchanged, with the log
  line now noting `(rate limited; not counted toward the poison threshold)`
  when applicable.
- **`docs/guides/google-connect.md`**: new "Rate limits during backfill"
  subsection under Continuous sync.

**Deliberately not done**: the task's *optional* "sleep before continuing
the batch after a rate-limit failure." The per-request retry budget above
already backs off substantially (exponential + jitter, up to ~2 cumulative
minutes across 6 attempts) before a thread is finally marked failed —
stacking a third layer of blanket inter-thread sleep on top mostly adds
latency without changing the rate-limit-recovery dynamics, and would need
its own knob to stay testable without slowing the suite. Open to adding it
if it turns out to matter in practice.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/google/google-clients.ts` to HEAD
(pre-fix), ran `test/google-clients.test.ts` → 31 pass / 4 fail. Restored →
all 36 pass. (The reverted source is missing the new `rateLimitBackoffMs`
export the test file imports by name — a static-import crash rather than a
behavioral signal — so this run temporarily dropped that one import/describe
block to isolate a clean, non-vacuous result: 4 genuine assertion failures
on the retry-count tests, 31 unrelated tests still passing. The committed
test file is unchanged; this was a local-only step to get an honest number.)

Discrimination test: reverted `src/core/google/google-source.ts` to HEAD
(pre-fix), ran `test/google-source-materialize.test.ts` → 18 pass / 1 fail
(exactly the new rate-limit poison-accounting test; every other test in the
file — including the existing hard-failure poison-ledger test — ran and
passed, so this is not an import-crash artifact). Restored → all 19 pass.

## Tests

- `test/google-clients.test.ts`: updated the existing 429-exhaustion test
  for the new (bigger) default budget, plus 6 new cases — an explicit
  smaller `rateLimitRetries` override, the env var raising the budget, an
  invalid env var falling back to the default, a 403 quota reason getting
  the same patient budget as 429, a 401 still exhausting at its own
  (unchanged, smaller) budget, and bounds checks on the new
  `rateLimitBackoffMs` jitter helper.
- `test/google-source-materialize.test.ts`: extended the fake Gmail fixture
  with a `rateLimitThreads` set (429 + `retry-after: 0`, so the client's
  real retry loop still runs its full attempt count with zero actual delay)
  and added a new test — a thread rate-limited for 5 consecutive runs (more
  than `MAX_THREAD_FAILURES`) never accumulates a `gmail_fail_counts` entry
  and is fetched (not skipped) every run; once the rate limit clears, the
  thread imports normally and the backfill completes.

Local run: `bun test test/google-clients.test.ts
test/google-source-materialize.test.ts test/google-source-reconcile.test.ts
test/google-redirect.test.ts` → **95 pass / 0 fail** (reconcile + redirect
included as adjacent-surface sanity; unaffected). `bun run typecheck` →
clean. Also ran `bash scripts/check-test-isolation.sh`,
`bash scripts/check-privacy.sh`, `bash scripts/check-trailing-newline.sh`,
`bash scripts/check-module-size.sh`, `bash scripts/check-exports-count.sh`,
`bash scripts/check-source-config-leak.sh` → all clean. Did not run the full
`bun run verify` battery or `test:e2e` (needs Docker + Postgres) — ran the
CI-relevant subset for the touched files instead.

## Tradeoffs

- A thread that's genuinely, persistently rate-limited (not just a passing
  burst) now takes longer to fail per attempt (up to ~6 tries instead of 3)
  before the sweep reports it — intentional; the whole point is not to give
  up early on something that would have cleared.
- Independent of the batch-size PR under review (`feat/gmail-backfill-batch-config`)
  — branched from `master`, no dependency either way. The production repro
  above happened to be running with a larger-than-default batch size (which
  raises a batch's odds of containing at least one rate-limited thread), but
  the root cause and fix here are batch-size-independent: the same poisoning
  risk exists at the built-in default batch size too, just less frequently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V96ZPRHKGBN5WTMe3VqdCz
