### PR TITLE
fix(search): make the search statement_timeout configurable

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1579,7 +1579,7 @@ export class PostgresEngine implements BrainEngine {
     // shares the same transaction as the timeout.
     const runKeyword = (queryText: string) =>
       this.withScopedReadTransaction(opts?.sourceIds, opts?.sourceId, async (tx) => {
-        await tx`SET LOCAL statement_timeout = '8s'`;
+        await tx`SELECT set_config('statement_timeout', ${await this.searchStatementTimeout()}, true)`;
         const boundParams = [...params];
         boundParams[0] = queryText;
         return await tx.unsafe(rawQuery, boundParams as Parameters<typeof tx.unsafe>[1]);
@@ -1733,7 +1733,7 @@ export class PostgresEngine implements BrainEngine {
     // same scoped wrapper.
     const runTitles = (queryText: string) =>
       this.withScopedReadTransaction(opts?.sourceIds, opts?.sourceId, async (tx) => {
-        await tx`SET LOCAL statement_timeout = '8s'`;
+        await tx`SELECT set_config('statement_timeout', ${await this.searchStatementTimeout()}, true)`;
         const boundParams = [...params];
         boundParams[0] = queryText;
         return await tx.unsafe(rawQuery, boundParams as Parameters<typeof tx.unsafe>[1]);
@@ -1891,7 +1891,7 @@ export class PostgresEngine implements BrainEngine {
     // already wrapped this in sql.begin() for the SET LOCAL; flag off is
     // identical to that wrap, flag on adds set_config in the same tx.
     const rows = await this.withScopedReadTransaction(opts?.sourceIds, opts?.sourceId, async (tx) => {
-      await tx`SET LOCAL statement_timeout = '8s'`;
+      await tx`SELECT set_config('statement_timeout', ${await this.searchStatementTimeout()}, true)`;
       return await tx.unsafe(rawQuery, params as Parameters<typeof tx.unsafe>[1]);
     }, { alwaysTransaction: true });
     return rows.map(rowToSearchResult);
@@ -1907,7 +1907,7 @@ export class PostgresEngine implements BrainEngine {
     return searchKeywordCJKImpl(
       async (sqlText, params) =>
         await this.withScopedReadTransaction(ctx.opts?.sourceIds, ctx.opts?.sourceId, async (tx) => {
-          await tx`SET LOCAL statement_timeout = '8s'`;
+          await tx`SELECT set_config('statement_timeout', ${await this.searchStatementTimeout()}, true)`;
           return await tx.unsafe(sqlText, params as Parameters<typeof tx.unsafe>[1]) as unknown as Record<string, unknown>[];
         }, { alwaysTransaction: true }),
       query,
@@ -2123,7 +2123,7 @@ export class PostgresEngine implements BrainEngine {
     // pagination) but never emits: pool state is unknowable there.
     const runOnce = async (il: number) =>
       await this.withScopedReadTransaction(opts?.sourceIds, opts?.sourceId, async (tx) => {
-        await tx`SET LOCAL statement_timeout = '8s'`;
+        await tx`SELECT set_config('statement_timeout', ${await this.searchStatementTimeout()}, true)`;
         await tx`SELECT set_config('hnsw.ef_search', ${String(hnswEfSearchFor(il))}, true)`;
         return await tx.unsafe(rawQuery, params as Parameters<typeof tx.unsafe>[1]);
       }, { alwaysTransaction: true });
@@ -5149,6 +5149,46 @@ export class PostgresEngine implements BrainEngine {
       // guard; fail-loud — a reconnect throw propagates as the real cause.
       reconnect: (ctx) => this.reconnect(ctx),
     });
+  }
+
+  // #-- configurable search statement timeout ------------------------------
+  // The five search arms below (keyword, titles, keyword-chunks, CJK, vector)
+  // each set a transaction-scoped statement_timeout so one pathological query
+  // cannot pin a pooled connection. That bound was hardcoded to '8s', which is
+  // ample on a small brain and unreachable on a large one: on a 157k-page /
+  // 896MB `pages` table the keyword arm cannot finish inside it, so every
+  // search logs "searchKeyword arm failed (fail-open)" and silently degrades to
+  // vector-only. Exact-token lookups — an email address, a proper noun — stop
+  // working at exactly the corpus size where they matter most.
+  //
+  // Applied with set_config('statement_timeout', $1, true) rather than
+  // `SET LOCAL ... = '<value>'`: a GUC name cannot be parameterised in SET,
+  // so a dynamic value there means string interpolation. set_config takes the
+  // value as a bound parameter and the third argument scopes it to the
+  // transaction, which is exactly what SET LOCAL did.
+  //
+  // Resolution order matches isCrossSourceLinksEnabled: env, then the DB config
+  // plane, then the previous default. Memoised for 60s because this sits on the
+  // hot path and getConfig is a round trip per call; a longer-lived cache would
+  // make `gbrain config set` feel broken.
+  private _searchTimeoutCache: { value: string; at: number } | null = null;
+
+  private async searchStatementTimeout(): Promise<string> {
+    const envVal = process.env.GBRAIN_SEARCH_STATEMENT_TIMEOUT_MS;
+    if (envVal != null && /^\d+$/.test(envVal.trim())) return `${envVal.trim()}ms`;
+    const now = Date.now();
+    if (this._searchTimeoutCache && now - this._searchTimeoutCache.at < 60_000) {
+      return this._searchTimeoutCache.value;
+    }
+    let value = '8s';
+    try {
+      const raw = await this.getConfig('search.statement_timeout_ms');
+      if (raw != null && /^\d+$/.test(raw.trim())) value = `${raw.trim()}ms`;
+    } catch {
+      // A config read failure must never take search down; keep the old default.
+    }
+    this._searchTimeoutCache = { value, at: now };
+    return value;
   }
 
   async getConfig(key: string): Promise<string | null> {

--- a/test/search-statement-timeout.test.ts
+++ b/test/search-statement-timeout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The search arms' statement_timeout must be configurable (#--).
+ *
+ * Five search arms (keyword, titles, keyword-chunks, CJK, vector) bound their
+ * query with a transaction-scoped statement_timeout hardcoded to '8s'. That is
+ * ample on a small brain and unreachable on a large one: on a 157k-page /
+ * 896MB `pages` table the keyword arm cannot finish inside it, so every search
+ * logs "searchKeyword arm failed (fail-open)" and silently degrades to
+ * vector-only — exact-token lookups stop working at the corpus size where they
+ * matter most.
+ *
+ * Hermetic: Object.create(PostgresEngine.prototype) + a stubbed getConfig, the
+ * same shape as postgres-engine-reserved-routing.test.ts. No database.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+
+const ENV_KEY = 'GBRAIN_SEARCH_STATEMENT_TIMEOUT_MS';
+
+function makeEngine(configValue: string | null, opts: { throws?: boolean } = {}) {
+  // Reach past `private` deliberately: intersecting PostgresEngine with the
+  // private field collapses the type to `never` (TS2339), so go through unknown.
+  const engine = Object.create(PostgresEngine.prototype) as PostgresEngine;
+  const priv = engine as unknown as {
+    searchStatementTimeout(): Promise<string>;
+    _searchTimeoutCache: unknown;
+    getConfig: (k: string) => Promise<string | null>;
+  };
+  let reads = 0;
+  priv._searchTimeoutCache = null;
+  priv.getConfig = async (k: string) => {
+    reads++;
+    if (opts.throws) throw new Error('pooler drop');
+    return k === 'search.statement_timeout_ms' ? configValue : null;
+  };
+  return { engine: priv, reads: () => reads };
+}
+
+afterEach(() => { delete process.env[ENV_KEY]; });
+
+describe('search statement timeout is configurable', () => {
+  test('defaults to the historical 8s when nothing is configured', async () => {
+    const { engine } = makeEngine(null);
+    expect(await engine.searchStatementTimeout()).toBe('8s');
+  });
+
+  test('honours search.statement_timeout_ms from the config plane', async () => {
+    const { engine } = makeEngine('45000');
+    expect(await engine.searchStatementTimeout()).toBe('45000ms');
+  });
+
+  test('env override wins over config, for an immediate unblock', async () => {
+    process.env[ENV_KEY] = '30000';
+    const { engine, reads } = makeEngine('45000');
+    expect(await engine.searchStatementTimeout()).toBe('30000ms');
+    // env short-circuits before the round trip
+    expect(reads()).toBe(0);
+  });
+
+  test('ignores a non-numeric config value rather than emitting bad SQL', async () => {
+    const { engine } = makeEngine('30 seconds; DROP TABLE pages');
+    expect(await engine.searchStatementTimeout()).toBe('8s');
+  });
+
+  test('memoises so the hot path does not read config per query', async () => {
+    const { engine, reads } = makeEngine('20000');
+    await engine.searchStatementTimeout();
+    await engine.searchStatementTimeout();
+    await engine.searchStatementTimeout();
+    expect(reads()).toBe(1);
+  });
+
+  test('a config read failure never takes search down', async () => {
+    const { engine } = makeEngine(null, { throws: true });
+    expect(await engine.searchStatementTimeout()).toBe('8s');
+  });
+});


### PR DESCRIPTION
## What

Makes the search arms' transaction-scoped `statement_timeout` configurable instead of hardcoded to `'8s'`, via `search.statement_timeout_ms` (config plane) or `GBRAIN_SEARCH_STATEMENT_TIMEOUT_MS` (env). Default is unchanged, so existing installs behave identically until they opt in.

Five call sites shared the literal: `searchKeyword`, `searchTitles`, `searchKeywordChunks`, `_searchKeywordCJK`, `searchVector`.

## Why

`'8s'` is ample on a small brain and unreachable on a large one. On a 157k-page / 896MB `pages` table the keyword arm cannot finish inside it, so **every** search logs:

```
[gbrain] searchKeyword arm failed (fail-open, keyword candidates skipped):
canceling statement due to statement timeout
```

and silently degrades to vector-only. The practical effect is that **exact-token lookups stop working at exactly the corpus size where they matter most** — searching a literal email address, a surname, or a term like `KITAS` returns semantically similar prose instead of the page containing the string, while conceptual questions still look fine. The degradation is easy to miss because the arm fails open.

Ruled out as causes before touching the timeout: `idx_pages_search` (GIN on `search_vector`) exists, autoanalyze had run a day earlier with only 15k modifications since, and the session `statement_timeout` is `0`.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/postgres-engine.ts` to merge-base, ran `test/search-statement-timeout.test.ts` → 0 pass / 6 fail. Restored → all pass.

## Verification

- `bun run typecheck` — clean
- `bun test test/search-statement-timeout.test.ts` — 6 pass / 0 fail
- `bun test test/postgres-engine-reserved-routing.test.ts test/search-statement-timeout.test.ts test/brainstorm-timeout.test.ts` — 27 pass / 0 fail

## Tests

`test/search-statement-timeout.test.ts`, hermetic (`Object.create(PostgresEngine.prototype)` + stubbed `getConfig`, same shape as `postgres-engine-reserved-routing.test.ts`; no database). Covers:

- defaults to the historical `8s` when nothing is configured
- honours `search.statement_timeout_ms`
- env override wins and short-circuits before the round trip
- **a non-numeric config value is rejected** rather than reaching SQL (`'30 seconds; DROP TABLE pages'` → `8s`)
- memoised so the hot path does not read config per query
- a config read failure keeps the default rather than failing search

## Notes for review

- **`set_config`, not `SET LOCAL`.** A GUC name cannot be parameterised in `SET`, so a dynamic value there means string interpolation. `set_config('statement_timeout', $1, true)` binds the value as a parameter and the third argument scopes it to the transaction — same semantics as before, no injection surface.
- **60s memo.** `getConfig` is a round trip and this is the hot path. 60s keeps `gbrain config set` feeling responsive; happy to change the window or drop the memo if you'd rather take the read every query.
- **Key naming is yours.** I chose `search.statement_timeout_ms` over a keyword-specific name because the vector arm shares the bound. Happy to rename.

Found while running gbrain against a 158k-page personal brain; measurements above are from that install on v0.48.5.0.
