### PR TITLE
fix(mcp): defer --stdio-idle-timeout stdin listener until MCP transport attaches

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -334,7 +334,7 @@ export async function runServe(
   // the MCP client log "Failed to parse JSONRPC message" for every line.
   redirectStdoutLoggingToStderr();
 
-  installStdioLifecycle(engine, args, opts);
+  const activateStdioIdleActivityTracking = installStdioLifecycle(engine, args, opts);
 
   const start = opts.startMcpServer ?? startMcpServer;
 
@@ -371,13 +371,19 @@ export async function runServe(
 
   try {
     await start(engine, { surface, ...(sourceGuard ? { sourceGuard } : {}) });
+    // `--stdio-idle-timeout` arms its timer during lifecycle installation,
+    // but its stdin activity listener must wait until startMcpServer has
+    // attached the MCP SDK transport listener. Attaching any `data` listener
+    // earlier flips stdin into flowing mode and can consume a fast client's
+    // initialize frame before the SDK sees it.
+    activateStdioIdleActivityTracking();
   } finally {
     if (bootDeadline) clearTimeout(bootDeadline);
   }
-  // startMcpServer's `await server.connect(transport)` resolves once the
-  // SDK has wired up its stdin 'data' listener; that listener keeps the
-  // event loop alive. We deliberately do NOT add `await new Promise(() =>
-  // {})` here — it would block this async frame and stop the lifecycle
+  // startMcpServer returns after the SDK has wired up its stdin 'data'
+  // listener (and completed its engine-dependent boot); that listener keeps
+  // the event loop alive. We deliberately do NOT add `await new Promise(()
+  // => {})` here — it would block this async frame and stop the lifecycle
   // hooks from being able to call process.exit() cleanly.
 }
 
@@ -433,7 +439,7 @@ function installStdioLifecycle(
   engine: BrainEngine,
   args: string[],
   opts: ServeOptions,
-): void {
+): () => void {
   const deps: StdioLifecycleDeps = {
     stdin: opts.stdin ?? process.stdin,
     signals: opts.signals ?? process,
@@ -448,6 +454,7 @@ function installStdioLifecycle(
   let shuttingDown = false;
   let parentWatchdog: unknown = null;
   let idleSweepTimer: unknown = null;
+  let activateIdleActivityTracking = (): void => {};
   const beginShutdown = (reason: string): void => {
     if (shuttingDown) return;
     shuttingDown = true;
@@ -707,6 +714,7 @@ function installStdioLifecycle(
   const idleTimeoutSec = parseStdioIdleTimeout(args);
   if (idleTimeoutSec > 0) {
     let idleTimer: ReturnType<typeof setTimeout> | null = null;
+    let activityListenerAttached = false;
     const armIdle = (): void => {
       if (idleTimer) clearTimeout(idleTimer);
       idleTimer = setTimeout(
@@ -716,12 +724,21 @@ function installStdioLifecycle(
       idleTimer.unref?.();
     };
     armIdle();
-    // Reset on every chunk. We can't observe SDK-parsed messages from
-    // here, but every JSON-RPC frame causes a 'data' event on stdin, so
-    // chunk-level granularity is sufficient.
-    deps.stdin.on('data', armIdle);
+    activateIdleActivityTracking = (): void => {
+      if (activityListenerAttached || shuttingDown) return;
+      activityListenerAttached = true;
+      // Reset on every chunk. We can't observe SDK-parsed messages from
+      // here, but every JSON-RPC frame causes a 'data' event on stdin, so
+      // chunk-level granularity is sufficient. This listener is activated
+      // only after startMcpServer returns: adding it during lifecycle install
+      // would put stdin in flowing mode before the SDK transport attaches and
+      // race away the initialize frame.
+      deps.stdin.on('data', armIdle);
+    };
     deps.log(`GBrain MCP server: stdio idle timeout = ${idleTimeoutSec}s`);
   }
+
+  return activateIdleActivityTracking;
 }
 
 /**

--- a/test/e2e/serve-stdio-roundtrip.test.ts
+++ b/test/e2e/serve-stdio-roundtrip.test.ts
@@ -110,10 +110,12 @@ describe('serve stdio round-trip E2E (local PGLite → real MCP tool calls)', ()
     );
 
     // 3. Let the MCP SDK spawn `gbrain serve` (stdio) and run the initialize
-    //    handshake — exactly what `claude mcp add gbrain -- gbrain serve` does.
+    //    handshake with the opt-in idle timeout enabled. This pins the
+    //    production wrapper shape that previously let the timeout's activity
+    //    listener consume initialize before the SDK transport attached.
     transport = new StdioClientTransport({
       command: 'bun',
-      args: ['run', 'src/cli.ts', 'serve'],
+      args: ['run', 'src/cli.ts', 'serve', '--stdio-idle-timeout', '14400'],
       cwd: process.cwd(),
       env, // includes PATH (to find `bun`) + GBRAIN_HOME
     });

--- a/test/serve-stdio-lifecycle.test.ts
+++ b/test/serve-stdio-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { EventEmitter } from 'events';
 import { spawnSync } from 'node:child_process';
+import { PassThrough } from 'node:stream';
 import {
   runServe,
   isPidAlive,
@@ -408,6 +409,37 @@ describe('runServe stdio lifecycle', () => {
     h.signals.emit('SIGTERM');
     await h.exited;
     expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('--stdio-idle-timeout leaves stdin paused until the MCP transport listener is attached', async () => {
+    const h = makeHarness();
+    const stdin = new PassThrough();
+    h.opts.stdin = stdin;
+    const initializeFrame = '{"jsonrpc":"2.0","id":1,"method":"initialize"}\n';
+    let sdkReceived = '';
+
+    h.opts.startMcpServer = async () => {
+      // Model a fast MCP client: it writes initialize while startMcpServer is
+      // still booting, immediately before StdioServerTransport adds its data
+      // listener. A paused Readable buffers this frame for the SDK. Any earlier
+      // lifecycle data listener flips the stream to flowing mode and consumes
+      // the frame before the SDK can observe it.
+      stdin.write(initializeFrame);
+      stdin.on('data', (chunk: Buffer) => { sdkReceived += chunk.toString('utf8'); });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    };
+
+    await runServe(
+      h.engine as unknown as BrainEngine,
+      ['--stdio-idle-timeout', '60'],
+      h.opts,
+    );
+
+    expect(sdkReceived).toBe(initializeFrame);
+
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    stdin.destroy();
   });
 
   test('idle timer is reset on every stdin data chunk', async () => {


### PR DESCRIPTION
## What

`gbrain serve --stdio-idle-timeout <seconds>` silently hangs forever on the MCP `initialize` handshake for every client, unless the client happens to send its first frame slower than the SDK's own boot. The idle-timeout's stdin `data` listener was attached synchronously during lifecycle install (before `startMcpServer`/`server.connect(transport)` wires up the MCP SDK's own transport listener), which flips the stream into flowing mode early and can consume the client's `initialize` frame before the SDK ever sees it -- with no error, no log line, just silence.

## Why

Found via a production stdio MCP wrapper that hung on every client's `initialize` handshake. A/B test confirmed the root cause: `--stdio-idle-timeout 14400` → no reply after 65s; the identical request without the flag → immediate correct reply. Root-caused to the listener-attach ordering described above (Node/Bun streams enter flowing mode on the first `data` listener; whichever listener attaches first "wins" any bytes already buffered).

The ordinary idle-sweep code path just above this one in the same file already recognized this exact hazard and defers its own `data` listener to the first timer tick specifically to avoid racing the JSON-RPC handshake bytes -- `--stdio-idle-timeout` is the one path that didn't follow that pattern.

## Fix

`installStdioLifecycle()` now returns an idempotent activation callback instead of attaching the `--stdio-idle-timeout` listener eagerly. `runServe()` invokes it only after `await start(engine, ...)` resolves -- i.e. after the SDK transport has already attached its own stdin listener. The idle timer itself still arms immediately (unaffected by this race, since it's independent of stdin listeners).

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/commands/serve.ts` to merge-base (8c70f6255), ran `test/serve-stdio-lifecycle.test.ts` → 34 pass / 1 fail. Restored → all pass.

## Verification

Manual A/B repro against the fixed binary (not just the test suite): sent an `initialize` frame over stdio to `gbrain serve --stdio-idle-timeout 14400` before and after the fix.
- Before: 65s wait, 0 bytes on stdout.
- After: immediate 1053-byte correct JSON-RPC `initialize` response.

## Tests

- `test/serve-stdio-lifecycle.test.ts` — added `--stdio-idle-timeout leaves stdin paused until the MCP transport listener is attached`, modeling a fast client that writes `initialize` before the SDK attaches its listener via a `PassThrough` stream.
- `test/e2e/serve-stdio-roundtrip.test.ts` — updated the existing real `StdioClientTransport` round-trip (initialize → tools/list → tool calls) to run with `--stdio-idle-timeout 14400` enabled, pinning the exact production wrapper shape that hit this bug (previously untested with the flag on).

Local results (redirected, exit code checked, never piped through `tail`):
- Target files together: `44 pass / 0 fail`, 137 expect() calls.
- `bun run typecheck`: clean.
- `bun run verify`: 54/54 green.
- `bun run test:full`: 23593 pass / 168 fail -- the 168 are a pre-existing, environment-dependent cluster (launchd E2E requiring a real launchd service, IPC socket tests requiring a listening socket, PGLite snapshot subprocess tests) reproducible identically on the pre-fix tree; none touch the files changed here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)