### PR TITLE
fix(cycle): extract_atoms prompt tells the model to output [] for a content-free page

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -318,6 +318,10 @@ concept pages (e.g. "captive-portal", "channel-pricing-strategy") — never
 entity or brand names. Use the same label for the same topic across atoms;
 prefer a label you already used over coining a near-synonym.
 
+If the transcript has no extractable idea (metadata rows, status dumps,
+empty fields, boilerplate), output exactly [] — never invent an atom and
+never explain in prose.
+
 Output ONLY the JSON array, no prose.`;
 
 interface DiscoveredPage {

--- a/test/extract-atoms-empty-array-rule.test.ts
+++ b/test/extract-atoms-empty-array-rule.test.ts
@@ -1,0 +1,78 @@
+/**
+ * extract_atoms prompt — explicit zero-yield rule.
+ *
+ * Metadata-only pages (connector rows, status dumps, boilerplate) gave the
+ * model nothing to extract, and the prompt never said what to do then. Local
+ * and smaller models responded by inventing 1-3 atoms or by explaining in
+ * prose; prose parses as `no JSON array in response`, which is a counted
+ * deterministic failure, so the page burned every retry and was tombstoned
+ * for no reason. The prompt now tells the model to output exactly `[]` for a
+ * content-free transcript, which the parser already treats as an honest
+ * zero-yield (ok: true, atoms: []).
+ *
+ * Pins: the system prompt sent to the model carries the rule. Asserted on
+ * the prompt actually sent through the chat seam, not on source text.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runPhaseExtractAtoms, parseAtomsOutcome } from '../src/core/cycle/extract-atoms.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import type { ChatResult, ChatOpts } from '../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+function okChatResult(text: string): ChatResult {
+  return {
+    text,
+    blocks: [{ type: 'text', text }],
+    stopReason: 'end',
+    usage: { input_tokens: 100, output_tokens: 50, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    model: 'anthropic:claude-haiku-4-5',
+    providerId: 'anthropic',
+  } as ChatResult;
+}
+
+describe('extract_atoms prompt — content-free transcript rule', () => {
+  test('the system prompt tells the model to output exactly [] when nothing is extractable', async () => {
+    let capturedSystem = '';
+    await runPhaseExtractAtoms(engine, {
+      sourceId: 'default',
+      _transcripts: [],
+      _pages: [{ slug: 'documents/connector-row', content: 'status: open\nowner: alice-example\n', contentHash: 'b'.repeat(16) }],
+      _chat: async (opts: ChatOpts) => {
+        capturedSystem = String(opts.system ?? '');
+        return okChatResult('[]');
+      },
+    });
+    expect(capturedSystem.length).toBeGreaterThan(0); // the seam was hit
+    // The rule names the zero-yield shape AND forbids the two failure modes
+    // (invented atoms, prose).
+    expect(capturedSystem).toMatch(/no extractable idea[\s\S]*output exactly \[\]/);
+    expect(capturedSystem).toMatch(/never invent an atom/);
+    expect(capturedSystem).toMatch(/never explain in prose/);
+  });
+
+  test('[] is an honest zero-yield, not a parse failure (the path the rule steers into)', () => {
+    expect(parseAtomsOutcome('[]')).toEqual({ ok: true, atoms: [] });
+    // Positive control: the prose the rule prevents IS a failure.
+    expect(parseAtomsOutcome('This page has no extractable ideas.')).toEqual({
+      ok: false,
+      reason: 'no JSON array in response',
+    });
+  });
+});


### PR DESCRIPTION
## What

The `extract_atoms` system prompt now tells the model what to do with a content-free transcript: output exactly `[]`, never invent an atom, never explain in prose. The parser already treats `[]` as an honest zero-yield (`ok: true, atoms: []`, gbrain#4148), so no parser or handler change.

## Why

Metadata-only pages (connector rows, status dumps, boilerplate) give the model nothing to extract, and the prompt never said what to do then. Local and smaller models respond by inventing 1-3 atoms or by answering in prose. Prose parses as `no JSON array in response`, a counted deterministic failure, so the page burned all three retries and was tombstoned for no reason. Seen in production on a brain where ~4k `documents/` pages are Notion/Slack connector rows; with the rule those pages take the zero-yield path.

No issue filed; happy to open one if you want it tracked separately.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/extract-atoms.ts` to merge-base, ran `test/extract-atoms-empty-array-rule.test.ts` → 1 pass / 1 fail. Restored → all pass.

## Tests

- `test/extract-atoms-empty-array-rule.test.ts` (new): asserts the rule on the system prompt actually sent through the `_chat` seam (not on source text), plus a parse-level check that `[]` is a zero-yield and prose is a failure.
- Existing `extract-atoms-failure-classes`, `extract-atoms-drain`, `extract-atoms-page-discovery` still pass.
- `check-test-isolation`, `check-privacy`, `test-reads-source-smell`, `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1xAATCwsUkSqwCqZ5gxno
