### PR TITLE
fix(doctor): honour GBRAIN_DRIFT_LIMIT and GBRAIN_DRIFT_TIMEOUT_MS

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1679,7 +1679,9 @@ export async function buildChecks(
   // Engine is nullable in runDoctor (--fast / DB-down skip the DB phase);
   // bail silently here when engine is null since the check needs DB access.
   if (engine !== null) try {
-    const { findMisroutedPages } = await import('../core/multi-source-drift.ts');
+    const { findMisroutedPages, driftBudgetFromEnv } = await import(
+      '../core/multi-source-drift.ts'
+    );
     const sources = await engine!.executeRaw<{ id: string; local_path: string | null }>(
       `SELECT id, local_path FROM sources`,
     );
@@ -1688,6 +1690,7 @@ export async function buildChecks(
       const result = await findMisroutedPages(
         engine!,
         nonDefaultWithPath.map(s => ({ id: s.id, local_path: s.local_path as string })),
+        driftBudgetFromEnv(),
       );
       if (result.walk_truncated) {
         checks.push({

--- a/src/commands/doctor/report-remote.ts
+++ b/src/commands/doctor/report-remote.ts
@@ -277,7 +277,9 @@ export async function doctorReportRemote(
   // doctor's check at the same name. Runs server-side; the result is
   // returned to the thin-client over MCP.
   try {
-    const { findMisroutedPages } = await import('../../core/multi-source-drift.ts');
+    const { findMisroutedPages, driftBudgetFromEnv } = await import(
+      '../../core/multi-source-drift.ts'
+    );
     // Source isolation: a scoped caller's roster (and the sample slugs the
     // walk returns) stays inside its grant; unscoped = brain-wide.
     const sources = await engine.executeRaw<{ id: string; local_path: string | null }>(
@@ -286,9 +288,15 @@ export async function doctorReportRemote(
     );
     const nonDefaultWithPath = sources.filter(s => s.id !== 'default' && s.local_path);
     if (sources.length > 1 && nonDefaultWithPath.length > 0) {
+      // Same budget as the local check. The values come from the brain
+      // server's own environment, never from the MCP caller, so this does not
+      // widen what a scoped client can influence -- and an operator who raises
+      // the walk budget on the host should not find one of the two call sites
+      // quietly ignoring it.
       const result = await findMisroutedPages(
         engine,
         nonDefaultWithPath.map(s => ({ id: s.id, local_path: s.local_path as string })),
+        driftBudgetFromEnv(),
       );
       if (result.walk_truncated) {
         checks.push({

--- a/src/core/multi-source-drift.ts
+++ b/src/core/multi-source-drift.ts
@@ -78,6 +78,36 @@ const DEFAULT_TIMEOUT_MS = 5_000;
 const SAMPLE_LIMIT = 5;
 
 /**
+ * The walk budget as the environment overrides it.
+ *
+ * `multi_source_drift`'s truncation message tells the operator to re-run "via
+ * GBRAIN_DRIFT_LIMIT/GBRAIN_DRIFT_TIMEOUT_MS", and the sync_freshness tests
+ * describe those names as this module's "existing guard infrastructure" -- but
+ * nothing read them. `findMisroutedPages` was called from doctor.ts with no
+ * opts, so the two constants above were the only budget there was, and a brain
+ * whose non-default source holds more than 10,000 files truncated on every run
+ * with no way out.
+ *
+ * A non-numeric or non-positive value falls back to the default rather than
+ * propagating NaN -- which for the deadline would mean a walk that is already
+ * expired, i.e. a worse version of the bug being fixed. Same shape as
+ * GBRAIN_DOCTOR_FM_TIMEOUT_MS in doctor.ts.
+ */
+export function driftBudgetFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): { limit?: number; timeoutMs?: number } {
+  const positiveInt = (name: string): number | undefined => {
+    const raw = env[name];
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+  return {
+    limit: positiveInt('GBRAIN_DRIFT_LIMIT'),
+    timeoutMs: positiveInt('GBRAIN_DRIFT_TIMEOUT_MS'),
+  };
+}
+
+/**
  * Walk a directory tree for `.md` + `.mdx` files. Skips dotfiles (`.git`),
  * `_*.md` files (the existing extract.ts convention), and silently swallows
  * read errors on individual entries. Returns relative paths from `root`.


### PR DESCRIPTION
## The bug

`multi_source_drift` tells the operator to re-run "via `GBRAIN_DRIFT_LIMIT`/`GBRAIN_DRIFT_TIMEOUT_MS`" when its filesystem walk truncates, and `test/doctor.test.ts` describes those names as this module's *"existing guard infrastructure"*. Nothing reads them.

`findMisroutedPages` accepts `opts: { limit?, timeoutMs? }`, but both call sites — `src/commands/doctor.ts` and `src/commands/doctor/report-remote.ts` — called it with no `opts`, so `DEFAULT_FILE_LIMIT` (10,000) and `DEFAULT_TIMEOUT_MS` (5,000) were the only budget there was. On `v0.50.0.0` the two names appear three times in the tree — a message string, a comment, and a test comment — and zero times as a `process.env` read.

## Why it matters

On a brain whose non-default source holds more than 10,000 files, the walk truncates on every run and the advertised remedy changes nothing. The check is then permanently skipped with no way out: real drift goes unreported, while `doctor` emits a warn that looks actionable and is not. I hit this on a brain with two Gmail-connector sources of roughly 13,000 files each, raised both variables to 40,000 and 120,000ms, and measured no change before looking at the source.

## The change

A small exported helper, `driftBudgetFromEnv`, reads both names; both call sites pass it.

A non-numeric or non-positive value falls back to the default rather than propagating `NaN`. That guard is the load-bearing part: `Date.now() + NaN` is `NaN`, so every `Date.now() >= deadlineMs` comparison is false and the walk loses its stop condition — strictly worse than the bug being fixed. The shape matches the existing `GBRAIN_DOCTOR_FM_TIMEOUT_MS` reader in `doctor.ts`.

The remote path gets the same budget deliberately. Its values come from the brain server's own environment, never from the MCP caller, so this does not widen what a scoped client can influence — and an operator who raises the walk budget on the host should not find one of two call sites quietly ignoring it. The existing source-isolation and git-root-skip behaviour is untouched.

## Tests

Six cases in `test/multi-source-drift-env-budget.test.ts`, covering both knobs, each alone, junk and non-positive values, `parseInt` trailing-garbage parity with the existing reader, and the returned shape staying assignable to the callee's `opts`.

They take an injected env rather than mutating `process.env`, so they need no database and cannot leak state into neighbouring tests. `tsc --noEmit` is clean; `test/multi-source-drift-env-budget.test.ts`, `test/doctor-drift-advice.test.ts` and `test/drift-watch.test.ts` pass (28 tests). I could not run `test/multi-source-drift.test.ts` locally — it needs PGLite, which crashes on this host (macOS 26.3 / Apple M4, upstream #223) — but that file's behaviour is unchanged: it calls `findMisroutedPages` directly and passes `opts` explicitly where it cares.

## Alternative considered

Defaulting from `process.env` inside `multi-source-drift.ts` itself would be fewer lines, but that module currently has no `process.env` reads and keeping env at the CLI boundary seemed closer to the existing layering. Happy to switch if you would rather have it in the module.