### PR TITLE
fix(ai): declare gemini-embedding-2, price both Google embedding models

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -41,9 +41,23 @@ export const google: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['gemini-embedding-001'],
+      // gemini-embedding-2 (GA 2026-05-20) is the current Google-recommended
+      // embedding model — natively multimodal (text/image/video/audio/PDF
+      // into one vector space) and an 8,192-token input limit, vs. -001's
+      // text-only 2,048. Listed second (not as default_model) deliberately:
+      // -001 stays models[0] so every "pick a model for the user" surface
+      // (new-install auto-pick, the interactive picker) keeps its existing
+      // default rather than opting installs into the pricier model. Live
+      // model id (not `-2-preview`) verified against
+      // generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2
+      // with GOOGLE_GENERATIVE_AI_API_KEY; embedding at output_dimensionality
+      // 768 round-tripped correctly.
+      models: ['gemini-embedding-001', 'gemini-embedding-2'],
       default_dims: 768,
       dims_options: [768, 1536, 3072],
+      // Display hint for `gbrain providers` only (billing math goes through
+      // src/core/embedding-pricing.ts, which prices both models); reflects
+      // -001, models[0].
       cost_per_1m_tokens_usd: 0.15,
       price_last_verified: '2026-04-20',
       // Gemini's embedding endpoint has a low per-request cap relative to
@@ -54,6 +68,9 @@ export const google: Recipe = {
       // 20k budget × 0.8 safety keeps a batch well within request limits while
       // staying efficient. chars_per_token ~4 matches Gemini's SentencePiece
       // density on English. Tunable; recursion stays the backstop.
+      // (gemini-embedding-2's real per-input cap is 8,192 — 4x this budget —
+      // but this recipe doesn't yet declare a per-model max_input_tokens
+      // override, so both models share this conservative batching today.)
       max_batch_tokens: 20_000,
       chars_per_token: 4,
       safety_factor: 0.8,

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -62,6 +62,13 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   'voyage:voyage-3':               { pricePerMTok: 0.06 },
   'voyage:voyage-3-lite':          { pricePerMTok: 0.02 },
   'voyage:voyage-code-3':          { pricePerMTok: 0.18 },
+  // Google (https://ai.google.dev/gemini-api/docs/pricing, verified 2026-09-09).
+  // Paid-tier standard rate; the free tier has no per-token charge. The two
+  // models are separately priced (not aliases of one rate) — gemini-embedding-2
+  // costs 33% more per text token but adds native multimodal input and a 4x
+  // input-token limit over -001.
+  'google:gemini-embedding-001':   { pricePerMTok: 0.15 },
+  'google:gemini-embedding-2':     { pricePerMTok: 0.20 },
   // ZeroEntropy (https://www.zeroentropy.dev/pricing, verified 2026-07-28)
   'zeroentropyai:zembed-1':        { pricePerMTok: 0.05 },
   // ZeroEntropy reranker (docs/ai-providers/zeroentropy.md — $0.025/1M tokens).

--- a/test/embedding-pricing.test.ts
+++ b/test/embedding-pricing.test.ts
@@ -48,6 +48,19 @@ describe('lookupEmbeddingPrice — first-class providers', () => {
     expect(r.kind).toBe('known');
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(0.05);
   });
+
+  // Google, verified against ai.google.dev/gemini-api/docs/pricing 2026-09-09.
+  // Both models are native to the `google` recipe's embedding touchpoint —
+  // neither had a pricing-table row before, so `migrate embeddings --to
+  // google:<model>` always reported "estimated cost: unknown".
+  test.each([
+    ['google:gemini-embedding-001', 0.15],
+    ['google:gemini-embedding-2', 0.20],
+  ])('Google %s at $%d/MTok', (model, expected) => {
+    const r = lookupEmbeddingPrice(model);
+    expect(r.kind).toBe('known');
+    if (r.kind === 'known') expect(r.pricePerMTok).toBe(expected);
+  });
 });
 
 describe('lookupEmbeddingPrice — fall-through behavior', () => {
@@ -208,5 +221,20 @@ describe('#4344 — every hosted voyage recipe model has a pricing entry', () =>
     const r = lookupEmbeddingPrice(model);
     expect(r.kind).toBe('known');
     if (r.kind === 'known') expect(r.pricePerMTok).toBe(expected);
+  });
+});
+
+// Same coverage gate as #4344, for the `google` recipe: both
+// gemini-embedding-001 and gemini-embedding-2 are HOSTED models the recipe
+// offers, and until this change neither had a pricing row — every
+// `migrate embeddings --to google:<model>` cost estimate read "unknown".
+describe('every hosted google recipe model has a pricing entry', () => {
+  test('recipe models ⊆ pricing table', async () => {
+    const { google } = await import('../src/core/ai/recipes/google.ts');
+    const models: string[] = (google as any).touchpoints.embedding.models;
+    expect(models).toContain('gemini-embedding-001');
+    expect(models).toContain('gemini-embedding-2');
+    const missing = models.filter((m) => lookupEmbeddingPrice(`google:${m}`).kind !== 'known');
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The `google` recipe's embedding touchpoint only ever declared `gemini-embedding-001`, and **neither** Google model had a row in `embedding-pricing.ts` — so `migrate embeddings --to google:<model>` always printed "estimated cost: unknown" for a first-class native recipe, and `gemini-embedding-2` (GA 2026-05-20, now Google's own recommended default — 4x input context, native multimodal input) couldn't be selected from the models list at all.

- `src/core/ai/recipes/google.ts`: add `gemini-embedding-2` to the embedding touchpoint's `models`. Kept **second** — `models[0]` stays `gemini-embedding-001`, so every "pick a model for the user" surface (new-install auto-pick, the interactive picker) keeps its existing default rather than silently opting installs into the pricier model.
- `src/core/embedding-pricing.ts`: price both models against [ai.google.dev/gemini-api/docs/pricing](https://ai.google.dev/gemini-api/docs/pricing) (verified 2026-09-09): `gemini-embedding-001` $0.15/1M, `gemini-embedding-2` $0.20/1M (text).
- `test/embedding-pricing.test.ts`: pin both prices, and add the same hosted-recipe coverage gate #4344 already runs for Voyage ("every model this recipe declares has a pricing row"), for Google.

Live-verified the model id and 768d `outputDimensionality` round-trip directly against `generativelanguage.googleapis.com` with a real API key before relying on it — this is `gemini-embedding-2` (GA), not `gemini-embedding-2-preview`, which is a distinct, narrower id some third-party proxies (e.g. OpenRouter) list instead.

Found this while migrating a downstream deployment off a too-slow local `ollama:nomic-embed-text` setup onto hosted Google embeddings, and noticing the cost estimate was unavailable for either Google model, not just the new one.

## Test plan

- [x] `bun test test/embedding-pricing.test.ts` — 37 pass
- [x] `bun test test/ai/` — 631 pass, 0 fail (no regressions from the recipe edit)
- [x] `bun run typecheck` — clean
- [x] `bun run verify` — 54/54 checks green
- [x] Live-verified `gemini-embedding-2` against the real Gemini API (768d output, key-authenticated) before declaring it