### PR TITLE
fix(search): strip Korean particles in the CJK keyword fallback

### DIFF
--- a/src/core/cjk.ts
+++ b/src/core/cjk.ts
@@ -120,3 +120,55 @@ export function splitCJKQueryTerms(query: string): string[] {
   return Array.from(new Set(terms));
 }
 
+
+/**
+ * Korean postpositions (조사), longest-first.
+ *
+ * Korean is agglutinative: a particle attaches directly to the noun, so the
+ * ILIKE substring fallback sees "혈당에서" as one token and never matches a
+ * document that says "혈당 수치". Stripping the particle yields a stem that
+ * DOES match as a substring.
+ *
+ * Order matters — the scan takes the FIRST `endsWith` hit, so a longer
+ * particle must be tested before any shorter one it contains ("에서" before
+ * "에"/"서", "으로" before "로").
+ */
+export const KO_PARTICLES: readonly string[] = [
+  '에서는', '에게서', '으로는', '으로서',
+  '에서', '에게', '한테', '까지', '부터', '보다', '처럼', '마다',
+  '조차', '라도', '이나', '으로', '로서',
+  '은', '는', '이', '가', '을', '를', '에', '의', '로', '와', '과', '도', '만',
+];
+
+/**
+ * Minimum stem length kept after stripping a particle.
+ *
+ * One-syllable stems are indistinguishable from over-stripped fragments:
+ * "회의" ends in "의", "결과" ends in "과", "도로" ends in "로" — all would
+ * collapse to a single meaningless syllable that matches almost everything.
+ * Requiring 2+ characters rejects those while keeping the real cases
+ * ("혈당에서" → "혈당", "검진을" → "검진").
+ */
+export const KO_MIN_STEM_LENGTH = 2;
+
+/**
+ * Expand one query term into its match variants: `[original]`, or
+ * `[original, stem]` when a Korean particle was stripped.
+ *
+ * The caller ORs the variants within a term and ANDs across terms, so an
+ * added stem can only WIDEN recall — the original match is never lost. That
+ * makes over-stripping fail safe (extra results, never missing ones); the
+ * KO_MIN_STEM_LENGTH guard keeps the extras rare.
+ */
+export function koreanTermVariants(term: string): string[] {
+  if (!CJK_RANGES_REGEX.test(term)) return [term];
+  for (const p of KO_PARTICLES) {
+    if (term.length > p.length && term.endsWith(p)) {
+      const stem = term.slice(0, -p.length);
+      // Longest-first: this IS the longest matching particle, so a shorter
+      // one would only strip more. Stop either way.
+      return stem.length >= KO_MIN_STEM_LENGTH ? [term, stem] : [term];
+    }
+  }
+  return [term];
+}

--- a/src/core/search/cjk-keyword-sql.ts
+++ b/src/core/search/cjk-keyword-sql.ts
@@ -22,7 +22,7 @@
  */
 import type { SearchOpts } from '../types.ts';
 import { buildBestPerPagePoolCte } from './sql-ranking.ts';
-import { escapeLikePattern, splitCJKQueryTerms } from '../cjk.ts';
+import { escapeLikePattern, splitCJKQueryTerms, koreanTermVariants } from '../cjk.ts';
 
 /** Query-shape context shared by both engines' CJK fallback call sites. */
 export interface CjkKeywordCtx {
@@ -51,19 +51,31 @@ export function buildCJKKeywordSql(query: string, ctx: CjkKeywordCtx): CjkKeywor
   const terms = splitCJKQueryTerms(qRaw);
   if (terms.length === 0) return null;
 
+  // Korean-particle expansion: each term becomes [original] or
+  // [original, stem]. Variants are ORed within a term and ANDed across
+  // terms (see whereLikeClause), so a stem can only widen recall.
+  const variantGroups = terms.map(t => koreanTermVariants(t));
+
   const params: unknown[] = [];
 
-  // LIKE parameters: $1 .. $N (each escaped and wrapped with %)
-  const likeParamIndices: number[] = [];
-  for (const term of terms) {
-    params.push(`%${escapeLikePattern(term)}%`);
-    likeParamIndices.push(params.length);
+  // LIKE parameters, grouped per term (each escaped and wrapped with %).
+  const likeGroups: number[][] = [];
+  for (const group of variantGroups) {
+    const indices: number[] = [];
+    for (const variant of group) {
+      params.push(`%${escapeLikePattern(variant)}%`);
+      indices.push(params.length);
+    }
+    likeGroups.push(indices);
   }
 
-  // Raw term parameters for term-frequency scoring: $N+1 .. $2N
+  // Raw term parameters for term-frequency scoring: ONE representative per
+  // group — the stem when the term was expanded. The stem is a prefix of the
+  // inflected form, so scoring both would count the same occurrence twice and
+  // inflate inflected queries against uninflected ones.
   const rawTermIndices: number[] = [];
-  for (const term of terms) {
-    params.push(term);
+  for (const group of variantGroups) {
+    params.push(group[group.length - 1]!);
     rawTermIndices.push(params.length);
   }
 
@@ -133,8 +145,10 @@ export function buildCJKKeywordSql(query: string, ctx: CjkKeywordCtx): CjkKeywor
     extraFilter += ` AND p.source_id = $${params.length}`;
   }
 
-  const whereLikeClause = likeParamIndices
-    .map(idx => `cc.chunk_text ILIKE $${idx} ESCAPE '\\'`)
+  // OR within a term's variants, AND across terms: every term must match in
+  // SOME form, and the inflected original stays a valid way to match.
+  const whereLikeClause = likeGroups
+    .map(group => `(${group.map(idx => `cc.chunk_text ILIKE $${idx} ESCAPE '\\'`).join(' OR ')})`)
     .join(' AND ');
 
   const termFreqExpr = rawTermIndices

--- a/test/cjk-keyword-sql.test.ts
+++ b/test/cjk-keyword-sql.test.ts
@@ -142,3 +142,41 @@ describe('postgres-engine searchKeywordCJK executor (#3986)', () => {
     expect(called).toBe(false);
   });
 });
+
+describe('buildCJKKeywordSql — Korean particle variants', () => {
+  // These assert on the BUILDER's output, not on a new export, so they still
+  // EXECUTE (and fail) against the pre-fix source — the discrimination-test
+  // contract in CONTRIBUTING.md. A test that only imported the new helper
+  // would crash on import instead, which is the vacuous-failure class.
+
+  test('an inflected term binds its stem as an additional LIKE param', () => {
+    const { params } = buildCJKKeywordSql('혈당에서', ctx())!;
+    expect(params).toContain('%혈당에서%'); // original is never dropped
+    expect(params).toContain('%혈당%');     // stem is offered alongside it
+  });
+
+  test('variants are ORed within a term, ANDed across terms', () => {
+    const { sql } = buildCJKKeywordSql('혈당이 검진을', ctx())!;
+    const where = sql.match(/\(cc\.chunk_text ILIKE[^\n]*/)![0];
+    // Two parenthesised groups joined by AND, each holding an OR pair.
+    expect(where).toMatch(/\(cc\.chunk_text ILIKE \$\d+ ESCAPE '\\' OR cc\.chunk_text ILIKE \$\d+ ESCAPE '\\'\) AND \(/);
+  });
+
+  test('term-frequency scoring binds ONE representative per term, not both variants', () => {
+    // Counting the inflected form AND its stem would double-count the same
+    // occurrence and inflate inflected queries against uninflected ones. The
+    // non-LIKE string params are exactly [<term-frequency term>, <raw query>];
+    // the stem takes the scoring slot, and the inflected form appears only as
+    // the pre-existing raw-query param (contiguous-match bonus + tiebreaker).
+    const { params } = buildCJKKeywordSql('혈당에서', ctx())!;
+    const raw = params.filter(p => typeof p === 'string' && !p.startsWith('%'));
+    expect(raw).toEqual(['혈당', '혈당에서']);
+  });
+
+  test('a term with no strippable particle binds exactly one LIKE param', () => {
+    const like = (q: string) =>
+      buildCJKKeywordSql(q, ctx())!.params.filter(p => typeof p === 'string' && p.startsWith('%'));
+    expect(like('회의')).toEqual(['%회의%']);   // 1-syllable stem refused
+    expect(like('LDL')).toEqual(['%LDL%']);    // non-Korean untouched
+  });
+});

--- a/test/cjk.test.ts
+++ b/test/cjk.test.ts
@@ -9,6 +9,7 @@ import {
   CJK_CLAUSE_DELIMITERS,
   escapeLikePattern,
   splitCJKQueryTerms,
+  koreanTermVariants,
 } from '../src/core/cjk.ts';
 
 describe('hasCJK', () => {
@@ -169,3 +170,40 @@ describe('splitCJKQueryTerms', () => {
   });
 });
 
+
+describe('koreanTermVariants', () => {
+  test('strips a particle and offers the stem alongside the original', () => {
+    expect(koreanTermVariants('혈당에서')).toEqual(['혈당에서', '혈당']);
+    expect(koreanTermVariants('검진을')).toEqual(['검진을', '검진']);
+    expect(koreanTermVariants('수치는')).toEqual(['수치는', '수치']);
+    expect(koreanTermVariants('병원으로')).toEqual(['병원으로', '병원']);
+  });
+
+  test('prefers the LONGEST particle — a shorter one would over-strip', () => {
+    // '에서' must win over '서'/'에'; '으로서' over '로서'/'로'.
+    expect(koreanTermVariants('진료실에서')).toEqual(['진료실에서', '진료실']);
+    expect(koreanTermVariants('결과에서는')).toEqual(['결과에서는', '결과']);
+  });
+
+  test('refuses a 1-syllable stem: real words that merely END in a particle', () => {
+    // Stripping would leave 회/결/도 — near-universal substrings.
+    expect(koreanTermVariants('회의')).toEqual(['회의']);
+    expect(koreanTermVariants('결과')).toEqual(['결과']);
+    expect(koreanTermVariants('도로')).toEqual(['도로']);
+  });
+
+  test('leaves non-Korean terms untouched', () => {
+    expect(koreanTermVariants('LDL')).toEqual(['LDL']);
+    expect(koreanTermVariants('mg/dL')).toEqual(['mg/dL']);
+    expect(koreanTermVariants('2019-11-20')).toEqual(['2019-11-20']);
+  });
+
+  test('handles mixed ASCII+Hangul tokens (the acronym+particle case)', () => {
+    expect(koreanTermVariants('LDL수치가')).toEqual(['LDL수치가', 'LDL수치']);
+  });
+
+  test('a bare particle is never stripped to nothing', () => {
+    expect(koreanTermVariants('는')).toEqual(['는']);
+    expect(koreanTermVariants('에서')).toEqual(['에서']);
+  });
+});


### PR DESCRIPTION
## Problem

Korean is agglutinative — a postposition attaches directly to the noun. The CJK
ILIKE fallback saw `혈당에서` ("from blood sugar") as one token and never matched
a document saying `혈당 수치` ("blood sugar level"). Every particle-inflected
query — the natural way a Korean speaker types — returned zero keyword hits,
leaving hybrid search running on the vector arm alone.

## Fix

Each term expands to `[original, stem]` when a particle is stripped. Variants are
ORed within a term and ANDed across terms, so the original match is never lost
and recall can only widen. Term-frequency scoring binds one representative per
term (the stem) — counting both would double-count the same occurrence.

Over-stripping is guarded by a 2-character minimum stem: `회의`→`회`, `결과`→`결`,
`도로`→`도` would each collapse to a near-universal substring, so those terms are
left alone.

Chinese and Japanese are untouched — the expansion only fires on a Korean
particle suffix; non-CJK terms return early. This mirrors the existing `ZH_*_RE`
pattern block in `link-extraction.ts`, whose comment notes Korean handling was
not yet implemented.

## Measured

Keyword-only brain (no embeddings configured, so `search` is the keyword arm
alone), 6 Korean documents:

| query | before | after |
|---|---|---|
| 혈당에서 | 0 | 4 |
| 공복혈당이 | 0 | 4 |
| 콜레스테롤은 | 0 | 4 |
| 검진을 | 0 | 4 |
| 혈당이 검진을 (both tokens inflected) | 0 | 4 |
| 혈당 (control) | 4 | 4 |
| 디스크 (control) | 1 | 1 |

## Discrimination test

Discrimination test: reverted `src/core/cjk.ts` `src/core/search/cjk-keyword-sql.ts`
to merge-base, ran `test/cjk-keyword-sql.test.ts` → 12 pass / 3 fail. Restored →
all pass.

The new assertions live in `test/cjk-keyword-sql.test.ts` (the builder's output)
rather than importing the new helper, so they still EXECUTE against the pre-fix
source instead of crashing on import — the vacuous-failure class CONTRIBUTING.md
warns about.

## Verification

- `bun run typecheck` — clean
- `bun test test/cjk.test.ts test/cjk-keyword-sql.test.ts test/search.test.ts test/chunkers/ test/link-extraction.test.ts` — 429 pass / 0 fail

## Not run

`gbrain eval replay` — requires `CONTRIBUTOR_MODE` captured traffic I don't have.
Happy to add if a maintainer can point me at a corpus.

## Known limitations

- Verb conjugations (`높았던`) are not stripped — that needs a stemmer, not a
  particle list.
- Compound splitting (`혈당수치` vs `혈당 수치`) remains vector-arm territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgfJ8ikvZE4Ez39y5EEefs
