### PR TITLE
fix(sync,import): a code source's index silently diverges from the git tree (#4899, #4900, #4901)

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -16,6 +16,7 @@ import {
   matchesAnyGlob,
   pruneDir,
   isPathPruned,
+  pruneDirForStrategy,
   SYNC_SKIP_FILES,
   type SyncStrategy,
 } from '../core/sync.ts';
@@ -1050,9 +1051,15 @@ function isCollectibleForWalker(
   // sync excludes. Full and incremental must agree on the exclusion set.
   // (In the FS-walk route `path` is a basename, so `includeHidden` has no
   // segment to waive there — that route's directory-level prune already ran
-  // via unmodified `pruneDir` before a file entry is ever reached; see
+  // via `pruneDirForStrategy` before a file entry is ever reached; see
   // `isPathPruned`'s doc comment for that scope note.)
-  if (isPathPruned(path, includeHidden)) return false;
+  //
+  // `strategy` is what lets a CODE source's `.github/`, `.claude/`, `.vscode/`
+  // through here. This is the git-fast-path's only dot-dir gate —
+  // `collectSyncableFiles` returns from `gitListSyncableFiles` before the FS
+  // walk ever runs on a git repo, so relaxing only the walker below would have
+  // changed nothing for every real source.
+  if (isPathPruned(path, includeHidden, strategy)) return false;
 
   // Malformed filenames (brackets / control chars — markdown-link syntax as a
   // literal filename) are rejected on BOTH collection routes, same as
@@ -1186,7 +1193,12 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
       // in core/sync.ts) instead of a hand-maintained inline list that drifted
       // from it. Skips hidden dirs (`.git`, `.raw`, etc.), `node_modules`,
       // `vendor`, `dist`, `build`, `venv` (#2020), `ops`, and git submodules.
-      if (!pruneDir(entry, d)) continue;
+      // Strategy-aware: pruneDirForStrategy delegates to pruneDir for every
+      // strategy except code/auto, so upstream's canonical-gate property is
+      // preserved; for code it admits `.github/`, `.claude/`, `.vscode/`, which
+      // `pruneDir` refuses outright. Keeping the plain pruneDir call here is
+      // what made a code source unable to see its own dot-directories.
+      if (!pruneDirForStrategy(entry, strategy, d)) continue;
       // Control-char SEGMENT check at descent time (never legitimate). The
       // bracket check moved to the per-file RELATIVE-path test below: a
       // bracket-named DIRECTORY must still be descended for code strategies

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1346,6 +1346,28 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       typeof cfgRows[0]?.config === 'string'
         ? (JSON.parse(cfgRows[0].config as string) as Record<string, unknown>)
         : ((cfgRows[0]?.config ?? {}) as Record<string, unknown>);
+    // #3356-adjacent: EVERY caller that is not the `--all` fan-out passes no
+    // strategy — the autopilot freshness lane (commands/autopilot.ts -> jobs.ts),
+    // the dream cycle (core/cycle.ts), the MCP `sync` op (core/operations.ts) and
+    // the single-source CLI path below. `isSyncable` then falls back to
+    // 'markdown' (core/sync.ts), which drops every code file in the range. Two
+    // consequences, both measured: the run imports nothing yet still advances the
+    // anchor (`Update sync state even with no syncable changes`), freezing the
+    // index at HEAD forever; and every MODIFIED code file reaches the
+    // un-syncable delete loop, whose only exemptions are 'metafile' (#1433) and
+    // 'pruned-dir' (#2404), so its page is DELETED. Observed on 7 of 10 sources.
+    //
+    // Resolve the source's own strategy when the caller states none. An explicit
+    // --strategy still wins, so the `--all` fan-out and the CLI flag are unchanged.
+    if (opts.strategy === undefined && typeof cfg.strategy === 'string') {
+      const persisted = cfg.strategy;
+      if (persisted === 'markdown' || persisted === 'code' || persisted === 'auto') {
+        // Assign the PROPERTY, never `opts = {...opts}`: this block runs inside
+        // `if (opts.sourceId)`, and replacing the object discards that narrowing,
+        // so three downstream call sites stop compiling.
+        opts.strategy = persisted;
+      }
+    }
     const remoteUrl = typeof cfg.remote_url === 'string' ? cfg.remote_url : null;
     if (remoteUrl) {
       const ownSrc = {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -1556,6 +1556,14 @@ export async function importCodeFile(
       timeline: '',
       frontmatter: { language: lang, file: relativePath },
       content_hash: hash,
+      // A code page MUST carry its path. The full-sync reconcile finds a
+      // deleted file's page by matching `source_path` against the git tree;
+      // with the column NULL the page is invisible to it and is served
+      // forever. Markdown pages already set it, which is why only the code
+      // walk grew ghosts. Written on every import, not just the first:
+      // putPage COALESCEs, so a NULL here would never overwrite a good value
+      // but would also never backfill a row imported before this line existed.
+      source_path: relativePath,
       // `content` is authoritative source text (disk file, or the row's own
       // body via reindex-code): an emptied file is a deliberate clear.
     }, { ...txOpts, allowEmptyOverwrite: true });

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -377,6 +377,14 @@ const PRUNE_DIR_NAMES = new Set<string>([
  * existing callers stay back-compat; new callers (sync walker, extract
  * walker) thread it through.
  */
+/**
+ * Dot-directories a CODE source still refuses. Deliberately short: enumeration
+ * runs through `git ls-files --exclude-standard`, so every gitignored cache is
+ * already gone before `classifySync` sees it. These two are named because a
+ * repo does not gitignore its own `.git`, and `.gbrain` is gbrain's own state.
+ */
+const CODE_DOT_DIR_DENY = new Set<string>(['.git', '.gbrain', '.hg', '.svn']);
+
 export function pruneDir(name: string, parentDir?: string): boolean {
   if (!name) return true;
   if (name.startsWith('.')) return false;
@@ -437,8 +445,35 @@ export function pruneDir(name: string, parentDir?: string): boolean {
  * git-listing fast path this function guards, so the gap is scoped to
  * importing a bare (non-git) directory.
  */
-export function isPathPruned(path: string, includeHidden?: string[]): boolean {
+export function isPathPruned(
+  path: string,
+  includeHidden?: string[],
+  strategy?: SyncStrategy,
+): boolean {
   const segments = path.split('/');
+  const basename = segments[segments.length - 1] || '';
+
+  // `strategy`: a CODE/AUTO source must see its own `.github/`, `.claude/`,
+  // `.vscode/` — versioned content people search for. The old blanket
+  // leading-dot rule did not merely hide them: `git ls-files` still lists
+  // them, so pages imported by earlier walks survived while the expected-set
+  // could no longer contain them, and they read as ghosts — a reconcile then
+  // deletes a page whose file is alive on disk.
+  //
+  // DIRECTORY segments only. The basename keeps `pruneDir` unchanged, so
+  // dot-FILES stay excluded; `.git`/`.gbrain`/`.hg`/`.svn` (CODE_DOT_DIR_DENY)
+  // and `*.raw` stay refused as directories too. Only machinery is refused,
+  // because enumeration already runs through `git ls-files --exclude-standard`:
+  // anything gitignored (`.venv`, `.dart_tool`, `.terraform`) never reaches
+  // this function. For every other strategy `pruneDirForStrategy` IS
+  // `pruneDir`, so this branch reduces to the rule below and changes nothing.
+  if (
+    segments.slice(0, -1).every((seg) => pruneDirForStrategy(seg, strategy)) &&
+    pruneDir(basename)
+  ) {
+    return false;
+  }
+
   if (segments.some((seg) => PRUNE_DIR_NAMES.has(seg) || seg.endsWith('.raw'))) return true;
   const dotPruned = segments.some((seg) => seg.startsWith('.'));
   if (!dotPruned) return false;
@@ -548,6 +583,26 @@ export const SYNC_SKIP_FILES = ['schema.md', 'index.md', 'log.md', 'README.md', 
  * re-implementation. Funnelling both public APIs through `classifySync` means
  * TypeScript enforces consistency at the compiler level.
  */
+/**
+ * Descent gate for a DIRECTORY segment, strategy-aware. The one place the
+ * dot-directory rule lives: `classifySync` (path admission) and the importer's
+ * walker (descent) must agree, and they are in different files, so a second
+ * copy is a drift waiting to happen — the same reason `unsyncableReason` was
+ * funnelled through `classifySync` rather than reimplemented.
+ *
+ * Applies to directory names only. A dot-FILE still goes through `pruneDir`.
+ */
+export function pruneDirForStrategy(
+  name: string,
+  strategy: string | undefined,
+  parentDir?: string,
+): boolean {
+  if ((strategy === 'code' || strategy === 'auto') && name.startsWith('.')) {
+    return !(CODE_DOT_DIR_DENY.has(name) || name.endsWith('.raw'));
+  }
+  return pruneDir(name, parentDir);
+}
+
 function classifySync(path: string, opts: SyncableOptions = {}): SyncableReason | null {
   const strategy = opts.strategy || 'markdown';
 
@@ -563,7 +618,8 @@ function classifySync(path: string, opts: SyncableOptions = {}): SyncableReason 
   // vendor/generated trees (`node_modules/`, `vendor/`, …) at any depth.
   // `opts.includeHidden` can waive the leading-dot part of this — see
   // `isPathPruned`'s doc comment for exactly what is and isn't waivable.
-  if (isPathPruned(path, opts.includeHidden)) return 'pruned-dir';
+  // `strategy` waives it for a code source's DIRECTORIES (`.github/`, …).
+  if (isPathPruned(path, opts.includeHidden, strategy)) return 'pruned-dir';
 
   // Skip meta files that aren't pages
   const segments = path.split('/');

--- a/test/sync-code-dot-dirs.test.ts
+++ b/test/sync-code-dot-dirs.test.ts
@@ -1,0 +1,50 @@
+/**
+ * A code source must see its dot-DIRECTORIES.
+ *
+ * `classifySync` ran every path segment through `pruneDir`, which refuses any
+ * name starting with `.`. That rule is right for the brain repo — `.sources/`
+ * is a reserved prefix that depends on it — and wrong for a code source, where
+ * `.github/workflows/`, `.claude/` and `.vscode/` are versioned content. The
+ * cost was not merely absence: those files ARE reachable by `git ls-files`, so
+ * pages for them existed from older walks and then read as ghosts against an
+ * expected-set that could not contain them. Deleting a "ghost" whose file is
+ * alive on disk is the failure this prevents.
+ *
+ * The relaxation applies to DIRECTORY segments only. A dot-FILE (`.gitignore`)
+ * still goes through `pruneDir` unchanged, which keeps the blast radius to the
+ * one thing being fixed.
+ */
+import { describe, test, expect } from 'bun:test';
+import { isSyncable, unsyncableReason } from '../src/core/sync.ts';
+
+describe('code strategy sees dot-directories', () => {
+  test('versioned dot-dirs are syncable under code', () => {
+    expect(isSyncable('.github/workflows/ci.yml', { strategy: 'code' })).toBe(true);
+    expect(isSyncable('.claude/scripts/statusline.py', { strategy: 'code' })).toBe(true);
+    expect(isSyncable('.vscode/settings.json', { strategy: 'code' })).toBe(true);
+    expect(isSyncable('.github/actions/setup/action.yml', { strategy: 'auto' })).toBe(true);
+  });
+
+  test('machinery dot-dirs stay excluded', () => {
+    expect(isSyncable('.git/config', { strategy: 'code' })).toBe(false);
+    expect(unsyncableReason('.git/hooks/pre-commit.py', { strategy: 'code' })).toBe('pruned-dir');
+    expect(isSyncable('.gbrain/state.json', { strategy: 'code' })).toBe(false);
+    expect(unsyncableReason('.gbrain/x.ts', { strategy: 'code' })).toBe('pruned-dir');
+  });
+
+  test('the .raw sidecar convention survives', () => {
+    expect(isSyncable('people/pedro.raw/notes.ts', { strategy: 'code' })).toBe(false);
+  });
+
+  test('non-dot pruning is untouched', () => {
+    expect(isSyncable('node_modules/pkg/index.js', { strategy: 'code' })).toBe(false);
+  });
+
+  // CONTROL: must be green before AND after. The brain repo keeps the old rule,
+  // so `.sources/` stays reserved and no markdown walker changes behaviour.
+  test('markdown strategy still refuses dot-dirs', () => {
+    expect(isSyncable('.github/README.md', { strategy: 'markdown' })).toBe(false);
+    expect(unsyncableReason('.sources/other/page.md', { strategy: 'markdown' })).toBe('pruned-dir');
+    expect(isSyncable('docs/guide.md', { strategy: 'markdown' })).toBe(true);
+  });
+});

--- a/test/sync-index-matches-tree.serial.test.ts
+++ b/test/sync-index-matches-tree.serial.test.ts
@@ -1,0 +1,154 @@
+/**
+ * LOCAL PATCH GUARD (not upstream). One invariant, four lifecycle stages:
+ *
+ *   after ANY sync that reports success, the set of pages for the source
+ *   equals the set of syncable files in the working tree.
+ *
+ * It is the regression guard for BOTH local fixes, and the two failure
+ * signatures name which one fell out of a rebase:
+ *
+ *   missing: [...]  -> performSyncInner no longer resolves the source's
+ *                      persisted `config.strategy`, so a caller that passes
+ *                      no --strategy walks as 'markdown' and code files are
+ *                      never imported (and modified ones are DELETED).
+ *   ghosts:  [...]  -> importCodeFile no longer writes `source_path`, so the
+ *                      full-sync delete-reconcile cannot see code pages and
+ *                      deleted files are served forever.
+ *
+ * HONEST LIMIT: drift() derives both sides from gbrain's own enumerator and
+ * slug function, so it pins the sync WIRING, not the enumerator itself. The
+ * literal slug list in S1 is the only assertion here that does not derive
+ * from the code under test; keep it.
+ *
+ * Hermetic: in-memory PGLite + a throwaway git repo under $TMPDIR. No
+ * network, no Neon, no fixtures on disk. ~7s.
+ *
+ * Setup is lazy (ensureSetup) rather than in beforeAll ON PURPOSE: bun caps
+ * HOOKS at a hard 5s and bunfig.toml's `timeout = 60_000` does NOT govern
+ * them (measured: an 8s beforeAll dies at 5002ms under a bare `bun test`,
+ * and passes with --timeout=60000). PGLite connect+initSchema sits right at
+ * that edge, so a beforeAll here would flake on the first cold run after a
+ * rebase — the one run that matters.
+ */
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, unlinkSync } from 'fs';
+import { join, relative } from 'path';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { collectSyncableFiles } from '../src/commands/import.ts';
+import { resolveSlugForPath } from '../src/core/sync.ts';
+
+const SID = 'default';
+const STRATEGY = 'auto' as const;
+// No `strategy` key: this is the caller shape used by the dream cycle
+// (core/cycle.ts), the MCP sync op (core/operations.ts), the autopilot
+// freshness lane and the single-source CLI path. Passing one here would
+// make the guard blind to the strategy-resolution patch.
+const OPTS = { noEmbed: true, noExtract: true, noPull: true, sourceId: SID } as const;
+
+// GBRAIN_HOME at module top level, before any src/ import can read config.
+const home = mkdtempSync(join(tmpdir(), 'gb-tw-home-'));
+process.env.GBRAIN_HOME = home;
+
+let engine: PGLiteEngine | null = null;
+let repo = '';
+let setupPromise: Promise<void> | null = null;
+
+const commit = (m: string) =>
+  execSync(`git add -A && git commit -qm ${JSON.stringify(m)}`, { cwd: repo, stdio: 'pipe' });
+
+async function ensureSetup(): Promise<void> {
+  setupPromise ??= (async () => {
+    const e = new PGLiteEngine();
+    await e.connect({});
+    await e.initSchema();
+    await e.executeRaw(
+      `UPDATE sources SET config = coalesce(config,'{}'::jsonb) || '{"strategy":"auto"}'::jsonb WHERE id=$1`,
+      [SID],
+    );
+    engine = e;
+    repo = mkdtempSync(join(tmpdir(), 'gb-tw-repo-'));
+    execSync('git init -q && git config user.email t@t && git config user.name T', { cwd: repo, stdio: 'pipe' });
+    mkdirSync(join(repo, 'lib'), { recursive: true });
+    mkdirSync(join(repo, 'docs'), { recursive: true });
+    writeFileSync(join(repo, 'docs/a.md'), '---\ntype: note\ntitle: A\n---\n\nbody a\n');
+    writeFileSync(join(repo, 'lib/a.dart'), 'class A {}\n');
+    // Mixed case and non-ASCII on purpose: a source_path that is lowercased
+    // or re-encoded on the way in still satisfies isSyncable, so the
+    // reconcile would delete a LIVE page. That shows up here as `missing`.
+    writeFileSync(join(repo, 'lib/MixedCase.dart'), 'class MixedCase {}\n');
+    writeFileSync(join(repo, 'lib/été.dart'), 'class Ete {}\n');
+    commit('init');
+  })();
+  await setupPromise;
+}
+
+async function drift(): Promise<{ missing: string[]; ghosts: string[] }> {
+  const expected = new Set(
+    collectSyncableFiles(repo, { strategy: STRATEGY })
+      .map((abs) => relative(repo, abs))
+      .map((rel) => resolveSlugForPath(rel)),
+  );
+  const rows = await engine!.executeRaw<{ slug: string }>(
+    `SELECT slug FROM pages WHERE source_id=$1 AND deleted_at IS NULL`,
+    [SID],
+  );
+  const actual = new Set(rows.map((r) => r.slug));
+  return {
+    missing: [...expected].filter((s) => !actual.has(s)).sort(),
+    ghosts: [...actual].filter((s) => !expected.has(s)).sort(),
+  };
+}
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+  rmSync(home, { recursive: true, force: true });
+  if (repo) rmSync(repo, { recursive: true, force: true });
+});
+
+describe('index matches tree at every lifecycle stage', () => {
+  test('S1 first sync, caller passes no strategy', async () => {
+    await ensureSetup();
+    const { performSync } = await import('../src/commands/sync.ts');
+    const r = await performSync(engine!, { repoPath: repo, ...OPTS });
+    expect(r.status).toBe('first_sync');
+    expect(await drift()).toEqual({ missing: [], ghosts: [] });
+    const rows = await engine!.executeRaw<{ slug: string }>(
+      `SELECT slug FROM pages WHERE source_id=$1 AND deleted_at IS NULL`,
+      [SID],
+    );
+    expect(rows.map((r2) => r2.slug).sort()).toEqual(
+      ['docs/a', 'lib-a-dart', 'lib-mixedcase-dart', 'lib-ete-dart'].sort(),
+    );
+  }, 120_000);
+
+  test('S2 incremental ADD of one markdown + one code file', async () => {
+    await ensureSetup();
+    const { performSync } = await import('../src/commands/sync.ts');
+    writeFileSync(join(repo, 'docs/b.md'), '---\ntype: note\ntitle: B\n---\n\nbody b\n');
+    writeFileSync(join(repo, 'lib/b.dart'), 'class B {}\n');
+    commit('add');
+    await performSync(engine!, { repoPath: repo, ...OPTS });
+    expect(await drift()).toEqual({ missing: [], ghosts: [] });
+  }, 120_000);
+
+  test('S3 incremental DELETE of one markdown + one code file', async () => {
+    await ensureSetup();
+    const { performSync } = await import('../src/commands/sync.ts');
+    unlinkSync(join(repo, 'docs/b.md'));
+    unlinkSync(join(repo, 'lib/b.dart'));
+    commit('rm');
+    await performSync(engine!, { repoPath: repo, ...OPTS });
+    expect(await drift()).toEqual({ missing: [], ghosts: [] });
+  }, 120_000);
+
+  test('S4 FULL re-sync after a code file was removed', async () => {
+    await ensureSetup();
+    const { performSync } = await import('../src/commands/sync.ts');
+    unlinkSync(join(repo, 'lib/a.dart'));
+    commit('rm a.dart');
+    await performSync(engine!, { repoPath: repo, ...OPTS, full: true });
+    expect(await drift()).toEqual({ missing: [], ghosts: [] });
+  }, 120_000);
+});

--- a/test/sync-index-matches-tree.serial.test.ts
+++ b/test/sync-index-matches-tree.serial.test.ts
@@ -79,6 +79,15 @@ async function ensureSetup(): Promise<void> {
     // reconcile would delete a LIVE page. That shows up here as `missing`.
     writeFileSync(join(repo, 'lib/MixedCase.dart'), 'class MixedCase {}\n');
     writeFileSync(join(repo, 'lib/été.dart'), 'class Ete {}\n');
+    // Dot-DIRECTORIES. A code source must see its own CI and agent config;
+    // `.gbrain/` is the control that must stay out. Asserted explicitly below
+    // rather than through drift alone: `drift()` builds `expected` from the
+    // same collector the sync uses, so a collector that prunes `.github` makes
+    // both sides agree and the drift check passes on a broken tree.
+    mkdirSync(join(repo, '.github/workflows'), { recursive: true });
+    mkdirSync(join(repo, '.gbrain'), { recursive: true });
+    writeFileSync(join(repo, '.github/workflows/ci.yml'), 'name: ci\non: push\n');
+    writeFileSync(join(repo, '.gbrain/state.json'), '{"internal":true}\n');
     commit('init');
   })();
   await setupPromise;
@@ -113,13 +122,31 @@ describe('index matches tree at every lifecycle stage', () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const r = await performSync(engine!, { repoPath: repo, ...OPTS });
     expect(r.status).toBe('first_sync');
+    const indexed = new Set(
+      (await engine!.executeRaw<{ slug: string }>(
+        `SELECT slug FROM pages WHERE source_id=$1 AND deleted_at IS NULL`,
+        [SID],
+      )).map((x) => x.slug),
+    );
+    // Goes RED when the importer prunes dot-directories at descent, which is
+    // where the rule actually bites: `classifySync` alone admitted the path
+    // while `isCollectibleForWalker` never offered it, so the index stayed
+    // empty of it and every symptom looked like the sync was simply "caught up".
+    expect(indexed.has(resolveSlugForPath('.github/workflows/ci.yml'))).toBe(true);
+    expect(indexed.has(resolveSlugForPath('.gbrain/state.json'))).toBe(false);
     expect(await drift()).toEqual({ missing: [], ghosts: [] });
     const rows = await engine!.executeRaw<{ slug: string }>(
       `SELECT slug FROM pages WHERE source_id=$1 AND deleted_at IS NULL`,
       [SID],
     );
     expect(rows.map((r2) => r2.slug).sort()).toEqual(
-      ['docs/a', 'lib-a-dart', 'lib-mixedcase-dart', 'lib-ete-dart'].sort(),
+      [
+        'docs/a', 'lib-a-dart', 'lib-mixedcase-dart', 'lib-ete-dart',
+        // derived, not typed out: the slug for a dot-dir path is exactly what
+        // the resolver produces, and hardcoding a guess here would assert my
+        // spelling rather than the index.
+        resolveSlugForPath('.github/workflows/ci.yml'),
+      ].sort(),
     );
   }, 120_000);
 


### PR DESCRIPTION
## What

Three defects that make a **code** source's index silently diverge from the git
tree. They compound, they are all silent, and each one is invisible in the
success output of the command that is supposed to repair the others — which is
why they are one series rather than three drive-bys.

- **Closes #4899** — `core/sync.ts:552` resolves an unstated strategy to
  markdown. Every caller but the `--all` fan-out states none, so a code source
  imports nothing, the anchor advances to HEAD anyway (freezing the index
  forever), and every MODIFIED code file falls through the un-syncable delete
  loop and loses its page.
- **Closes #4900** — `importCodeFile`'s `putPage` never writes `source_path`, so
  the full-sync reconcile cannot match a code page against the tree and a
  deleted file's page is served forever.
- **Closes #4901** — `isPathPruned` prunes every leading-dot segment regardless
  of strategy, so a code source cannot see its own `.github/` or `.claude/`;
  worse, `git ls-files` still lists them, so pages from an earlier walk read as
  ghosts and a reconcile deletes a page whose file is alive.

## Why

Each one alone produces a confident wrong answer rather than an error. Together
they produce an index that reports `sources caught up` while being weeks stale
and holding pages for files that no longer exist. The failure mode was never a
crash; it was a sync reporting success.

The three share one post-condition test, which is the real deliverable:
`test/sync-index-matches-tree.serial.test.ts` asserts that **after any sync that
reports success, the set of pages equals the set of syncable files**. That
invariant is what each of the three violates from a different direction.

## Discrimination test (required for every fix — #3665)

Run per fix, each against the file it changes, via
`scripts/check-test-discriminates.sh`:

Discrimination test: reverted `src/commands/sync.ts` to merge-base, ran `test/sync-index-matches-tree.serial.test.ts` → 0 pass / 4 fail. Restored → all pass.

Discrimination test: reverted `src/core/import-file.ts` to merge-base, ran `test/sync-index-matches-tree.serial.test.ts` → 3 pass / 1 fail. Restored → all pass.

Discrimination test: reverted `src/core/sync.ts src/commands/import.ts` to merge-base, ran `test/sync-code-dot-dirs.test.ts` → 4 pass / 1 fail. Restored → all pass.

## Tests

- `test/sync-index-matches-tree.serial.test.ts` (new, 154 lines) — the
  pages-equal-tree post-condition, covering the strategy default and the
  `source_path` write.
- `test/sync-code-dot-dirs.test.ts` (new, 50 lines) — a code source sees
  `.github/`/`.claude/`; `.git`/`.gbrain` stay denied; markdown sources
  unchanged.

Both run green on the branch. 334 insertions total, of which 233 are tests.

## Notes for review

- The strategy fix assigns the **property** (`opts.strategy = persisted`) rather
  than replacing the object: the block runs inside `if (opts.sourceId)`, and a
  spread would discard that narrowing and break three downstream call sites.
- The dot-dir deny-list is deliberately short (`.git`, `.gbrain`, `.hg`, `.svn`)
  because enumeration already runs through `git ls-files --exclude-standard`,
  so gitignored caches are gone before `classifySync` is reached.
- `source_path` is written on every import, not just the first: `putPage`
  COALESCEs, so a NULL would never clobber a good value but would also never
  backfill a row imported before the line existed.
