### PR TITLE
fix(sync): strip Unicode variation selectors (VS16/IVS) in slugifySegment

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -637,6 +637,13 @@ export function slugifySegment(segment: string): string {
     // are already decomposed and their points strip too.
     .replace(/[\u0591-\u05c7]/g, '')      // Strip Hebrew niqqud + cantillation
     .normalize('NFC')                     // Recompose Hangul Jamo back to Syllables (v0.32.7)
+    // Strip variation selectors (emoji VS1–VS16 U+FE00–FE0F, ideographic IVS
+    // U+E0100–E01EF): they are Mn-category invisibles that survive \p{M} in
+    // SLUG_WORD_CHARS, so an emoji folder name like `🗂️ entities` produced a
+    // leading invisible U+FE0F in the slug and forked duplicate pages from
+    // clean-slug canon written via put_page. Selectors never alter letter
+    // identity, so stripping them is lossless for every script.
+    .replace(/[\uFE00-\uFE0F\u{E0100}-\u{E01EF}]/gu, '')
     .toLowerCase()
     .replace(SLUGIFY_KEEP_RE, '')         // Keep alnum, dots, spaces, _-, and CJK (v0.32.7)
     .replace(/[\s]+/g, '-')              // Spaces → hyphens

--- a/test/slug-unicode-scripts.test.ts
+++ b/test/slug-unicode-scripts.test.ts
@@ -145,3 +145,46 @@ describe('#3700: Hebrew niqqud + cantillation strip', () => {
     expect(slugifySegment('ภาษาไทย')).toBe('ภาษาไทย');
   });
 });
+
+// Variation selectors — emoji VS1–VS16 (U+FE00–FE0F) and ideographic IVS
+// (U+E0100–E01EF) are Mn-category invisibles. #3417 kept \p{M} in
+// SLUG_WORD_CHARS to protect Devanagari matras / Thai vowels, so variation
+// selectors survive slugification too: a folder named `🗂️ entities`
+// (U+1F5C2 U+FE0F) emitted a slug with a leading invisible U+FE0F and forked
+// duplicate pages from clean-slug canon. Selectors never alter letter
+// identity, so stripping them is lossless for every script above.
+describe('variation selectors strip (emoji VS16 / ideographic IVS)', () => {
+  test('emoji + VS16 folder name lands on the clean slug', () => {
+    expect(slugifySegment('🗂️ entities')).toBe('entities');
+    // With and without VS16 converge on the same page.
+    expect(slugifySegment('🗂 entities')).toBe(slugifySegment('🗂️ entities'));
+  });
+
+  test('ideographic IVS strips too', () => {
+    // 巻 with an ideographic variation selector (U+E0101) vs bare.
+    expect(slugifySegment('巻\u{E0101}')).toBe('巻');
+    expect(slugifySegment('巻\u{E0101}')).toBe(slugifySegment('巻'));
+  });
+
+  test('emoji-only input still collapses to empty (VS16 no longer rescues it)', () => {
+    expect(slugifySegment('🗂️')).toBe('');
+    expect(slugifySegment('🎉\uFE0F')).toBe('');
+  });
+
+  test('diacritic-bearing scripts unaffected by the strip', () => {
+    expect(slugifySegment('café')).toBe('cafe');
+    expect(slugifySegment('בְּרֵאשִׁית')).toBe('בראשית');        // niqqud still strips
+    expect(slugifySegment('हिन्दी')).toBe('हिन्दी');             // Devanagari matras preserved
+    expect(slugifySegment('한글'.normalize('NFD'))).toBe('한글'); // Hangul recomposition preserved
+    expect(slugifySegment('ภาษาไทย')).toBe('ภาษาไทย');          // Thai vowels preserved
+  });
+
+  test('NFC and NFD emoji filenames converge', () => {
+    expect(slugifySegment('🗂️ entities'.normalize('NFC'))).toBe('entities');
+    expect(slugifySegment('🗂️ entities'.normalize('NFD'))).toBe('entities');
+  });
+
+  test('emitted slugs are ACCEPTED by validatePageSlug', () => {
+    expect(() => validatePageSlug(slugifyPath('🗂️ entities/README.md'))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`slugifySegment()` preserves Unicode **variation selectors** because `SLUG_WORD_CHARS` keeps `\p{M}` — introduced for Devanagari matras / Thai vowels by #3417 — and U+FE00–FE0F (emoji VS1–VS16) plus U+E0100–E01EF (ideographic IVS) are all **Mn**-category.

So a folder name containing an emoji followed by VS16 — how macOS Finder and most emoji pickers write them, e.g. `🗂️ entities` (U+1F5C2 U+FE0F U+0020 `entities`) — slugifies to `<U+FE0F>-entities`: a leading **invisible** variation selector. The same folder named without the selector, or canon pages created via `put_page` with a clean slug, produces `entities`. The two forms are distinct pages: silent duplicate forks that are nearly impossible to spot, because the difference is an invisible code point.

## Fix

One line in `slugifySegment()` (plus comment): strip `[\uFE00-\uFE0F\u{E0100}-\u{E01EF}]` after the NFC recompose, before `toLowerCase()`.

Why this is lossless for every script #3417 protects: variation selectors never alter letter identity — they only select a presentation variant of the preceding character (Unicode §23.4, Variation Selectors). Concretely:

- Devanagari matras, Thai vowels, Arabic, Cyrillic, etc.: no variation selectors involved — untouched (tested).
- The Hebrew niqqud strip (#3700) operates on U+0591–U+05C7, disjoint from FE00–FE0F — unaffected.
- Emoji-only segments still collapse to empty; in fact this fix makes `🗂️`-with-VS16 collapse correctly too (pre-fix it survived as a lone invisible U+FE0F).

## Regression tests

`test/slug-unicode-scripts.test.ts` gains a `variation selectors strip` describe block, in the same behavioral style as the #3417/#3700 suites:

- `🗂️ entities` → `entities`, converging with the no-VS16 spelling `🗂 entities`
- ideographic IVS: `巻\u{E0101}` → `巻`
- emoji-only input still collapses to empty (VS16 no longer "rescues" it into a non-empty invisible slug)
- café / niqqud / Devanagari matras / Hangul recomposition / Thai vowels unchanged by the new strip
- NFC and NFD emoji filenames converge on the same slug
- emitted slugs are accepted by `validatePageSlug` (three-grammar coherence)

Verified: 4 of the 6 new tests fail on pre-fix master (the other 2 are invariant guards); all 28 tests in the file pass with the fix, and the related suites (`sync.test.ts`, `slug-validation.test.ts`, `audit-slug-fallback`, `sync-malformed-path`, `sync-delete-trailing-hyphen`) pass — 164 tests green.

## Context

Found against production vaults synced from folders with emoji+VS16 names: pages forked from clean-slug canon and both copies kept receiving writes. The change only touches the sync slug grammar; `validatePageSlug` accepts the stripped result unchanged, so no schema/grammar changes are needed.
