### PR TITLE
fix(google): gmail delta falls back to the bookmark window when history.list hits the pagination cap

### DIFF
--- a/src/core/google/google-clients.ts
+++ b/src/core/google/google-clients.ts
@@ -177,7 +177,25 @@ export class GoogleApiClient {
       pageToken = nextPageToken;
     }
     if (opts.partialOk) return out;
-    throw new CredentialError('upstream', `: pagination cap (${cap}) hit on ${apiHint}`);
+    throw new GooglePaginationCapError(cap, apiHint);
+  }
+}
+
+/**
+ * Thrown by drainPages when a listing needs more than `cap` pages and the
+ * caller did not opt into a partial result. A CredentialError subclass so the
+ * existing 'upstream' rendering (problem / fix / docs) is unchanged; the
+ * dedicated class exists so a caller can recognise "too much to drain in one
+ * go" and switch to a bounded lane instead of failing the whole sweep.
+ */
+export class GooglePaginationCapError extends CredentialError {
+  readonly cap: number;
+  readonly apiHint: ApiHint;
+  constructor(cap: number, apiHint: ApiHint) {
+    super('upstream', `: pagination cap (${cap}) hit on ${apiHint}`);
+    this.name = 'GooglePaginationCapError';
+    this.cap = cap;
+    this.apiHint = apiHint;
   }
 }
 

--- a/src/core/google/google-source.ts
+++ b/src/core/google/google-source.ts
@@ -43,6 +43,7 @@ import {
   GoogleCursorExpiredError,
   PeopleClient,
   type FetchImpl,
+  GooglePaginationCapError,
 } from './google-clients.ts';
 import {
   calendarRelPath,
@@ -785,13 +786,26 @@ async function sweepGmail(
       ...(deps.opts.signal ? { signal: deps.opts.signal } : {}),
     }));
   } catch (e) {
-    if (!(e instanceof GoogleCursorExpiredError)) throw e;
-    // History expired (~1 week idle): windowed fallback from the newest
-    // imported message. BOUNDED like the backfill (the same >cap population
-    // exists here) — and the fresh historyId is only re-anchored when the
-    // listing was COMPLETE; a capped partial listing keeps the fallback lane
-    // active (gmail_newest_ms advances per processed thread, converging).
-    deps.log('[google] historyId expired; falling back to bookmark window');
+    if (!(e instanceof GoogleCursorExpiredError) && !(e instanceof GooglePaginationCapError)) throw e;
+    // Two ways into the same bounded lane:
+    //  - History expired (~1 week idle): the cursor is gone.
+    //  - History too large: history.list needed more than the pagination cap.
+    //    This is the only unbounded listing in the sweep, and a cap here used
+    //    to abort the whole sweep WITHOUT advancing gmail_history_id — so the
+    //    delta grew every day and the sweep failed the same way every night
+    //    (measured: eight days of mail missing behind a cursor that never
+    //    moved). Too much to drain in one go is the same situation as an
+    //    expired cursor: replay from the bookmark instead.
+    // Windowed fallback from the newest imported message. BOUNDED like the
+    // backfill (the same >cap population exists here) — and the fresh
+    // historyId is only re-anchored when the listing was COMPLETE; a capped
+    // partial listing keeps the fallback lane active (gmail_newest_ms
+    // advances per processed thread, converging).
+    deps.log(
+      e instanceof GooglePaginationCapError
+        ? `[google] history delta exceeded the pagination cap (${e.cap} pages); falling back to bookmark window`
+        : '[google] historyId expired; falling back to bookmark window',
+    );
     // Anchor BEFORE listing (mirrors the backfill's zero-gap ordering): a
     // message arriving between these two calls is either in the listing
     // (post-anchor arrival) or replayed by history.list from the anchor.

--- a/test/google-source-materialize.test.ts
+++ b/test/google-source-materialize.test.ts
@@ -90,6 +90,8 @@ interface FakeGoogle {
   history: string[][];
   historyResponseId: string;
   historyExpired: boolean;
+  /** Serve history.list with a nextPageToken on every page (never terminates) so drainPages hits its cap. */
+  historyEndless: boolean;
   failThreads: Set<string>;
   /** Threads that 429 (rate-limited) on every fetch — retry-after: 0 so tests
    *  don't actually sleep through the client's real backoff schedule. */
@@ -113,6 +115,7 @@ function emptyFx(): FakeGoogle {
     history: [],
     historyResponseId: '1000',
     historyExpired: false,
+    historyEndless: false,
     failThreads: new Set(),
     rateLimitThreads: new Set(),
     contacts: [],
@@ -169,6 +172,7 @@ function buildFetch(fx: FakeGoogle): FetchImpl {
       return json({
         historyId: fx.historyResponseId,
         history: fx.history.map((tids) => ({ messages: tids.map((tid) => ({ threadId: tid })) })),
+        ...(fx.historyEndless ? { nextPageToken: 'more' } : {}),
       });
     }
 
@@ -669,6 +673,47 @@ describe('google-source materialize', () => {
         const state = readGoogleState(dir);
         expect(state.gmail_history_id).toBe('2000'); // fresh anchor
         expect(state.gmail_backfill_done).toBe(true);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('history delta over the pagination cap falls back to the bookmark window instead of failing the sweep', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gsrc-histcap-'));
+    const fx = emptyFx();
+    gmailFixture(fx);
+    const vault = makeVault();
+    try {
+      await insertGoogleSource(dir);
+      await withHome(async () => {
+        await sweep(dir, fx, vault, {}, 'gmail');
+        const anchoredAt = readGoogleState(dir).gmail_history_id;
+        expect(anchoredAt).toBeTruthy();
+
+        // The delta has grown past what history.list can be drained in one
+        // sweep (the fake never stops paginating). A fresh thread arrived
+        // meanwhile. Before the fix this threw, the sweep failed, and the
+        // cursor stayed put — so tomorrow's delta was larger still.
+        fx.historyEndless = true;
+        fx.profileHistoryId = '3000';
+        fx.messages.push(
+          gmsg('18c2f4a9b3d21e07', T_C, hoursAgoMs(1), {
+            headers: { From: 'Erin Example <erin@example.com>', To: 'a@example.com', Subject: 'Fresh zephyr kickoff' },
+            body: 'Kicking off the fresh thread here.',
+          }),
+        );
+        const callsBefore = fx.calls.length;
+        const res = await sweep(dir, fx, vault, {}, 'gmail');
+        expect(res.status).toBe('synced');
+        expect(res.added).toBe(1); // the fresh thread landed via the bookmark window
+        const newCalls = fx.calls.slice(callsBefore);
+        expect(newCalls.some((c) => c.includes('/users/me/messages?'))).toBe(true);
+        expect(newCalls.some((c) => c.endsWith('/users/me/profile'))).toBe(true);
+        // The fallback listing was complete, so the cursor re-anchors on the fresh historyId.
+        const state = readGoogleState(dir);
+        expect(state.gmail_history_id).toBe('3000');
+        expect(state.gmail_history_id).not.toBe(anchoredAt);
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## The gap

The gmail sweep has three lanes. The initial backfill and the expired-cursor fallback are bounded: they take a window, advance a watermark per processed batch, and continue on the next sweep. The delta lane is the only unbounded one. It lists `history.list` from `gmail_history_id` through `drainPages`, which throws at `PAGINATION_CAP` (500 pages) unless the caller opted into a partial result, and the delta lane does not.

That throw aborted the whole sweep without advancing `gmail_history_id`. The next sweep therefore faced a strictly larger delta and failed the same way. A self-feeding loop.

Measured on one account: after the cursor fell eight days behind, every nightly sweep ended on `pagination cap (500) hit on gmail`, `last_sync_at` was never stamped again (so `gbrain waiting` correctly reported staleness), and eight days of mail were missing while the calendar sweep before it kept succeeding.

## What changes

"Too much to drain in one go" is the same situation as an expired cursor, and the sweep already has the right lane for it: the bookmark window from `gmail_newest_ms`, bounded to `FALLBACK_MAX_PAGES`, tolerant of a partial listing, and re-anchoring the historyId only when the listing was complete. The delta lane now takes that lane on a cap as well as on a 404.

To recognise the case without matching on message text, `drainPages` throws `GooglePaginationCapError`, a `CredentialError` subclass carrying `cap` and `apiHint`. The user-facing rendering (problem, fix, docs link) is unchanged; only the delta lane treats it specially. The cap itself is not raised.

## Test

`test/google-source-materialize.test.ts`: the fake serves `history.list` with a `nextPageToken` on every page. The second sweep takes the bookmark window (messages.list plus getProfile, anchor before listing as in the 404 test), the fresh thread lands, the sweep reports `synced`, and the cursor re-anchors on the fresh historyId.

`bun test test/google-source-materialize.test.ts` (21) and `test/google-clients.test.ts` (35) pass, `bun run typecheck` is clean.

## Where it has run

The same routing has been applied as a build-time patch on our brain since 2026-09-09. The first sweep after it pulled the eight missing days (mail for every day from 1 to 9 September), stamped `last_sync_at` again, and the following sweeps have been clean.
