### PR TITLE
v0.48.4.1 fix(mcp): warn on db-only remote put_page writes (#4844)

### DIFF
--- a/src/core/ops/pages.ts
+++ b/src/core/ops/pages.ts
@@ -12,7 +12,7 @@ import { clampSearchLimit } from '../engine.ts';
 import type { Page, PageType } from '../types.ts';
 import { importFromContent } from '../import-file.ts';
 import { serializePageToMarkdown } from '../markdown.ts';
-import { writePageThrough, deletePageThrough, resolvePageWriteTarget, type WriteThroughResult } from '../write-through.ts';
+import { writePageThrough, deletePageThrough, resolvePageWriteTarget, withNoRepoWriteThroughWarning, type WriteThroughResult } from '../write-through.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isGlobalBasenameEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from '../link-extraction.ts';
 // #3190: pack-aware link typing on the put_page auto-link path.
 import { loadActivePackForLocalEngine } from '../schema-pack/best-effort.ts';
@@ -328,7 +328,7 @@ const fetch_page: Operation = {
 
 const put_page: Operation = {
   name: 'put_page',
-  description: 'Write or replace a page (markdown with frontmatter). REPLACES the entire page; this is not a partial edit. Before modifying an existing page, read its canonical content with `get_page include_content:true`, then submit the complete page. Chunks, embeds, reconciles tags, and (when auto_link/auto_timeline are enabled) extracts + reconciles graph links and timeline entries. Remote (MCP) callers: body wikilinks are NOT reconciled into the graph — auto_link/auto_timeline are skipped for untrusted writers (response reports auto_links: {skipped: "remote"}); use local capture/put_page for link extraction. For large content on Windows (pipe-buffer limit ~45KB) or any file-as-input workflow, use `gbrain capture --file PATH --slug SLUG` — capture reads the file as a Buffer with a binary-NUL guard and adds provenance write-through (v0.39.3.0).',
+  description: 'Write or replace a page (markdown with frontmatter). REPLACES the entire page; this is not a partial edit. Before modifying an existing page, read its canonical content with `get_page include_content:true`, then submit the complete page. Chunks, embeds, reconciles tags, and (when auto_link/auto_timeline are enabled) extracts + reconciles graph links and timeline entries. Remote (MCP) callers: body wikilinks are NOT reconciled into the graph — auto_link/auto_timeline are skipped for untrusted writers (response reports auto_links: {skipped: "remote"}); use local capture/put_page for link extraction. Remote callers also receive write_through.warning when the resolved write source has no repo configured, because the DB row has no durable markdown file. For large content on Windows (pipe-buffer limit ~45KB) or any file-as-input workflow, use `gbrain capture --file PATH --slug SLUG` — capture reads the file as a Buffer with a binary-NUL guard and adds provenance write-through (v0.39.3.0).',
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Complete markdown content with YAML frontmatter. REPLACES the entire page; this is not a partial edit. Read the canonical page first with `get_page include_content:true` before modifying it.' },
@@ -824,7 +824,7 @@ const put_page: Operation = {
       ...(writerLint ? { writer_lint: writerLint } : {}),
       ...(factsQueued ? { facts_backstop: factsQueued } : {}),
       ...(chronicleQueued ? { chronicle_backstop: chronicleQueued } : {}),
-      ...(writeThrough ? { write_through: writeThrough } : {}),
+      ...(writeThrough ? { write_through: ctx.remote !== false ? withNoRepoWriteThroughWarning(writeThrough, ctx.sourceId ?? 'default') : writeThrough } : {}),
     };
   },
   cliHints: { name: 'put', positional: ['slug'], stdin: 'content' },

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -87,6 +87,8 @@ export interface WriteThroughResult {
    *     writing would silently clobber the OTHER slug's file (#2831) — refused.
    */
   skipped?: 'disabled_by_config' | 'no_repo_configured' | 'repo_not_found' | 'source_repo_belongs_to_other_source' | 'page_not_found_after_write' | 'path_escapes_source_root' | 'case_insensitive_collision';
+  /** Caller-visible advisory when a permitted DB-only outcome is still risky. */
+  warning?: string;
   /** Set when the render/write/rename itself threw (EACCES, ENOTDIR, disk full). */
   error?: string;
 }
@@ -96,6 +98,16 @@ export interface WritePageThroughOpts {
   /** Merged over the page's own frontmatter at render time (e.g. provenance). */
   frontmatterOverrides?: Record<string, unknown>;
   logger?: WriteThroughLogger;
+}
+
+export function withNoRepoWriteThroughWarning<T extends { written: boolean; skipped?: string; warning?: string }>(result: T, sourceId: string): T {
+  if (result.written || result.skipped !== 'no_repo_configured') return result;
+  return {
+    ...result,
+    warning:
+      `put_page wrote only to the database for source '${sourceId}': no repo/local_path is configured, so no durable markdown file was created. ` +
+      'Bind this MCP server/token to a git-backed source or configure source local_path/sync.repo_path before relying on the write.',
+  } as T;
 }
 
 /**

--- a/test/ingestion/put-page-write-through.test.ts
+++ b/test/ingestion/put-page-write-through.test.ts
@@ -4,7 +4,7 @@
  * Verifies that put_page writes the markdown file to disk alongside the
  * DB row when sync.repo_path is configured. Trust gating: subagent
  * sandbox writes stay DB-only; dry-run stays DB-only; missing-repo
- * stays DB-only.
+ * stays DB-only, with a loud warning for remote callers.
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
@@ -180,8 +180,22 @@ describe('put_page write-through — config edge cases', () => {
     const result = (await putPage.handler(ctx, {
       slug: 'inbox/no-repo',
       content: '---\ntitle: N\n---\n\nbody',
-    })) as { write_through?: { skipped?: string } };
+    })) as { write_through?: { skipped?: string; warning?: string } };
     expect(result.write_through?.skipped).toBe('no_repo_configured');
+    expect(result.write_through?.warning).toBeUndefined();
+  });
+
+  test('remote repo not configured → warns that the write is DB-only', async () => {
+    await engine.executeRaw("DELETE FROM config WHERE key = 'sync.repo_path'");
+    const ctx = makeCtx({ remote: true });
+    const result = (await putPage.handler(ctx, {
+      slug: 'inbox/no-repo-remote',
+      content: '---\ntitle: Remote\n---\n\nbody',
+    })) as { write_through?: { skipped?: string; warning?: string } };
+    expect(result.write_through?.skipped).toBe('no_repo_configured');
+    expect(result.write_through?.warning).toContain('wrote only to the database');
+    expect(result.write_through?.warning).toContain("source 'default'");
+    expect(result.write_through?.warning).toContain('no durable markdown file');
   });
 
   test('repo path points at a missing directory → put_page rejects, no orphan row', async () => {


### PR DESCRIPTION
Fixes #4844

## Summary
- Add an explicit remote-only `write_through.warning` when `put_page` succeeds in the DB but skips write-through because the resolved source has no repo or local path configured.
- Keep local CLI behavior unchanged while making MCP callers see that no durable markdown file was created.
- Document the warning in the `put_page` operation description and add focused regression coverage for remote DB-only writes.

## Verification
- `GBRAIN_TEST_ALLOW_DATABASE_URL=1 env -u DATABASE_URL -u GBRAIN_DATABASE_URL bash scripts/gbrain-gate.sh <worktree> test/ingestion/put-page-write-through.test.ts test/mcp-tool-defs.test.ts`

Gate evidence: `RESULT: GREEN`; verify non-typecheck checks passed and the local typecheck timeout reproduced on clean `upstream/master`, so the gate applied its baseline exception. Focused unit files reported 30 pass / 0 fail; diff-selected E2E was skipped because the selector returned the fail-closed all-set and CI runs the full suite.
