### PR TITLE
v0.48.5.3 fix(ai): claude-cli declares prompt caching — the CLI caches, --print included

### DIFF
--- a/src/core/ai/recipes/claude-cli.ts
+++ b/src/core/ai/recipes/claude-cli.ts
@@ -83,10 +83,20 @@ export const claudeCli: Recipe = {
       ],
       supports_tools: true,
       supports_subagent_loop: true,
-      // The CLI handles caching internally and does not surface it via the
-      // standard cache_control control plane. From the gateway's POV the
-      // model does not support prompt caching.
-      supports_prompt_cache: false,
+      // The CLI caches prompt prefixes automatically — including the
+      // `--print` runs this provider dispatches, which Claude Code puts in
+      // its "main conversation" TTL bucket (one hour on a Claude
+      // subscription, five minutes on an API key).
+      // https://code.claude.com/docs/en/prompt-caching
+      //
+      // This field asks "does the provider cache at all" — see the contract
+      // on ProviderCapabilities.supportsPromptCaching in ../capabilities.ts,
+      // which is explicit that it is NOT "does it honor our markers", and
+      // that the degraded:no_caching advice "is wrong for a provider that
+      // caches without being asked". It was exactly that advice this recipe
+      // used to trigger. Declaring `false` because the gateway cannot drive
+      // the cache answered the other question.
+      supports_prompt_cache: true,
       max_context_tokens: 200000,
       // Cost figures match the underlying Claude API tier, but the actual
       // bill is borne by the subscription. We report them for the budget

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -64,7 +64,11 @@ describe('chat touchpoint — recipe registry', () => {
     // it is a property of the whole provider. Anything else must declare no
     // caching.
     const PREDICATE = new Set(['openai', 'openrouter', 'google']);
-    const ALWAYS_CACHES = new Set(['anthropic', 'deepseek', 'llama-server']);
+    // claude-cli caches for the whole provider, so it is a boolean, not a
+    // predicate: Claude Code caches automatically on every model it routes,
+    // `--print` runs included. See the recipe for the measurement and
+    // test/ai/recipe-claude-cli-prompt-cache.test.ts for the behavior.
+    const ALWAYS_CACHES = new Set(['anthropic', 'deepseek', 'llama-server', 'claude-cli']);
     for (const r of listRecipes()) {
       if (!r.touchpoints.chat) continue;
       const flag = r.touchpoints.chat.supports_prompt_cache;

--- a/test/ai/recipe-claude-cli-prompt-cache.test.ts
+++ b/test/ai/recipe-claude-cli-prompt-cache.test.ts
@@ -1,0 +1,76 @@
+/**
+ * claude-cli declares prompt caching, because the CLI caches.
+ *
+ * The recipe used to declare `supports_prompt_cache: false` on the grounds
+ * that the CLI "does not surface it via the standard cache_control control
+ * plane" — true, but that is the wrong question. The contract on
+ * `ProviderCapabilities.supportsPromptCaching` (src/core/ai/capabilities.ts)
+ * is explicit that the field means "does it cache", by EITHER mechanism, and
+ * that the `degraded:no_caching` advice "is wrong for a provider that caches
+ * without being asked".
+ *
+ * Claude Code caches automatically, `--print` runs included — the mode this
+ * provider dispatches. Those runs sit in its "main conversation" TTL bucket,
+ * which is one hour on a Claude subscription:
+ * https://code.claude.com/docs/en/prompt-caching
+ *
+ * The user-visible symptom was doctor's `subagent_capability` telling every
+ * claude-cli operator their subagent loop "runs hot" and to switch to
+ * `anthropic:` — advice that trades a subscription-billed path for a metered
+ * one to buy caching the operator already had. Same unclearable-warning class
+ * as #4575, which is pinned in test/doctor-subagent-capability.test.ts.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { getProviderCapabilities, classifyCapabilities } from '../../src/core/ai/capabilities.ts';
+import { checkSubagentCapability } from '../../src/commands/doctor.ts';
+
+function fakeEngine(entries: Record<string, string>) {
+  const config = new Map(Object.entries(entries));
+  return {
+    async getConfig(key: string): Promise<string | null> {
+      return config.get(key) ?? null;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// Every chat model the recipe lists — the declaration is a flat boolean, so
+// none of them may classify as uncached.
+const CLAUDE_CLI_MODELS = getRecipe('claude-cli')!.touchpoints.chat!.models ?? [];
+
+describe('recipe: claude-cli prompt cache', () => {
+  test('the capability layer reports caching for every listed model', () => {
+    expect(CLAUDE_CLI_MODELS.length).toBeGreaterThan(0);
+    for (const id of CLAUDE_CLI_MODELS) {
+      expect(getProviderCapabilities(`claude-cli:${id}`).supportsPromptCaching).toBe(true);
+    }
+  });
+
+  test('classifyCapabilities does not grade claude-cli as degraded:no_caching', () => {
+    for (const id of CLAUDE_CLI_MODELS) {
+      const verdict = classifyCapabilities(`claude-cli:${id}`);
+      expect(verdict).not.toBe('degraded:no_caching');
+      // The recipe declares tools + subagent loop, so the only remaining
+      // verdict is a clean one. Asserting the exact value (rather than
+      // "not degraded") keeps this from passing on an 'unknown' regression.
+      expect(verdict).toBe('ok');
+    }
+  });
+
+  test('doctor subagent_capability is OK on a claude-cli subagent tier', async () => {
+    const engine = fakeEngine({
+      'models.tier.subagent': 'claude-cli:claude-sonnet-5',
+      // Short-circuits the unrelated non-Anthropic chat_model branch below the
+      // capability gate, so this test does not read the host's real config.
+      'agent.use_gateway_loop': 'true',
+    });
+    const check = await checkSubagentCapability(engine);
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('models.tier.subagent');
+    // The retired advice must not come back.
+    expect(check.message).not.toContain('prompt caching');
+    expect(check.message).not.toContain('runs hot');
+  });
+});


### PR DESCRIPTION
## What

The `claude-cli` recipe declared `supports_prompt_cache: false`, so
`classifyCapabilities()` graded every claude-cli model `degraded:no_caching`
and `gbrain doctor` told the operator their subagent loop "runs hot (cost
scales linearly with conversation length)" and to switch to
`anthropic:claude-sonnet-4-6`.

The CLI does cache. This flips the declaration to `true` and rewrites the
stale comment. No runtime behavior changes.

## Why

The old comment is accurate about the mechanism and answers a different
question than the field asks:

> The CLI handles caching internally and does not surface it via the standard
> `cache_control` control plane. From the gateway's POV the model does not
> support prompt caching.

`ProviderCapabilities.supportsPromptCaching` in `src/core/ai/capabilities.ts`
is explicit about which question it is:

> The provider caches prompt prefixes **at all** — by either mechanism:
> automatically server-side (OpenAI, DeepSeek; nothing to attach …), or when
> the request carries explicit `cache_control` markers (Anthropic). […] This is
> deliberately "does it cache", not "does it honor our markers":
> `enforceSubagentCapable` and `doctor` use it to decide whether to warn an
> operator off a provider for cost reasons, **and that advice is wrong for a
> provider that caches without being asked**.

claude-cli is precisely the provider that clause describes, and it was the one
triggering that advice.

### Sources that the CLI caches

Anthropic's Claude Code documentation, [How Claude Code uses prompt
caching](https://code.claude.com/docs/en/prompt-caching):

- Claude Code manages prompt caching itself and sends its own `cache_control`
  markers — the caller does nothing.
- Non-interactive `--print` runs, which is exactly what this provider
  dispatches, are named in the **main conversation** TTL bucket: *"your
  interactive turns, non-interactive `-p` runs, and Agent SDK turns"*.
- That bucket gets a **one-hour** TTL on a Claude subscription (five minutes on
  an API key or cloud provider).
- Cache scope is per machine + working directory. This provider spawns from a
  stable per-process scratch dir, so a long-lived gbrain process reuses one
  prefix across calls.

Underlying mechanism: [Prompt
caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching).

Measured here on a Max subscription — `claude -p "hello" --output-format json`,
`usage`:

```json
"input_tokens": 2,
"cache_read_input_tokens": 24902,
"cache_creation_input_tokens": 6723,
"cache_creation": {
  "ephemeral_1h_input_tokens": 6723,
  "ephemeral_5m_input_tokens": 0
}
```

24,902 tokens served from cache against 2 uncached, written into the one-hour
bucket. (Kept out of the source comment deliberately — it is one machine's
number and would go stale; the repro command is in the commit message.)

The module's own header already assumed this, while the flag below it said the
opposite:

> The **~42k cached tokens** from user-level instructions are accepted as a
> cost-trivial trade-off on the subscription path.
> — `src/core/ai/providers/claude-cli-language-model.ts`

### Why the warning mattered

The remediation inverted the economics it claimed to fix: it moved the operator
off a subscription-billed path onto a metered one to buy caching they already
had, and no configuration could clear it. That is the same unclearable-warning
class as #4575, on the same `subagent_capability` check.

### Why the flip is inert at runtime

`chat()` computes `useCache` from this flag and attaches Anthropic-namespaced
markers. claude-cli dispatches through `ClaudeCliLanguageModel`, which renders
the message array to text for `claude --print` stdin; it never reads
`cache_control` or `providerOptions` (zero occurrences in the module). The
markers are dropped by the adapter rather than reaching a wire body. There is
no `cache_control` control plane on this path to mis-drive — which is what the
old comment observed, and the reason declaring `true` costs nothing.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/ai/recipes/claude-cli.ts` to `upstream/master`, ran `test/ai/recipe-claude-cli-prompt-cache.test.ts` → 0 pass / 3 fail. Restored → all pass.

Run with `DISCRIMINATE_BASE=upstream/master` (this branch is cut from
`upstream/master`, and the default resolves `origin/master` on a fork).

## Verification

`gbrain doctor` on this brain, subagent tier `claude-cli:claude-sonnet-5`.

Broken state, on `upstream/master`:

```
[WARN] subagent_capability: models.tier.subagent is "claude-cli:claude-sonnet-5"
  — provider does not support prompt caching. The subagent loop runs hot (cost
  scales linearly with conversation length). For lower cost on long loops, use
  an Anthropic model: `gbrain config set models.tier.subagent anthropic:claude-sonnet-4-6`.

Ops checks:    95/100
Overall health score: 90/100. All checks OK (some warnings).
```

With this branch:

```
[OK] subagent_capability: Subagent model resolves via models.tier.subagent to
  "claude-cli:claude-sonnet-5" with full tool-loop capability

Ops checks:    100/100
Overall health score: 100/100. All checks passed.
```

## Tests

Added `test/ai/recipe-claude-cli-prompt-cache.test.ts` — three behavioral
assertions, no source-text regexes: the capability layer reports caching for
every model the recipe lists; `classifyCapabilities` returns `ok` rather than
`degraded:no_caching`; and `checkSubagentCapability` returns `ok` on a
claude-cli subagent tier, with the retired advice absent from the message. The
doctor case pins `agent.use_gateway_loop` so it does not read the host's real
config.

Updated `test/ai/gateway-chat.test.ts` — the registry ratchet asks for exactly
this ("some recipes here still declare false while their vendor does cache …
when one is fixed, add it here"), so `claude-cli` joins `ALWAYS_CACHES`. It is
a flat boolean, not a predicate: Claude Code caches on every model it routes.
This test caught the change, which is what it is for.

Local runs, all on this branch:

```
bun test test/ai/ test/doctor-subagent-capability.test.ts test/doctor.test.ts
  → exit 0, 863 pass / 0 fail across 68 files

bun run verify
  → exit 0, 54 checks, pass=54 fail=0
```

E2E not run locally (no `DATABASE_URL` configured on this machine); the change
touches no database or query path.



---

## Second commit: a test-isolation fix this PR surfaced

`test (9)` failed on two tests in `test/sweep-writeback-corpus.test.ts`
asserting `r1.corpusIngested` — expected 1, received 0, at a near-constant
~6.0s. Not a behaviour change from the recipe flag: the two failing tests do
not reference `claude-cli`, `supports_prompt_cache`, or any file this PR
touches.

**Cause.** `test/models-doctor-v1-hint.test.ts` calls `configureGateway({
base_urls: { litellm: 'http://localhost:4000' }, embedding_model:
'litellm:text-embedding-3-large' })` to exercise the /v1 reachability hint, and
restored nothing. `configureGateway` is process-global, so every later file in
the same shard inherited that embedding route. Nothing listens on :4000 during
a test run, so the first downstream file that really embeds — the sweep
ingesting a writeback turn — blocked until the transport gave up, then honestly
reported zero work done. The `BUDGET_TRACKER_NO_PRICING: model
"litellm:text-embedding-3-large"` line immediately above the failure in the
shard log is the leak announcing itself.

**Why this PR.** Shard membership is LPT-balanced over the whole corpus, so
adding one file repartitions it. The new
`test/ai/recipe-claude-cli-prompt-cache.test.ts` moves
`sweep-writeback-corpus.test.ts` into shard 9 next to `models-doctor-v1-hint`
for the first time. Neither file changed; they had never shared a process.

**Reproduction**, needing neither CI nor this PR's source change — on
`upstream/master`:

```
bun test test/models-doctor-v1-hint.test.ts test/sweep-writeback-corpus.test.ts
before: 34 pass / 2 fail   (same two tests, same assertion, 10.99s)
after:  36 pass / 0 fail   (904ms)
```

Fixed at the leak, not the victim: `afterAll(() => resetGateway())`, the reset
the gateway module already exports for this. Making the sweep test defensive
would mask a leak that reaches every file scheduled after this one, and would
move again on the next repartition.

**Overlap:** #4969 hit the same leak from a different repartition and carries
the identical one-line fix. Whichever lands first, the other can drop that
commit.

Local after the fix: `bun run verify` 54/54 green; the four affected files
81 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
