### PR TITLE
fix(slug): accept colon-separated namespace parts

### DIFF
--- a/src/core/ops/context.ts
+++ b/src/core/ops/context.ts
@@ -78,8 +78,11 @@ export function validateUploadPath(filePath: string, root: string, strict = true
 }
 
 /**
- * Op-boundary page-slug segment (#4665): cjk.ts's PAGE_SLUG_SEG shape widened
- * LOCALLY so `.` and `_` are allowed as segment-CONTINUATION characters. The
+ * Op-boundary page-slug segment (#4665/#5032): cjk.ts's PAGE_SLUG_SEG shape
+ * widened LOCALLY so `.` and `_` are allowed as part-CONTINUATION characters.
+ * Colon separates individually valid parts inside a path segment, preserving
+ * existing integration slugs such as `calendar:event-id` without admitting
+ * empty or dot-led parts (`calendar:../x` remains invalid). The
  * sync slugifier deliberately preserves both (`notes/v1.0.0`,
  * `people/my_file_name` — see slugifySegment in src/core/sync.ts), so the
  * put_page boundary must round-trip every slug sync can produce. The lead
@@ -94,13 +97,14 @@ export function validateUploadPath(filePath: string, root: string, strict = true
 // underscores (`_index.md` → `_index`, the Hugo convention), so rejecting
 // them recreates the un-updatable-synced-page class this widen closes.
 // Dot stays continuation-only — `..` traversal remains impossible.
-const OP_PAGE_SLUG_SEG = `[${SLUG_WORD_CHARS}_][${SLUG_WORD_CHARS}._\\-]*`;
+const OP_PAGE_SLUG_PART = `[${SLUG_WORD_CHARS}_][${SLUG_WORD_CHARS}._\\-]*`;
+const OP_PAGE_SLUG_SEG = `${OP_PAGE_SLUG_PART}(?::${OP_PAGE_SLUG_PART})*`;
 
 /**
  * Allowlist validator for page slugs. Rejects URL-encoded traversal, backslashes,
  * control chars, RTL overrides, Unicode lookalikes — anything outside the allowlist.
- * Format: lowercase alphanumeric segments (dot/underscore/hyphen continuation
- * allowed) separated by single forward slashes.
+ * Format: alphanumeric parts (dot/underscore/hyphen continuation allowed),
+ * optionally colon-separated within segments; segments use single forward slashes.
  */
 export function validatePageSlug(slug: string): void {
   if (typeof slug !== 'string' || slug.length === 0) {
@@ -113,7 +117,7 @@ export function validatePageSlug(slug: string): void {
   // for the \p{...} classes in OP_PAGE_SLUG_SEG). Shape rules (word-char lead,
   // dot/underscore/hyphen continuation) preserved.
   if (!new RegExp(`^${OP_PAGE_SLUG_SEG}(\\/${OP_PAGE_SLUG_SEG})*$`, 'iu').test(slug)) {
-    throw new OperationError('invalid_params', `Invalid page_slug: ${slug} (allowed: letters/numbers in any script, with '.', '_', '-' after the first character of a segment, forward-slash separated segments)`);
+    throw new OperationError('invalid_params', `Invalid page_slug: ${slug} (allowed: letters/numbers in any script, with '.', '_', '-' after the first character of a part, optional colon-separated namespace parts, and forward-slash separated segments)`);
   }
 }
 

--- a/test/e2e/delegated-grants-withdrawal.test.ts
+++ b/test/e2e/delegated-grants-withdrawal.test.ts
@@ -9,14 +9,21 @@ import { runExtractFacts } from '../../src/core/cycle/extract-facts.ts';
 
 const RUN = hasDatabase();
 const d = RUN ? describe : describe.skip;
-beforeAll(async () => {
-  if (!RUN) return;
-  const engine = await setupDB();
+async function cleanupClients() {
+  const engine = getEngine();
   for (const table of ['mcp_spend_reservations', 'mcp_spend_log', 'oauth_clients']) {
     await engine.executeRaw(`DELETE FROM ${table} WHERE client_id IN ('pg-agent-fixture','pg-budget-fixture')`);
   }
+}
+beforeAll(async () => {
+  if (!RUN) return;
+  await setupDB();
+  await cleanupClients();
 });
-afterAll(async () => { if (RUN) await teardownDB(); });
+afterAll(async () => {
+  if (!RUN) return;
+  try { await cleanupClients(); } finally { await teardownDB(); }
+});
 
 d('Postgres delegated admission and durable withdrawal', () => {
   test('concurrent queue submissions share one client row lock across queues', async () => {

--- a/test/file-upload-security.test.ts
+++ b/test/file-upload-security.test.ts
@@ -132,6 +132,18 @@ describe('validatePageSlug', () => {
     expect(() => validatePageSlug('people/my_file_name')).not.toThrow();
   });
 
+  it('accepts colon-separated namespace parts (#5032)', () => {
+    expect(() => validatePageSlug('calendar:abc123def456')).not.toThrow();
+    expect(() => validatePageSlug('integrations/calendar:event-123')).not.toThrow();
+  });
+
+  it('rejects empty or dot-led colon namespace parts (#5032)', () => {
+    expect(() => validatePageSlug('calendar:')).toThrow(OperationError);
+    expect(() => validatePageSlug(':event')).toThrow(OperationError);
+    expect(() => validatePageSlug('calendar::event')).toThrow(OperationError);
+    expect(() => validatePageSlug('calendar:../event')).toThrow(OperationError);
+  });
+
   it('accepts underscore-LED segments the slugifier produces (Hugo _index shape, #4665)', () => {
     // slugifySegment('_index') === '_index' — leading underscores survive
     // sync, so the op boundary must round-trip them too. Dots stay


### PR DESCRIPTION
## Summary

- accept colon-separated namespace parts in operation page slugs
- apply the existing lead/continuation grammar to every colon part, so empty and dot-led parts remain invalid
- clarify the validation error and add regression coverage for accepted and rejected namespace shapes
- clean up the delegated OAuth client fixtures so later E2E files observe a healthy database

## Problem

The operation boundary rejected existing `namespace:id` page slugs even though those rows remained readable. As a result, `put_page` and `capture` could not update affected pages.

The fix treats `:` as a separator between independently valid parts rather than adding it to the unrestricted continuation character class. This accepts `calendar:event-123` while keeping `calendar:../event`, empty parts, slash traversal, backslashes, controls, and encoded traversal invalid.

The mapped E2E sequence also exposed test pollution in `delegated-grants-withdrawal.test.ts`: it left two confidential OAuth client fixtures with empty secret hashes, causing the later Mechanical Doctor check to fail correctly. The test now removes the rows it owns before and after execution and always tears down the database in `finally`; its delegated-grant security assertions are unchanged.

Fixes #5032.

## Test plan

- [x] Regression demonstrated red on upstream master: `bun test test/file-upload-security.test.ts`
- [x] `bun test test/file-upload-security.test.ts test/slug-unicode-scripts.test.ts test/fuzz/mixed-validators.test.ts` — 60 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun run verify` — 54/54 checks green
- [x] `bun run check:privacy`
- [x] `delegated-grants-withdrawal.test.ts` followed by `mechanical.test.ts` in the upstream E2E runner — 83 pass, 0 fail (without fixture cleanup: 82 pass, 1 fail in `oauth_confidential_client_health`)
