### PR TITLE
fix(test): reset the gateway after the models-doctor probe tests (cross-shard leak)

### DIFF
--- a/test/models-doctor-v1-hint.test.ts
+++ b/test/models-doctor-v1-hint.test.ts
@@ -1,11 +1,19 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import { versionRoot, maybeAttachVersionSuffixHint } from '../src/core/ai/base-url-probe.ts';
 import {
   probeModel,
   probeEmbeddingReachability,
   probeRerankerReachability,
 } from '../src/commands/models.ts';
-import { configureGateway } from '../src/core/ai/gateway.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+
+// The probe tests reconfigure the module-global gateway (litellm embedding at
+// localhost:4000). The preload's beforeEach only re-applies the baseline when
+// the gateway is UNconfigured, so without this reset the litellm config leaks
+// into every later file in the same shard (sweep-writeback-corpus timed out
+// its 5s budget retrying embeds against a dead port once LPT re-sharding put
+// the two files together).
+afterEach(() => resetGateway());
 import type { AIGatewayConfig } from '../src/core/ai/types.ts';
 
 /**


### PR DESCRIPTION
## What

`test/models-doctor-v1-hint.test.ts` gains an `afterEach(() => resetGateway())`.

## Why

`probeEmbeddingReachability: an embedding 401 attaches the /v1 hint` calls `configureGateway` with a litellm embedding model at `localhost:4000` and never restores it. The legacy-embedding preload's `beforeEach` only re-applies the baseline when the gateway is *unconfigured*, so that litellm config leaks into every later test file in the same bun process.

It is invisible on master only because LPT sharding happens to put this file and `test/sweep-writeback-corpus.test.ts` in different shards. Any PR that adds a test file re-partitions the shards; #4975 and #4982 both landed the two files together in shard 9 and the sweep's 5s budget was spent retrying embeds against a dead port, so both "gate ON salient" tests reported `corpusIngested` 0 (~6s each). Master's own last Test run (03:34 today) is green with the old partition.

## Discrimination test (required for every fix — #3665)

A wrapper test importing `models-doctor-v1-hint.test.ts` then `sweep-writeback-corpus.test.ts` (the CI order in shard 9):

| | without the reset | with the reset |
|---|---|---|
| wrapper (36 tests) | 2 fail (`BUDGET_TRACKER_NO_PRICING: model "litellm:text-embedding-3-large"` then 0 ingested) | 36 pass |
| `models-doctor-v1-hint` alone | 30 pass | 30 pass |

## Tests

- `bun test test/models-doctor-v1-hint.test.ts` → 30 pass
- ordered wrapper above → 36 pass
- `bash scripts/check-privacy.sh` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1xAATCwsUkSqwCqZ5gxno
