### PR TITLE
v0.48.5.0 fix(context-audit): calibrate token estimates (#4988)

### DIFF
--- a/plugin-variants/gbrain-coding/skills/context-audit/SKILL.md
+++ b/plugin-variants/gbrain-coding/skills/context-audit/SKILL.md
@@ -81,8 +81,8 @@ This skill guarantees:
   (`gbrain bootstrap interview --set KEY "..."` then
   `gbrain bootstrap render --only <FILE> --force`), never as a direct edit.
   See [skills/soul-audit/SKILL.md](../soul-audit/SKILL.md) for the mechanics.
-- **Measured, not guessed.** Token figures come from the deterministic
-  pre-pass (`wc -c` / ~4 chars-per-token), never invented.
+- **Measured, not guessed.** Token estimates come from the deterministic
+  pre-pass (`wc -c`, then `chars / 2.8`), never invented. The host's exact per-category context counts take precedence over this estimate when available.
 - **Native judging.** The draft report is quality-gated through
   `gbrain eval cross-modal` — no raw model API calls, no hardcoded model IDs.
 - **Cost line.** Default judging is ONE cheap model (the user's utility-tier
@@ -98,12 +98,17 @@ List the always-loaded files for this harness and measure each:
 
 ```bash
 for f in CLAUDE.md AGENTS.md SOUL.md USER.md ACCESS_POLICY.md HEARTBEAT.md MEMORY.md; do
-  [ -f "$f" ] && echo "$f: $(wc -c < "$f") chars (~$(( $(wc -c < "$f") / 4 )) tokens)"
+  if [ -f "$f" ]; then
+    chars=$(wc -c < "$f")
+    echo "$f: $chars chars (~$(( (chars * 10 + 27) / 28 )) tokens; chars / 2.8 estimate)"
+  fi
 done
 ```
 
-Record the total. If a prior audit report exists in the brain, compute drift
-(net tokens grown/shrunk since last run, which files moved).
+Record the total and the `chars / 2.8` divisor so readers can re-derive it. If
+the host exposes exact per-category context counts, use those instead and cite
+them as the source of truth. If a prior audit report exists in the brain,
+compute drift (net tokens grown/shrunk since last run, which files moved).
 
 ### 2. Read and analyze (the agent does this — no model calls yet)
 
@@ -138,7 +143,7 @@ Write the draft report to a temp file, then gate it:
 JUDGE=$(gbrain config get models.tier.utility)
 
 gbrain eval cross-modal \
-  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; savings are measured (chars/4), not guessed; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
+  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; estimated savings use chars / 2.8 unless exact per-category context counts are available from the host, in which case those take precedence; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
   --output /tmp/context-audit-draft.md \
   --slug context-audit-report \
   --cycles 1 \
@@ -209,7 +214,8 @@ belongs: source file, answer bank/template, memory store, or a new skill.
 - **Auditing on-demand content as if always-loaded.** Skills and reference
   docs don't pay the per-turn tax; flagging them inflates savings numbers.
 - **Inventing token counts.** Measure with the pre-pass; estimates are labeled
-  as `~N` chars/4 approximations.
+  as `~N` using the `chars / 2.8` approximation and exact host counts are
+  identified when they take precedence.
 - **Rewriting identity content yourself.** If a finding is about WHAT an
   identity file says (wrong persona, outdated profile), route to soul-audit —
   the interview is the only author of that content.

--- a/plugin/skills/context-audit/SKILL.md
+++ b/plugin/skills/context-audit/SKILL.md
@@ -81,8 +81,8 @@ This skill guarantees:
   (`gbrain bootstrap interview --set KEY "..."` then
   `gbrain bootstrap render --only <FILE> --force`), never as a direct edit.
   See [skills/soul-audit/SKILL.md](../soul-audit/SKILL.md) for the mechanics.
-- **Measured, not guessed.** Token figures come from the deterministic
-  pre-pass (`wc -c` / ~4 chars-per-token), never invented.
+- **Measured, not guessed.** Token estimates come from the deterministic
+  pre-pass (`wc -c`, then `chars / 2.8`), never invented. The host's exact per-category context counts take precedence over this estimate when available.
 - **Native judging.** The draft report is quality-gated through
   `gbrain eval cross-modal` — no raw model API calls, no hardcoded model IDs.
 - **Cost line.** Default judging is ONE cheap model (the user's utility-tier
@@ -98,12 +98,17 @@ List the always-loaded files for this harness and measure each:
 
 ```bash
 for f in CLAUDE.md AGENTS.md SOUL.md USER.md ACCESS_POLICY.md HEARTBEAT.md MEMORY.md; do
-  [ -f "$f" ] && echo "$f: $(wc -c < "$f") chars (~$(( $(wc -c < "$f") / 4 )) tokens)"
+  if [ -f "$f" ]; then
+    chars=$(wc -c < "$f")
+    echo "$f: $chars chars (~$(( (chars * 10 + 27) / 28 )) tokens; chars / 2.8 estimate)"
+  fi
 done
 ```
 
-Record the total. If a prior audit report exists in the brain, compute drift
-(net tokens grown/shrunk since last run, which files moved).
+Record the total and the `chars / 2.8` divisor so readers can re-derive it. If
+the host exposes exact per-category context counts, use those instead and cite
+them as the source of truth. If a prior audit report exists in the brain,
+compute drift (net tokens grown/shrunk since last run, which files moved).
 
 ### 2. Read and analyze (the agent does this — no model calls yet)
 
@@ -138,7 +143,7 @@ Write the draft report to a temp file, then gate it:
 JUDGE=$(gbrain config get models.tier.utility)
 
 gbrain eval cross-modal \
-  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; savings are measured (chars/4), not guessed; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
+  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; estimated savings use chars / 2.8 unless exact per-category context counts are available from the host, in which case those take precedence; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
   --output /tmp/context-audit-draft.md \
   --slug context-audit-report \
   --cycles 1 \
@@ -209,7 +214,8 @@ belongs: source file, answer bank/template, memory store, or a new skill.
 - **Auditing on-demand content as if always-loaded.** Skills and reference
   docs don't pay the per-turn tax; flagging them inflates savings numbers.
 - **Inventing token counts.** Measure with the pre-pass; estimates are labeled
-  as `~N` chars/4 approximations.
+  as `~N` using the `chars / 2.8` approximation and exact host counts are
+  identified when they take precedence.
 - **Rewriting identity content yourself.** If a finding is about WHAT an
   identity file says (wrong persona, outdated profile), route to soul-audit —
   the interview is the only author of that content.

--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -65,7 +65,7 @@ test/cli.test.ts	CLI structure	6	readFileSync
 test/cli.test.ts	CLI version	2	readFileSync
 test/cli.test.ts	ask alias	2	readFileSync
 test/codex-plugin-manifest.test.ts	codex mcp.json	3	readFileSync
-test/codex-plugin-manifest.test.ts	curated tree membership + scanner guard	5	readFileSync
+test/codex-plugin-manifest.test.ts	curated tree membership + scanner guard	6	readFileSync
 test/codex-plugin-manifest.test.ts	generator negative fixtures (a guard that cannot fail is not coverage)	9	readFileSync
 test/codex-plugin-manifest.test.ts	variant ${def.plugin_name} (persona ${personaName})	5	readFileSync
 test/compile-view.test.ts	compileView — determinism	3	readFileSync

--- a/skills/context-audit/SKILL.md
+++ b/skills/context-audit/SKILL.md
@@ -81,8 +81,8 @@ This skill guarantees:
   (`gbrain bootstrap interview --set KEY "..."` then
   `gbrain bootstrap render --only <FILE> --force`), never as a direct edit.
   See [skills/soul-audit/SKILL.md](../soul-audit/SKILL.md) for the mechanics.
-- **Measured, not guessed.** Token figures come from the deterministic
-  pre-pass (`wc -c` / ~4 chars-per-token), never invented.
+- **Measured, not guessed.** Token estimates come from the deterministic
+  pre-pass (`wc -c`, then `chars / 2.8`), never invented. The host's exact per-category context counts take precedence over this estimate when available.
 - **Native judging.** The draft report is quality-gated through
   `gbrain eval cross-modal` — no raw model API calls, no hardcoded model IDs.
 - **Cost line.** Default judging is ONE cheap model (the user's utility-tier
@@ -98,12 +98,17 @@ List the always-loaded files for this harness and measure each:
 
 ```bash
 for f in CLAUDE.md AGENTS.md SOUL.md USER.md ACCESS_POLICY.md HEARTBEAT.md MEMORY.md; do
-  [ -f "$f" ] && echo "$f: $(wc -c < "$f") chars (~$(( $(wc -c < "$f") / 4 )) tokens)"
+  if [ -f "$f" ]; then
+    chars=$(wc -c < "$f")
+    echo "$f: $chars chars (~$(( (chars * 10 + 27) / 28 )) tokens; chars / 2.8 estimate)"
+  fi
 done
 ```
 
-Record the total. If a prior audit report exists in the brain, compute drift
-(net tokens grown/shrunk since last run, which files moved).
+Record the total and the `chars / 2.8` divisor so readers can re-derive it. If
+the host exposes exact per-category context counts, use those instead and cite
+them as the source of truth. If a prior audit report exists in the brain,
+compute drift (net tokens grown/shrunk since last run, which files moved).
 
 ### 2. Read and analyze (the agent does this — no model calls yet)
 
@@ -138,7 +143,7 @@ Write the draft report to a temp file, then gate it:
 JUDGE=$(gbrain config get models.tier.utility)
 
 gbrain eval cross-modal \
-  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; savings are measured (chars/4), not guessed; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
+  --task "Context-stack token-hygiene audit: every finding cites file + quoted evidence; estimated savings use chars / 2.8 unless exact per-category context counts are available from the host, in which case those take precedence; findings ranked by token savings; every rendered-file recommendation targets the interview answer bank or template, never a direct edit; risk class on every row" \
   --output /tmp/context-audit-draft.md \
   --slug context-audit-report \
   --cycles 1 \
@@ -209,7 +214,8 @@ belongs: source file, answer bank/template, memory store, or a new skill.
 - **Auditing on-demand content as if always-loaded.** Skills and reference
   docs don't pay the per-turn tax; flagging them inflates savings numbers.
 - **Inventing token counts.** Measure with the pre-pass; estimates are labeled
-  as `~N` chars/4 approximations.
+  as `~N` using the `chars / 2.8` approximation and exact host counts are
+  identified when they take precedence.
 - **Rewriting identity content yourself.** If a finding is about WHAT an
   identity file says (wrong persona, outdated profile), route to soul-audit —
   the interview is the only author of that content.

--- a/skills/skills.lock.json
+++ b/skills/skills.lock.json
@@ -42,7 +42,7 @@
   "company-brainify/routing-eval.jsonl": "6f27f835eda9ae77a2b694534c78a043a871349820e8c638c3d8bbba6d3aa17b",
   "concept-synthesis/SKILL.md": "ed02d2e385143b16a1e69ee5934288fb4d0b755f68c4312faff663e6b2d7c4ed",
   "concept-synthesis/routing-eval.jsonl": "96dbd7d9c1b606e9e06262d0c06282399741e2bccb8eeb7b9ca88c20f44cda0e",
-  "context-audit/SKILL.md": "6c811783349f740f039078bef991077bdc85007b2f730897465266e4c31b66da",
+  "context-audit/SKILL.md": "eb09121121138c2b0f0349c5794929413c2c95adabcf0108636c2d608104eebe",
   "context-audit/routing-eval.jsonl": "fb1832e24cc1b04163a74c5cde72bca53050a66246ca902e1a5f40303f52b5ab",
   "conventions/brain-first.md": "d9b18321150830d38586f5bd23ce9de735f08ac3b54d7ac63bc3184a61e17ef1",
   "conventions/brain-routing.md": "392998d9a109b330c9225af4ca5c8798b0ff02eba4d441c93fdb7c263687d0c6",

--- a/test/codex-plugin-manifest.test.ts
+++ b/test/codex-plugin-manifest.test.ts
@@ -410,6 +410,21 @@ describe('curated tree membership + scanner guard', () => {
     }
   });
 
+  test('context-audit ships its calibrated token estimate in every plugin lane', () => {
+    const paths = [
+      'skills/context-audit/SKILL.md',
+      'plugin/skills/context-audit/SKILL.md',
+      'plugin-variants/gbrain-coding/skills/context-audit/SKILL.md',
+    ];
+    for (const path of paths) {
+      const skill = read(path);
+      expect(skill).toContain('chars / 2.8');
+      expect(skill).toContain('exact per-category context counts take precedence');
+      expect(skill).not.toContain('chars/4');
+      expect(skill).not.toContain('chars-per-token');
+    }
+  });
+
   test('generator round-trip: curation record valid + starter_gaps snapshot fresh', () => {
     const out = mkdtempSync(join(tmpdir(), 'gbrain-plugin-tree-'));
     try {


### PR DESCRIPTION
Closes #4988.

Summary:
- calibrate context-audit token estimates to `chars / 2.8`
- make exact host-provided per-category context counts authoritative when available
- regenerate bundled plugin copies and the skills integrity manifest
- add regression coverage for every shipped plugin lane

Tests:
- `bun test test/codex-plugin-manifest.test.ts`
