### PR TITLE
fix(cycle): supersede stale atoms of a re-extracted source page (extract_atoms)

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -140,7 +140,7 @@ test/eval-takes-bootstrap.test.ts	corpus integrity	4	readFileSync
 test/exit-classification.test.ts	consumer wire-up — helper used by all 3 sites (no inline filters left)	5	doctor-source-helper,readFileSync
 test/extract-atoms-drain-errors.test.ts	runExtractAtomsDrainForSource forwards typed per-item failures (#4730)	1	readFileSync
 test/extract-atoms-drain.test.ts	extract-atoms-drain Minion handler retries on provider_failure (issue #3218)	2	readFileSync
-test/extract-atoms-drain.test.ts	shared wiring helper holds the cycle lock (5A)	2	readFileSync
+test/extract-atoms-drain.test.ts	shared wiring helper holds the cycle lock (5A)	3	readFileSync
 test/extract-workers.test.ts	extract.ts → workers wiring (T7)	10	readFileSync
 test/facts-backstop-remedy-verb.test.ts	facts backstop thin-client-fallback remedy verb (#4489)	3	readFileSync
 test/features.test.ts	CLI routing	2	bun-file

--- a/src/core/cycle/extract-atoms-drain.ts
+++ b/src/core/cycle/extract-atoms-drain.ts
@@ -99,6 +99,7 @@ export interface ExtractAtomsDrainDeps {
      */
     superseded?: number;
     reanchored?: number;
+    retirement_blocked?: number;
     providerFailure?: boolean;
     failureCount?: number;
     firstError?: string;
@@ -149,6 +150,8 @@ export interface ExtractAtomsDrainResult {
    */
   superseded: number;
   reanchored: number;
+  /** Always emitted by the drain; optional for callers constructing older summaries. */
+  retirement_blocked?: number;
   /** Eligible pages still pending after the window. null if the count errored. */
   remaining: number | null;
   /** Batches actually processed. */
@@ -191,6 +194,7 @@ export async function runExtractAtomsDrain(
     let skipped = 0;
     let superseded = 0;
     let reanchored = 0;
+    let retirement_blocked = 0;
     let batches = 0;
     let stopped: ExtractAtomsDrainResult['stopped'] = 'window';
     // issue #3218: latched once any batch reports providerFailure — drives
@@ -214,6 +218,7 @@ export async function runExtractAtomsDrain(
       skipped += r.skipped;
       superseded += nonNegativeCount(r.superseded);
       reanchored += nonNegativeCount(r.reanchored);
+      retirement_blocked += nonNegativeCount(r.retirement_blocked);
       batches++;
       // #4730: preserve typed per-item records (bounded, sanitized) while
       // keeping failure_count exact and reconcilable — count-only adapters
@@ -296,6 +301,7 @@ export async function runExtractAtomsDrain(
       skipped,
       superseded,
       reanchored,
+      retirement_blocked,
       remaining,
       batches,
       stopped,
@@ -398,6 +404,7 @@ export async function runExtractAtomsDrainForSource(
           // lane deletes rows it never reports.
           superseded: Number(d.atoms_superseded ?? 0),
           reanchored: Number(d.atoms_reanchored ?? 0),
+          retirement_blocked: Number(d.atoms_retirement_blocked ?? 0),
           providerFailure: failures.length > 0 && itemsSucceeded === 0,
           failureCount: failures.length,
           failures: typedFailures,

--- a/src/core/cycle/extract-atoms-drain.ts
+++ b/src/core/cycle/extract-atoms-drain.ts
@@ -91,6 +91,14 @@ export interface ExtractAtomsDrainDeps {
   runBatch: () => Promise<{
     extracted: number;
     skipped: number;
+    /**
+     * #4566: atoms the batch RETIRED (soft-deleted because their source page
+     * no longer supports them) and atoms it re-anchored to the page's current
+     * hash. Optional so the pure loop keeps accepting the pre-#4566 adapter
+     * shape; a missing value counts as 0.
+     */
+    superseded?: number;
+    reanchored?: number;
     providerFailure?: boolean;
     failureCount?: number;
     firstError?: string;
@@ -102,6 +110,15 @@ export interface ExtractAtomsDrainDeps {
   now: () => number;
   /** Optional progress sink (one line per batch). */
   onBatch?: (info: { batch: number; extracted: number; remaining: number | null }) => void;
+}
+
+/**
+ * Coerce an optional adapter-reported count to a whole, non-negative number —
+ * same defensive shape the failure counters use, so a malformed adapter can
+ * never make a total go backwards.
+ */
+function nonNegativeCount(n: number | undefined): number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
 }
 
 export interface ExtractAtomsDrainOpts {
@@ -123,6 +140,15 @@ export interface ExtractAtomsDrainResult {
   status: 'ok' | 'provider_failure';
   extracted: number;
   skipped: number;
+  /**
+   * #4566: atoms RETIRED across the window (soft-deleted because their source
+   * page no longer supports them) and atoms re-anchored to their page's
+   * current hash. The retirement count is the only destructive number this
+   * lane produces, so `--json` carries it verbatim — a drain that quietly
+   * deleted rows is otherwise unobservable in the lane that runs nightly.
+   */
+  superseded: number;
+  reanchored: number;
   /** Eligible pages still pending after the window. null if the count errored. */
   remaining: number | null;
   /** Batches actually processed. */
@@ -163,6 +189,8 @@ export async function runExtractAtomsDrain(
     const deadline = deps.now() + opts.windowMs;
     let extracted = 0;
     let skipped = 0;
+    let superseded = 0;
+    let reanchored = 0;
     let batches = 0;
     let stopped: ExtractAtomsDrainResult['stopped'] = 'window';
     // issue #3218: latched once any batch reports providerFailure — drives
@@ -184,6 +212,8 @@ export async function runExtractAtomsDrain(
       const r = await deps.runBatch();
       extracted += r.extracted;
       skipped += r.skipped;
+      superseded += nonNegativeCount(r.superseded);
+      reanchored += nonNegativeCount(r.reanchored);
       batches++;
       // #4730: preserve typed per-item records (bounded, sanitized) while
       // keeping failure_count exact and reconcilable — count-only adapters
@@ -264,6 +294,8 @@ export async function runExtractAtomsDrain(
       status: providerFailure ? 'provider_failure' : 'ok',
       extracted,
       skipped,
+      superseded,
+      reanchored,
       remaining,
       batches,
       stopped,
@@ -361,6 +393,11 @@ export async function runExtractAtomsDrainForSource(
         return {
           extracted: Number(d.atoms_extracted ?? 0),
           skipped: Number(d.duplicates_skipped ?? 0),
+          // #4566: the phase's destructive count (and its non-destructive
+          // twin) ride through to `--json`; without this mapping the drain
+          // lane deletes rows it never reports.
+          superseded: Number(d.atoms_superseded ?? 0),
+          reanchored: Number(d.atoms_reanchored ?? 0),
           providerFailure: failures.length > 0 && itemsSucceeded === 0,
           failureCount: failures.length,
           failures: typedFailures,

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -7,10 +7,11 @@ import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
 import { normForGrounding } from './synthesize-verify.ts';
 
 /**
- * A normalized quote shorter than this is not evidence enough to destroy a
- * row: at that length an accidental substring match (or miss) is as likely as
- * a real one, and the atom is cheap to keep and expensive to lose. Retirement
- * skips these; they stay live with their stale binding.
+ * A normalized quote shorter than this (under EITHER fold) is not evidence
+ * enough to destroy a row: at that length an accidental substring match — or
+ * miss — is as likely as a real one, and the atom is cheap to keep and
+ * expensive to lose. Retirement skips these; they stay live with their stale
+ * binding.
  */
 const MIN_RETIREMENT_QUOTE_CHARS = 8;
 
@@ -32,11 +33,14 @@ const MIN_RETIREMENT_QUOTE_CHARS = 8;
  * markers at line start, `[text](url)` → text, `<url>` → url, emphasis and
  * code marks), then the shared fold + whitespace collapse.
  *
- * Applied to BOTH sides — quote and page — so every transform above is
- * symmetric: it can only ever ADD matches relative to the grounding fold,
- * never remove one. That direction is the point. This function may keep an
- * atom the strict fold would have retired; it cannot retire one the strict
- * fold would have kept.
+ * It is applied to BOTH sides, but symmetry alone does NOT make it a superset
+ * of the strict fold: a quote that starts mid-link (`[Procurement](https://ex`
+ * — the model's span cut through the syntax) keeps its literal brackets while
+ * the page's copy folds to `Procurement`, and the strict fold would have found
+ * that text. So the caller does not REPLACE the strict test with this one — it
+ * requires BOTH to report the quote absent before retiring. The permissive
+ * fold can then only ever save an atom, never condemn one, by construction
+ * rather than by regex reasoning.
  */
 function normForRetirement(s: string): string {
   return normForGrounding(
@@ -95,15 +99,15 @@ function normForRetirement(s: string): string {
  * Presence is a plain normalized-containment test over the page's FULL current
  * content — deliberately looser than extract-atoms' `locateQuote` (which also
  * demands character-aligned boundaries and uniqueness), applied to the whole
- * page rather than the model's truncated cut, and normalized by
- * `normForRetirement` (NFKC + markdown-syntax fold) rather than the strict
- * grounding fold. All three choices err toward "still present", i.e. toward
- * keeping the atom.
+ * page rather than the model's truncated cut, and run under TWO folds (the
+ * strict grounding one and `normForRetirement`'s NFKC + markdown fold): either
+ * one finding the quote keeps the atom. All three choices err toward "still
+ * present", i.e. toward keeping the atom.
  *
  * RE-ANCHORING. A run that retires anything also repoints the atoms it KEPT on
- * evidence — same page, stale `source_hash`, verified quote still present — at
- * the hash just reconciled. Two reasons, and both are about not making the
- * retirement permanent:
+ * VERBATIM evidence — same page, stale `source_hash`, verified quote still
+ * present under the STRICT fold — at the hash just reconciled. Two reasons,
+ * and both are about not making the retirement permanent:
  *   - It is truthful. The atom is supported by the content at THIS hash; the
  *     hash it carried says only which pass minted it.
  *   - `discoverExtractablePages` skips a page when any live atom already
@@ -113,12 +117,31 @@ function normForRetirement(s: string): string {
  *     re-derived and the purge window ends them. Re-anchoring frees the old
  *     hash, the revert re-discovers the page, and the deterministic atom slug
  *     makes the re-import revive the soft-deleted row in place.
- * Only the evidenced set moves: an atom with no quote (or an unverified one)
- * has nothing to justify a new binding, so it keeps its hash and can still
- * mask an older one — the residual, narrowed to rows this reconciler would
- * never retire anyway. Runs that retire nothing re-anchor nothing: without a
- * retirement the old hash's extraction is still fully represented, and the
- * common no-op page must not pay a write.
+ * Only the verbatim-evidenced set moves. An atom with no quote, an unverified
+ * one, or one the permissive fold alone could find keeps its hash — and can
+ * still mask an older one. That residual is deliberate: those rows have no
+ * evidence strong enough to restate their provenance, and they are rows this
+ * reconciler would never retire anyway. Runs that retire nothing re-anchor
+ * nothing: without a retirement the old hash's extraction is still fully
+ * represented, and the common no-op page must not pay a write.
+ *
+ * The one contract this costs: the reconciliation deliberately lands BEFORE
+ * the item's completion markers so a failure leaves the page retryable, and a
+ * re-anchored row carries the current hash from that moment on. If the
+ * provisional→real flip that follows then fails, discovery skips the page
+ * (any live atom at the current hash makes it "already extracted") and this
+ * run's `pending:` rows wait for the next edit to that page instead of the
+ * next run. That window is the flip's own pre-existing crash window widened by
+ * two statements, it strands nothing that a later pass cannot reclaim (a
+ * `pending:` row is explicitly eligible here), and closing it properly means
+ * teaching discovery about incomplete runs — a change to the phase's
+ * eligibility rule, not to this reconciler.
+ *
+ * Revival after a revert is in-place for atoms at the current deterministic
+ * slug. A pre-#4733 LEGACY-slug atom is re-minted at the new-format slug
+ * instead: `resolvePageAtomSlug` adopts a legacy row only while it is live, so
+ * a retired one is invisible to it. The claim comes back either way; the row
+ * identity does not.
  *
  * `currentContent` is the snapshot the phase read before the model call, so
  * the work is gated on the live page STILL carrying `hash16`: if the page was
@@ -189,15 +212,29 @@ async function classifyStaleAtoms(
         )${lock ? '\n        FOR UPDATE' : ''}`,
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
-  const currentNorm = normForRetirement(args.currentContent);
+  // Two folds, both of which must miss before a row is retired: the strict
+  // grounding one (what the rest of the phase means by "quoted from here") and
+  // the permissive retirement one (cosmetic edits are not deletions).
+  const currentStrict = normForGrounding(args.currentContent);
+  const currentFolded = normForRetirement(args.currentContent);
   const verdict: Verdict = { retire: [], reanchor: [] };
   for (const r of rows) {
     // No verified quote → no evidence in either direction: neither retire nor
     // re-anchor, so the row keeps whatever binding it has.
     if (r.verified !== 'true' || !r.quote) continue;
-    const quote = normForRetirement(r.quote);
-    if (quote.length < MIN_RETIREMENT_QUOTE_CHARS) continue;
-    (currentNorm.includes(quote) ? verdict.reanchor : verdict.retire).push(r.slug);
+    const strict = normForGrounding(r.quote);
+    const folded = normForRetirement(r.quote);
+    if (Math.min(strict.length, folded.length) < MIN_RETIREMENT_QUOTE_CHARS) continue;
+    // Verbatim-present under the strict fold: strong enough to REBIND the row.
+    if (currentStrict.includes(strict)) { verdict.reanchor.push(r.slug); continue; }
+    // Present only under the permissive fold: strong enough to KEEP the row,
+    // not to restate its provenance. That fold is deliberately lossy (it drops
+    // `_`, and NFKC rewrites `x²` to `x2`), so a match can mean the page still
+    // carries the claim OR that an edit changed a token the fold erased. Keep
+    // — the destructive direction needs the evidence — but leave the binding
+    // alone so `atom_provenance_drift` still reports the row.
+    if (currentFolded.includes(folded)) continue;
+    verdict.retire.push(r.slug);
   }
   return verdict;
 }

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -7,6 +7,51 @@ import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
 import { normForGrounding } from './synthesize-verify.ts';
 
 /**
+ * A normalized quote shorter than this is not evidence enough to destroy a
+ * row: at that length an accidental substring match (or miss) is as likely as
+ * a real one, and the atom is cheap to keep and expensive to lose. Retirement
+ * skips these; they stay live with their stale binding.
+ */
+const MIN_RETIREMENT_QUOTE_CHARS = 8;
+
+/**
+ * The presence test that gates a DESTRUCTIVE decision, deliberately looser
+ * than `normForGrounding` (the grounding primitive, which folds only
+ * whitespace, curly quotes, unicode dashes, ellipsis and case — and is left
+ * alone here because other callers depend on its exact fold).
+ *
+ * Grounding asks "did the model quote this text?", where a strict fold is
+ * right. Retirement asks "is this claim still on the page?", where a stricter
+ * fold turns a COSMETIC edit into data loss: an NFC→NFD re-encode of Japanese
+ * prose, a half→full-width punctuation pass, `**emphasis**` added inside the
+ * quoted span, a link wrapped around one word, or re-bulleting two sentences
+ * all leave the claim verbatim on screen while changing its bytes.
+ *
+ * So, in order: NFKC (composes NFD, folds full-width forms to ASCII), strip
+ * the markdown syntax that carries no meaning (blockquote/heading/list
+ * markers at line start, `[text](url)` → text, `<url>` → url, emphasis and
+ * code marks), then the shared fold + whitespace collapse.
+ *
+ * Applied to BOTH sides — quote and page — so every transform above is
+ * symmetric: it can only ever ADD matches relative to the grounding fold,
+ * never remove one. That direction is the point. This function may keep an
+ * atom the strict fold would have retired; it cannot retire one the strict
+ * fold would have kept.
+ */
+function normForRetirement(s: string): string {
+  return normForGrounding(
+    s
+      .normalize('NFKC')
+      .replace(/^[ \t]*(?:>[ \t]?)+/gm, '')                 // blockquote markers
+      .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')                 // ATX headings
+      .replace(/^[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+/gm, '')  // list bullets
+      .replace(/!?\[([^\]\n]*)\]\([^)\n]*\)/g, '$1')        // [text](url) → text
+      .replace(/<((?:https?|mailto):[^>\s]+)>/g, '$1')      // <url> → url
+      .replace(/[`*_~]/g, ''),                              // emphasis / code marks
+  );
+}
+
+/**
  * #4566 follow-through — reclaim the atoms a re-extracted page has invalidated.
  *
  * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
@@ -49,9 +94,31 @@ import { normForGrounding } from './synthesize-verify.ts';
  *
  * Presence is a plain normalized-containment test over the page's FULL current
  * content — deliberately looser than extract-atoms' `locateQuote` (which also
- * demands character-aligned boundaries and uniqueness) and applied to the
- * whole page rather than the model's truncated cut. Both choices err toward
- * "still present", i.e. toward keeping the atom.
+ * demands character-aligned boundaries and uniqueness), applied to the whole
+ * page rather than the model's truncated cut, and normalized by
+ * `normForRetirement` (NFKC + markdown-syntax fold) rather than the strict
+ * grounding fold. All three choices err toward "still present", i.e. toward
+ * keeping the atom.
+ *
+ * RE-ANCHORING. A run that retires anything also repoints the atoms it KEPT on
+ * evidence — same page, stale `source_hash`, verified quote still present — at
+ * the hash just reconciled. Two reasons, and both are about not making the
+ * retirement permanent:
+ *   - It is truthful. The atom is supported by the content at THIS hash; the
+ *     hash it carried says only which pass minted it.
+ *   - `discoverExtractablePages` skips a page when any live atom already
+ *     carries its current hash. A kept atom still holding the OLD hash
+ *     therefore masks the old content forever: revert the page and discovery
+ *     says "already extracted", so the atoms retired at the new hash are never
+ *     re-derived and the purge window ends them. Re-anchoring frees the old
+ *     hash, the revert re-discovers the page, and the deterministic atom slug
+ *     makes the re-import revive the soft-deleted row in place.
+ * Only the evidenced set moves: an atom with no quote (or an unverified one)
+ * has nothing to justify a new binding, so it keeps its hash and can still
+ * mask an older one — the residual, narrowed to rows this reconciler would
+ * never retire anyway. Runs that retire nothing re-anchor nothing: without a
+ * retirement the old hash's extraction is still fully represented, and the
+ * common no-op page must not pay a write.
  *
  * `currentContent` is the snapshot the phase read before the model call, so
  * the work is gated on the live page STILL carrying `hash16`: if the page was
@@ -64,9 +131,10 @@ import { normForGrounding } from './synthesize-verify.ts';
  * — never open a transaction, so the batch phase keeps paying one SELECT.
  *
  * Soft-delete via `softDeletePages`, so rows stay recoverable inside the usual
- * purge window rather than being destroyed. Returns the number of rows
- * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
- * returns the would-be count without touching a row.
+ * purge window rather than being destroyed. Returns how many rows were
+ * actually flipped active → soft-deleted and how many were re-anchored.
+ * `dryRun` runs the SELECT only and returns the would-be counts without
+ * touching a row.
  *
  * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
  * out of scope: this only ever runs for a page that was just re-extracted.
@@ -80,18 +148,27 @@ interface SupersedeArgs {
   dryRun: boolean;
 }
 
+/** One page's stale-bound atoms, split by what the current content says. */
+interface Verdict {
+  /** Verified quote no longer in the page → soft-delete. */
+  retire: string[];
+  /** Verified quote still in the page → repoint at the current hash. */
+  reanchor: string[];
+}
+
 /**
  * The evidence query: which of this page's atoms its current text no longer
- * supports. `lock` adds `FOR UPDATE` so the transactional pass holds the
- * candidate atom rows themselves — otherwise a concurrent import could refresh
- * an atom's quote between the judgement and the soft-delete, and the delete
- * (which matches on slug alone) would retire a row that is supported again.
+ * supports, and which it still does. `lock` adds `FOR UPDATE` so the
+ * transactional pass holds the candidate atom rows themselves — otherwise a
+ * concurrent import could refresh an atom's quote between the judgement and
+ * the soft-delete, and the delete (which matches on slug alone) would retire a
+ * row that is supported again.
  */
-async function findUnsupportedAtoms(
+async function classifyStaleAtoms(
   engine: BrainEngine,
   args: SupersedeArgs,
   lock = false,
-): Promise<string[]> {
+): Promise<Verdict> {
   const rows = await engine.executeRaw<{ slug: string; quote: string | null; verified: string | null }>(
     `SELECT slug,
             frontmatter->>'source_quote' AS quote,
@@ -112,22 +189,73 @@ async function findUnsupportedAtoms(
         )${lock ? '\n        FOR UPDATE' : ''}`,
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
-  const currentNorm = normForGrounding(args.currentContent);
-  return rows
-    .filter(r => r.verified === 'true' && !!r.quote && !currentNorm.includes(normForGrounding(r.quote)))
-    .map(r => r.slug);
+  const currentNorm = normForRetirement(args.currentContent);
+  const verdict: Verdict = { retire: [], reanchor: [] };
+  for (const r of rows) {
+    // No verified quote → no evidence in either direction: neither retire nor
+    // re-anchor, so the row keeps whatever binding it has.
+    if (r.verified !== 'true' || !r.quote) continue;
+    const quote = normForRetirement(r.quote);
+    if (quote.length < MIN_RETIREMENT_QUOTE_CHARS) continue;
+    (currentNorm.includes(quote) ? verdict.reanchor : verdict.retire).push(r.slug);
+  }
+  return verdict;
 }
+
+/**
+ * Repoint kept-but-stale atoms at the hash just reconciled. Runs INSIDE the
+ * retirement transaction (same row locks, same all-or-nothing rollback), and
+ * touches only `frontmatter.source_hash` — not `updated_at`, matching
+ * `softDeletePages`, so a reconciliation does not read downstream as a content
+ * edit. Returns the rows actually repointed.
+ */
+async function reanchorAtoms(
+  tx: BrainEngine,
+  args: SupersedeArgs,
+  slugs: string[],
+): Promise<number> {
+  let moved = 0;
+  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
+    const rows = await tx.executeRaw<{ slug: string }>(
+      `UPDATE pages
+          SET frontmatter = frontmatter || jsonb_build_object('source_hash', $3::text)
+        WHERE source_id = $1
+          AND type = 'atom'
+          AND deleted_at IS NULL
+          AND frontmatter->>'source_slug' = $2
+          AND slug = ANY($4::text[])
+        RETURNING slug`,
+      [args.sourceId, args.pageSlug, args.hash16, slugs.slice(i, i + DELETE_BATCH_SIZE)],
+    );
+    moved += rows.length;
+  }
+  return moved;
+}
+
+export interface ReconcileCounts {
+  superseded: number;
+  reanchored: number;
+}
+
+const NOTHING: ReconcileCounts = { superseded: 0, reanchored: 0 };
 
 async function supersedeStaleAtomsForPage(
   engine: BrainEngine,
   args: SupersedeArgs,
-): Promise<number> {
-  if (args.dryRun) return (await findUnsupportedAtoms(engine, args)).length;
+): Promise<ReconcileCounts> {
+  if (args.dryRun) {
+    const would = await classifyStaleAtoms(engine, args);
+    // Report the same coupling a real run applies: no retirement, no
+    // re-anchoring.
+    return would.retire.length === 0
+      ? NOTHING
+      : { superseded: would.retire.length, reanchored: would.reanchor.length };
+  }
   // Fast path first: the overwhelming majority of re-extracted pages have
   // nothing to retire, and this is a batch phase — one plain SELECT per page,
   // no transaction. Only a page that actually has candidates pays for the
   // locked re-check below.
-  if ((await findUnsupportedAtoms(engine, args)).length === 0) return 0;
+  if ((await classifyStaleAtoms(engine, args)).retire.length === 0) return NOTHING;
   return engine.transaction(async (tx) => {
     // Take the "page still carries hash16" gate as a row lock: a concurrent
     // edit to this page now waits for the commit below instead of slipping in
@@ -139,26 +267,30 @@ async function supersedeStaleAtomsForPage(
         FOR UPDATE`,
       [args.sourceId, args.pageSlug, args.hash16],
     );
-    if (held.length === 0) return 0;
+    if (held.length === 0) return NOTHING;
     // Re-derived under the lock, not reused from the fast path: the lock is
     // what makes this list current.
-    const slugs = await findUnsupportedAtoms(tx, args, true);
+    const { retire, reanchor } = await classifyStaleAtoms(tx, args, true);
+    // The lock may have revealed that nothing is unsupported after all —
+    // then this is a no-op run and the kept atoms' bindings stay put.
+    if (retire.length === 0) return NOTHING;
     // softDeletePages is a single-batch primitive — oversized input throws.
     let superseded = 0;
-    for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
-      const flipped = await tx.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
+    for (let i = 0; i < retire.length; i += DELETE_BATCH_SIZE) {
+      const flipped = await tx.softDeletePages(retire.slice(i, i + DELETE_BATCH_SIZE), {
         sourceId: args.sourceId,
       });
       superseded += flipped.length;
     }
-    return superseded;
+    return { superseded, reanchored: await reanchorAtoms(tx, args, reanchor) };
   });
 }
 
 /**
  * Bind the reconciler to one phase run. The returned function is a no-op for
  * transcript items (a transcript is a file, not a page, so nothing is bound to
- * it) and otherwise returns how many of the page's atoms were retired.
+ * it) and otherwise returns how many of the page's atoms were retired and how
+ * many were re-anchored.
  *
  * It is allowed to THROW: callers must run it before the item's completion
  * markers, on the same footing as the provenance-edge flush. Both markers (the
@@ -171,8 +303,8 @@ export function createAtomReconciler(engine: BrainEngine, sourceId: string, dryR
   return async (
     item: { kind: string; slug?: string; content: string; contentHash: string },
     keepSlugs: string[],
-  ): Promise<number> => {
-    if (item.kind !== 'page' || !item.slug) return 0;
+  ): Promise<ReconcileCounts> => {
+    if (item.kind !== 'page' || !item.slug) return NOTHING;
     return supersedeStaleAtomsForPage(engine, {
       sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
       currentContent: item.content, keepSlugs, dryRun,

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -4,14 +4,15 @@
 
 import type { BrainEngine } from '../engine.ts';
 import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
+import { locateQuote } from './extract-atoms.ts';
 import { normForGrounding } from './synthesize-verify.ts';
 
 /**
  * A normalized quote shorter than this (under EITHER fold) is not evidence
  * enough to destroy a row: at that length an accidental substring match — or
  * miss — is as likely as a real one, and the atom is cheap to keep and
- * expensive to lose. Retirement skips these; they stay live with their stale
- * binding.
+ * expensive to lose. Retirement skips these; unless locatable, they block
+ * retirement and stay live with their stale binding.
  */
 const MIN_RETIREMENT_QUOTE_CHARS = 8;
 
@@ -30,8 +31,9 @@ const MIN_RETIREMENT_QUOTE_CHARS = 8;
  *
  * So, in order: NFKC (composes NFD, folds full-width forms to ASCII), strip
  * the markdown syntax that carries no meaning (blockquote/heading/list
- * markers at line start, `[text](url)` → text, `<url>` → url, emphasis and
- * code marks), then the shared fold + whitespace collapse.
+ * markers at line start, inline/reference links → text, reference definitions,
+ * `<url>` → url, emphasis and code marks), then the shared fold + whitespace
+ * collapse.
  *
  * It is applied to BOTH sides, but symmetry alone does NOT make it a superset
  * of the strict fold: a quote that starts mid-link (`[Procurement](https://ex`
@@ -54,6 +56,8 @@ function normForRetirement(s: string): string {
       // that allowance the fold stopped at the inner `)` and left a stray `)`
       // in the page text, so a supported quote read as absent and was retired.
       .replace(/!?\[([^\]\n]*)\]\((?:[^()\n]|\([^()\n]*\))*\)/g, '$1')
+      .replace(/^[ \t]*\[[^\]\n]+\]:[ \t]*(?:<[^>\n]+>|[^\s<>]+)[^\n]*(?:\n|$)/gm, '') // reference definitions
+      .replace(/!?\[([^\]\n]*)\]\[[^\]\n]*\]/g, '$1') // reference links / images
       .replace(/<((?:https?|mailto):[^>\s]+)>/g, '$1')      // <url> → url
       .replace(/[`*_~]/g, ''),                              // emphasis / code marks
   );
@@ -108,38 +112,24 @@ function normForRetirement(s: string): string {
  * one finding the quote keeps the atom. All three choices err toward "still
  * present", i.e. toward keeping the atom.
  *
- * RE-ANCHORING. A run that retires anything also repoints the atoms it KEPT on
- * VERBATIM evidence — same page, stale `source_hash`, verified quote still
- * present under the STRICT fold — at the hash just reconciled. Two reasons,
- * and both are about not making the retirement permanent:
- *   - It is truthful. The atom is supported by the content at THIS hash; the
- *     hash it carried says only which pass minted it.
- *   - `discoverExtractablePages` skips a page when any live atom already
- *     carries its current hash. A kept atom still holding the OLD hash
- *     therefore masks the old content forever: revert the page and discovery
- *     says "already extracted", so the atoms retired at the new hash are never
- *     re-derived and the purge window ends them. Re-anchoring frees the old
- *     hash, the revert re-discovers the page, and the deterministic atom slug
- *     makes the re-import revive the soft-deleted row in place.
- * Only the verbatim-evidenced set moves. An atom with no quote, an unverified
- * one, or one the permissive fold alone could find keeps its hash — and can
- * still mask an older one. That residual is deliberate: those rows have no
- * evidence strong enough to restate their provenance, and they are rows this
- * reconciler would never retire anyway. Runs that retire nothing re-anchor
- * nothing: without a retirement the old hash's extraction is still fully
- * represented, and the common no-op page must not pay a write.
+ * RE-ANCHORING. A run that retires anything also repoints every keeper
+ * whose verified quote can be located by extraction's `locateQuote`, updating
+ * both source_hash and source_quote_offset and keeping verification true.
+ * Containment under either fold alone is NOT enough: the locator requires
+ * unique, character-aligned evidence in the current content.
  *
- * The one contract this costs: the reconciliation deliberately lands BEFORE
- * the item's completion markers so a failure leaves the page retryable, and a
- * re-anchored row carries the current hash from that moment on. If the
- * provisional→real flip that follows then fails, discovery skips the page
- * (any live atom at the current hash makes it "already extracted") and this
- * run's `pending:` rows wait for the next edit to that page instead of the
- * next run. That window is the flip's own pre-existing crash window widened by
- * two statements, it strands nothing that a later pass cannot reclaim (a
- * `pending:` row is explicitly eligible here), and closing it properly means
- * teaching discovery about incomplete runs — a change to the phase's
- * eligibility rule, not to this reconciler.
+ * Revert-recovery requires the page's old hash to be fully released: discovery
+ * skips content when any live atom already carries its hash. Retirement is
+ * therefore deferred until every other stale-bound atom can be re-verified
+ * against the current content at extraction standard. A missing/unverified
+ * quote, fold-only match, ambiguous locator, or insufficient retirement
+ * evidence is a BLOCKER. Any blocker means no retirement and no re-anchoring
+ * for this page; the original atoms remain live even after a revert. Runs with
+ * no retirement also leave keeper bindings alone.
+ *
+ * The provisional→real hash flip shares the reconciliation transaction,
+ * ordered flip → retire → re-anchor. A failure anywhere rolls all three back,
+ * leaving imported atoms pending and the page retryable.
  *
  * Revival after a revert is in-place for atoms at the current deterministic
  * slug. A pre-#4733 LEGACY-slug atom is re-minted at the new-format slug
@@ -155,11 +145,11 @@ function normForRetirement(s: string): string {
  * whole judgement inside a transaction that holds a `FOR UPDATE` row lock on
  * the source page, so an edit cannot land between the evidence check and the
  * soft-delete either. Pages with nothing to retire — the overwhelming majority
- * — never open a transaction, so the batch phase keeps paying one SELECT.
+ * — pay one SELECT plus only the completion flip transaction when needed.
  *
  * Soft-delete via `softDeletePages`, so rows stay recoverable inside the usual
  * purge window rather than being destroyed. Returns how many rows were
- * actually flipped active → soft-deleted and how many were re-anchored.
+ * actually flipped active → soft-deleted, re-anchored, or blocked retirement.
  * `dryRun` runs the SELECT only and returns the would-be counts without
  * touching a row.
  *
@@ -173,6 +163,7 @@ interface SupersedeArgs {
   currentContent: string;
   keepSlugs: string[];
   dryRun: boolean;
+  flip?: (tx: BrainEngine) => Promise<void>;
 }
 
 /** One page's stale-bound atoms, split by what the current content says. */
@@ -180,7 +171,8 @@ interface Verdict {
   /** Verified quote no longer in the page → soft-delete. */
   retire: string[];
   /** Verified quote still in the page → repoint at the current hash. */
-  reanchor: string[];
+  reanchor: Array<{ slug: string; start: number; end: number }>;
+  blocked: number;
 }
 
 /**
@@ -221,23 +213,18 @@ async function classifyStaleAtoms(
   // the permissive retirement one (cosmetic edits are not deletions).
   const currentStrict = normForGrounding(args.currentContent);
   const currentFolded = normForRetirement(args.currentContent);
-  const verdict: Verdict = { retire: [], reanchor: [] };
+  const verdict: Verdict = { retire: [], reanchor: [], blocked: 0 };
   for (const r of rows) {
-    // No verified quote → no evidence in either direction: neither retire nor
-    // re-anchor, so the row keeps whatever binding it has.
-    if (r.verified !== 'true' || !r.quote) continue;
+    if (r.verified !== 'true' || !r.quote) { verdict.blocked++; continue; }
+    const loc = locateQuote(args.currentContent, r.quote);
+    if (loc) { verdict.reanchor.push({ slug: r.slug, ...loc }); continue; }
     const strict = normForGrounding(r.quote);
     const folded = normForRetirement(r.quote);
-    if (Math.min(strict.length, folded.length) < MIN_RETIREMENT_QUOTE_CHARS) continue;
-    // Verbatim-present under the strict fold: strong enough to REBIND the row.
-    if (currentStrict.includes(strict)) { verdict.reanchor.push(r.slug); continue; }
-    // Present only under the permissive fold: strong enough to KEEP the row,
-    // not to restate its provenance. That fold is deliberately lossy (it drops
-    // `_`, and NFKC rewrites `x²` to `x2`), so a match can mean the page still
-    // carries the claim OR that an edit changed a token the fold erased. Keep
-    // — the destructive direction needs the evidence — but leave the binding
-    // alone so `atom_provenance_drift` still reports the row.
-    if (currentFolded.includes(folded)) continue;
+    if (Math.min(strict.length, folded.length) < MIN_RETIREMENT_QUOTE_CHARS
+      || currentStrict.includes(strict) || currentFolded.includes(folded)) {
+      verdict.blocked++;
+      continue;
+    }
     verdict.retire.push(r.slug);
   }
   return verdict;
@@ -246,27 +233,32 @@ async function classifyStaleAtoms(
 /**
  * Repoint kept-but-stale atoms at the hash just reconciled. Runs INSIDE the
  * retirement transaction (same row locks, same all-or-nothing rollback), and
- * touches only `frontmatter.source_hash` — not `updated_at`, matching
+ * refreshes the hash, quote offsets and verification — not `updated_at`, matching
  * `softDeletePages`, so a reconciliation does not read downstream as a content
  * edit. Returns the rows actually repointed.
  */
 async function reanchorAtoms(
   tx: BrainEngine,
   args: SupersedeArgs,
-  slugs: string[],
+  anchors: Verdict['reanchor'],
 ): Promise<number> {
   let moved = 0;
-  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
+  for (let i = 0; i < anchors.length; i += DELETE_BATCH_SIZE) {
+    const batch = anchors.slice(i, i + DELETE_BATCH_SIZE);
     const rows = await tx.executeRaw<{ slug: string }>(
       `UPDATE pages
-          SET frontmatter = frontmatter || jsonb_build_object('source_hash', $3::text)
+          SET frontmatter = frontmatter || jsonb_build_object('source_hash', $3::text,
+                'source_quote_offset', jsonb_build_array(loc.start_offset, loc.end_offset),
+                'source_quote_verified', true)
+         FROM unnest($4::text[], $5::int[], $6::int[]) AS loc(slug, start_offset, end_offset)
         WHERE source_id = $1
           AND type = 'atom'
           AND deleted_at IS NULL
           AND frontmatter->>'source_slug' = $2
-          AND slug = ANY($4::text[])
-        RETURNING slug`,
-      [args.sourceId, args.pageSlug, args.hash16, slugs.slice(i, i + DELETE_BATCH_SIZE)],
+          AND pages.slug = loc.slug
+        RETURNING pages.slug`,
+      [args.sourceId, args.pageSlug, args.hash16, batch.map(a => a.slug),
+        batch.map(a => a.start), batch.map(a => a.end)],
     );
     moved += rows.length;
   }
@@ -276,27 +268,26 @@ async function reanchorAtoms(
 export interface ReconcileCounts {
   superseded: number;
   reanchored: number;
+  blocked: number;
 }
 
-const NOTHING: ReconcileCounts = { superseded: 0, reanchored: 0 };
+const NOTHING: ReconcileCounts = { superseded: 0, reanchored: 0, blocked: 0 };
 
 async function supersedeStaleAtomsForPage(
   engine: BrainEngine,
   args: SupersedeArgs,
 ): Promise<ReconcileCounts> {
+  const initial = await classifyStaleAtoms(engine, args);
   if (args.dryRun) {
-    const would = await classifyStaleAtoms(engine, args);
-    // Report the same coupling a real run applies: no retirement, no
-    // re-anchoring.
-    return would.retire.length === 0
-      ? NOTHING
-      : { superseded: would.retire.length, reanchored: would.reanchor.length };
+    return initial.blocked > 0 || initial.retire.length === 0
+      ? { ...NOTHING, blocked: initial.blocked }
+      : { superseded: initial.retire.length, reanchored: initial.reanchor.length, blocked: 0 };
   }
-  // Fast path first: the overwhelming majority of re-extracted pages have
-  // nothing to retire, and this is a batch phase — one plain SELECT per page,
-  // no transaction. Only a page that actually has candidates pays for the
-  // locked re-check below.
-  if ((await classifyStaleAtoms(engine, args)).retire.length === 0) return NOTHING;
+  // No retirement possible: only the completion flip needs a transaction.
+  if (initial.retire.length === 0 || initial.blocked > 0) {
+    if (args.flip) await engine.transaction(args.flip);
+    return { ...NOTHING, blocked: initial.blocked };
+  }
   return engine.transaction(async (tx) => {
     // Take the "page still carries hash16" gate as a row lock: a concurrent
     // edit to this page now waits for the commit below instead of slipping in
@@ -308,13 +299,17 @@ async function supersedeStaleAtomsForPage(
         FOR UPDATE`,
       [args.sourceId, args.pageSlug, args.hash16],
     );
-    if (held.length === 0) return NOTHING;
+    if (held.length === 0) {
+      await args.flip?.(tx);
+      return NOTHING;
+    }
     // Re-derived under the lock, not reused from the fast path: the lock is
     // what makes this list current.
-    const { retire, reanchor } = await classifyStaleAtoms(tx, args, true);
+    const { retire, reanchor, blocked } = await classifyStaleAtoms(tx, args, true);
+    await args.flip?.(tx);
     // The lock may have revealed that nothing is unsupported after all —
     // then this is a no-op run and the kept atoms' bindings stay put.
-    if (retire.length === 0) return NOTHING;
+    if (retire.length === 0 || blocked > 0) return { ...NOTHING, blocked };
     // softDeletePages is a single-batch primitive — oversized input throws.
     let superseded = 0;
     for (let i = 0; i < retire.length; i += DELETE_BATCH_SIZE) {
@@ -323,32 +318,32 @@ async function supersedeStaleAtomsForPage(
       });
       superseded += flipped.length;
     }
-    return { superseded, reanchored: await reanchorAtoms(tx, args, reanchor) };
+    return { superseded, reanchored: await reanchorAtoms(tx, args, reanchor), blocked: 0 };
   });
 }
 
 /**
- * Bind the reconciler to one phase run. The returned function is a no-op for
- * transcript items (a transcript is a file, not a page, so nothing is bound to
- * it) and otherwise returns how many of the page's atoms were retired and how
- * many were re-anchored.
+ * Bind the reconciler to one phase run. Transcript items only run the supplied
+ * completion flip (a transcript is a file, not a page, so nothing is bound to
+ * it). Page items return retired, re-anchored and blocker counts.
  *
- * It is allowed to THROW: callers must run it before the item's completion
- * markers, on the same footing as the provenance-edge flush. Both markers (the
- * `source_hash` flip and `atoms_scan_hash`) make the page undiscoverable for
- * this content, so a reconciliation that failed after them could never be
- * retried; failing first leaves the provisional hashes in place and the next
- * run redoes the whole item.
+ * It is allowed to THROW. The caller supplies the completion flip so it
+ * commits atomically with retirement and re-anchoring, then stamps the page
+ * only after this function succeeds. Dry-run never invokes the flip.
  */
 export function createAtomReconciler(engine: BrainEngine, sourceId: string, dryRun: boolean) {
   return async (
     item: { kind: string; slug?: string; content: string; contentHash: string },
     keepSlugs: string[],
+    flip?: (tx: BrainEngine) => Promise<void>,
   ): Promise<ReconcileCounts> => {
-    if (item.kind !== 'page' || !item.slug) return NOTHING;
+    if (item.kind !== 'page' || !item.slug) {
+      if (!dryRun) await flip?.(engine);
+      return NOTHING;
+    }
     return supersedeStaleAtomsForPage(engine, {
       sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
-      currentContent: item.content, keepSlugs, dryRun,
+      currentContent: item.content, keepSlugs, dryRun, flip,
     });
   };
 }

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -49,7 +49,11 @@ function normForRetirement(s: string): string {
       .replace(/^[ \t]*(?:>[ \t]?)+/gm, '')                 // blockquote markers
       .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')                 // ATX headings
       .replace(/^[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+/gm, '')  // list bullets
-      .replace(/!?\[([^\]\n]*)\]\([^)\n]*\)/g, '$1')        // [text](url) → text
+      // [text](url) → text. The destination may carry ONE level of balanced
+      // parentheses (`https://x/a_(b)`, a common wiki-style URL shape); without
+      // that allowance the fold stopped at the inner `)` and left a stray `)`
+      // in the page text, so a supported quote read as absent and was retired.
+      .replace(/!?\[([^\]\n]*)\]\((?:[^()\n]|\([^()\n]*\))*\)/g, '$1')
       .replace(/<((?:https?|mailto):[^>\s]+)>/g, '$1')      // <url> → url
       .replace(/[`*_~]/g, ''),                              // emphasis / code marks
   );

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -50,6 +50,14 @@ import { normForGrounding } from './synthesize-verify.ts';
  * whole page rather than the model's truncated cut. Both choices err toward
  * "still present", i.e. toward keeping the atom.
  *
+ * `currentContent` is the snapshot the phase read before the model call, so
+ * the query is gated on the live page STILL carrying `hash16`: if the page was
+ * edited while the model was thinking, the snapshot no longer describes it and
+ * the whole reconciliation yields nothing rather than judging a claim against
+ * text that has moved. (A write landing between this SELECT and the
+ * soft-delete below is still possible; the soft-delete is recoverable inside
+ * the purge window, and the edit re-eligibilizes the page for extraction.)
+ *
  * Soft-delete via `softDeletePages`, so rows stay recoverable inside the usual
  * purge window rather than being destroyed. Returns the number of rows
  * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
@@ -58,7 +66,7 @@ import { normForGrounding } from './synthesize-verify.ts';
  * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
  * out of scope: this only ever runs for a page that was just re-extracted.
  */
-export async function supersedeStaleAtomsForPage(
+async function supersedeStaleAtomsForPage(
   engine: BrainEngine,
   args: {
     sourceId: string;
@@ -81,7 +89,12 @@ export async function supersedeStaleAtomsForPage(
         AND frontmatter->>'source_hash' IS NOT NULL
         AND frontmatter->>'source_hash' NOT LIKE 'pending:%'
         AND frontmatter->>'source_hash' <> $3
-        AND NOT (slug = ANY($4::text[]))`,
+        AND NOT (slug = ANY($4::text[]))
+        AND EXISTS (
+          SELECT 1 FROM pages p
+           WHERE p.source_id = $1 AND p.slug = $2 AND p.deleted_at IS NULL
+             AND substring(p.content_hash from 1 for 16) = $3
+        )`,
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
   const currentNorm = normForGrounding(args.currentContent);
@@ -98,4 +111,29 @@ export async function supersedeStaleAtomsForPage(
     superseded += flipped.length;
   }
   return superseded;
+}
+
+/**
+ * Bind the reconciler to one phase run. The returned function is a no-op for
+ * transcript items (a transcript is a file, not a page, so nothing is bound to
+ * it) and otherwise returns how many of the page's atoms were retired.
+ *
+ * It is allowed to THROW: callers must run it before the item's completion
+ * markers, on the same footing as the provenance-edge flush. Both markers (the
+ * `source_hash` flip and `atoms_scan_hash`) make the page undiscoverable for
+ * this content, so a reconciliation that failed after them could never be
+ * retried; failing first leaves the provisional hashes in place and the next
+ * run redoes the whole item.
+ */
+export function createAtomReconciler(engine: BrainEngine, sourceId: string, dryRun: boolean) {
+  return async (
+    item: { kind: string; slug?: string; content: string; contentHash: string },
+    keepSlugs: string[],
+  ): Promise<number> => {
+    if (item.kind !== 'page' || !item.slug) return 0;
+    return supersedeStaleAtomsForPage(engine, {
+      sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
+      currentContent: item.content, keepSlugs, dryRun,
+    });
+  };
 }

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -1,38 +1,57 @@
-// Peeled out of extract-atoms.ts: the page lane's stale-atom
-// reconciliation, kept in its own module so the phase file stays under
-// the module-size ratchet.
+// Peeled out of extract-atoms.ts: the page lane's stale-atom reconciliation,
+// kept in its own module so the phase file stays under the module-size
+// ratchet.
 
 import type { BrainEngine } from '../engine.ts';
 import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
+import { normForGrounding } from './synthesize-verify.ts';
 
 /**
- * #4566 follow-through — supersede the atoms a re-extracted page has replaced.
+ * #4566 follow-through — reclaim the atoms a re-extracted page has invalidated.
  *
  * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
- * no longer matches any live page and is explicitly diagnostic: it never
- * deletes. Its larger bucket (`source_changed` — the source page still exists,
- * it was merely edited) had nothing to reclaim it. Re-extraction upserts an
- * atom in place only when the new pass produces the SAME title; a reworded
- * claim lands on a new deterministic slug and the old atom stays behind,
- * still searchable, still carrying a `source_quote` no current page contains.
+ * matches no live page and is explicitly diagnostic: it never deletes. Its
+ * larger bucket (`source_changed` — the source page still exists, it was
+ * merely edited) had nothing to reclaim it. Re-extraction upserts an atom in
+ * place only when the new pass produces the SAME title; a reworded claim
+ * lands on a new deterministic slug and the old atom stays behind, still
+ * searchable, still carrying a `source_quote` no current page contains.
  *
- * This reconciles ONE page's atom set at the moment its replacement set has
- * been imported and stamped with the current hash. An atom is superseded only
- * when ALL of these hold:
+ * OMISSION IS NOT EVIDENCE. The extractor sees a truncated cut of the page and
+ * is asked for a handful of atoms, so "this atom is not in the new set" does
+ * NOT mean the claim is gone — the same page can legitimately yield a
+ * different selection on the next pass. Deleting on omission alone would
+ * destroy still-valid atoms (soft-deletes are purged after the recovery
+ * window). So the gate is the same evidence the doctor check reports on: the
+ * atom's own VERIFIED quote can no longer be found in the page's current
+ * content. Everything else is left alone.
+ *
+ * An atom is superseded only when ALL of these hold:
  *   - `type = 'atom'`, live, in the SAME source as the write;
  *   - `source_slug` EQUALS this page's slug. This is the strict subset of
- *     `isCompatibleAtomBinding`: that predicate also adopts a pre-binding-era
- *     row (no `source_slug`/`source_path`) for upsert, but such a row is not
- *     bound to THIS page, so it is never reaped. Transcript-lane atoms carry
- *     `source_path` and no `source_slug`, so they cannot match either;
+ *     extract-atoms' `isCompatibleAtomBinding`: that predicate also adopts a
+ *     pre-binding-era row (no `source_slug`/`source_path`) for upsert, but
+ *     such a row is not bound to THIS page, so it is never reaped.
+ *     Transcript-lane atoms carry `source_path` and no `source_slug`, so they
+ *     cannot match either;
  *   - `source_hash` is present, is not the in-flight `pending:` marker, and
  *     differs from the page's current hash16 — the page's OWN current content
  *     is the staleness authority, judged inside the run that just wrote it;
- *   - the slug was NOT written by this run for this page (the `keepSlugs`
- *     exclusion) — a same-title atom is refreshed in place, not superseded.
+ *   - the slug was NOT written by this run for this page (`keepSlugs`) — a
+ *     same-title atom is refreshed in place, not superseded;
+ *   - the atom carries `source_quote_verified: true` AND that quote is absent
+ *     from `currentContent`. Atoms with no quote, or with a quote that was
+ *     never verified against its source (pre-#4706 rows, `quote_unverified`
+ *     paraphrases), carry no evidence either way and are never reaped.
  *
- * Soft-delete via `softDeletePages`, so the rows stay recoverable inside the
- * usual purge window rather than being destroyed. Returns the number of rows
+ * Presence is a plain normalized-containment test over the page's FULL current
+ * content — deliberately looser than extract-atoms' `locateQuote` (which also
+ * demands character-aligned boundaries and uniqueness) and applied to the
+ * whole page rather than the model's truncated cut. Both choices err toward
+ * "still present", i.e. toward keeping the atom.
+ *
+ * Soft-delete via `softDeletePages`, so rows stay recoverable inside the usual
+ * purge window rather than being destroyed. Returns the number of rows
  * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
  * returns the would-be count without touching a row.
  *
@@ -41,10 +60,19 @@ import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
  */
 export async function supersedeStaleAtomsForPage(
   engine: BrainEngine,
-  args: { sourceId: string; pageSlug: string; hash16: string; keepSlugs: string[]; dryRun: boolean },
+  args: {
+    sourceId: string;
+    pageSlug: string;
+    hash16: string;
+    currentContent: string;
+    keepSlugs: string[];
+    dryRun: boolean;
+  },
 ): Promise<number> {
-  const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT slug
+  const rows = await engine.executeRaw<{ slug: string; quote: string | null; verified: string | null }>(
+    `SELECT slug,
+            frontmatter->>'source_quote' AS quote,
+            frontmatter->>'source_quote_verified' AS verified
        FROM pages
       WHERE source_id = $1
         AND type = 'atom'
@@ -56,7 +84,10 @@ export async function supersedeStaleAtomsForPage(
         AND NOT (slug = ANY($4::text[]))`,
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
-  const slugs = rows.map(r => r.slug);
+  const currentNorm = normForGrounding(args.currentContent);
+  const slugs = rows
+    .filter(r => r.verified === 'true' && !!r.quote && !currentNorm.includes(normForGrounding(r.quote)))
+    .map(r => r.slug);
   if (args.dryRun || slugs.length === 0) return slugs.length;
   // softDeletePages is a single-batch primitive — oversized input throws.
   let superseded = 0;

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -80,8 +80,18 @@ interface SupersedeArgs {
   dryRun: boolean;
 }
 
-/** The evidence query: which of this page's atoms its current text no longer supports. */
-async function findUnsupportedAtoms(engine: BrainEngine, args: SupersedeArgs): Promise<string[]> {
+/**
+ * The evidence query: which of this page's atoms its current text no longer
+ * supports. `lock` adds `FOR UPDATE` so the transactional pass holds the
+ * candidate atom rows themselves — otherwise a concurrent import could refresh
+ * an atom's quote between the judgement and the soft-delete, and the delete
+ * (which matches on slug alone) would retire a row that is supported again.
+ */
+async function findUnsupportedAtoms(
+  engine: BrainEngine,
+  args: SupersedeArgs,
+  lock = false,
+): Promise<string[]> {
   const rows = await engine.executeRaw<{ slug: string; quote: string | null; verified: string | null }>(
     `SELECT slug,
             frontmatter->>'source_quote' AS quote,
@@ -99,7 +109,7 @@ async function findUnsupportedAtoms(engine: BrainEngine, args: SupersedeArgs): P
           SELECT 1 FROM pages p
            WHERE p.source_id = $1 AND p.slug = $2 AND p.deleted_at IS NULL
              AND substring(p.content_hash from 1 for 16) = $3
-        )`,
+        )${lock ? '\n        FOR UPDATE' : ''}`,
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
   const currentNorm = normForGrounding(args.currentContent);
@@ -132,7 +142,7 @@ async function supersedeStaleAtomsForPage(
     if (held.length === 0) return 0;
     // Re-derived under the lock, not reused from the fast path: the lock is
     // what makes this list current.
-    const slugs = await findUnsupportedAtoms(tx, args);
+    const slugs = await findUnsupportedAtoms(tx, args, true);
     // softDeletePages is a single-batch primitive — oversized input throws.
     let superseded = 0;
     for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -34,9 +34,12 @@ import { normForGrounding } from './synthesize-verify.ts';
  *     such a row is not bound to THIS page, so it is never reaped.
  *     Transcript-lane atoms carry `source_path` and no `source_slug`, so they
  *     cannot match either;
- *   - `source_hash` is present, is not the in-flight `pending:` marker, and
- *     differs from the page's current hash16 — the page's OWN current content
- *     is the staleness authority, judged inside the run that just wrote it;
+ *   - `source_hash` is present and is neither the page's current hash16 nor
+ *     THIS run's in-flight `pending:<hash16>` marker — the page's OWN current
+ *     content is the staleness authority, judged inside the run that just
+ *     wrote it. A `pending:` row left behind by an INTERRUPTED earlier run is
+ *     deliberately eligible: nothing else ever reclaims it, and it is judged
+ *     on the same quote evidence as any other row;
  *   - the slug was NOT written by this run for this page (`keepSlugs`) — a
  *     same-title atom is refreshed in place, not superseded;
  *   - the atom carries `source_quote_verified: true` AND that quote is absent
@@ -51,12 +54,14 @@ import { normForGrounding } from './synthesize-verify.ts';
  * "still present", i.e. toward keeping the atom.
  *
  * `currentContent` is the snapshot the phase read before the model call, so
- * the query is gated on the live page STILL carrying `hash16`: if the page was
+ * the work is gated on the live page STILL carrying `hash16`: if the page was
  * edited while the model was thinking, the snapshot no longer describes it and
- * the whole reconciliation yields nothing rather than judging a claim against
- * text that has moved. (A write landing between this SELECT and the
- * soft-delete below is still possible; the soft-delete is recoverable inside
- * the purge window, and the edit re-eligibilizes the page for extraction.)
+ * the reconciliation yields nothing rather than judging a claim against text
+ * that has moved. When there IS something to retire, the write re-runs the
+ * whole judgement inside a transaction that holds a `FOR UPDATE` row lock on
+ * the source page, so an edit cannot land between the evidence check and the
+ * soft-delete either. Pages with nothing to retire — the overwhelming majority
+ * — never open a transaction, so the batch phase keeps paying one SELECT.
  *
  * Soft-delete via `softDeletePages`, so rows stay recoverable inside the usual
  * purge window rather than being destroyed. Returns the number of rows
@@ -66,17 +71,17 @@ import { normForGrounding } from './synthesize-verify.ts';
  * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
  * out of scope: this only ever runs for a page that was just re-extracted.
  */
-async function supersedeStaleAtomsForPage(
-  engine: BrainEngine,
-  args: {
-    sourceId: string;
-    pageSlug: string;
-    hash16: string;
-    currentContent: string;
-    keepSlugs: string[];
-    dryRun: boolean;
-  },
-): Promise<number> {
+interface SupersedeArgs {
+  sourceId: string;
+  pageSlug: string;
+  hash16: string;
+  currentContent: string;
+  keepSlugs: string[];
+  dryRun: boolean;
+}
+
+/** The evidence query: which of this page's atoms its current text no longer supports. */
+async function findUnsupportedAtoms(engine: BrainEngine, args: SupersedeArgs): Promise<string[]> {
   const rows = await engine.executeRaw<{ slug: string; quote: string | null; verified: string | null }>(
     `SELECT slug,
             frontmatter->>'source_quote' AS quote,
@@ -87,7 +92,7 @@ async function supersedeStaleAtomsForPage(
         AND deleted_at IS NULL
         AND frontmatter->>'source_slug' = $2
         AND frontmatter->>'source_hash' IS NOT NULL
-        AND frontmatter->>'source_hash' NOT LIKE 'pending:%'
+        AND frontmatter->>'source_hash' <> ('pending:' || $3)
         AND frontmatter->>'source_hash' <> $3
         AND NOT (slug = ANY($4::text[]))
         AND EXISTS (
@@ -98,19 +103,46 @@ async function supersedeStaleAtomsForPage(
     [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
   );
   const currentNorm = normForGrounding(args.currentContent);
-  const slugs = rows
+  return rows
     .filter(r => r.verified === 'true' && !!r.quote && !currentNorm.includes(normForGrounding(r.quote)))
     .map(r => r.slug);
-  if (args.dryRun || slugs.length === 0) return slugs.length;
-  // softDeletePages is a single-batch primitive — oversized input throws.
-  let superseded = 0;
-  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
-    const flipped = await engine.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
-      sourceId: args.sourceId,
-    });
-    superseded += flipped.length;
-  }
-  return superseded;
+}
+
+async function supersedeStaleAtomsForPage(
+  engine: BrainEngine,
+  args: SupersedeArgs,
+): Promise<number> {
+  if (args.dryRun) return (await findUnsupportedAtoms(engine, args)).length;
+  // Fast path first: the overwhelming majority of re-extracted pages have
+  // nothing to retire, and this is a batch phase — one plain SELECT per page,
+  // no transaction. Only a page that actually has candidates pays for the
+  // locked re-check below.
+  if ((await findUnsupportedAtoms(engine, args)).length === 0) return 0;
+  return engine.transaction(async (tx) => {
+    // Take the "page still carries hash16" gate as a row lock: a concurrent
+    // edit to this page now waits for the commit below instead of slipping in
+    // between the evidence check and the soft-delete.
+    const held = await tx.executeRaw<{ ok: number }>(
+      `SELECT 1 AS ok FROM pages
+        WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL
+          AND substring(content_hash from 1 for 16) = $3
+        FOR UPDATE`,
+      [args.sourceId, args.pageSlug, args.hash16],
+    );
+    if (held.length === 0) return 0;
+    // Re-derived under the lock, not reused from the fast path: the lock is
+    // what makes this list current.
+    const slugs = await findUnsupportedAtoms(tx, args);
+    // softDeletePages is a single-batch primitive — oversized input throws.
+    let superseded = 0;
+    for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
+      const flipped = await tx.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
+        sourceId: args.sourceId,
+      });
+      superseded += flipped.length;
+    }
+    return superseded;
+  });
 }
 
 /**

--- a/src/core/cycle/extract-atoms-supersede.ts
+++ b/src/core/cycle/extract-atoms-supersede.ts
@@ -1,0 +1,70 @@
+// Peeled out of extract-atoms.ts: the page lane's stale-atom
+// reconciliation, kept in its own module so the phase file stays under
+// the module-size ratchet.
+
+import type { BrainEngine } from '../engine.ts';
+import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
+
+/**
+ * #4566 follow-through — supersede the atoms a re-extracted page has replaced.
+ *
+ * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
+ * no longer matches any live page and is explicitly diagnostic: it never
+ * deletes. Its larger bucket (`source_changed` — the source page still exists,
+ * it was merely edited) had nothing to reclaim it. Re-extraction upserts an
+ * atom in place only when the new pass produces the SAME title; a reworded
+ * claim lands on a new deterministic slug and the old atom stays behind,
+ * still searchable, still carrying a `source_quote` no current page contains.
+ *
+ * This reconciles ONE page's atom set at the moment its replacement set has
+ * been imported and stamped with the current hash. An atom is superseded only
+ * when ALL of these hold:
+ *   - `type = 'atom'`, live, in the SAME source as the write;
+ *   - `source_slug` EQUALS this page's slug. This is the strict subset of
+ *     `isCompatibleAtomBinding`: that predicate also adopts a pre-binding-era
+ *     row (no `source_slug`/`source_path`) for upsert, but such a row is not
+ *     bound to THIS page, so it is never reaped. Transcript-lane atoms carry
+ *     `source_path` and no `source_slug`, so they cannot match either;
+ *   - `source_hash` is present, is not the in-flight `pending:` marker, and
+ *     differs from the page's current hash16 — the page's OWN current content
+ *     is the staleness authority, judged inside the run that just wrote it;
+ *   - the slug was NOT written by this run for this page (the `keepSlugs`
+ *     exclusion) — a same-title atom is refreshed in place, not superseded.
+ *
+ * Soft-delete via `softDeletePages`, so the rows stay recoverable inside the
+ * usual purge window rather than being destroyed. Returns the number of rows
+ * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
+ * returns the would-be count without touching a row.
+ *
+ * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
+ * out of scope: this only ever runs for a page that was just re-extracted.
+ */
+export async function supersedeStaleAtomsForPage(
+  engine: BrainEngine,
+  args: { sourceId: string; pageSlug: string; hash16: string; keepSlugs: string[]; dryRun: boolean },
+): Promise<number> {
+  const rows = await engine.executeRaw<{ slug: string }>(
+    `SELECT slug
+       FROM pages
+      WHERE source_id = $1
+        AND type = 'atom'
+        AND deleted_at IS NULL
+        AND frontmatter->>'source_slug' = $2
+        AND frontmatter->>'source_hash' IS NOT NULL
+        AND frontmatter->>'source_hash' NOT LIKE 'pending:%'
+        AND frontmatter->>'source_hash' <> $3
+        AND NOT (slug = ANY($4::text[]))`,
+    [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
+  );
+  const slugs = rows.map(r => r.slug);
+  if (args.dryRun || slugs.length === 0) return slugs.length;
+  // softDeletePages is a single-batch primitive — oversized input throws.
+  let superseded = 0;
+  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
+    const flipped = await engine.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
+      sourceId: args.sourceId,
+    });
+    superseded += flipped.length;
+  }
+  return superseded;
+}

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -72,7 +72,7 @@ import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budg
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
-import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
+import { supersedeStaleAtomsForPage } from './extract-atoms-supersede.ts';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import { normalizeForGrounding } from './synthesize-verify.ts';
@@ -528,70 +528,6 @@ export async function atomsExistingForHashes(
     console.error(`[extract_atoms] batch idempotency check failed (assuming none extracted): ${msg}`);
     return new Set();
   }
-}
-
-/**
- * #4566 follow-through — supersede the atoms a re-extracted page has replaced.
- *
- * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
- * no longer matches any live page and is explicitly diagnostic: it never
- * deletes. Its larger bucket (`source_changed` — the source page still exists,
- * it was merely edited) had nothing to reclaim it. Re-extraction upserts an
- * atom in place only when the new pass produces the SAME title; a reworded
- * claim lands on a new deterministic slug and the old atom stays behind,
- * still searchable, still carrying a `source_quote` no current page contains.
- *
- * This reconciles ONE page's atom set at the moment its replacement set has
- * been imported and stamped with the current hash. An atom is superseded only
- * when ALL of these hold:
- *   - `type = 'atom'`, live, in the SAME source as the write;
- *   - `source_slug` EQUALS this page's slug. This is the strict subset of
- *     `isCompatibleAtomBinding`: that predicate also adopts a pre-binding-era
- *     row (no `source_slug`/`source_path`) for upsert, but such a row is not
- *     bound to THIS page, so it is never reaped. Transcript-lane atoms carry
- *     `source_path` and no `source_slug`, so they cannot match either;
- *   - `source_hash` is present, is not the in-flight `pending:` marker, and
- *     differs from the page's current hash16 — the page's OWN current content
- *     is the staleness authority, judged inside the run that just wrote it;
- *   - the slug was NOT written by this run for this page (the `keepSlugs`
- *     exclusion) — a same-title atom is refreshed in place, not superseded.
- *
- * Soft-delete via `softDeletePages`, so the rows stay recoverable inside the
- * usual purge window rather than being destroyed. Returns the number of rows
- * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
- * returns the would-be count without touching a row.
- *
- * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
- * out of scope: this only ever runs for a page that was just re-extracted.
- */
-async function supersedeStaleAtomsForPage(
-  engine: BrainEngine,
-  args: { sourceId: string; pageSlug: string; hash16: string; keepSlugs: string[]; dryRun: boolean },
-): Promise<number> {
-  const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT slug
-       FROM pages
-      WHERE source_id = $1
-        AND type = 'atom'
-        AND deleted_at IS NULL
-        AND frontmatter->>'source_slug' = $2
-        AND frontmatter->>'source_hash' IS NOT NULL
-        AND frontmatter->>'source_hash' NOT LIKE 'pending:%'
-        AND frontmatter->>'source_hash' <> $3
-        AND NOT (slug = ANY($4::text[]))`,
-    [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
-  );
-  const slugs = rows.map(r => r.slug);
-  if (args.dryRun || slugs.length === 0) return slugs.length;
-  // softDeletePages is a single-batch primitive — oversized input throws.
-  let superseded = 0;
-  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
-    const flipped = await engine.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
-      sourceId: args.sourceId,
-    });
-    superseded += flipped.length;
-  }
-  return superseded;
 }
 
 /**
@@ -1149,12 +1085,10 @@ export async function runPhaseExtractAtoms(
           [hash16, sourceId, importedSlugs],
         );
         // #4566 follow-through: the replacement set is live and stamped, so
-        // whatever this page's PREVIOUS content produced is now superseded.
-        // Runs after the flip, so the rows just written carry the current
-        // hash and are excluded by the predicate as well as by keepSlugs.
-        // Best-effort, like the receipt/rollup writers below: the extraction
-        // itself already committed, and reconciliation converges on the next
-        // re-extraction, so a failure here must not fail the item.
+        // this page's PREVIOUS atoms are now superseded. AFTER the flip on
+        // purpose (the rows just written already carry the current hash).
+        // Best-effort like the receipt/rollup writers below — the extraction
+        // committed, and reconciliation converges on the next re-extraction.
         if (item.kind === 'page') {
           try {
             atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
@@ -1165,16 +1099,13 @@ export async function runPhaseExtractAtoms(
               `[extract_atoms] supersede stale atoms failed for ${item.slug}: ${(err as Error).message}`,
             );
           }
-        }
-        if (item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
-        // Report-only twin of the reconciliation above. resolvePageAtomSlug is
-        // read-only, so the would-be write set can be resolved under dry-run —
-        // without it the count would include atoms a real run would refresh in
-        // place rather than supersede.
+        // Report-only twin of the above. resolvePageAtomSlug is read-only, so
+        // the would-be write set resolves under dry-run too — without it the
+        // count would include atoms a real run refreshes in place.
         if (item.kind === 'page') {
           try {
             const wouldWrite: string[] = [];
@@ -1182,11 +1113,8 @@ export async function runPhaseExtractAtoms(
               wouldWrite.push(await resolvePageAtomSlug(engine, atom.title, item.slug, sourceId));
             }
             atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
-              sourceId,
-              pageSlug: item.slug,
-              hash16: item.contentHash.slice(0, 16),
-              keepSlugs: wouldWrite,
-              dryRun: true,
+              sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
+              keepSlugs: wouldWrite, dryRun: true,
             });
           } catch (err) {
             console.error(

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -72,7 +72,7 @@ import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budg
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
-import { supersedeStaleAtomsForPage } from './extract-atoms-supersede.ts';
+import { createAtomReconciler } from './extract-atoms-supersede.ts';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import { normalizeForGrounding } from './synthesize-verify.ts';
@@ -882,28 +882,10 @@ export async function runPhaseExtractAtoms(
     }
   }
 
-  /**
-   * #4566 follow-through: reclaim atoms this page's CURRENT content no longer
-   * supports (evidence rule: see supersedeStaleAtomsForPage). Gets the FULL
-   * item content, not the model's cut. A failure lands in `failures` instead
-   * of throwing: the extraction committed, but the page is not re-discovered
-   * for this hash, so a silent log would hide a reconciliation that never ran.
-   */
-  async function reconcilePageAtoms(
-    item: { kind: string; slug?: string; content: string; contentHash: string },
-    keepSlugs: string[],
-  ): Promise<void> {
-    if (item.kind !== 'page' || !item.slug) return;
-    try {
-      atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
-        sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
-        currentContent: item.content, keepSlugs, dryRun: opts.dryRun === true,
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      failures.push({ source: item.slug, error: `atom reconciliation failed: ${msg}` });
-    }
-  }
+  // #4566 follow-through: retire the atoms a page's CURRENT content no longer
+  // supports. Evidence rule, throw-before-the-completion-markers contract and
+  // dry-run semantics all live in the reconciler module.
+  const reconcileAtoms = createAtomReconciler(engine, sourceId, opts.dryRun === true);
 
   await withBudgetTracker(budgetTracker, async () => {
   for (const item of work) {
@@ -979,14 +961,14 @@ export async function runPhaseExtractAtoms(
         // Only stamped after a SUCCESSFUL chat call — LLM failures take the
         // catch path below and stay retryable, and malformed output is
         // counted above (gbrain#4148), never stamped as success.
+        // Before the stamp: an edit that removed every extractable claim must
+        // still retire the atoms whose quotes it deleted, and a failure here
+        // has to leave the page unstamped so the next run retries. Nothing was
+        // written, so nothing is exempt.
+        atomsSuperseded += await reconcileAtoms(item, []);
         if (!opts.dryRun && item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
-        // Stamped done, so this is the page's last reconciliation chance for
-        // this content: an edit that removed every extractable claim must
-        // still retire the atoms whose quotes it deleted. Nothing was written,
-        // so nothing is exempt.
-        await reconcilePageAtoms(item, []);
         if (item.kind === 'transcript') transcriptsProcessed++;
         else pagesProcessed++;
         continue;
@@ -1102,6 +1084,11 @@ export async function runPhaseExtractAtoms(
         if (provenanceLinks.length > 0) {
           await engine.addLinksBatch(provenanceLinks, { auditSite: 'cycle.extract_atoms.provenance' }); // gbrain-allow-direct-insert: atom-provenance edges derived from the extraction itself (no markdown body to reconcile from)
         }
+        // #4566: retire what this page no longer supports, on the same
+        // before-the-flip footing as the provenance flush. The rows just
+        // written are exempt twice over — they are in importedSlugs, and their
+        // provisional `pending:` hashes are excluded by the predicate.
+        atomsSuperseded += await reconcileAtoms(item, importedSlugs);
         // Completion receipt: flip provisional → real in one statement (only
         // after every atom AND provenance edge persisted), then stamp the
         // source page. A crash between flip and stamp degrades to the legacy
@@ -1112,9 +1099,6 @@ export async function runPhaseExtractAtoms(
             WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
           [hash16, sourceId, importedSlugs],
         );
-        // AFTER the flip on purpose: the rows just written already carry the
-        // current hash, so the reconciliation predicate excludes them too.
-        await reconcilePageAtoms(item, importedSlugs);
         if (item.kind === 'page') await stampAtomsScanHash(item);
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
@@ -1124,7 +1108,7 @@ export async function runPhaseExtractAtoms(
         if (item.kind === 'page') {
           const wouldWrite: string[] = [];
           for (const a of atoms) wouldWrite.push(await resolvePageAtomSlug(engine, a.title, item.slug, sourceId));
-          await reconcilePageAtoms(item, wouldWrite);
+          atomsSuperseded += await reconcileAtoms(item, wouldWrite);
         }
       }
       if (item.kind === 'transcript') transcriptsProcessed++;

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -72,6 +72,7 @@ import { BudgetExhausted, BudgetTracker, isModelPriceable } from '../budget/budg
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { createHash } from 'crypto';
+import { DELETE_BATCH_SIZE } from '../engine-constants.ts';
 import { slugifySegment } from '../sync.ts';
 import { resolveTierDefault } from '../model-config.ts';
 import { normalizeForGrounding } from './synthesize-verify.ts';
@@ -530,6 +531,70 @@ export async function atomsExistingForHashes(
 }
 
 /**
+ * #4566 follow-through — supersede the atoms a re-extracted page has replaced.
+ *
+ * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
+ * no longer matches any live page and is explicitly diagnostic: it never
+ * deletes. Its larger bucket (`source_changed` — the source page still exists,
+ * it was merely edited) had nothing to reclaim it. Re-extraction upserts an
+ * atom in place only when the new pass produces the SAME title; a reworded
+ * claim lands on a new deterministic slug and the old atom stays behind,
+ * still searchable, still carrying a `source_quote` no current page contains.
+ *
+ * This reconciles ONE page's atom set at the moment its replacement set has
+ * been imported and stamped with the current hash. An atom is superseded only
+ * when ALL of these hold:
+ *   - `type = 'atom'`, live, in the SAME source as the write;
+ *   - `source_slug` EQUALS this page's slug. This is the strict subset of
+ *     `isCompatibleAtomBinding`: that predicate also adopts a pre-binding-era
+ *     row (no `source_slug`/`source_path`) for upsert, but such a row is not
+ *     bound to THIS page, so it is never reaped. Transcript-lane atoms carry
+ *     `source_path` and no `source_slug`, so they cannot match either;
+ *   - `source_hash` is present, is not the in-flight `pending:` marker, and
+ *     differs from the page's current hash16 — the page's OWN current content
+ *     is the staleness authority, judged inside the run that just wrote it;
+ *   - the slug was NOT written by this run for this page (the `keepSlugs`
+ *     exclusion) — a same-title atom is refreshed in place, not superseded.
+ *
+ * Soft-delete via `softDeletePages`, so the rows stay recoverable inside the
+ * usual purge window rather than being destroyed. Returns the number of rows
+ * actually flipped active → soft-deleted. `dryRun` runs the SELECT only and
+ * returns the would-be count without touching a row.
+ *
+ * Atoms whose source page was DELETED (the doctor's `source_gone` bucket) are
+ * out of scope: this only ever runs for a page that was just re-extracted.
+ */
+async function supersedeStaleAtomsForPage(
+  engine: BrainEngine,
+  args: { sourceId: string; pageSlug: string; hash16: string; keepSlugs: string[]; dryRun: boolean },
+): Promise<number> {
+  const rows = await engine.executeRaw<{ slug: string }>(
+    `SELECT slug
+       FROM pages
+      WHERE source_id = $1
+        AND type = 'atom'
+        AND deleted_at IS NULL
+        AND frontmatter->>'source_slug' = $2
+        AND frontmatter->>'source_hash' IS NOT NULL
+        AND frontmatter->>'source_hash' NOT LIKE 'pending:%'
+        AND frontmatter->>'source_hash' <> $3
+        AND NOT (slug = ANY($4::text[]))`,
+    [args.sourceId, args.pageSlug, args.hash16, args.keepSlugs],
+  );
+  const slugs = rows.map(r => r.slug);
+  if (args.dryRun || slugs.length === 0) return slugs.length;
+  // softDeletePages is a single-batch primitive — oversized input throws.
+  let superseded = 0;
+  for (let i = 0; i < slugs.length; i += DELETE_BATCH_SIZE) {
+    const flipped = await engine.softDeletePages(slugs.slice(i, i + DELETE_BATCH_SIZE), {
+      sourceId: args.sourceId,
+    });
+    superseded += flipped.length;
+  }
+  return superseded;
+}
+
+/**
  * The exact two-step model resolution `runPhaseExtractAtoms` uses:
  * `models.dream.extract_atoms` DB config wins if set (same plain-`||`
  * truthiness as always — a whitespace-only value IS "configured"), else the
@@ -726,6 +791,7 @@ export async function runPhaseExtractAtoms(
 
   // 4. Per work-item: extract atoms via the configured extract_atoms model
   let totalAtomsExtracted = 0;
+  let atomsSuperseded = 0;
   let transcriptsProcessed = 0;
   let pagesProcessed = 0;
   let transcriptsSkipped = 0;
@@ -1082,11 +1148,52 @@ export async function runPhaseExtractAtoms(
             WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
           [hash16, sourceId, importedSlugs],
         );
+        // #4566 follow-through: the replacement set is live and stamped, so
+        // whatever this page's PREVIOUS content produced is now superseded.
+        // Runs after the flip, so the rows just written carry the current
+        // hash and are excluded by the predicate as well as by keepSlugs.
+        // Best-effort, like the receipt/rollup writers below: the extraction
+        // itself already committed, and reconciliation converges on the next
+        // re-extraction, so a failure here must not fail the item.
+        if (item.kind === 'page') {
+          try {
+            atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
+              sourceId, pageSlug: item.slug, hash16, keepSlugs: importedSlugs, dryRun: false,
+            });
+          } catch (err) {
+            console.error(
+              `[extract_atoms] supersede stale atoms failed for ${item.slug}: ${(err as Error).message}`,
+            );
+          }
+        }
         if (item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
+        // Report-only twin of the reconciliation above. resolvePageAtomSlug is
+        // read-only, so the would-be write set can be resolved under dry-run —
+        // without it the count would include atoms a real run would refresh in
+        // place rather than supersede.
+        if (item.kind === 'page') {
+          try {
+            const wouldWrite: string[] = [];
+            for (const atom of atoms) {
+              wouldWrite.push(await resolvePageAtomSlug(engine, atom.title, item.slug, sourceId));
+            }
+            atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
+              sourceId,
+              pageSlug: item.slug,
+              hash16: item.contentHash.slice(0, 16),
+              keepSlugs: wouldWrite,
+              dryRun: true,
+            });
+          } catch (err) {
+            console.error(
+              `[extract_atoms] supersede dry-run count failed for ${item.slug}: ${(err as Error).message}`,
+            );
+          }
+        }
       }
       if (item.kind === 'transcript') transcriptsProcessed++;
       else pagesProcessed++;
@@ -1190,12 +1297,14 @@ export async function runPhaseExtractAtoms(
       `extract_atoms: ${totalAtomsExtracted} atoms from ` +
       `${transcriptsProcessed}/${transcripts.length} transcripts + ` +
       `${pagesProcessed}/${pages.length} pages` +
+      (atomsSuperseded > 0 ? ` (${atomsSuperseded} superseded)` : '') +
       (failures.length > 0 ? ` (${failures.length} failed)` : '') +
       (transcriptsSkipped + pagesSkipped > 0
         ? ` (${transcriptsSkipped + pagesSkipped} budget-skipped)`
         : ''),
     details: {
       atoms_extracted: totalAtomsExtracted,
+      atoms_superseded: atomsSuperseded,
       transcripts_processed: transcriptsProcessed,
       transcripts_total: transcripts.length,
       transcripts_skipped_budget: transcriptsSkipped,

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -728,6 +728,7 @@ export async function runPhaseExtractAtoms(
   // 4. Per work-item: extract atoms via the configured extract_atoms model
   let totalAtomsExtracted = 0;
   let atomsSuperseded = 0;
+  let atomsReanchored = 0;
   let transcriptsProcessed = 0;
   let pagesProcessed = 0;
   let transcriptsSkipped = 0;
@@ -886,6 +887,10 @@ export async function runPhaseExtractAtoms(
   // supports. Evidence rule, throw-before-the-completion-markers contract and
   // dry-run semantics all live in the reconciler module.
   const reconcileAtoms = createAtomReconciler(engine, sourceId, opts.dryRun === true);
+  const countReconciled = (c: { superseded: number; reanchored: number }) => {
+    atomsSuperseded += c.superseded;
+    atomsReanchored += c.reanchored;
+  };
 
   await withBudgetTracker(budgetTracker, async () => {
   for (const item of work) {
@@ -965,7 +970,7 @@ export async function runPhaseExtractAtoms(
         // still retire the atoms whose quotes it deleted, and a failure here
         // has to leave the page unstamped so the next run retries. Nothing was
         // written, so nothing is exempt.
-        atomsSuperseded += await reconcileAtoms(item, []);
+        countReconciled(await reconcileAtoms(item, []));
         if (!opts.dryRun && item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
@@ -1088,7 +1093,7 @@ export async function runPhaseExtractAtoms(
         // before-the-flip footing as the provenance flush. The rows just
         // written are exempt twice over — they are in importedSlugs, and their
         // provisional `pending:` hashes are excluded by the predicate.
-        atomsSuperseded += await reconcileAtoms(item, importedSlugs);
+        countReconciled(await reconcileAtoms(item, importedSlugs));
         // Completion receipt: flip provisional → real in one statement (only
         // after every atom AND provenance edge persisted), then stamp the
         // source page. A crash between flip and stamp degrades to the legacy
@@ -1108,7 +1113,7 @@ export async function runPhaseExtractAtoms(
         if (item.kind === 'page') {
           const wouldWrite: string[] = [];
           for (const a of atoms) wouldWrite.push(await resolvePageAtomSlug(engine, a.title, item.slug, sourceId));
-          atomsSuperseded += await reconcileAtoms(item, wouldWrite);
+          countReconciled(await reconcileAtoms(item, wouldWrite));
         }
       }
       if (item.kind === 'transcript') transcriptsProcessed++;
@@ -1221,6 +1226,7 @@ export async function runPhaseExtractAtoms(
     details: {
       atoms_extracted: totalAtomsExtracted,
       atoms_superseded: atomsSuperseded,
+      atoms_reanchored: atomsReanchored,
       transcripts_processed: transcriptsProcessed,
       transcripts_total: transcripts.length,
       transcripts_skipped_budget: transcriptsSkipped,

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -729,6 +729,7 @@ export async function runPhaseExtractAtoms(
   let totalAtomsExtracted = 0;
   let atomsSuperseded = 0;
   let atomsReanchored = 0;
+  let atomsRetirementBlocked = 0;
   let transcriptsProcessed = 0;
   let pagesProcessed = 0;
   let transcriptsSkipped = 0;
@@ -887,9 +888,10 @@ export async function runPhaseExtractAtoms(
   // supports. Evidence rule, throw-before-the-completion-markers contract and
   // dry-run semantics all live in the reconciler module.
   const reconcileAtoms = createAtomReconciler(engine, sourceId, opts.dryRun === true);
-  const countReconciled = (c: { superseded: number; reanchored: number }) => {
+  const countReconciled = (c: { superseded: number; reanchored: number; blocked: number }) => {
     atomsSuperseded += c.superseded;
     atomsReanchored += c.reanchored;
+    atomsRetirementBlocked += c.blocked;
   };
 
   await withBudgetTracker(budgetTracker, async () => {
@@ -1089,21 +1091,16 @@ export async function runPhaseExtractAtoms(
         if (provenanceLinks.length > 0) {
           await engine.addLinksBatch(provenanceLinks, { auditSite: 'cycle.extract_atoms.provenance' }); // gbrain-allow-direct-insert: atom-provenance edges derived from the extraction itself (no markdown body to reconcile from)
         }
-        // #4566: retire what this page no longer supports, on the same
-        // before-the-flip footing as the provenance flush. The rows just
-        // written are exempt twice over — they are in importedSlugs, and their
-        // provisional `pending:` hashes are excluded by the predicate.
-        countReconciled(await reconcileAtoms(item, importedSlugs));
-        // Completion receipt: flip provisional → real in one statement (only
-        // after every atom AND provenance edge persisted), then stamp the
-        // source page. A crash between flip and stamp degrades to the legacy
-        // atom-rows-mean-done semantics — safe, not lossy.
-        await engine.executeRaw(
-          `UPDATE pages
-              SET frontmatter = frontmatter || jsonb_build_object('source_hash', $1::text)
-            WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
-          [hash16, sourceId, importedSlugs],
-        );
+        // Commit completion and reconciliation together: flip → retire →
+        // re-anchor. Any failure keeps imported atoms pending and retryable.
+        countReconciled(await reconcileAtoms(item, importedSlugs, async (tx) => {
+          await tx.executeRaw(
+            `UPDATE pages
+                SET frontmatter = frontmatter || jsonb_build_object('source_hash', $1::text)
+              WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
+            [hash16, sourceId, importedSlugs],
+          );
+        }));
         if (item.kind === 'page') await stampAtomsScanHash(item);
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
@@ -1219,6 +1216,7 @@ export async function runPhaseExtractAtoms(
       `${transcriptsProcessed}/${transcripts.length} transcripts + ` +
       `${pagesProcessed}/${pages.length} pages` +
       (atomsSuperseded > 0 ? ` (${atomsSuperseded} superseded)` : '') +
+      (atomsRetirementBlocked > 0 ? ` (${atomsRetirementBlocked} retirement blocked)` : '') +
       (failures.length > 0 ? ` (${failures.length} failed)` : '') +
       (transcriptsSkipped + pagesSkipped > 0
         ? ` (${transcriptsSkipped + pagesSkipped} budget-skipped)`
@@ -1227,6 +1225,7 @@ export async function runPhaseExtractAtoms(
       atoms_extracted: totalAtomsExtracted,
       atoms_superseded: atomsSuperseded,
       atoms_reanchored: atomsReanchored,
+      atoms_retirement_blocked: atomsRetirementBlocked,
       transcripts_processed: transcriptsProcessed,
       transcripts_total: transcripts.length,
       transcripts_skipped_budget: transcriptsSkipped,

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -882,6 +882,29 @@ export async function runPhaseExtractAtoms(
     }
   }
 
+  /**
+   * #4566 follow-through: reclaim atoms this page's CURRENT content no longer
+   * supports (evidence rule: see supersedeStaleAtomsForPage). Gets the FULL
+   * item content, not the model's cut. A failure lands in `failures` instead
+   * of throwing: the extraction committed, but the page is not re-discovered
+   * for this hash, so a silent log would hide a reconciliation that never ran.
+   */
+  async function reconcilePageAtoms(
+    item: { kind: string; slug?: string; content: string; contentHash: string },
+    keepSlugs: string[],
+  ): Promise<void> {
+    if (item.kind !== 'page' || !item.slug) return;
+    try {
+      atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
+        sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
+        currentContent: item.content, keepSlugs, dryRun: opts.dryRun === true,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      failures.push({ source: item.slug, error: `atom reconciliation failed: ${msg}` });
+    }
+  }
+
   await withBudgetTracker(budgetTracker, async () => {
   for (const item of work) {
     await maybeYield();
@@ -959,6 +982,11 @@ export async function runPhaseExtractAtoms(
         if (!opts.dryRun && item.kind === 'page') {
           await stampAtomsScanHash(item);
         }
+        // Stamped done, so this is the page's last reconciliation chance for
+        // this content: an edit that removed every extractable claim must
+        // still retire the atoms whose quotes it deleted. Nothing was written,
+        // so nothing is exempt.
+        await reconcilePageAtoms(item, []);
         if (item.kind === 'transcript') transcriptsProcessed++;
         else pagesProcessed++;
         continue;
@@ -1084,43 +1112,19 @@ export async function runPhaseExtractAtoms(
             WHERE source_id = $2 AND type = 'atom' AND slug = ANY($3::text[]) AND deleted_at IS NULL`,
           [hash16, sourceId, importedSlugs],
         );
-        // #4566 follow-through: the replacement set is live and stamped, so
-        // this page's PREVIOUS atoms are now superseded. AFTER the flip on
-        // purpose (the rows just written already carry the current hash).
-        // Best-effort like the receipt/rollup writers below — the extraction
-        // committed, and reconciliation converges on the next re-extraction.
-        if (item.kind === 'page') {
-          try {
-            atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
-              sourceId, pageSlug: item.slug, hash16, keepSlugs: importedSlugs, dryRun: false,
-            });
-          } catch (err) {
-            console.error(
-              `[extract_atoms] supersede stale atoms failed for ${item.slug}: ${(err as Error).message}`,
-            );
-          }
-          await stampAtomsScanHash(item);
-        }
+        // AFTER the flip on purpose: the rows just written already carry the
+        // current hash, so the reconciliation predicate excludes them too.
+        await reconcilePageAtoms(item, importedSlugs);
+        if (item.kind === 'page') await stampAtomsScanHash(item);
       } else {
         totalAtomsExtracted += atoms.length; // count for dry-run reporting
-        // Report-only twin of the above. resolvePageAtomSlug is read-only, so
-        // the would-be write set resolves under dry-run too — without it the
-        // count would include atoms a real run refreshes in place.
+        // Report-only twin. resolvePageAtomSlug is read-only, so the would-be
+        // write set resolves under dry-run too — without it the count would
+        // include atoms a real run refreshes in place.
         if (item.kind === 'page') {
-          try {
-            const wouldWrite: string[] = [];
-            for (const atom of atoms) {
-              wouldWrite.push(await resolvePageAtomSlug(engine, atom.title, item.slug, sourceId));
-            }
-            atomsSuperseded += await supersedeStaleAtomsForPage(engine, {
-              sourceId, pageSlug: item.slug, hash16: item.contentHash.slice(0, 16),
-              keepSlugs: wouldWrite, dryRun: true,
-            });
-          } catch (err) {
-            console.error(
-              `[extract_atoms] supersede dry-run count failed for ${item.slug}: ${(err as Error).message}`,
-            );
-          }
+          const wouldWrite: string[] = [];
+          for (const a of atoms) wouldWrite.push(await resolvePageAtomSlug(engine, a.title, item.slug, sourceId));
+          await reconcilePageAtoms(item, wouldWrite);
         }
       }
       if (item.kind === 'transcript') transcriptsProcessed++;

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -1,28 +1,35 @@
 /**
- * #4566 follow-through — extract_atoms supersedes a re-extracted page's stale
- * atoms.
+ * #4566 follow-through — extract_atoms retires atoms its source page no longer
+ * supports.
  *
  * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
  * matches no live page and never deletes; its `source_changed` bucket (source
  * page edited, atom left behind) had nothing to reclaim it. The page lane now
- * soft-deletes, right after a page's replacement atom set has been imported
- * and stamped, every live atom bound to THAT page whose `source_hash` is
- * neither the in-flight `pending:` marker nor the page's current hash and
- * whose slug was not written by this run.
+ * soft-deletes, once a page has been scanned, every live atom bound to THAT
+ * page whose `source_hash` is neither the in-flight `pending:` marker nor the
+ * page's current hash, whose slug this run did not write, and whose VERIFIED
+ * `source_quote` is absent from the page's current content.
  *
  * What the cases pin:
- *   (a) reworded claim → the old atom is soft-deleted, the same-title atom is
- *       upserted IN PLACE (same slug, refreshed hash), the new atom is live.
+ *   (a) a reworded claim → the old atom is soft-deleted, the same-title atom
+ *       is upserted IN PLACE (same slug, refreshed hash), the new atom lives.
+ *   (a2) omission is NOT evidence: an atom the new pass simply did not re-emit
+ *       stays live while its quote is still in the page. This is the guard
+ *       against deleting still-valid atoms — the extractor sees a truncated
+ *       cut and returns only a handful of atoms per pass.
  *   (b) live-mix: an atom bound to a DIFFERENT page (same date prefix, same
  *       title — the #4733 locator-fold case) and a pre-binding-era atom (no
- *       source_slug/source_path) are both untouched.
- *   (c) reverse control for (b): in that same run, P's own stale atom WAS
- *       soft-deleted — so (b) cannot pass vacuously on a no-op implementation.
- *   (d) dry-run: no row changes at all, and the would-be count is reported.
- *   (e) idempotency: an identical re-run supersedes nothing and changes
- *       nothing.
+ *       source_slug/source_path) are untouched, even though both carry a
+ *       stale hash and a quote absent from this page.
+ *   (c) reverse control for (b): the same run DID soft-delete the page's own
+ *       invalidated atom — so (b) cannot pass vacuously on a no-op.
+ *   (d) dry-run: no row changes at all, and the reported would-be count
+ *       excludes a title this run would refresh in place.
+ *   (e) idempotency: an identical re-run retires nothing and moves no atom in
+ *       or out of the live set.
  *
- * PGLite round-trip with a stubbed chat gateway (no model calls).
+ * Every case seeds its own page namespace, so the tests are independent and
+ * can be run individually. PGLite round-trip, stubbed chat gateway.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
@@ -42,26 +49,40 @@ afterAll(async () => {
   if (engine) await engine.disconnect();
 }, 60_000);
 
-// Two same-date source pages, so their atoms share the `atoms/2026-07-01/`
-// slug prefix and only the locator fold separates them.
-const P = 'writings/2026-07-01-p-brief';
-const Q = 'writings/2026-07-01-q-brief';
+// Each quote is a distinct sentence that appears exactly once in whichever
+// body carries it, so extract_atoms' quote verification locates it uniquely
+// and stores `source_quote_verified: true`.
+const Q_SHARED = 'Enterprise buyers want tangible prototypes.';
+const Q_OLD = 'Renders close deals faster than anything physical.';
+const Q_KEEPER = 'Procurement decides long before the demo.';
+const Q_NEW = 'A working prototype survives the procurement review.';
+const Q_THIRD = 'Pilot budgets outlive the quarter they were approved in.';
+const Q_SIBLING = 'A second brief argues the opposite of the first.';
+const Q_LEGACY = 'An orphan sentence that lives in no page at all.';
+
+const T_SHARED = 'Prototypes beat renders';
+const T_OLD = 'Renders close deals';
+const T_KEEPER = 'Procurement decides early';
+const T_NEW = 'Prototypes survive review';
+
 const H1 = '1111111111111111';
 const H2 = '2222222222222222';
 const H3 = '3333333333333333';
 const HQ = '4444444444444444';
 
-const T_SHARED = 'Prototypes beat renders';
-const T_OLD = 'Enterprise buyers want renders';
-const T_NEW = 'Enterprise buyers want tangible prototypes';
-const T_THIRD = 'Procurement decides before the demo';
+const BODY_1 = [Q_SHARED, Q_OLD, Q_KEEPER].join(' ');
+// Q_OLD is gone (the reworded claim); Q_SHARED and Q_KEEPER survive verbatim.
+const BODY_2 = [Q_SHARED, Q_NEW, Q_KEEPER].join(' ');
+// Only Q_KEEPER survives; Q_SHARED and Q_NEW are both gone.
+const BODY_3 = [Q_THIRD, Q_KEEPER].join(' ');
 
-const LEGACY_SLUG = 'atoms/2026-07-01/legacy-unbound-atom-000000';
-const LEGACY_TITLE = 'Legacy unbound atom';
+type Pair = [title: string, quote: string];
 
-const stubChat = (titles: string[]) => async (_o: ChatOpts): Promise<ChatResult> => ({
+const stubChat = (pairs: Pair[]) => async (_o: ChatOpts): Promise<ChatResult> => ({
   text: JSON.stringify(
-    titles.map(title => ({ title, atom_type: 'insight', body: `Body for ${title}.` })),
+    pairs.map(([title, source_quote]) => ({
+      title, atom_type: 'insight', body: `Body for ${title}.`, source_quote,
+    })),
   ),
   blocks: [{ type: 'text', text: '' }],
   stopReason: 'end',
@@ -78,39 +99,38 @@ type AtomRow = {
   content_hash: string | null;
   source_hash: string | null;
   source_slug: string | null;
+  verified: string | null;
 };
+
+const ATOM_COLS = `slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
+                   content_hash,
+                   frontmatter->>'source_hash' AS source_hash,
+                   frontmatter->>'source_slug' AS source_slug,
+                   frontmatter->>'source_quote_verified' AS verified`;
 
 /** Every atom row in the brain, full enough that any write shows up. */
 async function atomSnapshot(): Promise<AtomRow[]> {
   return await engine.executeRaw<AtomRow>(
-    `SELECT slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
-            content_hash,
-            frontmatter->>'source_hash' AS source_hash,
-            frontmatter->>'source_slug' AS source_slug
-       FROM pages WHERE type = 'atom' ORDER BY slug`,
+    `SELECT ${ATOM_COLS} FROM pages WHERE type = 'atom' ORDER BY slug`,
   );
 }
 
 /**
  * The state this reconciliation owns: identity, liveness, binding. A re-run
  * legitimately re-imports each atom (extracted_at moves, so content_hash and
- * updated_at move with it) — that is the pre-existing upsert, not a
- * supersede, so the idempotency case asserts stillness on THIS projection.
+ * updated_at move with it) — that is the pre-existing upsert, not a retirement,
+ * so the idempotency case asserts stillness on THIS projection.
  */
 async function bindingSnapshot(): Promise<Array<Omit<AtomRow, 'updated_at' | 'content_hash'>>> {
-  return (await atomSnapshot()).map(({ slug, title, deleted_at, source_hash, source_slug }) => ({
-    slug, title, deleted_at, source_hash, source_slug,
+  return (await atomSnapshot()).map(({ slug, title, deleted_at, source_hash, source_slug, verified }) => ({
+    slug, title, deleted_at, source_hash, source_slug, verified,
   }));
 }
 
 /** One atom, keyed by title + binding (T_SHARED exists for both P and Q). */
 async function atomRow(title: string, sourceSlug: string | null): Promise<AtomRow | null> {
   const rows = await engine.executeRaw<AtomRow>(
-    `SELECT slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
-            content_hash,
-            frontmatter->>'source_hash' AS source_hash,
-            frontmatter->>'source_slug' AS source_slug
-       FROM pages
+    `SELECT ${ATOM_COLS} FROM pages
       WHERE type = 'atom' AND title = $1
         AND frontmatter->>'source_slug' IS NOT DISTINCT FROM $2`,
     [title, sourceSlug],
@@ -118,123 +138,154 @@ async function atomRow(title: string, sourceSlug: string | null): Promise<AtomRo
   return rows[0] ?? null;
 }
 
-// Captured before the re-extraction so (b) can assert byte-level stillness.
-let qBefore: AtomRow | null = null;
-let legacyBefore: AtomRow | null = null;
-let sharedSlugBefore = '';
+interface Fixture { p: string; q: string; legacySlug: string }
 
-describe('extract_atoms supersedes stale atoms of a re-extracted page (#4566 follow-through)', () => {
-  test('setup: P extracted at H1, sibling page Q extracted, plus a pre-binding-era atom', async () => {
-    await engine.putPage(P, {
-      type: 'note', title: 'P Brief',
-      compiled_truth: 'A long brief with extractable claims.', timeline: '',
-    });
-    await engine.putPage(Q, {
-      type: 'note', title: 'Q Brief',
-      compiled_truth: 'A second brief with extractable claims.', timeline: '',
-    });
-    // Pre-binding era: an atom with NO source_slug and NO source_path. It is
-    // adoptable by an upsert but bound to nothing, so it must never be reaped.
-    await engine.putPage(LEGACY_SLUG, {
-      type: 'atom', title: LEGACY_TITLE,
-      compiled_truth: 'An atom written before source bindings existed.', timeline: '',
-      frontmatter: { source_hash: 'ffffffffffffffff' },
-    });
+/**
+ * Two same-date source pages (so their atoms share the `atoms/2026-07-01/`
+ * prefix and only the locator fold separates them) plus a pre-binding-era
+ * atom. P is extracted at H1; Q is extracted once and never again, so its
+ * atom's hash stays stale for the rest of the fixture.
+ */
+async function seed(ns: string): Promise<Fixture> {
+  const p = `writings/2026-07-01-p-${ns}`;
+  const q = `writings/2026-07-01-q-${ns}`;
+  const legacySlug = `atoms/2026-07-01/legacy-unbound-${ns}`;
 
-    const first = await runPhaseExtractAtoms(engine, {
-      _transcripts: [],
-      _pages: [{ slug: P, content: 'A long brief with extractable claims.', contentHash: H1 }],
-      _chat: stubChat([T_SHARED, T_OLD]),
-    });
-    expect(first.status).toBe('ok');
-    expect(first.details?.atoms_extracted).toBe(2);
+  await engine.putPage(p, { type: 'note', title: `P ${ns}`, compiled_truth: BODY_1, timeline: '' });
+  await engine.putPage(q, { type: 'note', title: `Q ${ns}`, compiled_truth: Q_SIBLING, timeline: '' });
+  // Pre-binding era: no source_slug and no source_path. Deliberately given a
+  // stale hash AND a verified quote that appears in no page, so only the
+  // missing binding stands between it and the reconciler.
+  await engine.putPage(legacySlug, {
+    type: 'atom', title: `Legacy unbound atom ${ns}`,
+    compiled_truth: 'An atom written before source bindings existed.', timeline: '',
+    frontmatter: { source_hash: 'ffffffffffffffff', source_quote: Q_LEGACY, source_quote_verified: true },
+  });
 
-    // Q emits the SAME atom title on the SAME date — distinct slug via the
-    // #4733 locator fold — and is never re-extracted, so its source_hash stays
-    // stale relative to P's current content for the rest of the fixture.
-    const sibling = await runPhaseExtractAtoms(engine, {
-      _transcripts: [],
-      _pages: [{ slug: Q, content: 'A second brief with extractable claims.', contentHash: HQ }],
-      _chat: stubChat([T_SHARED]),
-    });
-    expect(sibling.status).toBe('ok');
+  const first = await runPhaseExtractAtoms(engine, {
+    _transcripts: [],
+    _pages: [{ slug: p, content: BODY_1, contentHash: H1 }],
+    _chat: stubChat([[T_SHARED, Q_SHARED], [T_OLD, Q_OLD], [T_KEEPER, Q_KEEPER]]),
+  });
+  expect(first.status).toBe('ok');
+  expect(first.details?.atoms_extracted).toBe(3);
+  // The whole design rests on these quotes verifying; assert it once here so a
+  // silent verification regression cannot make later cases pass vacuously.
+  expect((await atomRow(T_OLD, p))?.verified).toBe('true');
 
-    const sharedP = await atomRow(T_SHARED, P);
-    qBefore = await atomRow(T_SHARED, Q);
-    legacyBefore = await atomRow(LEGACY_TITLE, null);
-    expect(sharedP?.source_hash).toBe(H1);
-    expect(qBefore?.source_hash).toBe(HQ);
-    expect(qBefore!.slug).not.toBe(sharedP!.slug);
-    expect(legacyBefore?.slug).toBe(LEGACY_SLUG);
-    sharedSlugBefore = sharedP!.slug;
-  }, 120_000);
+  // Q emits the SAME atom title on the SAME date — distinct slug via the
+  // #4733 locator fold — with a quote that lives only in Q's own body.
+  const sibling = await runPhaseExtractAtoms(engine, {
+    _transcripts: [],
+    _pages: [{ slug: q, content: Q_SIBLING, contentHash: HQ }],
+    _chat: stubChat([[T_SHARED, Q_SIBLING]]),
+  });
+  expect(sibling.status).toBe('ok');
 
-  test('(a) re-extraction supersedes the reworded atom, upserts the unchanged one in place', async () => {
-    const result = await runPhaseExtractAtoms(engine, {
-      _transcripts: [],
-      _pages: [{ slug: P, content: 'A long brief, one claim reworded.', contentHash: H2 }],
-      _chat: stubChat([T_SHARED, T_NEW]),
-    });
+  return { p, q, legacySlug };
+}
+
+/** The re-extraction under test: P edited to BODY_2, one claim reworded. */
+function reextract(p: string) {
+  return runPhaseExtractAtoms(engine, {
+    _transcripts: [],
+    _pages: [{ slug: p, content: BODY_2, contentHash: H2 }],
+    _chat: stubChat([[T_SHARED, Q_SHARED], [T_NEW, Q_NEW]]),
+  });
+}
+
+describe('extract_atoms retires atoms its source page no longer supports (#4566 follow-through)', () => {
+  test('(a) a reworded claim is retired; the same-title atom is upserted in place', async () => {
+    const { p } = await seed('a');
+    const slugBefore = (await atomRow(T_SHARED, p))!.slug;
+
+    const result = await reextract(p);
     expect(result.status).toBe('ok');
     expect(result.details?.atoms_superseded).toBe(1);
     expect(String(result.summary)).toContain('1 superseded');
 
+    // The reworded claim's quote is gone from the page: retired.
+    const retired = await atomRow(T_OLD, p);
+    expect(retired!.source_hash).toBe(H1);
+    expect(retired!.deleted_at).not.toBeNull();
+
     // Unchanged title: SAME slug, refreshed hash, still live (upsert in place).
-    const shared = await atomRow(T_SHARED, P);
-    expect(shared!.slug).toBe(sharedSlugBefore);
+    const shared = await atomRow(T_SHARED, p);
+    expect(shared!.slug).toBe(slugBefore);
     expect(shared!.deleted_at).toBeNull();
     expect(shared!.source_hash).toBe(H2);
 
     // The replacement atom is live at the new hash.
-    const fresh = await atomRow(T_NEW, P);
+    const fresh = await atomRow(T_NEW, p);
     expect(fresh!.deleted_at).toBeNull();
     expect(fresh!.source_hash).toBe(H2);
   }, 120_000);
 
-  test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
-    const qAfter = await atomRow(T_SHARED, Q);
-    expect(qAfter).toEqual(qBefore);
-    expect(qAfter!.deleted_at).toBeNull();
-    expect(qAfter!.source_hash).toBe(HQ);
+  test('(a2) an atom the new pass merely omitted is KEPT while its quote survives', async () => {
+    const { p } = await seed('a2');
+    // T_KEEPER is not re-emitted by the re-extraction, but Q_KEEPER is still
+    // in BODY_2 verbatim — omission alone must never retire an atom.
+    const result = await reextract(p);
+    expect(result.details?.atoms_superseded).toBe(1);
 
-    const legacyAfter = await atomRow(LEGACY_TITLE, null);
-    expect(legacyAfter).toEqual(legacyBefore);
-    expect(legacyAfter!.deleted_at).toBeNull();
-  });
-
-  test('(c) reverse control: P\'s own stale atom in that same run WAS soft-deleted', async () => {
-    const stale = await atomRow(T_OLD, P);
-    expect(stale).not.toBeNull();
-    expect(stale!.source_hash).toBe(H1);
-    expect(stale!.deleted_at).not.toBeNull();
-  });
-
-  test('(e) an identical re-run supersedes nothing and moves no atom in or out of the live set', async () => {
-    const before = await bindingSnapshot();
-    const result = await runPhaseExtractAtoms(engine, {
-      _transcripts: [],
-      _pages: [{ slug: P, content: 'A long brief, one claim reworded.', contentHash: H2 }],
-      _chat: stubChat([T_SHARED, T_NEW]),
-    });
-    expect(result.status).toBe('ok');
-    expect(result.details?.atoms_superseded).toBe(0);
-    expect(String(result.summary)).not.toContain('superseded');
-    expect(await bindingSnapshot()).toEqual(before);
+    const keeper = await atomRow(T_KEEPER, p);
+    expect(keeper!.deleted_at).toBeNull();
+    expect(keeper!.source_hash).toBe(H1); // still stale, still kept
   }, 120_000);
 
-  test('(d) dry-run reports the would-be count and writes nothing', async () => {
+  test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
+    const { p, q, legacySlug } = await seed('b');
+    const qBefore = await atomRow(T_SHARED, q);
+    const legacyBefore = await atomRow(`Legacy unbound atom b`, null);
+    expect(qBefore).not.toBeNull();
+    expect(qBefore!.slug).not.toBe((await atomRow(T_SHARED, p))!.slug);
+    expect(legacyBefore!.slug).toBe(legacySlug);
+
+    await reextract(p);
+
+    expect(await atomRow(T_SHARED, q)).toEqual(qBefore);
+    expect(await atomRow('Legacy unbound atom b', null)).toEqual(legacyBefore);
+  }, 120_000);
+
+  test('(c) reverse control: in that same run, the page\'s own invalidated atom IS retired', async () => {
+    const { p } = await seed('c');
+    const result = await reextract(p);
+    expect(result.details?.atoms_superseded).toBe(1);
+    const retired = await atomRow(T_OLD, p);
+    expect(retired!.deleted_at).not.toBeNull();
+  }, 120_000);
+
+  test('(d) dry-run writes nothing and excludes a title it would refresh in place', async () => {
+    const { p } = await seed('d');
+    await reextract(p);
     const before = await atomSnapshot();
+
+    // BODY_3 drops BOTH Q_SHARED and Q_NEW, so both of those atoms' quotes are
+    // gone. T_SHARED is re-emitted (with a quote from the new body), so the
+    // run would refresh it in place and it must NOT be counted; T_NEW is not
+    // re-emitted and its quote is gone, so it must be. Without the
+    // written-this-run exclusion the count would be 2.
     const result = await runPhaseExtractAtoms(engine, {
       dryRun: true,
       _transcripts: [],
-      _pages: [{ slug: P, content: 'A long brief, rewritten again.', contentHash: H3 }],
-      // Neither surviving title is re-emitted, so both of P's live atoms
-      // would be superseded by a real run.
-      _chat: stubChat([T_THIRD]),
+      _pages: [{ slug: p, content: BODY_3, contentHash: H3 }],
+      _chat: stubChat([[T_SHARED, Q_THIRD]]),
     });
     expect(result.status).toBe('ok');
     expect(result.details?.dry_run).toBe(true);
-    expect(result.details?.atoms_superseded).toBe(2);
+    expect(result.details?.atoms_superseded).toBe(1);
     expect(await atomSnapshot()).toEqual(before);
+  }, 120_000);
+
+  test('(e) an identical re-run retires nothing and moves no atom in or out of the live set', async () => {
+    const { p } = await seed('e');
+    await reextract(p);
+    const before = await bindingSnapshot();
+
+    const again = await reextract(p);
+    expect(again.status).toBe('ok');
+    expect(again.details?.atoms_superseded).toBe(0);
+    expect(String(again.summary)).not.toContain('superseded');
+    expect(await bindingSnapshot()).toEqual(before);
   }, 120_000);
 });

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -1,0 +1,241 @@
+/**
+ * #4566 follow-through — extract_atoms supersedes a re-extracted page's stale
+ * atoms.
+ *
+ * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
+ * matches no live page and never deletes; its `source_changed` bucket (source
+ * page edited, atom left behind) had nothing to reclaim it. The page lane now
+ * soft-deletes, right after a page's replacement atom set has been imported
+ * and stamped, every live atom bound to THAT page whose `source_hash` is
+ * neither the in-flight `pending:` marker nor the page's current hash and
+ * whose slug was not written by this run.
+ *
+ * What the cases pin:
+ *   (a) reworded claim → the old atom is soft-deleted, the same-title atom is
+ *       upserted IN PLACE (same slug, refreshed hash), the new atom is live.
+ *   (b) live-mix: an atom bound to a DIFFERENT page (same date prefix, same
+ *       title — the #4733 locator-fold case) and a pre-binding-era atom (no
+ *       source_slug/source_path) are both untouched.
+ *   (c) reverse control for (b): in that same run, P's own stale atom WAS
+ *       soft-deleted — so (b) cannot pass vacuously on a no-op implementation.
+ *   (d) dry-run: no row changes at all, and the would-be count is reported.
+ *   (e) idempotency: an identical re-run supersedes nothing and changes
+ *       nothing.
+ *
+ * PGLite round-trip with a stubbed chat gateway (no model calls).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { runPhaseExtractAtoms } from '../../src/core/cycle/extract-atoms.ts';
+import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 120_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+// Two same-date source pages, so their atoms share the `atoms/2026-07-01/`
+// slug prefix and only the locator fold separates them.
+const P = 'writings/2026-07-01-p-brief';
+const Q = 'writings/2026-07-01-q-brief';
+const H1 = '1111111111111111';
+const H2 = '2222222222222222';
+const H3 = '3333333333333333';
+const HQ = '4444444444444444';
+
+const T_SHARED = 'Prototypes beat renders';
+const T_OLD = 'Enterprise buyers want renders';
+const T_NEW = 'Enterprise buyers want tangible prototypes';
+const T_THIRD = 'Procurement decides before the demo';
+
+const LEGACY_SLUG = 'atoms/2026-07-01/legacy-unbound-atom-000000';
+const LEGACY_TITLE = 'Legacy unbound atom';
+
+const stubChat = (titles: string[]) => async (_o: ChatOpts): Promise<ChatResult> => ({
+  text: JSON.stringify(
+    titles.map(title => ({ title, atom_type: 'insight', body: `Body for ${title}.` })),
+  ),
+  blocks: [{ type: 'text', text: '' }],
+  stopReason: 'end',
+  usage: { input_tokens: 500, output_tokens: 200, cache_read_tokens: 0, cache_creation_tokens: 0 },
+  model: 'anthropic:claude-haiku-4-5',
+  providerId: 'anthropic',
+});
+
+type AtomRow = {
+  slug: string;
+  title: string;
+  deleted_at: string | null;
+  updated_at: string | null;
+  content_hash: string | null;
+  source_hash: string | null;
+  source_slug: string | null;
+};
+
+/** Every atom row in the brain, full enough that any write shows up. */
+async function atomSnapshot(): Promise<AtomRow[]> {
+  return await engine.executeRaw<AtomRow>(
+    `SELECT slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
+            content_hash,
+            frontmatter->>'source_hash' AS source_hash,
+            frontmatter->>'source_slug' AS source_slug
+       FROM pages WHERE type = 'atom' ORDER BY slug`,
+  );
+}
+
+/**
+ * The state this reconciliation owns: identity, liveness, binding. A re-run
+ * legitimately re-imports each atom (extracted_at moves, so content_hash and
+ * updated_at move with it) — that is the pre-existing upsert, not a
+ * supersede, so the idempotency case asserts stillness on THIS projection.
+ */
+async function bindingSnapshot(): Promise<Array<Omit<AtomRow, 'updated_at' | 'content_hash'>>> {
+  return (await atomSnapshot()).map(({ slug, title, deleted_at, source_hash, source_slug }) => ({
+    slug, title, deleted_at, source_hash, source_slug,
+  }));
+}
+
+/** One atom, keyed by title + binding (T_SHARED exists for both P and Q). */
+async function atomRow(title: string, sourceSlug: string | null): Promise<AtomRow | null> {
+  const rows = await engine.executeRaw<AtomRow>(
+    `SELECT slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
+            content_hash,
+            frontmatter->>'source_hash' AS source_hash,
+            frontmatter->>'source_slug' AS source_slug
+       FROM pages
+      WHERE type = 'atom' AND title = $1
+        AND frontmatter->>'source_slug' IS NOT DISTINCT FROM $2`,
+    [title, sourceSlug],
+  );
+  return rows[0] ?? null;
+}
+
+// Captured before the re-extraction so (b) can assert byte-level stillness.
+let qBefore: AtomRow | null = null;
+let legacyBefore: AtomRow | null = null;
+let sharedSlugBefore = '';
+
+describe('extract_atoms supersedes stale atoms of a re-extracted page (#4566 follow-through)', () => {
+  test('setup: P extracted at H1, sibling page Q extracted, plus a pre-binding-era atom', async () => {
+    await engine.putPage(P, {
+      type: 'note', title: 'P Brief',
+      compiled_truth: 'A long brief with extractable claims.', timeline: '',
+    });
+    await engine.putPage(Q, {
+      type: 'note', title: 'Q Brief',
+      compiled_truth: 'A second brief with extractable claims.', timeline: '',
+    });
+    // Pre-binding era: an atom with NO source_slug and NO source_path. It is
+    // adoptable by an upsert but bound to nothing, so it must never be reaped.
+    await engine.putPage(LEGACY_SLUG, {
+      type: 'atom', title: LEGACY_TITLE,
+      compiled_truth: 'An atom written before source bindings existed.', timeline: '',
+      frontmatter: { source_hash: 'ffffffffffffffff' },
+    });
+
+    const first = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: P, content: 'A long brief with extractable claims.', contentHash: H1 }],
+      _chat: stubChat([T_SHARED, T_OLD]),
+    });
+    expect(first.status).toBe('ok');
+    expect(first.details?.atoms_extracted).toBe(2);
+    expect(first.details?.atoms_superseded).toBe(0);
+
+    // Q emits the SAME atom title on the SAME date — distinct slug via the
+    // #4733 locator fold — and is never re-extracted, so its source_hash stays
+    // stale relative to P's current content for the rest of the fixture.
+    const sibling = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: Q, content: 'A second brief with extractable claims.', contentHash: HQ }],
+      _chat: stubChat([T_SHARED]),
+    });
+    expect(sibling.status).toBe('ok');
+
+    const sharedP = await atomRow(T_SHARED, P);
+    qBefore = await atomRow(T_SHARED, Q);
+    legacyBefore = await atomRow(LEGACY_TITLE, null);
+    expect(sharedP?.source_hash).toBe(H1);
+    expect(qBefore?.source_hash).toBe(HQ);
+    expect(qBefore!.slug).not.toBe(sharedP!.slug);
+    expect(legacyBefore?.slug).toBe(LEGACY_SLUG);
+    sharedSlugBefore = sharedP!.slug;
+  }, 120_000);
+
+  test('(a) re-extraction supersedes the reworded atom, upserts the unchanged one in place', async () => {
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: P, content: 'A long brief, one claim reworded.', contentHash: H2 }],
+      _chat: stubChat([T_SHARED, T_NEW]),
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_superseded).toBe(1);
+    expect(String(result.summary)).toContain('1 superseded');
+
+    // Unchanged title: SAME slug, refreshed hash, still live (upsert in place).
+    const shared = await atomRow(T_SHARED, P);
+    expect(shared!.slug).toBe(sharedSlugBefore);
+    expect(shared!.deleted_at).toBeNull();
+    expect(shared!.source_hash).toBe(H2);
+
+    // The replacement atom is live at the new hash.
+    const fresh = await atomRow(T_NEW, P);
+    expect(fresh!.deleted_at).toBeNull();
+    expect(fresh!.source_hash).toBe(H2);
+  }, 120_000);
+
+  test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
+    const qAfter = await atomRow(T_SHARED, Q);
+    expect(qAfter).toEqual(qBefore);
+    expect(qAfter!.deleted_at).toBeNull();
+    expect(qAfter!.source_hash).toBe(HQ);
+
+    const legacyAfter = await atomRow(LEGACY_TITLE, null);
+    expect(legacyAfter).toEqual(legacyBefore);
+    expect(legacyAfter!.deleted_at).toBeNull();
+  });
+
+  test('(c) reverse control: P\'s own stale atom in that same run WAS soft-deleted', async () => {
+    const stale = await atomRow(T_OLD, P);
+    expect(stale).not.toBeNull();
+    expect(stale!.source_hash).toBe(H1);
+    expect(stale!.deleted_at).not.toBeNull();
+  });
+
+  test('(e) an identical re-run supersedes nothing and moves no atom in or out of the live set', async () => {
+    const before = await bindingSnapshot();
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: P, content: 'A long brief, one claim reworded.', contentHash: H2 }],
+      _chat: stubChat([T_SHARED, T_NEW]),
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_superseded).toBe(0);
+    expect(String(result.summary)).not.toContain('superseded');
+    expect(await bindingSnapshot()).toEqual(before);
+  }, 120_000);
+
+  test('(d) dry-run reports the would-be count and writes nothing', async () => {
+    const before = await atomSnapshot();
+    const result = await runPhaseExtractAtoms(engine, {
+      dryRun: true,
+      _transcripts: [],
+      _pages: [{ slug: P, content: 'A long brief, rewritten again.', contentHash: H3 }],
+      // Neither surviving title is re-emitted, so both of P's live atoms
+      // would be superseded by a real run.
+      _chat: stubChat([T_THIRD]),
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.dry_run).toBe(true);
+    expect(result.details?.atoms_superseded).toBe(2);
+    expect(await atomSnapshot()).toEqual(before);
+  }, 120_000);
+});

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -19,8 +19,10 @@
  *       cut and returns only a handful of atoms per pass.
  *   (b) live-mix: an atom bound to a DIFFERENT page (same date prefix, same
  *       title — the #4733 locator-fold case) and a pre-binding-era atom (no
- *       source_slug/source_path) are untouched, even though both carry a
- *       stale hash and a quote absent from this page.
+ *       source_slug/source_path) are untouched, even though neither carries
+ *       the hash being reconciled and neither's quote is in this page. Only
+ *       the binding check saves them. (Q's own hash is current for Q; it is
+ *       simply not P's.)
  *   (c) reverse control for (b): the same run DID soft-delete the page's own
  *       invalidated atom — so (b) cannot pass vacuously on a no-op.
  *   (d) dry-run: no row changes at all, and the reported would-be count
@@ -178,8 +180,8 @@ interface Fixture { ns: string; p: string; q: string; legacyTitle: string; legac
 /**
  * Two same-date source pages (so their atoms share the `atoms/2026-07-01/`
  * prefix and only the locator fold separates them) plus a pre-binding-era
- * atom. P is extracted at body1(ns); Q is extracted once and never again, so its
- * atom's hash stays stale for the rest of the fixture.
+ * atom. P is extracted at body1(ns); Q is extracted once and never again, so
+ * Q's atom keeps Q's hash — current for Q, but never P's.
  */
 async function seed(ns: string): Promise<Fixture> {
   const p = `writings/2026-07-01-p-${ns}`;
@@ -210,7 +212,8 @@ async function seed(ns: string): Promise<Fixture> {
   expect((await atomRow(T_OLD, p))?.verified).toBe('true');
 
   // Q emits the SAME atom title on the SAME date — distinct slug via the
-  // #4733 locator fold — with a quote that lives only in Q's own body.
+  // #4733 locator fold — with a quote that lives only in Q's own body, so
+  // reconciling P sees a bound-elsewhere row whose quote P does not contain.
   const sibling = await runPhaseExtractAtoms(engine, {
     _transcripts: [],
     _pages: [{ slug: q, content: body([Q_SIBLING], ns), contentHash: hq }],

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -148,7 +148,6 @@ describe('extract_atoms supersedes stale atoms of a re-extracted page (#4566 fol
     });
     expect(first.status).toBe('ok');
     expect(first.details?.atoms_extracted).toBe(2);
-    expect(first.details?.atoms_superseded).toBe(0);
 
     // Q emits the SAME atom title on the SAME date — distinct slug via the
     // #4733 locator fold — and is never re-extracted, so its source_hash stays

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -131,13 +131,17 @@ type AtomRow = {
   source_hash: string | null;
   source_slug: string | null;
   verified: string | null;
+  quote: string | null;
+  offset: [number, number] | null;
 };
 
 const ATOM_COLS = `slug, title, deleted_at::text AS deleted_at, updated_at::text AS updated_at,
                    content_hash,
                    frontmatter->>'source_hash' AS source_hash,
                    frontmatter->>'source_slug' AS source_slug,
-                   frontmatter->>'source_quote_verified' AS verified`;
+                   frontmatter->>'source_quote_verified' AS verified,
+                   frontmatter->>'source_quote' AS quote,
+                   frontmatter->'source_quote_offset' AS offset`;
 
 /** Complete source and atom rows, including all frontmatter and timestamps. */
 async function reconciliationSnapshot(pageSlug: string) {
@@ -150,7 +154,20 @@ async function reconciliationSnapshot(pageSlug: string) {
 
 function isReanchorUpdate(sql: string): boolean {
   return /^\s*UPDATE pages/.test(sql)
-    && sql.includes("jsonb_build_object('source_hash', $3::text)");
+    && sql.includes("'source_quote_offset', jsonb_build_array");
+}
+
+function isFlipUpdate(sql: string): boolean {
+  return /^\s*UPDATE pages/.test(sql)
+    && sql.includes("jsonb_build_object('source_hash', $1::text)");
+}
+
+async function atomsAtHash(slug: string, hash: string) {
+  return engine.executeRaw(
+    `SELECT slug FROM pages WHERE source_id = 'default' AND type = 'atom'
+      AND frontmatter->>'source_slug' = $1 AND frontmatter->>'source_hash' = $2
+      AND deleted_at IS NULL`, [slug, hash],
+  );
 }
 
 /** One atom, keyed by title + binding (T_SHARED exists for both P and Q). */
@@ -285,6 +302,10 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     expect(keeper!.source_hash).not.toBe(keeperBefore.source_hash);
     expect(keeper!.source_hash).toBe((await atomRow(T_SHARED, p))!.source_hash);
     expect(result.details?.atoms_reanchored).toBe(1);
+    expect(result.details?.atoms_retirement_blocked).toBe(0);
+    expect(keeper!.verified).toBe('true');
+    expect(keeper!.offset).not.toEqual(keeperBefore.offset);
+    expect(body2(f.ns).slice(...keeper!.offset!)).toBe(keeper!.quote!);
   }, 120_000);
 
   test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
@@ -446,6 +467,7 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     let deletedSlugs: string[] = [];
     let deleteEngine: PGLiteEngine | undefined;
     let reanchorCompleted = false;
+    let flipEngine: PGLiteEngine | undefined;
     let failed;
     try {
       // Shadow the prototype method with an own property, and DELETE it to
@@ -454,12 +476,15 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
       // self-deadlock against the row lock it is holding.
       engine.softDeletePages = async function (slugs, opts) {
         const deleted = await PGLiteEngine.prototype.softDeletePages.call(this, slugs, opts);
+        expect(flipEngine).toBeDefined();
+        expect(this).toBe(flipEngine!);
         deleteEngine = this;
         deletedSlugs.push(...deleted);
         return deleted;
       };
       engine.executeRaw = async function <T>(sql: string, params?: unknown[]): Promise<T[]> {
         const rows = await PGLiteEngine.prototype.executeRaw.call(this, sql, params) as T[];
+        if (isFlipUpdate(sql)) flipEngine = this;
         if (isReanchorUpdate(sql)) {
           expect(this === deleteEngine).toBe(true);
           expect(this).not.toBe(engine);
@@ -490,6 +515,14 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     expect((await atomRow(T_KEEPER, p))!.deleted_at).toBeNull();
     expect((await atomRow(T_KEEPER, p))!.source_hash).toBe(keeperBefore.source_hash);
     expect(await atomRow(T_KEEPER, p)).toEqual(keeperBefore);
+
+    // The flip really executed first, but rolled back with the later failure.
+    expect(flipEngine).toBeDefined();
+    expect(flipEngine).not.toBe(engine);
+    const h2 = (await engine.getPage(p, { sourceId: 'default' }))!.content_hash!.slice(0, 16);
+    expect((await atomRow(T_SHARED, p))!.source_hash).toBe(`pending:${h2}`);
+    expect((await atomRow(T_NEW, p))!.source_hash).toBe(`pending:${h2}`);
+    expect(await atomsAtHash(p, h2)).toEqual([]);
 
     // And still retryable: the completion markers were never written, so REAL
     // discovery (not the _pages seam) still offers the page.
@@ -552,6 +585,26 @@ describe('(j) a cosmetically edited page keeps its atoms', () => {
       ns: 'j-balanced-link',
       quoted: 'Use the prototype for procurement.',
       pageCopy: 'Use [the prototype](https://example.invalid/a_(b)) for procurement.',
+    },
+    {
+      ns: 'j-reference-link',
+      quoted: 'Use the prototype for procurement.',
+      pageCopy: 'Use [the prototype][demo] for procurement.\n[demo]: https://example.invalid/demo\n',
+    },
+    {
+      ns: 'j-collapsed-reference',
+      quoted: 'Use the prototype for procurement.',
+      pageCopy: 'Use [the prototype][] for procurement.\n[the prototype]: <https://example.invalid/demo> "Demo"\n',
+    },
+    {
+      ns: 'j-reference-image',
+      quoted: 'Use the prototype for procurement.',
+      pageCopy: 'Use ![the prototype][demo] for procurement.\n[demo]: https://example.invalid/demo\n',
+    },
+    {
+      ns: 'j-definition-only',
+      quoted: 'Use the prototype for procurement. Review the demo before buying.',
+      pageCopy: 'Use the prototype for procurement.\n[demo]: <https://example.invalid/demo> "Demo"\nReview the demo before buying.',
     },
     {
       ns: 'j-mid-link',
@@ -749,4 +802,113 @@ describe('(l) a wide page retires and re-anchors every eligible atom in one pass
     );
     expect(rows).toEqual([{ total: 2 * candidates, retired: candidates, reanchored: candidates }]);
   }, 180_000);
+});
+
+
+describe('(m) blockers defer all retirement and re-anchoring for the page', () => {
+  for (const kind of ['cosmetic', 'unverified', 'missing', 'ambiguous'] as const) {
+    test(`${kind} keeper blocks retirement and preserves the original atoms across a revert`, async () => {
+      const ns = `m-${kind}`;
+      const slug = `writings/2026-07-01-${ns}`;
+      const gone = 'The old procurement claim is explicitly present.';
+      const kept = 'A working prototype survives the procurement review.';
+      const original = body([gone, kept, Q_KEEPER], ns);
+      const h1 = await putAndHash(slug, ns, original);
+      await runOne(slug, original, h1, [[`${ns} gone`, gone], [ns, kept], [`${ns} locatable`, Q_KEEPER]]);
+      expect((await atomRow(ns, slug))!.verified).toBe('true');
+      if (kind === 'unverified' || kind === 'missing') {
+        await engine.executeRaw(
+          `UPDATE pages SET frontmatter = CASE WHEN $2 = 'missing'
+             THEN frontmatter - 'source_quote'
+             ELSE frontmatter || jsonb_build_object('source_quote_verified', false) END
+           WHERE slug = $1 AND source_id = 'default'`,
+          [(await atomRow(ns, slug))!.slug, kind],
+        );
+      }
+      const before = await atomRow(ns, slug);
+      const goneBefore = await atomRow(`${ns} gone`, slug);
+      const locatableBefore = await atomRow(`${ns} locatable`, slug);
+      const copy = kind === 'cosmetic' ? kept.replace('prototype', '**prototype**')
+        : kind === 'ambiguous' ? `${kept} ${kept}` : kept;
+      const edited = body([copy, Q_KEEPER], `${ns} edited`);
+      const r = await editAndReconcile(slug, ns, edited);
+      expect(r.status).toBe('ok');
+      expect(r.details?.atoms_superseded).toBe(0);
+      expect(r.details?.atoms_reanchored).toBe(0);
+      expect(r.details?.atoms_retirement_blocked).toBe(1);
+      expect(r.summary).toContain('1 retirement blocked');
+      expect(await atomRow(ns, slug)).toEqual(before);
+      expect(await atomRow(`${ns} gone`, slug)).toEqual(goneBefore);
+      expect(await atomRow(`${ns} locatable`, slug)).toEqual(locatableBefore);
+      await putAndHash(slug, ns, original);
+      // A blocker must retain H1, so unchanged discovery still skips H1.
+      // No atom was retired: the restored claim needs no recovery or revival.
+      expect((await discoverExtractablePages(engine, 'default')).some(p => p.slug === slug)).toBe(false);
+      expect((await atomRow(`${ns} gone`, slug))!.deleted_at).toBeNull();
+    }, 120_000);
+  }
+
+  test('dry-run counts blockers without changing any rows or flipping imported hashes', async () => {
+    const f = await seed('m-dry');
+    const edited = body2(f.ns).replace(Q_KEEPER, Q_KEEPER.replace('Procurement', '**Procurement**'));
+    const h2 = await putAndHash(f.p, f.ns, edited);
+    const before = await reconciliationSnapshot(f.p);
+    const r = await runPhaseExtractAtoms(engine, {
+      dryRun: true, _transcripts: [],
+      _pages: [{ slug: f.p, content: edited, contentHash: h2 }],
+      _chat: stubChat([[T_SHARED, Q_SHARED], [T_NEW, Q_NEW]]),
+    });
+    expect(r.details?.atoms_superseded).toBe(0);
+    expect(r.details?.atoms_reanchored).toBe(0);
+    expect(r.details?.atoms_retirement_blocked).toBe(1);
+    expect(r.summary).toContain('1 retirement blocked');
+    expect(await reconciliationSnapshot(f.p)).toEqual(before);
+  }, 120_000);
+});
+
+describe('(n) the completion flip shares the reconciliation transaction', () => {
+  test('a flip failure rolls back its hash writes and leaves retirement and re-anchoring untouched', async () => {
+    const f = await seed('n');
+    const retiredBefore = await atomRow(T_OLD, f.p);
+    const keeperBefore = await atomRow(T_KEEPER, f.p);
+    let flipRan = false;
+    let deleteRan = false;
+    let reanchorRan = false;
+    let failed;
+    try {
+      engine.softDeletePages = async function (slugs, opts) {
+        deleteRan = true;
+        return PGLiteEngine.prototype.softDeletePages.call(this, slugs, opts);
+      };
+      engine.executeRaw = async function <T>(sql: string, params?: unknown[]): Promise<T[]> {
+        const rows = await PGLiteEngine.prototype.executeRaw.call(this, sql, params) as T[];
+        if (isReanchorUpdate(sql)) reanchorRan = true;
+        if (isFlipUpdate(sql)) {
+          expect(this).not.toBe(engine);
+          flipRan = true;
+          throw new Error('injected completion flip failure');
+        }
+        return rows;
+      };
+      failed = await reextract(f);
+    } finally {
+      delete (engine as { softDeletePages?: unknown }).softDeletePages;
+      delete (engine as { executeRaw?: unknown }).executeRaw;
+    }
+    expect(flipRan).toBe(true);
+    expect(deleteRan).toBe(false);
+    expect(reanchorRan).toBe(false);
+    expect(failed.status).toBe('warn');
+    expect(failed.details?.atoms_superseded).toBe(0);
+    expect(failed.details?.atoms_reanchored).toBe(0);
+    const failures = failed.details?.failures as Array<{ source: string; error: string }>;
+    expect(failures.some(r => r.source === f.p && r.error.includes('injected completion flip failure'))).toBe(true);
+    expect(await atomRow(T_OLD, f.p)).toEqual(retiredBefore);
+    expect(await atomRow(T_KEEPER, f.p)).toEqual(keeperBefore);
+    const h2 = (await engine.getPage(f.p, { sourceId: 'default' }))!.content_hash!.slice(0, 16);
+    expect((await atomRow(T_SHARED, f.p))!.source_hash).toBe(`pending:${h2}`);
+    expect((await atomRow(T_NEW, f.p))!.source_hash).toBe(`pending:${h2}`);
+    expect(await atomsAtHash(f.p, h2)).toEqual([]);
+    expect((await discoverExtractablePages(engine, 'default')).some(p => p.slug === f.p)).toBe(true);
+  }, 120_000);
 });

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -34,6 +34,14 @@
  *   (g) a reconciliation failure leaves the page RETRYABLE — it lands before
  *       the completion markers, so real discovery still returns the page and
  *       the next run finishes the job.
+ *   (j) a cosmetic edit is not evidence: NFKC-equal text (NFD re-encode,
+ *       full-width punctuation) and markdown reshaping (emphasis, a link,
+ *       re-bulleting) keep their atoms, while a genuinely deleted sentence
+ *       still retires — the reverse control that keeps (j) honest.
+ *   (k) a retirement is not permanent: reverting the page re-discovers it and
+ *       the re-extraction revives the retired atom in place, because the atoms
+ *       kept on evidence were re-anchored to the hash that retired it.
+ *   (l) no cap: 200 stale atoms on one page retire in a single pass.
  *
  * Every case seeds its own page namespace and drives the phase with the page's
  * REAL persisted content hash, so the reconciliation's "page still carries
@@ -274,7 +282,13 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
 
     const keeper = await atomRow(T_KEEPER, p);
     expect(keeper!.deleted_at).toBeNull();
-    expect(keeper!.source_hash).toBe(keeperBefore.source_hash); // still stale, still kept
+    // Kept on evidence — and therefore RE-ANCHORED: its quote is in the body
+    // at the new hash, and a live atom still carrying the OLD hash would mask
+    // that content in discovery forever, so a revert could never re-earn what
+    // this run retired (case (j)).
+    expect(keeper!.source_hash).not.toBe(keeperBefore.source_hash);
+    expect(keeper!.source_hash).toBe((await atomRow(T_SHARED, p))!.source_hash);
+    expect(result.details?.atoms_reanchored).toBe(1);
   }, 120_000);
 
   test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
@@ -334,6 +348,7 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     const again = await reextract(f);
     expect(again.status).toBe('ok');
     expect(again.details?.atoms_superseded).toBe(0);
+    expect(again.details?.atoms_reanchored).toBe(0); // no retirement, no re-binding
     expect(String(again.summary)).not.toContain('superseded');
     expect(await bindingSnapshot()).toEqual(before);
   }, 120_000);
@@ -434,4 +449,190 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
     expect((await discoverExtractablePages(engine, 'default')).some(d => d.slug === p)).toBe(false);
   }, 120_000);
+});
+
+/**
+ * Probe-derived: an independent adversarial probe of this branch found the
+ * retirement gate destroying atoms over edits that changed only bytes, and
+ * making a retirement permanent across a revert. These cases pin both fixes
+ * (and the reverse control that keeps them from passing vacuously).
+ */
+
+/** Drive the phase over one page with a stubbed model reply. */
+async function runOne(slug: string, content: string, contentHash: string, pairs: Pair[]) {
+  return runPhaseExtractAtoms(engine, {
+    _transcripts: [],
+    _pages: [{ slug, content, contentHash }],
+    _chat: stubChat(pairs),
+  });
+}
+
+/** A page whose body carries `quoted`, with one atom verified against it. */
+async function seedVerified(ns: string, quoted: string, title: string): Promise<[slug: string, body: string]> {
+  const slug = `writings/2026-07-01-${ns}`;
+  const b = body([quoted], ns);
+  const h = await putAndHash(slug, `P ${ns}`, b);
+  const first = await runOne(slug, b, h, [[title, quoted]]);
+  expect(first.status).toBe('ok');
+  // Load-bearing: an unverified quote makes every assertion below vacuous.
+  expect((await atomRow(title, slug))!.verified).toBe('true');
+  expect((await atomRow(title, slug))!.deleted_at).toBeNull();
+  return [slug, b];
+}
+
+/** Re-put an edited body and reconcile it in the zero-yield lane (nothing exempt). */
+async function editAndReconcile(slug: string, ns: string, edited: string) {
+  const h = await putAndHash(slug, `P ${ns}`, edited);
+  return runOne(slug, edited, h, []);
+}
+
+describe('(j) a cosmetically edited page keeps its atoms', () => {
+  test('NFD re-encoding of Japanese prose is not a deleted claim', async () => {
+    const quoted = 'ダミーのプロトタイプでも購買部長は納得する。';
+    const [slug, seeded] = await seedVerified('j-nfd', quoted, 'JP claim');
+    // Same visible text, decomposed — what a re-import from an NFD-producing
+    // source (macOS filesystem, some clipboard paths) yields.
+    const edited = seeded.normalize('NFD');
+    expect(edited).not.toBe(seeded);
+
+    const r = await editAndReconcile(slug, 'j-nfd', edited);
+    expect(r.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('JP claim', slug))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('half-width → full-width punctuation is not a deleted claim', async () => {
+    const quoted = 'The pilot budget (approved in Q2) outlives its quarter.';
+    const [slug, seeded] = await seedVerified('j-width', quoted, 'Width claim');
+    const edited = seeded.replace(/\(/g, '（').replace(/\)/g, '）');
+
+    const r = await editAndReconcile(slug, 'j-width', edited);
+    expect(r.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('Width claim', slug))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('emphasis added inside the quoted span is not a deleted claim', async () => {
+    const quoted = 'A working prototype survives the procurement review here.';
+    const [slug, seeded] = await seedVerified('j-em', quoted, 'Emphasis claim');
+    const edited = seeded.replace('prototype', '**prototype**');
+
+    const r = await editAndReconcile(slug, 'j-em', edited);
+    expect(r.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('Emphasis claim', slug))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('a link wrapped around a quoted word is not a deleted claim', async () => {
+    const quoted = 'Procurement decides long before the demo is booked.';
+    const [slug, seeded] = await seedVerified('j-link', quoted, 'Link claim');
+    const edited = seeded.replace('Procurement', '[Procurement](https://example.invalid/p)');
+
+    const r = await editAndReconcile(slug, 'j-link', edited);
+    expect(r.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('Link claim', slug))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('reflowing and then re-bulleting a two-sentence quote is not a deleted claim', async () => {
+    const quoted = 'Enterprise buyers want tangible prototypes here. Pilot budgets outlive the quarter here.';
+    const [slug] = await seedVerified('j-flow', quoted, 'Span claim');
+
+    // (i) pure whitespace reflow — the strict grounding fold already handled
+    // this one; it is the control for the markdown folds.
+    const reflow = [
+      'Enterprise buyers want tangible prototypes here.\n\n   Pilot budgets outlive the quarter here.',
+      FILLER, 'Filed under revision marker j-flow reflow.',
+    ].join('\n');
+    const rR = await editAndReconcile(slug, 'j-flow', reflow);
+    expect(rR.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('Span claim', slug))!.deleted_at).toBeNull();
+
+    // (ii) the same two sentences as list items. Claims unchanged.
+    const bulleted = [
+      '- Enterprise buyers want tangible prototypes here.',
+      '- Pilot budgets outlive the quarter here.',
+      FILLER, 'Filed under revision marker j-flow bullets.',
+    ].join('\n');
+    const rB = await editAndReconcile(slug, 'j-flow', bulleted);
+    expect(rB.details?.atoms_superseded).toBe(0);
+    expect((await atomRow('Span claim', slug))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('reverse control: a genuinely deleted sentence IS still retired', async () => {
+    // Without this the whole (j) group could pass on a reconciler that never
+    // retires anything.
+    const quoted = 'Renders close deals faster than anything physical here.';
+    const [slug] = await seedVerified('j-control', quoted, 'Gone claim');
+    const edited = body(['A wholly different claim now stands in its place.'], 'j-control edited');
+
+    const r = await editAndReconcile(slug, 'j-control', edited);
+    expect(r.details?.atoms_superseded).toBe(1);
+    expect((await atomRow('Gone claim', slug))!.deleted_at).not.toBeNull();
+  }, 120_000);
+});
+
+describe('(k) a retirement survives a revert', () => {
+  test('reverting the page re-discovers it and the re-extraction revives the atom', async () => {
+    const ns = 'k';
+    const slug = `writings/2026-07-01-${ns}`;
+    const qA = 'Enterprise buyers want tangible prototypes in the k body.';
+    const qB = 'Renders close deals faster than anything physical in the k body.';
+    const qK = 'Procurement decides long before the demo in the k body.';
+
+    const b1 = body([qA, qB, qK], `${ns} one`);
+    const h1 = await putAndHash(slug, `P ${ns}`, b1);
+    const first = await runOne(slug, b1, h1, [['k a', qA], ['k b', qB], ['k k', qK]]);
+    expect(first.details?.atoms_extracted).toBe(3);
+
+    // Edit: qB is gone. Re-emit only 'k a', so 'k k' stays live on evidence
+    // while still carrying h1 — the row that used to mask h1 forever.
+    const b2 = body([qA, qK], `${ns} two`);
+    const h2 = await putAndHash(slug, `P ${ns}`, b2);
+    const second = await runOne(slug, b2, h2, [['k a', qA]]);
+    expect(second.details?.atoms_superseded).toBe(1);
+    expect(second.details?.atoms_reanchored).toBe(1);
+    expect((await atomRow('k b', slug))!.deleted_at).not.toBeNull();
+    expect((await atomRow('k k', slug))!.source_hash).toBe(h2);
+
+    // Revert the page to its original body: no live atom carries h1 any more,
+    // so discovery offers the page again...
+    await putAndHash(slug, `P ${ns}`, b1);
+    expect((await discoverExtractablePages(engine, 'default')).some(d => d.slug === slug)).toBe(true);
+
+    // ...and re-extracting it revives the retired atom in place (deterministic
+    // slug → upsert, not a duplicate).
+    const retiredSlug = (await atomRow('k b', slug))!.slug;
+    const third = await runOne(slug, b1, h1, [['k b', qB]]);
+    expect(third.status).toBe('ok');
+    const revived = await atomRow('k b', slug);
+    expect(revived!.slug).toBe(retiredSlug);
+    expect(revived!.deleted_at).toBeNull();
+  }, 120_000);
+});
+
+describe('(l) a wide page retires every stale atom in one pass', () => {
+  test('200 stale atoms on one page, no cap and no leftovers', async () => {
+    const ns = 'l';
+    const slug = `writings/2026-07-01-${ns}`;
+    await putAndHash(slug, `P ${ns}`, body(['The l original claim stands here plainly.'], `${ns} one`));
+    for (let i = 0; i < 200; i++) {
+      await engine.putPage(`atoms/2026-07-01/l-${String(i).padStart(3, '0')}`, {
+        type: 'atom', title: `l atom ${i}`,
+        compiled_truth: `Atom ${i}.`, timeline: '',
+        frontmatter: {
+          source_slug: slug, source_hash: 'ffffffffffffffff',
+          source_quote: `Absent sentence number ${i} that no page contains at all.`,
+          source_quote_verified: true,
+        },
+      });
+    }
+
+    const edited = body(['A rewritten l body sharing nothing with the first.'], `${ns} two`);
+    const r = await editAndReconcile(slug, ns, edited);
+    expect(r.status).toBe('ok');
+    // DELETE_BATCH_SIZE chunking must not drop the tail.
+    expect(r.details?.atoms_superseded).toBe(200);
+    const live = await engine.executeRaw<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pages
+        WHERE type = 'atom' AND slug LIKE 'atoms/2026-07-01/l-%' AND deleted_at IS NULL`,
+    );
+    expect(live[0]!.n).toBe('0');
+  }, 180_000);
 });

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -27,8 +27,8 @@
  *       invalidated atom — so (b) cannot pass vacuously on a no-op.
  *   (d) dry-run: no row changes at all, and the reported would-be count
  *       excludes a title this run would refresh in place.
- *   (e) idempotency: an identical re-run retires nothing and moves no atom in
- *       or out of the live set.
+ *   (e) a changed hash with every quote preserved retires nothing and leaves
+ *       an omitted atom's old binding alone.
  *   (f) the zero-yield lane reconciles too: an edit that leaves no extractable
  *       claim still retires the atoms whose quotes it deleted.
  *   (g) a reconciliation failure leaves the page RETRYABLE — it lands before
@@ -41,7 +41,7 @@
  *   (k) a retirement is not permanent: reverting the page re-discovers it and
  *       the re-extraction revives the retired atom in place, because the atoms
  *       kept on evidence were re-anchored to the hash that retired it.
- *   (l) no cap: 200 stale atoms on one page retire in a single pass.
+ *   (l) deletion and re-anchoring each process two full batches plus a tail.
  *
  * Every case seeds its own page namespace and drives the phase with the page's
  * REAL persisted content hash, so the reconciliation's "page still carries
@@ -51,6 +51,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { DELETE_BATCH_SIZE } from '../../src/core/engine-constants.ts';
 import { runPhaseExtractAtoms, discoverExtractablePages } from '../../src/core/cycle/extract-atoms.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
 
@@ -138,23 +139,18 @@ const ATOM_COLS = `slug, title, deleted_at::text AS deleted_at, updated_at::text
                    frontmatter->>'source_slug' AS source_slug,
                    frontmatter->>'source_quote_verified' AS verified`;
 
-/** Every atom row in the brain, full enough that any write shows up. */
-async function atomSnapshot(): Promise<AtomRow[]> {
-  return await engine.executeRaw<AtomRow>(
-    `SELECT ${ATOM_COLS} FROM pages WHERE type = 'atom' ORDER BY slug`,
+/** Complete source and atom rows, including all frontmatter and timestamps. */
+async function reconciliationSnapshot(pageSlug: string) {
+  return engine.executeRaw(
+    `SELECT * FROM pages WHERE type = 'atom' OR (source_id = 'default' AND slug = $1)
+      ORDER BY source_id, slug`,
+    [pageSlug],
   );
 }
 
-/**
- * The state this reconciliation owns: identity, liveness, binding. A re-run
- * legitimately re-imports each atom (extracted_at moves, so content_hash and
- * updated_at move with it) — that is the pre-existing upsert, not a retirement,
- * so the idempotency case asserts stillness on THIS projection.
- */
-async function bindingSnapshot(): Promise<Array<Omit<AtomRow, 'updated_at' | 'content_hash'>>> {
-  return (await atomSnapshot()).map(({ slug, title, deleted_at, source_hash, source_slug, verified }) => ({
-    slug, title, deleted_at, source_hash, source_slug, verified,
-  }));
+function isReanchorUpdate(sql: string): boolean {
+  return /^\s*UPDATE pages/.test(sql)
+    && sql.includes("jsonb_build_object('source_hash', $3::text)");
 }
 
 /** One atom, keyed by title + binding (T_SHARED exists for both P and Q). */
@@ -318,7 +314,6 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     const f = await seed('d');
     const p = f.p;
     await reextract(f);
-    const before = await atomSnapshot();
 
     // body3 drops BOTH Q_SHARED and Q_NEW, so both of those atoms' quotes are
     // gone. T_SHARED is re-emitted (with a quote from the new body), so the
@@ -327,30 +322,58 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     // written-this-run exclusion the count would be 2.
     const b3 = body3(f.ns);
     const h3 = await putAndHash(p, `P ${f.ns}`, b3);
-    const result = await runPhaseExtractAtoms(engine, {
-      dryRun: true,
-      _transcripts: [],
-      _pages: [{ slug: p, content: b3, contentHash: h3 }],
-      _chat: stubChat([[T_SHARED, Q_THIRD]]),
-    });
+    const before = await reconciliationSnapshot(p);
+    let deleteCalls = 0;
+    let reanchorCalls = 0;
+    let result;
+    try {
+      // Unbound wrappers preserve the transaction engine's `this` as well.
+      engine.softDeletePages = async function (slugs, opts) {
+        deleteCalls++;
+        return PGLiteEngine.prototype.softDeletePages.call(this, slugs, opts);
+      };
+      engine.executeRaw = async function <T>(sql: string, params?: unknown[]): Promise<T[]> {
+        if (isReanchorUpdate(sql)) reanchorCalls++;
+        return PGLiteEngine.prototype.executeRaw.call(this, sql, params) as Promise<T[]>;
+      };
+      result = await runPhaseExtractAtoms(engine, {
+        dryRun: true,
+        _transcripts: [],
+        _pages: [{ slug: p, content: b3, contentHash: h3 }],
+        _chat: stubChat([[T_SHARED, Q_THIRD]]),
+      });
+    } finally {
+      delete (engine as { softDeletePages?: unknown }).softDeletePages;
+      delete (engine as { executeRaw?: unknown }).executeRaw;
+    }
     expect(result.status).toBe('ok');
     expect(result.details?.dry_run).toBe(true);
     expect(result.details?.atoms_superseded).toBe(1);
-    expect(await atomSnapshot()).toEqual(before);
+    expect(result.details?.atoms_reanchored).toBe(1);
+    expect(deleteCalls).toBe(0);
+    expect(reanchorCalls).toBe(0);
+    expect(await reconciliationSnapshot(p)).toEqual(before);
   }, 120_000);
 
-  test('(e) an identical re-run retires nothing and moves no atom in or out of the live set', async () => {
+  test('(e) a changed hash with every quote preserved does not re-bind an omitted atom', async () => {
     const f = await seed('e');
     const p = f.p;
-    await reextract(f);
-    const before = await bindingSnapshot();
+    const before = (await atomRow(T_KEEPER, p))!;
+    expect(before.verified).toBe('true');
+    const edited = body([Q_SHARED, Q_OLD, Q_KEEPER], `${f.ns} revised metadata`);
+    const h2 = await putAndHash(p, `P ${f.ns}`, edited);
+    expect(h2).not.toBe(before.source_hash);
 
-    const again = await reextract(f);
+    const again = await runOne(p, edited, h2, [[T_SHARED, Q_SHARED], [T_OLD, Q_OLD]]);
     expect(again.status).toBe('ok');
+    expect(again.details?.atoms_extracted).toBe(2);
     expect(again.details?.atoms_superseded).toBe(0);
     expect(again.details?.atoms_reanchored).toBe(0); // no retirement, no re-binding
     expect(String(again.summary)).not.toContain('superseded');
-    expect(await bindingSnapshot()).toEqual(before);
+    expect(await atomRow(T_KEEPER, p)).toEqual(before);
+    expect((await atomRow(T_KEEPER, p))!.source_hash).toBe(before.source_hash);
+    expect((await atomRow(T_OLD, p))!.deleted_at).toBeNull();
+    expect((await atomRow(T_SHARED, p))!.deleted_at).toBeNull();
   }, 120_000);
 
   test('(f) the zero-yield lane reconciles: an edit that yields no atoms still retires', async () => {
@@ -418,25 +441,55 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
   test('(g) a reconciliation failure leaves the page retryable, and the retry finishes it', async () => {
     const f = await seed('g');
     const p = f.p;
+    const retiredBefore = (await atomRow(T_OLD, p))!;
+    const keeperBefore = (await atomRow(T_KEEPER, p))!;
+    let deletedSlugs: string[] = [];
+    let deleteEngine: PGLiteEngine | undefined;
+    let reanchorCompleted = false;
     let failed;
     try {
       // Shadow the prototype method with an own property, and DELETE it to
       // restore: re-assigning an engine-BOUND copy would make the reconciler's
       // transaction write on the outer connection instead of its own and
       // self-deadlock against the row lock it is holding.
-      (engine as { softDeletePages?: unknown }).softDeletePages = async () => {
-        throw new Error('injected soft-delete failure');
+      engine.softDeletePages = async function (slugs, opts) {
+        const deleted = await PGLiteEngine.prototype.softDeletePages.call(this, slugs, opts);
+        deleteEngine = this;
+        deletedSlugs.push(...deleted);
+        return deleted;
+      };
+      engine.executeRaw = async function <T>(sql: string, params?: unknown[]): Promise<T[]> {
+        const rows = await PGLiteEngine.prototype.executeRaw.call(this, sql, params) as T[];
+        if (isReanchorUpdate(sql)) {
+          expect(this === deleteEngine).toBe(true);
+          expect(this).not.toBe(engine);
+          expect(deletedSlugs).toEqual([retiredBefore.slug]);
+          expect(rows as Array<{ slug: string }>).toEqual([{ slug: keeperBefore.slug }]);
+          // Fail AFTER both writes actually ran on the same transaction.
+          // Without rollback, both the deletion and the new binding leak.
+          reanchorCompleted = true;
+          throw new Error('injected re-anchor failure');
+        }
+        return rows;
       };
       failed = await reextract(f);
     } finally {
       delete (engine as { softDeletePages?: unknown }).softDeletePages;
+      delete (engine as { executeRaw?: unknown }).executeRaw;
     }
 
     // Surfaced, not swallowed.
+    expect(reanchorCompleted).toBe(true);
     expect(failed.status).toBe('warn');
     const failures = failed.details?.failures as Array<{ source: string; error: string }>;
-    expect(failures.some(f => f.source === p && f.error.includes('injected soft-delete failure'))).toBe(true);
+    expect(failures.some(f => f.source === p && f.error.includes('injected re-anchor failure'))).toBe(true);
     expect(failed.details?.atoms_superseded).toBe(0);
+    expect(failed.details?.atoms_reanchored).toBe(0);
+    expect((await atomRow(T_OLD, p))!.deleted_at).toBeNull();
+    expect(await atomRow(T_OLD, p)).toEqual(retiredBefore);
+    expect((await atomRow(T_KEEPER, p))!.deleted_at).toBeNull();
+    expect((await atomRow(T_KEEPER, p))!.source_hash).toBe(keeperBefore.source_hash);
+    expect(await atomRow(T_KEEPER, p)).toEqual(keeperBefore);
 
     // And still retryable: the completion markers were never written, so REAL
     // discovery (not the _pages seam) still offers the page.
@@ -446,7 +499,9 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
     const retry = await reextract(f);
     expect(retry.status).toBe('ok');
     expect(retry.details?.atoms_superseded).toBe(1);
+    expect(retry.details?.atoms_reanchored).toBe(1);
     expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
+    expect((await atomRow(T_KEEPER, p))!.source_hash).not.toBe(keeperBefore.source_hash);
     expect((await discoverExtractablePages(engine, 'default')).some(d => d.slug === p)).toBe(false);
   }, 120_000);
 });
@@ -487,6 +542,35 @@ async function editAndReconcile(slug: string, ns: string, edited: string) {
 }
 
 describe('(j) a cosmetically edited page keeps its atoms', () => {
+  for (const { ns, quoted, pageCopy } of [
+    {
+      ns: 'j-bullet-boundary',
+      quoted: 'Results: - Alpha is enabled.',
+      pageCopy: 'Results:\n- Alpha is enabled.',
+    },
+    {
+      ns: 'j-balanced-link',
+      quoted: 'Use the prototype for procurement.',
+      pageCopy: 'Use [the prototype](https://example.invalid/a_(b)) for procurement.',
+    },
+    {
+      ns: 'j-mid-link',
+      quoted: '[Procurement](https://ex',
+      pageCopy: '[Procurement](https://example.invalid/p) decides before the demo.',
+    },
+  ]) {
+    test(`${ns}: a supported quote survives markdown normalization boundaries`, async () => {
+      const [slug, seeded] = await seedVerified(ns, quoted, ns);
+      const before = (await atomRow(ns, slug))!;
+      const edited = seeded.replace(quoted, pageCopy);
+      const r = await editAndReconcile(slug, ns, edited);
+      expect(r.status).toBe('ok');
+      expect(r.details?.atoms_superseded).toBe(0);
+      expect((await atomRow(ns, slug))!.deleted_at).toBeNull();
+      expect((await atomRow(ns, slug))!.source_hash).toBe(before.source_hash);
+    }, 120_000);
+  }
+
   test('NFD re-encoding of Japanese prose is not a deleted claim', async () => {
     const quoted = 'ダミーのプロトタイプでも購買部長は納得する。';
     const [slug, seeded] = await seedVerified('j-nfd', quoted, 'JP claim');
@@ -607,32 +691,62 @@ describe('(k) a retirement survives a revert', () => {
   }, 120_000);
 });
 
-describe('(l) a wide page retires every stale atom in one pass', () => {
-  test('200 stale atoms on one page, no cap and no leftovers', async () => {
+describe('(l) a wide page retires and re-anchors every eligible atom in one pass', () => {
+  test('two full batches plus one tail row on both mutation paths', async () => {
     const ns = 'l';
     const slug = `writings/2026-07-01-${ns}`;
-    await putAndHash(slug, `P ${ns}`, body(['The l original claim stands here plainly.'], `${ns} one`));
-    for (let i = 0; i < 200; i++) {
-      await engine.putPage(`atoms/2026-07-01/l-${String(i).padStart(3, '0')}`, {
-        type: 'atom', title: `l atom ${i}`,
-        compiled_truth: `Atom ${i}.`, timeline: '',
-        frontmatter: {
-          source_slug: slug, source_hash: 'ffffffffffffffff',
-          source_quote: `Absent sentence number ${i} that no page contains at all.`,
-          source_quote_verified: true,
-        },
-      });
-    }
-
-    const edited = body(['A rewritten l body sharing nothing with the first.'], `${ns} two`);
-    const r = await editAndReconcile(slug, ns, edited);
-    expect(r.status).toBe('ok');
-    // DELETE_BATCH_SIZE chunking must not drop the tail.
-    expect(r.details?.atoms_superseded).toBe(200);
-    const live = await engine.executeRaw<{ n: string }>(
-      `SELECT count(*)::text AS n FROM pages
-        WHERE type = 'atom' AND slug LIKE 'atoms/2026-07-01/l-%' AND deleted_at IS NULL`,
+    const candidates = 2 * DELETE_BATCH_SIZE + 1;
+    const gone = 'The l original claim stands here plainly.';
+    const kept = 'The l preserved claim still stands here plainly.';
+    const h1 = await putAndHash(slug, `P ${ns}`, body([gone, kept], `${ns} one`));
+    // One bulk INSERT keeps 2,002 fixture rows cheap; each group contains
+    // 1,001 distinct atoms with a verified quote from the original body.
+    await engine.executeRaw(
+      `INSERT INTO pages (source_id, slug, type, title, compiled_truth, frontmatter)
+       SELECT 'default', 'atoms/2026-07-01/l-' || kind || '-' || i, 'atom',
+              'l ' || kind || ' atom ' || i, 'Atom ' || i,
+              jsonb_build_object('source_slug', $1::text, 'source_hash', $2::text,
+                                 'source_quote', quote, 'source_quote_verified', true)
+         FROM generate_series(1, $3::int) AS s(i)
+         CROSS JOIN (VALUES ('retire', $4::text), ('keep', $5::text)) AS groups(kind, quote)`,
+      [slug, h1, candidates, gone, kept],
     );
-    expect(live[0]!.n).toBe('0');
+
+    const edited = body([kept], `${ns} two`);
+    const h2 = await putAndHash(slug, `P ${ns}`, edited);
+    expect(h2).not.toBe(h1);
+    const deleteBatches: number[] = [];
+    const reanchorBatches: number[] = [];
+    let r;
+    try {
+      engine.softDeletePages = async function (slugs, opts) {
+        deleteBatches.push(slugs.length);
+        return PGLiteEngine.prototype.softDeletePages.call(this, slugs, opts);
+      };
+      engine.executeRaw = async function <T>(sql: string, params?: unknown[]): Promise<T[]> {
+        if (isReanchorUpdate(sql)) reanchorBatches.push((params![3] as string[]).length);
+        return PGLiteEngine.prototype.executeRaw.call(this, sql, params) as Promise<T[]>;
+      };
+      r = await runOne(slug, edited, h2, []);
+    } finally {
+      delete (engine as { softDeletePages?: unknown }).softDeletePages;
+      delete (engine as { executeRaw?: unknown }).executeRaw;
+    }
+    expect(r.status).toBe('ok');
+    expect(deleteBatches).toEqual([DELETE_BATCH_SIZE, DELETE_BATCH_SIZE, 1]);
+    expect(reanchorBatches).toEqual([DELETE_BATCH_SIZE, DELETE_BATCH_SIZE, 1]);
+    expect(r.details?.atoms_superseded).toBe(candidates);
+    expect(r.details?.atoms_reanchored).toBe(candidates);
+    const rows = await engine.executeRaw<{ total: number; retired: number; reanchored: number }>(
+      `SELECT count(*)::int AS total,
+              count(*) FILTER (WHERE slug LIKE 'atoms/2026-07-01/l-retire-%'
+                AND deleted_at IS NOT NULL AND frontmatter->>'source_hash' = $2)::int AS retired,
+              count(*) FILTER (WHERE slug LIKE 'atoms/2026-07-01/l-keep-%'
+                AND deleted_at IS NULL AND frontmatter->>'source_hash' = $3)::int AS reanchored
+         FROM pages WHERE source_id = 'default' AND type = 'atom'
+           AND frontmatter->>'source_slug' = $1`,
+      [slug, h1, h2],
+    );
+    expect(rows).toEqual([{ total: 2 * candidates, retired: candidates, reanchored: candidates }]);
   }, 180_000);
 });

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -5,10 +5,10 @@
  * The doctor's `atom_provenance_drift` check counts atoms whose `source_hash`
  * matches no live page and never deletes; its `source_changed` bucket (source
  * page edited, atom left behind) had nothing to reclaim it. The page lane now
- * soft-deletes, once a page has been scanned, every live atom bound to THAT
- * page whose `source_hash` is neither the in-flight `pending:` marker nor the
- * page's current hash, whose slug this run did not write, and whose VERIFIED
- * `source_quote` is absent from the page's current content.
+ * soft-deletes, before it marks a scanned page complete, every live atom bound
+ * to THAT page whose `source_hash` is neither the in-flight `pending:` marker
+ * nor the page's current hash, whose slug this run did not write, and whose
+ * VERIFIED `source_quote` is absent from the page's current content.
  *
  * What the cases pin:
  *   (a) a reworded claim → the old atom is soft-deleted, the same-title atom
@@ -27,14 +27,21 @@
  *       excludes a title this run would refresh in place.
  *   (e) idempotency: an identical re-run retires nothing and moves no atom in
  *       or out of the live set.
+ *   (f) the zero-yield lane reconciles too: an edit that leaves no extractable
+ *       claim still retires the atoms whose quotes it deleted.
+ *   (g) a reconciliation failure leaves the page RETRYABLE — it lands before
+ *       the completion markers, so real discovery still returns the page and
+ *       the next run finishes the job.
  *
- * Every case seeds its own page namespace, so the tests are independent and
- * can be run individually. PGLite round-trip, stubbed chat gateway.
+ * Every case seeds its own page namespace and drives the phase with the page's
+ * REAL persisted content hash, so the reconciliation's "page still carries
+ * this hash" guard is exercised rather than bypassed. PGLite round-trip,
+ * stubbed chat gateway.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
-import { runPhaseExtractAtoms } from '../../src/core/cycle/extract-atoms.ts';
+import { runPhaseExtractAtoms, discoverExtractablePages } from '../../src/core/cycle/extract-atoms.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
@@ -60,21 +67,34 @@ const Q_THIRD = 'Pilot budgets outlive the quarter they were approved in.';
 const Q_SIBLING = 'A second brief argues the opposite of the first.';
 const Q_LEGACY = 'An orphan sentence that lives in no page at all.';
 
+// Page discovery ignores bodies under 500 chars, and case (g) drives real
+// discovery, so every body carries neutral padding. The filler shares no
+// sentence with any quote above.
+const FILLER = [
+  'The brief opens with background on the buying committee and how it forms.',
+  'It walks through the evaluation window, the pilot, and the paperwork after.',
+  'It notes which stakeholders read the appendix and which never open it.',
+  'It closes with a short list of open questions for the next revision.',
+  'None of this padding carries a claim worth extracting on its own.',
+  'It exists so the body clears the discovery floor for page extraction.',
+  'The remaining lines simply restate the structure of the document itself.',
+  'A summary, a body, an appendix, and a list of unresolved follow-ups.',
+].join(' ');
+
 const T_SHARED = 'Prototypes beat renders';
 const T_OLD = 'Renders close deals';
 const T_KEEPER = 'Procurement decides early';
 const T_NEW = 'Prototypes survive review';
 
-const H1 = '1111111111111111';
-const H2 = '2222222222222222';
-const H3 = '3333333333333333';
-const HQ = '4444444444444444';
-
-const BODY_1 = [Q_SHARED, Q_OLD, Q_KEEPER].join(' ');
+// Bodies carry their namespace so two cases can never share a content_hash:
+// discovery's "already extracted" subquery matches ANY atom in the source with
+// that hash, so identical bodies in different namespaces would cross-talk.
+const body = (parts: string[], ns: string) => [...parts, FILLER, `Filed under revision marker ${ns}.`].join(' ');
+const body1 = (ns: string) => body([Q_SHARED, Q_OLD, Q_KEEPER], ns);
 // Q_OLD is gone (the reworded claim); Q_SHARED and Q_KEEPER survive verbatim.
-const BODY_2 = [Q_SHARED, Q_NEW, Q_KEEPER].join(' ');
+const body2 = (ns: string) => body([Q_SHARED, Q_NEW, Q_KEEPER], ns);
 // Only Q_KEEPER survives; Q_SHARED and Q_NEW are both gone.
-const BODY_3 = [Q_THIRD, Q_KEEPER].join(' ');
+const body3 = (ns: string) => body([Q_THIRD, Q_KEEPER], ns);
 
 type Pair = [title: string, quote: string];
 
@@ -138,33 +158,49 @@ async function atomRow(title: string, sourceSlug: string | null): Promise<AtomRo
   return rows[0] ?? null;
 }
 
-interface Fixture { p: string; q: string; legacySlug: string }
+/**
+ * Persist a body and hand back the hash the phase would have discovered for
+ * it. Using the REAL hash matters: reconciliation refuses to act when the live
+ * page no longer carries the hash the run is reconciling against.
+ */
+async function putAndHash(slug: string, title: string, body: string): Promise<string> {
+  // 'article' (not 'note') so the page is in the extractable-type allowlist —
+  // case (g) drives real discovery.
+  await engine.putPage(slug, { type: 'article', title, compiled_truth: body, timeline: '' });
+  const rows = await engine.executeRaw<{ h: string }>(
+    `SELECT content_hash AS h FROM pages WHERE slug = $1 AND source_id = 'default'`, [slug],
+  );
+  return rows[0]!.h.slice(0, 16);
+}
+
+interface Fixture { ns: string; p: string; q: string; legacyTitle: string; legacySlug: string }
 
 /**
  * Two same-date source pages (so their atoms share the `atoms/2026-07-01/`
  * prefix and only the locator fold separates them) plus a pre-binding-era
- * atom. P is extracted at H1; Q is extracted once and never again, so its
+ * atom. P is extracted at body1(ns); Q is extracted once and never again, so its
  * atom's hash stays stale for the rest of the fixture.
  */
 async function seed(ns: string): Promise<Fixture> {
   const p = `writings/2026-07-01-p-${ns}`;
   const q = `writings/2026-07-01-q-${ns}`;
   const legacySlug = `atoms/2026-07-01/legacy-unbound-${ns}`;
+  const legacyTitle = `Legacy unbound atom ${ns}`;
 
-  await engine.putPage(p, { type: 'note', title: `P ${ns}`, compiled_truth: BODY_1, timeline: '' });
-  await engine.putPage(q, { type: 'note', title: `Q ${ns}`, compiled_truth: Q_SIBLING, timeline: '' });
+  const h1 = await putAndHash(p, `P ${ns}`, body1(ns));
+  const hq = await putAndHash(q, `Q ${ns}`, body([Q_SIBLING], ns));
   // Pre-binding era: no source_slug and no source_path. Deliberately given a
   // stale hash AND a verified quote that appears in no page, so only the
   // missing binding stands between it and the reconciler.
   await engine.putPage(legacySlug, {
-    type: 'atom', title: `Legacy unbound atom ${ns}`,
+    type: 'atom', title: legacyTitle,
     compiled_truth: 'An atom written before source bindings existed.', timeline: '',
     frontmatter: { source_hash: 'ffffffffffffffff', source_quote: Q_LEGACY, source_quote_verified: true },
   });
 
   const first = await runPhaseExtractAtoms(engine, {
     _transcripts: [],
-    _pages: [{ slug: p, content: BODY_1, contentHash: H1 }],
+    _pages: [{ slug: p, content: body1(ns), contentHash: h1 }],
     _chat: stubChat([[T_SHARED, Q_SHARED], [T_OLD, Q_OLD], [T_KEEPER, Q_KEEPER]]),
   });
   expect(first.status).toBe('ok');
@@ -177,98 +213,107 @@ async function seed(ns: string): Promise<Fixture> {
   // #4733 locator fold — with a quote that lives only in Q's own body.
   const sibling = await runPhaseExtractAtoms(engine, {
     _transcripts: [],
-    _pages: [{ slug: q, content: Q_SIBLING, contentHash: HQ }],
+    _pages: [{ slug: q, content: body([Q_SIBLING], ns), contentHash: hq }],
     _chat: stubChat([[T_SHARED, Q_SIBLING]]),
   });
   expect(sibling.status).toBe('ok');
 
-  return { p, q, legacySlug };
+  return { ns, p, q, legacyTitle, legacySlug };
 }
 
-/** The re-extraction under test: P edited to BODY_2, one claim reworded. */
-function reextract(p: string) {
+/** The re-extraction under test: P edited to body2, one claim reworded. */
+async function reextract(f: Fixture, pairs: Pair[] = [[T_SHARED, Q_SHARED], [T_NEW, Q_NEW]]) {
+  const b2 = body2(f.ns);
+  const h2 = await putAndHash(f.p, `P ${f.ns}`, b2);
   return runPhaseExtractAtoms(engine, {
     _transcripts: [],
-    _pages: [{ slug: p, content: BODY_2, contentHash: H2 }],
-    _chat: stubChat([[T_SHARED, Q_SHARED], [T_NEW, Q_NEW]]),
+    _pages: [{ slug: f.p, content: b2, contentHash: h2 }],
+    _chat: stubChat(pairs),
   });
 }
 
 describe('extract_atoms retires atoms its source page no longer supports (#4566 follow-through)', () => {
   test('(a) a reworded claim is retired; the same-title atom is upserted in place', async () => {
-    const { p } = await seed('a');
-    const slugBefore = (await atomRow(T_SHARED, p))!.slug;
+    const f = await seed('a');
+    const p = f.p;
+    const before = (await atomRow(T_SHARED, p))!;
 
-    const result = await reextract(p);
+    const result = await reextract(f);
     expect(result.status).toBe('ok');
     expect(result.details?.atoms_superseded).toBe(1);
     expect(String(result.summary)).toContain('1 superseded');
 
     // The reworded claim's quote is gone from the page: retired.
     const retired = await atomRow(T_OLD, p);
-    expect(retired!.source_hash).toBe(H1);
+    expect(retired!.source_hash).toBe(before.source_hash);
     expect(retired!.deleted_at).not.toBeNull();
 
     // Unchanged title: SAME slug, refreshed hash, still live (upsert in place).
     const shared = await atomRow(T_SHARED, p);
-    expect(shared!.slug).toBe(slugBefore);
+    expect(shared!.slug).toBe(before.slug);
     expect(shared!.deleted_at).toBeNull();
-    expect(shared!.source_hash).toBe(H2);
+    expect(shared!.source_hash).not.toBe(before.source_hash);
 
     // The replacement atom is live at the new hash.
     const fresh = await atomRow(T_NEW, p);
     expect(fresh!.deleted_at).toBeNull();
-    expect(fresh!.source_hash).toBe(H2);
+    expect(fresh!.source_hash).toBe(shared!.source_hash);
   }, 120_000);
 
   test('(a2) an atom the new pass merely omitted is KEPT while its quote survives', async () => {
-    const { p } = await seed('a2');
+    const f = await seed('a2');
+    const p = f.p;
+    const keeperBefore = (await atomRow(T_KEEPER, p))!;
     // T_KEEPER is not re-emitted by the re-extraction, but Q_KEEPER is still
-    // in BODY_2 verbatim — omission alone must never retire an atom.
-    const result = await reextract(p);
+    // in body2 verbatim — omission alone must never retire an atom.
+    const result = await reextract(f);
     expect(result.details?.atoms_superseded).toBe(1);
 
     const keeper = await atomRow(T_KEEPER, p);
     expect(keeper!.deleted_at).toBeNull();
-    expect(keeper!.source_hash).toBe(H1); // still stale, still kept
+    expect(keeper!.source_hash).toBe(keeperBefore.source_hash); // still stale, still kept
   }, 120_000);
 
   test('(b) atoms bound elsewhere — sibling page Q, pre-binding era — are untouched', async () => {
-    const { p, q, legacySlug } = await seed('b');
+    const f = await seed('b');
+    const { p, q, legacyTitle, legacySlug } = f;
     const qBefore = await atomRow(T_SHARED, q);
-    const legacyBefore = await atomRow(`Legacy unbound atom b`, null);
+    const legacyBefore = await atomRow(legacyTitle, null);
     expect(qBefore).not.toBeNull();
     expect(qBefore!.slug).not.toBe((await atomRow(T_SHARED, p))!.slug);
     expect(legacyBefore!.slug).toBe(legacySlug);
 
-    await reextract(p);
+    await reextract(f);
 
     expect(await atomRow(T_SHARED, q)).toEqual(qBefore);
-    expect(await atomRow('Legacy unbound atom b', null)).toEqual(legacyBefore);
+    expect(await atomRow(legacyTitle, null)).toEqual(legacyBefore);
   }, 120_000);
 
   test('(c) reverse control: in that same run, the page\'s own invalidated atom IS retired', async () => {
-    const { p } = await seed('c');
-    const result = await reextract(p);
+    const f = await seed('c');
+    const p = f.p;
+    const result = await reextract(f);
     expect(result.details?.atoms_superseded).toBe(1);
-    const retired = await atomRow(T_OLD, p);
-    expect(retired!.deleted_at).not.toBeNull();
+    expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
   }, 120_000);
 
   test('(d) dry-run writes nothing and excludes a title it would refresh in place', async () => {
-    const { p } = await seed('d');
-    await reextract(p);
+    const f = await seed('d');
+    const p = f.p;
+    await reextract(f);
     const before = await atomSnapshot();
 
-    // BODY_3 drops BOTH Q_SHARED and Q_NEW, so both of those atoms' quotes are
+    // body3 drops BOTH Q_SHARED and Q_NEW, so both of those atoms' quotes are
     // gone. T_SHARED is re-emitted (with a quote from the new body), so the
     // run would refresh it in place and it must NOT be counted; T_NEW is not
     // re-emitted and its quote is gone, so it must be. Without the
     // written-this-run exclusion the count would be 2.
+    const b3 = body3(f.ns);
+    const h3 = await putAndHash(p, `P ${f.ns}`, b3);
     const result = await runPhaseExtractAtoms(engine, {
       dryRun: true,
       _transcripts: [],
-      _pages: [{ slug: p, content: BODY_3, contentHash: H3 }],
+      _pages: [{ slug: p, content: b3, contentHash: h3 }],
       _chat: stubChat([[T_SHARED, Q_THIRD]]),
     });
     expect(result.status).toBe('ok');
@@ -278,14 +323,88 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
   }, 120_000);
 
   test('(e) an identical re-run retires nothing and moves no atom in or out of the live set', async () => {
-    const { p } = await seed('e');
-    await reextract(p);
+    const f = await seed('e');
+    const p = f.p;
+    await reextract(f);
     const before = await bindingSnapshot();
 
-    const again = await reextract(p);
+    const again = await reextract(f);
     expect(again.status).toBe('ok');
     expect(again.details?.atoms_superseded).toBe(0);
     expect(String(again.summary)).not.toContain('superseded');
     expect(await bindingSnapshot()).toEqual(before);
+  }, 120_000);
+
+  test('(f) the zero-yield lane reconciles: an edit that yields no atoms still retires', async () => {
+    const f = await seed('f');
+    const p = f.p;
+    const b2 = body2(f.ns);
+    const h2 = await putAndHash(p, `P ${f.ns}`, b2);
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: p, content: b2, contentHash: h2 }],
+      _chat: stubChat([]), // model finds nothing extractable in the edited body
+    });
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_extracted).toBe(0);
+    expect(result.details?.atoms_superseded).toBe(1);
+    expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
+    // Omission-immune here too: the zero-yield pass exempts nothing, so only
+    // the quote evidence keeps T_KEEPER and T_SHARED alive.
+    expect((await atomRow(T_KEEPER, p))!.deleted_at).toBeNull();
+    expect((await atomRow(T_SHARED, p))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('(h) a page edited while the model was thinking is not judged on the stale snapshot', async () => {
+    const f = await seed('h');
+    const p = f.p;
+    const b2 = body2(f.ns);
+    const h2 = await putAndHash(p, `P ${f.ns}`, b2);
+
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: p, content: b2, contentHash: h2 }],
+      // The page is edited back to body1 (Q_OLD returns) mid-call, so the
+      // snapshot the phase is holding no longer describes the live page.
+      _chat: async (o) => {
+        await putAndHash(p, `P ${f.ns}`, body1(f.ns));
+        return stubChat([[T_SHARED, Q_SHARED], [T_NEW, Q_NEW]])(o);
+      },
+    });
+
+    expect(result.details?.atoms_superseded).toBe(0);
+    expect((await atomRow(T_OLD, p))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('(g) a reconciliation failure leaves the page retryable, and the retry finishes it', async () => {
+    const f = await seed('g');
+    const p = f.p;
+    const original = engine.softDeletePages.bind(engine);
+    let failed;
+    try {
+      (engine as { softDeletePages: unknown }).softDeletePages = async () => {
+        throw new Error('injected soft-delete failure');
+      };
+      failed = await reextract(f);
+    } finally {
+      (engine as { softDeletePages: unknown }).softDeletePages = original;
+    }
+
+    // Surfaced, not swallowed.
+    expect(failed.status).toBe('warn');
+    const failures = failed.details?.failures as Array<{ source: string; error: string }>;
+    expect(failures.some(f => f.source === p && f.error.includes('injected soft-delete failure'))).toBe(true);
+    expect(failed.details?.atoms_superseded).toBe(0);
+
+    // And still retryable: the completion markers were never written, so REAL
+    // discovery (not the _pages seam) still offers the page.
+    const discovered = await discoverExtractablePages(engine, 'default');
+    expect(discovered.some(d => d.slug === p)).toBe(true);
+
+    const retry = await reextract(f);
+    expect(retry.status).toBe('ok');
+    expect(retry.details?.atoms_superseded).toBe(1);
+    expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
+    expect((await discoverExtractablePages(engine, 'default')).some(d => d.slug === p)).toBe(false);
   }, 120_000);
 });

--- a/test/cycle/extract-atoms-supersede-stale.test.ts
+++ b/test/cycle/extract-atoms-supersede-stale.test.ts
@@ -372,22 +372,46 @@ describe('extract_atoms retires atoms its source page no longer supports (#4566 
       },
     });
 
+    // The run really did reach reconciliation — it succeeded and imported its
+    // atoms; the zero count is the guard firing, not an early exception.
+    expect(result.status).toBe('ok');
+    expect(result.details?.atoms_extracted).toBe(2);
     expect(result.details?.atoms_superseded).toBe(0);
     expect((await atomRow(T_OLD, p))!.deleted_at).toBeNull();
+  }, 120_000);
+
+  test('(i) a pending row abandoned by an interrupted earlier run is reclaimable', async () => {
+    const f = await seed('i');
+    const p = f.p;
+    // An interrupted run leaves atoms stamped `pending:<its hash>`; nothing
+    // else ever reclaims them, so only THIS run's marker is exempt.
+    await engine.executeRaw(
+      `UPDATE pages SET frontmatter = frontmatter || jsonb_build_object('source_hash', 'pending:aaaaaaaaaaaaaaaa')
+        WHERE type = 'atom' AND title = $1 AND frontmatter->>'source_slug' = $2`,
+      [T_OLD, p],
+    );
+    expect((await atomRow(T_OLD, p))!.source_hash).toBe('pending:aaaaaaaaaaaaaaaa');
+
+    const result = await reextract(f);
+    expect(result.details?.atoms_superseded).toBe(1);
+    expect((await atomRow(T_OLD, p))!.deleted_at).not.toBeNull();
   }, 120_000);
 
   test('(g) a reconciliation failure leaves the page retryable, and the retry finishes it', async () => {
     const f = await seed('g');
     const p = f.p;
-    const original = engine.softDeletePages.bind(engine);
     let failed;
     try {
-      (engine as { softDeletePages: unknown }).softDeletePages = async () => {
+      // Shadow the prototype method with an own property, and DELETE it to
+      // restore: re-assigning an engine-BOUND copy would make the reconciler's
+      // transaction write on the outer connection instead of its own and
+      // self-deadlock against the row lock it is holding.
+      (engine as { softDeletePages?: unknown }).softDeletePages = async () => {
         throw new Error('injected soft-delete failure');
       };
       failed = await reextract(f);
     } finally {
-      (engine as { softDeletePages: unknown }).softDeletePages = original;
+      delete (engine as { softDeletePages?: unknown }).softDeletePages;
     }
 
     // Surfaced, not swallowed.

--- a/test/dream-drain-failure-summary.serial.test.ts
+++ b/test/dream-drain-failure-summary.serial.test.ts
@@ -52,6 +52,8 @@ function baseResult(overrides: Partial<ExtractAtomsDrainResult>): ExtractAtomsDr
     status: 'ok',
     extracted: 1,
     skipped: 0,
+    superseded: 0,
+    reanchored: 0,
     remaining: 0, // fully drained → dream exits 0 (no process.exit call)
     batches: 1,
     stopped: 'drained',

--- a/test/extract-atoms-drain.test.ts
+++ b/test/extract-atoms-drain.test.ts
@@ -202,13 +202,13 @@ describe('shared wiring helper holds the cycle lock (5A)', () => {
   // destructive count has to be READ from its details, not dropped on the
   // floor. Run the real adapter with a stubbed phase and lock; restore every
   // spy so the shared module exports remain usable by neighboring tests.
-  it('runBatch maps the phase details\' retired/re-anchored atom counts', async () => {
+  it('runBatch maps the phase details\' retired/re-anchored/blocked atom counts', async () => {
     const phase = await import('../src/core/cycle/extract-atoms.ts');
     const locks = await import('../src/core/db-lock.ts');
     const lock = spyOn(locks, 'withRefreshingLock').mockImplementation(async (_engine, _id, work) => work());
     const batch = spyOn(phase, 'runPhaseExtractAtoms').mockResolvedValue({
       phase: 'extract_atoms', status: 'ok', summary: 'stubbed phase', duration_ms: 0,
-      details: { atoms_extracted: 1, pages_processed: 1, atoms_superseded: 2, atoms_reanchored: 7 },
+      details: { atoms_extracted: 1, pages_processed: 1, atoms_superseded: 2, atoms_reanchored: 7, atoms_retirement_blocked: 4 },
     });
     const backlog = spyOn(phase, 'countExtractAtomsBacklog').mockImplementation(seq([1, 0, 0]));
     try {
@@ -224,6 +224,7 @@ describe('shared wiring helper holds the cycle lock (5A)', () => {
       expect(result.stopped).toBe('drained');
       expect(result.superseded).toBe(2);
       expect(result.reanchored).toBe(7);
+      expect(result.retirement_blocked).toBe(4);
     } finally {
       backlog.mockRestore();
       batch.mockRestore();
@@ -288,11 +289,11 @@ describe('#2144: zero-yield tombstone progress semantics', () => {
   // #4566 — the drain lane is where extract_atoms runs nightly, so the only
   // DESTRUCTIVE number the phase produces has to survive the adapter into
   // `--json`. Missing values (the pre-#4566 adapter shape) count as 0.
-  it('sums the retired/re-anchored atom counts across batches, defaulting absent ones to 0', async () => {
+  it('sums the retired/re-anchored/blocked atom counts across batches, defaulting absent ones to 0', async () => {
     const counts = [
-      { extracted: 1, skipped: 0, superseded: 2, reanchored: 1 },
+      { extracted: 1, skipped: 0, superseded: 2, reanchored: 1, retirement_blocked: 2 },
       { extracted: 1, skipped: 0 },
-      { extracted: 1, skipped: 0, superseded: 3, reanchored: 6 },
+      { extracted: 1, skipped: 0, superseded: 3, reanchored: 6, retirement_blocked: 3 },
     ];
     let i = 0;
     const result = await runExtractAtomsDrain(
@@ -307,6 +308,7 @@ describe('#2144: zero-yield tombstone progress semantics', () => {
     expect(result.batches).toBe(3);
     expect(result.superseded).toBe(5);
     expect(result.reanchored).toBe(7);
+    expect(result.retirement_blocked).toBe(5);
   });
 
   it('stops no_progress when a zero-atom batch leaves the backlog flat', async () => {

--- a/test/extract-atoms-drain.test.ts
+++ b/test/extract-atoms-drain.test.ts
@@ -8,14 +8,16 @@
  *  - a busy lock (withLock throws) propagates so the caller reports skipped
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import {
   runExtractAtomsDrain,
+  runExtractAtomsDrainForSource,
   type ExtractAtomsDrainDeps,
 } from '../src/core/cycle/extract-atoms-drain.ts';
 import { isProtectedJobName, PROTECTED_JOB_NAMES } from '../src/core/minions/protected-names.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
 
 function seq(values: Array<number | null>): () => Promise<number | null> {
   let i = 0;
@@ -198,12 +200,35 @@ describe('shared wiring helper holds the cycle lock (5A)', () => {
   // same 'warn' value — the exact discard the issue reports).
   // #4566 — the wiring adapter is what a real drain runs; the phase's
   // destructive count has to be READ from its details, not dropped on the
-  // floor. (The adapter itself needs a live engine + lock, so this reads the
-  // mapping; the pure-loop case above pins the arithmetic.)
-  it('runBatch maps the phase details\' retired/re-anchored atom counts', () => {
-    const runBatchBlock = src.slice(src.indexOf('runBatch: async () => {'));
-    expect(runBatchBlock).toContain("superseded: Number(d.atoms_superseded ?? 0)");
-    expect(runBatchBlock).toContain("reanchored: Number(d.atoms_reanchored ?? 0)");
+  // floor. Run the real adapter with a stubbed phase and lock; restore every
+  // spy so the shared module exports remain usable by neighboring tests.
+  it('runBatch maps the phase details\' retired/re-anchored atom counts', async () => {
+    const phase = await import('../src/core/cycle/extract-atoms.ts');
+    const locks = await import('../src/core/db-lock.ts');
+    const lock = spyOn(locks, 'withRefreshingLock').mockImplementation(async (_engine, _id, work) => work());
+    const batch = spyOn(phase, 'runPhaseExtractAtoms').mockResolvedValue({
+      phase: 'extract_atoms', status: 'ok', summary: 'stubbed phase', duration_ms: 0,
+      details: { atoms_extracted: 1, pages_processed: 1, atoms_superseded: 2, atoms_reanchored: 7 },
+    });
+    const backlog = spyOn(phase, 'countExtractAtomsBacklog').mockImplementation(seq([1, 0, 0]));
+    try {
+      const engine = {} as BrainEngine;
+      const result = await runExtractAtomsDrainForSource(engine, {
+        sourceId: 'default', windowSeconds: 60,
+      });
+      expect(batch).toHaveBeenCalledTimes(1);
+      expect(batch).toHaveBeenCalledWith(engine, {
+        sourceId: 'default', dryRun: false, brainDir: undefined,
+      });
+      expect(result.batches).toBe(1);
+      expect(result.stopped).toBe('drained');
+      expect(result.superseded).toBe(2);
+      expect(result.reanchored).toBe(7);
+    } finally {
+      backlog.mockRestore();
+      batch.mockRestore();
+      lock.mockRestore();
+    }
   });
 
   it('runBatch derives providerFailure from failures.length + zero processed items, not r.status', () => {
@@ -267,7 +292,7 @@ describe('#2144: zero-yield tombstone progress semantics', () => {
     const counts = [
       { extracted: 1, skipped: 0, superseded: 2, reanchored: 1 },
       { extracted: 1, skipped: 0 },
-      { extracted: 1, skipped: 0, superseded: 3, reanchored: 4 },
+      { extracted: 1, skipped: 0, superseded: 3, reanchored: 6 },
     ];
     let i = 0;
     const result = await runExtractAtomsDrain(
@@ -281,7 +306,7 @@ describe('#2144: zero-yield tombstone progress semantics', () => {
     );
     expect(result.batches).toBe(3);
     expect(result.superseded).toBe(5);
-    expect(result.reanchored).toBe(5);
+    expect(result.reanchored).toBe(7);
   });
 
   it('stops no_progress when a zero-atom batch leaves the backlog flat', async () => {

--- a/test/extract-atoms-drain.test.ts
+++ b/test/extract-atoms-drain.test.ts
@@ -196,6 +196,16 @@ describe('shared wiring helper holds the cycle lock (5A)', () => {
   // (failures.length > 0 && transcripts_processed + pages_processed === 0),
   // not from `r.status` (which collapses partial and total failure into the
   // same 'warn' value — the exact discard the issue reports).
+  // #4566 — the wiring adapter is what a real drain runs; the phase's
+  // destructive count has to be READ from its details, not dropped on the
+  // floor. (The adapter itself needs a live engine + lock, so this reads the
+  // mapping; the pure-loop case above pins the arithmetic.)
+  it('runBatch maps the phase details\' retired/re-anchored atom counts', () => {
+    const runBatchBlock = src.slice(src.indexOf('runBatch: async () => {'));
+    expect(runBatchBlock).toContain("superseded: Number(d.atoms_superseded ?? 0)");
+    expect(runBatchBlock).toContain("reanchored: Number(d.atoms_reanchored ?? 0)");
+  });
+
   it('runBatch derives providerFailure from failures.length + zero processed items, not r.status', () => {
     const runBatchBlock = src.slice(src.indexOf('runBatch: async () => {'));
     expect(runBatchBlock).toContain('d.failures');
@@ -248,6 +258,30 @@ describe('#2144: zero-yield tombstone progress semantics', () => {
     expect(result.extracted).toBe(0);
     expect(result.remaining).toBe(0);
     expect(batches).toBe(2);
+  });
+
+  // #4566 — the drain lane is where extract_atoms runs nightly, so the only
+  // DESTRUCTIVE number the phase produces has to survive the adapter into
+  // `--json`. Missing values (the pre-#4566 adapter shape) count as 0.
+  it('sums the retired/re-anchored atom counts across batches, defaulting absent ones to 0', async () => {
+    const counts = [
+      { extracted: 1, skipped: 0, superseded: 2, reanchored: 1 },
+      { extracted: 1, skipped: 0 },
+      { extracted: 1, skipped: 0, superseded: 3, reanchored: 4 },
+    ];
+    let i = 0;
+    const result = await runExtractAtomsDrain(
+      {
+        withLock: passThroughLock,
+        countRemaining: seq([3, 2, 1, 0, 0]),
+        runBatch: async () => counts[i++]!,
+        now: () => 0,
+      },
+      { windowMs: 1_000_000 },
+    );
+    expect(result.batches).toBe(3);
+    expect(result.superseded).toBe(5);
+    expect(result.reanchored).toBe(5);
   });
 
   it('stops no_progress when a zero-atom batch leaves the backlog flat', async () => {


### PR DESCRIPTION
## What

`extract_atoms` retires the atoms a re-extracted source page no longer supports. When a page is scanned, a live atom bound to that page (`source_slug` = the page slug, same source) is soft-deleted only if all of the following hold: its `source_hash` is a stale, non-null value (not the page's current hash16 and not this run's in-flight `pending:` marker), this run did not write its slug, the page still carries the hash the run read, and the atom's `source_quote_verified: true` quote is absent from the page's full current content. The phase reports `atoms_superseded` in its summary and details.

This is the deletion side of a feature that shipped as diagnostic-only, so it is a proposal for a product decision rather than a plain bug fix. The question itself is in #4908; this PR is the concrete shape I would suggest if automatic retirement is wanted at all. Related to #4566 and #4908.

## Why

The doctor check `atom_provenance_drift` (#4566) counts atoms whose `source_hash` matches no live page and states that it never deletes. Nothing else reclaims the edited-source bucket: re-extraction upserts an atom in place only when the new pass yields the same title, so a reworded claim lands on a new deterministic slug and the old atom stays live, still returned by search with a quote no current page contains.

The check's docstring warns that a GC keyed on drift alone would delete mostly-recoverable knowledge. This is not keyed on drift, and it is not keyed on omission either (the extractor sees a truncated cut of the page, so a page legitimately yields a different selection next time). The trigger is the atom's own verified quote being absent from the page's current content. The check's SQL only tests hash resolution and source existence; the quote criterion here is stricter than what the check measures, and it errs toward keeping the atom: containment is tested on normalized text over the whole page, not on the model's cut. A rewrite that drops the quote but keeps the claim would still retire the atom, which is the trade-off #4908 asks about.

## How

- Reconciliation runs when the page is marked scanned, before the `source_hash` flip and the `atoms_scan_hash` stamp, and is allowed to throw, the same posture as the provenance-edge flush, so a failure leaves the page retryable.
- Pages with nothing to retire cost one SELECT. When there are candidates, the judgement is re-derived inside a transaction holding `FOR UPDATE` on the source page and the candidate rows, so an edit that lands during the model call is not judged on the stale snapshot.
- Soft-delete via `softDeletePages` (recoverable, behind the usual `deleted_at` filters). In dry-run the reconciliation only counts and makes no atom-row changes; the phase's pre-existing dry-run behavior around the model call (and its usage accounting) is unchanged by this PR. A second identical run retires nothing.
- Pre-binding-era atoms (no `source_slug`/`source_path`) and transcript-lane atoms (`source_path` only) cannot match the predicate. Out of scope: the transcript lane (#4806), `source_gone` atoms, and the doctor check itself.
- The helper lives in `src/core/cycle/extract-atoms-supersede.ts` because `extract-atoms.ts` would otherwise cross the `check:module-size` cap.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/extract-atoms.ts` `src/core/cycle/extract-atoms-supersede.ts` to merge-base, ran `test/cycle/extract-atoms-supersede-stale.test.ts` → 1 pass / 9 fail. Restored → all pass. (via `scripts/check-test-discriminates.sh`)

## Tests

`test/cycle/extract-atoms-supersede-stale.test.ts` (10 cases, PGLite round-trip, stubbed gateway, real persisted `content_hash` per case): reworded claim retired while the same-title atom is upserted in place; an omitted-but-still-quoted atom is kept; a sibling page's atom and a pre-binding-era atom are untouched, with a reverse control showing the page's own invalidated atom is retired in the same run; dry-run makes no atom-row changes; idempotent re-run; zero-yield lane reconciles; a reconciliation failure leaves the page retryable; a mid-model-call edit is not judged on the stale snapshot; an abandoned `pending:` row is reclaimable.

`bun test test/cycle/extract-atoms-*.test.ts`: 86 pass / 0 fail across 8 files. `bun run typecheck` clean. `bun run verify`: 52 of 54 green; `check:wasm` and `check:pglite-embedded` fail identically on the unmodified merge base in this worktree (no local `node_modules`), so they are environmental.

## Notes

- Open PR #4623 also supersedes atoms in this lane: it soft-deletes (`deleted_at = now()`) and stamps `extraction_profile_state: superseded` on atoms whose `source_hash` equals the current hash16 and whose `extraction_profile_sha256` differs. This PR only touches atoms whose `source_hash` differs from the current hash16, so the two candidate sets are disjoint; the code sits close enough to conflict textually.
- Consequence to be aware of: `discoverExtractablePages` treats a page as done when any atom already carries its current hash. That predicate is pre-existing, but retirement is what makes it matter: if a page is reverted to an older body after a retirement, a surviving atom from that body still marks it done, so the retired atom is not re-derived until the content changes again. Widening that predicate is a separate change and I have not attempted it here.
- Not covered by tests: concurrent writers on real Postgres (PGLite is single-connection).
