### PR TITLE
fix(synthesize-concepts): read cycle.synthesize_concepts.budget_usd, mirroring extract_atoms (#4906)

### DIFF
--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -191,7 +191,26 @@ export async function runPhaseSynthesizeConcepts(
   // 4. Per group: synthesize narrative (LLM for T1/T2, deterministic for T3+)
   let conceptsWritten = 0;
   let estimatedSpendUsd = 0;
-  const budgetCap = DEFAULT_BUDGET_USD;
+  // #4529-shaped knob, mirroring the sibling phase. `extract_atoms` has read
+  // `cycle.extract_atoms.budget_usd` since it shipped (extract-atoms.ts); this
+  // one hardcoded its cap, so the only way past it was a source edit. The two
+  // phases run from the same cycle, on the same brain, against the same
+  // provider — the asymmetry was an omission, not a decision.
+  //
+  // Same validation as the sibling: a value that is not a finite positive
+  // number leaves the default in place rather than disabling the cap. Read
+  // failures are swallowed for the same reason the sibling swallows them — a
+  // config lookup must never be the thing that stops a maintenance phase.
+  let budgetCap = DEFAULT_BUDGET_USD;
+  try {
+    const configured = await engine.getConfig('cycle.synthesize_concepts.budget_usd');
+    if (configured) {
+      const n = Number(configured);
+      if (Number.isFinite(n) && n > 0) budgetCap = n;
+    }
+  } catch {
+    // keep the default
+  }
   const failures: Array<{ concept: string; error: string }> = [];
   // #3044 adoption: shared halt policy — auth/billing halt on the first
   // hit, a rate_limit streak halts after 3 consecutive failures, a

--- a/test/cycle-synthesize-concepts-budget-config.test.ts
+++ b/test/cycle-synthesize-concepts-budget-config.test.ts
@@ -1,0 +1,103 @@
+// synthesize_concepts reads `cycle.synthesize_concepts.budget_usd`.
+//
+// The sibling phase `extract_atoms` has read `cycle.extract_atoms.budget_usd`
+// since it shipped; this one hardcoded `const budgetCap = DEFAULT_BUDGET_USD`,
+// so the only way past $1.50 was editing the source. The cap does not stop the
+// phase — it silently swaps the Sonnet narrative for a deterministic stub and
+// stamps `budget_fallback` — so an operator with more budget than the default
+// got a quietly degraded corpus and no error to notice.
+//
+// These tests drive the REAL phase through its `_chat` / `_atoms` seams under
+// `dryRun`, so no page is written and no provider is called. Every assertion is
+// on the phase's own returned counts, not on a re-implementation of the rule.
+import { test, expect } from 'bun:test';
+import { runPhaseSynthesizeConcepts } from '../src/core/cycle/synthesize-concepts.ts';
+
+/** Three T1 groups (>= 10 atoms each), so every one is LLM-eligible. */
+function atoms(groups = 3, per = 10) {
+  const out: Array<{ slug: string; concept_refs: string[]; body: string; title: string }> = [];
+  for (let g = 0; g < groups; g++) {
+    for (let i = 0; i < per; i++) {
+      out.push({
+        slug: `atoms/2026-09-05/g${g}-a${i}`,
+        concept_refs: [`concept-${g}`],
+        title: `atom ${g}.${i}`,
+        body: `body of atom ${g}.${i}`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Each answer costs $0.90 at Sonnet fallback pricing (300k input * $3/M).
+ *
+ * The cap is checked BEFORE each call, so the call that CROSSES it still runs:
+ * group 1 ($0.90) and group 2 ($1.80) are answered, and only group 3 sees
+ * estimatedSpendUsd >= 1.50 and stubs. That off-by-one is the real behaviour,
+ * not a rounding detail — asserting llm=1 here would have been asserting a
+ * rule that does not exist.
+ */
+const chat = (async () => ({
+  model: 'test:unpriced-model',       // canonical miss -> FALLBACK_PRICING
+  text: 'a synthesized narrative.',
+  usage: { input_tokens: 300_000, output_tokens: 0 },
+})) as never;
+
+function engineWith(configured: string | null) {
+  return {
+    getConfig: async (k: string) =>
+      k === 'cycle.synthesize_concepts.budget_usd' ? configured : null,
+  } as never;
+}
+
+async function modes(configured: string | null) {
+  const r = await runPhaseSynthesizeConcepts(engineWith(configured), {
+    dryRun: true,
+    _atoms: atoms(),
+    _chat: chat,
+  } as never);
+  const d = (r as { details?: Record<string, unknown> }).details ?? {};
+  return (d.synthesis_mode_counts ?? d) as Record<string, number>;
+}
+
+test('the default cap still degrades past $1.50 — the behaviour being made configurable', async () => {
+  const m = await modes(null);
+  expect(m.llm).toBe(2);
+  expect(m.budget_fallback).toBe(1);
+});
+
+test('a configured budget is honoured: every eligible group gets a real narrative', async () => {
+  const m = await modes('20');
+  expect(m.llm).toBe(3);
+  expect(m.budget_fallback).toBe(0);
+});
+
+test('a non-numeric budget leaves the default in place rather than disabling the cap', async () => {
+  const m = await modes('not-a-number');
+  expect(m.llm).toBe(2);
+  expect(m.budget_fallback).toBe(1);
+});
+
+test('a zero or negative budget is refused, not applied — it would disable every LLM call', async () => {
+  for (const bad of ['0', '-5']) {
+    const m = await modes(bad);
+    expect(m.llm).toBe(2);
+    expect(m.budget_fallback).toBe(1);
+  }
+});
+
+test('a getConfig that throws does not stop the phase', async () => {
+  // getConfig also backs resolveModel (model-config.ts). Throwing for every key
+  // would test model resolution, not this read — so throw for OURS only.
+  const engine = {
+    getConfig: async (k: string) => {
+      if (k === 'cycle.synthesize_concepts.budget_usd') throw new Error('config plane down');
+      return null;
+    },
+  } as never;
+  const r = await runPhaseSynthesizeConcepts(engine, {
+    dryRun: true, _atoms: atoms(), _chat: chat,
+  } as never);
+  expect((r as { status: string }).status).not.toBe('error');
+});


### PR DESCRIPTION
## What

**Closes #4906.** `synthesize_concepts` reads
`cycle.synthesize_concepts.budget_usd`, mirroring the key `extract_atoms` has
read since it shipped.

## Why

The two phases run from the same cycle, on the same brain, against the same
provider, and only one of them could be told how much to spend. The asymmetry
looks like an omission rather than a decision.

It costs more than a missing knob normally would, because the cap **does not stop
the phase** — past it, the Sonnet narrative is silently replaced by
`deterministicNarrative()` and stamped `synthesis_mode: 'budget_fallback'`. The
symptom is not an error, it is a quietly degraded corpus.

And re-running does not recover it. Group order is deterministic (tier, evidence
count desc, slug) and nothing skips a group that already has a narrative, so a
second run spends its fresh budget re-narrating the same head of the list while
the stubbed tail stays stubbed. Editing the constant was the only way through.

On the brain this was found on: 3,380 atoms, 259 LLM-eligible groups, ~$2.72 at
observed rates against a $1.50 cap — about half the corpus permanently stubbed.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/synthesize-concepts.ts` to merge-base, ran `test/cycle-synthesize-concepts-budget-config.test.ts` → 4 pass / 1 fail. Restored → all pass.

## Tests

`test/cycle-synthesize-concepts-budget-config.test.ts` (new, 5 tests). They drive
the REAL phase through its `_chat` / `_atoms` seams under `dryRun` — no page
written, no provider called — and assert the phase's own returned
`synthesis_mode_counts` rather than a re-implementation of the rule:

- the default still degrades past $1.50 (the behaviour being made configurable);
- a configured budget is honoured: every eligible group gets a real narrative;
- a non-numeric value leaves the default in place;
- `0` and `-5` are refused rather than applied — applying either would disable
  every LLM call;
- a `getConfig` that throws does not stop the phase.

`5 pass / 0 fail` on the branch.

## Notes for review

Two corrections the tests needed, kept as fixture comments because both are easy
to re-introduce:

- The cap is checked **before** each call, so the call that crosses it still
  runs. With $0.90 answers and a $1.50 cap, groups 1 and 2 are answered and only
  group 3 stubs. A first draft asserted `llm=1` and would have pinned a rule that
  does not exist.
- `getConfig` also backs `resolveModel` (`model-config.ts`), so a fake engine that
  throws for every key tests model resolution rather than this read. The fixture
  throws for this key only.

Validation deliberately matches the sibling rather than improving on it: same
`Number.isFinite(n) && n > 0` shape, same swallowed read failure, so the two keys
behave identically for an operator who has learned one of them.
