### PR TITLE
fix(extract-atoms): scan for the atoms array instead of the first '['

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -1247,33 +1247,97 @@ export function parseAtomsOutcome(raw: string): AtomsParseOutcome {
   return direct;
 }
 
+/**
+ * Bound on how many `[` offsets the anchor scan will try. Completions are
+ * already capped by `max_output_tokens`, so this is a belt-and-braces guard
+ * against a pathological bracket-dense response, not a functional limit —
+ * every failing candidate fails at ~offset 0 of its own slice, so the scan is
+ * cheap. Reached-the-cap behaves exactly like found-nothing: the FIRST
+ * offset's outcome is returned, i.e. today's behaviour.
+ */
+const MAX_ARRAY_ANCHOR_CANDIDATES = 64;
+
+/**
+ * Parse the JSON array anchored at ONE `[` offset, reproducing the historical
+ * two-step exactly: whole-slice parse, then a trim-back to the last `]` to
+ * recover from trailing prose. Split out of parseAtomsOutcomeInner so the
+ * anchor scan can try successive offsets without duplicating the reason
+ * strings — those are asserted by tests and ride the drain's `last_error`.
+ */
+function parseArrayAtOffset(
+  cleaned: string,
+  start: number,
+): { ok: true; parsed: unknown[] } | { ok: false; reason: string } {
+  const slice = cleaned.slice(start);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(slice);
+  } catch {
+    // Try trimming back from the end to recover from trailing prose.
+    const arrayEnd = slice.lastIndexOf(']');
+    if (arrayEnd === -1) return { ok: false, reason: 'unterminated JSON array' };
+    try {
+      parsed = JSON.parse(slice.slice(0, arrayEnd + 1));
+    } catch {
+      return { ok: false, reason: 'unparseable JSON array' };
+    }
+  }
+  if (!Array.isArray(parsed)) return { ok: false, reason: 'JSON value is not an array' };
+  return { ok: true, parsed };
+}
+
 function parseAtomsOutcomeInner(raw: string): AtomsParseOutcome {
   // Strip markdown code fences if the LLM wrapped JSON in them.
   let cleaned = raw.trim();
   const fenceMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (fenceMatch) cleaned = fenceMatch[1].trim();
 
-  // Find the first JSON array bracket.
-  const arrayStart = cleaned.indexOf('[');
-  if (arrayStart === -1) return { ok: false, reason: 'no JSON array in response' };
-  cleaned = cleaned.slice(arrayStart);
+  const firstStart = cleaned.indexOf('[');
+  if (firstStart === -1) return { ok: false, reason: 'no JSON array in response' };
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(cleaned);
-  } catch {
-    // Try trimming back from the end to recover from trailing prose.
-    const arrayEnd = cleaned.lastIndexOf(']');
-    if (arrayEnd === -1) return { ok: false, reason: 'unterminated JSON array' };
-    try {
-      parsed = JSON.parse(cleaned.slice(0, arrayEnd + 1));
-    } catch {
-      return { ok: false, reason: 'unparseable JSON array' };
+  // ANCHOR SCAN. Pre-fix this committed to `indexOf('[')` — the FIRST bracket
+  // anywhere in the response. Any bracket in a preamble hijacked the anchor,
+  // and a brain whose house style mandates inline `[Source: …]` citations and
+  // `[[wikilink]]` backlinks (or whose transcripts carry `[user]` / `[tool: …]`
+  // role markers) makes the model echo one while narrating, so a response
+  // carrying a perfectly good array was reported `unparseable JSON array`.
+  //
+  // Acceptance requires the candidate to parse AND to yield >= 1 atom-shaped
+  // element. Parseability alone is NOT enough: `atomsFromParsedArray` skips
+  // every element that fails the shape gate, so an array-of-strings scraped
+  // out of prose would parse to `ok: true, atoms: []` — and a zero-yield
+  // result is exactly what TOMBSTONES a page (#2144). A shape-blind scan would
+  // therefore permanently retire pages that still had real content: strictly
+  // worse than the bug it fixes. `coerceAtom` is the single source of truth
+  // for "atom-shaped" so this gate cannot drift from the one that builds them.
+  let firstAttempt: ReturnType<typeof parseArrayAtOffset> | null = null;
+  let candidates = 0;
+  for (
+    let start = firstStart;
+    start !== -1 && candidates < MAX_ARRAY_ANCHOR_CANDIDATES;
+    start = cleaned.indexOf('[', start + 1)
+  ) {
+    candidates++;
+    const attempt = parseArrayAtOffset(cleaned, start);
+    // Captured on the FIRST iteration only — every reason string this function
+    // can return still describes the first bracket, unchanged.
+    if (firstAttempt === null) firstAttempt = attempt;
+    if (attempt.ok) {
+      const atoms = atomsFromParsedArray(attempt.parsed);
+      if (atoms.length > 0) return { ok: true, atoms };
     }
   }
 
-  if (!Array.isArray(parsed)) return { ok: false, reason: 'JSON value is not an array' };
-  return { ok: true, atoms: atomsFromParsedArray(parsed) };
+  // Nothing later yielded a real atom. Fall back to the FIRST offset's outcome
+  // VERBATIM — never a later one. That keeps this function byte-identical to
+  // pre-fix behaviour for every response that already parsed, and confines the
+  // new leniency to the one case that motivated it: a later offset held a
+  // genuinely atom-shaped array. In particular an honest `[]` still returns
+  // `ok: true, atoms: []` and keeps its #4148 zero-yield tombstone semantics,
+  // rather than being reclassified as malformed output.
+  if (firstAttempt === null) return { ok: false, reason: 'no JSON array in response' };
+  if (firstAttempt.ok) return { ok: true, atoms: atomsFromParsedArray(firstAttempt.parsed) };
+  return firstAttempt;
 }
 
 /**
@@ -1286,39 +1350,54 @@ export function parseAtomsResponse(raw: string): ExtractedAtom[] {
   return outcome.ok ? outcome.atoms : [];
 }
 
-function atomsFromParsedArray(parsed: unknown[]): ExtractedAtom[] {
+/**
+ * Coerce ONE parsed element into an ExtractedAtom, or null when it fails the
+ * shape gate (not an object, or missing/invalid title, atom_type, or body).
+ *
+ * Lifted verbatim out of atomsFromParsedArray's loop body so that "is this
+ * element atom-shaped?" has exactly ONE definition. The anchor scan in
+ * parseAtomsOutcomeInner needs that predicate to reject a parseable-but-wrong
+ * array, and a second hand-written copy of these checks would be free to drift
+ * from the one that actually builds atoms — at which point the scan would
+ * accept candidates that then yield nothing and tombstone a live page.
+ */
+function coerceAtom(item: unknown): ExtractedAtom | null {
+  if (typeof item !== 'object' || item === null) return null;
+  const obj = item as Record<string, unknown>;
+  const title = typeof obj.title === 'string' ? obj.title.slice(0, 200) : null;
+  const atomType = typeof obj.atom_type === 'string' ? obj.atom_type.trim().toLowerCase() : null;
+  const body = typeof obj.body === 'string' ? obj.body : null;
+  if (!title || !atomType || !body) return null;
+  if (!ATOM_TYPES.includes(atomType as typeof ATOM_TYPES[number])) return null;
+  return {
+    title,
+    atom_type: atomType as typeof ATOM_TYPES[number],
+    body,
+    source_quote: typeof obj.source_quote === 'string' ? obj.source_quote.slice(0, 500) : undefined,
+    lesson: typeof obj.lesson === 'string' ? obj.lesson : undefined,
+    concepts: (() => {
+      if (!Array.isArray(obj.concepts)) return undefined;
+      const labels = obj.concepts
+        .filter((c): c is string => typeof c === 'string' && CONCEPT_LABEL_RE.test(c))
+        .slice(0, 3);
+      return labels.length > 0 ? labels : undefined;
+    })(),
+    virality_score:
+      typeof obj.virality_score === 'number' &&
+      obj.virality_score >= 0 &&
+      obj.virality_score <= 100
+        ? obj.virality_score
+        : undefined,
+    emotional_register:
+      typeof obj.emotional_register === 'string' ? obj.emotional_register : undefined,
+  };
+}
 
+function atomsFromParsedArray(parsed: unknown[]): ExtractedAtom[] {
   const atoms: ExtractedAtom[] = [];
   for (const item of parsed) {
-    if (typeof item !== 'object' || item === null) continue;
-    const obj = item as Record<string, unknown>;
-    const title = typeof obj.title === 'string' ? obj.title.slice(0, 200) : null;
-    const atomType = typeof obj.atom_type === 'string' ? obj.atom_type.trim().toLowerCase() : null;
-    const body = typeof obj.body === 'string' ? obj.body : null;
-    if (!title || !atomType || !body) continue;
-    if (!ATOM_TYPES.includes(atomType as typeof ATOM_TYPES[number])) continue;
-    atoms.push({
-      title,
-      atom_type: atomType as typeof ATOM_TYPES[number],
-      body,
-      source_quote: typeof obj.source_quote === 'string' ? obj.source_quote.slice(0, 500) : undefined,
-      lesson: typeof obj.lesson === 'string' ? obj.lesson : undefined,
-      concepts: (() => {
-        if (!Array.isArray(obj.concepts)) return undefined;
-        const labels = obj.concepts
-          .filter((c): c is string => typeof c === 'string' && CONCEPT_LABEL_RE.test(c))
-          .slice(0, 3);
-        return labels.length > 0 ? labels : undefined;
-      })(),
-      virality_score:
-        typeof obj.virality_score === 'number' &&
-        obj.virality_score >= 0 &&
-        obj.virality_score <= 100
-          ? obj.virality_score
-          : undefined,
-      emotional_register:
-        typeof obj.emotional_register === 'string' ? obj.emotional_register : undefined,
-    });
+    const atom = coerceAtom(item);
+    if (atom) atoms.push(atom);
   }
   return atoms;
 }

--- a/test/extract-atoms-array-anchor-scan.test.ts
+++ b/test/extract-atoms-array-anchor-scan.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Atoms-array ANCHOR SCAN (`parseAtomsOutcomeInner`).
+ *
+ * The extractor used to commit to `cleaned.indexOf('[')` — the FIRST left
+ * bracket anywhere in the response. Any bracket in a preamble hijacked that
+ * anchor, so a response carrying a perfectly good atoms array was reported as
+ * `unparseable JSON array` and the page counted a deterministic failure.
+ *
+ * This is not a hypothetical: a brain whose house style mandates inline
+ * `[Source: …]` citations and `[[wikilink]]` backlinks, and whose transcripts
+ * carry `[user]` / `[assistant]` / `[tool: …]` role markers, hands the model
+ * bracketed prose to echo while it narrates its answer.
+ *
+ * THE HAZARD the scan must avoid: `atomsFromParsedArray` skips every element
+ * failing the shape gate, so a parseable-but-wrong array (say an array of
+ * strings lifted out of prose) yields `ok: true, atoms: []`. A zero-yield
+ * result is what TOMBSTONES a page (#2144), so a shape-blind scan would
+ * permanently retire pages that still had real content — worse than the bug.
+ * Acceptance therefore requires >= 1 atom-shaped element, not mere parseability.
+ *
+ * NOTE: assertions go through the PUBLIC `parseAtomsOutcome` entry point, which
+ * exists pre-fix, so a reverted-source run fails on BEHAVIOUR rather than dying
+ * with a module-load SyntaxError (the vacuous failure class in CONTRIBUTING.md).
+ */
+import { describe, expect, test } from 'bun:test';
+import { parseAtomsOutcome } from '../src/core/cycle/extract-atoms.ts';
+
+/** A minimally valid atom: title + atom_type (in ATOM_TYPES) + body. */
+const ATOM = {
+  title: 'Brackets in prose hijack the parse anchor',
+  atom_type: 'insight',
+  body: 'The extractor anchored on the first bracket, not the first array.',
+};
+const ATOM_ARRAY = JSON.stringify([ATOM]);
+
+function atomsOf(raw: string) {
+  const outcome = parseAtomsOutcome(raw);
+  if (!outcome.ok) throw new Error(`expected ok, got reason: ${outcome.reason}`);
+  return outcome.atoms;
+}
+
+describe('anchor scan — bracketed preamble no longer hijacks the parse', () => {
+  test('recovers the array after a preamble carrying a [Source: …] citation', () => {
+    const raw =
+      'Looking at the page, the claim is supported by ' +
+      '[Source: Mario, Claude Code session, 2026-09-03], so here are the atoms:\n' +
+      ATOM_ARRAY;
+    expect(atomsOf(raw)).toHaveLength(1);
+    expect(atomsOf(raw)[0]!.title).toBe(ATOM.title);
+  });
+
+  test('recovers the array after a preamble naming a [[wikilink]]', () => {
+    const raw = 'The page backlinks [[people/mario]] and [[companies/firecrawl]].\n' + ATOM_ARRAY;
+    expect(atomsOf(raw)).toHaveLength(1);
+  });
+
+  test('recovers the array after a transcript [user] role marker in the preamble', () => {
+    const raw = 'The [user] turn sets up the problem and [assistant] answers it.\n' + ATOM_ARRAY;
+    expect(atomsOf(raw)).toHaveLength(1);
+  });
+
+  test('HAZARD: skips a parseable-but-WRONG array rather than reporting zero atoms', () => {
+    // The dangerous case. `["a","b"]` parses cleanly, so a scan that accepted
+    // the first *parseable* candidate would return atoms: [] — a zero-yield
+    // that TOMBSTONES the page and silently discards the real payload below.
+    const raw = 'Candidate labels were ["a","b"] before I settled on:\n' + ATOM_ARRAY;
+    const atoms = atomsOf(raw);
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0]!.title).toBe(ATOM.title);
+  });
+
+  test('HAZARD: skips an array of atom-shaped-but-empty objects', () => {
+    // Objects, but every one fails the shape gate (no title/atom_type/body).
+    const raw = 'Draft skeleton: [{"note":"tbd"},{"note":"tbd"}] — final answer:\n' + ATOM_ARRAY;
+    expect(atomsOf(raw)).toHaveLength(1);
+  });
+});
+
+describe('anchor scan — preserved behaviour', () => {
+  test('an honest empty array is still a zero-yield SUCCESS, not malformed output', () => {
+    // #4148 keeps "malformed output" and "the model found nothing" distinct:
+    // only the latter is a legitimate tombstone. The scan must not blur that
+    // by reclassifying `[]` as a parse failure just because it yields no atom.
+    const outcome = parseAtomsOutcome('[]');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.atoms).toEqual([]);
+  });
+
+  test('an empty array after prose is still a zero-yield success', () => {
+    const outcome = parseAtomsOutcome('Nothing worth extracting here.\n[]');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.atoms).toEqual([]);
+  });
+
+  test('a clean array with no preamble is unchanged', () => {
+    expect(atomsOf(ATOM_ARRAY)).toHaveLength(1);
+  });
+
+  test('a fenced array is unchanged', () => {
+    expect(atomsOf('```json\n' + ATOM_ARRAY + '\n```')).toHaveLength(1);
+  });
+
+  test('trailing prose after a valid array is still recovered', () => {
+    expect(atomsOf(ATOM_ARRAY + '\n\nThose are the atoms I found.')).toHaveLength(1);
+  });
+
+  test('a parseable array that yields no atoms still reports ok with zero atoms', () => {
+    // Byte-identical to pre-fix: nothing later in the response holds a real
+    // atom, so the FIRST offset's successful parse is returned verbatim.
+    const outcome = parseAtomsOutcome('[{"claim":"Water is wet","kind":"fact"}]');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.atoms).toEqual([]);
+  });
+});
+
+describe('anchor scan — failure reasons still describe the FIRST bracket', () => {
+  test('no bracket at all', () => {
+    const outcome = parseAtomsOutcome('I could not extract anything from this content.');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.reason).toBe('no JSON array in response');
+  });
+
+  test('an opened-but-never-closed array reports unterminated, not unparseable', () => {
+    const outcome = parseAtomsOutcome('here goes [{"title":"a"');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.reason).toBe('unterminated JSON array');
+  });
+
+  test('bracketed prose with no recoverable array anywhere still reports unparseable', () => {
+    // The scan exhausts every candidate and falls back to the FIRST offset's
+    // reason — never a later offset's, which would silently change the string
+    // the drain surfaces as `last_error`.
+    const outcome = parseAtomsOutcome('see [Source: X] and [[people/mario]] for details]');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.reason).toBe('unparseable JSON array');
+  });
+});


### PR DESCRIPTION
## The hazard first, because it shapes the whole fix

`parseAtomsOutcomeInner` anchors on `cleaned.indexOf('[')` — the **first** left bracket anywhere in the response. Any bracket in a preamble hijacks it: the slice starts mid-prose, `JSON.parse` throws, the trim-back to the last `]` inherits the same bad start, and a response carrying a perfectly good atoms array is reported `unparseable JSON array`. The page then counts a deterministic failure toward its #4148 tombstone.

**The obvious fix — take the first `[` that parses — would be worse than the bug.** `atomsFromParsedArray` `continue`s past every element failing the shape gate, so a parseable-but-unrelated array scraped out of prose (say `["a","b"]`) does not produce a parse error. It produces `ok: true, atoms: []`. A zero-yield is exactly what **tombstones** a page (#2144). A shape-blind scan would therefore silently and permanently retire pages that still had real content, converting a loud recoverable failure into quiet data loss.

So acceptance requires the candidate to **parse AND yield at least one atom-shaped element**. Two tests pin that hazard directly: an array of strings, and an array of objects that all fail the gate, each placed before the real payload.

## How the shape gate is kept honest

`atomsFromParsedArray`'s loop body is lifted **verbatim** into `coerceAtom(item): ExtractedAtom | null`. The builder and the scan now share one definition, so "atom-shaped" cannot drift into two implementations — and if it ever did, the drift would express itself as exactly the tombstone hazard above. No behavioural change in that extraction.

## Why this is not hypothetical

A brain whose house style mandates inline `[Source: …]` citations and `[[wikilink]]` backlinks, and whose transcripts carry `[user]` / `[assistant]` / `[tool: …]` role markers, hands the model bracketed prose to echo while it narrates its answer. Same defect class as the `extractToolCalls` first-`indexOf` bug.

## Byte-identical for anything that parsed before

- **The fallback is deliberately first-offset-only.** If no later offset yields a real atom, the **first** offset's outcome is returned verbatim — success, or its original reason string — never a later offset's. Without that constraint the fallback would be *broader* than current behaviour and would simply relocate the tombstone hazard from the scan into the fallback.
- Every reason string still describes the first bracket, so `unterminated JSON array` vs `unparseable JSON array` is unchanged and `--drain`'s `last_error` text does not shift.
- **An honest `[]` still returns `ok: true, atoms: []`**, preserving the #4148 split between malformed output and a genuine zero-yield — and with it the legitimate tombstone. This fix does not blur that distinction.
- The scan is capped at `MAX_ARRAY_ANCHOR_CANDIDATES = 64`. Completions are already bounded by `max_output_tokens` and each failing candidate fails at ~offset 0 of its own slice, so this guards pathological input rather than limiting function; hitting the cap behaves exactly like finding nothing.

## New code rather than reuse — both candidates checked

- `parseLlmJsonInner`'s greedy `/\[[\s\S]*\]/` spans the first `[` to the last `]`, which **fails on precisely this input shape** rather than fixing it.
- `isWellFormedEmptyExtraction` (`propose-takes.ts`) carries the same `indexOf('[')` defect *and* does no shape validation.

Neither fits. Both are noted as adjacent cleanups rather than pulled into scope.

## Tests

14 in a new file, all through the public `parseAtomsOutcome`. Five are behavioural and **verified failing on unmodified `8c70f62`**; the other nine are preservation guards that pass both before and after — they exist to catch regressions, not to prove the fix.

| suite | before | after |
|---|---|---|
| `test/extract-atoms-array-anchor-scan.test.ts` | 9 pass / 5 fail | **14 pass / 0 fail** |
| 12-file atoms + llm-json regression set | 146 pass / 0 fail | **146 pass / 0 fail** (identical — the byte-identical evidence) |
| `bun run typecheck` | — | clean |

### The full suite was NOT run to completion

Targeted files only. Flagging rather than quoting a partial run as complete, and the second reason is worth a maintainer's attention:

1. On the host this was developed on, `scripts/run-unit-parallel.sh` self-throttled to `mem-adapted 4x4→1x1 (avail=3988MB, 1536MB/file)` and managed ~12 of 1645 files in 10 minutes.
2. More seriously, **the run overwrote live files in the operator's real `~/.gbrain`**: `autopilot-run.sh` was rewritten with (already-deleted) test-fixture paths, which started the autopilot's 3-strike self-disable guard, and `~/.gbrain/env` was reduced to a single test marker, destroying that host's `GBRAIN_HOOKS=0` self-ingestion kill switch. Both were repaired.

`test/helpers/gbrain-home-preload.ts` only points `GBRAIN_HOME` at a scratch dir when it is **not already set**, and subprocess-spawning tests need both `HOME` and `GBRAIN_HOME` redirected or the child inherits the operator's real one. `run-unit-parallel.sh`'s header says it strips an ambient `GBRAIN_HOME` at its boundary; empirically that did not happen. That looks like a genuine bug worth a separate issue.

CI should be unaffected (no ambient `GBRAIN_HOME`), and typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP3ZaS5CScim9toGEeyDoU
