### PR TITLE
fix(search): cap reranker document text by chars and tokens before the rerank call

### DIFF
--- a/src/core/search/rerank.ts
+++ b/src/core/search/rerank.ts
@@ -28,6 +28,7 @@ import type { SearchResult } from '../types.ts';
 import { rerank as gatewayRerank, RerankError, type RerankInput, type RerankResult } from '../ai/gateway.ts';
 import { BudgetExhausted } from '../budget/budget-tracker.ts';
 import { logRerankFailure, type RerankFailureReason } from '../rerank-audit.ts';
+import { estimateTokens } from '../chunkers/token-estimate.ts';
 import { warnOncePerProcess } from '../utils.ts';
 
 /** #4648: the two audited success-shaped pass-through causes. */
@@ -85,6 +86,22 @@ function classifyRerankFailure(err: unknown): RerankFailureReason {
   return 'unknown';
 }
 
+// cl100k estimate; Qwen-family tokenizers run ~35% worse on hex-heavy text, so
+// 1400 here stays under a 2048-token reranker batch with margin.
+const RERANK_MAX_DOC_TOKENS = 1400;
+const RERANK_MAX_DOC_CHARS = 6000;
+
+/** Trim a reranker document to ~RERANK_MAX_DOC_TOKENS (char cap first, then shrink by measured ratio). */
+export function capRerankDoc(text: string): string {
+  let doc = text.slice(0, RERANK_MAX_DOC_CHARS);
+  for (let i = 0; i < 4; i++) {
+    const tokens = estimateTokens(doc);
+    if (tokens <= RERANK_MAX_DOC_TOKENS) break;
+    doc = doc.slice(0, Math.floor(doc.length * (RERANK_MAX_DOC_TOKENS / tokens) * 0.95));
+  }
+  return doc;
+}
+
 /**
  * Reorder the top `topNIn` results by reranker relevance score. The
  * un-reranked tail (any rows past topNIn) preserves its original RRF
@@ -112,7 +129,11 @@ export async function applyReranker(
   // Document text — chunk_text is the matched span. Fall back to title if
   // empty (shouldn't happen in practice; defensive). Empty docs would
   // confuse the reranker, but we still send them — the upstream model decides.
-  const documents = head.map(r => r.chunk_text || r.title || '');
+  // Cap each document so a self-hosted reranker (llama-server, TEI) with a
+  // small physical batch never 500s on an oversized code/hex-heavy chunk;
+  // hosted rerankers truncate server-side anyway. Token-aware, not just
+  // char-capped, because hex-dense pages tokenize at ~1 char/token.
+  const documents = head.map(r => capRerankDoc(r.chunk_text || r.title || ''));
 
   let reranked: RerankResult[];
   try {

--- a/test/rerank-doc-cap.test.ts
+++ b/test/rerank-doc-cap.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Reranker document cap — self-hosted rerankers (llama-server, TEI) have a
+ * small physical batch and 500 on an oversized chunk; hosted rerankers
+ * truncate server-side. applyReranker now caps each document to a char AND
+ * token ceiling before the call. Hex-dense text (index pages, hashes) is the
+ * hazard the token ceiling exists for: ~1 char/token, so a char cap alone
+ * still overflows the batch.
+ *
+ * Pins:
+ *  - short prose passes through untouched
+ *  - a long document is cut to the char ceiling
+ *  - a hex-dense document under the char ceiling is still cut to the token ceiling
+ *  - the cap is applied on the applyReranker path (via the rerankerFn seam)
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as rerankMod from '../src/core/search/rerank.ts';
+import type { RerankerOpts } from '../src/core/search/rerank.ts';
+// Namespace import on purpose: with the fix reverted, capRerankDoc is undefined and the
+// tests below FAIL at the call site instead of the file crashing at import (a vacuous
+// non-zero exit is not a discrimination result — see scripts/check-test-discriminates.sh).
+const { applyReranker, capRerankDoc } = rerankMod;
+import { estimateTokens } from '../src/core/chunkers/token-estimate.ts';
+import type { SearchResult } from '../src/core/types.ts';
+import type { RerankInput } from '../src/core/ai/gateway.ts';
+
+const MAX_DOC_CHARS = 6000;
+const MAX_DOC_TOKENS = 1400;
+
+// Deterministic hex-dense text: every 8 chars is a distinct nibble run, so
+// cl100k cannot merge it into long tokens.
+function hexDense(chars: number): string {
+  let out = '';
+  let i = 0;
+  while (out.length < chars) {
+    out += (i++ * 2654435761 >>> 0).toString(16).padStart(8, '0') + ' ';
+  }
+  return out.slice(0, chars);
+}
+
+function result(chunk_text: string, i = 0): SearchResult {
+  return {
+    slug: `doc/${i}`,
+    page_id: i + 1,
+    title: `Doc ${i}`,
+    type: 'note',
+    chunk_text,
+    chunk_source: 'compiled_truth',
+    chunk_id: i + 100,
+    chunk_index: 0,
+    score: 1,
+    stale: false,
+  };
+}
+
+describe('capRerankDoc', () => {
+  test('short prose passes through unchanged', () => {
+    const doc = 'A short chunk about channel pricing strategy.';
+    expect(capRerankDoc(doc)).toBe(doc);
+  });
+
+  test('a long document is cut to the char ceiling', () => {
+    const doc = 'word '.repeat(5000); // 25k chars, ~5k tokens
+    const capped = capRerankDoc(doc);
+    expect(capped.length).toBeLessThanOrEqual(MAX_DOC_CHARS);
+    expect(estimateTokens(capped)).toBeLessThanOrEqual(MAX_DOC_TOKENS);
+  });
+
+  test('hex-dense text under the char ceiling is still cut to the token ceiling', () => {
+    const doc = hexDense(MAX_DOC_CHARS - 100);
+    // Positive control: the input itself overflows the token ceiling.
+    expect(estimateTokens(doc)).toBeGreaterThan(MAX_DOC_TOKENS);
+    const capped = capRerankDoc(doc);
+    expect(capped.length).toBeLessThan(doc.length);
+    expect(estimateTokens(capped)).toBeLessThanOrEqual(MAX_DOC_TOKENS);
+    expect(doc.startsWith(capped)).toBe(true); // a prefix, never rewritten
+  });
+});
+
+describe('applyReranker applies the cap to every document', () => {
+  test('the reranker receives capped documents', async () => {
+    const results = [result(hexDense(20_000), 0), result('tiny', 1)];
+    let seen: RerankInput | null = null;
+    const opts: RerankerOpts = {
+      enabled: true,
+      topNIn: 30,
+      topNOut: null,
+      rerankerFn: async (input) => {
+        seen = input;
+        return [{ index: 0, relevanceScore: 0.9 }, { index: 1, relevanceScore: 0.1 }];
+      },
+    };
+    await applyReranker('q', results, opts);
+    expect(seen).not.toBeNull();
+    const docs = seen!.documents;
+    expect(docs).toHaveLength(2);
+    expect(docs[0].length).toBeLessThanOrEqual(MAX_DOC_CHARS);
+    expect(estimateTokens(docs[0])).toBeLessThanOrEqual(MAX_DOC_TOKENS);
+    expect(docs[1]).toBe('tiny');
+  });
+});


### PR DESCRIPTION
## What

`applyReranker` now caps every document it sends to the reranker: first to 6000 chars, then down to ~1400 cl100k tokens (shrinking by the measured ratio). Short chunks are untouched. Hosted rerankers truncate server-side anyway, so their results do not change.

## Why

Self-hosted rerankers (llama-server, TEI) have a small physical batch and return 500 on an oversized chunk. That fails the whole rerank call, so the query silently drops to un-reranked RRF order. Hex-dense pages (index pages, hashes, connector rows) tokenize at ~1 char/token, so a char cap alone still overflows a 2048-token batch. Seen in production with a local Qwen3-Reranker behind llama-server; the cap made the failure class disappear.

No issue filed; happy to open one if you want it tracked separately.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/search/rerank.ts` to merge-base, ran `test/rerank-doc-cap.test.ts` → 0 pass / 4 fail. Restored → all pass.

## Tests

- `test/rerank-doc-cap.test.ts` (new): short prose passes through; long doc cut to the char ceiling; hex-dense doc under the char ceiling still cut to the token ceiling (with a positive control that the input overflows); the cap is applied on the `applyReranker` path via the `rerankerFn` seam.
- Existing reranker tests (`balanced-reranker-default`, `rerank-audit`, `reranker-default-seam`, `hybrid-reranker-skipped.serial`) still pass.
- `check-test-isolation`, `check-privacy`, `test-reads-source-smell`, `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1xAATCwsUkSqwCqZ5gxno
