### PR TITLE
v0.48.2.0 fix: repair remote asset diagnostics and isolated CI gates

### DIFF
--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -1,5 +1,7 @@
 # Key files — per-file index (gbrain repo)
 
+- `src/commands/doctor-asset-paths.ts` — image path resolution and storage-lane classification. Explicit git/local metadata keeps filesystem verification even when the configured default is remote; cloud metadata, or a remote default for legacy unmarked rows, prevents filesystem checks on object keys. `image_assets` reports remote objects as unverified and points to backend-aware `gbrain files verify`, never claiming cloud availability from a local stat. Local/source-root and Windows/WSL path checks remain separate.
+
 On-demand reference. CLAUDE.md (the always-loaded orientation file) routes here
 via its Reference map. **Read a file's entry before editing that file.**
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -317,11 +317,11 @@ fi
 INNER_CMD=$(cat <<'EOF'
 set -euo pipefail
 echo "[runner] bun version: $(bun --version)"
-# The oven/bun image omits git; many unit tests use mkdtemp + git init for fixtures.
-if ! command -v git >/dev/null 2>&1; then
-  echo "[runner] Installing git (debian apt)..."
+# The image omits git and ps; fixtures need git and PID-reuse tests need ps.
+if ! command -v git >/dev/null 2>&1 || ! command -v ps >/dev/null 2>&1; then
+  echo "[runner] Installing git + procps (debian apt)..."
   apt-get update -qq >/dev/null
-  apt-get install -y -qq git ca-certificates >/dev/null
+  apt-get install -y -qq git ca-certificates procps >/dev/null
 fi
 # Container runs as root (uid 0) against a host-uid bind-mount; mark repo +
 # any worktree gitdir as safe so `git status` etc. don't refuse.
@@ -358,7 +358,8 @@ if [ -f .git ]; then
 fi
 
 echo "[ci-local] Running checks inside runner container..."
-docker compose -f "$COMPOSE_FILE" run --rm "${EXTRA_MOUNTS[@]}" runner bash -c "$INNER_CMD"
+# Bash 3.2 treats an empty array as unset under nounset; preserve zero argv.
+docker compose -f "$COMPOSE_FILE" run --rm ${EXTRA_MOUNTS[@]+"${EXTRA_MOUNTS[@]}"} runner bash -c "$INNER_CMD"
 
 echo ""
 echo "[ci-local] All checks passed."

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -317,11 +317,12 @@ fi
 INNER_CMD=$(cat <<'EOF'
 set -euo pipefail
 echo "[runner] bun version: $(bun --version)"
-# The image omits git and ps; fixtures need git and PID-reuse tests need ps.
-if ! command -v git >/dev/null 2>&1 || ! command -v ps >/dev/null 2>&1; then
-  echo "[runner] Installing git + procps (debian apt)..."
+# Fixtures need git/jq, PID-reuse tests need ps, and the security scanner needs python3.
+if ! command -v git >/dev/null 2>&1 || ! command -v ps >/dev/null 2>&1 \
+  || ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  echo "[runner] Installing git + procps + jq + python3 (debian apt)..."
   apt-get update -qq >/dev/null
-  apt-get install -y -qq git ca-certificates procps >/dev/null
+  apt-get install -y -qq git ca-certificates procps jq python3 >/dev/null
 fi
 # Container runs as root (uid 0) against a host-uid bind-mount; mark repo +
 # any worktree gitdir as safe so `git status` etc. don't refuse.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -200,10 +200,11 @@ SELECTED=$(bun run scripts/select-e2e.ts)
 if [ -z "$SELECTED" ]; then
   echo "[runner] selector emitted nothing (doc-only diff); skipping E2E."
 else
-  DATABASE_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
+  printf "%s\n" "$SELECTED" | \
+  GBRAIN_TEST_DB=1 DATABASE_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
   GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \
   GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
-  echo "$SELECTED" | xargs bash scripts/run-e2e.sh
+  xargs bash scripts/run-e2e.sh
 fi'
   else
     RUN_PHASES_CMD='echo "[runner] guards + typecheck"
@@ -215,7 +216,7 @@ bun run typecheck
 echo "[runner] unit (unsharded, DATABASE_URL unset)"
 env -u DATABASE_URL bash scripts/run-unit-shard.sh
 echo "[runner] e2e (unsharded)"
-DATABASE_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
+GBRAIN_TEST_DB=1 DATABASE_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
 GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \
 GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \
 bash scripts/run-e2e.sh'
@@ -270,13 +271,13 @@ printf '%s\\n' 1 2 3 4 | xargs -P4 -I{} sh -c '
   echo \"[shard \${shard}] e2e phase (SHARD=\${shard}/4, DATABASE_URL=postgres-\${shard})\" >> \$log
   if [ -s /tmp/e2e-selected.txt ]; then
     SHARD=\${shard}/4 \\
-    DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
+    GBRAIN_TEST_DB=1 DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
     GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \\
     GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \\
     xargs -a /tmp/e2e-selected.txt bash scripts/run-e2e.sh >> \$log 2>&1
   else
     SHARD=\${shard}/4 \\
-    DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
+    GBRAIN_TEST_DB=1 DATABASE_URL=postgresql://postgres:postgres@postgres-\${shard}:5432/gbrain_test \\
     GBRAIN_PGBOUNCER_URL=postgresql://postgres:postgres@pgbouncer:5432/gbrain_pgbouncer \\
     GBRAIN_PGBOUNCER_DIRECT_URL=postgresql://postgres:postgres@postgres-1:5432/gbrain_test \\
     bash scripts/run-e2e.sh >> \$log 2>&1

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -117,6 +117,8 @@ for _e2e_var in $(env | grep -oE '^(CONDUCTOR_|MCP_|OPENCLAW_|HERMES_|GROK_|OPEN
     GBRAIN_HOME) ;;  # required for HOME isolation (set above) — keep
     GBRAIN_PGLITE_SNAPSHOT) ;;  # snapshot fast-path fixture (exported by ci-local.sh / runners) — keep
     GBRAIN_TEST_ALLOW_DATABASE_URL) ;;  # #3485 preload opt-in (set above) — keep
+    GBRAIN_TEST_DB) ;;  # explicit Docker test-host reset opt-in; test-shaped DB floor still applies
+    GBRAIN_PGBOUNCER_URL|GBRAIN_PGBOUNCER_DIRECT_URL) ;;  # isolated CI pooler targets
     GBRAIN_TEST_KEEP_PROVIDER_KEYS) ;;  # provider-keys preload opt-in (set above) — keep
     GBRAIN_E2E_FILE_TIMEOUT) ;;  # per-file cap override — read AFTER this scrub, so it must survive it
     GBRAIN_E2E_ALLOW_DB) ;;  # #3485 name-floor opt-in — the guard's own error

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -52,6 +52,7 @@ test/check-bootstrap-guards.test.ts	verify + workflow wiring	6	readFileSync
 test/check-update.test.ts	check-update CLI	3	bun-file
 test/child-worker-supervisor.test.ts	issue #1801 — restartCurrentChild + killChild liveness fix	3	readFileSync
 test/chronicle-extract.test.ts	runChronicleExtract	9	readFileSync
+test/ci-local-e2e-env.test.ts	(file-level)	1	readFileSync
 test/ci-local-empty-mounts.test.ts	(file-level)	1	readFileSync
 test/ci-local-runner-tools.test.ts	(file-level)	1	readFileSync
 test/claude-cli-recipe.test.ts	claude-cli LanguageModel — abort + error envelopes	13	readFileSync

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -52,6 +52,8 @@ test/check-bootstrap-guards.test.ts	verify + workflow wiring	6	readFileSync
 test/check-update.test.ts	check-update CLI	3	bun-file
 test/child-worker-supervisor.test.ts	issue #1801 — restartCurrentChild + killChild liveness fix	3	readFileSync
 test/chronicle-extract.test.ts	runChronicleExtract	9	readFileSync
+test/ci-local-empty-mounts.test.ts	(file-level)	1	readFileSync
+test/ci-local-runner-tools.test.ts	(file-level)	1	readFileSync
 test/claude-cli-recipe.test.ts	claude-cli LanguageModel — abort + error envelopes	13	readFileSync
 test/claude-cli-recipe.test.ts	claude-cli LanguageModel — context isolation	2	readFileSync
 test/claude-cli-recipe.test.ts	claude-cli LanguageModel — text-only round trip	4	readFileSync

--- a/src/commands/doctor-asset-paths.ts
+++ b/src/commands/doctor-asset-paths.ts
@@ -38,6 +38,17 @@ export interface AssetPathResolution {
   foreign: boolean;
 }
 
+/** Explicit per-file storage wins over the configured fallback backend. */
+export function isRemoteImageAsset(metadata: unknown, storageConfig?: unknown): boolean {
+  const backend = storageConfig !== null && typeof storageConfig === 'object' && 'backend' in storageConfig
+    ? storageConfig.backend : undefined;
+  const lane = metadata !== null && typeof metadata === 'object' && 'storage' in metadata
+    ? metadata.storage : undefined;
+  if (lane === 'git' || lane === 'local') return false;
+  return lane === 'supabase' || lane === 's3' || lane === 'r2'
+    || (lane === undefined && (backend === 'supabase' || backend === 's3'));
+}
+
 /**
  * Resolve a files.storage_path to a stat-able absolute path.
  * `opts.platform` / `opts.wslMountRoot` exist for tests; production callers

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3869,18 +3869,24 @@ export async function buildChecks(
   if (engine) {
     progress.heartbeat('image_assets');
     try {
-      const rows = await engine.executeRaw<{ storage_path: string; source_local_path: string | null }>(
-        `SELECT f.storage_path, s.local_path AS source_local_path FROM files f LEFT JOIN sources s ON s.id = COALESCE(f.source_id, 'default') WHERE f.mime_type LIKE 'image/%' LIMIT 1000`
+      const rows = await engine.executeRaw<{ storage_path: string; metadata: unknown; source_local_path: string | null }>(
+        `SELECT f.storage_path, f.metadata, s.local_path AS source_local_path FROM files f LEFT JOIN sources s ON s.id = COALESCE(f.source_id, 'default') WHERE f.mime_type LIKE 'image/%' LIMIT 1000`
       );
       let vanished = 0;
       let foreign = 0;
+      let remote = 0;
       const vanishedPaths: string[] = [];
       const fs = await import('node:fs');
-      const { resolveImageAssetPath } = await import('./doctor-asset-paths.ts');
+      const { resolveImageAssetPath, isRemoteImageAsset } = await import('./doctor-asset-paths.ts');
+      const storageConfig = loadConfig()?.storage;
       // storage_path is repo-relative for sync-ingested assets. Prefer the
       // owning source's root; sync.repo_path is only a legacy fallback.
       const repoRoot = (await engine.getConfig('sync.repo_path')) ?? process.cwd();
       for (const r of rows) {
+        if (isRemoteImageAsset(r.metadata, storageConfig)) {
+          remote++;
+          continue;
+        }
         // #1835: Windows drive paths (D:/…) translate to the WSL automount
         // (/mnt/d/…) under WSL, and are SKIPPED (not "missing") on hosts
         // where they cannot exist (macOS / plain Linux) — never joined onto
@@ -3897,20 +3903,22 @@ export async function buildChecks(
           if (vanishedPaths.length < 5) vanishedPaths.push(r.storage_path);
         }
       }
-      const checked = rows.length - foreign;
+      const checked = rows.length - foreign - remote;
+      const remoteNote = remote > 0
+        ? ` ${remote} remote image(s) not verified by this local check; run \`gbrain files verify\` to check storage.` : '';
       const foreignNote = foreign > 0
         ? ` (${foreign} Windows-drive path(s) skipped — not resolvable on this platform)`
         : '';
       if (rows.length === 0) {
         checks.push({ name: 'image_assets', status: 'ok', message: 'No image assets indexed yet' });
       } else if (vanished === 0) {
-        checks.push({ name: 'image_assets', status: 'ok', message: `${checked} image(s) all present on disk${foreignNote}` });
+        checks.push({ name: 'image_assets', status: remote > 0 ? 'warn' : 'ok', message: `${checked} local image(s) all present on disk${foreignNote}${remoteNote}` });
       } else {
         checks.push({
           name: 'image_assets',
           status: 'warn',
           message: `${vanished} of ${checked} image(s) missing from disk (e.g. ${vanishedPaths.join(', ')})${foreignNote}. ` +
-                   `Fix: restore from git, or \`gbrain sync --skip-failed\` to acknowledge.`,
+                   `Fix: restore from git, or \`gbrain sync --skip-failed\` to acknowledge.${remoteNote}`,
         });
       }
     } catch {

--- a/src/commands/doctor/bootstrap-checks.ts
+++ b/src/commands/doctor/bootstrap-checks.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import type { BrainEngine } from '../../core/engine.ts';
+import type { EnvProbeSignals } from '../../core/execution-env.ts';
 import { LATEST_VERSION } from '../../core/migrate.ts';
 // Agent-bootstrap doctor group (plan B2/B4/ENG-4 + one-live-serve note).
 import { readHarnessReceiptState, readReceipt } from '../../core/bootstrap/format.ts';
@@ -24,7 +25,7 @@ import type { Check } from '../doctor.ts';
  * `gbrain bootstrap` get ZERO checks from this group. Every probe is
  * fail-soft: a broken telemetry file degrades to a warn, never a throw.
  */
-export async function bootstrapDoctorChecks(engine: BrainEngine | null): Promise<Check[]> {
+export async function bootstrapDoctorChecks(engine: BrainEngine | null, envSignals: EnvProbeSignals = {}): Promise<Check[]> {
   const checks: Check[] = [];
   let home: string;
   try {
@@ -372,7 +373,7 @@ export async function bootstrapDoctorChecks(engine: BrainEngine | null): Promise
   try {
     if (ws !== null && receipt !== null) {
       const { detectExecutionEnvironment } = await import('../../core/execution-env.ts');
-      const envKind = detectExecutionEnvironment();
+      const envKind = detectExecutionEnvironment(envSignals);
       if (envKind !== 'local') {
         // Answered BEFORE the subprocess probes — cloud/container doctor
         // runs must not pay launchctl/crontab spawns for an answer that is

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -19,7 +19,7 @@
  */
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { GBrainConfig } from './config.ts';
 import { discoverOAuth, mintClientCredentialsToken } from './remote-mcp-probe.ts';
 
@@ -328,12 +328,9 @@ export async function callRemoteTool(
     try {
       return await tryCall(initialToken);
     } catch (e) {
-      // RemoteMcpError already-typed: bubble unless it's a tool_error that
-      // happens to look 401-shaped (e.g. SDK wrapping HTTP 401 in a tool
-      // error). For plain Error, do the 401 sniff.
-      const message = e instanceof Error ? e.message : String(e);
-      const looksLike401 = /401|unauthor|invalid.token/i.test(message);
-      if (!looksLike401) throw e;
+      // Refresh only on an actual HTTP 401. Authenticated tool errors may
+      // contain arbitrary text or client IDs with "401"; preserve them.
+      if (!(e instanceof StreamableHTTPError) || e.code !== 401) throw e;
       // Drop cached token and retry once with a fresh mint.
       tokenCache.delete(remote.mcp_url);
       let freshToken: string;
@@ -352,8 +349,7 @@ export async function callRemoteTool(
       try {
         return await tryCall(freshToken);
       } catch (e2) {
-        const m2 = e2 instanceof Error ? e2.message : String(e2);
-        if (/401|unauthor|invalid.token/i.test(m2)) {
+        if (e2 instanceof StreamableHTTPError && e2.code === 401) {
           throw new RemoteMcpError(
             'auth_after_refresh',
             `Auth failed after token refresh. Verify oauth_client_id and secret are still valid; the host operator may need to re-run \`gbrain auth register-client\`.`,

--- a/test/bootstrap-doctor-checks.test.ts
+++ b/test/bootstrap-doctor-checks.test.ts
@@ -714,7 +714,7 @@ describe('bootstrap_durability_job [B7/D7]', () => {
     tmpDirs.push(fakeHome);
     const checks = await withEnv(
       { ...NEUTRAL_ENV, GBRAIN_HOME: parent, HOME: fakeHome },
-      () => bootstrapDoctorChecks(null),
+      () => bootstrapDoctorChecks(null, { env: {}, fileExists: () => false }),
     );
     const c = byName(checks, 'bootstrap_durability_job');
     expect(c?.status).toBe('warn');

--- a/test/ci-local-e2e-env.test.ts
+++ b/test/ci-local-e2e-env.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const source = readFileSync(new URL('../scripts/ci-local.sh', import.meta.url), 'utf8');
+const start = source.indexOf('echo "[runner] e2e (unsharded, --diff selected)"');
+const selectedPhase = source.slice(start, source.indexOf("\nfi'", start) + 3);
+
+test('selected E2E receives database opt-in and pooler targets on the consumer side of the pipe', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-ci-env-'));
+  const report = join(dir, 'report.txt');
+  try {
+    mkdirSync(join(dir, 'scripts'));
+    writeFileSync(join(dir, 'scripts/run-e2e.sh'), [
+      'set -eu',
+      'printf "%s\\n" "$GBRAIN_TEST_DB" "$DATABASE_URL" "$GBRAIN_PGBOUNCER_URL" "$GBRAIN_PGBOUNCER_DIRECT_URL" "$@" > "$REPORT"',
+    ].join('\n'));
+    const result = spawnSync('/bin/bash', ['-c', [
+      'set -eu',
+      'bun() { printf "%s\\n" test/e2e/example.test.ts; }',
+      selectedPhase,
+    ].join('\n')], { cwd: dir, env: { PATH: process.env.PATH, REPORT: report }, encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    const [optIn, database, pooled, direct, file] = readFileSync(report, 'utf8').trim().split('\n');
+    expect(optIn).toBe('1');
+    expect(new URL(database).hostname).toBe('postgres-1');
+    expect(new URL(database).pathname).toBe('/gbrain_test');
+    expect(new URL(pooled).hostname).toBe('pgbouncer');
+    expect(new URL(direct).hostname).toBe('postgres-1');
+    expect(file).toBe('test/e2e/example.test.ts');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/ci-local-empty-mounts.test.ts
+++ b/test/ci-local-empty-mounts.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+// Execute the real runner invocation with Docker replaced by an argv recorder.
+// On macOS /bin/bash is 3.2, where an empty array under nounset is special.
+const line = readFileSync(new URL('../scripts/ci-local.sh', import.meta.url), 'utf8')
+  .split('\n').find(value => value.startsWith('docker compose ') && value.includes('EXTRA_MOUNTS'));
+
+for (const populated of [false, true]) {
+  test(`ci-local runner preserves ${populated ? 'worktree' : 'empty'} mount argv`, () => {
+    expect(line).toBeDefined();
+    const script = [
+      'set -eu',
+      'COMPOSE_FILE=compose.yml',
+      'INNER_CMD="echo test"',
+      populated ? 'EXTRA_MOUNTS=(-v "/tmp/path with spaces:/git:ro")' : 'EXTRA_MOUNTS=()',
+      'docker() { printf "<%s>\\n" "$@"; }',
+      line!,
+    ].join('\n');
+    const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const expected = ['compose', '-f', 'compose.yml', 'run', '--rm',
+      ...(populated ? ['-v', '/tmp/path with spaces:/git:ro'] : []),
+      'runner', 'bash', '-c', 'echo test'];
+    expect(result.stdout).toBe(expected.map(value => `<${value}>\n`).join(''));
+  });
+}

--- a/test/ci-local-runner-tools.test.ts
+++ b/test/ci-local-runner-tools.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const source = readFileSync(new URL('../scripts/ci-local.sh', import.meta.url), 'utf8');
+const bootstrap = source.slice(source.indexOf('if ! command -v git '), source.indexOf('# Container runs as root'));
+
+for (const git of [false, true]) {
+  for (const ps of [false, true]) {
+    test(`runner provisions required tools: git=${git}, ps=${ps}`, () => {
+      expect(bootstrap).toContain('apt-get');
+      const script = [
+        'set -eu',
+        `command() { case "$*" in '-v git') return ${git ? 0 : 1} ;; '-v ps') return ${ps ? 0 : 1} ;; *) return 1 ;; esac; }`,
+        'apt-get() { printf "%s\\n" "$*" >&2; }',
+        bootstrap,
+      ].join('\n');
+      const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8' });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe(git && ps ? '' : 'update -qq\ninstall -y -qq git ca-certificates procps\n');
+    });
+  }
+}

--- a/test/ci-local-runner-tools.test.ts
+++ b/test/ci-local-runner-tools.test.ts
@@ -5,19 +5,17 @@ import { spawnSync } from 'node:child_process';
 const source = readFileSync(new URL('../scripts/ci-local.sh', import.meta.url), 'utf8');
 const bootstrap = source.slice(source.indexOf('if ! command -v git '), source.indexOf('# Container runs as root'));
 
-for (const git of [false, true]) {
-  for (const ps of [false, true]) {
-    test(`runner provisions required tools: git=${git}, ps=${ps}`, () => {
-      expect(bootstrap).toContain('apt-get');
-      const script = [
-        'set -eu',
-        `command() { case "$*" in '-v git') return ${git ? 0 : 1} ;; '-v ps') return ${ps ? 0 : 1} ;; *) return 1 ;; esac; }`,
-        'apt-get() { printf "%s\\n" "$*" >&2; }',
-        bootstrap,
-      ].join('\n');
-      const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8' });
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe(git && ps ? '' : 'update -qq\ninstall -y -qq git ca-certificates procps\n');
-    });
-  }
+for (const missing of ['git', 'ps', 'jq', 'python3', null]) {
+  test(`runner provisions tools when missing: ${missing ?? 'none'}`, () => {
+    expect(bootstrap).toContain('apt-get');
+    const script = [
+      'set -eu',
+      `command() { [ "$*" != '-v ${missing}' ]; }`,
+      'apt-get() { printf "%s\\n" "$*" >&2; }',
+      bootstrap,
+    ].join('\n');
+    const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe(missing === null ? '' : 'update -qq\ninstall -y -qq git ca-certificates procps jq python3\n');
+  });
 }

--- a/test/doctor-image-assets-remote.test.ts
+++ b/test/doctor-image-assets-remote.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await engine.executeRaw(
+    `INSERT INTO files (filename, storage_path, mime_type, content_hash, metadata)
+     VALUES ('example.png', 'cloud/example.png', 'image/png', 'example-hash', $1::text::jsonb)`,
+    [JSON.stringify({ storage: 'supabase' })],
+  );
+});
+
+afterAll(async () => { await engine.disconnect(); });
+
+test('remote image objects are not diagnosed as missing local files', async () => {
+  const checks = await buildChecks(engine, ['--scope=brain']);
+  const assets = checks.find(check => check.name === 'image_assets');
+  expect(assets).toBeDefined();
+  expect(assets!.message).not.toContain('missing from disk');
+  expect(assets!.message).not.toContain('restore from git');
+  expect(assets!.message).toContain('remote');
+  expect(assets!.message).toContain('gbrain files verify');
+});
+
+test('a remote image does not hide a missing local image', async () => {
+  await engine.executeRaw(
+    `INSERT INTO files (filename, storage_path, mime_type, content_hash, metadata)
+     VALUES ('missing.png', 'missing-local/example.png', 'image/png', 'local-hash', $1::text::jsonb)`,
+    [JSON.stringify({ storage: 'git' })],
+  );
+  try {
+    const checks = await buildChecks(engine, ['--scope=brain']);
+    const assets = checks.find(check => check.name === 'image_assets');
+    expect(assets!.status).toBe('warn');
+    expect(assets!.message).toContain('1 of 1 image(s) missing from disk');
+    expect(assets!.message).toContain('1 remote image(s) not verified');
+  } finally {
+    await engine.executeRaw(`DELETE FROM files WHERE content_hash = 'local-hash'`);
+  }
+});

--- a/test/doctor-image-assets.test.ts
+++ b/test/doctor-image-assets.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveImageAssetPath } from '../src/commands/doctor-asset-paths.ts';
+import { isRemoteImageAsset, resolveImageAssetPath } from '../src/commands/doctor-asset-paths.ts';
+
+describe('doctor remote image classification', () => {
+  test('explicit cloud lanes never resolve to local paths', () => {
+    for (const storage of ['supabase', 's3', 'r2']) {
+      expect(isRemoteImageAsset({ storage })).toBe(true);
+    }
+  });
+  test('git and local metadata override a remote default', () => {
+    for (const storage of ['git', 'local']) {
+      expect(isRemoteImageAsset({ storage }, { backend: 'supabase' })).toBe(false);
+    }
+  });
+  test('legacy rows use the configured backend', () => {
+    expect(isRemoteImageAsset({}, { backend: 'supabase' })).toBe(true);
+    expect(isRemoteImageAsset(null, { backend: 's3' })).toBe(true);
+    expect(isRemoteImageAsset({}, { backend: 'local' })).toBe(false);
+    expect(isRemoteImageAsset({}, undefined)).toBe(false);
+    expect(isRemoteImageAsset({}, 'invalid')).toBe(false);
+  });
+});
 
 describe('doctor image asset path resolution', () => {
   test('uses the owning source local_path before the global sync fallback', () => {

--- a/test/e2e/pgbouncer-teardown.test.ts
+++ b/test/e2e/pgbouncer-teardown.test.ts
@@ -54,9 +54,15 @@ async function runCli(
   timeoutMs: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string; wallMs: number }> {
   const t0 = Date.now();
+  // The E2E runner's direct shard URL must not override this fixture's
+  // pooled config. Otherwise `get` queries gbrain_test, not gbrain_pgbouncer.
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, ...env, GBRAIN_SKIP_STARTUP_HOOKS: '1' };
+  delete childEnv.DATABASE_URL;
+  delete childEnv.GBRAIN_DATABASE_URL;
+  delete childEnv.GBRAIN_DIRECT_DATABASE_URL;
   const proc = Bun.spawn(['bun', 'run', join(REPO, 'src', 'cli.ts'), ...args], {
     cwd: REPO,
-    env: { ...process.env, ...env, GBRAIN_SKIP_STARTUP_HOOKS: '1' },
+    env: childEnv,
     stdout: 'pipe',
     stderr: 'pipe',
   });

--- a/test/helpers/operator-env-preload.ts
+++ b/test/helpers/operator-env-preload.ts
@@ -61,6 +61,13 @@ const KEEP_EXACT = new Set([
 // in-process by test/e2e/install-real-*.serial.test.ts.
 const KEEP_PREFIX = /^GBRAIN_(TEST_|CI_|E2E_|REAL_)/;
 
+// Pooler targets are test infrastructure only after the database lane opted in.
+// Bare unit runs must not inherit ambient pooler connections.
+if (process.env.GBRAIN_TEST_ALLOW_DATABASE_URL === '1') {
+  KEEP_EXACT.add('GBRAIN_PGBOUNCER_URL');
+  KEEP_EXACT.add('GBRAIN_PGBOUNCER_DIRECT_URL');
+}
+
 if (process.env.GBRAIN_TEST_KEEP_AMBIENT_ENV !== '1') {
   const removed: string[] = [];
   for (const name of Object.keys(process.env)) {

--- a/test/loops-store.test.ts
+++ b/test/loops-store.test.ts
@@ -77,22 +77,27 @@ describe('upsertOpenLoop', () => {
   });
 
   test('reopen: a closed loop flips back to open (closed_at/closed_by cleared) on conflict', async () => {
-    const { id } = await upsertOpenLoop(engine, loop({ lastActivityAt: '2026-08-20T00:00:00.000Z' }));
-    const closed = await closeOpenLoop(engine, 'g1', id, 'done', 'manual');
-    expect(closed?.status).toBe('done');
+    // SQL now() is constant within a transaction: the fixture must supply
+    // genuinely newer activity, not depend on the database clock advancing.
+    await engine.transaction(async (tx) => {
+      const { id } = await upsertOpenLoop(tx, loop({ lastActivityAt: '2026-08-20T00:00:00.000Z' }));
+      const closed = await closeOpenLoop(tx, 'g1', id, 'done', 'manual');
+      expect(closed?.status).toBe('done');
 
-    const again = await upsertOpenLoop(engine, loop({
-      summary: 'they pinged again',
-      lastActivityAt: '2026-08-24T00:00:00.000Z',
-    }));
-    expect(again.created).toBe(false);
-    expect(again.id).toBe(id);
+      const again = await upsertOpenLoop(tx, loop({
+        summary: 'they pinged again',
+        lastActivityAt: '2026-08-24T00:00:00.000Z',
+      }));
+      expect(again.applied).toBe(true);
+      expect(again.created).toBe(false);
+      expect(again.id).toBe(id);
 
-    const rows = await listOpenLoops(engine, { sourceIds: ['g1'] });
-    expect(rows[0].status).toBe('open');
-    expect(rows[0].closed_at).toBeNull();
-    expect(rows[0].closed_by).toBeNull();
-    expect(rows[0].summary).toBe('they pinged again');
+      const rows = await listOpenLoops(tx, { sourceIds: ['g1'] });
+      expect(rows[0].status).toBe('open');
+      expect(rows[0].closed_at).toBeNull();
+      expect(rows[0].closed_by).toBeNull();
+      expect(rows[0].summary).toBe('they pinged again');
+    });
   });
 
   test('evidence is REPLACED on upsert, not merged', async () => {

--- a/test/loops-store.test.ts
+++ b/test/loops-store.test.ts
@@ -77,11 +77,14 @@ describe('upsertOpenLoop', () => {
   });
 
   test('reopen: a closed loop flips back to open (closed_at/closed_by cleared) on conflict', async () => {
-    const { id } = await upsertOpenLoop(engine, loop());
+    const { id } = await upsertOpenLoop(engine, loop({ lastActivityAt: '2026-08-20T00:00:00.000Z' }));
     const closed = await closeOpenLoop(engine, 'g1', id, 'done', 'manual');
     expect(closed?.status).toBe('done');
 
-    const again = await upsertOpenLoop(engine, loop({ summary: 'they pinged again' }));
+    const again = await upsertOpenLoop(engine, loop({
+      summary: 'they pinged again',
+      lastActivityAt: '2026-08-24T00:00:00.000Z',
+    }));
     expect(again.created).toBe(false);
     expect(again.id).toBe(id);
 

--- a/test/mcp-client.test.ts
+++ b/test/mcp-client.test.ts
@@ -34,6 +34,7 @@ let tokenStatus = 200;
 let mcpResponseFor: (req: { method: string; params?: unknown }) => unknown = () => ({});
 let mcpStatusOverride: number | null = null;
 let mcpStatusOnce: number | null = null;
+let toolStatusOnce: number | null = null;
 let tokenMintCount = 0;
 
 beforeAll(async () => {
@@ -87,6 +88,12 @@ beforeAll(async () => {
           serverInfo: { name: 'mcp-client-test-fixture', version: '1' },
         };
       } else if (body.method === 'tools/call') {
+        if (toolStatusOnce !== null) {
+          res.statusCode = toolStatusOnce;
+          toolStatusOnce = null;
+          res.end(res.statusCode === 401 ? '' : 'upstream error: unauthorized client-401-fixture');
+          return;
+        }
         result = mcpResponseFor({ method: body.method, params: body.params });
       } else {
         result = {};
@@ -114,6 +121,7 @@ beforeEach(() => {
   tokenMintCount = 0;
   mcpStatusOverride = null;
   mcpStatusOnce = null;
+  toolStatusOnce = null;
   mcpResponseFor = () => ({ content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] });
   _clearMcpClientTokenCache();
 });
@@ -159,6 +167,13 @@ describe('callRemoteTool — happy path', () => {
 });
 
 describe('callRemoteTool — 401 refresh-on-once', () => {
+  test('HTTP 401 during tools/call (after initialization) refreshes once', async () => {
+    toolStatusOnce = 401;
+    const result = await callRemoteTool(makeConfig(), 'noop', {});
+    expect(unpackToolResult<{ ok: boolean }>(result)).toEqual({ ok: true });
+    expect(tokenMintCount).toBe(2);
+  });
+
   test('persistent HTTP 401 fails after exactly one refresh', async () => {
     mcpStatusOverride = 401;
     await expect(callRemoteTool(makeConfig(), 'noop', {})).rejects.toMatchObject({
@@ -190,6 +205,12 @@ describe('callRemoteTool — 401 refresh-on-once', () => {
 });
 
 describe('callRemoteTool — error surfaces', () => {
+  test.each([403, 500])('HTTP %i during tools/call does not refresh credentials', async (status) => {
+    toolStatusOnce = status;
+    await expect(callRemoteTool(makeConfig(), 'noop', {})).rejects.toBeInstanceOf(RemoteMcpError);
+    expect(tokenMintCount).toBe(1);
+  });
+
   test.each(['client-401-fixture', 'unauthorized namespace', 'invalid token in document'])('tool error containing %s is not an HTTP auth failure', async (marker) => {
     const message = `put_page: ${marker} is outside bound_slug_prefixes`;
     let calls = 0;

--- a/test/mcp-client.test.ts
+++ b/test/mcp-client.test.ts
@@ -33,6 +33,7 @@ let port: number;
 let tokenStatus = 200;
 let mcpResponseFor: (req: { method: string; params?: unknown }) => unknown = () => ({});
 let mcpStatusOverride: number | null = null;
+let mcpStatusOnce: number | null = null;
 let tokenMintCount = 0;
 
 beforeAll(async () => {
@@ -61,8 +62,9 @@ beforeAll(async () => {
     }
     if (req.url === '/mcp' && req.method === 'POST') {
       // Test-controlled status override (used to simulate 401 from MCP).
-      if (mcpStatusOverride !== null) {
-        res.statusCode = mcpStatusOverride;
+      if (mcpStatusOnce !== null || mcpStatusOverride !== null) {
+        res.statusCode = mcpStatusOnce ?? mcpStatusOverride!;
+        mcpStatusOnce = null;
         res.end();
         return;
       }
@@ -111,6 +113,7 @@ beforeEach(() => {
   tokenStatus = 200;
   tokenMintCount = 0;
   mcpStatusOverride = null;
+  mcpStatusOnce = null;
   mcpResponseFor = () => ({ content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] });
   _clearMcpClientTokenCache();
 });
@@ -156,50 +159,51 @@ describe('callRemoteTool — happy path', () => {
 });
 
 describe('callRemoteTool — 401 refresh-on-once', () => {
+  test('persistent HTTP 401 fails after exactly one refresh', async () => {
+    mcpStatusOverride = 401;
+    await expect(callRemoteTool(makeConfig(), 'noop', {})).rejects.toMatchObject({
+      reason: 'auth_after_refresh',
+    });
+    expect(tokenMintCount).toBe(2);
+  });
+
+  test('a tool denial after a real 401 refresh keeps its original error', async () => {
+    mcpStatusOnce = 401;
+    mcpResponseFor = () => ({
+      content: [{ type: 'text', text: 'client-401-fixture is outside bound_slug_prefixes' }],
+      isError: true,
+    });
+    await expect(callRemoteTool(makeConfig(), 'put_page', {})).rejects.toMatchObject({
+      reason: 'tool_error',
+    });
+    expect(tokenMintCount).toBe(2);
+  });
+
   test('401 from /mcp → re-mint token + retry succeeds', async () => {
-    // Pre-seed cache with a fresh-but-server-rejected token by first
-    // succeeding once, then flipping the server to 401 just once.
     await callRemoteTool(makeConfig(), 'first_success', {});
     expect(tokenMintCount).toBe(1);
-
-    // Next call: the /mcp endpoint will return 401 on the first attempt;
-    // the client should re-mint and retry. We simulate "rejected once,
-    // accepted on retry" by counting requests.
-    let mcpCallCount = 0;
-    mcpStatusOverride = null;
-    const origResponse = mcpResponseFor;
-    mcpResponseFor = ({ method, params }) => {
-      if (method === 'tools/call') mcpCallCount++;
-      // First call: instruct fixture to return 401 by setting override THEN restore
-      // Actually simpler: throw on first attempt by setting mcpStatusOverride pre-emptively
-      return origResponse({ method, params });
-    };
-
-    // Easier path: install a once-only 401 on /mcp by setting mcpStatusOverride
-    // for one request; we need a counter. Use a flag.
-    let overrideUsed = false;
-    const realServer = server;
-    void realServer;
-    mcpStatusOverride = null;
-    // Wrap mcpResponseFor with a one-shot rejector — but the override is a
-    // status-line mechanism, not a body mechanism. Use a small hack: make
-    // the next /mcp request return a tool-error envelope that the client
-    // interprets as 401-equivalent. Actually the SDK throws on 401 status,
-    // so we need a real 401. Use mcpStatusOverride for one request.
-    // For test simplicity: expect that calling with stale-cached-token-then-
-    // 401 flow will re-mint. Achieve by setting tokenStatus to a failing
-    // value AFTER first success, then restoring. Skipped for this case;
-    // covered indirectly by the cache-reuse test above.
-
-    // Instead, assert that the cache invalidation API works: clear cache,
-    // call again, expect new token.
-    _clearMcpClientTokenCache();
-    await callRemoteTool(makeConfig(), 'after_clear', {});
+    mcpStatusOnce = 401;
+    await callRemoteTool(makeConfig(), 'after_401', {});
     expect(tokenMintCount).toBe(2);
+
   });
 });
 
 describe('callRemoteTool — error surfaces', () => {
+  test.each(['client-401-fixture', 'unauthorized namespace', 'invalid token in document'])('tool error containing %s is not an HTTP auth failure', async (marker) => {
+    const message = `put_page: ${marker} is outside bound_slug_prefixes`;
+    let calls = 0;
+    mcpResponseFor = () => {
+      calls++;
+      return { content: [{ type: 'text', text: message }], isError: true };
+    };
+    await expect(callRemoteTool(makeConfig(), 'put_page', {})).rejects.toMatchObject({
+      reason: 'tool_error', message: `Remote tool put_page failed: ${message}`,
+    });
+    expect(calls).toBe(1);
+    expect(tokenMintCount).toBe(1);
+  });
+
   test('config has no remote_mcp → throws RemoteMcpError(config)', async () => {
     await expect(callRemoteTool({ engine: 'postgres' }, 'foo', {})).rejects.toThrow(RemoteMcpError);
   });

--- a/test/operator-env-preload.test.ts
+++ b/test/operator-env-preload.test.ts
@@ -153,6 +153,23 @@ describe('operator-env-preload (#4023)', () => {
     expect(r.report.GBRAIN_SOURCE).toBe('default');
   }, 30_000);
 
+  for (const optedIn of [false, true]) {
+    test(`pooler URLs survive only an opted-in database test lane: ${optedIn}`, () => {
+      const urls = {
+        GBRAIN_PGBOUNCER_URL: 'postgresql://localhost:6554/gbrain_pgbouncer',
+        GBRAIN_PGBOUNCER_DIRECT_URL: 'postgresql://localhost:5544/gbrain_test',
+      };
+      const r = runProbe(
+        { ...urls, GBRAIN_TEST_ALLOW_DATABASE_URL: optedIn ? '1' : '0' },
+        Object.keys(urls),
+      );
+      expect(r.exitCode).toBe(0);
+      for (const [name, url] of Object.entries(urls)) {
+        expect(r.report[name]).toBe(optedIn ? url : null);
+      }
+    }, 30_000);
+  }
+
   test('GBRAIN_DEBUG_PRELOAD=1 logs removed names, never values', () => {
     const r = runProbe(
       { GBRAIN_SOURCE: 'hunter2-not-for-logs', GBRAIN_DEBUG_PRELOAD: '1' },


### PR DESCRIPTION
## Purpose

Fix two user-facing diagnostic/authentication defects and six local CI/test defects. These are small changes at their existing ownership boundaries; no search, embedding, schema, authorization-policy or provider changes.

## Review map

| Issue | Defect and value | Fix / behavioral evidence |
|---|---|---|
| #4910 | Cloud image keys were reported as missing local files, suggesting an incorrect restore. | Doctor separates remote objects, explicitly says **unverified**, and points to `files verify`. Mixed real PGLite fixtures still detect missing git/local images. Explicit per-file storage wins over the configured default. |
| #4931 | Error text containing `401`/`unauthorized` was mistaken for HTTP authentication failure, while empty-body HTTP 401 could be missed. | Use the SDK's typed HTTP status, refresh at most once. Real loopback HTTP tests cover initialize/tool-call 401, persistent 401, application denials and HTTP 403/500. Write-boundary denials remain denials. |
| #4911 | Bash 3.2 plus `set -u` aborted normal clones with an empty worktree mount array. | Optional-array expansion preserves zero arguments and quoted paths. The actual invocation runs with a Docker argv recorder on `/bin/bash`, including paths with spaces. |
| #4914 | Official runner lacked `ps`, `jq`, `python3`; git-only bootstrap skipped them when git existed. | Provision the tools required by existing fixtures; cover each missing executable and the fully provisioned no-op. Previously validated inside the official ARM64 Bun container. |
| #4915 | A nominally local bootstrap fixture detected the runner's real `/.dockerenv`. | Pass through the detector's existing optional probe signals; only the local test injects them. Production detection defaults unchanged; local/container cases retained. |
| #4918 | E2E scrub/preload removed PgBouncer inputs; CLI fixture then queried the direct shard DB instead of its configured pooler DB. | Preserve explicit pooler inputs only in the opted-in database lane; clear direct URL overrides in that fixture's child. Actual pooled tests execute instead of skipping. |
| #4919 | Dedicated Docker E2E lacked the existing test-reset opt-in, so schema parity compared against earlier test residue. | Set `GBRAIN_TEST_DB=1` at that runner boundary and preserve it. Test-shaped database-name guard unchanged. Selected unsharded pipeline now exports inputs to `xargs`, not `echo`. |
| #4928 | A reopen fixture expected strictly newer activity while letting both timestamps come from the wall clock. | Explicit ordered activity timestamps, now exercised with SQL `now()` held constant inside one transaction. This is fixture hardening, not a production reopen-policy change. See evidence qualification below. |

Fixes #4910
Fixes #4911
Fixes #4914
Fixes #4915
Fixes #4918
Fixes #4919
Fixes #4928
Fixes #4931

## Disputed fixture: deterministic evidence, not a stress-run claim

Automated triage independently reproduced #4910, #4915, #4918 and #4919. It did **not** reproduce #4928 in 40 repetitions per pinned lane. A passing stress run does not establish clock independence, but neither does our original failed assertion prove that two timestamps were equal: that run did not capture the database timestamps.

The current `reopen:` test in `test/loops-store.test.ts` runs within `engine.transaction()`, where SQL `now()` is constant. It succeeds with the explicit older/newer activity values. Removing only those two `lastActivityAt` inputs deterministically fails (`applied: false` rather than `true`); retaining them passes. This controls the suspected collision condition without claiming to reproduce its natural frequency. Existing equal/older-activity tests still require a closed loop to stay closed. No sleeps, retries, clock-resolution assumptions, assertion weakening, or product SQL changes.

## Validation by revision

- **`141e2557`**: full official `bun run ci:local --no-shard`, exit 0. Unit: 23,720 passed / 15 skipped / 0 failed; PostgreSQL E2E: 224 files passed, 1,589 tests reported passed, 0 failed. Real PgBouncer and schema parity ran. This is the full-suite baseline, not a claim about subsequent commits.
- **`13c88ac7`** (MCP product fix): 69 targeted unit + 20 real Docker E2E tests passed; typecheck passed; all executed GitHub checks passed, including Selected E2E, unit shards, serial/slow, Verify and security. Optional heavy/live-provider lanes were skipped by the existing workflow.
- **`39841237`** (test-only follow-up): 163 targeted tests across 11 files passed, 0 failed; `bun run typecheck`, `git diff --check` and changed-content gitleaks passed. Reverting only the MCP implementation to `141e2557` yields **9 failures / 12 passes** in the real HTTP fixture; restored implementation yields **21 passes / 0 failures**. Clock-collision mutation fails as described above. No additional product files changed. Final GitHub checks on `39841237f90e21d6f4cb6e38f7e52d33eab85dfd` completed: **29 passed, 0 failed/pending; 12 optional lanes skipped** under the existing workflow. [Selected E2E](https://github.com/garrytan/gbrain/actions/runs/34023220547/job/101459522986) passed; GitHub reports `MERGEABLE` / `CLEAN`.

Reproduce the focused follow-up with production DB inputs removed:

```sh
env -u DATABASE_URL -u GBRAIN_DATABASE_URL -u GBRAIN_DIRECT_DATABASE_URL -u GBRAIN_HOME \
  bun test test/loops-store.test.ts test/mcp-client.test.ts test/mcp-client-hardening.test.ts \
  test/doctor-image-assets.test.ts test/doctor-image-assets-remote.test.ts \
  test/bootstrap-doctor-checks.test.ts test/execution-env.test.ts \
  test/ci-local-empty-mounts.test.ts test/ci-local-runner-tools.test.ts \
  test/ci-local-e2e-env.test.ts test/operator-env-preload.test.ts
bun run typecheck
```

## Scope and limitations

Contributor PR, not a release or deployment. Synthetic fixtures and disposable test databases only. The production installation remains on the official release. Doctor does not prove remote object availability; `files verify` owns that check. Live provider quality and optional heavy lanes are not claimed. No migration, dependency on a private operator setup, or production configuration changes. Changes remain in reviewable commits; merge/release belongs to the maintainer.
