### PR TITLE
fix(sync): persist include_hidden so --all, autopilot and dream honor the waiver

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1749,6 +1749,36 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     }
   } catch { /* config unreadable — never break a sync over the scope read */ }
 
+  // #4901: the same persisted-scope treatment for the WAIVER that `sync.exclude`
+  // above gets for the narrowing.
+  //
+  // `--include-hidden` is per-invocation, so only a CLI caller could ever admit a
+  // committed dot-directory; autopilot, minion sync jobs and the dream cycle have
+  // nowhere to put one. And `sync --all` REFUSES the flag outright ("they cannot
+  // be combined with --all"), which is the form a scheduled sync actually uses —
+  // so the waiver could not be expressed at all on the only path that runs
+  // unattended.
+  //
+  // THE DEFAULT DOES NOT MOVE: an unset key admits nothing, exactly as today.
+  // This is plumbing for an opt-in that already exists, not the product decision
+  // about indexing dot-directories by default, which #4901 leaves open.
+  //
+  // Union, not override, and the same dialect and trailing-slash normalization as
+  // `exclude` — an ad-hoc flag widens further but never silently closes a scope
+  // the operator persisted. Best-effort read for the same reason: a config the
+  // engine cannot serve must not break a sync.
+  try {
+    const storedHidden = await engine.getConfig('sync.include_hidden');
+    const hiddenPatterns = (storedHidden ?? '')
+      .split(/[\n,]/)
+      .map(p => p.trim())
+      .filter(Boolean)
+      .map(p => (p.endsWith('/') ? `${p}**` : p));
+    if (hiddenPatterns.length > 0) {
+      opts = { ...opts, includeHidden: [...new Set([...(opts.includeHidden ?? []), ...hiddenPatterns])] };
+    }
+  } catch { /* config unreadable — never break a sync over the scope read */ }
+
   // #1970: bookmark reachability. The ONLY thing that should force a full
   // reconcile is a truly-absent object; a present-but-non-ancestor bookmark
   // (history rewrite: force-push, master→main consolidation, squash) is still

--- a/test/sync-include-hidden-config.test.ts
+++ b/test/sync-include-hidden-config.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The hidden-path WAIVER must reach callers that never touch the CLI (#4901).
+ *
+ * `--include-hidden` is a per-invocation flag. `sync.exclude` already has a
+ * persisted twin so autopilot, minion sync jobs and the dream cycle inherit an
+ * operator's narrowing; the waiver has none, so an operator who wants a
+ * committed `.github/` indexed can say so on one code path and nowhere else.
+ *
+ * The gap is sharper than "less convenient". `sync --all` REFUSES the flag
+ * outright — "--src-subpath/--exclude/--include-hidden scope a single sync
+ * invocation; they cannot be combined with --all" — and `--all` is the form a
+ * scheduled sync uses. So today the waiver cannot be expressed at all on the
+ * only path that runs unattended.
+ *
+ * THE DEFAULT DOES NOT MOVE. An unset key admits nothing, exactly as today.
+ * This is the plumbing for an opt-in that already exists, not the product
+ * decision about whether dot-directories should be indexed by default, which
+ * #4901 leaves to the maintainer.
+ *
+ * Under test:
+ *   1. Baseline — with no config and no flag, a committed dot-directory is not
+ *      indexed. Without this, case 2 could pass because the file never landed.
+ *   2. `sync.include_hidden` is honored with NO flag passed.
+ *   3. A trailing slash is normalized to a subtree glob, as `sync.exclude` is:
+ *      `.github/` without the `**` matches the directory entry and none of the
+ *      files inside it — silent, and indistinguishable from the feature not
+ *      working.
+ *   4. A per-call flag UNIONS with the persisted waiver rather than replacing
+ *      it, so an ad-hoc admission never silently closes one the operator
+ *      persisted.
+ *   5. The waiver is scoped: a dot-directory the operator did NOT name stays
+ *      pruned. A test that only proves admission would pass on a change that
+ *      admits everything.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { performSync } from '../src/commands/sync.ts';
+import { runSources } from '../src/commands/sources.ts';
+
+let engine: PGLiteEngine;
+let repoPath: string;
+const SOURCE_ID = 'testsrc-inchid-cfg';
+
+function commitAll(msg: string): void {
+  execSync('git add -A', { cwd: repoPath, stdio: 'pipe' });
+  execSync(`git commit -m "${msg}"`, { cwd: repoPath, stdio: 'pipe' });
+}
+
+async function pageExists(slug: string): Promise<boolean> {
+  const rows = await engine.executeRaw<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM pages WHERE slug = $1 AND source_id = $2 AND deleted_at IS NULL`,
+    [slug, SOURCE_ID],
+  );
+  return Number(rows[0]?.n ?? 0) > 0;
+}
+
+/** No `includeHidden` key: this is exactly what an internal caller passes. */
+const baseOpts = () => ({
+  repoPath,
+  sourceId: SOURCE_ID,
+  noPull: true,
+  noEmbed: true,
+  noExtract: true,
+});
+
+describe('sync.include_hidden config reaches non-CLI callers', () => {
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    await runSources(engine, ['add', SOURCE_ID, '--no-federated']);
+
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-inchid-cfg-'));
+    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "t@t.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "T"', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'notes'), { recursive: true });
+    writeFileSync(join(repoPath, 'notes/base.md'), '# Base\n\ncommitted\n');
+    commitAll('base');
+
+    const first = await performSync(engine, baseOpts());
+    expect(first.status).toBe('first_sync');
+    expect(await pageExists('notes/base')).toBe(true);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (engine) await engine.disconnect();
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  }, 60_000);
+
+  test('baseline: with no config and no flag, a dot-directory is not indexed', async () => {
+    mkdirSync(join(repoPath, '.github/workflows'), { recursive: true });
+    writeFileSync(join(repoPath, '.github/workflows/ci.md'), '# CI\n\nbaseline\n');
+    writeFileSync(join(repoPath, 'notes/sibling.md'), '# Sibling\n\nindexed\n');
+    commitAll('dot-dir baseline');
+
+    await performSync(engine, baseOpts());
+
+    expect(await pageExists('.github/workflows/ci')).toBe(false);
+    // The control: the same commit's non-hidden file DID land, so a false in
+    // the line above is the prune and not a sync that did nothing.
+    expect(await pageExists('notes/sibling')).toBe(true);
+  }, 60_000);
+
+  test('persisted sync.include_hidden is honored with no flag passed', async () => {
+    await engine.setConfig('sync.include_hidden', '.github/');
+
+    writeFileSync(join(repoPath, '.github/workflows/release.md'), '# Release\n\nmust be indexed\n');
+    commitAll('release workflow');
+
+    await performSync(engine, baseOpts());
+
+    // The whole point: no caller passed --include-hidden, and the waiver held.
+    expect(await pageExists('.github/workflows/release')).toBe(true);
+  }, 60_000);
+
+  test('a trailing slash covers the files inside, not just the directory entry', async () => {
+    mkdirSync(join(repoPath, '.github/ISSUE_TEMPLATE'), { recursive: true });
+    writeFileSync(join(repoPath, '.github/ISSUE_TEMPLATE/bug.md'), '# Bug\n\nnested\n');
+    commitAll('nested template');
+
+    await performSync(engine, baseOpts());
+
+    // LOWERCASED, underscores kept: the slug for `.github/ISSUE_TEMPLATE/bug.md`
+    // is `.github/issue_template/bug`. The directory keeps GitHub's real casing
+    // on disk on purpose — asserting the on-disk spelling here is how this case
+    // first failed, and it read exactly like the waiver not reaching nested paths.
+    expect(await pageExists('.github/issue_template/bug')).toBe(true);
+  }, 60_000);
+
+  test('an unnamed dot-directory stays pruned', async () => {
+    // Scope, not blanket admission. Without this a change that waived every
+    // dot-prefixed directory would pass every case above.
+    mkdirSync(join(repoPath, '.vscode'), { recursive: true });
+    writeFileSync(join(repoPath, '.vscode/notes.md'), '# Editor\n\nmust stay out\n');
+    commitAll('vscode');
+
+    await performSync(engine, baseOpts());
+
+    expect(await pageExists('.vscode/notes')).toBe(false);
+  }, 60_000);
+
+  test('a per-call flag unions with the persisted waiver', async () => {
+    mkdirSync(join(repoPath, '.claude'), { recursive: true });
+    writeFileSync(join(repoPath, '.claude/adhoc.md'), '# Ad hoc\n\nadmitted by the flag\n');
+    writeFileSync(join(repoPath, '.github/workflows/union.md'), '# Union\n\nadmitted by the config\n');
+    commitAll('union case');
+
+    await performSync(engine, { ...baseOpts(), includeHidden: ['.claude/**'] });
+
+    // The flag admits its own path AND does not close the persisted one.
+    expect(await pageExists('.claude/adhoc')).toBe(true);
+    expect(await pageExists('.github/workflows/union')).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
Closes the plumbing half of #4901. **The default does not move**, which I think is what makes this separable from the product question you left open there.

## The gap

`--include-hidden` is per-invocation. `sync.exclude` already has a persisted twin — read in `performSyncInner`, unioned with the flag, trailing slash normalized to a subtree glob — so autopilot, minion sync jobs and the dream cycle inherit an operator's narrowing. The waiver has no twin, so an operator who wants a committed `.github/` indexed can say so on one code path and nowhere else.

It is sharper than "less convenient". `sync --all` refuses the flag outright:

```
--src-subpath/--exclude/--include-hidden scope a single sync invocation;
they cannot be combined with --all.
```

and `--all` is the form a scheduled sync uses — on my box a systemd timer running `gbrain sync --all --workers 1` every four hours. So today the waiver cannot be expressed at all on the only path that runs unattended.

## What this does

Reads `sync.include_hidden` exactly as `sync.exclude` is read ten lines above: same dialect, same `[\n,]` split, same trailing-slash normalization, same union-not-override, same best-effort `try`/`catch` so a config the engine cannot serve never breaks a sync.

## What this is not

It does not change what an unset key does. Nothing is admitted by default, no dot-directory starts indexing on its own, and there is no deny-list — the shape you objected to in the earlier patch. The product question #4901 raises, whether dot-directories should be indexed by default on `auto` sources, is untouched and still yours.

This is option (a) from your comment on #4903, taken as literally as I could.

## Test

`test/sync-include-hidden-config.test.ts`, modelled on `sync-exclude-config.test.ts`.

On master: **2 pass / 3 fail**. The two that pass are the controls — a dot-directory is not indexed without config, and an unnamed dot-directory stays pruned — which is what keeps the three reds from being a sync that simply did nothing.

| mutation | result |
|---|---|
| the config read deleted | 3 fail |
| union replaced by override | 1 fail (the union case only) |
| trailing-slash normalization dropped | 3 fail |

`typecheck` clean. `sync-exclude-config`, `sync-include-hidden` and `sync-index-matches-tree.serial` pass unchanged (22/22).

## One note for review

The slug for `.github/ISSUE_TEMPLATE/bug.md` is `.github/issue_template/bug`. The fixture keeps GitHub's real casing on disk and asserts the lowercased slug — asserting the on-disk spelling is how that case first failed for me, and it read exactly like the waiver failing to reach nested paths rather than like a wrong assertion.

Thanks for the detailed close on #4903 and #4904 — the reasoning about why the dot-directory admission was a default shift rather than a fix is what this PR is built on.
