### PR TITLE
fix(google): bound the calendar syncToken delta to a 12-month horizon

### DIFF
--- a/src/core/google/google-source.ts
+++ b/src/core/google/google-source.ts
@@ -58,6 +58,7 @@ import {
   type GoogleService,
   type GoogleSourceConfig,
   type GoogleSourceState,
+  CalendarEventData,
 } from './types.ts';
 import { LOOPS_EXTRACT_WINDOW_DAYS, loopExtractionEligibility } from './loops-extract.ts';
 
@@ -174,6 +175,8 @@ export function myAddressSet(entry: CredentialEntry): Set<string> {
 interface GoogleSyncSummary {
   /** 'up_to_date'/'first_sync' are computed on the SyncResult, never here. */
   status: 'synced' | 'partial';
+  /** Calendar instances skipped because they start beyond CALENDAR_DELTA_HORIZON_DAYS (recurring-series expansion). */
+  calendarSkippedBeyondHorizon?: number;
   added: number;
   modified: number;
   deleted: number;
@@ -392,6 +395,15 @@ async function calendarPageRelPathByEventId(
 
 
 
+/** Recurring-series expansion horizon for the syncToken delta (see sweepCalendar). */
+export const CALENDAR_DELTA_HORIZON_DAYS = 365;
+
+/** True when the instance starts after `beforeMs`. An unparseable start is kept: cancelled skeletons carry no start and must still reach the reconcile path below. */
+function startsBeyond(ev: CalendarEventData, beforeMs: number): boolean {
+  const ms = Date.parse(ev.startIso);
+  return Number.isFinite(ms) && ms > beforeMs;
+}
+
 async function sweepCalendar(
   deps: GoogleSyncDeps,
   calendar: CalendarClient,
@@ -405,6 +417,16 @@ async function sweepCalendar(
     timeMinIso: new Date(now - deps.cfg.historyDays * 86_400_000).toISOString(),
     timeMaxIso: new Date(now + 60 * 86_400_000).toISOString(),
   };
+  // The windowed listing is bounded by timeMax, but the syncToken delta is
+  // not: the Calendar API rejects timeMin/timeMax alongside a syncToken, and
+  // when a recurring series is touched (rescheduled, retitled, an attendee
+  // added) the delta carries EVERY expanded instance to the end of the
+  // series. Measured on a weekly meeting: ~700 instances reaching into 2040,
+  // and 8,840 pages past 2027 across one account. Those pages then burn the
+  // sync's page budget and dominate date-sorted views. Instances that start
+  // beyond this horizon are skipped; they re-enter naturally once the series
+  // is touched again within a year of their start.
+  const materializeBeforeMs = now + CALENDAR_DELTA_HORIZON_DAYS * 86_400_000;
   // The stored token is bound to the calendar it was minted for (legacy state
   // without calendar_id predates secondary calendars, so it was primary's).
   // A re-pointed source starts a fresh window; pairing the NEW calendar with
@@ -438,6 +460,10 @@ async function sweepCalendar(
   }
   for (const ev of result.events) {
     if (deps.opts.signal?.aborted) return;
+    if (startsBeyond(ev, materializeBeforeMs)) {
+      summary.calendarSkippedBeyondHorizon = (summary.calendarSkippedBeyondHorizon ?? 0) + 1;
+      continue;
+    }
     // The page path derives from MUTABLE fields (start date, summary) while
     // identity is the immutable event id — look up the existing page by
     // frontmatter event_id so reschedules move (old page deleted) and
@@ -453,6 +479,11 @@ async function sweepCalendar(
       await deletePageByRelPath(deps, existingPath, summary); // rescheduled → moved
     }
     await importRendered(deps, rendered.relPath, rendered.markdown, activePack, summary, countedSlugs);
+  }
+  if (summary.calendarSkippedBeyondHorizon) {
+    deps.log(
+      `[google] calendar: skipped ${summary.calendarSkippedBeyondHorizon} instance(s) starting more than ${CALENDAR_DELTA_HORIZON_DAYS} days out`,
+    );
   }
   if (result.nextSyncToken) {
     state.calendar_sync_token = result.nextSyncToken;

--- a/test/google-source-materialize.test.ts
+++ b/test/google-source-materialize.test.ts
@@ -629,6 +629,48 @@ describe('google-source materialize', () => {
     }
   });
 
+  test('calendar delta: instances starting beyond the horizon are skipped, near ones land, the token still advances', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gsrc-cal-horizon-'));
+    const fx = emptyFx();
+    calendarFixture(fx);
+    const vault = makeVault();
+    try {
+      await insertGoogleSource(dir);
+      await withHome(async () => {
+        await sweep(dir, fx, vault, {}, 'calendar');
+        expect(readGoogleState(dir).calendar_sync_token).toBe('cal-sync-1');
+
+        // A touched weekly series comes back through the syncToken delta as
+        // EVERY expanded instance to the end of the series. Two arrive: one
+        // next week, one three years out. Only the first may materialize.
+        const inst = (id: string, startMs: number) => ({
+          id,
+          status: 'confirmed',
+          summary: 'Weekly zephyr standup',
+          start: { dateTime: new Date(startMs).toISOString() },
+          end: { dateTime: new Date(startMs + 1_800_000).toISOString() },
+          organizer: { email: 'a@example.com' },
+          attendees: [{ email: 'a@example.com', self: true, responseStatus: 'accepted' }],
+          htmlLink: `https://calendar.google.com/calendar/event?eid=${id}`,
+        });
+        fx.calendarDelta = [inst('evt0000000000w001', NOW_MS + 7 * 86_400_000), inst('evt0000000000w999', NOW_MS + 3 * 365 * 86_400_000)];
+        // Calendar-only source: the result status reflects the gmail lane (never run here), so assert on what landed.
+        const res = await sweep(dir, fx, vault, {}, 'calendar');
+        expect(res.added).toBe(1);
+
+        const meetings = await slugsWhere(`slug LIKE 'calendar/%'`);
+        expect(meetings.length).toBe(2); // the original fixture meeting + the near instance
+        expect(meetings.some((s) => s.includes('weekly-zephyr-standup'))).toBe(true);
+        const farYear = new Date(NOW_MS + 3 * 365 * 86_400_000).getUTCFullYear();
+        expect(meetings.some((s) => s.startsWith(`calendar/${farYear}/`))).toBe(false);
+        // The delta was consumed: the token advances even though an instance was skipped.
+        expect(readGoogleState(dir).calendar_sync_token).toBe('cal-sync-2');
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('history 404 falls back to a bookmark window and re-anchors a fresh historyId', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'gsrc-expired-'));
     const fx = emptyFx();


### PR DESCRIPTION
## The gap

`sweepCalendar` bounds the windowed listing with `timeMax` (now + 60 days), but the syncToken delta cannot carry a window: the Calendar API rejects `timeMin`/`timeMax` alongside a `syncToken`. When a recurring series is touched (rescheduled, retitled, an attendee added), the delta returns every expanded instance to the end of the series.

Measured on one account (weekly and biweekly meetings, `singleEvents=true`):

- one touched weekly series delivered about 700 instances reaching into 2040;
- over a week, 8,840 calendar pages dated past 2027 accumulated, out to 2099;
- each nightly sweep spent its page budget materializing those, and anything sorted by date surfaced meetings decades out.

## What changes

Instances that start more than `CALENDAR_DELTA_HORIZON_DAYS` (365) ahead are skipped in the events loop. They are not lost: the next touch of the series within a year of their start delivers them again through the delta, and the windowed listing already bounds a first sync to 60 days. Cancelled skeletons carry no start and are deliberately kept, so the existing reconcile path (`calendarPageRelPathByEventId`, delete on cancel) still sees them.

The sweep counts skips on the summary (`calendarSkippedBeyondHorizon`) and logs one line per sweep with the count only, so the behaviour is visible without leaking event content.

## Test

`test/google-source-materialize.test.ts`: a delta with one instance next week and one three years out materializes only the near one, leaves no page under the far year, and still advances the sync token to `cal-sync-2`.

`bun test test/google-source-materialize.test.ts` passes (21), `bun run typecheck` is clean.

## Where it has run

The same guard has been applied as a build-time patch on our brain since 2026-09-09. The first sweep after it materialized 23 new calendar pages, all within 2027, and no new pages beyond the horizon.
