### PR TITLE
fix(facts): include a bounded error-type label in facts extraction failure messages

### DIFF
--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -348,6 +348,40 @@ export type ExtractFactsOutcome =
     };
 
 /**
+ * Best-effort diagnostic breadcrumb: the cause's constructor name (never its
+ * message, never its `.name` property). A real class name like `TypeError`
+ * or `APICallError` identifies which error class was thrown — not every
+ * underlying cause, since e.g. auth, quota, and malformed-request failures
+ * can all share the same class — but it's a plain identifier with no
+ * interpolated content, so an ordinary provider error response can't
+ * smuggle a key/org id through it the way `cause.message` can. This is
+ * defense-in-depth, not a hard security boundary — a dependency that
+ * already runs arbitrary code could in principle construct an Error whose
+ * constructor name is attacker-chosen, so the value is validated against a
+ * plain-identifier shape and dropped (not substituted) if it doesn't match.
+ *
+ * `constructor`/`name` are each read into a local EXACTLY ONCE — a getter
+ * could otherwise return a different value on a second read (validate one
+ * string, emit another), and `typeof === 'string'` runs before the regex so
+ * a non-string `.name` (e.g. an object whose `toString()` is impure) can't
+ * be coerced twice with two different results. The whole thing is wrapped
+ * in try/catch so a hostile or throwing `constructor`/`name` getter can
+ * never mask the real `FactsExtractionError` with an unrelated crash.
+ */
+function extractSafeCauseLabel(cause: unknown): string | undefined {
+  try {
+    if (!(cause instanceof Error)) return undefined;
+    const ctor: unknown = cause.constructor;
+    if (typeof ctor !== 'function') return undefined;
+    const name: unknown = ctor.name;
+    if (typeof name !== 'string') return undefined;
+    return /^[A-Za-z_][A-Za-z0-9_]{0,63}$/.test(name) ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Typed carrier for extraction failures that must PROPAGATE (throw) rather
  * than collapse to zero counts — `truncated_output` has no underlying error
  * object to rethrow and `provider_error.error` is optional, so a synthesized
@@ -361,12 +395,19 @@ export class FactsExtractionError extends Error {
   readonly reason: ExtractFailureReason;
   readonly model?: string;
   constructor(reason: ExtractFailureReason, model?: string, cause?: unknown) {
-    // The MESSAGE deliberately carries only reason + model — never
-    // `cause.message`. This error's message flows to remote MCP callers
-    // (dispatch returns e.message) and into persisted logs (ingest_log,
-    // mcp_request_log), and provider 4xx bodies echo partially-redacted API
-    // keys / org ids. The full cause stays attached for local debugging.
-    super(`[facts-extract] ${reason}${model ? ` (model=${model})` : ''}`);
+    // The MESSAGE deliberately carries only reason + model + a safe cause
+    // breadcrumb (see `extractSafeCauseLabel`) — never `cause.message`. This
+    // error's message flows to remote MCP callers (dispatch returns
+    // e.message) and into persisted logs (ingest_log, mcp_request_log), and
+    // provider 4xx bodies echo partially-redacted API keys / org ids. The
+    // full cause stays attached for local debugging.
+    //
+    // Without the breadcrumb, a `provider_error` in a durable job's
+    // persisted `error_text` (dead_jobs, minion_jobs) can't be told apart
+    // from any other occurrence once the in-process `cause` is gone — a
+    // timeout, an auth failure, and a malformed request all read identically.
+    const causeName = extractSafeCauseLabel(cause);
+    super(`[facts-extract] ${reason}${model ? ` (model=${model})` : ''}${causeName ? ` (cause=${causeName})` : ''}`);
     this.name = 'FactsExtractionError';
     this.reason = reason;
     this.model = model;

--- a/test/facts-backstop-outcome.serial.test.ts
+++ b/test/facts-backstop-outcome.serial.test.ts
@@ -352,4 +352,92 @@ describe('coverage-gap additions (ship review)', () => {
     // The cause stays reachable for local debugging.
     expect(String((err as { cause?: unknown }).cause)).toContain('401');
   });
+
+  test('FactsExtractionError surfaces the cause CONSTRUCTOR name, never its .name or .message', () => {
+    class FakeApiCallError extends Error {
+      constructor(message: string) {
+        super(message);
+        // Deliberately different from the class name, so a test that reads
+        // `.name` instead of `.constructor.name` would fail here — pinning
+        // WHICH property the breadcrumb reads, not just that some name shows up.
+        this.name = 'org_abc123_over_quota';
+      }
+    }
+    const err = new FactsExtractionError('provider_error', 'claude-cli:claude-sonnet-5',
+      new FakeApiCallError('rate limited: over quota'));
+    // The class name is a diagnostic breadcrumb — it survives into the
+    // persisted message so a durable job's `error_text` (which is all that
+    // remains once the in-process `cause` is gone) can still distinguish
+    // "which kind of provider failure" across occurrences.
+    expect(err.message).toContain('(cause=FakeApiCallError)');
+    // The message-carried breadcrumb is the CONSTRUCTOR name, never `.name`
+    // and never `.message` — no room for a provider body to leak through it.
+    expect(err.message).not.toContain('org_abc123');
+    expect(err.message).not.toContain('rate limited');
+    expect(JSON.stringify(err)).not.toContain('org_abc123');
+  });
+
+  test('FactsExtractionError drops a cause-constructor name that is not a plain identifier', () => {
+    // A dependency could in principle construct an Error whose
+    // `constructor.name` is an attacker-chosen string (this needs the
+    // dependency to already run arbitrary code — not a normal provider
+    // error path). The breadcrumb is validated against a plain-identifier
+    // shape and DROPPED (not substituted) rather than trusted verbatim.
+    class WeirdError extends Error {}
+    Object.defineProperty(WeirdError, 'name', { value: 'org_example_secret sk-proj-fake123' });
+    const err = new FactsExtractionError('provider_error', 'openai:gpt-5.2', new WeirdError('x'));
+    expect(err.message).not.toContain('cause=');
+    expect(err.message).not.toContain('org_example_secret');
+    expect(err.message).not.toContain('sk-proj');
+  });
+
+  test('FactsExtractionError construction never throws when cause.constructor is missing', () => {
+    const cause = new Error('original failure');
+    Object.defineProperty(cause, 'constructor', { value: null });
+    // Must not throw — a malformed cause must never mask the original
+    // FactsExtractionError with a fresh, unrelated TypeError.
+    const err = new FactsExtractionError('provider_error', 'openai:gpt-5.2', cause);
+    expect(err).toBeInstanceOf(FactsExtractionError);
+    expect(err.message).not.toContain('cause=');
+  });
+
+  test('FactsExtractionError construction never throws when constructor is a throwing getter', () => {
+    const cause = new Error('original failure');
+    Object.defineProperty(cause, 'constructor', {
+      get() { throw new Error('getter blew up'); },
+    });
+    const err = new FactsExtractionError('provider_error', 'openai:gpt-5.2', cause);
+    expect(err).toBeInstanceOf(FactsExtractionError);
+    expect(err.message).not.toContain('cause=');
+  });
+
+  test('FactsExtractionError never validates one string and emits a different one', () => {
+    // A `.name` whose value is an object (not a string) with an impure
+    // `toString()` could otherwise pass a `regex.test()` coercion on one
+    // read and interpolate a different value on a later read of the SAME
+    // property. `.name` must be read exactly once and rejected outright
+    // unless it is already a string primitive.
+    let reads = 0;
+    class ImpureName extends Error {}
+    Object.defineProperty(ImpureName, 'name', {
+      value: { toString: () => (++reads === 1 ? 'TypeError' : 'org_secret_leak') },
+    });
+    const err = new FactsExtractionError('provider_error', 'openai:gpt-5.2', new ImpureName('x'));
+    expect(err.message).not.toContain('cause=');
+    expect(err.message).not.toContain('org_secret_leak');
+    expect(err.message).not.toContain('TypeError');
+  });
+
+  test('FactsExtractionError omits the cause breadcrumb when there is no cause', () => {
+    const err = new FactsExtractionError('truncated_output', 'openai:gpt-5.2');
+    expect(err.message).toBe('[facts-extract] truncated_output (model=openai:gpt-5.2)');
+    expect(err.message).not.toContain('cause=');
+  });
+
+  test('FactsExtractionError omits the cause breadcrumb when cause is not an Error', () => {
+    const err = new FactsExtractionError('provider_error', 'openai:gpt-5.2', 'a raw string cause');
+    expect(err.message).not.toContain('cause=');
+    // The raw cause still stays reachable for local debugging.
+    expect((err as { cause?: unknown }).cause).toBe('a raw string cause');
+  });
 });


### PR DESCRIPTION
## What

`FactsExtractionError`'s message now includes a small diagnostic breadcrumb — the `cause`'s constructor name (e.g. `TypeError`, `APICallError`) — alongside the existing `reason`/`model` fields, when a `provider_error` occurs.

## Why

The message has always deliberately excluded `cause.message` (it can carry partially-redacted API keys/org ids). But that also means the durable `facts-absorb` job's persisted `minion_jobs.error_text` (including jobs in the `dead` status) can't distinguish one `provider_error` from another once the in-process `cause` is gone — a timeout, an auth failure, and a malformed request all read identically as `[facts-extract] provider_error (model=X)`. I hit this directly: two `facts-absorb` jobs died with this exact message and no way to tell what actually failed.

The new `extractSafeCauseLabel()` helper reads `cause.constructor` and its `.name` each exactly once into locals, requires the result to be a string matching a plain-identifier shape (`/^[A-Za-z_][A-Za-z0-9_]{0,63}$/`), and drops (never substitutes) anything that doesn't match. The whole thing is wrapped in `try/catch` so a malformed or hostile `cause` (a throwing `constructor` getter, a non-function `constructor`, a `.name` whose value coerces to two different strings across reads) can never mask the original `FactsExtractionError` with an unrelated crash.

No behavior change to any other path — purely additive to the persisted/logged message.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/facts/extract.ts` to `upstream/master`, ran `test/facts-backstop-outcome.serial.test.ts` → 21 pass / 1 fail. Restored → all pass.

## Tests

`test/facts-backstop-outcome.serial.test.ts` — 7 new cases:
- surfaces the cause CONSTRUCTOR name, never its `.name` or `.message`
- drops a cause-constructor name that isn't a plain identifier
- construction never throws when `cause.constructor` is missing
- construction never throws when `constructor` is a throwing getter
- never validates one string and emits a different one (impure `.name` `toString()`)
- omits the breadcrumb when there's no cause
- omits the breadcrumb when cause isn't an `Error`

Local run: `bun test test/facts-backstop-outcome.serial.test.ts` → 22 pass, 0 fail. Broader sweep (`facts-absorb-log`, `facts-backstop*`, `facts-extract*`, `facts-classify`, `extract-conversation-facts`) → 149 pass, 0 fail. `bun run typecheck` clean.
