### PR TITLE
v0.48.5.2 fix(transcripts): claude-code workflow artifacts no longer read as host-format drift

### DIFF
--- a/src/commands/transcripts.ts
+++ b/src/commands/transcripts.ts
@@ -22,7 +22,10 @@ import type { TranscriptFormat } from '../core/transcripts/types.ts';
 import { runTranscriptsIngest, type TranscriptsIngestResult } from '../core/transcripts/ingest.ts';
 import { isOpenclawCheckpointFile } from '../core/transcripts/openclaw.ts';
 import { isGrokSessionSidecarStrict } from '../core/transcripts/grok.ts';
-import { isClaudeCodeSubagentFile } from '../core/transcripts/claude-code.ts';
+import {
+  isClaudeCodeSubagentFile,
+  isClaudeCodeWorkflowArtifactFile,
+} from '../core/transcripts/claude-code.ts';
 
 interface RecentOpts {
   days?: number;
@@ -291,7 +294,11 @@ export async function expandPaths(specs: string[]): Promise<string[]> {
     }
   }
   return [...new Set(out)].filter(
-    (p) => !isOpenclawCheckpointFile(p) && !isGrokSessionSidecarStrict(p) && !isClaudeCodeSubagentFile(p),
+    (p) =>
+      !isOpenclawCheckpointFile(p) &&
+      !isGrokSessionSidecarStrict(p) &&
+      !isClaudeCodeSubagentFile(p) &&
+      !isClaudeCodeWorkflowArtifactFile(p),
   );
 }
 

--- a/src/core/transcripts/claude-code-jsonl.ts
+++ b/src/core/transcripts/claude-code-jsonl.ts
@@ -530,6 +530,14 @@ export interface ParsedClaudeSession {
   turns: TimedTurn[];
   bytesRead: number;
   skippedLines: number;
+  /**
+   * Records that CLAIM to be importable turns: `type` user/assistant and not
+   * `isSidechain`. Zero of them means the file never had anything to import
+   * (a title/metadata-only stub, or all-subagent traffic) — understood, not
+   * host-format drift. Above zero with `turns` still empty is the real drift
+   * signal: turn records exist but no longer yield text.
+   */
+  turnShapedLines: number;
 }
 
 /**
@@ -552,6 +560,7 @@ export function parseClaudeSessionFile(
   let sessionId = '';
   let cwd: string | undefined;
   let skippedLines = 0;
+  let turnShapedLines = 0;
   for (const line of raw.split('\n')) {
     const t = line.trim();
     if (!t) continue;
@@ -565,6 +574,9 @@ export function parseClaudeSessionFile(
     const e = entry as Record<string, unknown>;
     if (!sessionId && typeof e.sessionId === 'string' && e.sessionId) sessionId = e.sessionId;
     if (!cwd && typeof e.cwd === 'string' && e.cwd) cwd = e.cwd;
+    if (e.isSidechain !== true && (e.type === 'user' || e.type === 'assistant')) {
+      turnShapedLines++;
+    }
     const turn = entryToTurn(entry);
     if (!turn) continue;
     const timestamp = typeof e.timestamp === 'string' ? e.timestamp : '';
@@ -577,6 +589,7 @@ export function parseClaudeSessionFile(
     turns,
     bytesRead: size,
     skippedLines,
+    turnShapedLines,
   };
 }
 

--- a/src/core/transcripts/claude-code.ts
+++ b/src/core/transcripts/claude-code.ts
@@ -43,13 +43,42 @@ const CLAUDE_CONTROL_TYPES = new Set([
  * and carries the PARENT session's id — it is not a session and can never
  * import. Discovery and explicit-path expansion both skip these so they stop
  * reading as a permanent not-yet-imported backlog + host-format drift (#4796).
- * STRICT shape (parent dir literally `subagents` AND basename `agent-*.jsonl`)
- * so a user project whose slug merely contains "subagents" is never hidden.
+ * STRICT shape (a path segment literally `subagents` AND basename
+ * `agent-*.jsonl`) so a user project whose slug merely contains "subagents" is
+ * never hidden: Claude Code encodes a whole project path as ONE slug segment
+ * (`-Users-me-subagents-thing`), which never equals `subagents` exactly.
+ *
+ * The segment is matched at ANY depth above the file, not just the immediate
+ * parent. Workflow runs nest a second level —
+ * `<session>/subagents/workflows/<wf-id>/agent-<id>.jsonl` — and an
+ * immediate-parent check missed every one of them, so they stayed a permanent
+ * gap-table phantom and re-fired DRIFT WARNING on every ingest: the exact
+ * failure this function exists to prevent.
  */
 export function isClaudeCodeSubagentFile(path: string): boolean {
   const segs = path.split(/[/\\]/);
   const base = segs[segs.length - 1] ?? '';
-  return segs[segs.length - 2] === 'subagents' && /^agent-[^/\\]+\.jsonl$/.test(base);
+  if (!/^agent-[^/\\]+\.jsonl$/.test(base)) return false;
+  return segs.slice(0, -1).includes('subagents');
+}
+
+/**
+ * True for a file inside a Claude Code WORKFLOW run directory:
+ * `<session>/subagents/workflows/<wf-id>/...`. The tree holds one
+ * `agent-<id>.jsonl` per fanned-out agent plus a `journal.jsonl` run log —
+ * bookkeeping for a workflow, never a top-level session. The journal is not
+ * a transcript in ANY adapter's format, so leaving it discoverable made every
+ * ingest report `unknown format` and, because an errored file also clears
+ * `cleanScan`, held the `--since last` watermark frozen indefinitely.
+ *
+ * Deliberately narrower than "everything under `subagents/`": a UUID-named
+ * file directly under `subagents/` IS a real session and must stay
+ * discoverable (pinned by transcripts-self-exclusion.test.ts).
+ */
+export function isClaudeCodeWorkflowArtifactFile(path: string): boolean {
+  const segs = path.split(/[/\\]/);
+  const i = segs.indexOf('subagents');
+  return i !== -1 && segs[i + 1] === 'workflows' && segs.length > i + 2;
 }
 
 /** Keys that mark a Claude Code project transcript. */
@@ -164,13 +193,27 @@ export const claudeCodeAdapter: TranscriptAdapter = {
         })),
       };
     }
+    // A file with NO turn-shaped records never had anything to import: a
+    // title/metadata-only stub (`last-prompt` + `custom-title` and nothing
+    // else) or all-`isSidechain` subagent traffic. That is understood, not
+    // host-format drift, so it must not freeze the shared watermark — the
+    // same distinction grok draws with expectedEmpty. Turn records that stop
+    // yielding text (`turnShapedLines > 0` with zero turns) still drift, and
+    // so does any file with unparseable lines.
+    const expectedEmpty =
+      sessions === 0 && r.skippedLines === 0 && r.turnShapedLines === 0;
     return {
       bytesRead: r.bytesRead,
       skippedLines: r.skippedLines,
       truncated: false,
       sessions,
+      expectedEmpty: expectedEmpty || undefined,
       zeroSessionsReason:
-        sessions === 0 ? 'no user or assistant turns in file' : undefined,
+        sessions === 0
+          ? expectedEmpty
+            ? 'no turn records in file (title/metadata-only or all-subagent)'
+            : 'no user or assistant turns in file'
+          : undefined,
     };
   },
 };

--- a/src/core/transcripts/discover.ts
+++ b/src/core/transcripts/discover.ts
@@ -23,7 +23,7 @@ import type { TranscriptFormat } from './types.ts';
 import { harnessRoots, type HarnessRoot } from './detect.ts';
 import { isOpenclawCheckpointFile } from './openclaw.ts';
 import { isGrokChatHistoryFile } from './grok.ts';
-import { isClaudeCodeSubagentFile } from './claude-code.ts';
+import { isClaudeCodeSubagentFile, isClaudeCodeWorkflowArtifactFile } from './claude-code.ts';
 import { isClaudeCliSelfTranscriptPath } from '../ai/providers/claude-cli-scratch.ts';
 
 export interface DiscoveredFile {
@@ -98,6 +98,10 @@ export function discoverTranscriptFiles(roots?: HarnessRoot[], opts: DiscoverOpt
       // session id, so they can never import. Left in, each one is a
       // permanent gap-table phantom + a false DRIFT WARNING every ingest.
       if (format === 'claude-code' && isClaudeCodeSubagentFile(p)) continue;
+      // Workflow run bookkeeping (agent logs + a journal.jsonl that matches no
+      // adapter format). Discoverable, it errored every ingest and froze the
+      // shared --since watermark via cleanScan.
+      if (format === 'claude-code' && isClaudeCodeWorkflowArtifactFile(p)) continue;
       // #4472: skip gbrain's own claude-cli subprocess sessions (see
       // DiscoverOpts.includeSelf) — the scratch-cwd fingerprint survives
       // Claude Code's project-dir slugification.

--- a/test/transcripts-claude-code-workflow-drift.test.ts
+++ b/test/transcripts-claude-code-workflow-drift.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Claude Code workflow-run artifacts must not read as host-format drift.
+ *
+ * `gbrain transcripts ingest` reported "DRIFT WARNING: 27 file(s) parsed to
+ * zero sessions" on a real brain, and every one was a false positive:
+ *
+ *   1. 22 subagent logs at `<session>/subagents/workflows/<wf>/agent-<id>.jsonl`.
+ *      isClaudeCodeSubagentFile checked the IMMEDIATE parent for `subagents`,
+ *      so the workflow nesting slipped past the filter it was written for.
+ *   2. 5 title/metadata-only session stubs (`last-prompt` + `custom-title`,
+ *      no turn records at all). The claude-code adapter never set
+ *      `expectedEmpty`, which the drift predicate
+ *      (`bytesRead > 0 && sessions === 0 && !expectedEmpty`) reads.
+ *
+ * Both cleared `cleanScan`, which by design holds the `--since last`
+ * watermark back — so the archive re-scanned them forever and the warning
+ * could never clear.
+ *
+ * The negative cases matter as much as the positives: turn records that stop
+ * yielding text, and files with unparseable lines, MUST still drift.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  claudeCodeAdapter,
+  isClaudeCodeSubagentFile,
+} from '../src/core/transcripts/claude-code.ts';
+import type { FileDiagnostics } from '../src/core/transcripts/types.ts';
+
+let dir: string;
+
+/** Drain the adapter generator and hand back its FileDiagnostics return. */
+async function diagnose(path: string): Promise<FileDiagnostics> {
+  const gen = claudeCodeAdapter.parse(path);
+  let step = await gen.next();
+  while (!step.done) step = await gen.next();
+  return step.value;
+}
+
+function write(name: string, lines: unknown[]): string {
+  const p = join(dir, name);
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return p;
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'gbrain-wf-drift-'));
+  mkdirSync(join(dir, 'nested'), { recursive: true });
+});
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const SESS = '/Users/me/.claude/projects/-Users-me-proj/9e1f3d87-95f6-46bc-bb48-97404d8d1890';
+
+describe('workflow-nested subagent logs are recognized', () => {
+  test('agent log inside a workflow run dir is a subagent file', () => {
+    expect(
+      isClaudeCodeSubagentFile(`${SESS}/subagents/workflows/wf_e37e5872-c19/agent-af0c665.jsonl`),
+    ).toBe(true);
+  });
+
+  test('the immediate-parent cases keep their existing behaviour', () => {
+    expect(isClaudeCodeSubagentFile(`${SESS}/subagents/agent-a5364e5.jsonl`)).toBe(true);
+    // A real session directly under subagents/ stays discoverable.
+    expect(isClaudeCodeSubagentFile(`${SESS}/subagents/61c79e08-716f-44df.jsonl`)).toBe(false);
+    // A project SLUG containing "subagents" is not a subagents segment.
+    expect(
+      isClaudeCodeSubagentFile('/Users/me/.claude/projects/-Users-me-subagents/agent-abc.jsonl'),
+    ).toBe(false);
+  });
+
+  test('workflow journal is an artifact; a session under subagents/ is not', async () => {
+    // Imported dynamically, not statically: this export does not exist before
+    // the fix, and a static named import would crash the whole FILE with a
+    // SyntaxError — the vacuous-failure class CONTRIBUTING.md rejects. Loading
+    // the module by value lets the other tests in this file run (and fail on
+    // their own assertions) against pre-fix source.
+    const mod = await import('../src/core/transcripts/claude-code.ts');
+    const isArtifact = mod.isClaudeCodeWorkflowArtifactFile;
+    expect(typeof isArtifact).toBe('function');
+    expect(isArtifact(`${SESS}/subagents/workflows/wf_e37e5872-c19/journal.jsonl`)).toBe(true);
+    expect(isArtifact(`${SESS}/subagents/61c79e08-716f-44df.jsonl`)).toBe(false);
+    expect(isArtifact(`${SESS}/subagents/workflows`)).toBe(false);
+  });
+});
+
+describe('expectedEmpty separates understood-empty from drift', () => {
+  test('a title/metadata-only stub is understood, not drift', async () => {
+    const p = write('meta-only.jsonl', [
+      { sessionId: 's1', type: 'last-prompt', prompt: 'hi' },
+      { sessionId: 's1', type: 'custom-title', title: 'Some title' },
+      { sessionId: 's1', type: 'ai-title', title: 'Another' },
+    ]);
+    const d = await diagnose(p);
+    expect(d.sessions).toBe(0);
+    expect(d.bytesRead).toBeGreaterThan(0);
+    expect(d.expectedEmpty).toBe(true);
+  });
+
+  test('an all-sidechain subagent log is understood, not drift', async () => {
+    const p = write('sidechain.jsonl', [
+      {
+        sessionId: 's2',
+        type: 'user',
+        isSidechain: true,
+        message: { role: 'user', content: 'sub work' },
+      },
+      {
+        sessionId: 's2',
+        type: 'assistant',
+        isSidechain: true,
+        message: { role: 'assistant', content: 'sub reply' },
+      },
+    ]);
+    const d = await diagnose(p);
+    expect(d.sessions).toBe(0);
+    expect(d.expectedEmpty).toBe(true);
+  });
+
+  test('turn records that yield no text STILL drift', async () => {
+    // The real regression signal: the host kept `type: user` but changed the
+    // message shape. Marking this expectedEmpty would silence exactly the
+    // breakage the drift counter exists to catch.
+    const p = write('shape-drift.jsonl', [
+      { sessionId: 's3', type: 'last-prompt', prompt: 'hi' },
+      { sessionId: 's3', type: 'user', message: null },
+      { sessionId: 's3', type: 'assistant', message: null },
+    ]);
+    const d = await diagnose(p);
+    expect(d.sessions).toBe(0);
+    expect(d.expectedEmpty).toBeFalsy();
+  });
+
+  test('unparseable lines STILL drift', async () => {
+    const p = join(dir, 'malformed.jsonl');
+    writeFileSync(p, '{"sessionId":"s4","type":"last-prompt"}\nnot json at all\n');
+    const d = await diagnose(p);
+    expect(d.sessions).toBe(0);
+    expect(d.skippedLines).toBeGreaterThan(0);
+    expect(d.expectedEmpty).toBeFalsy();
+  });
+
+  test('a real session still imports and is not marked empty', async () => {
+    const p = write('real.jsonl', [
+      { sessionId: 's5', type: 'last-prompt', prompt: 'hi' },
+      {
+        sessionId: 's5',
+        type: 'user',
+        timestamp: '2026-09-08T10:00:00.000Z',
+        message: { role: 'user', content: 'hello there' },
+      },
+      {
+        sessionId: 's5',
+        type: 'assistant',
+        timestamp: '2026-09-08T10:00:01.000Z',
+        message: { role: 'assistant', content: 'hi back' },
+      },
+    ]);
+    const d = await diagnose(p);
+    expect(d.sessions).toBe(1);
+    expect(d.expectedEmpty).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## What

`gbrain transcripts ingest` reported `DRIFT WARNING: 27 file(s) parsed to zero sessions — the host format may have changed` on every run against a real 278-file archive. All 27 were false positives, and because a drifting file also clears `cleanScan`, the `--since last` watermark stayed frozen — so the same files were re-scanned on every ingest and the warning could never clear on its own.

After the fix, the same archive reports 0 drift files and 0 errored files.

## Why

Three causes, in two classes plus one that would have blocked the fix from mattering.

**1 — 22 workflow-nested subagent logs.** `isClaudeCodeSubagentFile` checked the IMMEDIATE parent for a `subagents` segment, so it caught `<session>/subagents/agent-<id>.jsonl` but missed every `<session>/subagents/workflows/<wf-id>/agent-<id>.jsonl`. Same all-`isSidechain` files, one directory deeper than the filter looked — the exact "permanent gap-table phantom + a false DRIFT WARNING every ingest" that `discover.ts` already documents for the shallow case.

The segment is now matched at any depth. The exact-segment test is kept deliberately: Claude Code encodes a whole project path as ONE slug segment (`-Users-me-subagents-thing`), which never equals `subagents` exactly, so a project whose slug merely contains the word is still never hidden.

**2 — 5 title/metadata-only stubs.** Files holding only `last-prompt` + `custom-title` records, with no turn records at all. The drift predicate is `bytesRead > 0 && sessions === 0 && !expectedEmpty`, but the claude-code adapter never set `expectedEmpty` — only grok did. A file with zero turn-shaped records never had anything to import: understood, not drift.

`expectedEmpty` is derived from the **absence of turn-shaped records**, not from an allow-list of known record types. The archive this was measured against carries 18 distinct `type` values while `CLAUDE_CONTROL_TYPES` knows 6, so an allow-list would fire drift every time the host adds a record type. Records that *claim* to be turns (`type` user/assistant, not sidechain) but yield no text still drift — that is the real host-change signal — and so does any file with unparseable lines.

**3 — `journal.jsonl`.** Each workflow run dir also holds a run log matching no adapter format, so ingest reported `unknown format` every run; an errored file clears `cleanScan` too. Fixing only 1 and 2 would have left the watermark frozen and the operational problem unsolved. Skipped via a deliberately narrow `subagents/workflows/` predicate — a UUID-named file directly under `subagents/` IS a real session and stays discoverable, as `transcripts-self-exclusion.test.ts` pins.

## Second commit: a test-isolation fix, and why it is in this PR

`b415a4eb` touches `test/models-doctor-v1-hint.test.ts`, which looks unrelated to transcripts. It is here because this PR could not go green without it, and fixing it anywhere else would have masked the defect.

CI failed twice on `test (9)`, both times on two tests in `test/sweep-writeback-corpus.test.ts` asserting `r1.corpusIngested` — expected 1, received 0, at a near-constant ~6.0s.

`test/models-doctor-v1-hint.test.ts` calls `configureGateway({ base_urls: { litellm: 'http://localhost:4000' }, embedding_model: 'litellm:text-embedding-3-large' })` to exercise the `/v1` reachability hint, and had no `afterAll`/`afterEach` of any kind. `configureGateway` is process-global, so every later file in the same shard process inherited that embedding route. Nothing listens on `:4000` during a test run, so the first downstream file that actually embeds — the sweep ingesting a writeback turn — blocked until the transport gave up, then honestly reported zero work done.

Shard membership is LPT-balanced across the whole corpus, so **adding one test file repartitions it**. On master `sweep-writeback-corpus.test.ts` sits in shard 5, without `models-doctor-v1-hint`. With this PR's new test file (itself in shard 3) it moves to shard 9, with it. The two had never shared a process before; the leak is pre-existing and this PR only relocated it into view.

Reproducible on master, needing neither CI nor any source change from this PR:

```
bun test test/models-doctor-v1-hint.test.ts test/sweep-writeback-corpus.test.ts
before: 34 pass / 2 fail   (same two tests, same assertion, 5002ms)
after:  36 pass / 0 fail
```

The fix is `afterAll(() => resetGateway())` — the reset the gateway module already exports for this. Fixed at the leak rather than in the victim on purpose: making the sweep test defensive would have left a leak that reaches every file scheduled after this one, and it would surface somewhere else on the next repartition.

Happy to split this into its own PR if you would rather keep the two changes separate — flagging it as reviewable on its own rather than burying it.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/transcripts/claude-code.ts src/core/transcripts/claude-code-jsonl.ts` to merge-base, ran `test/transcripts-claude-code-workflow-drift.test.ts` → `4 pass / 4 fail`. Restored → all pass.

The 4 pre-fix failures are behavioral, not load errors: the nested-path assertion returns `false`, the artifact predicate is `undefined`, and both `expectedEmpty` assertions return `undefined`. The 4 that pass both ways are the regression guards.

Worth flagging for reviewers: the new predicate is imported **dynamically** inside its own test on purpose. A static named import of an export that does not exist pre-fix crashes the entire file with `SyntaxError: Export named ... not found` — which the helper's exit-code heuristic accepts as a pass while producing `0 pass / 1 fail`, i.e. the vacuous-failure class this field exists to exclude. Loading the module by value lets the other tests execute and fail on their own assertions.

## Verification

Against the real 278-file archive that surfaced this:

| | before | after |
|---|---|---|
| files discovered | 278 | 255 |
| `driftFiles` | 27 | 0 |
| `erroredFiles` | 1 | 0 |
| `truncatedFiles` | 0 | 0 |
| files with `skippedLines > 0` | 0 of 256 | 0 of 256 |

With every one of those at zero, the dry-run flag itself (`if (opts.dryRun) result.cleanScan = false`) is the only remaining reason `cleanScan` is false, so a real unlimited run now advances the watermark.

## Tests

`test/transcripts-claude-code-workflow-drift.test.ts` (new, 8 tests): nested and immediate-parent matcher cases, the project-slug false-positive guard, the workflow-artifact predicate, understood-empty (metadata-only and all-sidechain), and the two drift cases that must keep firing (turn records yielding no text, unparseable lines).

Local runs, redirected to files with exit codes checked:

```
bun test test/transcripts-claude-code-workflow-drift.test.ts   exit=0    8 pass / 0 fail
bun test test/*transcript* test/*claude-code*                  exit=0  205 pass / 0 fail (17 files)
bun run verify                                                 exit=0   54/54 checks green
```

No existing assertion changed; `transcripts-self-exclusion.test.ts` passes unmodified.

For the isolation fix: shard 9 in full `exit=0` 2389 pass / 0 fail, and `test/models-doctor-v1-hint.test.ts` alone `exit=0` 30 pass / 0 fail. All checks green on `b415a4eb` (25 passed, 12 skipped).

Note on history: `48c1119` is an empty retrigger commit from when I still believed shard 9 was flaking. Its reasoning is superseded by the analysis above — a fork contributor cannot re-run failed jobs, so pushing was the only way to retrigger. Left in place rather than force-pushed over; say the word and I will squash the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
