### PR TITLE
fix(doctor): correct atom_provenance_drift warning overclaim

### DIFF
--- a/scripts/structural-suites.tsv
+++ b/scripts/structural-suites.tsv
@@ -95,7 +95,7 @@ test/destructive-guard.test.ts	assessDestructiveImpact	5	readFileSync
 test/destructive-guard.test.ts	formatters (display helpers)	4	readFileSync
 test/destructive-guard.test.ts	purgeExpiredSources — clone cleanup containment	1	readFileSync
 test/detached-stderr.test.ts	jobs.ts detach branch (source pin, #4418)	2	readFileSync
-test/doctor-atom-provenance-drift.test.ts	computeAtomProvenanceDriftCheck	18	doctor-source-helper
+test/doctor-atom-provenance-drift.test.ts	computeAtomProvenanceDriftCheck	19	doctor-source-helper
 test/doctor-embedding-env-override.test.ts	cross-surface parity (source-grep regression guard)	1	doctor-source-helper
 test/doctor-fix.test.ts	gbrain doctor --fix CLI integration	3	readFileSync
 test/doctor-frontmatter-partial.test.ts	doctor frontmatter_integrity — load-bearing render strings	5	doctor-source-helper

--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -779,12 +779,12 @@ export async function computeExtractAtomsBacklogCheck(
  * unreferenced.
  *
  * Why this needs a signal: a drifted atom is still returned by search, still
- * carries a `source_quote`, and still reads as sourced — but the hash
- * mismatch only proves the source page changed since extraction; whether the
- * quote itself survived that edit is unverified (it often does — see the
- * `source_changed`/`source_gone` split below). It is the one class of
- * derived page whose provenance has silently gone unverified against the
- * corpus it claims to summarize.
+ * carries a `source_quote`, and still reads as sourced — but a changed
+ * source_hash only means the source page (or its record) changed since
+ * extraction. This check does not string-match the quote against current
+ * page content, so it cannot say whether the quote itself survived that
+ * change. It is the one class of derived page whose provenance has silently
+ * gone unverified against the corpus it claims to summarize.
  *
  * Measured on a 17-source brain (30.7k pages, 4.0k atoms) before shipping this:
  * 1,001 of 3,999 atoms (25.0%) had drifted; 932 still had a live source page
@@ -917,7 +917,7 @@ export async function computeAtomProvenanceDriftCheck(
           `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
           `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
           (oldestDays != null ? `; oldest ${oldestDays}d` : '') + su +
-          `. These still surface in search with a source_quote whose presence in the current page has not been reverified — the hash mismatch only proves the source changed, not that the quote is gone (it often still is). Fix: ${fix}`,
+          `. These atoms still surface in search. This check does not verify whether their source_quote remains in any live page; a changed source hash alone does not establish that the quote is gone. Fix: ${fix}`,
         details,
       };
     }

--- a/src/commands/doctor/checks/extraction-sync.ts
+++ b/src/commands/doctor/checks/extraction-sync.ts
@@ -779,9 +779,12 @@ export async function computeExtractAtomsBacklogCheck(
  * unreferenced.
  *
  * Why this needs a signal: a drifted atom is still returned by search, still
- * carries a `source_quote`, and still reads as sourced — but its quote can no
- * longer be located in any current page. It is the one class of derived page
- * that silently diverges from the corpus it claims to summarize.
+ * carries a `source_quote`, and still reads as sourced — but the hash
+ * mismatch only proves the source page changed since extraction; whether the
+ * quote itself survived that edit is unverified (it often does — see the
+ * `source_changed`/`source_gone` split below). It is the one class of
+ * derived page whose provenance has silently gone unverified against the
+ * corpus it claims to summarize.
  *
  * Measured on a 17-source brain (30.7k pages, 4.0k atoms) before shipping this:
  * 1,001 of 3,999 atoms (25.0%) had drifted; 932 still had a live source page
@@ -914,7 +917,7 @@ export async function computeAtomProvenanceDriftCheck(
           `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
           `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
           (oldestDays != null ? `; oldest ${oldestDays}d` : '') + su +
-          `. These still surface in search with a source_quote that no current page contains. Fix: ${fix}`,
+          `. These still surface in search with a source_quote whose presence in the current page has not been reverified — the hash mismatch only proves the source changed, not that the quote is gone (it often still is). Fix: ${fix}`,
         details,
       };
     }

--- a/test/doctor-atom-provenance-drift.test.ts
+++ b/test/doctor-atom-provenance-drift.test.ts
@@ -54,7 +54,7 @@ async function seedSource(slug: string, body: string) {
   await engine.putPage(slug, { type: 'article', title: slug, compiled_truth: body });
 }
 
-async function seedAtom(slug: string, sourceSlug: string, sourceHash: string) {
+async function seedAtom(slug: string, sourceSlug: string, sourceHash: string, sourceQuote?: string) {
   await engine.putPage(slug, {
     type: 'atom',
     title: slug,
@@ -64,6 +64,7 @@ async function seedAtom(slug: string, sourceSlug: string, sourceHash: string) {
       source_slug: sourceSlug,
       source_hash: sourceHash,
       extracted_at: new Date().toISOString(),
+      ...(sourceQuote != null ? { source_quote: sourceQuote } : {}),
     },
   });
 }
@@ -288,8 +289,9 @@ describe('computeAtomProvenanceDriftCheck', () => {
     // quote is gone.
     const quote = 'the treaty was signed under a full moon';
     await seedSource('src-w', `${quote} — background paragraph.`);
+    const originalHash = await hashOf('src-w');
     for (let i = 0; i < 30; i++) {
-      await seedAtom(`atoms/2026-01-01/w-${String(i).padStart(6, '0')}`, 'src-w', await hashOf('src-w'));
+      await seedAtom(`atoms/2026-01-01/w-${String(i).padStart(6, '0')}`, 'src-w', originalHash, quote);
     }
     // Edit prepends unrelated text; the quoted passage itself is untouched.
     await seedSource('src-w', `An unrelated new intro paragraph.\n\n${quote} — background paragraph.`);
@@ -300,20 +302,36 @@ describe('computeAtomProvenanceDriftCheck', () => {
     expect(d.drifted).toBe(30);
     expect(d.source_changed).toBe(30);
 
-    // Ground truth: the quote the drifted atoms cite is, in fact, still
-    // present verbatim in the current live page — this is the case the old
-    // "no current page contains [the quote]" wording overclaimed against.
-    const rows = await engine.executeRaw<{ compiled_truth: string }>(
+    // Ground truth: each drifted atom's OWN stored source_quote is, in fact,
+    // still present verbatim in the current live page — this is the case
+    // the old "no current page contains [the quote]" wording overclaimed
+    // against. Read the quote back from the atom's frontmatter rather than
+    // asserting against the free-standing `quote` variable, so the check
+    // exercises what the atom actually cites, not just test-local state.
+    const atomRows = await engine.executeRaw<{ q: string }>(
+      `SELECT frontmatter->>'source_quote' AS q FROM pages
+        WHERE type = 'atom' AND deleted_at IS NULL AND slug LIKE 'atoms/2026-01-01/w-%'`,
+      [],
+    );
+    expect(atomRows.length).toBe(30);
+    const pageRows = await engine.executeRaw<{ compiled_truth: string }>(
       `SELECT compiled_truth FROM pages WHERE slug = $1 AND deleted_at IS NULL`,
       ['src-w'],
     );
-    expect(rows[0].compiled_truth).toContain(quote);
+    for (const { q } of atomRows) {
+      expect(q).toBe(quote);
+      expect(pageRows[0].compiled_truth).toContain(q);
+    }
 
     // The message must not assert the quote is unreachable...
     expect(c.message).not.toContain('no current page contains');
-    // ...and must instead flag it as unverified rather than gone.
-    expect(c.message).toContain('has not been reverified');
-    expect(c.message).toContain('not that the quote is gone');
+    // ...and must instead say the check never verified it, without claiming
+    // any particular frequency for how often the quote survives (Codex
+    // review: "it often does/still is" is an unsupported frequency claim —
+    // source_changed/source_gone measure page liveness, not quote survival).
+    expect(c.message).toContain('does not verify whether their source_quote remains in any live page');
+    expect(c.message).toContain('does not establish that the quote is gone');
+    expect(c.message).not.toMatch(/\bit often\b/i);
   }, 60_000);
 
   it('does not count a slug-unbound atom (source_path only, no source_slug) as source_gone — or as drift at all (#4806)', async () => {

--- a/test/doctor-atom-provenance-drift.test.ts
+++ b/test/doctor-atom-provenance-drift.test.ts
@@ -278,6 +278,44 @@ describe('computeAtomProvenanceDriftCheck', () => {
     expect(c.message).toContain('30/30');
     expect(c.message).toContain('source page is gone');
   });
+
+  it('warns with an accurate (not overclaiming) message when the edit that caused drift left the atom quote intact', async () => {
+    // Regression for the warning-text overclaim: the hash check can only see
+    // that the source page's content_hash moved, not whether the specific
+    // quote an atom cites survived the edit. Prepending unrelated text to a
+    // page still moves the hash (drift correctly fires) even though the
+    // quoted passage itself is untouched — the message must not assert the
+    // quote is gone.
+    const quote = 'the treaty was signed under a full moon';
+    await seedSource('src-w', `${quote} — background paragraph.`);
+    for (let i = 0; i < 30; i++) {
+      await seedAtom(`atoms/2026-01-01/w-${String(i).padStart(6, '0')}`, 'src-w', await hashOf('src-w'));
+    }
+    // Edit prepends unrelated text; the quoted passage itself is untouched.
+    await seedSource('src-w', `An unrelated new intro paragraph.\n\n${quote} — background paragraph.`);
+
+    const c = await computeAtomProvenanceDriftCheck(engine);
+    const d = c.details as Record<string, number>;
+    expect(c.status).toBe('warn');
+    expect(d.drifted).toBe(30);
+    expect(d.source_changed).toBe(30);
+
+    // Ground truth: the quote the drifted atoms cite is, in fact, still
+    // present verbatim in the current live page — this is the case the old
+    // "no current page contains [the quote]" wording overclaimed against.
+    const rows = await engine.executeRaw<{ compiled_truth: string }>(
+      `SELECT compiled_truth FROM pages WHERE slug = $1 AND deleted_at IS NULL`,
+      ['src-w'],
+    );
+    expect(rows[0].compiled_truth).toContain(quote);
+
+    // The message must not assert the quote is unreachable...
+    expect(c.message).not.toContain('no current page contains');
+    // ...and must instead flag it as unverified rather than gone.
+    expect(c.message).toContain('has not been reverified');
+    expect(c.message).toContain('not that the quote is gone');
+  }, 60_000);
+
   it('does not count a slug-unbound atom (source_path only, no source_slug) as source_gone — or as drift at all (#4806)', async () => {
     // Transcript-origin atoms carry `source_path` but no `source_slug`
     // (isCompatibleAtomBinding in extract-atoms.ts) -- this is the CURRENT,


### PR DESCRIPTION
## What

Corrects an overclaim in the `atom_provenance_drift` doctor check's WARN message and its docstring. No logic, SQL, threshold, or counted-bucket change.

## Why

`atom_provenance_drift` flags an atom as drifted when its stored `source_hash` matches none of the first-16-characters `content_hash` prefixes among every currently-live page in the same source (not specifically the one page it is slug-bound to — see `live_hashes` in the query). The WARN message asserted `"These still surface in search with a source_quote that no current page contains"` — but the check never compares the atom's `source_quote` text against any page body; it is a hash-set membership test. An edit to the bound page that changes its hash (e.g. prepending a paragraph) still fires drift even when the atom's quoted passage is untouched and still present verbatim in that same page.

This is a follow-up to #4927, which proposed surfacing a new per-page `atoms_source_changed` count in cycle output. That direction was not adopted (new surface, maintainer product call — see the discussion in #4908). This PR keeps to a strictly smaller scope: no new count, no new CLI/config/JSON field — just correcting what the existing WARN message claims.

## How

- `src/commands/doctor/checks/extraction-sync.ts` — reworded the WARN message and its docstring paragraph. Both no longer assert or imply a frequency ("it often still is" / "it often does") about whether the quote survives — that isn't something this check measures.
- `test/doctor-atom-provenance-drift.test.ts` — new regression test: seeds an atom carrying a `source_quote`, drifts it by editing the bound page (prepending unrelated text while leaving the quoted passage verbatim), confirms drift still correctly fires as `source_changed`, confirms via ground-truth query that the quote is in fact still present in the live page, and asserts the WARN message no longer contains the overclaim and does contain the corrected phrasing.

## Diff

```diff
- `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
- `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
- (oldestDays != null ? `; oldest ${oldestDays}d` : '') + su +
- `. These still surface in search with a source_quote that no current page contains. Fix: ${fix}`,
+ `${drifted}/${total} atom(s) (${details.drift_pct}%) reference a source_hash no live page carries ` +
+ `— ${sourceChanged} whose source page still exists (edited), ${sourceGone} whose source page is gone` +
+ (oldestDays != null ? `; oldest ${oldestDays}d` : '') + su +
+ `. These atoms still surface in search. This check does not verify whether their source_quote remains in any live page; a changed source hash alone does not establish that the quote is gone. Fix: ${fix}`,
```

## Tests

`bun test test/doctor-atom-provenance-drift.test.ts` → 19 pass / 0 fail, 139 expect() calls.

Discrimination test: reverted src/commands/doctor/checks/extraction-sync.ts to upstream/master, ran test/doctor-atom-provenance-drift.test.ts → 18 pass / 1 fail. Restored → all pass.

`bun run typecheck` → exit 0. `bun run check:module-size` → exit 0.
