### PR TITLE
fix(codex-hook): reach archived rollouts — missing_path rung + two-root fence

### DIFF
--- a/src/core/bootstrap/host-specs.ts
+++ b/src/core/bootstrap/host-specs.ts
@@ -371,6 +371,19 @@ export function codexSessionsDir(): string {
 }
 
 /**
+ * Codex ARCHIVED rollout store — (CODEX_HOME || ~/.codex)/archived_sessions/
+ * rollout-*.jsonl. Codex moves a rollout here when a session is archived, and
+ * the store is FLAT: no YYYY/MM/DD nesting, unlike codexSessionsDir (verified
+ * on a live 0.147.0 host — 363 rollouts, zero subdirectories). It is the same
+ * codex-owned trust boundary as the live store, so the hook lane confines to
+ * BOTH; a moved rollout is otherwise refused as outside_projects_dir and is
+ * invisible to the discovery fallback.
+ */
+export function codexArchivedSessionsDir(): string {
+  return join(codexHome(), 'archived_sessions');
+}
+
+/**
  * Codex hooks file — (CODEX_HOME || ~/.codex)/hooks.json, USER-GLOBAL (no
  * per-project scope for the user layer gbrain writes). Written by
  * codex-hooks.ts together with its config.toml trust-state entry; see

--- a/src/core/transcripts/codex-hook-lane.ts
+++ b/src/core/transcripts/codex-hook-lane.ts
@@ -11,10 +11,12 @@
  *
  * Confinement [S3#8]: the SessionEnd stdin payload is codex-supplied and an
  * agent-steerable input; `transcript_path` is confined to the pinned rollout
- * store (codexSessionsDir — CODEX_HOME-resolved, since the spawner IS codex)
- * with the same ladder as the claude root. No WSL cross-OS branch v1
- * (uncharacterized for codex; the reason codes are shared so widening later
- * is additive).
+ * stores (codexSessionsDir AND codexArchivedSessionsDir — both CODEX_HOME-
+ * resolved, since the spawner IS codex) with the same ladder as the claude
+ * root. Archived rollouts are inside the fence because codex MOVES a rollout
+ * there on archive: fencing only the live store refused a still-valid path as
+ * outside_projects_dir. No WSL cross-OS branch v1 (uncharacterized for codex;
+ * the reason codes are shared so widening later is additive).
  *
  * Engine-free by construction: node:fs/path + host-specs + codex.ts only —
  * never discover.ts (it imports BrainEngine); discovery is reimplemented
@@ -31,7 +33,7 @@
 
 import { closeSync, lstatSync, openSync, readdirSync, readFileSync, readSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { codexSessionsDir } from '../bootstrap/host-specs.ts';
+import { codexArchivedSessionsDir, codexSessionsDir } from '../bootstrap/host-specs.ts';
 import { isPathContained } from '../path-confine.ts';
 import type { ConfineTranscriptResult, ParsedTranscript, ToolCallRecord } from './claude-code-jsonl.ts';
 import { capToolCallInput, TRANSCRIPT_HARD_CAP_BYTES, TRANSCRIPT_MAX_BYTES_DEFAULT } from './claude-code-jsonl.ts';
@@ -45,28 +47,53 @@ const HOOK_HEAD_WINDOW_BYTES = 256 * 1024;
 /**
  * Validate an untrusted codex `transcript_path` from hook stdin — the same
  * ladder as claude's confineTranscriptPath, rooted at the codex rollout
- * store. `opts.root` is a TEST SEAM only; production callers use the pinned
- * default.
+ * stores (live + archived). `opts.root` / `opts.archivedRoot` are a TEST SEAM
+ * only; production callers use the pinned defaults.
  */
 export function confineCodexTranscriptPath(
   p: unknown,
-  opts: { root?: string; maxBytes?: number } = {},
+  opts: { root?: string; archivedRoot?: string; maxBytes?: number } = {},
 ): ConfineTranscriptResult {
   if (typeof p !== 'string' || p.length === 0) return { ok: false, reason: 'missing_path' };
   if (!p.endsWith('.jsonl')) return { ok: false, reason: 'not_jsonl' };
   let st: ReturnType<typeof lstatSync>;
   try {
     st = lstatSync(p);
-  } catch {
+  } catch (err) {
+    // ENOENT (nothing at the path) and ENOTDIR (a path component is a file,
+    // so the path cannot exist AS GIVEN) both mean "no such transcript",
+    // which is the rung hook.ts gates its discovery fallback on. Collapsing
+    // them into `unreadable` — a permission/IO fault the caller must NOT
+    // paper over — is what left a moved rollout unrecoverable. Discovery is
+    // itself id-filtered and root-confined, so routing ENOTDIR there bounds
+    // the blast radius of a malformed payload.
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { ok: false, reason: 'missing_path' };
     return { ok: false, reason: 'unreadable' };
   }
   if (st.isSymbolicLink()) return { ok: false, reason: 'symlink' };
   if (!st.isFile()) return { ok: false, reason: 'not_file' };
   const cap = opts.maxBytes ?? TRANSCRIPT_HARD_CAP_BYTES;
   if (st.size > cap) return { ok: false, reason: 'too_large' };
-  const root = opts.root ?? codexSessionsDir();
-  if (!isPathContained(p, root)) return { ok: false, reason: 'outside_projects_dir' };
+  const [root, archivedRoot] = codexRootsFor(opts);
+  const contained =
+    isPathContained(p, root) || (archivedRoot !== undefined && isPathContained(p, archivedRoot));
+  if (!contained) return { ok: false, reason: 'outside_projects_dir' };
   return { ok: true, path: p, size: st.size };
+}
+
+/**
+ * The confinement/discovery roots for a call. Production (no pinned `root`)
+ * gets BOTH codex-owned stores — live and archived. An explicitly pinned
+ * `root` stays single-root unless `archivedRoot` is pinned too, so the test
+ * seam can never be widened by the widening itself.
+ */
+function codexRootsFor(opts: {
+  root?: string;
+  archivedRoot?: string;
+}): [live: string, archived: string | undefined] {
+  if (opts.root) return [opts.root, opts.archivedRoot];
+  return [codexSessionsDir(), opts.archivedRoot ?? codexArchivedSessionsDir()];
 }
 
 export interface ParsedCodexTranscript extends ParsedTranscript {
@@ -184,21 +211,25 @@ export function parseCodexHookTranscript(
 const DISCOVERY_DIRENT_CAP = 4096;
 
 /**
- * Bounded newest-first discovery over the rollout store — the fallback for a
- * SessionEnd payload whose transcript_path is null, and the sweep seam for
- * SIGKILL'd sessions (SessionEnd never fires on SIGKILL). Fs-only walk:
- * newest 2 year dirs → newest 2 month dirs → newest 3 day dirs →
- * rollout-*.jsonl files (symlinks rejected). With a session id, the filename
- * must contain it (codex embeds the id in rollout filenames — verified
- * 0.147.0); without one, newest mtime wins and the caller's degrade names
- * the weaker match. Every miss is a typed reason at the caller — discovery
- * is never silent.
+ * Bounded newest-first discovery over the rollout stores — the fallback for a
+ * SessionEnd payload whose transcript_path is null or has MOVED (archived),
+ * and the sweep seam for SIGKILL'd sessions (SessionEnd never fires on
+ * SIGKILL). Fs-only walk of the live store: newest 2 year dirs → newest 2
+ * month dirs → newest 3 day dirs → rollout-*.jsonl files (symlinks
+ * rejected), then a FLAT pass over the archived store, both under one dirent
+ * budget. With a session id, the filename must contain it (codex embeds the
+ * id in rollout filenames — verified 0.147.0); without one, newest mtime
+ * wins across BOTH stores and the caller's degrade names the weaker match.
+ * An id-matched archived hit is a MATCH, not a guess — hook.ts reads
+ * `transcript_discovered_newest` as "guessed" and suppresses the relay on it,
+ * so the archived pass must never relabel a real match. Every miss is a typed
+ * reason at the caller — discovery is never silent.
  */
 export function discoverNewestCodexRollout(
   sessionId: string | null,
-  opts: { root?: string } = {},
+  opts: { root?: string; archivedRoot?: string } = {},
 ): { path: string; degrade: 'transcript_discovered' | 'transcript_discovered_newest' } | null {
-  const root = opts.root ?? codexSessionsDir();
+  const [root, archivedRoot] = codexRootsFor(opts);
   let seen = 0;
   const numericDesc = (dir: string, take: number): string[] => {
     try {
@@ -212,32 +243,48 @@ export function discoverNewestCodexRollout(
       return [];
     }
   };
+  const rolloutsIn = (dir: string): string[] => {
+    try {
+      return readdirSync(dir).filter((f) => f.startsWith('rollout-') && f.endsWith('.jsonl'));
+    } catch {
+      return [];
+    }
+  };
   let best: { path: string; mtimeMs: number } | null = null;
-  for (const y of numericDesc(root, 2)) {
+  /** Fold one directory's rollouts into `best`; true means the cap tripped. */
+  const consider = (dir: string, files: string[]): boolean => {
+    for (const f of files) {
+      if (++seen > DISCOVERY_DIRENT_CAP) return true;
+      if (sessionId && !f.includes(sessionId)) continue;
+      const p = join(dir, f);
+      try {
+        const st = lstatSync(p);
+        if (st.isSymbolicLink() || !st.isFile()) continue;
+        if (!best || st.mtimeMs > best.mtimeMs) best = { path: p, mtimeMs: st.mtimeMs };
+      } catch {
+        /* raced away — skip */
+      }
+    }
+    return false;
+  };
+
+  let capped = false;
+  dated: for (const y of numericDesc(root, 2)) {
     for (const m of numericDesc(join(root, y), 2)) {
       for (const d of numericDesc(join(root, y, m), 3)) {
         const day = join(root, y, m, d);
-        let files: string[];
-        try {
-          files = readdirSync(day).filter((f) => f.startsWith('rollout-') && f.endsWith('.jsonl'));
-        } catch {
-          continue;
-        }
-        for (const f of files) {
-          if (++seen > DISCOVERY_DIRENT_CAP) return best ? finish(best, sessionId) : null;
-          if (sessionId && !f.includes(sessionId)) continue;
-          const p = join(day, f);
-          try {
-            const st = lstatSync(p);
-            if (st.isSymbolicLink() || !st.isFile()) continue;
-            if (!best || st.mtimeMs > best.mtimeMs) best = { path: p, mtimeMs: st.mtimeMs };
-          } catch {
-            /* raced away — skip */
-          }
+        if (consider(day, rolloutsIn(day))) {
+          capped = true;
+          break dated;
         }
       }
     }
   }
+  // The archived store is FLAT — no YYYY/MM/DD — so the dated walk above can
+  // never reach it (see codexArchivedSessionsDir). Scanned under the SAME
+  // dirent budget, and skipped entirely once the cap has tripped so a
+  // pathological live store still degrades to "not found", never a hang.
+  if (!capped && archivedRoot) consider(archivedRoot, rolloutsIn(archivedRoot));
   return best ? finish(best, sessionId) : null;
 }
 

--- a/test/codex-hook-lane-archived.test.ts
+++ b/test/codex-hook-lane-archived.test.ts
@@ -1,0 +1,182 @@
+/**
+ * codex hook lane — the two coupled defects that made an archived rollout
+ * unreachable end-to-end:
+ *
+ *  1. `confineCodexTranscriptPath` collapsed EVERY lstat failure to
+ *     `unreadable`, so a vanished path never reached hook.ts's
+ *     `reason === 'missing_path'` gate and discovery never engaged.
+ *  2. Confinement and discovery both knew only `<codex home>/sessions`, so a
+ *     rollout codex had moved to `<codex home>/archived_sessions` was refused
+ *     as `outside_projects_dir` and was invisible to the fallback walk.
+ *
+ * The archived store is FLAT (no YYYY/MM/DD nesting), which is why the dated
+ * walk alone could never see it.
+ *
+ * The degrade label matters: hook.ts computes
+ * `discoveryWasGuess = found.degrade === 'transcript_discovered_newest'`, so
+ * an id-MATCHED archived hit must keep `transcript_discovered` — labelling it
+ * `_newest` would misclassify a real match as a guess and suppress the relay.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  confineCodexTranscriptPath,
+  discoverNewestCodexRollout,
+} from '../src/core/transcripts/codex-hook-lane.ts';
+
+let dir: string;
+let prevCodexHome: string | undefined;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'gb-cdx-arch-'));
+  prevCodexHome = process.env.CODEX_HOME;
+});
+afterEach(() => {
+  if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = prevCodexHome;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const meta = JSON.stringify({
+  timestamp: 't0',
+  type: 'session_meta',
+  payload: { id: 'r-1', session_id: 'cdx-sess-1', timestamp: 't0', cwd: '/repo', cli_version: '0.147.0' },
+});
+
+/** Seed the FLAT archived store under a codex home. */
+function seedArchived(home: string, name = 'rollout-2026-08-20-zzz-sess-arch.jsonl'): string {
+  const arch = join(home, 'archived_sessions');
+  mkdirSync(arch, { recursive: true });
+  const p = join(arch, name);
+  writeFileSync(p, meta + '\n');
+  return p;
+}
+
+describe('confineCodexTranscriptPath — the missing_path rung', () => {
+  test('a vanished path reports missing_path, not unreadable (hook.ts gates discovery on it)', () => {
+    const root = join(dir, 'sessions');
+    const day = join(root, '2026', '08', '25');
+    mkdirSync(day, { recursive: true });
+    expect(confineCodexTranscriptPath(join(day, 'gone.jsonl'), { root })).toEqual({
+      ok: false,
+      reason: 'missing_path',
+    });
+
+    // ENOTDIR — a path component that is a file, not a directory. Also "this
+    // path does not exist as given", so it takes the same rung.
+    const real = join(day, 'rollout-real-sess-a.jsonl');
+    writeFileSync(real, meta + '\n');
+    expect(confineCodexTranscriptPath(join(real, 'nested.jsonl'), { root })).toEqual({
+      ok: false,
+      reason: 'missing_path',
+    });
+  });
+});
+
+describe('confineCodexTranscriptPath — the archived store is inside the fence', () => {
+  test('a rollout under archived_sessions is accepted by the PRODUCTION default (root undefined)', () => {
+    process.env.CODEX_HOME = dir;
+    mkdirSync(join(dir, 'sessions'), { recursive: true });
+    const archived = seedArchived(dir);
+    expect(confineCodexTranscriptPath(archived)).toEqual({
+      ok: true,
+      path: archived,
+      size: expect.any(Number),
+    });
+
+    // The live store still resolves through that same default.
+    const day = join(dir, 'sessions', '2026', '08', '25');
+    mkdirSync(day, { recursive: true });
+    const live = join(day, 'rollout-live-sess-b.jsonl');
+    writeFileSync(live, meta + '\n');
+    expect(confineCodexTranscriptPath(live)).toEqual({ ok: true, path: live, size: expect.any(Number) });
+  });
+
+  test('PRESERVED: an explicitly pinned root stays single-root — the test seam never widens', () => {
+    process.env.CODEX_HOME = dir; // the production default WOULD accept it
+    const root = join(dir, 'sessions');
+    mkdirSync(root, { recursive: true });
+    const archived = seedArchived(dir);
+    expect(confineCodexTranscriptPath(archived, { root })).toEqual({
+      ok: false,
+      reason: 'outside_projects_dir',
+    });
+    expect(discoverNewestCodexRollout('sess-arch', { root })).toBeNull();
+  });
+
+  test('PRESERVED: paths outside BOTH stores are still refused', () => {
+    process.env.CODEX_HOME = dir;
+    mkdirSync(join(dir, 'sessions'), { recursive: true });
+    mkdirSync(join(dir, 'archived_sessions'), { recursive: true });
+
+    const outside = join(dir, 'outside.jsonl');
+    writeFileSync(outside, meta + '\n');
+    expect(confineCodexTranscriptPath(outside)).toEqual({ ok: false, reason: 'outside_projects_dir' });
+
+    // A directory that merely shares the archived NAME but sits elsewhere is
+    // not a root — the widening is two pinned paths, not a name match.
+    const decoy = join(dir, 'nested', 'archived_sessions');
+    mkdirSync(decoy, { recursive: true });
+    const decoyFile = join(decoy, 'rollout-decoy-sess-d.jsonl');
+    writeFileSync(decoyFile, meta + '\n');
+    expect(confineCodexTranscriptPath(decoyFile)).toEqual({ ok: false, reason: 'outside_projects_dir' });
+  });
+
+  test('PRESERVED: the whole ladder applies to the archived root in the same order', () => {
+    process.env.CODEX_HOME = dir;
+    mkdirSync(join(dir, 'sessions'), { recursive: true });
+    const arch = join(dir, 'archived_sessions');
+    mkdirSync(arch, { recursive: true });
+
+    expect(confineCodexTranscriptPath('')).toEqual({ ok: false, reason: 'missing_path' });
+    expect(confineCodexTranscriptPath(join(arch, 'x.txt'))).toEqual({ ok: false, reason: 'not_jsonl' });
+
+    const evil = join(dir, 'evil.jsonl');
+    writeFileSync(evil, meta + '\n');
+    const link = join(arch, 'rollout-link-sess-e.jsonl');
+    symlinkSync(evil, link);
+    expect(confineCodexTranscriptPath(link)).toEqual({ ok: false, reason: 'symlink' });
+
+    const fat = join(arch, 'rollout-fat-sess-f.jsonl');
+    writeFileSync(fat, 'x'.repeat(64));
+    expect(confineCodexTranscriptPath(fat, { maxBytes: 16 })).toEqual({ ok: false, reason: 'too_large' });
+  });
+});
+
+describe('discoverNewestCodexRollout — reaches the flat archived store', () => {
+  test('an id match in archived_sessions is found and is NOT labelled a guess', () => {
+    process.env.CODEX_HOME = dir;
+    mkdirSync(join(dir, 'sessions'), { recursive: true });
+    const archived = seedArchived(dir);
+    // Production default: root undefined → both stores.
+    expect(discoverNewestCodexRollout('sess-arch')).toEqual({
+      path: archived,
+      degrade: 'transcript_discovered',
+    });
+  });
+
+  test('with no id the newest across BOTH stores wins; archived symlinks are still refused', () => {
+    const root = join(dir, 'sessions');
+    const arch = join(dir, 'archived_sessions');
+    const day = join(root, '2026', '08', '25');
+    mkdirSync(day, { recursive: true });
+    mkdirSync(arch, { recursive: true });
+    const live = join(day, 'rollout-live-sess-g.jsonl');
+    const archived = join(arch, 'rollout-arch-sess-h.jsonl');
+    writeFileSync(live, meta + '\n');
+    writeFileSync(archived, meta + '\n');
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(live, past, past); // the archived copy is newer
+
+    expect(discoverNewestCodexRollout(null, { root, archivedRoot: arch })).toEqual({
+      path: archived,
+      degrade: 'transcript_discovered_newest',
+    });
+
+    const evil = join(dir, 'evil2.jsonl');
+    writeFileSync(evil, meta + '\n');
+    symlinkSync(evil, join(arch, 'rollout-linked-sess-i.jsonl'));
+    expect(discoverNewestCodexRollout('sess-i', { root, archivedRoot: arch })).toBeNull();
+  });
+});

--- a/test/codex-hook-lane.test.ts
+++ b/test/codex-hook-lane.test.ts
@@ -116,7 +116,10 @@ describe('confineCodexTranscriptPath — the S3#8 ladder on the codex root', () 
 
     expect(confineCodexTranscriptPath(undefined, { root })).toEqual({ ok: false, reason: 'missing_path' });
     expect(confineCodexTranscriptPath(join(day, 'x.txt'), { root })).toEqual({ ok: false, reason: 'not_jsonl' });
-    expect(confineCodexTranscriptPath(join(day, 'absent.jsonl'), { root })).toEqual({ ok: false, reason: 'unreadable' });
+    // A path that simply is not there is `missing_path`, NOT `unreadable` —
+    // hook.ts gates its discovery fallback on that rung, and `unreadable` is
+    // reserved for a real permission/IO fault.
+    expect(confineCodexTranscriptPath(join(day, 'absent.jsonl'), { root })).toEqual({ ok: false, reason: 'missing_path' });
 
     const outside = join(dir, 'outside.jsonl');
     writeFileSync(outside, meta + '\n');


### PR DESCRIPTION
## The defect

An **archived** codex rollout is unrecoverable end-to-end in the SessionEnd hook lane. Two defects compound; neither fix alone restores the path.

**1. Every `lstat` failure was `unreadable`.**

```ts
try { st = lstatSync(p); }
catch { return { ok: false, reason: 'unreadable' }; }
```

`hook.ts` engages its discovery fallback only on `!conf.ok && conf.reason === 'missing_path'`. A `transcript_path` whose file has moved therefore never reached the fallback — it was reported as an IO/permission fault and the session was dropped.

**2. The lane knew only `<codex home>/sessions`.**

Codex *moves* a rollout to `<codex home>/archived_sessions` when a session is archived. Confinement refused that still-valid, still-codex-owned path as `outside_projects_dir`, and `discoverNewestCodexRollout` could not see it either — the archived store is **flat**, with no `YYYY/MM/DD` nesting, so the dated walk (`newest 2 years → 2 months → 3 days`) never descends into it.

## The fix

- **`missing_path` rung** — `ENOENT` and `ENOTDIR` now return `missing_path`. `unreadable` stays reserved for a genuine permission/IO fault that a caller must *not* paper over. `ENOTDIR` is included because a path component that is a file means the path cannot exist *as given*; it can also arise from a malformed payload, but discovery is itself id-filtered and root-confined, so the blast radius is bounded either way.
- **Two-root fence** — new `codexArchivedSessionsDir()` joins the same `CODEX_HOME` resolution as `codexSessionsDir()`, and the lane confines to both. Discovery adds a flat pass over the archived store under the **same** `DISCOVERY_DIRENT_CAP` budget, skipped once the cap has tripped so a pathological store still degrades to "not found" rather than hanging.
- An explicitly pinned `root` stays **single-root** unless `archivedRoot` is pinned too — the widening cannot leak through the test seam.

## One deliberate non-change, argued

An id-**matched** archived hit keeps `degrade: 'transcript_discovered'`. It would have been tempting to mark archived hits as `_newest` or invent a third reason string, but `hook.ts` computes:

```ts
discoveryWasGuess = found.degrade === 'transcript_discovered_newest';
```

and a guess is barred from the relay. An archived rollout matched by session id is not a guess — labelling it `_newest` would suppress a legitimate relay, replacing the old bug with a new one. The existing pair already encodes the only distinction the caller acts on, so no new reason string is added.

## Verification

- **Verified against a live host** (codex-cli 0.147.0): `archived_sessions` is flat — 363 rollouts, zero subdirectories. That flatness is the reason the dated walk cannot reach it, and it is why the new pass is a flat scan rather than a second dated walk.
- **Behavioural tests fail on unmodified `8c70f6255` for the right reasons**, not incidentally: the vanished-path test receives `unreadable`, archived confinement receives `outside_projects_dir`, archived discovery receives `null`, and the cross-store newest test picks the live file. 4 fail / 3 pass before; 7/7 after.
- **Targeted suites**: `codex-hook-lane`, `codex-hook-lane-archived`, `codex-toml`, `opencode-json`, `bootstrap-harness-writers`, `bootstrap-hooks-writers`, `bootstrap-verify-hook-carrier-overlap`, `skillpack-scaffold-harness`, `transcript-adapters` → **222 pass / 0 fail** (17/0 for the two codex-hook-lane files alone, up from 10/0). `tsc --noEmit` clean.
- `test/hook-command.serial.test.ts` reports 59 pass / 11 fail **both with and without this change** — the failures are unix-socket bind refusals in my sandbox, unrelated to this lane. Stated because I could not get a clean run of the direct caller's test file, not because I am claiming it passes.

## Disclosures

- **One existing assertion flips.** `test/codex-hook-lane.test.ts` asserted `reason: 'unreadable'` for an absent path — it pinned the defect. It now asserts `missing_path`.
- **`claude-code` has the same `catch` shape** (`claude-code-jsonl.ts`, `confineTranscriptPath`), but `CAPTURE_SPECS['claude-code']` has **no** `discover`. The reason string is therefore currently *inert* there: fixing it alone would change no behaviour, because there is no fallback to unlock. Left untouched; it needs a discovery implementation before it means anything.
- **`detect.ts` `harnessRoots()` is NOT changed here.** Adding `archived_sessions` as a second codex root would make `gbrain transcripts --all` sweep archived sessions too, and the plumbing tolerates it (`discoverTranscriptFiles` iterates roots; `buildStatusRows` dedups by format and sums files). I left it out because it is not the one-line addition it looks like: `test/transcript-adapters.test.ts` pins `formats` to exactly `['claude-code','codex','openclaw','hermes','grok']`, and `transcripts.ts` builds its `--all-discovery` checkpoint fingerprint from the sorted root list, so a new root silently resets that watermark. Both are defensible on their own merits — they just aren't this bug fix, and burying a watermark reset inside it seemed wrong. Happy to send it as a follow-up.
- **Pre-existing inconsistency, not addressed**: `detect.ts` hardcodes `~/.codex/sessions` and does not honor `CODEX_HOME`, while `host-specs.ts` does. The new helper follows `host-specs.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP3ZaS5CScim9toGEeyDoU
