### PR TITLE
fix(reindex-code): an EMPTY source file is counted as a failure and skipped (#4902)

### DIFF
--- a/src/commands/reindex-code.ts
+++ b/src/commands/reindex-code.ts
@@ -283,7 +283,20 @@ export async function runReindexCode(
               reporter.tick();
               return;
             }
-            if (!row.compiled_truth) {
+            // `!row.compiled_truth` here counted every EMPTY file as a
+            // failure — every `__init__.py` in every Python package — and
+            // skipped it, so the page never received its `source_path` and the
+            // full-sync reconcile could never match it against the tree. The
+            // page for a deleted empty file was therefore served forever: the
+            // exact defect the source_path write exists to close, surviving
+            // inside the command written to backfill it. Measured on two real
+            // sources: 3 pages, all `__init__.py`, all reported as `missing
+            // compiled_truth` by a backfill that reported success.
+            //
+            // `pages.compiled_truth` is NOT NULL, so the value cannot actually
+            // be missing and this branch has no reachable subject; it is kept
+            // as a type-level guard only, because the row type admits null.
+            if (row.compiled_truth == null) {
               failed++;
               failures.push({ slug: row.slug, error: 'missing compiled_truth' });
               reporter.tick();

--- a/test/reindex-code-empty-file.test.ts
+++ b/test/reindex-code-empty-file.test.ts
@@ -1,0 +1,96 @@
+/**
+ * An EMPTY source file must still be reindexed, and must get its `source_path`.
+ *
+ * `reindex-code` guarded with `if (!row.compiled_truth)` and reported
+ * `missing compiled_truth`. `!''` is true, so a legitimately empty file — every
+ * `__init__.py` in every Python package — was counted as a FAILURE and skipped.
+ *
+ * That is not cosmetic. The page then never receives `source_path`, and the
+ * full-sync reconcile matches deleted files by that column, so the page for a
+ * deleted empty file is served forever. It is the exact defect the source_path
+ * write exists to close, surviving inside the command written to backfill it.
+ *
+ * Measured before the fix: 3 pages across 2 real sources, all `__init__.py`,
+ * all reported as `missing compiled_truth` by a backfill that reported success.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { runReindexCode } from '../src/commands/reindex-code.ts';
+
+let engine: PGLiteEngine;
+let prevNudge: string | undefined;
+
+// Timeouts are explicit: PGLite's WASM cold start + initSchema is ~20s, well
+// past bun's default hook timeout, and the failure surfaces as a beforeEach
+// timeout on a beforeAll that simply had not finished.
+beforeAll(async () => {
+  prevNudge = process.env.GBRAIN_NO_CODE_MODEL_NUDGE;
+  process.env.GBRAIN_NO_CODE_MODEL_NUDGE = '1';
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 120_000);
+afterAll(async () => {
+  await engine.disconnect();
+  if (prevNudge === undefined) delete process.env.GBRAIN_NO_CODE_MODEL_NUDGE;
+  else process.env.GBRAIN_NO_CODE_MODEL_NUDGE = prevNudge;
+}, 60_000);
+beforeEach(async () => { await resetPgliteState(engine); }, 60_000);
+
+/** A code page as it existed BEFORE the source_path write: no path stored. */
+async function legacyCodePage(slug: string, file: string, content: string): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'code' as string,
+    page_kind: 'code',
+    title: `${file} (python)`,
+    compiled_truth: content,
+    timeline: '',
+    frontmatter: { language: 'python', file },
+    content_hash: `hash-${slug}`,
+  });
+}
+
+const pathOf = async (slug: string): Promise<string | null> => {
+  const rows = await engine.executeRaw<{ source_path: string | null }>(
+    'SELECT source_path FROM pages WHERE slug = $1', [slug],
+  );
+  return rows[0]?.source_path ?? null;
+};
+
+describe('reindex-code repairs empty files', () => {
+  test('an empty file gets its source_path and is not a failure', async () => {
+    await legacyCodePage('pkg-__init__-py', 'pkg/__init__.py', '');
+    expect(await pathOf('pkg-__init__-py')).toBeNull();   // premise
+
+    const r = await runReindexCode(engine, { force: true, noEmbed: true, yes: true });
+
+    expect(await pathOf('pkg-__init__-py')).toBe('pkg/__init__.py');
+    expect(r.failed).toBe(0);
+  }, 60_000);
+
+  // CONTROL: a non-empty page must be repaired too, so a green run above can
+  // never be explained by "reindex repairs nothing at all".
+  test('a non-empty file is repaired the same way', async () => {
+    await legacyCodePage('pkg-mod-py', 'pkg/mod.py', 'def f():\n    return 1\n');
+    expect(await pathOf('pkg-mod-py')).toBeNull();
+
+    const r = await runReindexCode(engine, { force: true, noEmbed: true, yes: true });
+
+    expect(await pathOf('pkg-mod-py')).toBe('pkg/mod.py');
+    expect(r.failed).toBe(0);
+  }, 60_000);
+
+  // Why the guard was not merely too strict but unreachable-by-design: the
+  // column is NOT NULL, so `compiled_truth` can never actually be missing.
+  // `!row.compiled_truth` therefore had exactly one possible subject — the
+  // empty string — and every hit it ever reported was a false positive.
+  // Written as a test because the first fix I reached for was a null check,
+  // and this is what proves that branch is dead rather than defensive.
+  test('compiled_truth cannot be null, so the falsy guard had no real target', async () => {
+    await legacyCodePage('pkg-broken-py', 'pkg/broken.py', 'x = 1\n');
+    await expect(
+      engine.executeRaw('UPDATE pages SET compiled_truth = NULL WHERE slug = $1', ['pkg-broken-py']),
+    ).rejects.toThrow(/not-null constraint/);
+  }, 60_000);
+});


### PR DESCRIPTION
## What

**Closes #4902.** `reindex-code` counted an EMPTY source file as a failure and
skipped it. `commands/reindex-code.ts:286` reads:

```ts
if (!row.compiled_truth) { failed++; failures.push({ slug, error: 'missing compiled_truth' }); return; }
```

`pages.compiled_truth` is `NOT NULL`, so the value can never actually be
missing — the branch only ever fires on the empty string, i.e. a legitimately
empty file. Every `__init__.py` in every Python package hits it.

Changed to `row.compiled_truth == null`, keeping the branch as a type-level
guard because the row type admits null even though the column does not.

## Why

The skipped page never receives its `source_path`, so the full-sync reconcile
can never match it against the tree and the page for a deleted empty file is
served forever — the exact defect this command is normally run to repair,
surviving inside the command written to repair it.

And the run **reports success**: the failures are counted but the command exits
0, so a backfill can report done while leaving pages behind. That is the shape
that makes it expensive: not a crash, a green run that did not do the job.
Measured on two real sources: 3 pages, all `__init__.py`, all reported as
`missing compiled_truth` by a backfill that reported success.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/reindex-code.ts` to merge-base, ran `test/reindex-code-empty-file.test.ts` → 2 pass / 1 fail. Restored → all pass.

## Tests

`test/reindex-code-empty-file.test.ts` (new, 96 lines): an empty file
round-trips through `reindex-code` without being counted as a failure, and its
page carries `source_path` afterwards. Green on the branch.
