### PR TITLE
fix(claude-cli): stop discarding valid tool calls, and catch zero-attempt write failures

### DIFF
--- a/src/core/ai/providers/claude-cli-language-model.ts
+++ b/src/core/ai/providers/claude-cli-language-model.ts
@@ -457,6 +457,34 @@ interface ParsedToolCall {
 }
 
 /**
+ * #4823 — process-wide count of `<use_tools>` blocks that failed to parse.
+ * Each one is a tool call the model made and the runtime dropped, so a run
+ * with a non-zero count wrote less than the model believed it did. Read (and
+ * reset) by the dream cycle to populate `details.synthesis.tool_block_parse_failures`.
+ */
+let toolBlockParseFailures = 0;
+let lastToolBlockParseError: string | null = null;
+
+function recordToolBlockParseFailure(message: string): void {
+  toolBlockParseFailures += 1;
+  lastToolBlockParseError = message;
+  process.stderr.write(`[claude-cli] <use_tools> block failed to parse — tool call discarded: ${message}\n`);
+}
+
+/** Returns the running count plus the most recent parse error, without resetting. */
+export function peekToolBlockParseFailures(): { count: number; lastError: string | null } {
+  return { count: toolBlockParseFailures, lastError: lastToolBlockParseError };
+}
+
+/** Returns the running count and resets it — for per-phase telemetry. */
+export function drainToolBlockParseFailures(): { count: number; lastError: string | null } {
+  const snapshot = { count: toolBlockParseFailures, lastError: lastToolBlockParseError };
+  toolBlockParseFailures = 0;
+  lastToolBlockParseError = null;
+  return snapshot;
+}
+
+/**
  * Locate and parse the `<use_tools>...</use_tools>` block in the assistant's
  * raw text response. Returns the parsed tool calls plus whatever prose
  * surrounded the block. Returns an empty `toolCalls` array when no block is
@@ -470,13 +498,22 @@ function extractToolCalls(raw: string): {
 } {
   const openTag = '<use_tools>';
   const closeTag = '</use_tools>';
-  const openIdx = raw.indexOf(openTag);
-  if (openIdx === -1) {
+  // #4823: anchor on the CLOSING tag first, then take the LAST opening tag
+  // before it. The old `indexOf(openTag)` anchored on the FIRST occurrence,
+  // so a model that *mentions* the tag in prose before using it — e.g.
+  // "Let me use the correct `<use_tools>` format:" — shifted the slice origin
+  // onto the backticked mention. `inner` then began "` format:\n\n<use_tools>…",
+  // JSON.parse threw, and the catch below discarded a complete, valid tool
+  // call as prose. Scanning back from the close tag (not `lastIndexOf` over
+  // the whole string, which trailing prose could re-break) picks the real
+  // block in both the plain and the mentioned-then-used shapes.
+  const closeIdx = raw.indexOf(closeTag);
+  if (closeIdx === -1) {
+    // Unterminated block (or none at all) — recover gracefully.
     return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
   }
-  const closeIdx = raw.indexOf(closeTag, openIdx + openTag.length);
-  if (closeIdx === -1) {
-    // Unterminated block — recover gracefully.
+  const openIdx = raw.lastIndexOf(openTag, closeIdx);
+  if (openIdx === -1) {
     return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
   }
 
@@ -491,7 +528,12 @@ function extractToolCalls(raw: string): {
   let parsed: unknown;
   try {
     parsed = JSON.parse(inner);
-  } catch {
+  } catch (e) {
+    // #4823: never swallow silently. A malformed block is a LOST tool call —
+    // the caller sees prose and the job completes having written nothing.
+    // Counted so the dream phase can surface `tool_block_parse_failures`
+    // instead of reporting a clean run over discarded work.
+    recordToolBlockParseFailure(e instanceof Error ? e.message : String(e));
     return { toolCalls: [], beforeText: raw.trim(), afterText: '' };
   }
   if (!Array.isArray(parsed)) {

--- a/src/core/minions/handlers/subagent-persistence.ts
+++ b/src/core/minions/handlers/subagent-persistence.ts
@@ -219,6 +219,33 @@ export async function persistToolExecComplete(
 }
 
 /**
+ * #4823 — evidence that the child TRIED to write a page and the write never
+ * reached the tool dispatcher, so no `subagent_tool_executions` row exists.
+ *
+ * The claude-cli recipe registers no native tools (`--tools ''`); tool calls
+ * travel as a prompt-taught `<use_tools>` text block that `extractToolCalls`
+ * parses back out. Three ways a real write evaporates without a ledger row:
+ *
+ *  1. an unparsed `<use_tools>` block — the block reached the final text
+ *     instead of being consumed (a parse failure reclassifies it as prose);
+ *  2. `No such tool available` — the model used native tool-calling syntax,
+ *     which the CLI rejects because every built-in tool is disabled;
+ *  3. a fabricated `[tool_result ...]` — the model wrote the result envelope
+ *     itself and reported success for a call that never happened.
+ *
+ * All three are indistinguishable from a clean Task-D skip by stop_reason
+ * alone: each ends `end_turn` with prose. A genuine skip contains none of
+ * them, which is what keeps the legitimate no-op completing.
+ */
+export function detectUnlandedWriteEvidence(text: string | undefined | null): string | null {
+  if (!text) return null;
+  if (text.includes('<use_tools>')) return 'unparsed <use_tools> block in final text';
+  if (text.includes('No such tool available')) return 'native tool-call rejected by the CLI (tools are disabled)';
+  if (text.includes('[tool_result')) return 'fabricated [tool_result] envelope — no such call was dispatched';
+  return null;
+}
+
+/**
  * #4217 — structural write accounting. A subagent job's status used to reflect
  * only "the agent turn finished"; 22 consecutive jobs once reported
  * `completed` while every put_page failed (embedding-dimension mismatch) and
@@ -295,6 +322,22 @@ export async function finalizeWriteAccounting(
     throw new UnrecoverableError(
       `job produced zero put_page writes and did not finish cleanly (stop_reason: ${result.stop_reason}) — not a legitimate skip`,
     );
+  }
+  // #4823: a clean `end_turn` with zero attempts is a legitimate skip ONLY
+  // when the child never tried to write. The April-2026 backfill lost 8 of 20
+  // children here: each composed a full page, failed to land it through the
+  // text tool protocol, narrated the page as prose, and ended `end_turn` — so
+  // `attempted === 0` sailed past both guards above and the run reported
+  // `status: ok` with `dead_jobs: 0`. Evidence of an unlanded write turns that
+  // silent loss into a dead-letter (the idempotency key releases and the next
+  // cycle re-synthesizes the transcript).
+  if (opts.requireWrites && attempted === 0) {
+    const evidence = detectUnlandedWriteEvidence(result.result);
+    if (evidence) {
+      throw new UnrecoverableError(
+        `job produced zero put_page writes but attempted one — ${evidence}`,
+      );
+    }
   }
   return accounted;
 }

--- a/src/core/minions/handlers/subagent-persistence.ts
+++ b/src/core/minions/handlers/subagent-persistence.ts
@@ -246,6 +246,47 @@ export function detectUnlandedWriteEvidence(text: string | undefined | null): st
 }
 
 /**
+ * #4823 D4 — a child that claims a write it never made.
+ *
+ * The three signals above all key on an ARTIFACT of a failed attempt (a
+ * mangled block, a rejection string, a forged result envelope), so they only
+ * fire when the child actually tried. The April re-run surfaced a child that
+ * did not try at all: one assistant message, zero tool calls, reading
+ * "**Done.** One page written" and naming a slug that was never created.
+ * There is no artifact to find — it confabulated the SUMMARY rather than the
+ * envelope, one level above every signal we had.
+ *
+ * `turns === 0` cannot separate it: a legitimate Task-D skip is also
+ * `turns: 0`. What separates them is WHAT the text says. A real skip explains
+ * why nothing was written; a confabulation cites the page it claims to have
+ * written — and that slug necessarily carries this job's own hash suffix,
+ * because the prompt hands it to the child ("Transcript hash suffix (USE THIS
+ * in slugs): <suffix>"). Verified on the pair: the confabulation cites it, the
+ * genuine decline never mentions it.
+ *
+ * Requiring a `/` before the suffix keeps this to slug-SHAPED tokens, so a
+ * child that merely quotes its suffix in prose does not trip the check.
+ *
+ * Deliberately fails toward flagging: a false positive dead-letters a job
+ * whose key then releases for the next cycle (one wasted retry, and the job is
+ * VISIBLE as dead). A false negative is permanent silent data loss. Given that
+ * asymmetry, a decline that names a slug it chose not to write is an
+ * acceptable cost.
+ */
+export function detectConfabulatedWriteClaim(
+  text: string | undefined | null,
+  slugSuffix: string | undefined | null,
+): string | null {
+  if (!text || !slugSuffix) return null;
+  const escaped = slugSuffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // slug-shaped: at least one path separator before the job's own suffix
+  const slugLike = new RegExp(`[A-Za-z0-9._-]+/[A-Za-z0-9._/-]*${escaped}`);
+  const match = slugLike.exec(text);
+  if (!match) return null;
+  return `claims a page slug it never wrote (${match[0]})`;
+}
+
+/**
  * #4217 — structural write accounting. A subagent job's status used to reflect
  * only "the agent turn finished"; 22 consecutive jobs once reported
  * `completed` while every put_page failed (embedding-dimension mismatch) and
@@ -271,7 +312,7 @@ export async function finalizeWriteAccounting(
   engine: BrainEngine,
   jobId: number,
   result: SubagentResult,
-  opts: { requireWrites: boolean; scopeToolUseIdPrefix?: string },
+  opts: { requireWrites: boolean; scopeToolUseIdPrefix?: string; slugSuffix?: string },
 ): Promise<SubagentResult> {
   let rows: Array<{ status: string; error: string | null }>;
   try {
@@ -336,6 +377,13 @@ export async function finalizeWriteAccounting(
     if (evidence) {
       throw new UnrecoverableError(
         `job produced zero put_page writes but attempted one — ${evidence}`,
+      );
+    }
+    // D4: no artifact of an attempt, but the child says it wrote a page.
+    const confabulated = detectConfabulatedWriteClaim(result.result, opts.slugSuffix);
+    if (confabulated) {
+      throw new UnrecoverableError(
+        `job produced zero put_page writes and ${confabulated}`,
       );
     }
   }

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -306,6 +306,11 @@ export function makeSubagentHandler(deps: SubagentDeps) {
         : inner;
     return finalizeWriteAccounting(engine, ctx.id, stamped, {
       requireWrites: dataForAccounting.require_writes === true,
+      // #4823 D4: the child's own hash suffix, so a claimed-but-unwritten slug
+      // is distinguishable from a genuine skip.
+      ...(typeof dataForAccounting.oneshot_slug_suffix === 'string'
+        ? { slugSuffix: dataForAccounting.oneshot_slug_suffix }
+        : {}),
       // OV-4: a successful oneshot job's verdict is scoped to its own
       // invocation family; a fallback wrote through the loop (no oneshot
       // rows exist — validation precedes all writes), so job-wide is exact.

--- a/test/claude-cli-recipe.test.ts
+++ b/test/claude-cli-recipe.test.ts
@@ -370,6 +370,64 @@ describe('claude-cli LanguageModel — tool use', () => {
     });
   });
 
+  // ── #4823 regression: prose that MENTIONS the tag before using it ──────
+  //
+  // Shape taken from a real dream-synthesis child that produced no page while
+  // its job reported `completed`. The model opened with a self-correction that
+  // named the tag inside backticks, THEN emitted a valid block. The old parser
+  // anchored on `indexOf(openTag)`, landing on the backticked mention, so
+  // `inner` began "` format:\n\n<use_tools>…" — JSON.parse threw and the catch
+  // discarded a complete tool call as prose. Content here is synthetic; only
+  // the structure (mention-then-use, multi-line string payload) is reproduced.
+  test('anchors on the real block when the tag is mentioned in prose first', async () => {
+    await withStubEnv(async () => {
+      stageResponse(
+        baseEnvelope(
+          [
+            'I used the wrong invocation format. Let me use the correct `<use_tools>` format:',
+            '',
+            '<use_tools>',
+            '[{"name": "search", "input": {"query": "line one\\nline two\\nline three"}}]',
+            '</use_tools>',
+          ].join('\n'),
+        ),
+      );
+      const { ClaudeCliLanguageModel } = await import('../src/core/ai/providers/claude-cli-language-model.ts');
+      const model = new ClaudeCliLanguageModel('claude-sonnet-4-6');
+      const result = await model.doGenerate({
+        prompt: [userMessage('mention then use')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      const calls = result.content.filter(c => c.type === 'tool-call');
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({ type: 'tool-call', toolName: 'search' });
+      expect(result.finishReason).toBe('tool-calls');
+    });
+  });
+
+  test('counts a malformed <use_tools> block instead of silently dropping it', async () => {
+    await withStubEnv(async () => {
+      const { drainToolBlockParseFailures, ClaudeCliLanguageModel } = await import(
+        '../src/core/ai/providers/claude-cli-language-model.ts'
+      );
+      drainToolBlockParseFailures();
+      stageResponse(
+        baseEnvelope(['<use_tools>', '[{"name": "search", "input": {ohno}}]', '</use_tools>'].join('\n')),
+      );
+      const model = new ClaudeCliLanguageModel('claude-sonnet-4-6');
+      const result = await model.doGenerate({
+        prompt: [userMessage('malformed')],
+        tools: [{ type: 'function', name: 'search', description: '', inputSchema: { type: 'object', properties: {} } }],
+      } as LanguageModelV2CallOptions);
+
+      expect(result.content.filter(c => c.type === 'tool-call')).toHaveLength(0);
+      const drained = drainToolBlockParseFailures();
+      expect(drained.count).toBe(1);
+      expect(drained.lastError).toBeTruthy();
+    });
+  });
+
   test('tolerates fenced JSON inside <use_tools>', async () => {
     await withStubEnv(async () => {
       stageResponse(

--- a/test/subagent-handler.test.ts
+++ b/test/subagent-handler.test.ts
@@ -918,6 +918,70 @@ describe('write accounting (#4217)', () => {
     expect(result.pages_failed).toBe(0);
   });
 
+  // ── #4823: zero attempts is a skip ONLY when nothing was attempted ──────
+  //
+  // These sit deliberately alongside the Task-D skip test above. All four end
+  // `end_turn` with zero ledger rows, so stop_reason alone cannot separate
+  // them — the discriminator is evidence in the final text that a write was
+  // attempted and evaporated before reaching the dispatcher. The skip must
+  // stay `completed` and these must dead-letter; collapsing them to one
+  // outcome is the bug (8 of 20 children lost their pages to it).
+  const zeroAttemptClient = (text: string) =>
+    new FakeMessagesClient([{ content: [{ type: 'text', text }] as any, stop_reason: 'end_turn' as const }]);
+
+  test('zero attempts + unparsed <use_tools> block → UnrecoverableError', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('Let me retry:\n<use_tools>\n[{"name":"brain_put_page","input":{}}]\n</use_tools>'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true });
+    await expect(handler(ctx)).rejects.toThrow(/zero put_page writes but attempted one.*unparsed <use_tools>/s);
+  });
+
+  test('zero attempts + native tool-call rejection → UnrecoverableError', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('No such tool available. Here is the page for the orchestrator instead: ...'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true });
+    await expect(handler(ctx)).rejects.toThrow(/zero put_page writes but attempted one.*native tool-call rejected/s);
+  });
+
+  test('zero attempts + fabricated tool_result → UnrecoverableError', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('[tool_result {"slug":"wiki/x","chunks":5}]\n\nPage written successfully.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true });
+    await expect(handler(ctx)).rejects.toThrow(/zero put_page writes but attempted one.*fabricated/s);
+  });
+
+  test('zero attempts with no write evidence still completes (skip is not a failure)', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('Reviewed the transcript; nothing met the bar for a page.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+    expect(result.stop_reason).toBe('end_turn');
+  });
+
+  test('write evidence WITHOUT require_writes stays completed', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('No such tool available — answering directly instead.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'answer me' });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+  });
+
   test('non-put_page tool failures do not count toward write accounting', async () => {
     const client = new FakeMessagesClient([
       { content: [{ type: 'tool_use', id: 'tu_b', name: 'broken', input: {} }] as any, stop_reason: 'tool_use' },

--- a/test/subagent-handler.test.ts
+++ b/test/subagent-handler.test.ts
@@ -982,6 +982,69 @@ describe('write accounting (#4217)', () => {
     expect(result.pages_attempted).toBe(0);
   });
 
+  // ── #4823 D4: the child claims a write it never made ────────────────────
+  //
+  // Distinct from the three cases above: there is no artifact of an attempt to
+  // find. One message, zero tool calls, "Done. One page written" naming a slug
+  // that does not exist. `turns === 0` cannot separate it from a genuine skip —
+  // only the text can, via the job's own hash suffix that the prompt supplies.
+  test('zero attempts + claimed slug carrying the job hash suffix → UnrecoverableError', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient(
+        '**Done.** One page written.\n\n1. `wiki/originals/ideas/2026-04-13-sequence-first-abc123`',
+      ),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true, oneshot_slug_suffix: 'abc123' });
+    await expect(handler(ctx)).rejects.toThrow(/zero put_page writes and claims a page slug it never wrote/);
+  });
+
+  test('decline naming NO slug stays completed even with a suffix configured', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('Reviewed the transcript; nothing met the bar. No page warranted.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true, oneshot_slug_suffix: 'abc123' });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+    expect(result.stop_reason).toBe('end_turn');
+  });
+
+  test('suffix quoted in prose but not slug-shaped stays completed', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('The transcript hash suffix abc123 was supplied, but nothing met the bar.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true, oneshot_slug_suffix: 'abc123' });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+  });
+
+  test('claimed slug for a DIFFERENT suffix does not trip this job', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('Related prior work lives at `wiki/originals/ideas/something-999zzz`; nothing new to write.'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'write pages', require_writes: true, oneshot_slug_suffix: 'abc123' });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+  });
+
+  test('claimed slug WITHOUT require_writes stays completed', async () => {
+    const handler = makeSubagentHandler({
+      engine,
+      client: zeroAttemptClient('**Done.** `wiki/originals/ideas/x-abc123`'),
+      toolRegistry: [makePutPageTool('ok')],
+    });
+    const ctx = await makeCtx({ prompt: 'answer', oneshot_slug_suffix: 'abc123' });
+    const result = await handler(ctx);
+    expect(result.pages_attempted).toBe(0);
+  });
+
   test('non-put_page tool failures do not count toward write accounting', async () => {
     const client = new FakeMessagesClient([
       { content: [{ type: 'tool_use', id: 'tu_b', name: 'broken', input: {} }] as any, stop_reason: 'tool_use' },


### PR DESCRIPTION
Three related bugs let a dream-synthesis child compose a page — or claim to have written one — fail to persist it, and still report `completed` with `dead_jobs: 0`. Observed on a synthesize backfill where **8 of 20 children produced no pages while the run reported success**; re-running the same transcripts under fixes 1 and 2 recovered **7 of 8**. The eighth failed through a mode neither of those fixes can see, and that is fix 3.

None of the three bugs is in the model's output — all are in the runtime that consumes it.

## 1. `extractToolCalls` anchors on the first `indexOf('<use_tools>')`

The claude-cli recipe registers no native tools (`--tools ''`, `--strict-mcp-config`), so tool calls travel as a prompt-taught `<use_tools>` text block that `extractToolCalls` parses back out.

When the model *mentions* the tag before using it — ``Let me use the correct `<use_tools>` format:`` — the first occurrence is the **backticked mention**, so the slice began:

```
` format:\n\n<use_tools>\n[ ...
```

`JSON.parse` threw, and the bare `catch` returned `{toolCalls: []}`, reclassifying a complete and valid tool call as prose. The job ended `end_turn` having written nothing.

Verified against a real 4,581-char stored result: `open_tag_count = 2`, `first_open = 60`, close at 3318. Old path throws; new path parses and recovers the call.

**Fix:** anchor on the closing tag, then take the last opening tag at or before it. Scanning back from the close tag (rather than `lastIndexOf` over the whole string) stays correct when trailing prose mentions the tag again.

The parse failure is also no longer swallowed — `recordToolBlockParseFailure` counts it and writes to stderr, with `drain`/`peek` accessors so callers can surface the count instead of reporting a clean run over discarded work.

## 2. `finalizeWriteAccounting` only fires on `attempted > 0`

`require_writes` jobs throw `UnrecoverableError` when writes were attempted and all failed, and separately when zero attempts end on a non-clean `stop_reason`.

A child whose tool call never reached the dispatcher records **zero ledger rows** and ends `end_turn` — passing both guards. That is precisely the silent loss this accounting exists to prevent; the function's own docstring cites the precedent ("the dream cycle silently produced nothing for 9 hours").

**Fix:** for `require_writes` jobs with zero attempts, look for server-side evidence that a write was attempted and evaporated:

- an unparsed `<use_tools>` block in the final text
- `No such tool available` — the CLI rejecting a native tool call
- a fabricated `[tool_result]` envelope the model wrote itself

Evidence is **detected, not declared**, so no prompt change is required and a legitimate Task-D skip — which contains none of these — keeps completing untouched.

## 3. A child that claims a write it never made

Every signal in fix 2 keys on an **artifact of a failed attempt** — a mangled block, a rejection string, a forged result envelope — so all three only fire when the child actually tried.

The eighth transcript of the backfill never tried. Its child emitted **one** assistant message — `**Done.** One page written`, naming a concrete slug — with **zero tool calls**: no `<use_tools>` block, no rejection string, no fabricated `[tool_result]`. It confabulated the *summary* rather than the envelope, one level above anything fix 2 looks for. The page does not exist and no `subagent_tool_executions` row was ever written.

`turns === 0` cannot separate it, because a legitimate Task-D skip is also `turns: 0`. Only the **text** distinguishes them: a real skip explains why it wrote nothing, while a confabulation cites the page it claims to have written — and that slug necessarily carries the job's own hash suffix, because the prompt supplies it (`Transcript hash suffix (USE THIS in slugs): <suffix>`).

**Fix:** `detectConfabulatedWriteClaim(text, slugSuffix)` requires a path separator before the job's own suffix, so a slug-shaped claim trips it and a bare mention of the suffix in prose does not:

```ts
const slugLike = new RegExp(`[A-Za-z0-9._-]+/[A-Za-z0-9._/-]*${escaped}`);
```

`slugSuffix` is threaded from `dataForAccounting.oneshot_slug_suffix` at the handler's call site (5 lines in `subagent.ts`). **Absent it, the check is inert** — no behavior change for any job that does not supply one.

Validated on the production pair: the confabulating job flags with the exact slug; a genuine decline carrying a different suffix passes.

It **fails toward flagging** by design. A false positive dead-letters a job whose key then releases for the next cycle — one wasted retry, and the job is *visible* as dead. A false negative is permanent silent data loss. Given that asymmetry, a decline that names a slug it chose not to write is an acceptable cost.

## Tests

- **5** write-accounting cases pinning skip vs. each fix-2 failure mode as distinct outcomes, alongside the existing zero-attempt skip test (**unchanged, still green**)
- **2** parser cases: the mention-then-use regression, and the failure counter
- **5** fix-3 cases chosen to pin the boundary rather than the happy path: claimed slug carrying the job's own suffix (`UnrecoverableError`); decline naming no slug (completed); suffix quoted in prose but not slug-shaped (completed); a slug for a *different* suffix (completed); claimed slug without `require_writes` (completed)

```
100 pass / 0 fail   across the two files this PR modifies
                    (test/claude-cli-recipe.test.ts, test/subagent-handler.test.ts)
                    — 95 before fix 3, +5 new
166 pass / 0 fail   across the 8 subagent + claude-cli test files
typecheck (tsc --noEmit)   exit 0
check:test-names           OK
check:test-isolation       OK   (1654 non-serial unit files scanned)
check:newlines             OK   (2340 files)
```

Fixture content is synthetic — only the *structure* of the real failure is reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP3ZaS5CScim9toGEeyDoU
