### PR TITLE
fix(pricing): price Gemini embeddings so cost estimates stop reading unavailable

### DIFF
--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -74,15 +74,18 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   // Perplexity (https://docs.perplexity.ai/getting-started/pricing, verified 2026-07-28)
   'perplexity:pplx-embed-v1-0.6b': { pricePerMTok: 0.004 },
   'perplexity:pplx-embed-v1-4b':   { pricePerMTok: 0.03 },
-  // Google (https://ai.google.dev/gemini-api/docs/pricing, verified 2026-08-30).
-  // #4344 class: gemini-embedding-001 is in the hosted recipe list
-  // (src/core/ai/recipes/google.ts) but had no row, so cost estimates read
-  // "unavailable" for every brain on it — including the OpenRouter-routed ones,
-  // since `openrouter:google/gemini-embedding-001` resolves here through the
-  // #2504 nested-vendor retry. gemini-embedding-2 is deliberately absent: it is
-  // in the same recipe list, but its published rate is unverified and a guessed
-  // row is worse than `unknown` (the voyage-4-nano rationale above).
+  // Google (https://ai.google.dev/gemini-api/docs/pricing, verified 2026-09-07).
+  // #4344 class: both models are in the hosted recipe list
+  // (src/core/ai/recipes/google.ts) but had no rows, so cost estimates read
+  // "unavailable" for every brain on them — including the OpenRouter-routed
+  // ones, since `openrouter:google/gemini-embedding-001` resolves here through
+  // the #2504 nested-vendor retry. The two rates differ, so one shared row
+  // would misprice whichever model it didn't come from.
   'google:gemini-embedding-001':   { pricePerMTok: 0.15 },
+  // gemini-embedding-2 is multimodal and priced per input kind ($0.45/1M image,
+  // $6.50 audio, $12.00 video). Same convention as voyage-multimodal-3 above:
+  // the TEXT rate is the row, pixel/audio token pricing is out of scope here.
+  'google:gemini-embedding-2':     { pricePerMTok: 0.20 },
 };
 
 export type PriceLookupResult =

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -74,6 +74,15 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   // Perplexity (https://docs.perplexity.ai/getting-started/pricing, verified 2026-07-28)
   'perplexity:pplx-embed-v1-0.6b': { pricePerMTok: 0.004 },
   'perplexity:pplx-embed-v1-4b':   { pricePerMTok: 0.03 },
+  // Google (https://ai.google.dev/gemini-api/docs/pricing, verified 2026-08-30).
+  // #4344 class: gemini-embedding-001 is in the hosted recipe list
+  // (src/core/ai/recipes/google.ts) but had no row, so cost estimates read
+  // "unavailable" for every brain on it — including the OpenRouter-routed ones,
+  // since `openrouter:google/gemini-embedding-001` resolves here through the
+  // #2504 nested-vendor retry. gemini-embedding-2 is deliberately absent: it is
+  // in the same recipe list, but its published rate is unverified and a guessed
+  // row is worse than `unknown` (the voyage-4-nano rationale above).
+  'google:gemini-embedding-001':   { pricePerMTok: 0.15 },
 };
 
 export type PriceLookupResult =

--- a/test/embedding-pricing.test.ts
+++ b/test/embedding-pricing.test.ts
@@ -55,8 +55,10 @@ describe('lookupEmbeddingPrice — first-class providers', () => {
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.15);
   });
 
-  test('gemini-embedding-2 is deliberately unpriced (rate unverified)', () => {
-    expect(lookupEmbeddingPrice('google:gemini-embedding-2').kind).toBe('unknown');
+  test('Google gemini-embedding-2 at $0.20/MTok (text rate, not shared with -001)', () => {
+    const r = lookupEmbeddingPrice('google:gemini-embedding-2');
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.20);
   });
 });
 

--- a/test/embedding-pricing.test.ts
+++ b/test/embedding-pricing.test.ts
@@ -48,6 +48,16 @@ describe('lookupEmbeddingPrice — first-class providers', () => {
     expect(r.kind).toBe('known');
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.05);
   });
+
+  test('Google gemini-embedding-001 at $0.15/MTok', () => {
+    const r = lookupEmbeddingPrice('google:gemini-embedding-001');
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.15);
+  });
+
+  test('gemini-embedding-2 is deliberately unpriced (rate unverified)', () => {
+    expect(lookupEmbeddingPrice('google:gemini-embedding-2').kind).toBe('unknown');
+  });
 });
 
 describe('lookupEmbeddingPrice — fall-through behavior', () => {
@@ -114,6 +124,7 @@ describe('lookupEmbeddingPrice — nested gateway ids (#2504)', () => {
     ['openrouter:openai/text-embedding-3-large', 0.13, 'openai:text-embedding-3-large'],
     ['openrouter:voyage/voyage-4', 0.06, 'voyage:voyage-4'],
     ['openrouter:mistral/mistral-embed', 0.10, 'mistral:mistral-embed'],
+    ['openrouter:google/gemini-embedding-001', 0.15, 'google:gemini-embedding-001'],
   ])('%s falls back to the nested vendor row', (model, expected, key) => {
     const r = lookupEmbeddingPrice(model as string);
     expect(r.kind).toBe('known');


### PR DESCRIPTION
## What's wrong

`src/core/ai/recipes/google.ts` lists `gemini-embedding-001` and `gemini-embedding-2` in its hosted embedding touchpoint, but `EMBEDDING_PRICING` has no `google:` row at all — the table currently covers openai, voyage, zeroentropyai, mistral and perplexity. So `lookupEmbeddingPrice` returns `unknown` for both, and every cost surface prints "estimate unavailable" for brains on them.

Same class as #4344, where `voyage-3.5` / `voyage-3.5-lite` were in the hosted recipe list with no pricing rows.

## The fix

Two vendor rows, verified against https://ai.google.dev/gemini-api/docs/pricing:

| Model | Rate | Note |
|---|---|---|
| `google:gemini-embedding-001` | $0.15 / 1M tokens | text |
| `google:gemini-embedding-2` | $0.20 / 1M tokens | multimodal; text rate |

**The two rates differ**, so a single shared row would misprice whichever model it didn't come from. `gemini-embedding-2` is priced per input kind ($0.45/1M image, $6.50 audio, $12.00 video); the row carries the TEXT rate, following the `voyage-multimodal-3` convention already in this table ("multimodal rate is per 1M TEXT tokens — image pixel-token pricing is out of scope here").

Deliberately **vendor** rows, not router rows. The #2504 nested-gateway retry re-keys `openrouter:google/<model>` onto `google:<model>`, so these two rows also cover router-hosted brains — and it matches the table's existing shape, which holds vendor rows only. Verified at runtime:

```
google:gemini-embedding-001              -> 0.15  (key google:gemini-embedding-001)
google:gemini-embedding-2                -> 0.20  (key google:gemini-embedding-2)
openrouter:google/gemini-embedding-001   -> 0.15  (key google:gemini-embedding-001)
openrouter:google/gemini-embedding-2     -> 0.20  (key google:gemini-embedding-2)
```

## Tests

Both vendor rows, plus a row added to the existing `#2504` nested-gateway `test.each` table so the router path is pinned rather than assumed.

- `bun test test/embedding-pricing.test.ts` — 37 pass / 0 fail
- `bun run verify` — 54/54, all checks green
