### PR TITLE
v0.50.0.1 feat(ai): OpenRouter xAI (x-ai/) routes may drive the subagent loop — live abort/retry pin

### DIFF
--- a/src/core/ai/openrouter-families.ts
+++ b/src/core/ai/openrouter-families.ts
@@ -8,12 +8,13 @@
  *
  *   anthropic/  test/e2e/openrouter-anthropic-subagent-replay.live.test.ts
  *   deepseek/   test/e2e/openrouter-deepseek-subagent-replay.live.test.ts
+ *   x-ai/       test/e2e/openrouter-xai-subagent-replay.live.test.ts
  *
  * Other proxied families stay refused until they get their own pin
  * (TODOS.md OpenRouter follow-up). Shared by the recipe predicate and the
  * subagent handler's auto-route so the two can never disagree.
  */
-export const OPENROUTER_SUBAGENT_FAMILIES: readonly string[] = ['anthropic/', 'deepseek/'];
+export const OPENROUTER_SUBAGENT_FAMILIES: readonly string[] = ['anthropic/', 'deepseek/', 'x-ai/'];
 
 /** `modelId` is the bare OpenRouter id (`anthropic/claude-haiku-4.5`), no `openrouter:` prefix. */
 export function openrouterModelSupportsSubagentLoop(modelId: string): boolean {

--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -63,8 +63,8 @@ export function openrouterThinkingByDefault(modelId: string): boolean {
  * Which proxied families may drive the subagent loop. The gateway loop keys
  * replay on gbrain_tool_use_id, not the raw provider id, so a family only
  * needs a live abort/retry pin proving its tool-call envelope survives a
- * resume. Anthropic and DeepSeek have one (test/e2e/openrouter-*-subagent-
- * replay.live.test.ts); other families stay refused until they do
+ * resume. Anthropic, DeepSeek and xAI have one (test/e2e/openrouter-*-
+ * subagent-replay.live.test.ts); other families stay refused until they do
  * (TODOS.md OpenRouter follow-up). List lives in ../openrouter-families.ts.
  */
 export function openrouterSupportsSubagentLoop(modelId: string): boolean {
@@ -177,9 +177,9 @@ export const openrouterCompatFetch = (async (
  * downstream agent stacks (OpenClaw deployments, etc.) get their own
  * attribution on OR's leaderboard instead of polluting gbrain's.
  *
- * Subagent loops: Anthropic (`anthropic/…`) and DeepSeek (`deepseek/…`)
- * routes declare `supports_subagent_loop` so classifyCapabilities() allows
- * them, and the handler auto-routes those jobs through `gateway.toolLoop()`
+ * Subagent loops: Anthropic (`anthropic/…`), DeepSeek (`deepseek/…`) and
+ * xAI (`x-ai/…`) routes declare `supports_subagent_loop` so
+ * classifyCapabilities() allows them, and the handler auto-routes those jobs through `gateway.toolLoop()`
  * (OR is not a native Anthropic provider, so the Messages SDK path is never
  * used for `openrouter:*`). Other OR families stay refused until they get a
  * live abort/retry pin (TODOS.md).

--- a/test/e2e/openrouter-xai-subagent-replay.live.test.ts
+++ b/test/e2e/openrouter-xai-subagent-replay.live.test.ts
@@ -1,0 +1,172 @@
+/**
+ * LIVE e2e — OpenRouter xAI (Grok) subagent abort/retry (TODOS.md OpenRouter follow-up).
+ *
+ * Skip-gated on OPENROUTER_API_KEY. First turn hits real OR Grok 4.6, persists
+ * the tool-call, completes the observation, then aborts before the follow-up
+ * model turn. Resume must keep those persisted tool-call ids byte-identical
+ * and must not re-dispatch the completed tool.
+ *
+ * The gateway loop swallows tool-execute errors (they become tool-result
+ * isError blocks). Abort is therefore the job AbortSignal after the first
+ * successful observation — not a throw from execute.
+ *
+ * OpenRouter proxies xAI through the OpenAI-compatible tool envelope; the
+ * gateway loop keys replay on gbrain_tool_use_id, so what this pins is that
+ * the proxied envelope survives an abort + resume byte-identically.
+ *
+ * Run (keep-keys required — unit preload strips OPENROUTER_API_KEY):
+ *   GBRAIN_TEST_KEEP_PROVIDER_KEYS=1 OPENROUTER_API_KEY=... \
+ *     bun test test/e2e/openrouter-xai-subagent-replay.live.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import { makeSubagentHandler } from '../../src/core/minions/handlers/subagent.ts';
+import type { MinionJobContext, ToolDef, ToolCtx } from '../../src/core/minions/types.ts';
+import { configureGateway, resetGateway } from '../../src/core/ai/gateway.ts';
+
+const MODEL = 'openrouter:x-ai/grok-4.6';
+const API_KEY = process.env.OPENROUTER_API_KEY;
+const skipAll = !API_KEY;
+const SYSTEM =
+  'You are a tool-using intern. You MUST call ping before you say anything else. Never answer in prose first.';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  resetGateway();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('version', '85');
+  // Flag OFF on purpose: OR xAI must auto-route through the gateway.
+  await engine.unsetConfig('agent.use_gateway_loop');
+  if (skipAll) return;
+  configureGateway({
+    chat_model: MODEL,
+    embedding_model: 'openrouter:openai/text-embedding-3-small',
+    embedding_dimensions: 1024,
+    expansion_model: MODEL,
+    env: { OPENROUTER_API_KEY: API_KEY! },
+  });
+});
+
+function makeCtx(
+  jobId: number,
+  prompt: string,
+  signal: AbortSignal,
+): MinionJobContext {
+  return {
+    id: jobId,
+    name: 'subagent',
+    data: { prompt, model: MODEL, max_turns: 4, system: SYSTEM },
+    attempts_made: 0,
+    signal,
+    deadlineAtMs: null,
+    shutdownSignal: new AbortController().signal,
+    updateProgress: async () => {},
+    updateTokens: async () => {},
+    log: async () => {},
+    isActive: async () => true,
+    readInbox: async () => [],
+  };
+}
+
+async function makeJob(prompt: string): Promise<{ jobId: number }> {
+  const rows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO minion_jobs (submission_authority, name, status, data, queue, priority, created_at)
+     VALUES ('{"version":1,"kind":"application"}'::jsonb, 'subagent', 'active', $1::jsonb, 'default', 0, now())
+     RETURNING id`,
+    [JSON.stringify({ prompt, model: MODEL, max_turns: 4, system: SYSTEM })],
+  );
+  return { jobId: rows[0]!.id };
+}
+
+describe('OpenRouter xAI live — abort mid-loop and resume', () => {
+  test('persisted tool-call ids stay byte-identical across resume', async () => {
+    if (skipAll) {
+      console.warn('[skip] OPENROUTER_API_KEY not set');
+      return;
+    }
+
+    let pingCalls = 0;
+    const firstAbort = new AbortController();
+    const tools: ToolDef[] = [
+      {
+        name: 'ping',
+        description: 'Mandatory ping. Call this tool once with {"who":"gbrain"} before answering.',
+        input_schema: {
+          type: 'object',
+          properties: { who: { type: 'string' } },
+          required: ['who'],
+        },
+        idempotent: true,
+        async execute(_input: unknown, _ctx: ToolCtx) {
+          pingCalls += 1;
+          if (pingCalls === 1) {
+            // Observation is complete; abort before the follow-up model turn.
+            firstAbort.abort();
+          }
+          return { pong: true };
+        },
+      },
+    ];
+
+    const handler = makeSubagentHandler({
+      engine,
+      config: {} as never,
+      toolRegistry: tools,
+      makeAnthropic: () => ({
+        messages: {
+          create: async () => {
+            throw new Error('legacy Anthropic SDK must not run for openrouter:*');
+          },
+        },
+      }) as never,
+    });
+
+    const prompt = 'Call the ping tool exactly once with who=gbrain, then say done. Do not skip the tool.';
+    const { jobId } = await makeJob(prompt);
+
+    const first = await handler(makeCtx(jobId, prompt, firstAbort.signal));
+    expect(pingCalls).toBe(1);
+    expect(first.stop_reason).toBe('error');
+
+    const firstRows = await engine.executeRaw<{ content_blocks: unknown }>(
+      `SELECT content_blocks FROM subagent_messages
+        WHERE job_id = $1 AND role = 'assistant'
+        ORDER BY message_idx ASC LIMIT 1`,
+      [jobId],
+    );
+    expect(firstRows.length).toBe(1);
+    const firstBlocks = typeof firstRows[0]!.content_blocks === 'string'
+      ? firstRows[0]!.content_blocks
+      : JSON.stringify(firstRows[0]!.content_blocks);
+    expect(firstBlocks).toMatch(/tool-call|tool_use/);
+
+    const resume = await handler(makeCtx(jobId, prompt, new AbortController().signal));
+    expect(resume.stop_reason).toBe('end_turn');
+    // First observation already completed; resume must not re-execute it.
+    expect(pingCalls).toBe(1);
+
+    const secondRows = await engine.executeRaw<{ content_blocks: unknown }>(
+      `SELECT content_blocks FROM subagent_messages
+        WHERE job_id = $1 AND role = 'assistant'
+        ORDER BY message_idx ASC LIMIT 1`,
+      [jobId],
+    );
+    const secondBlocks = typeof secondRows[0]!.content_blocks === 'string'
+      ? secondRows[0]!.content_blocks
+      : JSON.stringify(secondRows[0]!.content_blocks);
+    expect(secondBlocks).toBe(firstBlocks);
+  }, 90_000);
+});

--- a/test/model-config.serial.test.ts
+++ b/test/model-config.serial.test.ts
@@ -325,6 +325,7 @@ describe('resolveModel — v0.31.12 tier system', () => {
     expect(isOpenRouterSubagentFamily('openrouter:anthropic/claude-haiku-4.5')).toBe(true);
     expect(isOpenRouterSubagentFamily('openrouter:deepseek/deepseek-v4-flash')).toBe(true);
     expect(isOpenRouterSubagentFamily('openrouter:DeepSeek/deepseek-chat')).toBe(true);
+    expect(isOpenRouterSubagentFamily('openrouter:x-ai/grok-4.6')).toBe(true);
     expect(isOpenRouterSubagentFamily('openrouter:openai/gpt-5.2')).toBe(false);
     expect(isOpenRouterSubagentFamily('openrouter:google/gemini-3-flash-preview')).toBe(false);
     expect(isOpenRouterSubagentFamily('deepseek:deepseek-v4-flash')).toBe(false);


### PR DESCRIPTION
## What

`openrouter:x-ai/*` models (Grok 4.6 etc.) can now drive the subagent loop. `x-ai/` joins `anthropic/` and `deepseek/` in `OPENROUTER_SUBAGENT_FAMILIES`, so `classifyCapabilities()` accepts the model and the handler auto-routes the job through `gateway.toolLoop()`. Every other OpenRouter family stays refused, as before.

## Why

The families registry says a proxied family is admitted only once it has a live abort/retry pin proving its tool-call envelope survives an abort mid-loop and a resume byte-identically. Anthropic and DeepSeek have one; xAI did not, so a brain configured with `openrouter:x-ai/grok-4.6` as its subagent model was refused even though the OpenAI-compatible envelope OpenRouter uses for xAI replays cleanly (the gateway keys replay on `gbrain_tool_use_id`, not the provider id).

`test/e2e/openrouter-xai-subagent-replay.live.test.ts` is that pin, a sibling of the DeepSeek one: first turn calls the tool once, the job aborts after the observation, the resume finishes with `end_turn` without re-executing the tool, and the persisted assistant `content_blocks` are identical across the resume. Skip-gated on `OPENROUTER_API_KEY`.

I have been running Grok 4.6 as the subagent model on a Postgres brain with this one-line change carried as a local patch since 2026-09-01 (dream / autopilot subagent jobs), with no replay problems.

## Discrimination test (required for every fix — #3665)

Discrimination test: reverted `src/core/ai/openrouter-families.ts` to merge-base, ran `test/model-config.serial.test.ts` → 45 pass / 1 fail. Restored → all pass.

Discrimination test: reverted `src/core/ai/openrouter-families.ts` to merge-base, ran `test/e2e/openrouter-xai-subagent-replay.live.test.ts` → 0 pass / 1 fail. Restored → all pass.

## Tests

- `GBRAIN_TEST_KEEP_PROVIDER_KEYS=1 OPENROUTER_API_KEY=… bun test test/e2e/openrouter-xai-subagent-replay.live.test.ts` → 1 pass, 7 expect() calls, ~4s against live OpenRouter `x-ai/grok-4.6`. Run twice, both green.
- `bun test test/model-config.serial.test.ts` → 46 pass (adds `isOpenRouterSubagentFamily('openrouter:x-ai/grok-4.6')` → true).
- `bun run typecheck` clean.
- Docstrings in `src/core/ai/recipes/openrouter.ts` that enumerate the allowed families updated to include xAI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
