### PR TITLE
fix(llm-json): strip <thinking> blocks, not just <think>

### DIFF
--- a/src/core/llm-json.ts
+++ b/src/core/llm-json.ts
@@ -16,20 +16,42 @@
  * Strip a reasoning model's chain-of-thought block.
  *
  * Reasoning models (DeepSeek-R1, MiniMax M2.x/M3, and any model configured to
- * emit visible thinking) put a `<think>` block BEFORE the answer, in the same
+ * emit visible thinking) put a reasoning block BEFORE the answer, in the same
  * text channel. That reasoning routinely contains braces, because the model
  * drafts its JSON while thinking. This defeats strategy 3 in parseLlmJson: the
  * greedy `/\{[\s\S]*\}/` spans from the FIRST brace inside the reasoning to
  * the LAST brace of the real answer, so the parse fails and the caller records
  * an "unparseable" result even though a perfectly good object was returned.
  *
- * Handles both shapes: a closed `<think>…</think>` pair, and a truncated block
- * that was opened and never closed (the model exhausted its output budget).
+ * TAG COVERAGE — `<think>` AND `<thinking>`. The original stripper matched only
+ * `<think>`, which silently excluded every Claude-family model: prompted to
+ * reason in tags, they emit `<thinking>…</thinking>`. The effect was worst for
+ * the ARRAY callers (`array: true` / parseAtomsOutcome), because a brain whose
+ * prose carries bracketed citations — `[Source: …]`, `[[wikilink]]`, transcript
+ * role markers like `[user]` — makes the model echo a bracket while reasoning.
+ * The first-`[` anchor then lands inside the reasoning, the parse fails as
+ * "unparseable JSON array", and the ladder's stripped retry could never repair
+ * it because the tag was not recognised. Widening the tag is what arms that
+ * retry for these models.
+ *
+ * Deliberately NOT covered: `<reasoning>` and MiniMax's `◁think▷` sentinel.
+ * Neither appears anywhere in this repo's providers or fixtures, and this
+ * helper is a recovery path, not a general sanitiser — add a wrapper here only
+ * with a provider or a captured payload that demonstrates it.
+ *
+ * Handles both shapes: a closed `<think(ing)>…</think(ing)>` pair, and a
+ * truncated block that was opened and never closed (the model exhausted its
+ * output budget). The closed-pair arm backreferences the opening tag so a
+ * `<think>` is only ever closed by `</think>` — that keeps behaviour on
+ * `<think>` input byte-identical to before, with `<thinking>` purely additive;
+ * a MISMATCHED pair still falls through to the open-ended arm exactly as it
+ * did pre-change. Order matters: closed pairs first, then any surviving
+ * unclosed opener to end-of-string.
  */
 export function stripReasoningBlocks(raw: string): string {
   return raw
-    .replace(/<think>[\s\S]*?<\/think>/gi, '')
-    .replace(/<think>[\s\S]*$/i, '')
+    .replace(/<(think|thinking)>[\s\S]*?<\/\1>/gi, '')
+    .replace(/<(?:think|thinking)>[\s\S]*$/i, '')
     .trim();
 }
 
@@ -39,7 +61,7 @@ export function parseLlmJson<T>(raw: string, opts: { array?: boolean } = {}): T 
   if (direct !== null) return direct;
   // A fallback LADDER, not a pre-filter: the raw text is parsed first, so every
   // existing call site behaves byte-for-byte as before and a payload that
-  // legitimately contains "<think>" is unaffected. The stripped retry runs only
+  // legitimately contains "<think>"/"<thinking>" is unaffected. The retry runs only
   // after the raw parse has already failed, and text with no reasoning block
   // strips to itself — so the added cost on the success path is zero.
   const stripped = stripReasoningBlocks(raw);

--- a/test/llm-json-reasoning-ladder.test.ts
+++ b/test/llm-json-reasoning-ladder.test.ts
@@ -57,6 +57,36 @@ describe('parseLlmJson — reasoning ladder', () => {
     expect(parseLlmJson('<think>only reasoning, no answer</think>')).toBeNull();
     expect(parseLlmJson('')).toBeNull();
   });
+
+  test('recovers the ANSWER from a closed <thinking> block (Claude-family tag)', () => {
+    // Claude models prompted to reason in tags emit <thinking>, not <think>.
+    // Pre-fix the tag was unrecognised, the strip was a no-op, and the retry
+    // never ran — so this returned null.
+    const raw = '<thinking>I will answer {"answer":"draft"} probably</thinking>{"answer":"final"}';
+    expect(parseLlmJson<{ answer: string }>(raw)).toEqual({ answer: 'final' });
+  });
+
+  test('is case-insensitive about the <thinking> tag too', () => {
+    const raw = '<THINKING>draft {"answer":"draft"}</THINKING>{"answer":"final"}';
+    expect(parseLlmJson<{ answer: string }>(raw)).toEqual({ answer: 'final' });
+  });
+
+  test('is a ladder for <thinking> as well: valid JSON containing the literal tag is untouched', () => {
+    // Twin of the <think> ladder-ordering guard above. Without it, widening the
+    // tag would silently narrow that protection to half the vocabulary.
+    const raw = '{"note":"the <thinking> tag is literal here"}';
+    expect(parseLlmJson<{ note: string }>(raw)).toEqual({
+      note: 'the <thinking> tag is literal here',
+    });
+  });
+
+  test('a MISMATCHED pair still falls through to the open-ended arm (unchanged semantics)', () => {
+    // The closed-pair arm backreferences its opening tag, so <think>…</thinking>
+    // is not a pair. It is then eaten by the unclosed arm to end-of-string —
+    // exactly what pre-change code did with an unclosed <think>. Nothing is
+    // recoverable here, and null is the honest answer.
+    expect(parseLlmJson('<think>draft {"a":1}</thinking>{"answer":"final"}')).toBeNull();
+  });
 });
 
 describe('extractors route through the ladder', () => {
@@ -86,6 +116,30 @@ describe('extractors route through the ladder', () => {
     const outcome = parseAtomsOutcome(raw);
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) expect(outcome.reason).toBe('unterminated JSON array');
+  });
+
+  test('atoms extractor recovers a <thinking>-wrapped array whose reasoning cites [Source: …]', () => {
+    // The real-world shape this fix exists for. parseAtomsOutcomeInner anchors
+    // on the FIRST '[' in the response; a brain whose house style mandates
+    // inline `[Source: …]` citations makes the model echo one while reasoning,
+    // so the anchor lands in the reasoning and the parse dies as
+    // "unparseable JSON array". Verified to fail on unmodified 8c70f62.
+    const raw =
+      '<thinking>The page cites [Source: Mario, Claude Code session, 2026-09-03], ' +
+      'so the quote should come from there.</thinking>' +
+      '[{"claim":"Water is wet","kind":"fact"}]';
+    const outcome = parseAtomsOutcome(raw);
+    expect(outcome.ok).toBe(true);
+  });
+
+  test('atoms extractor recovers a <thinking>-wrapped array whose reasoning names a [[wikilink]]', () => {
+    // Same anchor defect, second bracket source: backlink markup. Also verified
+    // to fail pre-fix with "unparseable JSON array".
+    const raw =
+      '<thinking>It links [[people/mario]] and [[companies/firecrawl]].</thinking>' +
+      '[{"claim":"Backlinks are mandatory","kind":"fact"}]';
+    const outcome = parseAtomsOutcome(raw);
+    expect(outcome.ok).toBe(true);
   });
 
   test('atoms extractor: non-reasoning garbage returns the direct reason untouched (strip is a no-op)', () => {


### PR DESCRIPTION
## What

`stripReasoningBlocks` matched only `<think>…</think>`. Widened to cover `<thinking>…</thinking>` as well, in both arms (closed pair, and an unclosed block running to end-of-string).

## Why it matters

The helper backs a fallback *ladder*: `parseLlmJson` and `parseAtomsOutcome` parse the raw text first and only retry with reasoning stripped when that fails. For any model that emits `<thinking>` rather than `<think>`, the strip was a no-op, so `stripped === raw.trim()` and **the retry never ran**. The recovery path existed but was unreachable for that whole model family.

## Please read this before assuming it fixes more than it does

This change was found while investigating live `unparseable JSON array` failures in `extract_atoms`. **It does not fix them,** and I want that on the record rather than left to inference:

- The provider in question is `claude-cli`. `ClaudeCliLanguageModel.doGenerate` parses `result.result` — the CLI's *final* text. Extended thinking is billed in `usage.output_tokens` but is never emitted as tagged text into the string the parser sees.
- `grep -rn "<thinking>\|</thinking>" src/` returns **zero hits** anywhere in this repo.
- An *untagged* prose preamble strips to itself, so the ladder's guard (`stripped !== raw.trim()`) is false and the retry still never runs.

So the honest scope is: this arms a recovery ladder that was dead for `<thinking>`-emitting models. It is not a repair for observed failures. The anchor bug those failures actually hit is a separate defect.

## Design notes

- The closed-pair arm backreferences its opening tag — `<(think|thinking)>[\s\S]*?<\/\1>` — so `<think>` can still only be closed by `</think>`. Behaviour on existing `<think>` input is byte-identical; `<thinking>` is purely additive; a mismatched pair still falls through to the open-ended arm exactly as before.
- Deliberately **not** covering `<reasoning>` or MiniMax's `◁think▷`: neither appears in this repo's providers or fixtures, and this helper is a recovery path, not a general sanitiser.
- Noted but out of scope: `src/core/cycle/propose-takes.ts` carries its own inline `<think>`-only stripper (lines 461, 498) that this change does not reach.

## Tests

Six added to `test/llm-json-reasoning-ladder.test.ts`, all through the public parse entry points per that file's stated convention (it deliberately avoids importing the helper directly so a reverted-source run fails on behaviour, not module load).

Four are behavioural and **verified failing on unmodified `8c70f62`** before the edit — two as `unparseable JSON array`, two as `null`. Two are ordering guards: the `<thinking>` twin of the existing ladder-not-a-pre-filter test, and a mismatched-pair case pinning the unchanged fall-through.

| suite | before | after |
|---|---|---|
| `test/llm-json-reasoning-ladder.test.ts` | 12 pass / 4 fail | **16 pass / 0 fail** |
| 12-file atoms + llm-json set | 146 pass / 0 fail | **152 pass / 0 fail** |
| downstream `parseLlmJson` consumers (facts-extract, conversation-parser/), 8 files | — | **185 pass / 0 fail** |
| `bun run typecheck` | — | clean |

### The full suite was NOT run to completion

Targeted files only. I am flagging this rather than quoting a partial run as complete, and the second reason is worth a maintainer's attention:

1. On the host this was developed on, `scripts/run-unit-parallel.sh` self-throttled to `mem-adapted 4x4→1x1 (avail=3988MB, 1536MB/file)` and managed ~12 of 1645 files in 10 minutes.
2. More seriously, **the run overwrote live files in the operator's real `~/.gbrain`**: `autopilot-run.sh` was rewritten with (already-deleted) test-fixture paths, which started the autopilot's 3-strike self-disable guard, and `~/.gbrain/env` was reduced to a single test marker, destroying that host's `GBRAIN_HOOKS=0` self-ingestion kill switch. Both were repaired.

`test/helpers/gbrain-home-preload.ts` only points `GBRAIN_HOME` at a scratch dir when it is **not already set**, and subprocess-spawning tests need both `HOME` and `GBRAIN_HOME` redirected or the child inherits the operator's real one. `run-unit-parallel.sh`'s header says it strips an ambient `GBRAIN_HOME` at its boundary; empirically that did not happen. That looks like a genuine bug worth a separate issue.

CI should be unaffected (no ambient `GBRAIN_HOME`), and this change is two files with a clean typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP3ZaS5CScim9toGEeyDoU
