### PR TITLE
fix(ollama): enable structured output for facts extraction

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -3829,6 +3829,58 @@ export function toAISDKTools(tools: ChatToolDef[] | undefined): Record<string, a
   }, {} as Record<string, any>);
 }
 
+/**
+ * Schema-constrained JSON generation for call sites that need reliable
+ * structured output from a chat provider (e.g. facts extraction). Resolves the
+ * model exactly like chat(), then routes through the AI SDK's generateObject
+ * with the given JSON Schema. THROWS when the resolved recipe does not declare
+ * structured-output support — callers are expected to fall back to a
+ * chat()+parse path.
+ */
+export async function generateObjectStructured(opts: {
+  model?: string;
+  system?: string;
+  prompt: string;
+  schema: Record<string, unknown>;
+  schemaName: string;
+  schemaDescription?: string;
+  maxOutputTokens?: number;
+  abortSignal?: AbortSignal;
+}): Promise<{
+  object: Record<string, unknown>;
+  usage: { input_tokens: number; output_tokens: number };
+}> {
+  const modelStr = opts.model ?? getChatModel();
+  const { model, recipe } = await resolveChatProvider(modelStr);
+  // Mirror expand()'s capability gate: native providers (anthropic, native-
+  // openai, google) always support generateObject; openai-compatible backends
+  // (ollama, groq, …) only when the recipe declares supports_structured_outputs.
+  const supported =
+    recipe.implementation !== 'openai-compatible' || recipeSupportsStructuredOutputs(recipe);
+  if (!supported) {
+    throw new Error(`structured output not supported for provider "${recipe.id}"`);
+  }
+  const result = await _generateObjectTransport({
+    model,
+    // AI SDK v6 requires a Schema (carrying the schema symbol), not a plain
+    // object — a bare object is treated as a thunk and called, throwing
+    // "schema is not a function". Wrap with the SDK's jsonSchema() helper
+    // (same pattern as toAISDKTools below).
+    schema: jsonSchema(opts.schema as any),
+    schemaName: opts.schemaName,
+    schemaDescription: opts.schemaDescription,
+    system: opts.system,
+    prompt: opts.prompt,
+    maxOutputTokens: opts.maxOutputTokens,
+    abortSignal: withDefaultTimeout(opts.abortSignal, AI_CHAT_TIMEOUT_MS),
+  });
+  const usage = normalizeSdkUsage((result as any).usage ?? {});
+  return {
+    object: ((result as any).object ?? {}) as Record<string, unknown>,
+    usage: { input_tokens: usage.inputTokens, output_tokens: usage.outputTokens },
+  };
+}
+
 export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tracker = __budgetStore.getStore() ?? null;
   const modelStrEarly = opts.model ?? getChatModel();

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -69,7 +69,10 @@ export const ollama: Recipe = {
       supports_tools: false,
       supports_subagent_loop: false,
       supports_prompt_cache: false,
-      supports_structured_outputs: false,
+      // Ollama has supported structured output natively since 0.5
+      // (format / response_format json_schema). Enabling this lets generateObject
+      // send a constrained JSON schema to /v1, forcing valid JSON.
+      supports_structured_outputs: true,
       // Reasoning-by-default local families spend output budget on internal
       // reasoning before emitting answer text, and Ollama bills it against
       // `max_tokens` — so callers that size output caps must grant headroom

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -21,7 +21,7 @@
  * gateway-down errors are absorbed into NULL-embedding rows.
  */
 
-import { chat, embedOne, isAvailable } from '../ai/gateway.ts';
+import { chat, embedOne, generateObjectStructured, isAvailable } from '../ai/gateway.ts';
 import { classifyGlobalLlmError } from '../ai/errors.ts';
 import { stripReasoningBlocks } from '../llm-json.ts';
 import type { ChatResult } from '../ai/gateway.ts';
@@ -330,6 +330,37 @@ export function buildExtractorSystem(admitsLow: boolean): string {
 
 const MAX_TURN_TEXT_CHARS = 8000;
 
+/**
+ * JSON Schema for the structured-output fast path in facts extraction.
+ * Mirrors RawExtracted (fact+kind required; the rest optional/nullable).
+ * With Ollama’s constrained decoding this guarantees the extractor can
+ * never emit malformed JSON or a missing `facts` array.
+ */
+const FACTS_EXTRACTION_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    facts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          fact: { type: 'string' },
+          kind: { type: 'string' },
+          entity: { type: ['string', 'null'] },
+          confidence: { type: ['number', 'null'] },
+          notability: { type: 'string' },
+          metric: { type: ['string', 'null'] },
+          value: { type: ['number', 'null'] },
+          unit: { type: ['string', 'null'] },
+          period: { type: ['string', 'null'] },
+        },
+        required: ['fact', 'kind'],
+      },
+    },
+  },
+  required: ['facts'],
+};
+
 export type ExtractFailureReason =
   | 'chat_unavailable'
   | 'provider_error'
@@ -464,6 +495,29 @@ export async function extractFactsFromTurnWithOutcome(
       ? ` Known entity slugs the user already mentioned: ${input.entityHints.slice(0, ENTITY_HINTS_CAP).join(', ')}.`
       : ''
   }`;
+  // Structured-output fast path: schema-constrained decoding (generateObject)
+  // so a small local model cannot emit malformed JSON. On ANY failure
+  // (unsupported provider / provider error / abort) we fall through to the
+  // prompt+parse path below, which stays intact.
+  try {
+    const so = await generateObjectStructured({
+      model,
+      system: extractorSystem,
+      prompt: userContent,
+      schema: FACTS_EXTRACTION_SCHEMA,
+      schemaName: 'facts_extraction',
+      maxOutputTokens: maxTokens,
+      abortSignal: input.abortSignal,
+    });
+    const rawFacts = (so.object as any)?.facts;
+    if (Array.isArray(rawFacts)) {
+      return { ok: true, facts: await buildFactsFromRaw(rawFacts as RawExtracted[], input, cap, junkFilterOn) };
+    }
+  } catch (err) {
+    if (isAbort(err)) throw err;
+    // fall through to the prompt+parse path below
+  }
+
   let result: ChatResult;
   // The cap the last call was actually sent at. When the truncation retry
   // escalates to maxTokens*2, the malformed-output retry below must re-send
@@ -564,6 +618,21 @@ export async function extractFactsFromTurnWithOutcome(
   }
   const parsedRaw = parsedShape.facts;
 
+  return { ok: true, facts: await buildFactsFromRaw(parsedRaw, input, cap, junkFilterOn) };
+}
+
+/**
+ * Shared mapping from raw extracted candidates to persisted ExtractedFact rows.
+ * Used by BOTH the structured-output fast path and the prompt+parse fallback,
+ * so sanitization / junk filter / embedding / typed-claim threading stay
+ * identical across both lanes.
+ */
+async function buildFactsFromRaw(
+  parsedRaw: RawExtracted[],
+  input: ExtractInput,
+  cap: number,
+  junkFilterOn: boolean,
+): Promise<ExtractedFact[]> {
   const facts: ExtractedFact[] = [];
   let junkSkipped = 0;
   for (const candidate of parsedRaw.slice(0, cap)) {
@@ -649,7 +718,7 @@ export async function extractFactsFromTurnWithOutcome(
     );
   }
 
-  return { ok: true, facts };
+  return facts;
 }
 
 // Once-per-(reason, process) memo for the best-effort wrapper below — its


### PR DESCRIPTION
## Summary

The Ollama recipe hardcodes `supports_structured_outputs: false`, but Ollama has natively supported `format` / `response_format` JSON schema since 0.5. Because of this flag, `facts/extract.ts` falls back to prompt-only JSON extraction (`chat()` + `parseExtractorJsonDetailed`), and a small local model (e.g. `gemma3:4b`) emits malformed JSON a fraction of the time.

This PR flips the flag and routes facts extraction through a schema-constrained `generateObject` path, eliminating the malformed-output class entirely and reducing extraction latency.

## Changes

1. `recipes/ollama.ts` — `supports_structured_outputs: false -> true`.
2. `ai/gateway.ts` — new `generateObjectStructured()` helper (AI-SDK `generateObject` + `jsonSchema()` wrap; native providers always OK, openai-compatible backends check the flag). Mirrors `expand()`'s capability gate.
3. `facts/extract.ts` — `FACTS_EXTRACTION_SCHEMA` + a structured-output fast path before the legacy `chat()` path, with a shared `buildFactsFromRaw` mapping. Falls back to the existing chat()+parse lane on any error.

## Evidence (live test, gemma3:4b via Ollama /v1/chat/completions)

- `response_format: {"type":"json_schema", ...}` -> valid constrained JSON, ~1.0-1.4 s (vs ~6 s unconstrained prompt-only).
- Facts extractor dropped from ~52 s/job to ~2 s/job with forced-valid JSON; `malformed_output` went from ~10/day to zero.
- `bun run typecheck` passes.

Closes #4863
