### PR TITLE
fix: parse pgvector embeddings before cosine re-score (NaN relevance scores)

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -275,7 +275,12 @@ export class PostgresEngine implements BrainEngine {
     `;
     const result = new Map<number, Float32Array>();
     for (const row of rows) {
-      if (row.embedding) result.set(row.id as number, row.embedding as Float32Array);
+      if (row.embedding) {
+        const emb = typeof row.embedding === 'string'
+          ? new Float32Array(JSON.parse(row.embedding))
+          : row.embedding as Float32Array;
+        result.set(row.id as number, emb);
+      }
     }
     return result;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -44,13 +44,17 @@ export function rowToPage(row: Record<string, unknown>): Page {
 }
 
 export function rowToChunk(row: Record<string, unknown>, includeEmbedding = false): Chunk {
+  const rawEmbedding = includeEmbedding ? row.embedding : null;
+  const embedding = rawEmbedding
+    ? (typeof rawEmbedding === 'string' ? new Float32Array(JSON.parse(rawEmbedding)) : rawEmbedding as Float32Array)
+    : null;
   return {
     id: row.id as number,
     page_id: row.page_id as number,
     chunk_index: row.chunk_index as number,
     chunk_text: row.chunk_text as string,
     chunk_source: row.chunk_source as 'compiled_truth' | 'timeline',
-    embedding: includeEmbedding && row.embedding ? row.embedding as Float32Array : null,
+    embedding,
     model: row.model as string,
     token_count: row.token_count as number | null,
     embedded_at: row.embedded_at ? new Date(row.embedded_at as string) : null,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -98,6 +98,21 @@ describe('rowToChunk', () => {
     }, true);
     expect(chunk.embedding).not.toBeNull();
   });
+
+  test('parses a pgvector string embedding into a real Float32Array (regression: postgres driver returns vector columns as text, not typed arrays)', () => {
+    const chunk = rowToChunk({
+      id: 1, page_id: 1, chunk_index: 0, chunk_text: 'text',
+      chunk_source: 'compiled_truth', embedding: '[0.1,0.2,0.3]',
+      model: 'test', token_count: 5, embedded_at: '2024-01-01',
+    }, true);
+    expect(chunk.embedding).toBeInstanceOf(Float32Array);
+    expect(chunk.embedding![0]).toBeCloseTo(0.1, 5);
+    expect(chunk.embedding![1]).toBeCloseTo(0.2, 5);
+    expect(chunk.embedding![2]).toBeCloseTo(0.3, 5);
+    // A naive `as Float32Array` cast on the raw string would leave every
+    // element `undefined`, which propagates to NaN in cosine similarity math.
+    expect(Number.isNaN(chunk.embedding![0])).toBe(false);
+  });
 });
 
 describe('rowToSearchResult', () => {


### PR DESCRIPTION
## Summary
- `content_chunks.embedding` comes back from the `postgres` driver as the vector type's text representation (e.g. `"[0.1,0.2,...]"`), not a typed array. `getEmbeddingsByChunkIds()` (postgres engine) and `rowToChunk()` (shared utils) did a bare `as Float32Array` cast, which is a no-op at runtime, so the value stayed a string.
- Indexing a string with a numeric index in `cosineSimilarity()` returns individual characters, which coerce to `NaN` through the dot-product math, so every hybrid-search cosine re-score came out `NaN` and `gbrain query` printed nonsense relevance scores.
- The PGLite engine already handled this correctly (`new Float32Array(JSON.parse(row.embedding))`); ported the same fix to the postgres engine and the shared `rowToChunk` helper, since pgvector's text output is valid JSON.
- Added a regression test in `test/utils.test.ts` covering the string-input case.

Found while diagnosing why `gbrain query` failed to surface a document that should have ranked highly by content, even though it was correctly ingested and embedded — the ranking itself was silently broken.

## Test plan
- [x] `bun test` — 970 pass, 1 pre-existing unrelated failure (`test/e2e/upgrade.test.ts`, fails identically on `master` with this change stashed, unrelated to search/embeddings)
- [x] `bun run test:e2e` against a fresh `pgvector/pgvector:pg16` container — 95 pass, same 1 pre-existing unrelated failure
- [x] Manually verified against a real vault: `gbrain query` returned real relevance scores (0.87, 0.84, 0.83...) instead of `NaN` after the fix