### PR TITLE
v0.48.5.4 fix(write-through): commit page removals on durability-hardened brains (#4993)

### DIFF
--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -446,14 +446,23 @@ export function isDurabilityHardened(repoPath: string): boolean {
  * never swept into the commit. Never throws; returns false on any failure
  * (index.lock contention, nothing changed, detached states) — the DB row and
  * the on-disk file remain the durable sinks either way.
+ *
+ * `git add -- <path>` stages a removal as readily as an edit, so
+ * `deletePageThrough` reuses this helper with `action: 'delete write-through'`
+ * — same hardening gate, same explicit-path discipline, distinct subject line.
  */
-export function commitWriteThroughFile(repoPath: string, absPath: string, slug: string): boolean {
+export function commitWriteThroughFile(
+  repoPath: string,
+  absPath: string,
+  slug: string,
+  action: 'write-through' | 'delete write-through' = 'write-through',
+): boolean {
   try {
     const rel = relative(repoPath, absPath);
     if (!rel || rel.startsWith('..') || isAbsolute(rel)) return false;
     const gitOpts = { stdio: 'ignore', timeout: 30_000, env: { ...process.env, ...GIT_ENV } } as const;
     execFileSync('git', ['-C', repoPath, 'add', '--', rel], gitOpts);
-    execFileSync('git', ['-C', repoPath, 'commit', '-m', `gbrain: write-through ${slug}`, '--', rel], gitOpts);
+    execFileSync('git', ['-C', repoPath, 'commit', '-m', `gbrain: ${action} ${slug}`, '--', rel], gitOpts);
     return true;
   } catch {
     return false;

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -489,6 +489,13 @@ export interface DeleteThroughResult {
   /** The path that was removed (or would have been). */
   path?: string;
   /**
+   * True when the removal was also committed (path-limited) because the repo
+   * is durability-hardened — the delete-side twin of
+   * `WriteThroughResult.committed`. Absent on unhardened repos and when the
+   * best-effort commit did not land (the unlink still stands).
+   */
+  committed?: boolean;
+  /**
    * Non-error reasons nothing was removed. Shares the target-resolution skip
    * vocabulary (kept in lockstep via the Extract), plus:
    *   - disabled_by_config: the operator opted the brain out of the disk sink.
@@ -538,14 +545,27 @@ export async function deletePageThrough(
     }
     const target = opts.target ?? await resolvePageWriteTarget(engine, slug, sourceId);
     if (!target.ok) return { removed: false, skipped: target.skipped };
-    const { filePath } = target;
+    const { filePath, writeRoot } = target;
 
     if (!existsSync(filePath)) {
       return { removed: false, path: filePath, skipped: 'file_not_present' };
     }
 
     unlinkSync(filePath);
-    return { removed: true, path: filePath };
+    // Mirror writePageThrough (#2426): on a durability-hardened repo, commit
+    // the removal (path-limited) so the post-commit hook pushes it. Pre-fix
+    // the deletion sat in the working tree as an uncommitted ` D` — invisible
+    // to commit-driven sync (the autopilot's own sync then warned "N
+    // uncommitted file(s) invisible to commit-driven sync") until a human
+    // committed it by hand. Best-effort, like the write side: a commit failure
+    // never fails the delete (the DB row + the unlink are the durable state).
+    let committed = false;
+    try {
+      if (isDurabilityHardened(writeRoot)) {
+        committed = commitWriteThroughFile(writeRoot, filePath, slug, 'delete write-through');
+      }
+    } catch { /* best-effort */ }
+    return { removed: true, path: filePath, ...(committed ? { committed } : {}) };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     opts.logger?.warn(`[write-through] delete failed for ${slug}: ${msg}`);

--- a/test/delete-write-through-commit.serial.test.ts
+++ b/test/delete-write-through-commit.serial.test.ts
@@ -1,0 +1,143 @@
+/**
+ * deletePageThrough reaches git on durability-hardened repos.
+ *
+ * Bug class (the delete-side twin of #2426): `delete_page` unlinked the
+ * write-through `.md` in `sync.repo_path` but NOTHING ever committed the
+ * removal. The post-commit hook only fires after a commit, so the deletion sat
+ * in the working tree as an uncommitted ` D` — invisible to commit-driven
+ * sync, which then warned "N uncommitted file(s) invisible to commit-driven
+ * sync" every tick until a human committed it by hand.
+ *
+ * Fix: `deletePageThrough` best-effort commits the removal (path-limited) when
+ * the repo carries the gbrain durability post-commit hook, exactly as
+ * `writePageThrough` does for writes. Unhardened repos keep the old
+ * unlink-only behavior.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync, existsSync } from 'fs';
+import { execSync, execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { writePageThrough, deletePageThrough } from '../src/core/write-through.ts';
+
+let engine: PGLiteEngine;
+let repo: string;
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', ['-C', cwd, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8',
+  }).trim();
+}
+
+/** Hook file carrying the gbrain durability banner (what `isDurabilityHardened`
+ *  looks for) with a no-op body so tests never attempt a real push. */
+function installFakeDurabilityHook(repoPath: string): void {
+  const hooksDir = join(repoPath, '.git', 'hooks');
+  mkdirSync(hooksDir, { recursive: true });
+  const hookPath = join(hooksDir, 'post-commit');
+  writeFileSync(hookPath, [
+    '#!/usr/bin/env bash',
+    '# gbrain brain-durability post-commit hook (v0.42.44+)',
+    'exit 0',
+    '',
+  ].join('\n'));
+  chmodSync(hookPath, 0o755);
+}
+
+async function seedPage(slug: string): Promise<void> {
+  await engine.putPage(slug, {
+    type: 'concept',
+    title: 'Page that will be deleted',
+    compiled_truth: 'Content whose removal must reach git.',
+    timeline: '',
+    frontmatter: { type: 'concept' },
+  });
+}
+
+describe('deletePageThrough auto-commit on durability-hardened repos', () => {
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  }, 60_000);
+
+  afterAll(async () => {
+    if (engine) await engine.disconnect();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    repo = mkdtempSync(join(tmpdir(), 'gbrain-dwt-'));
+    execSync('git init', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.email "t@t.t"', { cwd: repo, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repo, stdio: 'pipe' });
+    writeFileSync(join(repo, 'seed.md'), 'seed\n');
+    execSync('git add -A && git commit -m init', { cwd: repo, stdio: 'pipe' });
+    await engine.setConfig('sync.repo_path', repo);
+  });
+
+  afterEach(() => {
+    if (repo) rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('on a hardened repo, the removal is committed (path-limited)', async () => {
+    installFakeDurabilityHook(repo);
+    await seedPage('notes/hello');
+    const written = await writePageThrough(engine, 'notes/hello');
+    expect(written.committed).toBe(true);
+    // Unrelated dirty edit — must NOT be swept into the delete commit.
+    writeFileSync(join(repo, 'seed.md'), 'dirty unrelated edit\n');
+
+    const result = await deletePageThrough(engine, 'notes/hello');
+
+    expect(result.removed).toBe(true);
+    expect(result.committed).toBe(true);
+    expect(existsSync(join(repo, 'notes', 'hello.md'))).toBe(false);
+    // The removal is committed…
+    expect(git(repo, 'log', '-1', '--format=%s')).toBe('gbrain: delete write-through notes/hello');
+    expect(git(repo, 'log', '-1', '--name-only', '--format=')).toBe('notes/hello.md');
+    expect(git(repo, 'status', '--porcelain', 'notes/hello.md')).toBe('');
+    // …and the unrelated edit stays uncommitted (explicit-path discipline).
+    expect(git(repo, 'status', '--porcelain', 'seed.md')).not.toBe('');
+  }, 60_000);
+
+  test('on an unhardened repo, the file is unlinked but NOT committed (no behavior change)', async () => {
+    await seedPage('notes/plain');
+    await writePageThrough(engine, 'notes/plain');
+    // Track the page so the unlink shows up as a working-tree deletion.
+    execSync('git add -A && git commit -m seed-page', { cwd: repo, stdio: 'pipe' });
+
+    const result = await deletePageThrough(engine, 'notes/plain');
+
+    expect(result.removed).toBe(true);
+    expect(result.committed).toBeUndefined();
+    expect(existsSync(join(repo, 'notes', 'plain.md'))).toBe(false);
+    // Deleted in the working tree, uncommitted — the pre-existing contract.
+    // (`git()` trims, so porcelain's leading worktree-column space is gone.)
+    expect(git(repo, 'status', '--porcelain', 'notes/plain.md')).toMatch(/^ ?D notes\/plain\.md$/);
+    expect(git(repo, 'log', '-1', '--format=%s')).toBe('seed-page');
+  }, 60_000);
+
+  test('hardened AFTER the write: the never-committed page is unlinked with nothing to commit (no empty commit)', async () => {
+    // Written while unhardened → the artifact is untracked (pre-#2426 contract).
+    await seedPage('notes/late');
+    const written = await writePageThrough(engine, 'notes/late');
+    expect(written.committed).toBeUndefined();
+    expect(git(repo, 'status', '--porcelain', 'notes/late.md')).toContain('?? notes/late.md');
+    // Harden between the write and the delete.
+    installFakeDurabilityHook(repo);
+
+    const result = await deletePageThrough(engine, 'notes/late');
+
+    expect(result.removed).toBe(true);
+    expect(existsSync(join(repo, 'notes', 'late.md'))).toBe(false);
+    // `git add -- <vanished untracked path>` fails → the best-effort commit
+    // reports false → no `committed`, no empty commit, and nothing left behind.
+    expect(result.committed).toBeUndefined();
+    expect(git(repo, 'status', '--porcelain')).toBe('');
+    expect(git(repo, 'log', '-1', '--format=%s')).toBe('init');
+  }, 60_000);
+});


### PR DESCRIPTION
## What

`deletePageThrough` now commits the removal — path-limited, best-effort — when the brain repo carries the gbrain durability post-commit hook, exactly what `writePageThrough` has done for writes since #2426 and what cycle lint does for its auto-fixes since #4815. Subject line: `gbrain: delete write-through <slug>`. `DeleteThroughResult` gains `committed?: boolean`, the delete-side twin of `WriteThroughResult.committed`. Unhardened repos are unchanged (unlink only). Fixes #4993.

## Why

On a hardened brain, a `delete_page` left an uncommitted ` D <slug>.md` in `sync.repo_path`. Nothing ever committed it, so the post-commit hook never pushed it and commit-driven sync could not see it; the autopilot's sync phase warned "N uncommitted file(s) are invisible to commit-driven sync" on every tick until a human committed by hand. Same failure class as #2426 (writes) and #4815 (lint fixes); this closes the last write-through sink that still left the tree dirty.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/write-through.ts src/core/brain-repo-durability.ts` to merge-base, ran `test/delete-write-through-commit.serial.test.ts` → 2 pass / 1 fail. Restored → all pass.

## Tests

- New `test/delete-write-through-commit.serial.test.ts`, mirroring `write-through-commit.serial.test.ts`, three cases: hardened repo → removal committed path-limited with an unrelated dirty edit left uncommitted; unhardened repo → file unlinked, nothing committed, ` D` in the working tree; hardened *after* the write → the never-committed (untracked) page is unlinked, `git add` of the vanished path fails so the best-effort commit reports false, no empty commit, clean tree.
- `bun test` over the write-through, fence-write and timeline-write-through suites: 94 pass / 0 fail. `bun run verify`: 54/54 green.
- Verified on a live hardened brain: `put_page` then `delete_page` over MCP now yields a `gbrain: delete write-through <slug>` commit and a clean working tree.

## Changes

- `src/core/brain-repo-durability.ts` — `commitWriteThroughFile(repoPath, absPath, slug, action = 'write-through')`: optional subject-line label. All existing callers unchanged.
- `src/core/write-through.ts` — `deletePageThrough` commits after `unlinkSync` when hardened; the result carries `committed: true` when it landed.

No version or CHANGELOG bump in this PR (left to the release wave per `docs/RELEASING.md`); the title carries the next free micro.
