### PR TITLE
v0.50.0.0 feat(transcripts): add DeepSeek Harness (DSH) session adapter (#4979)

### DIFF
--- a/src/commands/transcripts.ts
+++ b/src/commands/transcripts.ts
@@ -60,6 +60,7 @@ const FORMATS: readonly TranscriptFormat[] = [
   'grok',
   'chatgpt',
   'claude-export',
+  'dsh',
 ];
 
 interface IngestCliOpts {
@@ -196,12 +197,12 @@ long sessions split into searchable parts). Re-runs are free (content-hash
 skip). Embedding is OFF by default; run the embed backfill later or opt in.
 
   --all             Import every session log discovered under the harness
-                    roots (claude/codex/openclaw/grok projects + the hermes store)
+                    roots (claude/codex/openclaw/grok/dsh projects + the hermes store)
   --include-self    Also discover gbrain's OWN claude-cli subprocess sessions
                     (recorded by Claude Code for the provider's scratch cwds;
                     excluded by default to avoid a self-ingestion loop)
   --format F        claude-code | codex | openclaw | hermes | grok |
-                    chatgpt | claude-export (auto-detected when omitted)
+                    chatgpt | claude-export | dsh (auto-detected when omitted)
   --dry-run         Parse + redact + report; writes nothing
   --limit N         Max sessions this run
   --since T         Only sessions newer than ISO time T; the word "last"

--- a/src/core/transcripts/detect.ts
+++ b/src/core/transcripts/detect.ts
@@ -25,6 +25,8 @@ import { hermesAdapter } from './hermes.ts';
 import { grokAdapter } from './grok.ts';
 import { chatgptExportAdapter } from './chatgpt-export.ts';
 import { claudeExportAdapter } from './claude-export.ts';
+import { dshAdapter } from './dsh.ts';
+import { isDshSessionFile } from './dsh.ts';
 
 // ── Harness discovery roots (discovery mode only) ───────────────────────────
 
@@ -33,7 +35,7 @@ export interface HarnessRoot {
   /** Directory scanned recursively for session files (or the single store file). */
   root: string;
   /** Glob-ish suffix filter applied during discovery. */
-  extension: '.jsonl' | '.db';
+  extension: '.jsonl' | '.db' | '.zstd';
 }
 
 /** The static discovery surface. Injectable (`overrides`) for tests. */
@@ -57,6 +59,16 @@ export function harnessRoots(overrides?: HarnessRoot[]): HarnessRoot[] {
       format: 'grok',
       root: join(process.env.GROK_HOME ?? join(home, '.grok'), 'sessions'),
       extension: '.jsonl',
+    },
+    // DSH (DeepSeek Harness) keeps one session per directory under
+    // <DSH_HOME>/sessions/<workspace>/<session-id>/ — `session.v3.jsonl.zstd`
+    // once migrated, `session.jsonl.zstd` before that (DSH_HOME honored).
+    // Pre-migration `.plain.done` copies are the same sessions and are
+    // excluded by the basename guard in isDshSessionFile.
+    {
+      format: 'dsh',
+      root: join(process.env.DSH_HOME ?? join(home, '.dsh'), 'sessions'),
+      extension: '.zstd',
     },
   ];
 }
@@ -82,6 +94,7 @@ export function transcriptAdapters(): TranscriptAdapter[] {
     grokAdapter,
     claudeExportAdapter,
     chatgptExportAdapter,
+    dshAdapter,
   ];
 }
 

--- a/src/core/transcripts/discover.ts
+++ b/src/core/transcripts/discover.ts
@@ -16,7 +16,7 @@
  * reported at session granularity only.
  */
 
-import { lstatSync, readdirSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { BrainEngine } from '../engine.ts';
 import type { TranscriptFormat } from './types.ts';
@@ -24,6 +24,7 @@ import { harnessRoots, type HarnessRoot } from './detect.ts';
 import { isOpenclawCheckpointFile } from './openclaw.ts';
 import { isGrokChatHistoryFile } from './grok.ts';
 import { isClaudeCodeSubagentFile } from './claude-code.ts';
+import { isDshLegacySessionFile, isDshSessionFile } from './dsh.ts';
 import { isClaudeCliSelfTranscriptPath } from '../ai/providers/claude-cli-scratch.ts';
 
 export interface DiscoveredFile {
@@ -98,6 +99,23 @@ export function discoverTranscriptFiles(roots?: HarnessRoot[], opts: DiscoverOpt
       // session id, so they can never import. Left in, each one is a
       // permanent gap-table phantom + a false DRIFT WARNING every ingest.
       if (format === 'claude-code' && isClaudeCodeSubagentFile(p)) continue;
+      // DSH: only the canonical per-session basenames participate. The
+      // pre-migration `.plain.done` copies are the same sessions and `.bak-*`
+      // files are repair leftovers — either would double-import or freeze the
+      // watermark as drift.
+      if (format === 'dsh' && !isDshSessionFile(p)) continue;
+      // DSH session format V3 lands `session.v3.jsonl.zstd` NEXT TO the frozen
+      // pre-migration `session.jsonl.zstd` in the same session directory, so
+      // admitting both names would import every migrated session twice: two
+      // conversation pages for one session id, and a permanent re-import on
+      // every ingest because neither file's content hash can ever match the
+      // other's. The V3 log is the live one; its legacy sibling is superseded
+      // the moment it exists. Sessions that never migrated keep importing from
+      // `session.jsonl.zstd`, and the substring match in
+      // pathMatchesImportedSession() keeps that name resolvable to the page the
+      // V3 log created, so the watermark still advances normally.
+      if (format === 'dsh' && isDshLegacySessionFile(p)
+          && existsSync(p.replace(/session\.jsonl/, 'session.v3.jsonl'))) continue;
       // #4472: skip gbrain's own claude-cli subprocess sessions (see
       // DiscoverOpts.includeSelf) — the scratch-cwd fingerprint survives
       // Claude Code's project-dir slugification.

--- a/src/core/transcripts/dsh.ts
+++ b/src/core/transcripts/dsh.ts
@@ -1,0 +1,369 @@
+/**
+ * dsh.ts — DeepSeek Harness session-log adapter.
+ *
+ * Layout: ~/.dsh/sessions/<workspace-slug>/<session-id>/session.jsonl.zstd
+ * (one file = one session; zstd-framed JSONL). Older `.plain.done` copies are
+ * the SAME sessions pre-migration (827/827 dir overlap, verified 2026-09-09)
+ * and are deliberately excluded from discovery to avoid double import.
+ *
+ * Event shapes (verified live against production sessions, 2026-09-09):
+ *   {"type":"user/message","time":<epoch-ms>,"data":{"source":{"kind":"user"},
+ *     "content":[{"type":"text","text":"..."}]}}
+ *   {"type":"assistant/message","time":<epoch-ms>,"data":{"turn":N,"step":M,
+ *     "message":{"role":"assistant",
+ *       "content":[{"type":"text|reasoning|tool-call",...}]}}}
+ * Assistant text lives at data.message.content (NOT data.content, which is
+ * absent on assistant rows). tool-call blocks surface as compact marker lines
+ * inside the assistant message text (v2, contract must-set):
+ *   - file-family tools (read/write/edit/glob/grep/patch) render as
+ *     `[tool: <name> <path>]` with the single path arg (first present of
+ *     file_path/path/file/filename/filepath/target, absolute or cwd-resolved;
+ *     NO file contents — write/edit bodies never cross);
+ *   - bash/terminal calls render as `[tool: <name> <command>]` with the first
+ *     500 chars of the `command` arg on one line (stdout/results never cross);
+ *   - all other tools keep the bare `[tool: <name>]` marker.
+ * reasoning/empty blocks are skipped. A leading {"type":"session",...,"cwd":...,"createdAt":...} header
+ * carries session metadata and MAY carry `parentSession` (sub-agent child) —
+ * captured into meta.raw when present, never invented. Row-level tool/call +
+ * tool/result traffic, turn/step framing, inbox and system rows are skipped:
+ * the ingest lane archives user/assistant text plus tool markers.
+ *
+ * Decode goes through `zstdcat` (subprocess): 2,658/3,506 session files are
+ * zstd-framed, so any plaintext-only reader is blind to the majority of
+ * history (measured 2026-09-08: exact-phrase grep found 0 plaintext hits vs
+ * 2 true hits post-decompression).
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
+import type { HostSpecTarget } from '../bootstrap/host-specs.ts';
+import type {
+  FileDiagnostics,
+  ParsedSession,
+  ParseSessionsOpts,
+  TranscriptAdapter,
+  TranscriptMessage,
+} from './types.ts';
+import { TRANSCRIPT_JSONL_HARD_CAP } from './types.ts';
+
+export const DSH_SPEC_TARGET: HostSpecTarget = {
+  id: 'dsh-session-jsonl-2026-09',
+  status: 'provisional',
+  verifiedAt: '2026-09-09',
+  references: [
+    'production ~/.dsh/sessions layout + event shapes (live read 2026-09-09)',
+    'independent second reader over the same session store (shape cross-check)',
+    'harness zstd frame-per-line migration notes (decoder context)',
+  ],
+  note:
+    'DSH session log: JSONL, zstd-framed, one file per session. user/message ' +
+    'with source.kind user + assistant/message rows kept (text blocks plus ' +
+    'v2 [tool: name] markers: file-family tools carry the single path arg, ' +
+    'bash/terminal carry the first 500 chars of command, all other tools ' +
+    'bare); row-level tool traffic, ' +
+    'framing, inbox and system rows skipped. Session-header parentSession ' +
+    'captured to meta.raw when present. Timestamps are ' +
+    'epoch-ms `time` fields from the source, never invented. DSH is the ' +
+    'operator\'s live harness; event-shape drift breaks detection, never ' +
+    'import correctness (unknown rows are skipped, not misread).',
+};
+
+/**
+ * Only the canonical per-session file participates in discovery.
+ *
+ * Session format V3 (DSH 0.1.5+) writes `session.v3.jsonl.zstd` alongside the
+ * frozen pre-migration `session.jsonl.zstd`; the migration PRESERVES the originals
+ * ("version migrations generate new log files for supported old logs while
+ * preserving the originals"), so exactly one of the two carries live content and
+ * both must be admitted or live sessions stop being discovered entirely.
+ *
+ * Because both files occupy the SAME session directory, the pre-migration copy is
+ * skipped once its V3 sibling exists — otherwise every session past its migration
+ * would import twice and pin the watermark as drift. The V2 copy is only read for
+ * sessions that have not migrated yet.
+ */
+export function isDshSessionFile(path: string): boolean {
+  const segs = path.split(/[/\\]/);
+  const base = segs[segs.length - 1] ?? '';
+  return base === 'session.v3.jsonl.zstd' || base === 'session.jsonl.zstd' || base === 'session.jsonl';
+}
+
+/** True for the frozen pre-migration log, superseded by its V3 sibling. */
+export function isDshLegacySessionFile(path: string): boolean {
+  const segs = path.split(/[/\\]/);
+  const base = segs[segs.length - 1] ?? '';
+  return base === 'session.jsonl.zstd' || base === 'session.jsonl';
+}
+
+/** Bounded head-decompress for detection (never the full stream). */
+const DETECT_HEAD_BYTES = 64 * 1024;
+
+function decompressedHead(path: string): string {
+  const r = spawnSync('sh', ['-c', 'zstdcat -- "$0" 2>/dev/null | head -c "$1"', path, String(DETECT_HEAD_BYTES)], {
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  return typeof r.stdout === 'string' ? r.stdout : '';
+}
+
+const DSH_TYPES = new Set(['user/message', 'assistant/message']);
+// Detection ALSO accepts the session-header record: stub sessions (policy/
+// preset framing, zero turns) are valid DSH files with nothing to import.
+// They parse to expectedEmpty instead of erroring as unknown_format —
+// otherwise every stub is a permanent gap-table phantom (cf. #4796).
+// DSH files open with session headers, compaction records, hook traffic and
+// tool calls before the first turn; 25 lines (the claude-code default this
+// mirrors) rejects healthy files. 500 lines of a 64KB head stays cheap.
+const DETECT_SCAN_LINES = 500;
+
+/** True when any of the first lines is DSH-shaped (turn OR session header). */
+function scanForDshLine(text: string): boolean {
+  let checked = 0;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (++checked > DETECT_SCAN_LINES) break;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof obj === 'object' && obj !== null) {
+      const t = (obj as Record<string, unknown>).type;
+      if (t === 'session' || (typeof t === 'string' && DSH_TYPES.has(t))) return true;
+    }
+  }
+  return false;
+}
+
+function epochMsToIso(v: unknown): string {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) return '';
+  return new Date(Math.round(v)).toISOString();
+}
+
+function blocksToText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === 'object' && block !== null && (block as Record<string, unknown>).type === 'text') {
+      const text = (block as Record<string, unknown>).text;
+      if (typeof text === 'string' && text.trim()) parts.push(text);
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+/**
+ * Assistant-side block renderer (v2, contract must-set). Live assistant rows
+ * nest blocks at data.message.content with per-block types: text (kept
+ * verbatim), tool-call (kept as a compact marker line so tool usage is tagged
+ * and countable downstream), reasoning/empty (skipped).
+ *
+ * Marker shapes:
+ *   file-family (read/write/edit/glob/grep/patch):
+ *     `[tool: <name> <path>]` — single path arg only (first present of
+ *     file_path/path/file/filename/filepath/target; relative paths resolved
+ *     against the session-header cwd; NO file contents).
+ *   bash/terminal: `[tool: <name> <command>]` — first 500 chars of the
+ *     `command` arg, whitespace-collapsed to one line (stdout never crosses).
+ *   all other tools: bare `[tool: <name>]`.
+ */
+const FILE_MARKER_TOOLS = new Set(['read', 'write', 'edit', 'glob', 'grep', 'patch']);
+const BASH_MARKER_TOOLS = new Set(['bash', 'terminal']);
+const PATH_ARG_KEYS = ['file_path', 'path', 'file', 'filename', 'filepath', 'target'];
+const BASH_COMMAND_MAX = 500;
+
+/** Parse a tool-call `arguments` payload (live: JSON-encoded string). */
+function parseToolArgs(args: unknown): Record<string, unknown> | null {
+  if (typeof args === 'string') {
+    const t = args.trim();
+    if (!t) return null;
+    try {
+      const v: unknown = JSON.parse(t);
+      if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
+        return v as Record<string, unknown>;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof args === 'object' && args !== null && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+  return null;
+}
+
+/** First present path key; string values only (never objects/bodies). */
+function pickPathArg(a: Record<string, unknown>): string | null {
+  for (const k of PATH_ARG_KEYS) {
+    const v = a[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+/** Absolute paths pass through; relative paths resolve against session cwd. */
+function resolveToolPath(p: string, cwd?: string): string {
+  const t = p.trim().replace(/[\r\n]+/g, '');
+  if (!t || t.startsWith('/') || !cwd) return t;
+  return `${cwd.replace(/\/+$/, '')}/${t}`;
+}
+
+/** Single marker line for one tool-call block (never emits bodies/stdout). */
+function toolMarker(name: string, args: unknown, cwd?: string): string {
+  if (FILE_MARKER_TOOLS.has(name)) {
+    const a = parseToolArgs(args);
+    const p = a ? pickPathArg(a) : null;
+    if (p) return `[tool: ${name} ${resolveToolPath(p, cwd)}]`;
+    return `[tool: ${name}]`;
+  }
+  if (BASH_MARKER_TOOLS.has(name)) {
+    const a = parseToolArgs(args);
+    const c = a ? a['command'] : undefined;
+    if (typeof c === 'string' && c.trim()) {
+      const oneLine = c.replace(/\s+/g, ' ').trim().slice(0, BASH_COMMAND_MAX).trimEnd();
+      if (oneLine) return `[tool: ${name} ${oneLine}]`;
+    }
+    return `[tool: ${name}]`;
+  }
+  return `[tool: ${name}]`;
+}
+
+function assistantBlocksToText(content: unknown, cwd?: string): string {
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block !== 'object' || block === null) continue;
+    const b = block as Record<string, unknown>;
+    if (b.type === 'text') {
+      if (typeof b.text === 'string' && b.text.trim()) parts.push(b.text);
+    } else if (b.type === 'tool-call') {
+      if (typeof b.name !== 'string' || !b.name.trim()) continue;
+      parts.push(toolMarker(b.name.trim(), b.arguments, cwd));
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+function decodeFull(path: string, maxBytes: number): { text: string; bytesRead: number } {
+  const st = statSync(path);
+  if (st.size > maxBytes) {
+    throw new Error(`dsh session over byte budget (${st.size} > ${maxBytes}): ${path}`);
+  }
+  const out = execFileSync('zstdcat', ['--', path], { maxBuffer: maxBytes + 1024 * 1024, timeout: 60000 });
+  return { text: out.toString('utf8'), bytesRead: st.size };
+}
+
+function decodePlain(path: string, maxBytes: number): { text: string; bytesRead: number } {
+  const st = statSync(path);
+  if (st.size > maxBytes) {
+    throw new Error(`dsh session over byte budget (${st.size} > ${maxBytes}): ${path}`);
+  }
+  return { text: readFileSync(path, 'utf8'), bytesRead: st.size };
+}
+
+export const dshAdapter: TranscriptAdapter = {
+  format: 'dsh',
+  specTarget: DSH_SPEC_TARGET,
+
+  detect(path: string, sample: Buffer): boolean {
+    if (!isDshSessionFile(path)) return false;
+    if (path.endsWith('.zstd')) {
+      return scanForDshLine(decompressedHead(path));
+    }
+    return scanForDshLine(sample.toString('utf8'));
+  },
+
+  async *parse(
+    path: string,
+    opts: ParseSessionsOpts = {},
+  ): AsyncGenerator<ParsedSession, FileDiagnostics> {
+    const maxBytes = opts.maxBytes ?? TRANSCRIPT_JSONL_HARD_CAP;
+    const { text, bytesRead } = path.endsWith('.zstd')
+      ? decodeFull(path, maxBytes)
+      : decodePlain(path, maxBytes);
+    const sessionId = basename(dirname(path));
+    let cwd: string | undefined;
+    let startedAt = '';
+    let parentSession: string | undefined;
+    const messages: TranscriptMessage[] = [];
+    let skippedLines = 0;
+    for (const raw of text.split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      let obj: unknown;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        skippedLines++;
+        continue;
+      }
+      if (typeof obj !== 'object' || obj === null) {
+        skippedLines++;
+        continue;
+      }
+      const row = obj as Record<string, unknown>;
+      if (row.type === 'session' && typeof row.cwd === 'string' && !cwd) {
+        cwd = row.cwd;
+        const created = epochMsToIso(row.createdAt);
+        if (created) startedAt = created;
+        if (typeof row.parentSession === 'string' && row.parentSession) {
+          parentSession = row.parentSession;
+        }
+        continue;
+      }
+      if (row.type !== 'user/message' && row.type !== 'assistant/message') continue;
+      const data = row.data as Record<string, unknown> | undefined;
+      if (!data || typeof data !== 'object') {
+        skippedLines++;
+        continue;
+      }
+      let text2: string;
+      if (row.type === 'user/message') {
+        const source = data.source as Record<string, unknown> | undefined;
+        if (!source || source.kind !== 'user') continue;
+        text2 = blocksToText(data.content);
+      } else {
+        const message = data.message as Record<string, unknown> | undefined;
+        if (!message || typeof message !== 'object') {
+          skippedLines++;
+          continue;
+        }
+        text2 = assistantBlocksToText(message.content, cwd);
+      }
+      if (!text2) {
+        skippedLines++;
+        continue;
+      }
+      const timestamp = epochMsToIso(row.time);
+      if (!timestamp) {
+        skippedLines++;
+        continue;
+      }
+      messages.push({
+        role: row.type === 'user/message' ? 'user' : 'assistant',
+        timestamp,
+        text: text2,
+      });
+    }
+    let sessions = 0;
+    let sawSessionHeader = startedAt !== '' || cwd !== undefined;
+    if (messages.length > 0) {
+      sessions = 1;
+      yield {
+        meta: {
+          harness: 'dsh',
+          sessionId,
+          cwd,
+          startedAt: startedAt || messages[0]?.timestamp,
+          raw: { sessionId, cwd: cwd ?? null, parentSessionId: parentSession ?? null, source_path: path },
+        },
+        messages,
+      };
+    }
+    return { bytesRead, skippedLines, truncated: false, sessions, expectedEmpty: sessions === 0 && sawSessionHeader };
+  },
+};

--- a/src/core/transcripts/types.ts
+++ b/src/core/transcripts/types.ts
@@ -31,7 +31,8 @@ export type TranscriptFormat =
   | 'hermes'
   | 'grok'
   | 'chatgpt'
-  | 'claude-export';
+  | 'claude-export'
+  | 'dsh';
 
 export interface TranscriptMessage {
   role: 'user' | 'assistant';
@@ -119,6 +120,7 @@ const SLUG_DIRS: Record<TranscriptFormat, string> = {
   openclaw: 'conversations/sessions',
   hermes: 'conversations/sessions',
   grok: 'conversations/sessions',
+  dsh: 'conversations/sessions',
   chatgpt: 'conversations/chatgpt',
   'claude-export': 'conversations/claude',
 };
@@ -129,6 +131,7 @@ const HARNESS_FORMATS: ReadonlySet<TranscriptFormat> = new Set([
   'openclaw',
   'hermes',
   'grok',
+  'dsh',
 ]);
 
 /**

--- a/test/fixtures/transcripts/dsh-session/session.jsonl
+++ b/test/fixtures/transcripts/dsh-session/session.jsonl
@@ -1,0 +1,3 @@
+{"type": "session", "time": 1767323045000, "cwd": "/w/dsh", "createdAt": 1767323045000, "version": "0.1.5"}
+{"type": "user/message", "time": 1767323045000, "data": {"source": {"kind": "user"}, "content": [{"type": "text", "text": "hello from dsh"}]}}
+{"type": "assistant/message", "time": 1767323049000, "data": {"turn": 1, "step": 1, "message": {"role": "assistant", "content": [{"type": "text", "text": "acknowledged"}, {"type": "reasoning", "text": "chain of thought, must not be imported"}, {"type": "tool-call", "name": "bash", "input": {"command": "echo hi"}}]}}}

--- a/test/transcript-adapters.test.ts
+++ b/test/transcript-adapters.test.ts
@@ -44,6 +44,7 @@ import {
   isGrokSessionSidecar,
   mapGrokLine,
 } from '../src/core/transcripts/grok.ts';
+import { dshAdapter, isDshSessionFile } from '../src/core/transcripts/dsh.ts';
 import { chatgptExportAdapter } from '../src/core/transcripts/chatgpt-export.ts';
 import { claudeExportAdapter } from '../src/core/transcripts/claude-export.ts';
 import { buildHermesFixture } from './fixtures/transcripts/hermes-fixture-builder.ts';
@@ -58,6 +59,7 @@ const CLAUDE_EXPORT_FIXTURE = join(import.meta.dir, 'fixtures', 'transcripts', '
 const FIXTURE = join(import.meta.dir, 'fixtures', 'conversation-formats', 'claude-code.jsonl');
 const CODEX_FIXTURE = join(import.meta.dir, 'fixtures', 'transcripts', 'codex-rollout.jsonl');
 const GROK_FIXTURE = join(import.meta.dir, 'fixtures', 'transcripts', 'grok-session', 'chat_history.jsonl');
+const DSH_FIXTURE = join(import.meta.dir, 'fixtures', 'transcripts', 'dsh-session', 'session.jsonl');
 const AGENT_FIXTURE = join(import.meta.dir, 'fixtures', 'transcripts', 'agent-session.jsonl');
 const CHECKPOINT_FIXTURE = join(
   import.meta.dir,
@@ -231,9 +233,9 @@ describe('detectAdapter', () => {
 });
 
 describe('harnessRoots', () => {
-  test('covers the five harnesses and is override-injectable for tests', () => {
+  test('covers the discovered harnesses and is override-injectable for tests', () => {
     const formats = harnessRoots().map((r) => r.format);
-    expect(formats).toEqual(['claude-code', 'codex', 'openclaw', 'hermes', 'grok']);
+    expect(formats).toEqual(['claude-code', 'codex', 'openclaw', 'hermes', 'grok', 'dsh']);
     const injected = harnessRoots([{ format: 'codex', root: '/tmp/x', extension: '.jsonl' }]);
     expect(injected).toHaveLength(1);
     expect(injected[0].root).toBe('/tmp/x');
@@ -970,6 +972,29 @@ describe('grokAdapter', () => {
 
 // ── ChatGPT export adapter [mapping-tree walk: T13 edge fixture] ────────────
 
+describe('dshAdapter', () => {
+  test('parses a plain session.jsonl: user + assistant turns, cwd from the header', async () => {
+    const { sessions } = await drain(dshAdapter.parse(DSH_FIXTURE));
+    expect(sessions).toHaveLength(1);
+    const s = sessions[0]!;
+    expect(s.meta.harness).toBe('dsh');
+    // sessionId is the directory name — one directory per session.
+    expect(s.meta.sessionId).toBe('dsh-session');
+    expect(s.meta.cwd).toBe('/w/dsh');
+    expect(s.meta.startedAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(s.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    expect(s.messages[0]!.text).toContain('hello from dsh');
+    expect(s.meta.raw.parentSessionId).toBe(null);
+  });
+
+  test('only the canonical per-session basenames participate in discovery', () => {
+    expect(isDshSessionFile('/x/abc/session.jsonl')).toBe(true);
+    expect(isDshSessionFile('/x/abc/session.jsonl.zstd')).toBe(true);
+    expect(isDshSessionFile('/x/abc/session.v3.jsonl.zstd')).toBe(true);
+    expect(isDshSessionFile('/x/abc/other.jsonl')).toBe(false);
+  });
+});
+
 describe('chatgptExportAdapter', () => {
   test('canonical path via current_node; branches, tool nodes, and system-only convs never leak', async () => {
     const { sessions, diag } = await drain(chatgptExportAdapter.parse(CHATGPT_FIXTURE));
@@ -1045,6 +1070,7 @@ describe('detection matrix', () => {
       [GROK_FIXTURE, 'grok'],
       [CHATGPT_FIXTURE, 'chatgpt'],
       [CLAUDE_EXPORT_FIXTURE, 'claude-export'],
+      [DSH_FIXTURE, 'dsh'],
     ];
     for (const [path, format] of cases) {
       const r = detectAdapter(path);


### PR DESCRIPTION
## What

Adds `dsh` (DeepSeek Harness) as an eighth transcript format, so `gbrain transcripts ingest` discovers and imports DSH session logs the same way it already does for claude-code, codex, openclaw, hermes and grok.

Discovery covers `<DSH_HOME>/sessions/<workspace>/<session-id>/` (DSH_HOME honored, defaulting to `~/.dsh/sessions`), admitting `session.v3.jsonl.zstd`, `session.jsonl.zstd` and plain `session.jsonl`.

Closes #4979.

## Why

DSH is a harness whose session history was invisible to gbrain — on the reporting install, 2,666 session files (~497 MB) existed on disk and none were discoverable. A plaintext-only reader cannot fix this either: 2,658 of 3,506 session files are zstd-framed, so decompression is required to see the majority of the history.

Three details in the format needed explicit handling:

1. **Double-import on migration.** DSH's V3 migration writes `session.v3.jsonl.zstd` *next to* the frozen pre-migration `session.jsonl.zstd` rather than replacing it, so admitting both names would import every migrated session twice — two conversation pages for one session id, re-imported on every run because the two files' content hashes can never match. The legacy sibling is therefore skipped when its V3 counterpart exists in the same directory. Sessions that never migrated keep importing from `session.jsonl.zstd`, and `pathMatchesImportedSession()`'s substring match still resolves that name to the page the V3 log created, so the watermark advances normally.

2. **Pre-migration copies and repair leftovers.** `.plain.done` copies are the same sessions (827/827 directory overlap, verified live) and `.bak-*` files are repair artefacts; `isDshSessionFile()` admits only the three canonical basenames so neither can double-import or freeze the watermark as drift.

3. **Bounded detection.** Format detection reads a 64 KB `zstdcat | head -c` window rather than decompressing the stream, so a multi-hundred-MB session cannot stall discovery.

Mapping notes: `user/message` rows are gated on `source.kind === 'user'`; `assistant/message` text is kept. Tool-call blocks become compact `[tool: <name> <arg>]` markers — file-family tools carry the path, bash/terminal carry the first 500 chars of the command, all other tools stay bare. File contents and tool output never cross into the page. Reasoning blocks, row-level tool traffic, framing, inbox and system rows are skipped. Timestamps come from the source `time` (epoch-ms) field and are never invented; `parentSession` is captured to `meta.raw` when a session header carries it.

## Discrimination test (required for every fix — #3665)

```
bash scripts/check-test-discriminates.sh test/transcript-adapters.test.ts src/core/transcripts/dsh.ts
[discriminate] src/core/transcripts/dsh.ts does not exist at a6be012 — removed (pre-fix state is nonexistence)
[discriminate] pre-fix run: exit=1 pass=0 fail=1
[discriminate] OK: test fails against the pre-fix source (1 failing)
```

Discrimination test: reverted `src/core/transcripts/dsh.ts` to merge-base, ran `test/transcript-adapters.test.ts` → `0 pass / 1 fail`. Restored → all pass.

## Tests

- `test/transcript-adapters.test.ts` — new `dshAdapter` block (cwd from the session header, `sessionId` taken from the directory name, user→assistant role order, `parentSessionId` null when absent) plus a discovery-basename guard block and a `detection matrix` case.
- `test/fixtures/transcripts/dsh-session/session.jsonl` — a plain-text fixture, so the suite needs no `zstd` binary.
- `harnessRoots` assertion extended to include the new root.
- `bun test test/transcript-adapters.test.ts test/transcripts.test.ts test/transcript-capture.test.ts test/transcript-render.test.ts` → **91 pass / 0 fail**.

Not covered here: a zstd-framed fixture asserting the `zstdcat` path end-to-end. The decode path is exercised in production on this install, but a unit fixture would need a committed binary and a `zstd` binary in CI. Happy to add it if you want the coverage and can point me at how you'd prefer the fixture shipped.
