### PR TITLE
v0.48.5.0 docs(auth): expose the existing owner admin login flow (#5007)

### DIFF
--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -109,6 +109,46 @@ and per-client config export.
 > stderr warning fires at startup). Multi-tenant deployments should leave it on
 > the redacted default.
 
+### Owner login links for AI agents
+
+**Say to your agent:** *"Give me the GBrain admin login link"* — the agent
+uses the existing HTTP mint endpoint described below.
+
+When an authenticated owner asks **"Give me the GBrain admin login link"**,
+use the existing single-use login flow. A static `/admin/` URL opens the login
+page; it does not authenticate the owner.
+
+1. Confirm the requesting owner and a private destination for the login link.
+2. Obtain the running server's bootstrap credential through the host's existing
+   protected credential mechanism. `GBRAIN_ADMIN_BOOTSTRAP_TOKEN` is the supported
+   deployment setting. Never expose its value in chat, logs, shell arguments,
+   or a URL. If the credential is unavailable, report that specific setup blocker;
+   do not claim the login-link capability is missing, scrape logs or process memory,
+   or silently replace the server's credential.
+3. Send `POST /admin/api/issue-magic-link` to the running server, with the
+   bootstrap credential in the `Authorization: Bearer` header through that
+   protected mechanism. An MCP client bearer token or client secret is not the
+   server bootstrap credential.
+4. The response contains `url` and `expires_in` (300 seconds). The returned URL
+   uses the server's configured `--public-url`; without it, the fallback is
+   localhost. Ensure the deployment has an owner-reachable public URL rather
+   than substituting a remembered tunnel address.
+5. Deliver the returned short-lived login link only to the requesting owner in
+   private. In a shared channel, acknowledge private delivery without reproducing
+   the link. Never put it into a public issue or commit.
+
+**Do not GET or fetch the generated login URL to verify it.** That redeems the
+single-use nonce before the owner can use it. Check the base `/admin/` page and
+non-secret response metadata separately. The link expires after five minutes,
+cannot be replayed, and is invalidated by a server restart. Successful redemption
+establishes the admin browser session and redirects to `/admin/`.
+
+This logs the owner into the dashboard; it does not create, reveal, or rotate an
+MCP client credential. Register the intended OAuth client separately in the
+credential-reveal screen below. For unattended deployments, provision the
+bootstrap credential through the operator's protected configuration before
+starting the server; generated secrets are deliberately hidden in captured logs.
+
 ### 2. Register OAuth clients
 
 Register clients from the **`/admin` dashboard**:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5014,6 +5014,46 @@ and per-client config export.
 > stderr warning fires at startup). Multi-tenant deployments should leave it on
 > the redacted default.
 
+### Owner login links for AI agents
+
+**Say to your agent:** *"Give me the GBrain admin login link"* — the agent
+uses the existing HTTP mint endpoint described below.
+
+When an authenticated owner asks **"Give me the GBrain admin login link"**,
+use the existing single-use login flow. A static `/admin/` URL opens the login
+page; it does not authenticate the owner.
+
+1. Confirm the requesting owner and a private destination for the login link.
+2. Obtain the running server's bootstrap credential through the host's existing
+   protected credential mechanism. `GBRAIN_ADMIN_BOOTSTRAP_TOKEN` is the supported
+   deployment setting. Never expose its value in chat, logs, shell arguments,
+   or a URL. If the credential is unavailable, report that specific setup blocker;
+   do not claim the login-link capability is missing, scrape logs or process memory,
+   or silently replace the server's credential.
+3. Send `POST /admin/api/issue-magic-link` to the running server, with the
+   bootstrap credential in the `Authorization: Bearer` header through that
+   protected mechanism. An MCP client bearer token or client secret is not the
+   server bootstrap credential.
+4. The response contains `url` and `expires_in` (300 seconds). The returned URL
+   uses the server's configured `--public-url`; without it, the fallback is
+   localhost. Ensure the deployment has an owner-reachable public URL rather
+   than substituting a remembered tunnel address.
+5. Deliver the returned short-lived login link only to the requesting owner in
+   private. In a shared channel, acknowledge private delivery without reproducing
+   the link. Never put it into a public issue or commit.
+
+**Do not GET or fetch the generated login URL to verify it.** That redeems the
+single-use nonce before the owner can use it. Check the base `/admin/` page and
+non-secret response metadata separately. The link expires after five minutes,
+cannot be replayed, and is invalidated by a server restart. Successful redemption
+establishes the admin browser session and redirects to `/admin/`.
+
+This logs the owner into the dashboard; it does not create, reveal, or rotate an
+MCP client credential. Register the intended OAuth client separately in the
+credential-reveal screen below. For unattended deployments, provision the
+bootstrap credential through the operator's protected configuration before
+starting the server; generated secrets are deliberately hidden in captured logs.
+
 ### 2. Register OAuth clients
 
 Register clients from the **`/admin` dashboard**:

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -10,6 +10,7 @@ test/apply-migrations.test.ts	resolveSchemaBehind (#1530)	5	readFileSync
 test/apply-migrations.test.ts	runApplyMigrations exit codes (v0.36.1.x #1062)	1	readFileSync
 test/archived-source-scoping.test.ts	#3880 structural pins — all-source local_path selections filter archived	2	readFileSync
 test/asymmetric-encoding-contract.test.ts	Source-text contract (cheap belt + suspenders)	3	readFileSync
+test/auth-admin-login-discovery.test.ts	(file-level)	5	readFileSync
 test/auto-link-targeted-probe-2544.test.ts	#2544 — auto-link behavior through put_page (targeted probe)	6	readFileSync
 test/autopilot-auto-drain-wiring.test.ts	autopilot auto-drain wiring	8	readFileSync
 test/autopilot-cycle-failure-classification.test.ts	autopilot cycle-failure classification — only 'failed' trips the circuit breaker	2	readFileSync

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1105,6 +1105,13 @@ export function parseAuthCreateArgs(rest: string[]): { name: string; takesHolder
 
 const AUTH_USAGE = `GBrain Token Management
 
+Admin dashboard login (running HTTP server):
+  For "Give me the GBrain admin login link", use POST /admin/api/issue-magic-link
+  with the server bootstrap credential through the host's protected credential flow.
+  It returns a five-minute, single-use owner login link. Deliver it privately;
+  do not GET the generated link to check it. A static /admin/ URL only opens the login page.
+  This does not create an MCP bearer token. See docs/mcp/DEPLOY.md.
+
 Usage:
   gbrain auth create <name> [--takes-holders world,garry,brain] [--scopes read,write]
                                                           Create a legacy bearer token. v0.28: --takes-holders

--- a/test/auth-admin-login-discovery.test.ts
+++ b/test/auth-admin-login-discovery.test.ts
@@ -1,0 +1,38 @@
+// test-reads-source-ok: this documentation/help discoverability contract checks source spelling intentionally; the existing endpoint registration anchors the documented route.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const read = (relative: string) => readFileSync(new URL(relative, import.meta.url), 'utf8');
+const deploy = read('../docs/mcp/DEPLOY.md');
+const auth = read('../src/commands/auth.ts');
+const server = read('../src/commands/serve-http.ts');
+
+describe('admin login-link discoverability', () => {
+  test('documents the owner request and existing mint endpoint', () => {
+    expect(deploy).toContain('Give me the GBrain admin login link');
+    expect(deploy).toContain('POST /admin/api/issue-magic-link');
+    expect(server).toContain("app.post('/admin/api/issue-magic-link'");
+  });
+  test('auth help points to the owner login flow without inventing a CLI command', () => {
+    expect(auth).toContain('Admin dashboard login (running HTTP server):');
+    expect(auth).toContain('POST /admin/api/issue-magic-link');
+    expect(auth).toContain('See docs/mcp/DEPLOY.md.');
+  });
+  test('warns against consuming the nonce during link verification', () => {
+    expect(deploy).toContain('Do not GET or fetch the generated login URL');
+    expect(auth).toContain('do not GET the generated link');
+  });
+  test('preserves private delivery and protected-bootstrap requirements', () => {
+    expect(deploy).toContain('GBRAIN_ADMIN_BOOTSTRAP_TOKEN');
+    expect(deploy).toContain('only to the requesting owner in');
+    expect(deploy).toContain('Never expose its value in chat, logs, shell arguments,');
+    expect(deploy).toContain('An MCP client bearer token or client secret is not the');
+  });
+  test('distinguishes login from client creation and describes lifecycle limits', () => {
+    expect(deploy).toContain('does not create, reveal, or rotate');
+    expect(deploy).toContain('expires after five minutes');
+    expect(deploy).toContain('cannot be replayed');
+    expect(deploy).toContain('invalidated by a server restart');
+    expect(deploy).toContain("server's configured `--public-url`");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #5007. The admin UI asks owners to request a login link from their agent, but auth help and the deployment guide omitted the existing single-use mint flow. This is a discoverability problem compounded by agent handling, not an absent authentication endpoint.

## Observed behavior

Pre-fix auth help listed token and client management only. The deployment guide described bootstrap-token login and client registration without the agent-callable link route. No credentials or private deployment details are included here.

## Investigation

Confirmed the existing server endpoint and UI prompt. Related #2624 intentionally protects generated bootstrap credentials from captured logs; this change preserves that protection. An initial unit run was refused by the database-URL guard. Subsequent checks removed production database variables and used an isolated HOME, with no guard override. The new structural test required regenerating the structural-suite manifest.

## Solution

- Document the exact owner request, protected bootstrap access, current public URL, private delivery, expiry, replay and restart behavior.
- Auth help points to the existing HTTP mint endpoint and distinguishes it from issuing an MCP bearer credential.
- Warn against GET/fetch verification of a one-time URL, which consumes it.
- Add five discovery-contract tests and refresh the required structural manifest and documentation bundles.
- No authentication logic, permissions, cookie policy or rate-limit change.

## Testing

- Focused unit tests, admin-route structural guard, and documentation-bundle tests: **21 pass, 0 fail**.
- Actual auth --help smoke: endpoint and credential-handling guidance present.
- Discrimination: pre-fix docs/help yield **0 pass / 5 fail**; restored focused checks pass.
- git diff --check: pass.
- Public change-content and PR body PII scans: pass.
- Full repository verify: **PASS — all 54 checks**.

## Deployment

Not deployed or merged. No production settings changed, no server restarted, and no credential or login nonce was minted or rotated.
