### PR TITLE
fix(migrations): never record a failed phase as complete

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -15,7 +15,7 @@
 import { VERSION } from '../version.ts';
 import { loadConfig } from '../core/config.ts';
 import { loadCompletedMigrations, appendCompletedMigration, type CompletedMigrationEntry } from '../core/preferences.ts';
-import { migrations, compareVersions, type Migration, type OrchestratorOpts } from './migrations/index.ts';
+import { migrations, compareVersions, type Migration, type OrchestratorOpts, type OrchestratorResult } from './migrations/index.ts';
 import {
   indexCompletedEntries,
   statusForVersion as ledgerStatusForVersion,
@@ -137,6 +137,24 @@ function statusForVersion(
   idx: CompletedIndex,
 ): 'complete' | 'partial' | 'pending' | 'wedged' {
   return ledgerStatusForVersion(version, idx.byVersion);
+}
+
+/**
+ * Ledger status to record for a finished orchestrator run.
+ *
+ * Invariant: `complete` is never recorded over a failed phase.
+ * `statusForVersion`'s "complete wins" rule is deliberate, so such a row is
+ * permanently unretryable — the failed phase becomes unreachable by the
+ * documented repair (`gbrain apply-migrations --yes`) and the only evidence is
+ * a downstream symptom. Orchestrators are each expected to sweep their own
+ * phases, but several derive status without it, so the invariant is enforced
+ * at the single write site instead of at eighteen call sites.
+ *
+ * Exported for unit tests.
+ */
+export function resolveRecordStatus(result: OrchestratorResult): 'complete' | 'partial' {
+  if (result.status === 'partial') return 'partial';
+  return result.phases.some(p => p.status === 'failed') ? 'partial' : 'complete';
 }
 
 interface Plan {
@@ -527,13 +545,33 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
         break;
       }
 
+      // Class-level invariant: `complete` must never be recorded over a
+      // failed phase. `statusForVersion`'s "complete wins" rule is
+      // deliberate, so such a row is permanently unretryable — the failed
+      // phase becomes unreachable by the documented repair and the only
+      // evidence is a downstream symptom. Orchestrators are each expected to
+      // sweep their own phases (v0_12_0 / v0_28_0 do), but several derive
+      // status without it, so enforce the invariant at the single write site
+      // rather than trusting eighteen call sites to remember.
+      const failedPhases = result.phases.filter(p => p.status === 'failed');
+      const recordStatus = resolveRecordStatus(result);
+      if (recordStatus !== result.status && failedPhases.length > 0) {
+        console.error(
+          `Migration v${m.version} reported ${result.status} but ${failedPhases.length} phase(s) failed; ` +
+            `recording as partial so \`gbrain apply-migrations --yes\` retries it.`,
+        );
+        for (const p of failedPhases) {
+          console.error(`  phase ${p.name}: ${p.detail ?? '(no detail)'}`);
+        }
+      }
+
       // Persist the terminal outcome. appendCompletedMigration no-ops when
       // the last entry for this version is already 'complete' (idempotency
       // guard), so repeated clean runs don't spam the ledger.
       try {
         appendCompletedMigration({
           version: m.version,
-          status: result.status, // 'complete' | 'partial'
+          status: recordStatus, // 'complete' | 'partial'
           phases: result.phases,
           files_rewritten: result.files_rewritten,
           autopilot_installed: result.autopilot_installed,
@@ -547,7 +585,7 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
         break;
       }
 
-      if (result.status === 'partial') {
+      if (recordStatus === 'partial') {
         console.log(`Migration v${m.version} finished as PARTIAL. Re-run \`gbrain apply-migrations --yes\` after resolving any pending host-work items.`);
       } else {
         console.log(`Migration v${m.version} complete.`);
@@ -570,6 +608,7 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
 /** Exported for unit tests only. Do not use from production code. */
 export const __testing = {
   parseArgs,
+  resolveRecordStatus,
   buildPlan,
   indexCompleted,
   statusForVersion,

--- a/src/commands/migrations/v0_11_0.ts
+++ b/src/commands/migrations/v0_11_0.ts
@@ -452,8 +452,26 @@ async function orchestrator(opts: OrchestratorOpts): Promise<OrchestratorResult>
   // Bug 3 — Phase G (record in completed.jsonl) moved to the runner. The
   // runner in apply-migrations.ts persists the result after orchestrator
   // returns, so we just decide the status here.
-  const status: 'complete' | 'partial' = (pending_host_work > 0) ? 'partial' : 'complete';
+  // A failed phase must never record as `complete`. The runner's ledger write
+  // is what `apply-migrations` diffs against, and `statusForVersion`'s
+  // "complete wins" rule then makes the documented repair
+  // (`gbrain apply-migrations --yes`, advertised as idempotent and safe to
+  // re-run) a permanent no-op — the failed phase becomes unreachable. Phases
+  // A-D early-return on failure; E and F do not, so sweep every recorded
+  // phase here. `partial` (not `failed`) is the right verdict: the migration
+  // made real progress, `partial` is the resume-missing-phases state the
+  // runner retries, and MAX_CONSECUTIVE_PARTIALS stays the backstop against
+  // retrying forever. Matches the sweep in v0_12_0 / v0_28_0.
+  const failedPhases = phases.filter(p => p.status === 'failed');
+  const status = deriveOverallStatus(phases, pending_host_work);
   phases.push({ name: 'record', status: opts.dryRun ? 'skipped' : 'complete', detail: `status=${status} (ledger write in runner)` });
+
+  // #921 surfaces phase detail on stderr for status=failed; a
+  // partial-with-failures needs the same visibility, or the operator sees only
+  // a cheerful "finished as PARTIAL" and never learns which phase died.
+  for (const p of failedPhases) {
+    console.error(`Phase ${p.name} failed: ${p.detail ?? '(no detail)'}`);
+  }
 
   // Post-run: print pending-host-work summary if anything needs host action.
   if (pending_host_work > 0) {
@@ -479,6 +497,25 @@ async function orchestrator(opts: OrchestratorOpts): Promise<OrchestratorResult>
   };
 }
 
+/**
+ * Overall status for the v0.11.0 run.
+ *
+ * `partial` when host work remains (the original rule) OR when any recorded
+ * phase failed. The second clause is load-bearing: phases A-D early-return on
+ * failure but E and F do not, so without the sweep a failed autopilot install
+ * recorded as `complete` — and `statusForVersion`'s "complete wins" rule then
+ * made the failure permanently unretryable.
+ *
+ * Exported for unit tests.
+ */
+export function deriveOverallStatus(
+  phases: OrchestratorPhaseResult[],
+  pendingHostWork: number,
+): 'complete' | 'partial' {
+  if (pendingHostWork > 0) return 'partial';
+  return phases.some(p => p.status === 'failed') ? 'partial' : 'complete';
+}
+
 export const v0_11_0: Migration = {
   version: '0.11.0',
   featurePitch: {
@@ -495,6 +532,7 @@ export const v0_11_0: Migration = {
 
 /** Exported for unit tests. */
 export const __testing = {
+  deriveOverallStatus,
   injectAgentsMdMarker,
   rewriteCronManifest,
   phaseEHost,

--- a/test/migration-ledger-failed-phase.test.ts
+++ b/test/migration-ledger-failed-phase.test.ts
@@ -1,0 +1,116 @@
+/**
+ * A failed phase must never be recorded as `complete`.
+ *
+ * `statusForVersion` implements a deliberate "complete wins" rule: a later
+ * `partial` append cannot undo a completed migration. That safety rule turns
+ * a false-green ledger row into a permanent one — `apply-migrations` buckets
+ * the version as `applied` and only ever runs `[...partial, ...pending]`, so
+ * the failed phase is unreachable by the documented repair
+ * (`gbrain apply-migrations --yes`, advertised as idempotent and safe to
+ * re-run). The failure then shows up only as a downstream symptom.
+ *
+ * Two layers are covered:
+ *   - `deriveOverallStatus` — v0.11.0's own sweep (phases A-D early-return on
+ *     failure, E and F do not).
+ *   - `resolveRecordStatus` — the runner's class-level backstop, which holds
+ *     for every registered orchestrator including ones that derive status
+ *     without sweeping their phases.
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import { __testing as v11 } from '../src/commands/migrations/v0_11_0.ts';
+import { __testing as runner } from '../src/commands/apply-migrations.ts';
+import { statusForVersion, indexCompletedEntries } from '../src/core/migration-ledger.ts';
+import type { OrchestratorPhaseResult, OrchestratorResult } from '../src/commands/migrations/types.ts';
+
+const { deriveOverallStatus } = v11;
+const { resolveRecordStatus } = runner;
+
+const ok = (name: string): OrchestratorPhaseResult => ({ name, status: 'complete' });
+const failed = (name: string, detail = 'boom'): OrchestratorPhaseResult => ({ name, status: 'failed', detail });
+const skipped = (name: string): OrchestratorPhaseResult => ({ name, status: 'skipped' });
+
+function result(over: Partial<OrchestratorResult> = {}): OrchestratorResult {
+  return { version: '0.11.0', status: 'complete', phases: [ok('schema')], ...over };
+}
+
+describe('deriveOverallStatus — v0.11.0 phase sweep', () => {
+  test('clean run with no host work is complete', () => {
+    expect(deriveOverallStatus([ok('schema'), ok('prefs'), ok('install')], 0)).toBe('complete');
+  });
+
+  test('skipped phases do not make a run partial', () => {
+    // --no-autopilot-install and --dry-run both record `skipped`; neither is
+    // a failure and neither should block the ledger from completing.
+    expect(deriveOverallStatus([ok('schema'), skipped('install')], 0)).toBe('complete');
+  });
+
+  test('pending host work is partial (the original rule)', () => {
+    expect(deriveOverallStatus([ok('schema'), ok('host')], 3)).toBe('partial');
+  });
+
+  test('a failed install phase is partial, NOT complete', () => {
+    // The regression: Phase F failing while every other phase succeeded and
+    // no host work remained used to yield `complete`.
+    const phases = [ok('schema'), ok('smoke'), ok('mode'), ok('prefs'), ok('host'), failed('install')];
+    expect(deriveOverallStatus(phases, 0)).toBe('partial');
+  });
+
+  test('a failed host phase is partial too', () => {
+    expect(deriveOverallStatus([ok('schema'), failed('host')], 0)).toBe('partial');
+  });
+});
+
+describe('resolveRecordStatus — runner backstop', () => {
+  test('complete stays complete when no phase failed', () => {
+    expect(resolveRecordStatus(result({ phases: [ok('a'), skipped('b')] }))).toBe('complete');
+  });
+
+  test('an orchestrator reporting complete over a failed phase is downgraded', () => {
+    expect(resolveRecordStatus(result({ status: 'complete', phases: [ok('a'), failed('b')] }))).toBe('partial');
+  });
+
+  test('partial is preserved', () => {
+    expect(resolveRecordStatus(result({ status: 'partial', phases: [ok('a')] }))).toBe('partial');
+  });
+
+  test('holds for any orchestrator version, not just v0.11.0', () => {
+    const r = result({ version: '0.43.0', status: 'complete', phases: [failed('detect')] });
+    expect(resolveRecordStatus(r)).toBe('partial');
+  });
+});
+
+describe('why it matters — a false-green row is unretryable', () => {
+  test('"complete wins" makes a complete-over-failure row permanent', () => {
+    // This is the shape the bug wrote: status complete, install phase failed.
+    const falseGreen = [
+      { ts: '2026-01-01T00:00:00.000Z', version: '0.11.0', status: 'complete' as const,
+        phases: [ok('schema'), failed('install')] },
+    ];
+    expect(statusForVersion('0.11.0', indexCompletedEntries(falseGreen))).toBe('complete');
+
+    // Appending a later partial cannot rescue it — by design.
+    const withPartial = [...falseGreen,
+      { ts: '2026-01-02T00:00:00.000Z', version: '0.11.0', status: 'partial' as const, phases: [] }];
+    expect(statusForVersion('0.11.0', indexCompletedEntries(withPartial))).toBe('complete');
+  });
+
+  test('recording partial instead keeps the migration retryable', () => {
+    const honest = [
+      { ts: '2026-01-01T00:00:00.000Z', version: '0.11.0', status: 'partial' as const,
+        phases: [ok('schema'), failed('install')] },
+    ];
+    expect(statusForVersion('0.11.0', indexCompletedEntries(honest))).toBe('partial');
+  });
+
+  test('an existing false-green row is recoverable only via an explicit retry marker', () => {
+    // Documented escape hatch for brains already carrying a bad row.
+    const withRetry = [
+      { ts: '2026-01-01T00:00:00.000Z', version: '0.11.0', status: 'complete' as const,
+        phases: [failed('install')] },
+      { ts: '2026-01-02T00:00:00.000Z', version: '0.11.0', status: 'retry' as const },
+    ];
+    expect(statusForVersion('0.11.0', indexCompletedEntries(withRetry as never))).toBe('pending');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4998.

A migration phase that fails is currently recorded as `status: "complete"`.
`statusForVersion`'s "complete wins" rule — correct in itself — then makes that
row permanent, so `gbrain apply-migrations --yes` can never retry the failed
phase. The documented repair becomes a guaranteed no-op and the install stays
half-finished, with the failure visible only as a downstream symptom.

This records `partial` instead whenever any phase failed. `partial` is already
the resume-missing-phases state the runner retries, and
`MAX_CONSECUTIVE_PARTIALS` remains the backstop against retrying forever, so no
new state or config is introduced.

## What changed

Two layers, deliberately:

**`src/commands/migrations/v0_11_0.ts`** — the orchestrator now sweeps its own
phases, matching the existing idiom in `v0_12_0.ts:224` and `v0_28_0.ts:219`:

```ts
export function deriveOverallStatus(
  phases: OrchestratorPhaseResult[],
  pendingHostWork: number,
): 'complete' | 'partial' {
  if (pendingHostWork > 0) return 'partial';
  return phases.some(p => p.status === 'failed') ? 'partial' : 'complete';
}
```

Phases A–D early-return on failure; E and F did not, and Phase F's result was
consumed only by `autopilot_installed`. Failed phases are also now printed to
stderr, mirroring what #921 already does for `status: 'failed'` — without it the
operator sees a cheerful "finished as PARTIAL" and never learns which phase died.

**`src/commands/apply-migrations.ts`** — the same invariant at the single ledger
write site, so it holds for every registered orchestrator:

```ts
export function resolveRecordStatus(result: OrchestratorResult): 'complete' | 'partial' {
  if (result.status === 'partial') return 'partial';
  return result.phases.some(p => p.status === 'failed') ? 'partial' : 'complete';
}
```

The runner already handled `result.status === 'failed'` properly (records
`partial`, prints each failed phase, exits 1) — that branch was simply
unreachable for this class, because the orchestrator self-reported `complete`.
Of the eighteen registered orchestrators, several derive status without
sweeping their phases, so enforcing it once at the write site seemed better
than trusting each one to remember. If you would rather keep the fix minimal,
this half is separable and the v0_11_0 change alone closes the reported bug.

### Back-compat

- No schema, config, CLI or output-format change.
- `skipped` phases are unaffected — `--dry-run` and `--no-autopilot-install`
  both record `skipped`, neither is a failure, and neither blocks completion.
  Covered by a test.
- A clean run still records `complete` and `appendCompletedMigration` still
  no-ops on repeat, so the ledger does not grow on healthy re-runs.

### One thing this does not do

**Existing false-green rows are not repaired.** "Complete wins" is deliberate,
and silently rewriting history on upgrade felt worse than leaving it. Affected
brains need the existing escape hatch — a trailing `status: "retry"` entry for
the version — which `statusForVersion` honours but `docs/guides/minions-fix.md`
does not currently mention. Happy to add either a doctor check
(`complete` row carrying a failed phase → advise the retry marker) or the
documentation line, in this PR or a follow-up, whichever you prefer. I did not
want to guess at a migration-repairing-migration without a maintainer's view.

## Tests

`test/migration-ledger-failed-phase.test.ts` — 12 tests, three groups:

- `deriveOverallStatus` — clean/skipped/host-work/failed-install/failed-host.
  The regression case is a run where every phase but `install` succeeded and no
  host work remained: previously `complete`, now `partial`.
- `resolveRecordStatus` — the runner backstop, including that it holds for a
  non-v0.11.0 orchestrator version.
- "why it matters" — asserts the read-side consequence directly: a
  complete-over-failure row stays `complete` even after a later `partial` is
  appended, an honest `partial` row stays retryable, and a trailing `retry`
  marker returns the version to `pending`. These lock in the reason the fix is
  needed, not just its mechanics.

```
12 pass, 0 fail
```

## Verification

- `bun run typecheck` clean.
- Existing suites over the touched paths pass: `apply-migrations`,
  `migrations-v0_11_0`, `migration-ledger`, `migration-resume`,
  `migrations-registry`, `doctor-minions-check`.
- Verified against the live install that surfaced this: the failed Phase F
  re-ran successfully once invoked directly, autopilot installed as a systemd
  user service, the worker drained all five backlogged `facts-absorb` jobs, and
  `wedged_queue` returned to OK.

Test caveat, in the interests of honesty: this ran on a WSL setup reading the
repo over `/mnt/c`, which is slow enough that several scan-heavy tests in the
full suite time out at their 5s limit **on clean master as well**, and the
`serial-files` contract cannot run `git ls-files` against a Windows-hosted
worktree. Those failures are environmental and present on the baseline; I have
not counted them as introduced.

## Not included

No VERSION, `package.json`, CHANGELOG, `llms-full.txt`, plugin-tree or
`admin/dist` changes — CONTRIBUTING indicates community PRs are batched into
release waves with the maintainer assigning the version, so the PR title
carries no `vX.Y.Z.W` prefix either. Retitle freely if you would rather it did.
