### PR TITLE
feat(cycle): synthesize_concepts skips groups that already have an LLM narrative; budget cap reads config

### DIFF
--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -223,10 +223,43 @@ export async function runPhaseSynthesizeConcepts(
     b.atomTitles.length - a.atomTitles.length ||
     a.conceptSlug.localeCompare(b.conceptSlug));
 
+  // Concept pages that already carry an LLM narrative for the SAME atom
+  // count are skipped, so the bounded budget rotates to groups that never
+  // got one instead of regenerating the same top slice every run. A group
+  // whose atom count moved re-synthesizes as before.
+  const freshLlm = new Map<string, number>();
+  try {
+    const rows = await engine.executeRaw<{ slug: string; frontmatter: Record<string, unknown> | string | null }>(
+      `SELECT slug, frontmatter
+         FROM pages
+        WHERE type = 'concept'
+          AND deleted_at IS NULL
+          AND source_id = $1
+          AND (frontmatter->>'synthesis_mode') = 'llm'`,
+      [opts.sourceId ?? 'default'],
+    );
+    for (const r of rows) {
+      const fm = typeof r.frontmatter === 'string' ? JSON.parse(r.frontmatter) : (r.frontmatter ?? {});
+      const n = Number(fm.mention_count);
+      if (Number.isFinite(n)) freshLlm.set(r.slug, n);
+    }
+  } catch {
+    // No pages table / query failed — no skip, every group synthesizes.
+  }
+
   // 4. Per group: synthesize narrative (LLM for T1/T2, deterministic for T3+)
   let conceptsWritten = 0;
+  let skippedFresh = 0;
   let estimatedSpendUsd = 0;
-  const budgetCap = DEFAULT_BUDGET_USD;
+  // Budget cap: config override (a local model priced through the fallback
+  // table exhausts the default in ~165 calls), else the built-in default.
+  // Same shape as cycle.extract_atoms.budget_usd.
+  let budgetCap = DEFAULT_BUDGET_USD;
+  const configuredBudget = await engine.getConfig('cycle.synthesize_concepts.budget_usd');
+  if (configuredBudget) {
+    const n = Number(configuredBudget);
+    if (Number.isFinite(n) && n > 0) budgetCap = n;
+  }
   const failures: Array<{ concept: string; error: string }> = [];
   // #4589 provenance-link problems. Kept OUT of `failures`: that list means
   // "the LLM call failed → template fallback" downstream (summary wording,
@@ -277,9 +310,14 @@ export async function runPhaseSynthesizeConcepts(
   const synthMaxOutputTokens = resolveSynthMaxOutputTokens(synthModel);
   for (const group of atomGroups) {
     tierCounts[group.tier]++;
+    const title = group.conceptSlug.split('/').pop() ?? group.conceptSlug;
     let narrative: string;
     let synthesisMode: ConceptSynthesisMode;
     if (group.tier === 'T1' || group.tier === 'T2') {
+      if (freshLlm.get(`concepts/${title}`) === group.atomTitles.length) {
+        skippedFresh++;
+        continue;
+      }
       if (estimatedSpendUsd >= budgetCap) {
         narrative = deterministicNarrative(group);
         synthesisMode = 'budget_fallback';
@@ -355,7 +393,6 @@ export async function runPhaseSynthesizeConcepts(
     synthesisModeCounts[synthesisMode]++;
 
     if (!opts.dryRun) {
-      const title = group.conceptSlug.split('/').pop() ?? group.conceptSlug;
       // #2163: serialize to markdown and import via the canonical pipeline so
       // the page is chunked (+ embedded when a provider is configured) —
       // mirrors put_page's isAvailable('embedding') → noEmbed gate.
@@ -440,7 +477,8 @@ export async function runPhaseSynthesizeConcepts(
           `Synthesized ${conceptsWritten} concepts ` +
           `(T1=${tierCounts.T1} T2=${tierCounts.T2} T3=${tierCounts.T3}) ` +
           `(llm=${synthesisModeCounts.llm} deterministic=${synthesisModeCounts.deterministic_tier} ` +
-          `budget_fallback=${synthesisModeCounts.budget_fallback} error_fallback=${synthesisModeCounts.error_fallback}) ` +
+          `budget_fallback=${synthesisModeCounts.budget_fallback} error_fallback=${synthesisModeCounts.error_fallback} ` +
+          `skipped_fresh=${skippedFresh}) ` +
           `from ${atomGroups.length} groups across ${atoms.length} atoms.`,
       });
     } catch (err) {
@@ -464,10 +502,12 @@ export async function runPhaseSynthesizeConcepts(
     summary:
       `synthesize_concepts: ${conceptsWritten} concepts ` +
       `(T1=${tierCounts.T1} T2=${tierCounts.T2} T3=${tierCounts.T3})` +
+      (skippedFresh > 0 ? ` (${skippedFresh} already synthesized, skipped)` : '') +
       (failures.length > 0 ? ` (${failures.length} LLM-failed → template fallback)` : '') +
       (linkWarnings.length > 0 ? ` (${linkWarnings.length} provenance-link warning(s))` : ''),
     details: {
       concepts_written: conceptsWritten,
+      skipped_fresh: skippedFresh,
       tier_counts: tierCounts,
       synthesis_mode_counts: synthesisModeCounts,
       groups_found: atomGroups.length,

--- a/test/cycle/synthesize-concepts-skip-fresh.test.ts
+++ b/test/cycle/synthesize-concepts-skip-fresh.test.ts
@@ -1,0 +1,75 @@
+// synthesize_concepts: a T1/T2 group whose concept page already carries an
+// LLM narrative for the same atom count is skipped, so the bounded budget
+// rotates to groups that never got one instead of re-spending on the same
+// top slice every run. A changed atom count re-synthesizes. The budget cap
+// reads `cycle.synthesize_concepts.budget_usd` (mirrors extract_atoms).
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-concepts.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 240000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+}, 120000);
+
+// Five atoms on one concept → T2 → LLM path. (Atoms are not real pages, so
+// provenance links warn; status is not asserted — calls + details are.)
+function atomsFor(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    slug: `a${i}`, title: `A${i}`, body: `body ${i}`, concept_refs: ['theme'],
+  }));
+}
+
+function chatStub() {
+  const calls: number[] = [];
+  const chat = (async () => {
+    calls.push(1);
+    return {
+      text: 'A synthesized narrative about the theme.',
+      blocks: [],
+      stopReason: 'end',
+      model: 'stub',
+      usage: { input_tokens: 10, output_tokens: 10 },
+    };
+  }) as unknown as NonNullable<Parameters<typeof runPhaseSynthesizeConcepts>[1]>['_chat'];
+  return { chat, calls };
+}
+
+describe('synthesize_concepts skips already-synthesized groups', () => {
+  test('second run with the same atoms makes no LLM call; a changed atom count re-synthesizes', async () => {
+    const { chat, calls } = chatStub();
+
+    const first = await runPhaseSynthesizeConcepts(engine, { _atoms: atomsFor(5), _chat: chat });
+    expect(calls.length).toBe(1);
+    expect((first.details as { skipped_fresh: number }).skipped_fresh).toBe(0);
+
+    const second = await runPhaseSynthesizeConcepts(engine, { _atoms: atomsFor(5), _chat: chat });
+    expect(calls.length).toBe(1);
+    expect((second.details as { skipped_fresh: number }).skipped_fresh).toBe(1);
+    expect((second.details as { concepts_written: number }).concepts_written).toBe(0);
+
+    const third = await runPhaseSynthesizeConcepts(engine, { _atoms: atomsFor(6), _chat: chat });
+    expect(calls.length).toBe(2);
+    expect((third.details as { skipped_fresh: number }).skipped_fresh).toBe(0);
+  }, 120000);
+
+  test('budget cap reads cycle.synthesize_concepts.budget_usd', async () => {
+    await engine.setConfig('cycle.synthesize_concepts.budget_usd', '12.5');
+    const { chat } = chatStub();
+    const result = await runPhaseSynthesizeConcepts(engine, { _atoms: atomsFor(5), _chat: chat, dryRun: true });
+    expect((result.details as { budget_usd: number }).budget_usd).toBe(12.5);
+  }, 120000);
+});

--- a/test/cycle/synthesize-concepts-task-model.test.ts
+++ b/test/cycle/synthesize-concepts-task-model.test.ts
@@ -101,7 +101,10 @@ describe('synthesize_concepts task-model routing', () => {
 
     await engine.setConfig('models.dream.synthesize', 'anthropic:claude-sonnet-4-6');
     const second: Array<string | undefined> = [];
-    await runPhaseSynthesizeConcepts(engine, { _atoms: t2Atoms(), _chat: capturingChat(second) });
+    // A fresh concept: an already-synthesized group with the same atom count
+    // is skipped (no chat call), which would leave `second` empty.
+    const secondAtoms = t2Atoms().map((a) => ({ ...a, concept_refs: ['concepts/y'] }));
+    await runPhaseSynthesizeConcepts(engine, { _atoms: secondAtoms, _chat: capturingChat(second) });
 
     expect(new Set(first)).toEqual(new Set(['anthropic:claude-haiku-4-5']));
     expect(new Set(second)).toEqual(new Set(['anthropic:claude-sonnet-4-6']));

--- a/test/cycle/synthesize-concepts-token-cap.test.ts
+++ b/test/cycle/synthesize-concepts-token-cap.test.ts
@@ -99,6 +99,9 @@ describe('synthesize_concepts wires the cap into the narrative call', () => {
     // An explicit non-thinking model (not "unset"): resolveModel's unset path
     // falls through to GBRAIN_MODEL and a key-aware tier default, so the 500
     // pin would otherwise depend on which provider keys the runner has.
+    // local: skip-fresh would skip concepts/x (same atom count, narrative already
+    // banked by the run above), so reset between the two runs.
+    await resetPgliteState(engine);
     await engine.setConfig('models.dream.synthesize', 'anthropic:claude-sonnet-4-6');
     const plain: Array<number | undefined> = [];
     await runPhaseSynthesizeConcepts(engine, { _atoms: t2Atoms(), _chat: capturingChat(plain) });

--- a/test/models-doctor-v1-hint.test.ts
+++ b/test/models-doctor-v1-hint.test.ts
@@ -1,11 +1,19 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import { versionRoot, maybeAttachVersionSuffixHint } from '../src/core/ai/base-url-probe.ts';
 import {
   probeModel,
   probeEmbeddingReachability,
   probeRerankerReachability,
 } from '../src/commands/models.ts';
-import { configureGateway } from '../src/core/ai/gateway.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+
+// The probe tests reconfigure the module-global gateway (litellm embedding at
+// localhost:4000). The preload's beforeEach only re-applies the baseline when
+// the gateway is UNconfigured, so without this reset the litellm config leaks
+// into every later file in the same shard (sweep-writeback-corpus timed out
+// its 5s budget retrying embeds against a dead port once LPT re-sharding put
+// the two files together).
+afterEach(() => resetGateway());
 import type { AIGatewayConfig } from '../src/core/ai/types.ts';
 
 /**


### PR DESCRIPTION
## What

`synthesize_concepts` now skips a T1/T2 group whose concept page already carries an LLM narrative (`synthesis_mode: llm`) for the same `mention_count`, and counts it as `skipped_fresh` in the phase summary, receipt and `details`. A group whose atom count changed is re-synthesized as before. The per-run budget cap now reads `cycle.synthesize_concepts.budget_usd` (same shape as `cycle.extract_atoms.budget_usd`); the default stays $1.50, so nothing changes for a brain that never sets it.

## Why

The phase sorts groups by tier then atom count and spends the budget top-down with no "already synthesized" check. On a brain with ~1,900 T1/T2 concepts and a budget that covers ~165 LLM calls, the same top 165 groups were regenerated every cycle and every other T1/T2 concept kept its deterministic stub forever. With the skip, the backlog cleared in nine runs on a production brain; each later run finishes in ~10 minutes at $0 instead of ~100 minutes at the full cap. The config key exists because a local model is priced at the Sonnet fallback rate, so the fixed $1.50 was a call-count limit rather than a spend limit for that setup.

Failed groups (`error_fallback`) are not marked `llm`, so they are retried on the next run rather than skipped.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/cycle/synthesize-concepts.ts` to merge-base, ran `test/cycle/synthesize-concepts-skip-fresh.test.ts` → 0 pass / 2 fail. Restored → 16 pass across `test/cycle/synthesize-concepts*`.

## Tests

- `test/cycle/synthesize-concepts-skip-fresh.test.ts` (new): second run with the same atoms makes no chat call and reports `skipped_fresh: 1`, a changed atom count re-synthesizes, and the cap reads the config key.
- `test/cycle/synthesize-concepts-token-cap.test.ts`: resets PGLite state between its two runs, since the second run would otherwise be skipped.
- `test/cycle/synthesize-concepts-task-model.test.ts`: the second run uses a different concept for the same reason.
- `check:privacy` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1xAATCwsUkSqwCqZ5gxno
