### PR TITLE
fix(extract-atoms): stop re-spending budget on the same transcripts forever

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -530,6 +530,50 @@ export async function atomsExistingForHashes(
 }
 
 /**
+ * Composite key for the transcript-state Set. A transcript is identified by
+ * BOTH path and content hash (the table's PK carries both), so neither alone
+ * is a safe Set member: two files can share content, and one file changes hash
+ * when edited. NUL is the separator because it cannot occur in a POSIX path.
+ */
+export function transcriptStateKey(filePath: string, contentHash16: string): string {
+  return `${filePath}\u0000${contentHash16}`;
+}
+
+/**
+ * Batch-read the v146 transcript tombstones for this source, mirroring
+ * `atomsExistingForHashes` — ONE query for the whole corpus rather than N
+ * per-file probes, same fail-soft posture (on error return empty, i.e. treat
+ * everything as live and re-attempt, which is the pre-v146 behaviour).
+ *
+ * Only TOMBSTONED rows are returned. A row carrying an in-progress failure
+ * streak (fail_count 1 or 2) is deliberately still live: those items must keep
+ * being retried until the streak reaches MAX_DETERMINISTIC_FAILURES, exactly as
+ * a page with `atoms_fail_count` below the bound stays in the page backlog.
+ */
+export async function tombstonedTranscriptsForHashes(
+  engine: BrainEngine,
+  sourceId: string,
+  contentHash16s: string[],
+): Promise<Set<string>> {
+  if (contentHash16s.length === 0) return new Set();
+  try {
+    const rows = await engine.executeRaw<{ file_path: string; content_hash: string }>(
+      `SELECT file_path, content_hash
+         FROM extract_atoms_transcript_state
+        WHERE source_id = $1
+          AND tombstoned
+          AND content_hash = ANY($2::text[])`,
+      [sourceId, contentHash16s],
+    );
+    return new Set(rows.map(r => transcriptStateKey(r.file_path, r.content_hash)));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[extract_atoms] transcript tombstone check failed (assuming none tombstoned): ${msg}`);
+    return new Set();
+  }
+}
+
+/**
  * The exact two-step model resolution `runPhaseExtractAtoms` uses:
  * `models.dream.extract_atoms` DB config wins if set (same plain-`||`
  * truthiness as always — a whitespace-only value IS "configured"), else the
@@ -642,8 +686,23 @@ export async function runPhaseExtractAtoms(
   // short-circuit shows a sign of life (closes Issue 2 silent-phase pain).
   opts.progress?.heartbeat(`checking existing atoms for ${allHashes16.length} transcripts`);
   const existingHashes = await atomsExistingForHashes(engine, sourceId, allHashes16);
+  // v146 READ SIDE. The counter written above is inert without this: transcript
+  // eligibility was gated ONLY by "does an atom row exist for this hash", so a
+  // tombstone nothing consults would leave the item in the pool forever. Pages
+  // need no equivalent edit — their tombstone (`atoms_scan_hash`) is already
+  // read by discoverExtractablePages' SQL, which this change does not touch.
+  const tombstonedTranscriptKeys = await tombstonedTranscriptsForHashes(
+    engine,
+    sourceId,
+    allHashes16,
+  );
   for (const t of transcripts) {
-    if (existingHashes.has(t.contentHash.slice(0, 16))) {
+    const hash16 = t.contentHash.slice(0, 16);
+    if (existingHashes.has(hash16)) {
+      duplicatesSkipped++;
+      continue;
+    }
+    if (tombstonedTranscriptKeys.has(transcriptStateKey(t.filePath, hash16))) {
       duplicatesSkipped++;
       continue;
     }
@@ -830,6 +889,11 @@ export async function runPhaseExtractAtoms(
   // ── gbrain#4148 helpers ────────────────────────────────────────────
   let malformedOutputs = 0;
   const tombstonedForFailures: string[] = [];
+  // v146: transcript tombstones ride a SEPARATE array. `tombstoned_for_failures`
+  // is a list of page SLUGS; transcripts are filesystem paths, and mixing the two
+  // into one array would be a silent type confusion for any future consumer that
+  // resolves those strings as slugs. Both are report-only today.
+  const tombstonedTranscripts: string[] = [];
   // #3044 adoption: shared halt policy — auth/billing halt on the first hit,
   // a rate_limit streak halts after 3 consecutive failures, a successful
   // chat call resets the streak.
@@ -854,12 +918,62 @@ export async function runPhaseExtractAtoms(
   }
 
   /**
+   * Stamp the transcript-side tombstone (v146). The file-backed mirror of
+   * `stampAtomsScanHash`: transcripts have no frontmatter, and their discovery
+   * is gated ONLY by `atomsExistingForHashes`, so a transcript that yields no
+   * atom row has nothing to mark it done and is re-attempted every cycle.
+   * Row is (source_id, file_path, content_hash)-keyed, so an edited transcript
+   * is a different row and re-eligibilizes automatically.
+   */
+  async function stampTranscriptTombstone(filePath: string, contentHash: string): Promise<void> {
+    try {
+      await engine.executeRaw(
+        `INSERT INTO extract_atoms_transcript_state
+           (source_id, file_path, content_hash, fail_count, tombstoned, updated_at)
+         VALUES ($1, $2, $3, 0, TRUE, now())
+         ON CONFLICT (source_id, file_path, content_hash)
+         DO UPDATE SET tombstoned = TRUE, updated_at = now()`,
+        [sourceId, filePath, contentHash.slice(0, 16)],
+      );
+    } catch { /* fail-soft: transcript stays rediscoverable */ }
+  }
+
+  /**
    * Durable per-item failure count, keyed to the CURRENT content hash so a
    * content edit resets the streak. Returns the new consecutive count, or
-   * null for transcripts / on write failure (never blocks the phase).
+   * null on write failure (never blocks the phase).
+   *
+   * v146: transcripts are covered too. Pages keep their frontmatter counter;
+   * transcripts are files with no frontmatter, so theirs lives in
+   * `extract_atoms_transcript_state`. Both reset on a content change for the
+   * same reason — the page counter is hash-keyed, the transcript row IS
+   * hash-keyed — and both feed the same MAX_DETERMINISTIC_FAILURES bound.
    */
-  async function recordPageFailureCount(item: { kind: string; slug?: string; contentHash: string }): Promise<number | null> {
-    if (item.kind !== 'page' || !item.slug || opts.dryRun) return null;
+  async function recordItemFailureCount(
+    item: { kind: string; slug?: string; filePath?: string; contentHash: string },
+  ): Promise<number | null> {
+    if (opts.dryRun) return null;
+    const hash16 = item.contentHash.slice(0, 16);
+    if (item.kind === 'transcript') {
+      if (!item.filePath) return null;
+      try {
+        const rows = await engine.executeRaw<{ cnt: number | string }>(
+          `INSERT INTO extract_atoms_transcript_state
+             (source_id, file_path, content_hash, fail_count, updated_at)
+           VALUES ($1, $2, $3, 1, now())
+           ON CONFLICT (source_id, file_path, content_hash)
+           DO UPDATE SET fail_count = extract_atoms_transcript_state.fail_count + 1,
+                         updated_at = now()
+           RETURNING fail_count AS cnt`,
+          [sourceId, item.filePath, hash16],
+        );
+        const cnt = rows[0]?.cnt;
+        return cnt == null ? null : Number(cnt);
+      } catch {
+        return null;
+      }
+    }
+    if (item.kind !== 'page' || !item.slug) return null;
     try {
       const rows = await engine.executeRaw<{ cnt: number | string }>(
         `UPDATE pages
@@ -871,7 +985,7 @@ export async function runPhaseExtractAtoms(
                         ELSE 1 END)
           WHERE source_id = $2 AND slug = $3 AND deleted_at IS NULL
           RETURNING (frontmatter->>'atoms_fail_count')::int AS cnt`,
-        [item.contentHash.slice(0, 16), sourceId, item.slug],
+        [hash16, sourceId, item.slug],
       );
       const cnt = rows[0]?.cnt;
       return cnt == null ? null : Number(cnt);
@@ -925,7 +1039,7 @@ export async function runPhaseExtractAtoms(
       if (!parseOutcome.ok) {
         malformedOutputs++;
         hardFailureCount++;
-        const failCount = await recordPageFailureCount(item);
+        const failCount = await recordItemFailureCount(item);
         failures.push({
           source: originLabel,
           error: `malformed model output: ${parseOutcome.reason}` +
@@ -936,9 +1050,15 @@ export async function runPhaseExtractAtoms(
         // content hash, tombstone so the backlog floor clears; a content
         // edit re-eligibilizes (stamp is hash-keyed). Transient provider
         // errors never reach here — they throw and take the catch path.
-        if (failCount != null && failCount >= MAX_DETERMINISTIC_FAILURES && !opts.dryRun && item.kind === 'page') {
-          await stampAtomsScanHash(item);
-          tombstonedForFailures.push(item.slug);
+        // v146: transcripts get the identical bound, via their own store.
+        if (failCount != null && failCount >= MAX_DETERMINISTIC_FAILURES && !opts.dryRun) {
+          if (item.kind === 'page') {
+            await stampAtomsScanHash(item);
+            tombstonedForFailures.push(item.slug);
+          } else {
+            await stampTranscriptTombstone(item.filePath, item.contentHash);
+            tombstonedTranscripts.push(item.filePath);
+          }
         }
         continue;
       }
@@ -954,8 +1074,17 @@ export async function runPhaseExtractAtoms(
         // Only stamped after a SUCCESSFUL chat call — LLM failures take the
         // catch path below and stay retryable, and malformed output is
         // counted above (gbrain#4148), never stamped as success.
-        if (!opts.dryRun && item.kind === 'page') {
-          await stampAtomsScanHash(item);
+        //
+        // v146: transcripts now stamp too, IMMEDIATELY, exactly as pages do —
+        // a zero-yield is a settled answer about this content, not a failure,
+        // so it needs no streak. Pre-fix transcripts were the one item kind
+        // with no zero-yield marker at all, so an honestly-empty transcript
+        // re-entered the pool and re-spent budget on every cycle forever. The
+        // row is (source_id, file_path, content_hash)-keyed, so editing the
+        // file re-eligibilizes it — which is what makes the permanence safe.
+        if (!opts.dryRun) {
+          if (item.kind === 'page') await stampAtomsScanHash(item);
+          else await stampTranscriptTombstone(item.filePath, item.contentHash);
         }
         if (item.kind === 'transcript') transcriptsProcessed++;
         else pagesProcessed++;
@@ -1108,7 +1237,7 @@ export async function runPhaseExtractAtoms(
       // suppress a page's atoms.
       const message = err instanceof Error ? err.message : String(err);
       // #3044: a whole-run LLM outage halts the phase. No
-      // recordPageFailureCount here — a global outage says nothing about the
+      // recordItemFailureCount here — a global outage says nothing about the
       // content, so it must not pre-charge the per-page tombstone counter.
       const decision = llmHalt.observe(err);
       if (decision !== 'continue') {
@@ -1123,7 +1252,7 @@ export async function runPhaseExtractAtoms(
       const transient =
         llmHalt.lastClass() === 'rate_limit' || TRANSIENT_EXTRACT_ERROR_RE.test(message);
       if (!transient) {
-        await recordPageFailureCount(item);
+        await recordItemFailureCount(item);
         hardFailureCount++;
       }
       failures.push({
@@ -1207,6 +1336,7 @@ export async function runPhaseExtractAtoms(
       ...(abortedGlobalError ? { aborted_global_error: abortedGlobalError } : {}),
       malformed_outputs: malformedOutputs,
       tombstoned_for_failures: tombstonedForFailures,
+      tombstoned_transcripts: tombstonedTranscripts,
       estimated_spend_usd: estimatedSpendUsd,
       budget_usd: budgetCap,
       model: extractModel,

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -6440,6 +6440,66 @@ export const MIGRATIONS: Migration[] = [
       END $$;
     `,
   },
+  {
+    version: 146,
+    name: 'extract_atoms_transcript_state_table',
+    // #4148 follow-on: extend the failure-count / tombstone machinery to
+    // TRANSCRIPT items. Pre-fix `recordPageFailureCount` returned null for
+    // `kind !== 'page'`, so a transcript that deterministically produced
+    // malformed output — or that honestly yielded zero atoms — re-entered
+    // discovery and re-spent LLM budget on EVERY cycle, forever. Pages avoid
+    // this via frontmatter (`atoms_fail_count` / `atoms_fail_hash` /
+    // `atoms_scan_hash`); transcripts are files, not pages, so they have no
+    // frontmatter to carry it and need their own store.
+    //
+    // Precedent: dream_verdicts (v30), the other transcript-keyed cache, whose
+    // comment already establishes why this cannot live in raw_data — "Distinct
+    // from raw_data (page-scoped); transcripts aren't pages" (raw_data.page_id
+    // is NOT NULL REFERENCES pages(id)). It also must NOT be columns on
+    // dream_verdicts itself: that table is documented as rebuildable via
+    // `gbrain dream retriage --force`, which clears it wholesale, and atom
+    // extraction state would be swept away as collateral.
+    //
+    // KEYED (source_id, file_path, content_hash), which adds source_id to the
+    // dream_verdicts shape. dream_verdicts can be source-free because it caches
+    // a content-level judgment ("is this transcript worth processing"), which is
+    // genuinely source-independent. A failure streak and a tombstone GATE
+    // EXTRACTION, and extraction is source-scoped throughout this phase — the
+    // discovery SQL, the NOT EXISTS idempotency subquery, and every putPage all
+    // take sourceId. This file's own header records what happens when that is
+    // forgotten here: "Pre-fix the putPage call was missing the sourceId arg —
+    // atoms always wrote to 'default' regardless of source, which made the NOT
+    // EXISTS guard ineffective on federated brains." An unscoped tombstone would
+    // let one source permanently suppress another source's extraction of the
+    // same file.
+    //
+    // content_hash holds the 16-char prefix, matching `atoms.frontmatter
+    // ->>'source_hash'` and the page-side `atoms_fail_hash`, so every hash
+    // comparison in this phase is on the same unit. Including it in the PK is
+    // what makes "a content edit resets the streak" fall out for free: an edited
+    // transcript is simply a different row, mirroring the page-side hash-keyed
+    // reset.
+    //
+    // RLS: covered by the v35 auto_rls_on_create_table event trigger on
+    // Postgres, same as v126's session_context_state — no explicit ALTER here.
+    // Keep in sync with src/schema.sql and src/core/pglite-schema.ts
+    // (test/schema-bootstrap-coverage.test.ts enforces the PGLite parity).
+    idempotent: true,
+    sql: `
+      CREATE TABLE IF NOT EXISTS extract_atoms_transcript_state (
+        source_id    TEXT        NOT NULL DEFAULT 'default',
+        file_path    TEXT        NOT NULL,
+        content_hash TEXT        NOT NULL,
+        fail_count   INTEGER     NOT NULL DEFAULT 0,
+        tombstoned   BOOLEAN     NOT NULL DEFAULT FALSE,
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (source_id, file_path, content_hash)
+      );
+      CREATE INDEX IF NOT EXISTS extract_atoms_transcript_state_live_idx
+        ON extract_atoms_transcript_state (source_id, content_hash)
+        WHERE tombstoned;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -1035,6 +1035,25 @@ CREATE TABLE IF NOT EXISTS session_context_state (
 CREATE INDEX IF NOT EXISTS session_context_state_updated_idx
   ON session_context_state (updated_at);
 
+-- extract_atoms_transcript_state (migration v146 — #4148 follow-on).
+-- Failure streak + tombstone for TRANSCRIPT extraction items, which are files
+-- and so have no page frontmatter to carry it. See src/schema.sql for the full
+-- rationale (why not raw_data, why not dream_verdicts columns, why source_id is
+-- in the key). content_hash is the 16-char prefix, matching
+-- atoms.frontmatter->>'source_hash'.
+CREATE TABLE IF NOT EXISTS extract_atoms_transcript_state (
+  source_id    TEXT        NOT NULL DEFAULT 'default',
+  file_path    TEXT        NOT NULL,
+  content_hash TEXT        NOT NULL,
+  fail_count   INTEGER     NOT NULL DEFAULT 0,
+  tombstoned   BOOLEAN     NOT NULL DEFAULT FALSE,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (source_id, file_path, content_hash)
+);
+CREATE INDEX IF NOT EXISTS extract_atoms_transcript_state_live_idx
+  ON extract_atoms_transcript_state (source_id, content_hash)
+  WHERE tombstoned;
+
 -- chat_usage_log (#4218 / migration v140). See src/schema.sql for rationale.
 CREATE TABLE IF NOT EXISTS chat_usage_log (
   id                 BIGSERIAL PRIMARY KEY,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -790,6 +790,47 @@ CREATE TABLE IF NOT EXISTS session_context_state (
 CREATE INDEX IF NOT EXISTS session_context_state_updated_idx
   ON session_context_state (updated_at);
 
+-- extract_atoms_transcript_state (migration v146 — #4148 follow-on): failure
+-- streak + tombstone for TRANSCRIPT extraction items. Pages carry this in
+-- frontmatter (atoms_fail_count / atoms_fail_hash / atoms_scan_hash), but
+-- transcripts are files with no frontmatter, so pre-fix a transcript that
+-- deterministically produced malformed output — or that honestly yielded zero
+-- atoms — re-entered discovery and re-spent LLM budget on every cycle forever.
+--
+-- Why its own table. raw_data is page-scoped (page_id NOT NULL REFERENCES
+-- pages(id)) and transcripts aren't pages, exactly as dream_verdicts' own
+-- comment notes. And NOT columns on dream_verdicts: that cache is documented
+-- rebuildable via `gbrain dream retriage --force`, which clears it wholesale,
+-- so extraction state stored there would be swept away as collateral.
+--
+-- Why source_id is in the key, unlike dream_verdicts. That table caches a
+-- content-level judgment ("is this transcript worth processing"), which does
+-- not vary by source. A failure streak and a tombstone GATE EXTRACTION, and
+-- extraction is source-scoped throughout the phase — discovery SQL, the NOT
+-- EXISTS idempotency subquery, and every putPage take sourceId. An unscoped
+-- tombstone would let one source permanently suppress another source's
+-- extraction of the same file.
+--
+-- content_hash is the 16-char prefix, matching atoms.frontmatter->>'source_hash'
+-- and the page-side atoms_fail_hash. Having it in the PK is what makes "a
+-- content edit resets the streak" fall out for free: an edited transcript is a
+-- different row, mirroring the page-side hash-keyed reset.
+--
+-- RLS: covered by the v35 auto_rls_on_create_table event trigger, same posture
+-- as session_context_state (v126) and chat_usage_log (v140).
+CREATE TABLE IF NOT EXISTS extract_atoms_transcript_state (
+  source_id    TEXT        NOT NULL DEFAULT 'default',
+  file_path    TEXT        NOT NULL,
+  content_hash TEXT        NOT NULL,
+  fail_count   INTEGER     NOT NULL DEFAULT 0,
+  tombstoned   BOOLEAN     NOT NULL DEFAULT FALSE,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (source_id, file_path, content_hash)
+);
+CREATE INDEX IF NOT EXISTS extract_atoms_transcript_state_live_idx
+  ON extract_atoms_transcript_state (source_id, content_hash)
+  WHERE tombstoned;
+
 -- chat_usage_log (#4218 / migration v140): durable per-call chat usage
 -- ledger. One row per SUCCESSFUL gateway.chat() call, written fire-and-forget
 -- by the chat-usage sink (src/core/ai/chat-usage.ts). cost_usd is a

--- a/test/extract-atoms-transcript-failure-classes.test.ts
+++ b/test/extract-atoms-transcript-failure-classes.test.ts
@@ -1,0 +1,275 @@
+/**
+ * v146 — extract_atoms failure classes for TRANSCRIPT items.
+ *
+ * The transcript half of gbrain#4148. Pre-fix `recordPageFailureCount` opened
+ * with `if (item.kind !== 'page' ...) return null`, and both tombstone stamps
+ * were gated `item.kind === 'page'`, so transcripts had:
+ *   - no durable failure count,
+ *   - no bounded tombstone for deterministically-malformed output,
+ *   - no zero-yield marker at all.
+ * Transcript eligibility is gated ONLY by `atomsExistingForHashes` ("does an
+ * atom row exist for this content hash"), and a failed or empty extraction
+ * leaves no atom row — so such a transcript re-entered the work pool and
+ * re-spent LLM budget on EVERY cycle, forever. TODOS.md P2(b).
+ *
+ * These mirror test/extract-atoms-failure-classes.test.ts, which is the house
+ * convention for this machinery, with the page assertions restated against the
+ * `extract_atoms_transcript_state` table instead of page frontmatter.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  runPhaseExtractAtoms,
+  MAX_DETERMINISTIC_FAILURES,
+} from '../src/core/cycle/extract-atoms.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import type { ChatResult, ChatOpts } from '../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+function okChatResult(text: string): ChatResult {
+  return {
+    text,
+    blocks: [{ type: 'text', text }],
+    stopReason: 'end',
+    usage: { input_tokens: 100, output_tokens: 50, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'anthropic:claude-haiku-4-5',
+    providerId: 'anthropic',
+  } as ChatResult;
+}
+
+const HASH_A = 'a'.repeat(16);
+const HASH_B = 'b'.repeat(16);
+const FILE = '/corpus/session-one.txt';
+const ATOM_JSON = JSON.stringify([
+  { title: 'A durable insight', atom_type: 'insight', body: 'The insight body prose.' },
+]);
+
+/** The transcript work-item seam, mirroring `_pages` in the sibling file. */
+function transcript(filePath: string, contentHash: string) {
+  return { filePath, content: 'transcript prose body', contentHash };
+}
+
+async function stateRow(
+  filePath: string,
+  contentHash: string,
+): Promise<{ fail_count: number; tombstoned: boolean } | undefined> {
+  const rows = await engine.executeRaw<{ fail_count: number | string; tombstoned: boolean | string }>(
+    `SELECT fail_count, tombstoned FROM extract_atoms_transcript_state
+      WHERE source_id = 'default' AND file_path = $1 AND content_hash = $2`,
+    [filePath, contentHash],
+  );
+  const r = rows[0];
+  if (!r) return undefined;
+  return { fail_count: Number(r.fail_count), tombstoned: r.tombstoned === true || r.tombstoned === 't' };
+}
+
+describe('transcript failure counting (v146)', () => {
+  test('malformed output is a COUNTED failure for a transcript, not a silent retry-forever', async () => {
+    const result = await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('no json in sight'),
+    });
+    expect(result.details.malformed_outputs).toBe(1);
+    const failures = result.details.failures as Array<{ error: string }>;
+    expect(failures[0].error).toContain('malformed model output');
+    // Pre-fix the count was null for transcripts, so the message carried no
+    // streak suffix at all — that absence WAS the bug's fingerprint.
+    expect(failures[0].error).toContain('consecutive failure 1 on this content');
+    const row = await stateRow(FILE, HASH_A);
+    expect(row).toBeDefined();
+    expect(row!.fail_count).toBe(1);
+    expect(row!.tombstoned).toBe(false);
+  });
+
+  test(`tombstones only after ${MAX_DETERMINISTIC_FAILURES} consecutive same-content malformed failures`, async () => {
+    const opts = {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('still not json'),
+    };
+    for (let i = 1; i < MAX_DETERMINISTIC_FAILURES; i++) {
+      const r = await runPhaseExtractAtoms(engine, opts);
+      expect(r.details.tombstoned_transcripts).toEqual([]);
+      const row = await stateRow(FILE, HASH_A);
+      expect(row!.fail_count).toBe(i);
+      expect(row!.tombstoned).toBe(false);
+    }
+    const final = await runPhaseExtractAtoms(engine, opts);
+    expect(final.details.tombstoned_transcripts).toEqual([FILE]);
+    const row = await stateRow(FILE, HASH_A);
+    expect(row!.fail_count).toBe(MAX_DETERMINISTIC_FAILURES);
+    expect(row!.tombstoned).toBe(true);
+  });
+
+  test('a content edit resets the streak (state is hash-keyed)', async () => {
+    const mk = (hash: string) => ({
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, hash)],
+      _chat: async (_o: ChatOpts) => okChatResult('nope'),
+    });
+    await runPhaseExtractAtoms(engine, mk(HASH_A));
+    await runPhaseExtractAtoms(engine, mk(HASH_A));
+    expect((await stateRow(FILE, HASH_A))!.fail_count).toBe(2);
+    await runPhaseExtractAtoms(engine, mk(HASH_B)); // edited transcript
+    expect((await stateRow(FILE, HASH_B))!.fail_count).toBe(1);
+    // The old row survives untouched — the streak did not carry over.
+    expect((await stateRow(FILE, HASH_A))!.fail_count).toBe(2);
+  });
+
+  test('transient provider errors are retryable: no count, no tombstone', async () => {
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => { throw new Error('fetch failed: 503 upstream timeout'); },
+    });
+    expect(await stateRow(FILE, HASH_A)).toBeUndefined();
+  });
+});
+
+describe('transcript zero-yield tombstone (v146)', () => {
+  test('an honest empty extraction tombstones IMMEDIATELY, as it does for pages', async () => {
+    // The behaviour with the largest practical effect: pre-fix a transcript
+    // that legitimately yields nothing left no atom row, so it was re-attempted
+    // on every cycle forever. One clean call is a settled answer about this
+    // content and needs no streak.
+    const result = await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('[]'),
+    });
+    expect(result.details.transcripts_processed).toBe(1);
+    expect(result.details.atoms_extracted).toBe(0);
+    const row = await stateRow(FILE, HASH_A);
+    expect(row).toBeDefined();
+    expect(row!.tombstoned).toBe(true);
+    expect(row!.fail_count).toBe(0); // a zero-yield is NOT a failure
+  });
+
+  test('the zero-yield tombstone is honored on the next run (the read side)', async () => {
+    // Without the discovery-filter half, the row above would be written and
+    // then ignored — a counter nothing reads is inert.
+    const empty = async (_o: ChatOpts) => okChatResult('[]');
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default', _pages: [], _transcripts: [transcript(FILE, HASH_A)], _chat: empty,
+    });
+    let calls = 0;
+    const second = await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (o: ChatOpts) => { calls++; return empty(o); },
+    });
+    expect(calls).toBe(0); // never reached the LLM again
+    expect(second.details.transcripts_processed).toBe(0);
+    expect(second.details.duplicates_skipped).toBe(1);
+  });
+
+  test('editing a tombstoned transcript re-eligibilizes it', async () => {
+    // This is what makes the permanence safe: the tombstone is bound to the
+    // content that earned it, never to the path.
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('[]'),
+    });
+    let calls = 0;
+    const after = await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_B)], // same path, edited content
+      _chat: async (_o: ChatOpts) => { calls++; return okChatResult(ATOM_JSON); },
+    });
+    expect(calls).toBe(1);
+    expect(after.details.atoms_extracted).toBe(1);
+  });
+
+  test('a malformed-output tombstone is honored on the next run too', async () => {
+    const opts = {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('not json'),
+    };
+    for (let i = 0; i < MAX_DETERMINISTIC_FAILURES; i++) {
+      await runPhaseExtractAtoms(engine, opts);
+    }
+    let calls = 0;
+    const after = await runPhaseExtractAtoms(engine, {
+      ...opts,
+      _chat: async (_o: ChatOpts) => { calls++; return okChatResult('not json'); },
+    });
+    expect(calls).toBe(0); // budget no longer burned on this content
+    expect(after.details.duplicates_skipped).toBe(1);
+  });
+
+  test('an in-progress streak does NOT suppress the transcript (only a tombstone does)', async () => {
+    // fail_count 1 or 2 must stay live and keep being retried, mirroring a page
+    // whose atoms_fail_count is below the bound.
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('not json'),
+    });
+    let calls = 0;
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => { calls++; return okChatResult('not json'); },
+    });
+    expect(calls).toBe(1);
+  });
+});
+
+describe('transcript state is source-scoped (v146)', () => {
+  test("one source's tombstone does not suppress the same file under another source", async () => {
+    // The reason source_id is in the key. The phase is source-scoped
+    // throughout — discovery SQL, the NOT EXISTS idempotency subquery, and
+    // every putPage take sourceId — and this file's header records the
+    // federated-brain bug caused by forgetting it once already.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('dept-x', 'dept-x') ON CONFLICT (id) DO NOTHING`,
+    );
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => okChatResult('[]'),
+    });
+    expect((await stateRow(FILE, HASH_A))!.tombstoned).toBe(true);
+
+    let calls = 0;
+    const other = await runPhaseExtractAtoms(engine, {
+      sourceId: 'dept-x',
+      _pages: [],
+      _transcripts: [transcript(FILE, HASH_A)],
+      _chat: async (_o: ChatOpts) => { calls++; return okChatResult(ATOM_JSON); },
+    });
+    expect(calls).toBe(1); // dept-x still extracts it
+    expect(other.details.atoms_extracted).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes the transcript half of #4148, tracked in `TODOS.md` as P2(b):

> extract-atoms tombstones cover pages only: `recordPageFailureCount` returns null for `kind !== 'page'`, so a transcript that deterministically yields malformed output re-spends LLM budget every cycle forever.

## Read this first: the intended production effect is dramatic

**The zero-yield tombstone is the first mechanism that removes a transcript from the work pool without it ever producing an atom.** Every transcript that legitimately returns `[]` will tombstone on its **first** post-deploy run and never be retried until the file changes.

On the brain that surfaced this, **24 of 42 corpus transcripts had never produced an atom** and were being re-attempted on every cycle, against a per-run budget that admits roughly 15 LLM calls. So the first extraction run after this lands will shrink the transcript pool sharply and permanently. That is the fix working, not a regression — but a maintainer watching a sudden pool collapse without knowing it was intended would reasonably suspect one. The safety net is that the tombstone is bound to the content that earned it, never to the path: editing the file re-eligibilizes it, and that is pinned by a test.

## The bug

Three holes, all gated `item.kind === 'page'`: no durable failure count for transcripts, no bounded tombstone after `MAX_DETERMINISTIC_FAILURES`, and no zero-yield marker at all.

Transcript eligibility is gated **only** by `atomsExistingForHashes` — "does an atom row exist for this content hash". A failed extraction leaves no atom row, and neither does an honest empty one, so both classes re-entered the pool indefinitely.

## Write side

`recordPageFailureCount` → `recordItemFailureCount`, handling both kinds. Pages keep the identical frontmatter UPDATE (same SQL, same params); transcripts get a row in the new table. Both reset on a content change for the same reason — the page counter is hash-keyed, the transcript row *is* hash-keyed — and both feed the same `MAX_DETERMINISTIC_FAILURES = 3`. `stampTranscriptTombstone` mirrors `stampAtomsScanHash`. Zero-yield tombstones immediately, as it already does for pages: a clean call returning `[]` is a settled answer about this content, not a failure, so it needs no streak.

## Read side — not optional, and it fails open

The counter is inert without it: the transcript filter consulted only `atomsExistingForHashes`, so a tombstone nothing reads leaves the item in the pool regardless. That is why both halves are in one PR.

`tombstonedTranscriptsForHashes` is the batch probe, mirroring `atomsExistingForHashes` — one query for the corpus, and **the same fail-soft posture: a probe error returns empty, treating everything as live.** A new gate that fails open re-attempts work; one that failed closed would silently suppress it. Only `tombstoned` rows suppress — a row at `fail_count` 1 or 2 stays live and keeps being retried, mirroring a page whose `atoms_fail_count` is below the bound.

## Pages are byte-identical — structurally, not by test luck

This is the claim a reviewer most needs and can least easily reconstruct, so here is the argument rather than just the green numbers. Green tests would only show that the tests check what I thought they checked.

1. I mapped the post-image line ranges of `discoverExtractablePages` (350-407) and `countExtractAtomsBacklog` (424-477) and intersected them with the changed lines of every diff hunk. **Zero changed lines inside either.** Page discovery and the page backlog count are untouched.
2. The read-side edit is confined to the `transcriptsLive` loop, which pages never traverse.
3. Every new branch in the shared item loop is `item.kind`-gated. The malformed tombstone was `… && item.kind === 'page'` and is now the same condition with an inner `if (item.kind === 'page')` / `else`; the zero-yield stamp likewise. Pages take the identical path.
4. A page-only run issues **no** new query: the batch probe short-circuits on an empty hash list before touching the DB.

## Schema

```sql
CREATE TABLE IF NOT EXISTS extract_atoms_transcript_state (
  source_id    TEXT        NOT NULL DEFAULT 'default',
  file_path    TEXT        NOT NULL,
  content_hash TEXT        NOT NULL,
  fail_count   INTEGER     NOT NULL DEFAULT 0,
  tombstoned   BOOLEAN     NOT NULL DEFAULT FALSE,
  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
  PRIMARY KEY (source_id, file_path, content_hash)
);
```

- **Not `raw_data`**: `page_id INTEGER NOT NULL REFERENCES pages(id)`, and transcripts aren't pages — the same reason `dream_verdicts`' own v30 comment gives for existing.
- **Not columns on `dream_verdicts`**: that cache is documented rebuildable via `gbrain dream retriage --force`, which clears it wholesale; extraction state living there would be swept away as collateral.
- **`source_id` is in the key**, unlike `dream_verdicts`. That table caches a content-level judgment ("is this transcript worth processing") which does not vary by source. A failure streak and a tombstone *gate extraction*, and extraction is source-scoped throughout this phase — the discovery SQL, the NOT EXISTS subquery, `atomsExistingForHashes` (`source_id = $1`), and every `putPage`. `extract-atoms.ts`'s own header records the cost of forgetting that here once already: *"atoms always wrote to 'default' regardless of source, which made the NOT EXISTS guard ineffective on federated brains."* An unscoped tombstone would let one source permanently suppress another's extraction of the same file. A test pins it.
- `content_hash` is the 16-char prefix, matching `atoms.frontmatter->>'source_hash'` and the page-side `atoms_fail_hash`. Carrying it in the PK is what makes "a content edit resets the streak" fall out for free.
- Defined in `migrate.ts` (v146), `pglite-schema.ts`, **and** `schema.sql` — the `session_context_state` (v126) pattern rather than `dream_verdicts`' older migration-only one, because `test/schema-bootstrap-coverage.test.ts` enforces PGLite parity. RLS comes from the v35 `auto_rls_on_create_table` event trigger, same posture as v126/v140.

### Migration number

Upstream `master` is at **v145**, so **v146** is next and collides with nothing today. #4898 (the only other open PR from this fork) touches no migration or schema file. **If another migration lands before this merges, the number needs a bump.**

## Details field

`tombstoned_transcripts` is a **separate** field rather than mixing filesystem paths into `tombstoned_for_failures`, which carries page **slugs**. Merging them would be a silent type confusion for any consumer that later resolves those strings as slugs. I verified both are report-only today — written at one site, read at one site, asserted in two tests.

## Tests

10 in a new file mirroring `test/extract-atoms-failure-classes.test.ts`, the house convention for this machinery.

**Pre-fix baseline methodology:** the v146 schema was applied and **only `extract-atoms.ts` was reverted**, so the failures demonstrate *missing behaviour* rather than a missing table. Reverting both would have produced failures that prove nothing about the code.

| suite | before | after |
|---|---|---|
| `test/extract-atoms-transcript-failure-classes.test.ts` | 3 pass / 7 fail | **10 pass / 0 fail** |
| 14-file regression set (incl. `schema-bootstrap-coverage`, `extract-atoms-failure-classes`) | 159 pass / 0 fail | **169 pass / 0 fail** (= 159 + 10 new, zero regressions) |
| `test/schema-bootstrap-coverage.test.ts` (PGLite parity) | — | **13 pass / 0 fail** |
| `bun run typecheck` | — | clean |

The three tests that pass both ways are guards: transient errors uncounted, edit re-eligibilizes, in-progress streak does not suppress.

### The full suite was NOT run to completion

Targeted files only. Flagging rather than quoting a partial run as complete, and the second reason is worth a maintainer's attention:

1. On the host this was developed on, `scripts/run-unit-parallel.sh` self-throttled to `mem-adapted 4x4→1x1 (avail=3988MB, 1536MB/file)` and managed ~12 of 1645 files in 10 minutes.
2. More seriously, **the run overwrote live files in the operator's real `~/.gbrain`**: `autopilot-run.sh` was rewritten with (already-deleted) test-fixture paths, which started the autopilot's 3-strike self-disable guard, and `~/.gbrain/env` was reduced to a single test marker, destroying that host's `GBRAIN_HOOKS=0` self-ingestion kill switch. Both were repaired.

`test/helpers/gbrain-home-preload.ts` only points `GBRAIN_HOME` at a scratch dir when it is **not already set**, and subprocess-spawning tests need both `HOME` and `GBRAIN_HOME` redirected or the child inherits the operator's real one. `run-unit-parallel.sh`'s header says it strips an ambient `GBRAIN_HOME` at its boundary; empirically that did not happen. That looks like a genuine bug worth a separate issue.

CI should be unaffected (no ambient `GBRAIN_HOME`), and typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP3ZaS5CScim9toGEeyDoU
